### PR TITLE
fix(torghut): preserve hpairs target evidence summaries

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -9910,13 +9910,29 @@ def _next_paper_route_target_summaries(
     targets: Sequence[Mapping[str, object]],
 ) -> list[dict[str, object]]:
     summaries: list[dict[str, object]] = []
-    for target in targets:
+    for item in targets:
+        nested_target = _as_mapping(item.get("target"))
+        target = nested_target if nested_target else item
         strategy_name = _safe_text(target.get("strategy_name"))
         runtime_strategy_name = _safe_text(target.get("runtime_strategy_name"))
         source_decision_readiness = _as_mapping(target.get("source_decision_readiness"))
         execution_readiness = _as_mapping(
             target.get("paper_route_execution_readiness_contract")
         )
+        symbol_actions = dict(
+            _as_mapping(target.get("paper_route_probe_symbol_actions"))
+        )
+        symbols = _unique_text_items(target.get("paper_route_probe_symbols"))
+        if not symbols:
+            symbols = sorted(str(symbol) for symbol in symbol_actions if str(symbol))
+        bounded_notional = _target_capacity_notional(target)
+        symbol_quantities = _paper_route_probe_symbol_quantities(target, symbols)
+        symbol_quantity_source = _safe_text(
+            target.get("paper_route_probe_symbol_quantity_source")
+        )
+        if not symbol_quantities and bounded_notional > 0 and symbols:
+            symbol_quantities = {symbol: "1" for symbol in symbols}
+            symbol_quantity_source = "target_notional_runtime_sizing_seed"
         summaries.append(
             {
                 "hypothesis_id": _safe_text(target.get("hypothesis_id")),
@@ -9927,10 +9943,10 @@ def _next_paper_route_target_summaries(
                 "runtime_strategy_id": runtime_strategy_name or strategy_name,
                 "account_label": _safe_text(target.get("account_label")),
                 "source_kind": _safe_text(target.get("source_kind")),
-                "symbols": _unique_text_items(target.get("paper_route_probe_symbols")),
-                "symbol_actions": dict(
-                    _as_mapping(target.get("paper_route_probe_symbol_actions"))
-                ),
+                "symbols": symbols,
+                "symbol_actions": symbol_actions,
+                "symbol_quantities": symbol_quantities,
+                "symbol_quantity_source": symbol_quantity_source,
                 "pair_balance_required": bool(
                     target.get("paper_route_probe_pair_balance_required")
                 ),
@@ -9943,6 +9959,10 @@ def _next_paper_route_target_summaries(
                 "next_session_max_notional": _safe_text(
                     target.get("paper_route_probe_next_session_max_notional")
                 )
+                or "0",
+                "target_notional": _safe_text(target.get("target_notional")) or "0",
+                "bounded_paper_collection_notional": _decimal_text(bounded_notional),
+                "capital_promotion_max_notional": _safe_text(target.get("max_notional"))
                 or "0",
                 "bounded_evidence_collection_authorized": bool(
                     target.get("bounded_evidence_collection_authorized")

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -30,6 +30,7 @@ from app.models import (
     TradeDecision,
 )
 from app.trading.hypotheses import JangarDependencyQuorumStatus
+from app.trading.paper_route_evidence import _next_paper_route_target_summaries
 from app.trading.paper_route_target_plan import (
     materialize_bounded_paper_route_target_plan,
 )
@@ -616,6 +617,56 @@ class TestSubmissionCouncil(TestCase):
                 payload["target_plan_identity"]["target_symbol_quantities"],
                 {"AAPL": "0.10", "AMZN": "0.10"},
             )
+
+    def test_hpairs_target_summary_reads_audit_target_and_bounded_notional(
+        self,
+    ) -> None:
+        target = cast(dict[str, Any], self._hpairs_clean_target_plan()["targets"][0])
+        target = {
+            **target,
+            "target_notional": "1000000",
+            "bounded_evidence_collection_max_notional": "1000000",
+            "paper_route_probe_next_session_max_notional": "1000000",
+            "paper_route_probe_effective_max_notional": "1000000",
+            "paper_route_probe_symbol_quantities": {},
+            "paper_route_probe_symbol_quantity_source": (
+                "target_notional_runtime_sizing"
+            ),
+            "max_notional": "0",
+        }
+
+        summaries = _next_paper_route_target_summaries(
+            [
+                {
+                    "target": target,
+                    "readiness": {"state": "paper_evidence_collecting"},
+                }
+            ]
+        )
+
+        self.assertEqual(len(summaries), 1)
+        summary = summaries[0]
+        self.assertEqual(summary["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(summary["candidate_id"], "c88421d619759b2cfaa6f4d0")
+        self.assertEqual(summary["symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(
+            summary["symbol_actions"],
+            {"AAPL": "buy", "AMZN": "sell"},
+        )
+        self.assertEqual(
+            summary["symbol_quantities"],
+            {"AAPL": "1", "AMZN": "1"},
+        )
+        self.assertEqual(
+            summary["symbol_quantity_source"],
+            "target_notional_runtime_sizing_seed",
+        )
+        self.assertEqual(summary["target_notional"], "1000000")
+        self.assertEqual(summary["bounded_paper_collection_notional"], "1000000")
+        self.assertEqual(summary["bounded_evidence_collection_max_notional"], "1000000")
+        self.assertEqual(summary["next_session_max_notional"], "1000000")
+        self.assertEqual(summary["capital_promotion_max_notional"], "0")
+        self.assertFalse(summary["final_promotion_allowed"])
 
     def test_hpairs_target_plan_materialization_blocks_dirty_incomplete_or_unbounded_targets(
         self,


### PR DESCRIPTION
## Summary

- Normalize H-PAIRS paper-route evidence summaries when inputs are target-audit rows by reading the nested `target` payload.
- Expose bounded paper collection notional, symbol actions, seed quantities, and capital-promotion max notional as separate summary fields.
- Add regression coverage for an audit-shaped H-PAIRS target with `target_notional=1000000` while `max_notional=0` remains the promotion guard.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py -k 'hpairs_target_summary_reads_audit_target_and_bounded_notional or hpairs_target_plan_materializes_auditable_source_decisions or hpairs_target_plan_materialization_blocks_dirty_incomplete_or_unbounded_targets'`
- `uv run --frozen pytest tests/test_submission_council.py`
- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_submission_council.py`
- `uv run --frozen python -m compileall app/trading/paper_route_evidence.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py --cov=app.trading.paper_route_evidence --cov-branch --cov-report=term-missing --cov-report=xml --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
