### PR TITLE
fix(torghut): hand off stale account windows

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -258,6 +258,8 @@ _HPAIRS_EXPECTED_MARKET_CLOSED_DRIFT_CHECK_BYPASS_REASONS = frozenset(
 )
 PAPER_ROUTE_ACCOUNT_STATE_DISCARD_BLOCKERS = frozenset(
     {
+        "paper_route_account_window_start_snapshot_missing",
+        "paper_route_account_window_start_snapshot_stale",
         "paper_route_account_window_start_not_flat",
         "paper_route_account_window_start_positions_present",
         "paper_route_account_window_start_target_positions_present",
@@ -9748,24 +9750,41 @@ def _target_audits_have_source_backed_runtime_window_import_evidence(
     )
 
 
-def _target_audit_runtime_window_discard_blockers(
+def _target_audit_runtime_window_contamination_discard_blockers(
     audit: Mapping[str, object],
 ) -> list[str]:
     evidence_window_contract = _as_mapping(audit.get("evidence_window_contract"))
     account_contamination = _as_mapping(audit.get("account_contamination"))
-    account_state = _as_mapping(audit.get("account_state"))
     contract_state = _safe_text(evidence_window_contract.get("state"))
     contamination_blockers = _unique_text_items(account_contamination.get("blockers"))
-    account_state_discard_blockers = [
+    if contract_state == "contaminated_window_discarded":
+        return contamination_blockers or [contract_state]
+    return contamination_blockers
+
+
+def _target_audit_runtime_window_account_state_discard_blockers(
+    audit: Mapping[str, object],
+) -> list[str]:
+    account_state = _as_mapping(audit.get("account_state"))
+    return [
         blocker
         for blocker in _unique_text_items(account_state.get("blockers"))
         if blocker in PAPER_ROUTE_ACCOUNT_STATE_DISCARD_BLOCKERS
     ]
+
+
+def _target_audit_runtime_window_discard_blockers(
+    audit: Mapping[str, object],
+) -> list[str]:
+    contamination_blockers = (
+        _target_audit_runtime_window_contamination_discard_blockers(audit)
+    )
+    account_state_discard_blockers = (
+        _target_audit_runtime_window_account_state_discard_blockers(audit)
+    )
     blockers = _unique_text_items(
         [*contamination_blockers, *account_state_discard_blockers]
     )
-    if contract_state == "contaminated_window_discarded":
-        return blockers or [contract_state]
     if contamination_blockers or account_state_discard_blockers:
         return blockers
     return blockers
@@ -9791,6 +9810,28 @@ def _runtime_window_import_candidate_discard_blockers(
     )
 
 
+def _runtime_window_import_candidate_followup_discard_blockers(
+    target_audits: Sequence[Mapping[str, object]],
+) -> list[str]:
+    contamination_blockers = {
+        blocker
+        for audit in target_audits
+        for blocker in _target_audit_runtime_window_contamination_discard_blockers(
+            audit
+        )
+    }
+    account_state_blockers: set[str] = set()
+    if _target_audits_have_source_backed_runtime_window_import_evidence(target_audits):
+        account_state_blockers = {
+            blocker
+            for audit in target_audits
+            for blocker in _target_audit_runtime_window_account_state_discard_blockers(
+                audit
+            )
+        }
+    return sorted(contamination_blockers | account_state_blockers)
+
+
 def _runtime_window_import_candidate_selection(
     *,
     latest_closed_targets: Mapping[str, object],
@@ -9800,7 +9841,7 @@ def _runtime_window_import_candidate_selection(
     source_backed = _target_audits_have_source_backed_runtime_window_import_evidence(
         latest_closed_target_audits
     )
-    discard_blockers = _runtime_window_import_candidate_discard_blockers(
+    discard_blockers = _runtime_window_import_candidate_followup_discard_blockers(
         latest_closed_target_audits
     )
     clean_importable = source_backed and not discard_blockers
@@ -11762,7 +11803,7 @@ def build_paper_route_target_plan_payload(
             )
             if latest_closed_importable:
                 runtime_window_import_plan = latest_closed_targets
-            elif _runtime_window_import_candidate_discard_blockers(
+            elif _runtime_window_import_candidate_followup_discard_blockers(
                 latest_closed_runtime_window_import_target_audits
             ):
                 followup_window_start, followup_window_end = (
@@ -12265,7 +12306,7 @@ def build_paper_route_evidence_audit(
             if latest_closed_importable:
                 runtime_window_import_plan = latest_closed_targets
                 runtime_window_import_target_audits = latest_closed_target_audits
-            elif _runtime_window_import_candidate_discard_blockers(
+            elif _runtime_window_import_candidate_followup_discard_blockers(
                 latest_closed_target_audits
             ):
                 if closed_window_end is None:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -13859,6 +13859,216 @@ class TestPaperRouteEvidenceAudit(TestCase):
             import_audit["session_window"]["start"], "2026-05-27T13:30:00+00:00"
         )
 
+    def test_stale_account_window_start_snapshot_schedules_next_clean_import(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="account-state-stale-proof-strategy",
+                description="paper account stale state fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "sell",
+                    "qty": "1",
+                    "candidate_id": "candidate-account-state-stale",
+                    "hypothesis_id": "H-ACCOUNT-STATE-STALE",
+                },
+                rationale="paper route stale account state fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=10),
+                executed_at=window_start + timedelta(minutes=11),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="torghut-account-state-stale-order",
+                client_order_id="torghut-account-state-stale-client",
+                symbol="AAPL",
+                side="sell",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_start + timedelta(minutes=12),
+                updated_at=window_start + timedelta(minutes=12),
+                last_update_at=window_start + timedelta(minutes=12),
+            )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    PositionSnapshot(
+                        alpaca_account_label="TORGHUT_SIM",
+                        as_of=window_start - timedelta(minutes=16),
+                        equity=Decimal("100000"),
+                        cash=Decimal("100000"),
+                        buying_power=Decimal("200000"),
+                        positions=[],
+                    ),
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side="sell",
+                        arrival_price=Decimal("101"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("-1"),
+                        slippage_bps=Decimal("5"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("5"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=window_start + timedelta(minutes=13),
+                        created_at=window_start + timedelta(minutes=13),
+                        updated_at=window_start + timedelta(minutes=13),
+                    ),
+                    StrategyPromotionDecision(
+                        run_id="paper-route-account-state-stale-run",
+                        candidate_id="candidate-account-state-stale",
+                        hypothesis_id="H-ACCOUNT-STATE-STALE",
+                        promotion_target="paper",
+                        state="allowed",
+                        allowed=True,
+                        reason_summary="paper_evidence_collecting",
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                ]
+            )
+            self._add_flat_account_close_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_end=window_end,
+            )
+            session.commit()
+
+            live_submission_gate = {
+                "allowed": False,
+                "reason": "paper_route_probe_only",
+                "blocked_reasons": [],
+                "runtime_ledger_paper_probation_import_plan": {
+                    "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                    "target_count": "1",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-ACCOUNT-STATE-STALE",
+                            "candidate_id": "candidate-account-state-stale",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "account-state-stale-proof-strategy",
+                            "strategy_id": "account_state_stale_proof_strategy@research",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "source_manifest_ref": "config/trading/hypotheses/h-account-state-stale.json",
+                            "window_start": window_start.isoformat(),
+                            "window_end": window_end.isoformat(),
+                            "paper_probation_authorized": True,
+                            "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                        }
+                    ],
+                },
+            }
+            route_reacquisition_book = {
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "summary": {
+                    "paper_route_probe_eligible_symbols": ["AAPL"],
+                    "paper_route_probe_active_symbols": ["AAPL"],
+                },
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": True,
+                    "effective_max_notional": 25,
+                    "next_session_max_notional": 25,
+                },
+            }
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate=live_submission_gate,
+                route_reacquisition_book=route_reacquisition_book,
+                generated_at=now,
+            )
+            target_plan_payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate=live_submission_gate,
+                route_reacquisition_book=route_reacquisition_book,
+                generated_at=now,
+            )
+
+        audit = payload["next_runtime_window_target_audits"][0]
+        account_state = audit["account_state"]
+        self.assertEqual(account_state["state"], "blocked")
+        self.assertFalse(account_state["flat"])
+        self.assertEqual(account_state["snapshot_offset_seconds"], -960)
+        self.assertIn(
+            "paper_route_account_window_start_snapshot_stale",
+            audit["readiness"]["blockers"],
+        )
+        self.assertEqual(audit["account_close_state"]["state"], "clean")
+        latest_closed_selection = payload[
+            "latest_closed_runtime_window_import_selection"
+        ]
+        self.assertFalse(latest_closed_selection["selected"])
+        self.assertEqual(
+            latest_closed_selection["state"],
+            "rejected_contaminated_or_unclean",
+        )
+        self.assertTrue(latest_closed_selection["source_backed_evidence_present"])
+        self.assertFalse(latest_closed_selection["clean_window_importable"])
+        self.assertEqual(
+            latest_closed_selection["discard_blockers"],
+            ["paper_route_account_window_start_snapshot_stale"],
+        )
+        followup_plan = payload[
+            "next_clean_paper_route_runtime_window_targets_after_discard"
+        ]
+        self.assertEqual(
+            followup_plan["purpose"],
+            "next_clean_session_paper_route_runtime_window_collection_after_discard",
+        )
+        self.assertEqual(
+            followup_plan["session_window"]["start"],
+            "2026-05-27T13:30:00+00:00",
+        )
+        self.assertEqual(
+            payload["runtime_window_import_plan"]["purpose"],
+            "next_clean_session_paper_route_runtime_window_collection_after_discard",
+        )
+        self.assertEqual(
+            target_plan_payload["runtime_window_import_plan"]["purpose"],
+            "next_clean_session_paper_route_runtime_window_collection_after_discard",
+        )
+        self.assertEqual(
+            target_plan_payload["targets"][0]["paper_route_probe_window_start"],
+            "2026-05-27T13:30:00+00:00",
+        )
+
     def test_paper_route_source_activity_requires_candidate_lineage(self) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

- Treat missing or stale paper-route account start snapshots as closed-window discard blockers.
- Split discard blocker selection so contaminated account windows still force a clean followup, while start-state blockers only force followup once the closed candidate is source-backed.
- Add regression coverage proving a source-backed stale start snapshot schedules the next clean runtime-window import plan in both evidence and target-plan payloads.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'stale_account_window_start_snapshot_schedules_next_clean_import or account_window_start_positions_block_runtime_window_import or contaminated_closed_window_schedules_next_clean_import'`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen python -m compileall app tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
