### PR TITLE
fix(torghut-options): decode alpaca option stream frames

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
@@ -91,7 +91,7 @@ object AlpacaMapper {
         put("price", message.price)
         put("size", message.size)
         put("exchange", message.exchange)
-        put("trade_id", message.id.toString())
+        message.id?.let { put("trade_id", it.toString()) }
         putJsonArray("conditions") {
           message.conditions.orEmpty().forEach { add(JsonPrimitive(it)) }
         }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMessageSerializer.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMessageSerializer.kt
@@ -6,8 +6,12 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
 /** Polymorphic dispatch on Alpaca market data field `T`. */
@@ -27,8 +31,8 @@ object AlpacaMessageSerializer : KSerializer<AlpacaMessage> {
       obj["T"]?.let { runCatching { it.jsonPrimitive.content }.getOrNull() }
         ?: return AlpacaUnknownMessage("missing_T", obj)
     return when (type) {
-      "t" -> input.json.decodeFromJsonElement(AlpacaTrade.serializer(), obj)
-      "q" -> input.json.decodeFromJsonElement(AlpacaQuote.serializer(), obj)
+      "t" -> input.json.decodeFromJsonElement(AlpacaTrade.serializer(), normalizeConditions(obj))
+      "q" -> input.json.decodeFromJsonElement(AlpacaQuote.serializer(), normalizeConditions(obj))
       "b" -> input.json.decodeFromJsonElement(AlpacaBar.serializer(), obj)
       "u" -> input.json.decodeFromJsonElement(AlpacaUpdatedBar.serializer(), obj)
       "s" -> input.json.decodeFromJsonElement(AlpacaStatus.serializer(), obj)
@@ -37,5 +41,12 @@ object AlpacaMessageSerializer : KSerializer<AlpacaMessage> {
       "error" -> input.json.decodeFromJsonElement(AlpacaError.serializer(), obj)
       else -> AlpacaUnknownMessage(type, obj)
     }
+  }
+
+  private fun normalizeConditions(obj: JsonObject): JsonObject {
+    val condition = obj["c"] ?: return obj
+    if (condition is JsonArray) return obj
+    val scalar = runCatching { condition.jsonPrimitive.contentOrNull }.getOrNull() ?: return obj
+    return JsonObject(obj + ("c" to buildJsonArray { add(JsonPrimitive(scalar)) }))
   }
 }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaModels.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaModels.kt
@@ -47,7 +47,7 @@ data class AlpacaSubscription(
 data class AlpacaTrade(
   @SerialName("T") override val type: String = "t",
   @SerialName("S") val symbol: String,
-  @SerialName("i") val id: Long,
+  @SerialName("i") val id: Long? = null,
   @SerialName("x") val exchange: String? = null,
   @SerialName("p") val price: Double,
   @SerialName("s") val size: Double,

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -1019,7 +1019,7 @@ class ForwarderApp(
       is AlpacaTrade -> {
         val dedupKey =
           if (config.alpacaMarketType == AlpacaMarketType.OPTIONS) {
-            "${msg.symbol}:${msg.timestamp}:${msg.price}:${msg.size}:${msg.id}"
+            "${msg.symbol}:${msg.timestamp}:${msg.price}:${msg.size}:${msg.exchange}:${msg.conditions.orEmpty().joinToString("|")}"
           } else {
             msg.id.toString()
           }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
@@ -91,8 +91,10 @@ class AlpacaMapperTest {
   @Test
   fun `maps options quote to normalized payload`() {
     val msg =
-      """{"T":"q","S":"AAPL260320C00100000","bp":2.1,"bs":10,"ap":2.2,"as":8,"bx":"A","ax":"B","c":["R"],"t":"2026-03-08T18:00:01Z"}"""
+      """{"T":"q","S":"AAPL260320C00100000","bp":2.1,"bs":10,"ap":2.2,"as":8,"bx":"A","ax":"B","c":"R","t":"2026-03-08T18:00:01Z"}"""
     val decoded = AlpacaMapper.decode(msg)
+    assertTrue(decoded is AlpacaQuote)
+    assertEquals(listOf("R"), decoded.conditions)
     val env = AlpacaMapper.toEnvelope(decoded, AlpacaMarketType.OPTIONS, "opra") { 1 }
     assertNotNull(env)
     assertEquals("quote", env.channel)
@@ -102,5 +104,24 @@ class AlpacaMapperTest {
     assertEquals("AAPL", payload["underlying_symbol"]?.toString()?.trim('"'))
     assertEquals("2.1", payload["bid_price"]?.toString())
     assertEquals("2.2", payload["ask_price"]?.toString())
+    assertEquals("R", payload["quote_condition"]?.toString()?.trim('"'))
+  }
+
+  @Test
+  fun `maps options trade with scalar condition to normalized payload`() {
+    val msg =
+      """{"T":"t","S":"AAPL240315C00172500","t":"2024-03-11T13:35:35.133122560Z","p":2.84,"s":1,"x":"N","c":"S"}"""
+    val decoded = AlpacaMapper.decode(msg)
+    assertTrue(decoded is AlpacaTrade)
+    assertEquals(listOf("S"), decoded.conditions)
+
+    val env = AlpacaMapper.toEnvelope(decoded, AlpacaMarketType.OPTIONS, "indicative") { 1 }
+    assertNotNull(env)
+    assertEquals("trade", env.channel)
+    assertEquals("AAPL240315C00172500", env.symbol)
+    val payload = env.payload.jsonObject
+    assertEquals("AAPL", payload["underlying_symbol"]?.toString()?.trim('"'))
+    assertEquals("2.84", payload["price"]?.toString())
+    assertEquals("1.0", payload["size"]?.toString())
   }
 }


### PR DESCRIPTION
## Summary

- Normalizes Alpaca option trade/quote scalar condition fields before websocket decode.
- Allows option trade frames without a stock-style trade id and omits `trade_id` when absent.
- Adds regression coverage for documented Alpaca option quote/trade payload shapes.

## Related Issues

None

## Testing

- `./gradlew :websockets:test --rerun-tasks` from `services/dorvud`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
