### PR TITLE
fix(torghut): clear completed lifecycle authority blockers

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -10194,6 +10194,8 @@ def _profitability_lifecycle_authority_blockers(
     ):
         satisfied.update(PROFITABILITY_LIFECYCLE_RUNTIME_IMPORT_SATISFIED_BLOCKERS)
     if runtime_ledger_status == "complete":
+        if runtime_import_status == "complete":
+            satisfied.update(PROFITABILITY_LIFECYCLE_RUNTIME_IMPORT_SATISFIED_BLOCKERS)
         satisfied.update(PROFITABILITY_LIFECYCLE_RUNTIME_LEDGER_SATISFIED_BLOCKERS)
     return sorted(
         blocker for blocker in _unique_text_items(blockers) if blocker not in satisfied

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -4321,6 +4321,45 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "runtime_ledger_ready_for_gate_review",
         )
 
+    def test_profitability_lifecycle_clears_completed_lineage_blockers_when_account_window_dirty(
+        self,
+    ) -> None:
+        stale_lineage_blockers = {
+            "paper_route_runtime_ledger_import_pending",
+            "runtime_ledger_source_materialization_missing",
+            "runtime_ledger_source_refs_missing",
+            "runtime_ledger_source_window_ids_missing",
+            "runtime_ledger_source_window_missing",
+            "runtime_ledger_source_offsets_missing",
+            "runtime_ledger_trade_decision_refs_missing",
+            "runtime_ledger_execution_refs_missing",
+            "runtime_ledger_execution_order_event_refs_missing",
+            "runtime_ledger_authority_class_missing",
+            "runtime_ledger_bucket_missing",
+            "runtime_ledger_evidence_grade_bucket_missing",
+        }
+        blockers = paper_route_evidence._profitability_lifecycle_authority_blockers(
+            blockers=[
+                *sorted(stale_lineage_blockers),
+                "live_runtime_ledger_required",
+                "paper_route_account_window_start_snapshot_stale",
+                "simple_submit_disabled",
+            ],
+            collection_status="complete",
+            clean_window_status="blocked",
+            source_decision_status="complete",
+            source_activity_status="complete",
+            runtime_import_status="complete",
+            runtime_import_state="import_due_account_state_not_clean",
+            runtime_import_blockers=["paper_route_account_window_start_snapshot_stale"],
+            runtime_ledger_status="complete",
+        )
+
+        self.assertFalse(stale_lineage_blockers & set(blockers))
+        self.assertIn("paper_route_account_window_start_snapshot_stale", blockers)
+        self.assertIn("live_runtime_ledger_required", blockers)
+        self.assertIn("simple_submit_disabled", blockers)
+
     def test_source_runtime_window_import_plan_keeps_next_session_window(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Clears completed paper-route source-lineage/runtime-import blocker codes from the profitability lifecycle authority summary once runtime import and evidence-grade runtime-ledger stages are complete.
- Preserves the real blockers still blocking profitability, including dirty account-window snapshots, live runtime-ledger requirement, submit-disabled, and promotion authority failures.
- Adds a regression for the live-observed state where runtime ledger evidence is present but the account window is not clean.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'completed_lineage_blockers or latest_closed_window_before_next_open'`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen python -m compileall app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
