### PR TITLE
fix(torghut-options): decouple ta status sink delivery

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f94248fb3b6f6e75ef349e1afd460938a6e1e6a6931040fc41ee234518dc8198
   imagePullPolicy: IfNotPresent
-  restartNonce: 9
+  restartNonce: 10
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -43,6 +43,8 @@ spec:
           env:
             - name: TA_KAFKA_DELIVERY_GUARANTEE
               value: EXACTLY_ONCE
+            - name: OPTIONS_TA_STATUS_KAFKA_DELIVERY_GUARANTEE
+              value: AT_LEAST_ONCE
             - name: TA_KAFKA_USERNAME
               value: torghut-options
             - name: TA_KAFKA_PASSWORD

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTaConfig.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTaConfig.kt
@@ -36,6 +36,7 @@ data class OptionsTaConfig(
   val s3AccessKey: String?,
   val s3SecretKey: String?,
   val deliveryGuarantee: DeliveryGuarantee,
+  val statusDeliveryGuarantee: DeliveryGuarantee,
   val transactionTimeoutMs: Long,
   val clickhouseUrl: String?,
   val clickhouseUsername: String?,
@@ -77,19 +78,6 @@ data class OptionsTaConfig(
         fallback: String? = null,
         default: Boolean,
       ): Boolean = envEither(preferred, fallback)?.lowercase()?.let { it in setOf("1", "true", "yes") } ?: default
-
-      fun envDeliveryGuarantee(
-        preferred: String,
-        fallback: String? = null,
-        default: DeliveryGuarantee,
-      ): DeliveryGuarantee =
-        when (envEither(preferred, fallback)?.trim()?.uppercase()) {
-          null -> default
-          "EXACTLY_ONCE" -> DeliveryGuarantee.EXACTLY_ONCE
-          "AT_LEAST_ONCE" -> DeliveryGuarantee.AT_LEAST_ONCE
-          "NONE" -> DeliveryGuarantee.NONE
-          else -> default
-        }
 
       val checkpointBase =
         envEither(
@@ -137,7 +125,15 @@ data class OptionsTaConfig(
         s3AccessKey = envEither("OPTIONS_TA_S3_ACCESS_KEY", "TA_S3_ACCESS_KEY"),
         s3SecretKey = envEither("OPTIONS_TA_S3_SECRET_KEY", "TA_S3_SECRET_KEY"),
         deliveryGuarantee =
-          envDeliveryGuarantee("OPTIONS_TA_KAFKA_DELIVERY_GUARANTEE", "TA_KAFKA_DELIVERY_GUARANTEE", DeliveryGuarantee.EXACTLY_ONCE),
+          parseOptionsDeliveryGuarantee(
+            envEither("OPTIONS_TA_KAFKA_DELIVERY_GUARANTEE", "TA_KAFKA_DELIVERY_GUARANTEE"),
+            DeliveryGuarantee.EXACTLY_ONCE,
+          ),
+        statusDeliveryGuarantee =
+          parseOptionsDeliveryGuarantee(
+            envEither("OPTIONS_TA_STATUS_KAFKA_DELIVERY_GUARANTEE", "TA_STATUS_KAFKA_DELIVERY_GUARANTEE"),
+            DeliveryGuarantee.AT_LEAST_ONCE,
+          ),
         transactionTimeoutMs = envLong("OPTIONS_TA_KAFKA_TRANSACTION_TIMEOUT_MS", "TA_KAFKA_TRANSACTION_TIMEOUT_MS", 120_000),
         clickhouseUrl = clickhouseUrl,
         clickhouseUsername = envEither("OPTIONS_TA_CLICKHOUSE_USERNAME", "TA_CLICKHOUSE_USERNAME", "torghut"),
@@ -171,3 +167,15 @@ data class OptionsTaConfig(
     }
   }
 }
+
+internal fun parseOptionsDeliveryGuarantee(
+  value: String?,
+  default: DeliveryGuarantee,
+): DeliveryGuarantee =
+  when (value?.trim()?.uppercase()) {
+    null -> default
+    "EXACTLY_ONCE" -> DeliveryGuarantee.EXACTLY_ONCE
+    "AT_LEAST_ONCE" -> DeliveryGuarantee.AT_LEAST_ONCE
+    "NONE" -> DeliveryGuarantee.NONE
+    else -> default
+  }

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt
@@ -302,9 +302,9 @@ private fun optionsStatusSink(
     KafkaSink
       .builder<Envelope<OptionsTaStatusPayload>>()
       .setBootstrapServers(config.bootstrapServers)
-      .setDeliveryGuarantee(config.deliveryGuarantee)
+      .setDeliveryGuarantee(config.statusDeliveryGuarantee)
 
-  if (config.deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
+  if (config.statusDeliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
     builder.setTransactionalIdPrefix("${config.clientId}-options-status")
     builder.setProperty("transaction.timeout.ms", config.transactionTimeoutMs.toString())
   }

--- a/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJobTest.kt
+++ b/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJobTest.kt
@@ -1,11 +1,30 @@
 package ai.proompteng.dorvud.ta.flink
 
 import ai.proompteng.dorvud.ta.stream.OptionsContractFeaturePayload
+import org.apache.flink.connector.base.DeliveryGuarantee
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class OptionsTechnicalAnalysisJobTest {
+  @Test
+  fun `status sink delivery guarantee defaults to non transactional status output`() {
+    assertEquals(DeliveryGuarantee.AT_LEAST_ONCE, parseOptionsDeliveryGuarantee(null, DeliveryGuarantee.AT_LEAST_ONCE))
+    assertEquals(
+      DeliveryGuarantee.AT_LEAST_ONCE,
+      parseOptionsDeliveryGuarantee("AT_LEAST_ONCE", DeliveryGuarantee.EXACTLY_ONCE),
+    )
+    assertEquals(
+      DeliveryGuarantee.EXACTLY_ONCE,
+      parseOptionsDeliveryGuarantee("exactly_once", DeliveryGuarantee.AT_LEAST_ONCE),
+    )
+    assertEquals(DeliveryGuarantee.NONE, parseOptionsDeliveryGuarantee("none", DeliveryGuarantee.AT_LEAST_ONCE))
+    assertEquals(
+      DeliveryGuarantee.AT_LEAST_ONCE,
+      parseOptionsDeliveryGuarantee("bad-value", DeliveryGuarantee.AT_LEAST_ONCE),
+    )
+  }
+
   @Test
   fun `surface payload is suppressed until coverage is meaningful`() {
     val payload =


### PR DESCRIPTION
## Summary

- Split Torghut options TA status-sink delivery semantics from the core options Kafka output delivery guarantee.
- Keep contract bar, contract feature, and surface feature outputs on `EXACTLY_ONCE`, while defaulting the non-authoritative status heartbeat sink to `AT_LEAST_ONCE`.
- Configure the live `torghut-options-ta` FlinkDeployment with the status override and bump `restartNonce` so GitOps reconciles the failed job.

## Related Issues

None

## Testing

- `./gradlew :technical-analysis-flink:test --tests 'ai.proompteng.dorvud.ta.flink.OptionsTechnicalAnalysisJobTest'`
- `./gradlew :technical-analysis-flink:test`
- `./gradlew :technical-analysis-flink:check`
- `kubectl kustomize argocd/applications/torghut-options`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
