### PR TITLE
chore(torghut): promote image ef2734ae

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: materialize-targets
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -148,9 +148,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+                  value: sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
                 - name: TORGHUT_COMMIT
-                  value: f2d4e8f97efbe61cb040e4e2a649acba2dfb785d
+                  value: ef2734ae23a687f8526720effcb44099bef52395
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-06T14:37:21Z"
+        client.knative.dev/updateTimestamp: "2026-06-06T15:12:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           ports:
             - name: http1
               containerPort: 8181
@@ -533,11 +533,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-391-gf2d4e8f97
+              value: v0.596.0-393-gef2734ae2
             - name: TORGHUT_COMMIT
-              value: f2d4e8f97efbe61cb040e4e2a649acba2dfb785d
+              value: ef2734ae23a687f8526720effcb44099bef52395
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              value: sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-06T14:37:21Z"
+        client.knative.dev/updateTimestamp: "2026-06-06T15:12:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           ports:
             - name: http1
               containerPort: 8181
@@ -395,11 +395,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-391-gf2d4e8f97
+              value: v0.596.0-393-gef2734ae2
             - name: TORGHUT_COMMIT
-              value: f2d4e8f97efbe61cb040e4e2a649acba2dfb785d
+              value: ef2734ae23a687f8526720effcb44099bef52395
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              value: sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -88,7 +88,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+                  value: sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -125,7 +125,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -197,6 +197,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+                  value: sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: f2d4e8f97efbe61cb040e4e2a649acba2dfb785d
+            value: ef2734ae23a687f8526720effcb44099bef52395
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+            value: sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e24f04147d82432b1ca172b5a333c5179000282dd295f93f52537adcbf8d3055
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ef2734ae23a687f8526720effcb44099bef52395`
- Image tag: `ef2734ae`
- Image digest: `sha256:6ad55df43f6e3db9b2231b30d72e198b057fcbdab9ae9edb15059cad23b126ab`