### PR TITLE
fix(torghut): select closed paper-route evidence in auto audit

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1006,6 +1006,26 @@ def _following_regular_equities_session_window(
     return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
 
 
+def _auto_runtime_import_audit_may_select_latest_closed(
+    *,
+    generated_at: datetime,
+    next_targets: Mapping[str, object],
+) -> bool:
+    """Keep same-day pre-open evidence reads cheap while allowing stale backlog review."""
+
+    session_window = _as_mapping(next_targets.get("session_window"))
+    next_window_start = _parse_datetime(session_window.get("start"))
+    if next_window_start is None:
+        return True
+    zone = ZoneInfo(US_EQUITIES_TIMEZONE)
+    local_generated_at = generated_at.astimezone(zone)
+    local_next_start = next_window_start.astimezone(zone)
+    return not (
+        local_generated_at.date() == local_next_start.date()
+        and local_generated_at < local_next_start
+    )
+
+
 def _seconds_until(*, generated_at: datetime, target: datetime) -> int:
     return max(0, int((target - generated_at).total_seconds()))
 
@@ -10137,18 +10157,24 @@ def _profitability_proof_lifecycle(
     )
     next_counts = _runtime_window_target_counts(next_target_audits)
     import_counts = _runtime_window_target_counts(runtime_window_import_target_audits)
-    session_readiness = _as_mapping(next_targets.get("session_readiness"))
-    collection_readiness = _as_mapping(next_targets.get("collection_session_readiness"))
-    account_pre_session = _as_mapping(next_targets.get("account_pre_session_readiness"))
+    session_readiness = _as_mapping(
+        runtime_window_import_plan.get("session_readiness")
+    ) or _as_mapping(next_targets.get("session_readiness"))
+    collection_readiness = _as_mapping(
+        runtime_window_import_plan.get("collection_session_readiness")
+    ) or _as_mapping(next_targets.get("collection_session_readiness"))
+    account_pre_session = _as_mapping(
+        runtime_window_import_plan.get("account_pre_session_readiness")
+    ) or _as_mapping(next_targets.get("account_pre_session_readiness"))
     clean_window_baseline = _as_mapping(
-        next_targets.get("clean_window_baseline_readiness")
-    )
+        runtime_window_import_plan.get("clean_window_baseline_readiness")
+    ) or _as_mapping(next_targets.get("clean_window_baseline_readiness"))
     account_contamination = _as_mapping(
         runtime_window_import_plan.get("account_contamination_readiness")
     ) or _as_mapping(next_targets.get("account_contamination_readiness"))
     source_decision_readiness = _as_mapping(
-        next_targets.get("source_decision_readiness")
-    )
+        runtime_window_import_plan.get("source_decision_readiness")
+    ) or _as_mapping(next_targets.get("source_decision_readiness"))
     runtime_import_state = (
         _safe_text(runtime_window_import_audit.get("state")) or "unknown"
     )
@@ -10204,8 +10230,20 @@ def _profitability_proof_lifecycle(
         if source_decision_blockers
         else "pending"
     )
+    import_source_activity_seen = (
+        import_counts["source_activity"] > 0
+        or import_counts["rejected_signal_activity"] > 0
+    )
+    source_activity_seen = (
+        import_source_activity_seen
+        or next_counts["source_activity"] > 0
+        or next_counts["rejected_signal_activity"] > 0
+    )
+    runtime_import_ready = bool(runtime_window_import_audit.get("import_ready"))
     collection_status = (
-        "active"
+        "complete"
+        if runtime_import_ready and import_source_activity_seen
+        else "active"
         if session_state == "collecting_session_evidence" and not collection_blockers
         else "pending"
         if session_state
@@ -10216,12 +10254,6 @@ def _profitability_proof_lifecycle(
         else "blocked"
         if collection_blockers
         else "pending"
-    )
-    source_activity_seen = (
-        import_counts["source_activity"] > 0
-        or import_counts["rejected_signal_activity"] > 0
-        or next_counts["source_activity"] > 0
-        or next_counts["rejected_signal_activity"] > 0
     )
     source_activity_status = (
         "complete"
@@ -10235,7 +10267,6 @@ def _profitability_proof_lifecycle(
         }
         else "blocked"
     )
-    runtime_import_ready = bool(runtime_window_import_audit.get("import_ready"))
     runtime_import_status = (
         "complete"
         if runtime_import_state == "runtime_ledger_ready_for_gate_review"
@@ -10265,6 +10296,9 @@ def _profitability_proof_lifecycle(
     if target_status == "blocked":
         lifecycle_state = "target_plan_missing"
         recommended_next_action = "repair_runtime_ledger_paper_probation_import_plan"
+    elif runtime_import_status == "complete" and runtime_ledger_status == "complete":
+        lifecycle_state = runtime_import_state
+        recommended_next_action = runtime_import_next_action
     elif source_collection_next_actions:
         lifecycle_state = "source_collection_materialization_pending"
     elif session_state == "collecting_session_evidence":
@@ -10326,9 +10360,11 @@ def _profitability_proof_lifecycle(
         _profitability_proof_lifecycle_stage(
             name="bounded_live_paper_collection",
             status=collection_status,
-            blockers=collection_blockers,
+            blockers=[] if collection_status == "complete" else collection_blockers,
             next_action=(
-                "collect_paper_route_activity_until_close"
+                None
+                if collection_status == "complete"
+                else "collect_paper_route_activity_until_close"
                 if collection_status == "active"
                 else "wait_for_regular_session_open"
             ),
@@ -12017,14 +12053,49 @@ def build_paper_route_evidence_audit(
             generated_at=resolved_generated_at,
             target_account_audit_available=target_account_audit_available,
         )
-    next_import_readiness = _as_mapping(next_targets.get("session_readiness"))
-    next_import_handoff = _as_mapping(next_targets.get("runtime_window_import_handoff"))
-    next_import_ready = bool(
-        next_import_readiness.get("import_ready")
-        or next_import_handoff.get("import_ready")
+    latest_closed_targets: Mapping[str, Any] = {}
+    next_clean_after_discard_targets: Mapping[str, Any] = {}
+    closed_window_end: datetime | None = None
+    may_select_latest_closed = (
+        include_runtime_window_import_audit is True
+        or include_runtime_window_import_audit is None
+        and _auto_runtime_import_audit_may_select_latest_closed(
+            generated_at=resolved_generated_at,
+            next_targets=next_targets,
+        )
+    )
+    if may_select_latest_closed:
+        closed_window_start, closed_window_end = (
+            _latest_closed_regular_equities_session_window(resolved_generated_at)
+        )
+        latest_closed_targets = _next_paper_route_runtime_window_targets(
+            session=session,
+            targets=targets,
+            probe=probe,
+            live_submission_gate=live_submission_gate,
+            generated_at=resolved_generated_at,
+            require_clean_pre_session=False,
+            window_start=closed_window_start,
+            window_end=closed_window_end,
+            purpose="latest_closed_session_paper_route_runtime_window_import",
+            target_account_audit_available=target_account_audit_available,
+        )
+    auto_runtime_window_import_plan = _runtime_window_import_plan_for_audit(
+        latest_closed_targets=latest_closed_targets,
+        next_targets=next_targets,
+    )
+    auto_import_readiness = _as_mapping(
+        auto_runtime_window_import_plan.get("session_readiness")
+    )
+    auto_import_handoff = _as_mapping(
+        auto_runtime_window_import_plan.get("runtime_window_import_handoff")
+    )
+    auto_import_ready = bool(
+        auto_import_readiness.get("import_ready")
+        or auto_import_handoff.get("import_ready")
     )
     run_full_runtime_import_audit = (
-        next_import_ready
+        auto_import_ready
         if include_runtime_window_import_audit is None
         else include_runtime_window_import_audit
     )
@@ -12061,8 +12132,6 @@ def build_paper_route_evidence_audit(
     runtime_window_import_target_audits = next_target_audits
     source_targets: Mapping[str, Any] = source_collection_import_plan
     observed_strategy_source_targets: Mapping[str, Any] = {}
-    latest_closed_targets: Mapping[str, Any] = {}
-    next_clean_after_discard_targets: Mapping[str, Any] = {}
     latest_closed_runtime_window_import_selection = (
         _runtime_window_import_candidate_selection(
             latest_closed_targets=latest_closed_targets,
@@ -12072,21 +12141,6 @@ def build_paper_route_evidence_audit(
     )
 
     if run_full_runtime_import_audit:
-        closed_window_start, closed_window_end = (
-            _latest_closed_regular_equities_session_window(resolved_generated_at)
-        )
-        latest_closed_targets = _next_paper_route_runtime_window_targets(
-            session=session,
-            targets=targets,
-            probe=probe,
-            live_submission_gate=live_submission_gate,
-            generated_at=resolved_generated_at,
-            require_clean_pre_session=False,
-            window_start=closed_window_start,
-            window_end=closed_window_end,
-            purpose="latest_closed_session_paper_route_runtime_window_import",
-            target_account_audit_available=target_account_audit_available,
-        )
         latest_closed_runtime_window_import_selection = (
             _runtime_window_import_candidate_selection(
                 latest_closed_targets=latest_closed_targets,
@@ -12124,6 +12178,12 @@ def build_paper_route_evidence_audit(
             elif _runtime_window_import_candidate_discard_blockers(
                 latest_closed_target_audits
             ):
+                if closed_window_end is None:
+                    _closed_window_start, closed_window_end = (
+                        _latest_closed_regular_equities_session_window(
+                            resolved_generated_at
+                        )
+                    )
                 followup_window_start, followup_window_end = (
                     _following_regular_equities_session_window(closed_window_end)
                 )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -3969,11 +3969,144 @@ class TestPaperRouteEvidenceAudit(TestCase):
     def test_evidence_import_audit_uses_latest_closed_window_before_next_open(
         self,
     ) -> None:
-        generated_at = datetime(2026, 6, 1, 5, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 5, 31, 23, tzinfo=timezone.utc)
         closed_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
         closed_end = datetime(2026, 5, 29, 20, tzinfo=timezone.utc)
         strategy_name = "closed-window-paper-route"
+        event_at = closed_start + timedelta(minutes=45)
         with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="closed window paper-route source strategy",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=closed_start,
+                updated_at=closed_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "candidate_id": "candidate-closed-window",
+                    "hypothesis_id": "H-CLOSED-WINDOW",
+                    "params": {
+                        "paper_route_probe": {
+                            "source_candidate_ids": ["candidate-closed-window"],
+                            "source_hypothesis_ids": ["H-CLOSED-WINDOW"],
+                        }
+                    },
+                },
+                rationale="closed-window source-linked paper-route fixture",
+                status="executed",
+                created_at=event_at,
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="closed-window-order",
+                client_order_id="closed-window-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at,
+                updated_at=event_at,
+                last_update_at=event_at,
+                order_feed_last_event_ts=event_at,
+            )
+            session.add(execution)
+            session.flush()
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed",
+                source_topic="trade_updates",
+                source_partition=0,
+                alpaca_account_label="TORGHUT_SIM",
+                assignment_mode="group",
+                collector_identity="test-order-feed",
+                source_revision="alpaca_trade_updates_v1",
+                window_started_at=event_at,
+                window_ended_at=event_at,
+                start_offset=901,
+                end_offset=901,
+                consumed_count=1,
+                inserted_count=1,
+                status="inserted",
+                status_reason="linked_execution_and_decision",
+                payload_json={
+                    "source_ref": {
+                        "topic": "trade_updates",
+                        "partition": 0,
+                        "offset": 901,
+                    },
+                    "source_coverage_complete": True,
+                    "promotion_authority_eligible": False,
+                },
+            )
+            session.add(source_window)
+            session.flush()
+            session.add_all(
+                [
+                    ExecutionOrderEvent(
+                        event_fingerprint="closed-window-fill",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=901,
+                        alpaca_account_label="TORGHUT_SIM",
+                        feed_seq=901,
+                        event_ts=event_at,
+                        symbol="AAPL",
+                        alpaca_order_id="closed-window-order",
+                        client_order_id="closed-window-client",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        filled_qty_delta=Decimal("1"),
+                        filled_notional_delta=Decimal("100"),
+                        avg_fill_price=Decimal("100"),
+                        raw_event={"event": "fill", "side": "buy"},
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        source_window_id=source_window.id,
+                        created_at=event_at,
+                    ),
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side="buy",
+                        arrival_price=Decimal("99"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("1"),
+                        slippage_bps=Decimal("5"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("5"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=event_at,
+                        created_at=event_at,
+                        updated_at=event_at,
+                    ),
+                ]
+            )
             session.add(
                 StrategyRuntimeLedgerBucket(
                     run_id="closed-window-paper-route-run",
@@ -4007,6 +4140,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         suffix="closed-window",
                     ),
                 )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=closed_start,
             )
             session.commit()
 
@@ -4055,6 +4193,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     },
                 },
                 generated_at=generated_at,
+                include_runtime_window_import_audit=None,
             )
 
         next_plan = payload["next_paper_route_runtime_window_targets"]
@@ -4077,9 +4216,20 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "end": "2026-05-29T20:00:00+00:00",
             },
         )
+        self.assertEqual(payload["runtime_window_import_audit_mode"], "full")
+        latest_closed_selection = payload[
+            "latest_closed_runtime_window_import_selection"
+        ]
+        self.assertTrue(latest_closed_selection["selected"])
+        self.assertEqual(latest_closed_selection["state"], "selected")
+        self.assertTrue(latest_closed_selection["source_backed_evidence_present"])
+        self.assertTrue(latest_closed_selection["clean_window_importable"])
         import_audit = payload["runtime_window_import_audit"]
         self.assertEqual(import_audit["session_window"], import_plan["session_window"])
         self.assertTrue(import_audit["import_ready"])
+        self.assertEqual(
+            import_audit["next_action"], "review_runtime_ledger_profit_gates"
+        )
         self.assertEqual(import_audit["counts"]["targets_with_runtime_ledger"], 1)
         self.assertEqual(
             import_audit["counts"]["targets_with_evidence_grade_runtime_ledger"],
@@ -4104,6 +4254,18 @@ class TestPaperRouteEvidenceAudit(TestCase):
         runtime_import_audit = payload["runtime_window_import_target_audits"][0]
         self.assertEqual(runtime_import_audit["window"], import_plan["session_window"])
         self.assertEqual(runtime_import_audit["runtime_ledger"]["bucket_count"], 1)
+        lifecycle = payload["profitability_proof_lifecycle"]
+        self.assertEqual(lifecycle["state"], "runtime_ledger_ready_for_gate_review")
+        self.assertEqual(lifecycle["next_action"], "review_runtime_ledger_profit_gates")
+        stages = {stage["name"]: stage for stage in lifecycle["stages"]}
+        self.assertEqual(stages["runtime_window_import"]["status"], "complete")
+        self.assertEqual(stages["runtime_ledger_authority"]["status"], "complete")
+        self.assertEqual(stages["promotion_profit_authority"]["status"], "blocked")
+        self.assertFalse(lifecycle["promotion_authority_allowed"])
+        self.assertEqual(
+            payload["summary"]["profitability_proof_lifecycle_state"],
+            "runtime_ledger_ready_for_gate_review",
+        )
 
     def test_source_runtime_window_import_plan_keeps_next_session_window(
         self,


### PR DESCRIPTION
## Summary

- Fixes `/trading/paper-route-evidence` auto audit selection so off-day/weekend reads can select the latest closed import-ready paper-route window instead of deferring to the next session.
- Updates the profitability proof lifecycle to derive readiness from the selected runtime-window import plan before falling back to the next-session plan.
- Preserves proof boundaries: promotion and capital authority remain false until source-linked runtime-ledger profit gates pass.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'latest_closed_window_before_next_open or profitability_lifecycle'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen python -m compileall app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-branch --cov-report=xml:coverage.xml --cov-fail-under=0 tests/test_paper_route_evidence.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main` (`93.55%` changed-line coverage)
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
