### PR TITLE
fix(torghut-options): run ta kafka sinks at least once

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:aa891e7d9e056a9a269644c593d960e7933a5f934e86e68a0313d90a7b93651e
   imagePullPolicy: IfNotPresent
-  restartNonce: 11
+  restartNonce: 12
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -42,7 +42,7 @@ spec:
                 name: torghut-options-ta-config
           env:
             - name: TA_KAFKA_DELIVERY_GUARANTEE
-              value: EXACTLY_ONCE
+              value: AT_LEAST_ONCE
             - name: OPTIONS_TA_STATUS_KAFKA_DELIVERY_GUARANTEE
               value: AT_LEAST_ONCE
             - name: TA_KAFKA_USERNAME


### PR DESCRIPTION
## Summary

- Change only `torghut-options-ta` Kafka sinks from `EXACTLY_ONCE` to `AT_LEAST_ONCE`.
- Keep the new status-sink override at `AT_LEAST_ONCE`, so every options TA Kafka producer avoids transaction initialization.
- Bump the options TA FlinkDeployment `restartNonce` so GitOps rolls the currently promoted TA image with the simpler sink semantics.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut-options`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
