### PR TITLE
fix(torghut): repair jun11 sizing and db authority proof

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -44,6 +44,18 @@ spec:
                   PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json
                   HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT=/tmp/torghut-empirical-renewal/hpairs-source-proof-census.json
                   mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")" "$(dirname "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}")"
+                  WINDOW_END="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  WINDOW_START="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+                  /opt/venv/bin/python scripts/reconcile_cross_dsn_order_feed_links.py \
+                    --event-dsn-env DB_DSN \
+                    --canonical-dsn-env SIM_DB_DSN \
+                    --source-account-label PA3SX7FYNUTF \
+                    --canonical-account-label TORGHUT_SIM \
+                    --window-start "${WINDOW_START}" \
+                    --window-end "${WINDOW_END}" \
+                    --limit 5000 \
+                    --apply \
+                    --json
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -130,7 +130,11 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "1000000"
+              value: "25000"
+            - name: TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY
+              value: "0.25"
+            - name: TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY
+              value: "1.0"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
               value: http://torghut.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=next&limit=20
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -133,13 +133,13 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "1000000"
+              value: "25000"
+            - name: TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY
+              value: "0.25"
+            - name: TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY
+              value: "1.0"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
-            - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL
-              value: "http://agents.agents.svc.cluster.local/ready"
-            - name: TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS
-              value: "30"
             - name: TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS
               value: "5"
             - name: TRADING_MARKET_CONTEXT_REQUIRED
@@ -333,6 +333,10 @@ spec:
               value: http://agents.agents.svc.cluster.local/v1/agent-runs
             - name: AGENTS_BASE_URL
               value: http://agents.agents.svc.cluster.local
+            - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL
+              value: http://agents.agents.svc.cluster.local/ready
+            - name: TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS
+              value: "30"
             - name: INNGEST_APP_ID
               value: torghut
             - name: INNGEST_BASE_URL

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -44,6 +44,19 @@ spec:
                   set -euo pipefail
                   cd /app
                   echo "stage=repair_order_feed_source_windows started_at=$(date -Iseconds)"
+                  WINDOW_END="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  WINDOW_START="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+                  echo "stage=reconcile_cross_dsn_order_feed_links started_at=$(date -Iseconds) window_start=${WINDOW_START} window_end=${WINDOW_END}"
+                  /opt/venv/bin/python scripts/reconcile_cross_dsn_order_feed_links.py \
+                    --event-dsn-env DB_DSN \
+                    --canonical-dsn-env SIM_DB_DSN \
+                    --source-account-label PA3SX7FYNUTF \
+                    --canonical-account-label TORGHUT_SIM \
+                    --window-start "${WINDOW_START}" \
+                    --window-end "${WINDOW_END}" \
+                    --limit 5000 \
+                    --apply \
+                    --json
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env DB_DSN \
                     --account-label PA3SX7FYNUTF \

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1472,6 +1472,22 @@ class Settings(BaseSettings):
         alias="TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL",
         description="Simple-lane absolute exposure cap per symbol.",
     )
+    trading_simple_max_order_pct_equity: Optional[float] = Field(
+        default=0.25,
+        alias="TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY",
+        description=(
+            "Simple-lane max new-exposure order notional as a fraction of account "
+            "equity. Closing or covering quantity is exempt."
+        ),
+    )
+    trading_simple_max_gross_exposure_pct_equity: Optional[float] = Field(
+        default=1.0,
+        alias="TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY",
+        description=(
+            "Simple-lane max gross exposure as a fraction of account equity. "
+            "Closing or covering quantity is exempt."
+        ),
+    )
     trading_simple_buying_power_reserve_bps: float = Field(
         default=25.0,
         alias="TRADING_SIMPLE_BUYING_POWER_RESERVE_BPS",
@@ -2434,6 +2450,14 @@ class Settings(BaseSettings):
             (
                 self.trading_simple_max_notional_per_symbol,
                 "TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL must be >= 0",
+            ),
+            (
+                self.trading_simple_max_order_pct_equity,
+                "TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY must be >= 0",
+            ),
+            (
+                self.trading_simple_max_gross_exposure_pct_equity,
+                "TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY must be >= 0",
             ),
             (
                 self.trading_simple_buying_power_reserve_bps,

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -8737,7 +8737,9 @@ _SIMPLE_LANE_ALLOWED_REJECT_REASONS = {
     "invalid_qty_increment",
     "qty_below_min_after_clamp",
     "insufficient_buying_power",
+    "equity_required_for_exposure_increase",
     "max_notional_exceeded",
+    "max_gross_exposure_exceeded",
     "max_symbol_exposure_exceeded",
     "shorting_not_allowed_for_asset",
     "broker_precheck_failed",
@@ -8777,6 +8779,10 @@ def _build_simple_lane_status_payload() -> dict[str, object]:
         "route_symbol_filter_enabled": settings.trading_pipeline_mode == "simple",
         "max_notional_per_order": settings.trading_simple_max_notional_per_order,
         "max_notional_per_symbol": settings.trading_simple_max_notional_per_symbol,
+        "max_order_pct_equity": settings.trading_simple_max_order_pct_equity,
+        "max_gross_exposure_pct_equity": (
+            settings.trading_simple_max_gross_exposure_pct_equity
+        ),
         "allowed_reject_reasons": sorted(_SIMPLE_LANE_ALLOWED_REJECT_REASONS),
     }
 

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -3006,6 +3006,40 @@ def _isoformat_datetime(value: datetime | None) -> str | None:
     return _ensure_aware_utc(value).isoformat()
 
 
+def _cross_dsn_linkage_counts_for_source_window(
+    session: Session,
+    source_window_id: object,
+) -> dict[str, int]:
+    rows = session.execute(
+        select(ExecutionOrderEvent.raw_event).where(
+            ExecutionOrderEvent.source_window_id == source_window_id
+        )
+    ).all()
+    execution_refs = 0
+    decision_refs = 0
+    tca_refs = 0
+    for (raw_event,) in rows:
+        payload = coerce_json_payload(raw_event)
+        if not isinstance(payload, Mapping):
+            continue
+        payload_mapping = cast(Mapping[object, Any], payload)
+        raw_linkage = payload_mapping.get("_torghut_cross_dsn_linkage")
+        if not isinstance(raw_linkage, Mapping):
+            continue
+        linkage = cast(Mapping[object, Any], raw_linkage)
+        if linkage.get("canonical_execution_id"):
+            execution_refs += 1
+        if linkage.get("canonical_trade_decision_id"):
+            decision_refs += 1
+        if linkage.get("canonical_execution_tca_metric_id"):
+            tca_refs += 1
+    return {
+        "cross_dsn_execution_ref_count": execution_refs,
+        "cross_dsn_trade_decision_ref_count": decision_refs,
+        "cross_dsn_tca_ref_count": tca_refs,
+    }
+
+
 def _refresh_source_window_linkage_counts(
     session: Session, event: ExecutionOrderEvent
 ) -> None:
@@ -3081,6 +3115,16 @@ def _refresh_source_window_linkage_counts(
         )
     else:
         classification_counts.pop("unlinked_decision", None)
+    cross_dsn_counts = _cross_dsn_linkage_counts_for_source_window(
+        session,
+        event.source_window_id,
+    )
+    for count_key, count_value in cross_dsn_counts.items():
+        payload_dict[count_key] = count_value
+        if count_value:
+            classification_counts[count_key] = count_value
+        else:
+            classification_counts.pop(count_key, None)
     payload_dict["classification_counts"] = classification_counts
     source_window.classification_counts = classification_counts
     source_window_complete = bool(

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -79,7 +79,9 @@ _SIMPLE_ALLOWED_REJECT_REASONS = {
     "invalid_qty_increment",
     "qty_below_min_after_clamp",
     "insufficient_buying_power",
+    "equity_required_for_exposure_increase",
     "max_notional_exceeded",
+    "max_gross_exposure_exceeded",
     "max_symbol_exposure_exceeded",
     "shorting_not_allowed_for_asset",
     "broker_precheck_failed",
@@ -5152,6 +5154,16 @@ class SimpleTradingPipeline(TradingPipeline):
                 settings.trading_simple_buying_power_reserve_bps
             )
             or Decimal("0"),
+            max_order_pct_equity=_optional_decimal(
+                settings.trading_simple_max_order_pct_equity
+            ),
+            max_gross_exposure_pct_equity=_optional_decimal(
+                settings.trading_simple_max_gross_exposure_pct_equity
+            ),
+            require_equity_for_exposure_increase=(
+                settings.trading_simple_submit_enabled
+                or settings.trading_simple_paper_route_probe_enabled
+            ),
         )
         target_notional_sizing = _target_notional_sizing_audit_from_params(
             decision.params

--- a/services/torghut/app/trading/simple_risk.py
+++ b/services/torghut/app/trading/simple_risk.py
@@ -95,6 +95,9 @@ def prepare_simple_decision(
     max_notional_per_order: Decimal | None,
     max_notional_per_symbol: Decimal | None,
     buying_power_reserve_bps: Decimal = Decimal("0"),
+    max_order_pct_equity: Decimal | None = None,
+    max_gross_exposure_pct_equity: Decimal | None = None,
+    require_equity_for_exposure_increase: bool = False,
 ) -> SimpleRiskPreparation:
     price = _extract_decision_price(decision)
     current_qty = position_qty_for_symbol(positions, decision.symbol)
@@ -174,9 +177,16 @@ def prepare_simple_decision(
         )
 
     normalized_action = decision.action.strip().lower()
-    short_increasing = normalized_action == "sell" and quantized_qty > max(
-        current_qty, Decimal("0")
+    exposure_increase_qty = _exposure_increase_qty(
+        action=normalized_action,
+        qty=quantized_qty,
+        current_qty=current_qty,
     )
+    non_increasing_qty_allowance = quantized_qty - exposure_increase_qty
+    diagnostics["current_qty"] = str(current_qty)
+    diagnostics["exposure_increase_qty"] = str(exposure_increase_qty)
+    diagnostics["non_increasing_qty_allowance"] = str(non_increasing_qty_allowance)
+    short_increasing = normalized_action == "sell" and exposure_increase_qty > 0
     if short_increasing and not allow_shorts:
         return SimpleRiskPreparation(
             approved=False,
@@ -187,21 +197,63 @@ def prepare_simple_decision(
             diagnostics=diagnostics,
         )
 
-    enforce_exposure = normalized_action == "buy" or short_increasing
+    enforce_exposure = exposure_increase_qty > 0
     adjusted_qty = quantized_qty
     capped_by_order = False
     capped_by_symbol = False
+    capped_by_gross = False
     capped_by_buying_power = False
     buying_power: Decimal | None = None
+    equity = _resolve_decimal(account.get("equity"))
+    diagnostics["equity"] = str(equity) if equity is not None else None
+    if require_equity_for_exposure_increase and enforce_exposure and equity is None:
+        return SimpleRiskPreparation(
+            approved=False,
+            decision=decision,
+            quantity_resolution=resolution,
+            notional=price * quantized_qty,
+            reject_reason="equity_required_for_exposure_increase",
+            diagnostics=diagnostics,
+        )
 
     if (
         enforce_exposure
         and max_notional_per_order is not None
         and max_notional_per_order >= 0
     ):
-        order_cap_qty = quantize_qty_for_symbol(
-            decision.symbol,
-            max_notional_per_order / price,
+        order_cap_qty = _cap_qty_by_new_exposure_notional(
+            decision=decision,
+            price=price,
+            current_qty=current_qty,
+            cap_notional=max_notional_per_order,
+            fractional_equities_enabled=resolution.fractional_allowed,
+        )
+        if order_cap_qty < adjusted_qty:
+            adjusted_qty = order_cap_qty
+            capped_by_order = True
+
+    if (
+        enforce_exposure
+        and max_order_pct_equity is not None
+        and max_order_pct_equity >= 0
+    ):
+        if equity is None:
+            return SimpleRiskPreparation(
+                approved=False,
+                decision=decision,
+                quantity_resolution=resolution,
+                notional=price * quantized_qty,
+                reject_reason="equity_required_for_exposure_increase",
+                diagnostics=diagnostics,
+            )
+        equity_order_cap_notional = equity * max_order_pct_equity
+        diagnostics["max_order_pct_equity"] = str(max_order_pct_equity)
+        diagnostics["equity_order_cap_notional"] = str(equity_order_cap_notional)
+        order_cap_qty = _cap_qty_by_new_exposure_notional(
+            decision=decision,
+            price=price,
+            current_qty=current_qty,
+            cap_notional=equity_order_cap_notional,
             fractional_equities_enabled=resolution.fractional_allowed,
         )
         if order_cap_qty < adjusted_qty:
@@ -224,17 +276,67 @@ def prepare_simple_decision(
         diagnostics["current_symbol_abs_notional"] = str(current_abs_value)
         diagnostics["remaining_symbol_notional_room"] = str(remaining_notional)
         if remaining_notional <= 0:
-            adjusted_qty = Decimal("0")
+            symbol_cap_qty = _non_increasing_qty_allowance(
+                action=normalized_action,
+                current_qty=current_qty,
+            )
+            adjusted_qty = min(adjusted_qty, symbol_cap_qty)
             capped_by_symbol = True
         else:
-            symbol_cap_qty = quantize_qty_for_symbol(
-                decision.symbol,
-                remaining_notional / price,
+            symbol_cap_qty = _cap_qty_by_new_exposure_notional(
+                decision=decision,
+                price=price,
+                current_qty=current_qty,
+                cap_notional=remaining_notional,
                 fractional_equities_enabled=resolution.fractional_allowed,
             )
             if symbol_cap_qty < adjusted_qty:
                 adjusted_qty = symbol_cap_qty
                 capped_by_symbol = True
+
+    if (
+        enforce_exposure
+        and max_gross_exposure_pct_equity is not None
+        and max_gross_exposure_pct_equity >= 0
+    ):
+        if equity is None:
+            return SimpleRiskPreparation(
+                approved=False,
+                decision=decision,
+                quantity_resolution=resolution,
+                notional=price * quantized_qty,
+                reject_reason="equity_required_for_exposure_increase",
+                diagnostics=diagnostics,
+            )
+        current_gross_notional = portfolio_gross_notional(
+            positions,
+            decision.symbol,
+            fallback_price=price,
+        )
+        gross_cap_notional = equity * max_gross_exposure_pct_equity
+        remaining_gross_notional = gross_cap_notional - current_gross_notional
+        diagnostics["max_gross_exposure_pct_equity"] = str(
+            max_gross_exposure_pct_equity
+        )
+        diagnostics["current_gross_notional"] = str(current_gross_notional)
+        diagnostics["gross_cap_notional"] = str(gross_cap_notional)
+        diagnostics["remaining_gross_notional_room"] = str(remaining_gross_notional)
+        if remaining_gross_notional <= 0:
+            gross_cap_qty = _non_increasing_qty_allowance(
+                action=normalized_action,
+                current_qty=current_qty,
+            )
+        else:
+            gross_cap_qty = _cap_qty_by_new_exposure_notional(
+                decision=decision,
+                price=price,
+                current_qty=current_qty,
+                cap_notional=remaining_gross_notional,
+                fractional_equities_enabled=resolution.fractional_allowed,
+            )
+        if gross_cap_qty < adjusted_qty:
+            adjusted_qty = gross_cap_qty
+            capped_by_gross = True
 
     if enforce_exposure:
         buying_power = _resolve_decimal(account.get("buying_power"))
@@ -248,16 +350,13 @@ def prepare_simple_decision(
             )
             diagnostics["buying_power_reserve_bps"] = str(buying_power_reserve_bps)
             diagnostics["buying_power_after_reserve"] = str(effective_buying_power)
-            if effective_buying_power <= 0:
-                buying_power_cap_qty = Decimal("0")
-            else:
-                buying_power_cap_qty = _buying_power_cap_qty(
-                    decision=decision,
-                    price=price,
-                    buying_power=effective_buying_power,
-                    current_qty=current_qty,
-                    fractional_allowed=resolution.fractional_allowed,
-                )
+            buying_power_cap_qty = _buying_power_cap_qty(
+                decision=decision,
+                price=price,
+                buying_power=max(effective_buying_power, Decimal("0")),
+                current_qty=current_qty,
+                fractional_allowed=resolution.fractional_allowed,
+            )
             diagnostics["buying_power_cap_qty"] = str(buying_power_cap_qty)
             if buying_power_cap_qty < adjusted_qty:
                 adjusted_qty = buying_power_cap_qty
@@ -268,6 +367,8 @@ def prepare_simple_decision(
         reject_reason = "qty_below_min_after_clamp"
         if capped_by_symbol:
             reject_reason = "max_symbol_exposure_exceeded"
+        elif capped_by_gross:
+            reject_reason = "max_gross_exposure_exceeded"
         elif capped_by_buying_power:
             reject_reason = "insufficient_buying_power"
         elif capped_by_order:
@@ -296,14 +397,16 @@ def prepare_simple_decision(
 
     notional = price * adjusted_qty
     diagnostics["final_notional"] = str(notional)
+    buying_power_required = _buying_power_required_notional(
+        decision=decision,
+        qty=adjusted_qty,
+        price=price,
+        current_qty=current_qty,
+    )
+    diagnostics["buying_power_required_notional"] = str(buying_power_required)
+    if not enforce_exposure:
+        diagnostics.setdefault("buying_power_cap_qty", str(adjusted_qty))
     if enforce_exposure:
-        buying_power_required = _buying_power_required_notional(
-            decision=decision,
-            qty=adjusted_qty,
-            price=price,
-            current_qty=current_qty,
-        )
-        diagnostics["buying_power_required_notional"] = str(buying_power_required)
         effective_buying_power = (
             _buying_power_after_reserve(
                 buying_power=buying_power,
@@ -336,6 +439,7 @@ def prepare_simple_decision(
         "quantity_resolution": resolution.to_payload(),
         "capped_by_order": capped_by_order,
         "capped_by_symbol": capped_by_symbol,
+        "capped_by_gross": capped_by_gross,
         "capped_by_buying_power": capped_by_buying_power,
     }
     return SimpleRiskPreparation(
@@ -372,9 +476,12 @@ def _buying_power_cap_qty(
     current_qty: Decimal,
     fractional_allowed: bool,
 ) -> Decimal:
-    buying_power_qty = buying_power / price
-    if decision.action.strip().lower() == "sell" and current_qty > 0:
-        buying_power_qty += current_qty
+    buying_power_qty = _non_increasing_qty_allowance(
+        action=decision.action.strip().lower(),
+        current_qty=current_qty,
+    )
+    if buying_power > 0:
+        buying_power_qty += buying_power / price
     return quantize_qty_for_symbol(
         decision.symbol,
         buying_power_qty,
@@ -402,18 +509,98 @@ def _buying_power_required_notional(
     price: Decimal,
     current_qty: Decimal,
 ) -> Decimal:
-    if decision.action.strip().lower() == "buy":
-        return price * qty
-    if decision.action.strip().lower() != "sell" or qty <= 0:
+    exposure_increase_qty = _exposure_increase_qty(
+        action=decision.action.strip().lower(),
+        qty=qty,
+        current_qty=current_qty,
+    )
+    if exposure_increase_qty <= 0:
         return Decimal("0")
-    if current_qty >= qty:
+    return price * exposure_increase_qty
+
+
+def _exposure_increase_qty(
+    *,
+    action: str,
+    qty: Decimal,
+    current_qty: Decimal,
+) -> Decimal:
+    if qty <= 0:
         return Decimal("0")
-    short_increasing_qty = qty if current_qty <= 0 else qty - current_qty
-    return price * short_increasing_qty
+    if action == "buy":
+        if current_qty < 0:
+            return max(qty - abs(current_qty), Decimal("0"))
+        return qty
+    if action == "sell":
+        if current_qty > 0:
+            return max(qty - current_qty, Decimal("0"))
+        return qty
+    return Decimal("0")
+
+
+def _non_increasing_qty_allowance(*, action: str, current_qty: Decimal) -> Decimal:
+    if action == "buy" and current_qty < 0:
+        return abs(current_qty)
+    if action == "sell" and current_qty > 0:
+        return current_qty
+    return Decimal("0")
+
+
+def _cap_qty_by_new_exposure_notional(
+    *,
+    decision: StrategyDecision,
+    price: Decimal,
+    current_qty: Decimal,
+    cap_notional: Decimal,
+    fractional_equities_enabled: bool,
+) -> Decimal:
+    allowed_qty = _non_increasing_qty_allowance(
+        action=decision.action.strip().lower(),
+        current_qty=current_qty,
+    )
+    if cap_notional > 0:
+        allowed_qty += cap_notional / price
+    return quantize_qty_for_symbol(
+        decision.symbol,
+        allowed_qty,
+        fractional_equities_enabled=fractional_equities_enabled,
+    )
+
+
+def portfolio_gross_notional(
+    positions: list[dict[str, Any]],
+    symbol: str,
+    *,
+    fallback_price: Decimal | None,
+) -> Decimal:
+    normalized_symbol = symbol.strip().upper()
+    total = Decimal("0")
+    for position in positions:
+        raw_market_value = position.get("market_value")
+        if raw_market_value is not None:
+            try:
+                total += abs(Decimal(str(raw_market_value)))
+                continue
+            except (ArithmeticError, ValueError):
+                pass
+        if fallback_price is None:
+            continue
+        if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
+            continue
+        raw_qty = position.get("qty") or position.get("quantity")
+        if raw_qty is None:
+            continue
+        try:
+            qty = Decimal(str(raw_qty))
+        except (ArithmeticError, ValueError):
+            continue
+        total += abs(qty * fallback_price)
+    return total
 
 
 __all__ = [
     "SimpleRiskPreparation",
+    "portfolio_gross_notional",
     "position_qty_for_symbol",
     "position_value_for_symbol",
     "prepare_simple_decision",

--- a/services/torghut/scripts/reconcile_cross_dsn_order_feed_links.py
+++ b/services/torghut/scripts/reconcile_cross_dsn_order_feed_links.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Annotate live order-feed events with canonical SIM execution references."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence, cast
+
+from sqlalchemy import create_engine, func, or_, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.models import (
+    Execution,
+    ExecutionOrderEvent,
+    ExecutionTCAMetric,
+    OrderFeedSourceWindow,
+    TradeDecision,
+    coerce_json_payload,
+)
+
+
+_LINKAGE_KEY = "_torghut_cross_dsn_linkage"
+_LINKAGE_SCHEMA_VERSION = "torghut.cross-dsn-order-feed-linkage.v1"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cross-link live order-feed evidence to canonical SIM executions across DSNs "
+            "without creating live execution ledger rows."
+        ),
+    )
+    parser.add_argument("--event-dsn-env", default="DB_DSN")
+    parser.add_argument("--canonical-dsn-env", default="SIM_DB_DSN")
+    parser.add_argument("--source-account-label", required=True)
+    parser.add_argument("--canonical-account-label", required=True)
+    parser.add_argument("--window-start", required=True)
+    parser.add_argument("--window-end", required=True)
+    parser.add_argument("--limit", type=int, default=5000)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _parse_dt(value: object) -> datetime:
+    text = str(value).strip()
+    if not text:
+        raise SystemExit("empty_datetime")
+    parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
+def _event_window_expr() -> Any:
+    return func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+
+
+def _event_candidates(
+    session: Session,
+    *,
+    source_account_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    limit: int,
+) -> Sequence[ExecutionOrderEvent]:
+    window_expr = _event_window_expr()
+    return list(
+        session.scalars(
+            select(ExecutionOrderEvent)
+            .where(
+                ExecutionOrderEvent.alpaca_account_label == source_account_label,
+                or_(
+                    ExecutionOrderEvent.execution_id.is_(None),
+                    ExecutionOrderEvent.trade_decision_id.is_(None),
+                ),
+                or_(
+                    ExecutionOrderEvent.alpaca_order_id.is_not(None),
+                    ExecutionOrderEvent.client_order_id.is_not(None),
+                ),
+                window_expr >= window_start,
+                window_expr < window_end,
+            )
+            .order_by(window_expr.asc(), ExecutionOrderEvent.source_offset.asc())
+            .limit(max(1, min(int(limit), 5000)))
+        )
+    )
+
+
+def _unique_executions(rows: Sequence[Execution]) -> list[Execution]:
+    seen: set[uuid.UUID] = set()
+    unique_rows: list[Execution] = []
+    for row in rows:
+        if row.id in seen:
+            continue
+        seen.add(row.id)
+        unique_rows.append(row)
+    return unique_rows
+
+
+def _canonical_execution_matches(
+    session: Session,
+    event: ExecutionOrderEvent,
+    *,
+    canonical_account_label: str,
+) -> list[Execution]:
+    clauses = []
+    if event.alpaca_order_id:
+        clauses.append(Execution.alpaca_order_id == event.alpaca_order_id)
+    if event.client_order_id:
+        clauses.extend(
+            [
+                Execution.client_order_id == event.client_order_id,
+                Execution.execution_idempotency_key == event.client_order_id,
+            ]
+        )
+    if not clauses:
+        return []
+    rows = list(
+        session.scalars(
+            select(Execution)
+            .where(
+                Execution.alpaca_account_label == canonical_account_label,
+                or_(*clauses),
+            )
+            .order_by(Execution.created_at.asc(), Execution.id.asc())
+            .limit(2)
+        )
+    )
+    return _unique_executions(rows)
+
+
+def _canonical_decision_id(
+    session: Session,
+    event: ExecutionOrderEvent,
+    execution: Execution,
+    *,
+    canonical_account_label: str,
+) -> uuid.UUID | None:
+    if execution.trade_decision_id is not None:
+        return execution.trade_decision_id
+    if not event.client_order_id:
+        return None
+    rows = list(
+        session.scalars(
+            select(TradeDecision)
+            .where(
+                TradeDecision.alpaca_account_label == canonical_account_label,
+                TradeDecision.decision_hash == event.client_order_id,
+            )
+            .order_by(TradeDecision.created_at.asc(), TradeDecision.id.asc())
+            .limit(2)
+        )
+    )
+    if len(rows) == 1:
+        return rows[0].id
+    return None
+
+
+def _canonical_tca_id(session: Session, execution: Execution) -> uuid.UUID | None:
+    row = session.scalar(
+        select(ExecutionTCAMetric).where(
+            ExecutionTCAMetric.execution_id == execution.id
+        )
+    )
+    return row.id if row is not None else None
+
+
+def _event_raw_payload(event: ExecutionOrderEvent) -> dict[str, Any]:
+    raw_event = coerce_json_payload(event.raw_event)
+    if isinstance(raw_event, Mapping):
+        return {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], raw_event).items()
+        }
+    return {"raw_event": raw_event}
+
+
+def _linkage_payload(
+    *,
+    event: ExecutionOrderEvent,
+    execution: Execution,
+    decision_id: uuid.UUID | None,
+    tca_id: uuid.UUID | None,
+    event_dsn_env: str,
+    canonical_dsn_env: str,
+    source_account_label: str,
+    canonical_account_label: str,
+    linked_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "schema_version": _LINKAGE_SCHEMA_VERSION,
+        "basis": "matched_order_identity",
+        "source_dsn_env": event_dsn_env,
+        "canonical_dsn_env": canonical_dsn_env,
+        "source_account_label": source_account_label,
+        "canonical_account_label": canonical_account_label,
+        "alpaca_order_id": event.alpaca_order_id or execution.alpaca_order_id,
+        "client_order_id": event.client_order_id or execution.client_order_id,
+        "canonical_execution_id": str(execution.id),
+        "canonical_trade_decision_id": str(decision_id) if decision_id else None,
+        "canonical_execution_tca_metric_id": str(tca_id) if tca_id else None,
+        "promotion_authority_eligible": False,
+        "linked_at": linked_at.isoformat(),
+    }
+
+
+def _cross_dsn_counts_for_source_window(
+    session: Session,
+    source_window_id: uuid.UUID,
+) -> dict[str, int]:
+    execution_refs = 0
+    decision_refs = 0
+    tca_refs = 0
+    for raw_event in session.scalars(
+        select(ExecutionOrderEvent.raw_event).where(
+            ExecutionOrderEvent.source_window_id == source_window_id
+        )
+    ):
+        payload = coerce_json_payload(raw_event)
+        if not isinstance(payload, Mapping):
+            continue
+        linkage = payload.get(_LINKAGE_KEY)
+        if not isinstance(linkage, Mapping):
+            continue
+        if linkage.get("canonical_execution_id"):
+            execution_refs += 1
+        if linkage.get("canonical_trade_decision_id"):
+            decision_refs += 1
+        if linkage.get("canonical_execution_tca_metric_id"):
+            tca_refs += 1
+    return {
+        "cross_dsn_execution_ref_count": execution_refs,
+        "cross_dsn_trade_decision_ref_count": decision_refs,
+        "cross_dsn_tca_ref_count": tca_refs,
+    }
+
+
+def _mark_source_windows(
+    session: Session,
+    *,
+    source_window_ids: set[uuid.UUID],
+    event_dsn_env: str,
+    canonical_dsn_env: str,
+    source_account_label: str,
+    canonical_account_label: str,
+    canonical_execution_ids: set[uuid.UUID],
+    canonical_trade_decision_ids: set[uuid.UUID],
+    canonical_tca_ids: set[uuid.UUID],
+    linked_at: datetime,
+) -> int:
+    marked = 0
+    for source_window_id in source_window_ids:
+        source_window = session.get(OrderFeedSourceWindow, source_window_id)
+        if source_window is None:
+            continue
+        payload = coerce_json_payload(source_window.payload_json)
+        if isinstance(payload, Mapping):
+            payload_dict = {
+                str(key): value
+                for key, value in cast(Mapping[object, Any], payload).items()
+            }
+        else:
+            payload_dict = {}
+        counts = _cross_dsn_counts_for_source_window(session, source_window_id)
+        raw_classification_counts = payload_dict.get("classification_counts")
+        classification_counts = (
+            {
+                str(key): int(value)
+                for key, value in cast(
+                    Mapping[object, Any],
+                    raw_classification_counts,
+                ).items()
+                if isinstance(value, int)
+            }
+            if isinstance(raw_classification_counts, Mapping)
+            else {}
+        )
+        for count_key, count_value in counts.items():
+            payload_dict[count_key] = count_value
+            if count_value:
+                classification_counts[count_key] = count_value
+            else:
+                classification_counts.pop(count_key, None)
+        payload_dict[_LINKAGE_KEY] = {
+            "schema_version": _LINKAGE_SCHEMA_VERSION,
+            "source_dsn_env": event_dsn_env,
+            "canonical_dsn_env": canonical_dsn_env,
+            "source_account_label": source_account_label,
+            "canonical_account_label": canonical_account_label,
+            "canonical_execution_ids": sorted(
+                str(value) for value in canonical_execution_ids
+            ),
+            "canonical_trade_decision_ids": sorted(
+                str(value) for value in canonical_trade_decision_ids
+            ),
+            "canonical_execution_tca_metric_ids": sorted(
+                str(value) for value in canonical_tca_ids
+            ),
+            "promotion_authority_eligible": False,
+            "linked_at": linked_at.isoformat(),
+        }
+        payload_dict["classification_counts"] = classification_counts
+        source_window.classification_counts = coerce_json_payload(classification_counts)
+        source_window.payload_json = coerce_json_payload(payload_dict)
+        session.add(source_window)
+        marked += 1
+    return marked
+
+
+def reconcile_cross_dsn_order_feed_links(
+    event_session: Session,
+    canonical_session: Session,
+    *,
+    event_dsn_env: str,
+    canonical_dsn_env: str,
+    source_account_label: str,
+    canonical_account_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    limit: int = 5000,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    linked_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    events = _event_candidates(
+        event_session,
+        source_account_label=source_account_label,
+        window_start=window_start,
+        window_end=window_end,
+        limit=limit,
+    )
+    canonical_execution_ids: set[uuid.UUID] = set()
+    canonical_trade_decision_ids: set[uuid.UUID] = set()
+    canonical_tca_ids: set[uuid.UUID] = set()
+    source_window_ids: set[uuid.UUID] = set()
+    ambiguous_order_identities: list[dict[str, Any]] = []
+    unmatched_order_identities: list[dict[str, Any]] = []
+    events_matched = 0
+    events_ambiguous = 0
+    events_unmatched = 0
+    events_marked = 0
+    canonical_tca_missing = 0
+
+    for event in events:
+        matches = _canonical_execution_matches(
+            canonical_session,
+            event,
+            canonical_account_label=canonical_account_label,
+        )
+        if len(matches) > 1:
+            events_ambiguous += 1
+            if len(ambiguous_order_identities) < 25:
+                ambiguous_order_identities.append(
+                    {
+                        "event_id": str(event.id),
+                        "alpaca_order_id": event.alpaca_order_id,
+                        "client_order_id": event.client_order_id,
+                        "candidate_execution_ids": [str(row.id) for row in matches],
+                    }
+                )
+            continue
+        if not matches:
+            events_unmatched += 1
+            if len(unmatched_order_identities) < 25:
+                unmatched_order_identities.append(
+                    {
+                        "event_id": str(event.id),
+                        "alpaca_order_id": event.alpaca_order_id,
+                        "client_order_id": event.client_order_id,
+                    }
+                )
+            continue
+
+        execution = matches[0]
+        decision_id = _canonical_decision_id(
+            canonical_session,
+            event,
+            execution,
+            canonical_account_label=canonical_account_label,
+        )
+        tca_id = _canonical_tca_id(canonical_session, execution)
+        events_matched += 1
+        canonical_execution_ids.add(execution.id)
+        if decision_id is not None:
+            canonical_trade_decision_ids.add(decision_id)
+        if tca_id is not None:
+            canonical_tca_ids.add(tca_id)
+        else:
+            canonical_tca_missing += 1
+        if event.source_window_id is not None:
+            source_window_ids.add(event.source_window_id)
+        if apply:
+            payload = _event_raw_payload(event)
+            payload[_LINKAGE_KEY] = _linkage_payload(
+                event=event,
+                execution=execution,
+                decision_id=decision_id,
+                tca_id=tca_id,
+                event_dsn_env=event_dsn_env,
+                canonical_dsn_env=canonical_dsn_env,
+                source_account_label=source_account_label,
+                canonical_account_label=canonical_account_label,
+                linked_at=linked_at,
+            )
+            event.raw_event = coerce_json_payload(payload)
+            event_session.add(event)
+            events_marked += 1
+
+    source_windows_marked = (
+        _mark_source_windows(
+            event_session,
+            source_window_ids=source_window_ids,
+            event_dsn_env=event_dsn_env,
+            canonical_dsn_env=canonical_dsn_env,
+            source_account_label=source_account_label,
+            canonical_account_label=canonical_account_label,
+            canonical_execution_ids=canonical_execution_ids,
+            canonical_trade_decision_ids=canonical_trade_decision_ids,
+            canonical_tca_ids=canonical_tca_ids,
+            linked_at=linked_at,
+        )
+        if apply
+        else 0
+    )
+
+    return {
+        "status": "ok",
+        "apply": bool(apply),
+        "event_dsn_env": event_dsn_env,
+        "canonical_dsn_env": canonical_dsn_env,
+        "source_account_label": source_account_label,
+        "canonical_account_label": canonical_account_label,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+        "limit": max(1, min(int(limit), 5000)),
+        "selected": len(events),
+        "events_matched": events_matched,
+        "events_unmatched": events_unmatched,
+        "events_ambiguous": events_ambiguous,
+        "events_marked": events_marked,
+        "source_windows_marked": source_windows_marked,
+        "canonical_executions_matched": len(canonical_execution_ids),
+        "canonical_trade_decisions_matched": len(canonical_trade_decision_ids),
+        "canonical_tca_matched": len(canonical_tca_ids),
+        "canonical_tca_missing": canonical_tca_missing,
+        "promotion_authority_eligible": False,
+        "ambiguous_order_identities": ambiguous_order_identities,
+        "unmatched_order_identities": unmatched_order_identities,
+        "completed_at": linked_at.isoformat(),
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    event_dsn = os.environ.get(str(args.event_dsn_env).strip())
+    canonical_dsn = os.environ.get(str(args.canonical_dsn_env).strip())
+    if not event_dsn:
+        raise SystemExit(f"missing DSN env var: {args.event_dsn_env}")
+    if not canonical_dsn:
+        raise SystemExit(f"missing DSN env var: {args.canonical_dsn_env}")
+
+    window_start = _parse_dt(args.window_start)
+    window_end = _parse_dt(args.window_end)
+    if window_end <= window_start:
+        raise SystemExit("window_end_must_be_after_window_start")
+
+    event_engine = create_engine(
+        _sqlalchemy_dsn(event_dsn), pool_pre_ping=True, future=True
+    )
+    canonical_engine = create_engine(
+        _sqlalchemy_dsn(canonical_dsn),
+        pool_pre_ping=True,
+        future=True,
+    )
+    event_session_factory = sessionmaker(
+        bind=event_engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    canonical_session_factory = sessionmaker(
+        bind=canonical_engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+
+    with (
+        event_session_factory() as event_session,
+        canonical_session_factory() as canonical_session,
+    ):
+        payload = reconcile_cross_dsn_order_feed_links(
+            event_session,
+            canonical_session,
+            event_dsn_env=args.event_dsn_env,
+            canonical_dsn_env=args.canonical_dsn_env,
+            source_account_label=args.source_account_label,
+            canonical_account_label=args.canonical_account_label,
+            window_start=window_start,
+            window_end=window_end,
+            limit=max(1, min(int(args.limit), 5000)),
+            apply=bool(args.apply),
+        )
+        if args.apply:
+            event_session.commit()
+        else:
+            event_session.rollback()
+        canonical_session.rollback()
+
+    print(
+        json.dumps(payload, separators=(",", ":"))
+        if args.json
+        else json.dumps(payload, indent=2, default=str)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -802,6 +802,8 @@ class TestConfig(TestCase):
             TRADING_PIPELINE_MODE="simple",
             TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER=250.0,
             TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL=750.0,
+            TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY=0.2,
+            TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY=0.8,
             TRADING_SIMPLE_BUYING_POWER_RESERVE_BPS=50.0,
             TRADING_SIMPLE_SUBMIT_ENABLED=True,
             TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED=True,
@@ -813,11 +815,21 @@ class TestConfig(TestCase):
         self.assertEqual(settings.trading_pipeline_mode, "simple")
         self.assertEqual(settings.trading_simple_max_notional_per_order, 250.0)
         self.assertEqual(settings.trading_simple_max_notional_per_symbol, 750.0)
+        self.assertEqual(settings.trading_simple_max_order_pct_equity, 0.2)
+        self.assertEqual(settings.trading_simple_max_gross_exposure_pct_equity, 0.8)
         self.assertEqual(settings.trading_simple_buying_power_reserve_bps, 50.0)
         self.assertTrue(settings.trading_simple_submit_enabled)
         self.assertTrue(settings.trading_simple_order_feed_telemetry_enabled)
         self.assertTrue(settings.trading_simple_paper_route_probe_enabled)
         self.assertEqual(settings.trading_simple_paper_route_probe_max_notional, 15.0)
+
+        defaults = Settings(
+            TRADING_ENABLED=False,
+            TRADING_UNIVERSE_SOURCE="static",
+            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+        )
+        self.assertEqual(defaults.trading_simple_max_order_pct_equity, 0.25)
+        self.assertEqual(defaults.trading_simple_max_gross_exposure_pct_equity, 1.0)
 
     def test_parses_signal_staleness_critical_reasons(self) -> None:
         settings = Settings(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -30,6 +30,7 @@ _QUOTE_COVERED_PAPER_STRATEGY_UNIVERSE = ("AAPL", "AMZN", "INTC", "NVDA")
 _CHIP_UNIVERSE_SYMBOLS = set(_RESEARCHED_CHIP_TECH_UNIVERSE)
 _LIVE_EXECUTION_CHIP_UNIVERSE_SYMBOLS = set(_LIVE_EXECUTION_CHIP_TECH_UNIVERSE)
 _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL = "1000000"
+_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL = "25000"
 _HPAIRS_PAPER_ACCOUNT_FLATTEN_MAX_GROSS_MARKET_VALUE = (
     _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL
 )
@@ -694,7 +695,12 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
-            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
+            _SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL,
+        )
+        self.assertEqual(sim_env.get("TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY"), "0.25")
+        self.assertEqual(
+            sim_env.get("TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY"),
+            "1.0",
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
@@ -1500,6 +1506,17 @@ class TestLiveConfigManifestContract(TestCase):
             )
 
         args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/reconcile_cross_dsn_order_feed_links.py", args)
+        self.assertIn("--event-dsn-env DB_DSN", args)
+        self.assertIn("--canonical-dsn-env SIM_DB_DSN", args)
+        self.assertIn("--source-account-label PA3SX7FYNUTF", args)
+        self.assertIn("--canonical-account-label TORGHUT_SIM", args)
+        self.assertIn('--window-start "${WINDOW_START}"', args)
+        self.assertIn('--window-end "${WINDOW_END}"', args)
+        self.assertLess(
+            args.index("scripts/reconcile_cross_dsn_order_feed_links.py"),
+            args.index("scripts/repair_order_feed_source_windows.py"),
+        )
         self.assertIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env DB_DSN", args)
         self.assertIn("--account-label PA3SX7FYNUTF", args)
@@ -1511,6 +1528,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--batch-size 100", args)
         self.assertIn("--max-batches 4", args)
         self.assertIn("--account-label TORGHUT_REPLAY", args)
+        self.assertEqual(
+            args.count("scripts/reconcile_cross_dsn_order_feed_links.py"),
+            1,
+        )
         self.assertEqual(args.count("scripts/repair_order_feed_source_windows.py"), 3)
         self.assertEqual(args.count("--dsn-env SIM_DB_DSN"), 2)
         self.assertEqual(args.count("--backfill-execution-events"), 2)
@@ -1685,11 +1706,25 @@ class TestLiveConfigManifestContract(TestCase):
 
         self.assertEqual(
             live_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
-            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
+            _SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL,
         )
         self.assertEqual(
             sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
-            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
+            _SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL,
+        )
+        self.assertNotEqual(
+            live_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
+            "1000000",
+        )
+        self.assertEqual(live_env.get("TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY"), "0.25")
+        self.assertEqual(
+            live_env.get("TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY"),
+            "1.0",
+        )
+        self.assertEqual(sim_env.get("TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY"), "0.25")
+        self.assertEqual(
+            sim_env.get("TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY"),
+            "1.0",
         )
         self.assertIn(
             f"--max-notional {_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL}", args
@@ -2098,6 +2133,13 @@ class TestLiveConfigManifestContract(TestCase):
             )
 
         args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/reconcile_cross_dsn_order_feed_links.py", args)
+        self.assertIn("--event-dsn-env DB_DSN", args)
+        self.assertIn("--canonical-dsn-env SIM_DB_DSN", args)
+        self.assertIn("--source-account-label PA3SX7FYNUTF", args)
+        self.assertIn("--canonical-account-label TORGHUT_SIM", args)
+        self.assertIn('--window-start "${WINDOW_START}"', args)
+        self.assertIn('--window-end "${WINDOW_END}"', args)
         self.assertIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
@@ -2106,12 +2148,20 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--account-label TORGHUT_REPLAY", args)
         self.assertIn("--backfill-execution-events", args)
         self.assertEqual(args.count("--backfill-execution-events"), 2)
+        self.assertEqual(
+            args.count("scripts/reconcile_cross_dsn_order_feed_links.py"),
+            1,
+        )
         self.assertEqual(args.count("scripts/repair_order_feed_source_windows.py"), 2)
         self.assertIn("scripts/refresh_execution_tca_metrics.py", args)
         self.assertIn("--older-than-seconds 0", args)
         self.assertIn("--max-batches 5", args)
         self.assertEqual(args.count("scripts/refresh_execution_tca_metrics.py"), 1)
         self.assertEqual(args.count("--dsn-env SIM_DB_DSN"), 3)
+        self.assertLess(
+            args.index("scripts/reconcile_cross_dsn_order_feed_links.py"),
+            args.index("scripts/repair_order_feed_source_windows.py"),
+        )
         self.assertLess(
             args.index("scripts/refresh_execution_tca_metrics.py"),
             args.index("scripts/renew_latest_empirical_promotion_jobs.py"),
@@ -2175,7 +2225,10 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertNotIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
         self.assertNotIn('--runtime-window-target \'{"hypothesis_id"', args)
-        self.assertNotIn("PA3SX7FYNUTF", args)
+        renewal_args = args[
+            args.index("scripts/renew_latest_empirical_promotion_jobs.py") :
+        ]
+        self.assertNotIn("PA3SX7FYNUTF", renewal_args)
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
         self.assertIn("--runtime-window-observed-stage paper", args)
         self.assertIn("--runtime-window-source-dsn-env SIM_DB_DSN", args)
@@ -2453,7 +2506,12 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertTrue(_manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED"))
         self.assertEqual(
             env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
-            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
+            _SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL,
+        )
+        self.assertEqual(env.get("TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY"), "0.25")
+        self.assertEqual(
+            env.get("TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY"),
+            "1.0",
         )
         self.assertTrue(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FEED"), "iex")

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -4939,6 +4939,119 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
 
+    def test_source_window_refresh_counts_cross_dsn_refs_separately(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed-v1",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="PA3SX7FYNUTF",
+                assignment_mode="manual",
+                source_revision=ORDER_FEED_SOURCE_REVISION,
+                window_started_at=datetime(2026, 6, 11, 13, 30, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 6, 11, 20, 10, tzinfo=timezone.utc),
+                start_offset=1,
+                end_offset=4,
+                consumed_count=4,
+                inserted_count=4,
+                unlinked_execution_count=4,
+                unlinked_decision_count=4,
+                status="inserted",
+                classification_counts={
+                    "cross_dsn_execution_ref_count": 99,
+                },
+                payload_json={
+                    "classification_counts": {
+                        "cross_dsn_execution_ref_count": 99,
+                    }
+                },
+            )
+            session.add(source_window)
+            session.flush()
+            events = [
+                ExecutionOrderEvent(
+                    event_fingerprint="cross-dsn-raw-list",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=1,
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    event_ts=datetime(2026, 6, 11, 14, 0, tzinfo=timezone.utc),
+                    symbol="AMZN",
+                    raw_event=["not-a-mapping"],
+                    source_window_id=source_window.id,
+                ),
+                ExecutionOrderEvent(
+                    event_fingerprint="cross-dsn-no-linkage",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=2,
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    event_ts=datetime(2026, 6, 11, 14, 1, tzinfo=timezone.utc),
+                    symbol="AMZN",
+                    raw_event={"event": "fill"},
+                    source_window_id=source_window.id,
+                ),
+                ExecutionOrderEvent(
+                    event_fingerprint="cross-dsn-bad-linkage",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=3,
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    event_ts=datetime(2026, 6, 11, 14, 2, tzinfo=timezone.utc),
+                    symbol="AMZN",
+                    raw_event={"_torghut_cross_dsn_linkage": "bad"},
+                    source_window_id=source_window.id,
+                ),
+                ExecutionOrderEvent(
+                    event_fingerprint="cross-dsn-linked",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=4,
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    event_ts=datetime(2026, 6, 11, 14, 3, tzinfo=timezone.utc),
+                    symbol="AMZN",
+                    raw_event={
+                        "_torghut_cross_dsn_linkage": {
+                            "canonical_execution_id": "execution-1",
+                            "canonical_trade_decision_id": "decision-1",
+                            "canonical_execution_tca_metric_id": "tca-1",
+                        }
+                    },
+                    source_window_id=source_window.id,
+                ),
+            ]
+            session.add_all(events)
+            session.flush()
+
+            counts = order_feed_module._cross_dsn_linkage_counts_for_source_window(
+                session,
+                source_window.id,
+            )
+            order_feed_module._refresh_source_window_linkage_counts(
+                session,
+                events[-1],
+            )
+            session.commit()
+            session.refresh(source_window)
+
+        self.assertEqual(
+            counts,
+            {
+                "cross_dsn_execution_ref_count": 1,
+                "cross_dsn_trade_decision_ref_count": 1,
+                "cross_dsn_tca_ref_count": 1,
+            },
+        )
+        self.assertEqual(source_window.payload_json["cross_dsn_execution_ref_count"], 1)
+        self.assertEqual(
+            source_window.classification_counts["cross_dsn_trade_decision_ref_count"],
+            1,
+        )
+        self.assertEqual(source_window.unlinked_execution_count, 4)
+        self.assertEqual(source_window.unlinked_decision_count, 4)
+
     def test_duplicate_event_advances_cursor_accounting_and_commits(self) -> None:
         record = FakeRecord(
             value=(

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -4,10 +4,25 @@ import io
 import json
 import os
 import sys
-from datetime import timezone
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from unittest import TestCase
 from unittest.mock import patch
 
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.models import (
+    Base,
+    Execution,
+    ExecutionOrderEvent,
+    ExecutionTCAMetric,
+    OrderFeedSourceWindow,
+    Strategy,
+    TradeDecision,
+)
+from scripts import reconcile_cross_dsn_order_feed_links as cross_dsn_script
 from scripts import repair_order_feed_source_windows as script
 
 
@@ -854,3 +869,790 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             script._sqlalchemy_dsn("postgresql+psycopg://user:pass@postgres/torghut"),
             "postgresql+psycopg://user:pass@postgres/torghut",
         )
+
+
+def _sqlite_model_engine() -> object:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _seed_canonical_execution(
+    session: Session,
+    *,
+    order_id: str,
+    client_order_id: str,
+    execution_idempotency_key: str | None = None,
+    account_label: str = "TORGHUT_SIM",
+) -> tuple[TradeDecision, Execution, ExecutionTCAMetric]:
+    strategy = Strategy(
+        name=f"strategy-{client_order_id}",
+        description="canonical sim strategy",
+        enabled=True,
+        base_timeframe="1Min",
+        universe_type="symbols_list",
+        universe_symbols=["AMZN"],
+    )
+    session.add(strategy)
+    session.flush()
+    decision = TradeDecision(
+        strategy_id=strategy.id,
+        alpaca_account_label=account_label,
+        symbol="AMZN",
+        timeframe="1Min",
+        decision_json={"side": "buy", "qty": "1"},
+        rationale="test",
+        decision_hash=client_order_id,
+        status="executed",
+        executed_at=datetime(2026, 6, 11, 14, 30, tzinfo=timezone.utc),
+    )
+    session.add(decision)
+    session.flush()
+    execution = Execution(
+        trade_decision_id=decision.id,
+        alpaca_account_label=account_label,
+        alpaca_order_id=order_id,
+        client_order_id=client_order_id,
+        symbol="AMZN",
+        side="buy",
+        order_type="market",
+        time_in_force="day",
+        submitted_qty=Decimal("1"),
+        filled_qty=Decimal("1"),
+        avg_fill_price=Decimal("100"),
+        status="filled",
+        execution_idempotency_key=execution_idempotency_key,
+        raw_order={"id": order_id, "client_order_id": client_order_id},
+        last_update_at=datetime(2026, 6, 11, 14, 30, tzinfo=timezone.utc),
+    )
+    session.add(execution)
+    session.flush()
+    metric = ExecutionTCAMetric(
+        execution_id=execution.id,
+        trade_decision_id=decision.id,
+        strategy_id=strategy.id,
+        alpaca_account_label=account_label,
+        symbol="AMZN",
+        side="buy",
+        avg_fill_price=Decimal("100"),
+        filled_qty=Decimal("1"),
+        signed_qty=Decimal("1"),
+        computed_at=datetime(2026, 6, 11, 14, 31, tzinfo=timezone.utc),
+    )
+    session.add(metric)
+    session.flush()
+    return decision, execution, metric
+
+
+def _seed_live_source_window(
+    session: Session, *, event_count: int
+) -> OrderFeedSourceWindow:
+    source_window = OrderFeedSourceWindow(
+        consumer_group="torghut-order-feed-v1",
+        source_topic="torghut.trade-updates.v1",
+        source_partition=0,
+        alpaca_account_label="PA3SX7FYNUTF",
+        assignment_mode="group",
+        source_revision="alpaca-trade-updates-v1",
+        window_started_at=datetime(2026, 6, 11, 13, 30, tzinfo=timezone.utc),
+        window_ended_at=datetime(2026, 6, 11, 20, 10, tzinfo=timezone.utc),
+        start_offset=10_000,
+        end_offset=10_000 + event_count - 1,
+        consumed_count=event_count,
+        inserted_count=event_count,
+        unlinked_execution_count=event_count,
+        unlinked_decision_count=event_count,
+        status="inserted",
+        status_reason="missing_execution_and_decision_links",
+        classification_counts={
+            "inserted": event_count,
+            "unlinked_execution": event_count,
+            "unlinked_decision": event_count,
+        },
+        payload_json={
+            "classification_counts": {
+                "inserted": event_count,
+                "unlinked_execution": event_count,
+                "unlinked_decision": event_count,
+            }
+        },
+    )
+    session.add(source_window)
+    session.flush()
+    return source_window
+
+
+class TestCrossDsnOrderFeedReconciliationScript(TestCase):
+    def test_cross_dsn_parse_datetime_dsn_and_helper_edges(self) -> None:
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "reconcile_cross_dsn_order_feed_links.py",
+                "--source-account-label",
+                "PA3SX7FYNUTF",
+                "--canonical-account-label",
+                "TORGHUT_SIM",
+                "--window-start",
+                "2026-06-11T13:30:00Z",
+                "--window-end",
+                "2026-06-11T20:10:00Z",
+            ],
+        ):
+            args = cross_dsn_script._parse_args()
+
+        self.assertEqual(args.event_dsn_env, "DB_DSN")
+        self.assertEqual(args.canonical_dsn_env, "SIM_DB_DSN")
+        self.assertEqual(args.limit, 5000)
+        with self.assertRaisesRegex(SystemExit, "empty_datetime"):
+            cross_dsn_script._parse_dt(" ")
+        self.assertEqual(
+            cross_dsn_script._parse_dt("2026-06-11T13:30:00").isoformat(),
+            "2026-06-11T13:30:00+00:00",
+        )
+        self.assertEqual(
+            cross_dsn_script._sqlalchemy_dsn("postgres://example/live"),
+            "postgresql+psycopg://example/live",
+        )
+        self.assertEqual(
+            cross_dsn_script._sqlalchemy_dsn("postgresql://example/sim"),
+            "postgresql+psycopg://example/sim",
+        )
+        self.assertEqual(
+            cross_dsn_script._sqlalchemy_dsn("sqlite+pysqlite:///:memory:"),
+            "sqlite+pysqlite:///:memory:",
+        )
+
+        engine = _sqlite_model_engine()
+        with Session(engine) as session:
+            _, execution, _ = _seed_canonical_execution(
+                session,
+                order_id="duplicate-order",
+                client_order_id="duplicate-client",
+            )
+            session.commit()
+            self.assertEqual(
+                cross_dsn_script._unique_executions([execution, execution]),
+                [execution],
+            )
+            event_without_identity = ExecutionOrderEvent(
+                event_fingerprint="no-order-identity",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=1,
+                alpaca_account_label="PA3SX7FYNUTF",
+                symbol="AMZN",
+                raw_event={"event": "fill"},
+            )
+            self.assertEqual(
+                cross_dsn_script._canonical_execution_matches(
+                    session,
+                    event_without_identity,
+                    canonical_account_label="TORGHUT_SIM",
+                ),
+                [],
+            )
+            self.assertEqual(
+                cross_dsn_script._event_raw_payload(
+                    ExecutionOrderEvent(
+                        event_fingerprint="raw-list-event",
+                        source_topic="torghut.trade-updates.v1",
+                        source_partition=0,
+                        source_offset=2,
+                        alpaca_account_label="PA3SX7FYNUTF",
+                        symbol="AMZN",
+                        raw_event=["raw-list"],
+                    )
+                ),
+                {"raw_event": ["raw-list"]},
+            )
+
+    def test_cross_dsn_decision_fallback_handles_missing_no_match_and_single(
+        self,
+    ) -> None:
+        engine = _sqlite_model_engine()
+        with Session(engine) as session:
+            strategy = Strategy(
+                name="decision-fallback",
+                description="decision fallback",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="symbols_list",
+                universe_symbols=["AMZN"],
+            )
+            session.add(strategy)
+            session.flush()
+            decisions = [
+                TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AMZN",
+                    timeframe="1Min",
+                    decision_json={"side": "buy"},
+                    decision_hash="single-client",
+                    status="submitted",
+                ),
+            ]
+            session.add_all(decisions)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=None,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="fallback-order",
+                client_order_id="fallback-client",
+                symbol="AMZN",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("0"),
+                status="new",
+                raw_order={"id": "fallback-order"},
+                last_update_at=datetime(2026, 6, 11, 14, 30, tzinfo=timezone.utc),
+            )
+            session.add(execution)
+            session.flush()
+            event_without_client = ExecutionOrderEvent(
+                event_fingerprint="fallback-no-client",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=1,
+                alpaca_account_label="PA3SX7FYNUTF",
+                symbol="AMZN",
+                raw_event={"event": "fill"},
+            )
+            event_with_missing_client = ExecutionOrderEvent(
+                event_fingerprint="fallback-missing-client",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=2,
+                alpaca_account_label="PA3SX7FYNUTF",
+                client_order_id="missing-client",
+                symbol="AMZN",
+                raw_event={"event": "fill"},
+            )
+            event_with_single_client = ExecutionOrderEvent(
+                event_fingerprint="fallback-single-client",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=3,
+                alpaca_account_label="PA3SX7FYNUTF",
+                client_order_id="single-client",
+                symbol="AMZN",
+                raw_event={"event": "fill"},
+            )
+
+            self.assertIsNone(
+                cross_dsn_script._canonical_decision_id(
+                    session,
+                    event_without_client,
+                    execution,
+                    canonical_account_label="TORGHUT_SIM",
+                )
+            )
+            self.assertIsNone(
+                cross_dsn_script._canonical_decision_id(
+                    session,
+                    event_with_missing_client,
+                    execution,
+                    canonical_account_label="TORGHUT_SIM",
+                )
+            )
+            self.assertEqual(
+                cross_dsn_script._canonical_decision_id(
+                    session,
+                    event_with_single_client,
+                    execution,
+                    canonical_account_label="TORGHUT_SIM",
+                ),
+                decisions[-1].id,
+            )
+
+    def test_cross_dsn_source_window_marking_handles_missing_and_empty_counts(
+        self,
+    ) -> None:
+        event_engine = _sqlite_model_engine()
+        linked_at = datetime(2026, 6, 11, 21, 0, tzinfo=timezone.utc)
+
+        with Session(event_engine) as event_session:
+            source_window = _seed_live_source_window(event_session, event_count=1)
+            source_window.payload_json = ["not-a-mapping"]
+            source_window.classification_counts = {
+                "cross_dsn_execution_ref_count": 7,
+            }
+            event_session.commit()
+            source_window_id = source_window.id
+
+        with Session(event_engine) as event_session:
+            marked = cross_dsn_script._mark_source_windows(
+                event_session,
+                source_window_ids={uuid.uuid4(), source_window_id},
+                event_dsn_env="DB_DSN",
+                canonical_dsn_env="SIM_DB_DSN",
+                source_account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                canonical_execution_ids=set(),
+                canonical_trade_decision_ids=set(),
+                canonical_tca_ids=set(),
+                linked_at=linked_at,
+            )
+            event_session.commit()
+            source_window = event_session.get(OrderFeedSourceWindow, source_window_id)
+
+        self.assertEqual(marked, 1)
+        assert source_window is not None
+        self.assertEqual(
+            source_window.payload_json["cross_dsn_execution_ref_count"],
+            0,
+        )
+        self.assertNotIn(
+            "cross_dsn_execution_ref_count",
+            source_window.classification_counts,
+        )
+        self.assertEqual(
+            source_window.payload_json["_torghut_cross_dsn_linkage"][
+                "canonical_execution_ids"
+            ],
+            [],
+        )
+
+    def test_dry_run_and_apply_cross_dsn_refs_without_live_fks(self) -> None:
+        event_engine = _sqlite_model_engine()
+        canonical_engine = _sqlite_model_engine()
+        window_start = datetime(2026, 6, 11, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 11, 20, 10, tzinfo=timezone.utc)
+        linked_at = datetime(2026, 6, 11, 21, 0, tzinfo=timezone.utc)
+
+        with Session(canonical_engine) as canonical_session:
+            for index in range(4):
+                _seed_canonical_execution(
+                    canonical_session,
+                    order_id=f"sim-order-{index}",
+                    client_order_id=f"sim-client-{index}",
+                )
+            canonical_session.commit()
+
+        with Session(event_engine) as event_session:
+            source_window = _seed_live_source_window(event_session, event_count=16)
+            for order_index in range(4):
+                for event_index in range(4):
+                    offset = 10_000 + (order_index * 4) + event_index
+                    event_session.add(
+                        ExecutionOrderEvent(
+                            event_fingerprint=f"live-event-{order_index}-{event_index}",
+                            source_topic="torghut.trade-updates.v1",
+                            source_partition=0,
+                            source_offset=offset,
+                            alpaca_account_label="PA3SX7FYNUTF",
+                            event_ts=window_start
+                            + timedelta(minutes=order_index, seconds=event_index),
+                            symbol="AMZN",
+                            alpaca_order_id=f"sim-order-{order_index}",
+                            client_order_id=f"sim-client-{order_index}",
+                            event_type="fill",
+                            status="filled",
+                            qty=Decimal("1"),
+                            filled_qty=Decimal("1"),
+                            avg_fill_price=Decimal("100"),
+                            raw_event={"event": "fill", "source_offset": offset},
+                            source_window_id=source_window.id,
+                        )
+                    )
+            event_session.commit()
+
+        with (
+            Session(event_engine) as event_session,
+            Session(canonical_engine) as canonical_session,
+        ):
+            dry_run = cross_dsn_script.reconcile_cross_dsn_order_feed_links(
+                event_session,
+                canonical_session,
+                event_dsn_env="DB_DSN",
+                canonical_dsn_env="SIM_DB_DSN",
+                source_account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+                apply=False,
+                now=linked_at,
+            )
+            first_event = event_session.scalars(
+                select(ExecutionOrderEvent).order_by(ExecutionOrderEvent.source_offset)
+            ).first()
+
+        self.assertEqual(dry_run["selected"], 16)
+        self.assertEqual(dry_run["events_matched"], 16)
+        self.assertEqual(dry_run["canonical_executions_matched"], 4)
+        self.assertEqual(dry_run["canonical_trade_decisions_matched"], 4)
+        self.assertEqual(dry_run["canonical_tca_matched"], 4)
+        self.assertEqual(dry_run["events_ambiguous"], 0)
+        self.assertEqual(dry_run["events_marked"], 0)
+        assert first_event is not None
+        self.assertNotIn("_torghut_cross_dsn_linkage", first_event.raw_event)
+
+        with (
+            Session(event_engine) as event_session,
+            Session(canonical_engine) as canonical_session,
+        ):
+            applied = cross_dsn_script.reconcile_cross_dsn_order_feed_links(
+                event_session,
+                canonical_session,
+                event_dsn_env="DB_DSN",
+                canonical_dsn_env="SIM_DB_DSN",
+                source_account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+                apply=True,
+                now=linked_at,
+            )
+            event_session.commit()
+
+        self.assertEqual(applied["selected"], 16)
+        self.assertEqual(applied["events_matched"], 16)
+        self.assertEqual(applied["events_marked"], 16)
+        self.assertEqual(applied["source_windows_marked"], 1)
+        self.assertEqual(applied["canonical_executions_matched"], 4)
+        self.assertEqual(applied["canonical_trade_decisions_matched"], 4)
+        self.assertEqual(applied["canonical_tca_matched"], 4)
+
+        with Session(event_engine) as event_session:
+            events = list(
+                event_session.scalars(
+                    select(ExecutionOrderEvent).order_by(
+                        ExecutionOrderEvent.source_offset
+                    )
+                )
+            )
+            source_window = event_session.scalar(select(OrderFeedSourceWindow))
+
+        self.assertEqual(len(events), 16)
+        for event in events:
+            self.assertIsNone(event.execution_id)
+            self.assertIsNone(event.trade_decision_id)
+            linkage = event.raw_event["_torghut_cross_dsn_linkage"]
+            self.assertEqual(linkage["source_dsn_env"], "DB_DSN")
+            self.assertEqual(linkage["canonical_dsn_env"], "SIM_DB_DSN")
+            self.assertEqual(linkage["canonical_account_label"], "TORGHUT_SIM")
+            self.assertFalse(linkage["promotion_authority_eligible"])
+            self.assertTrue(linkage["canonical_execution_id"])
+            self.assertTrue(linkage["canonical_trade_decision_id"])
+            self.assertTrue(linkage["canonical_execution_tca_metric_id"])
+        assert source_window is not None
+        self.assertEqual(source_window.unlinked_execution_count, 16)
+        self.assertEqual(source_window.unlinked_decision_count, 16)
+        self.assertEqual(
+            source_window.payload_json["cross_dsn_execution_ref_count"], 16
+        )
+        self.assertEqual(
+            source_window.payload_json["cross_dsn_trade_decision_ref_count"],
+            16,
+        )
+        self.assertEqual(source_window.payload_json["cross_dsn_tca_ref_count"], 16)
+        self.assertEqual(
+            source_window.classification_counts["cross_dsn_execution_ref_count"],
+            16,
+        )
+        self.assertEqual(
+            len(
+                source_window.payload_json["_torghut_cross_dsn_linkage"][
+                    "canonical_execution_ids"
+                ]
+            ),
+            4,
+        )
+
+    def test_ambiguous_order_identity_fails_closed(self) -> None:
+        event_engine = _sqlite_model_engine()
+        canonical_engine = _sqlite_model_engine()
+        window_start = datetime(2026, 6, 11, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 11, 20, 10, tzinfo=timezone.utc)
+
+        with Session(canonical_engine) as canonical_session:
+            _seed_canonical_execution(
+                canonical_session,
+                order_id="ambiguous-order",
+                client_order_id="first-client",
+            )
+            _seed_canonical_execution(
+                canonical_session,
+                order_id="second-order",
+                client_order_id="second-client",
+                execution_idempotency_key="ambiguous-client",
+            )
+            canonical_session.commit()
+
+        with Session(event_engine) as event_session:
+            source_window = _seed_live_source_window(event_session, event_count=1)
+            event_session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="live-ambiguous-event",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=10_000,
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    event_ts=window_start + timedelta(minutes=1),
+                    symbol="AMZN",
+                    alpaca_order_id="ambiguous-order",
+                    client_order_id="ambiguous-client",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    raw_event={"event": "fill"},
+                    source_window_id=source_window.id,
+                )
+            )
+            event_session.commit()
+
+        with (
+            Session(event_engine) as event_session,
+            Session(canonical_engine) as canonical_session,
+        ):
+            result = cross_dsn_script.reconcile_cross_dsn_order_feed_links(
+                event_session,
+                canonical_session,
+                event_dsn_env="DB_DSN",
+                canonical_dsn_env="SIM_DB_DSN",
+                source_account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+                apply=True,
+                now=window_end,
+            )
+            event_session.commit()
+
+        self.assertEqual(result["selected"], 1)
+        self.assertEqual(result["events_matched"], 0)
+        self.assertEqual(result["events_ambiguous"], 1)
+        self.assertEqual(result["events_marked"], 0)
+        self.assertEqual(result["source_windows_marked"], 0)
+        self.assertFalse(result["promotion_authority_eligible"])
+
+        with Session(event_engine) as event_session:
+            event = event_session.scalar(select(ExecutionOrderEvent))
+            source_window = event_session.scalar(select(OrderFeedSourceWindow))
+
+        assert event is not None
+        self.assertIsNone(event.execution_id)
+        self.assertIsNone(event.trade_decision_id)
+        self.assertNotIn("_torghut_cross_dsn_linkage", event.raw_event)
+        assert source_window is not None
+        self.assertNotIn("_torghut_cross_dsn_linkage", source_window.payload_json)
+
+    def test_unmatched_and_missing_tca_are_reported_without_live_fks(self) -> None:
+        event_engine = _sqlite_model_engine()
+        canonical_engine = _sqlite_model_engine()
+        window_start = datetime(2026, 6, 11, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 11, 20, 10, tzinfo=timezone.utc)
+
+        with Session(canonical_engine) as canonical_session:
+            _, _, metric = _seed_canonical_execution(
+                canonical_session,
+                order_id="matched-without-tca",
+                client_order_id="matched-client",
+            )
+            canonical_session.delete(metric)
+            canonical_session.commit()
+
+        with Session(event_engine) as event_session:
+            source_window = _seed_live_source_window(event_session, event_count=2)
+            for offset, order_id, client_order_id in (
+                (10_000, "matched-without-tca", "matched-client"),
+                (10_001, "missing-canonical-order", "missing-client"),
+            ):
+                event_session.add(
+                    ExecutionOrderEvent(
+                        event_fingerprint=f"live-{order_id}",
+                        source_topic="torghut.trade-updates.v1",
+                        source_partition=0,
+                        source_offset=offset,
+                        alpaca_account_label="PA3SX7FYNUTF",
+                        event_ts=window_start + timedelta(minutes=1),
+                        symbol="AMZN",
+                        alpaca_order_id=order_id,
+                        client_order_id=client_order_id,
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("100"),
+                        raw_event={"event": "fill"},
+                        source_window_id=source_window.id,
+                    )
+                )
+            event_session.commit()
+
+        with (
+            Session(event_engine) as event_session,
+            Session(canonical_engine) as canonical_session,
+        ):
+            result = cross_dsn_script.reconcile_cross_dsn_order_feed_links(
+                event_session,
+                canonical_session,
+                event_dsn_env="DB_DSN",
+                canonical_dsn_env="SIM_DB_DSN",
+                source_account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+                apply=True,
+                now=window_end,
+            )
+            event_session.commit()
+
+        self.assertEqual(result["selected"], 2)
+        self.assertEqual(result["events_matched"], 1)
+        self.assertEqual(result["events_unmatched"], 1)
+        self.assertEqual(result["canonical_tca_matched"], 0)
+        self.assertEqual(result["canonical_tca_missing"], 1)
+        self.assertEqual(
+            result["unmatched_order_identities"][0]["alpaca_order_id"],
+            "missing-canonical-order",
+        )
+
+    def test_cross_dsn_main_rejects_missing_envs_and_invalid_window(self) -> None:
+        base_argv = [
+            "reconcile_cross_dsn_order_feed_links.py",
+            "--event-dsn-env",
+            "EVENT_DSN",
+            "--canonical-dsn-env",
+            "CANONICAL_DSN",
+            "--source-account-label",
+            "PA3SX7FYNUTF",
+            "--canonical-account-label",
+            "TORGHUT_SIM",
+            "--window-start",
+            "2026-06-11T20:10:00Z",
+            "--window-end",
+            "2026-06-11T13:30:00Z",
+        ]
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(sys, "argv", base_argv),
+        ):
+            with self.assertRaisesRegex(SystemExit, "missing DSN env var: EVENT_DSN"):
+                cross_dsn_script.main()
+        with (
+            patch.dict(
+                os.environ, {"EVENT_DSN": "postgres://example/live"}, clear=True
+            ),
+            patch.object(sys, "argv", base_argv),
+        ):
+            with self.assertRaisesRegex(
+                SystemExit,
+                "missing DSN env var: CANONICAL_DSN",
+            ):
+                cross_dsn_script.main()
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "EVENT_DSN": "postgres://example/live",
+                    "CANONICAL_DSN": "postgresql://example/sim",
+                },
+                clear=True,
+            ),
+            patch.object(sys, "argv", base_argv),
+            patch.object(cross_dsn_script, "create_engine") as create_engine,
+        ):
+            with self.assertRaisesRegex(
+                SystemExit,
+                "window_end_must_be_after_window_start",
+            ):
+                cross_dsn_script.main()
+
+        create_engine.assert_not_called()
+
+    def test_cross_dsn_main_transaction_and_output_modes(self) -> None:
+        def run_main(
+            *,
+            argv: list[str],
+            event_session: _FakeSession,
+            canonical_session: _FakeSession,
+            reconcile_payload: dict[str, object],
+        ) -> tuple[int, str]:
+            stdout = io.StringIO()
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "EVENT_DSN": "postgres://example/live",
+                        "CANONICAL_DSN": "postgresql://example/sim",
+                    },
+                    clear=True,
+                ),
+                patch.object(sys, "argv", argv),
+                patch.object(
+                    cross_dsn_script,
+                    "create_engine",
+                    return_value=object(),
+                ),
+                patch.object(
+                    cross_dsn_script,
+                    "sessionmaker",
+                    side_effect=[
+                        _FakeSessionFactory(event_session),
+                        _FakeSessionFactory(canonical_session),
+                    ],
+                ),
+                patch.object(
+                    cross_dsn_script,
+                    "reconcile_cross_dsn_order_feed_links",
+                    return_value=reconcile_payload,
+                ),
+                patch("sys.stdout", stdout),
+            ):
+                exit_code = cross_dsn_script.main()
+            return exit_code, stdout.getvalue()
+
+        base_argv = [
+            "reconcile_cross_dsn_order_feed_links.py",
+            "--event-dsn-env",
+            "EVENT_DSN",
+            "--canonical-dsn-env",
+            "CANONICAL_DSN",
+            "--source-account-label",
+            "PA3SX7FYNUTF",
+            "--canonical-account-label",
+            "TORGHUT_SIM",
+            "--window-start",
+            "2026-06-11T13:30:00Z",
+            "--window-end",
+            "2026-06-11T20:10:00Z",
+            "--limit",
+            "6000",
+        ]
+        dry_event_session = _FakeSession()
+        dry_canonical_session = _FakeSession()
+        dry_code, dry_output = run_main(
+            argv=base_argv,
+            event_session=dry_event_session,
+            canonical_session=dry_canonical_session,
+            reconcile_payload={"status": "ok", "apply": False},
+        )
+
+        self.assertEqual(dry_code, 0)
+        self.assertEqual(json.loads(dry_output)["apply"], False)
+        self.assertIn("\n  ", dry_output)
+        self.assertEqual(dry_event_session.commits, 0)
+        self.assertEqual(dry_event_session.rollbacks, 1)
+        self.assertEqual(dry_canonical_session.rollbacks, 1)
+
+        apply_event_session = _FakeSession()
+        apply_canonical_session = _FakeSession()
+        apply_code, apply_output = run_main(
+            argv=[*base_argv, "--apply", "--json"],
+            event_session=apply_event_session,
+            canonical_session=apply_canonical_session,
+            reconcile_payload={"status": "ok", "apply": True},
+        )
+
+        self.assertEqual(apply_code, 0)
+        self.assertEqual(json.loads(apply_output)["apply"], True)
+        self.assertNotIn("\n  ", apply_output)
+        self.assertEqual(apply_event_session.commits, 1)
+        self.assertEqual(apply_event_session.rollbacks, 0)
+        self.assertEqual(apply_canonical_session.rollbacks, 1)

--- a/services/torghut/tests/test_simple_risk.py
+++ b/services/torghut/tests/test_simple_risk.py
@@ -7,7 +7,9 @@ from unittest import TestCase
 from app.trading.models import StrategyDecision
 from app.trading.simple_risk import (
     _buying_power_required_notional,
+    _exposure_increase_qty,
     prepare_simple_decision,
+    portfolio_gross_notional,
 )
 
 
@@ -162,6 +164,216 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.reject_reason, "insufficient_buying_power")
         self.assertEqual(result.diagnostics["buying_power_cap_qty"], "0")
 
+    def test_buy_cover_short_requires_no_buying_power(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="1", price="100"),
+            account={"buying_power": "0", "equity": "10000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "1", "side": "short"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("1"))
+        self.assertEqual(result.diagnostics["buying_power_cap_qty"], "1")
+        self.assertEqual(result.diagnostics["buying_power_required_notional"], "0")
+        self.assertFalse(
+            result.decision.params["simple_lane"]["capped_by_buying_power"]
+        )
+
+    def test_buy_cover_short_with_zero_buying_power_caps_flip_to_long(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="2", price="100"),
+            account={"buying_power": "0", "equity": "10000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "1", "side": "short"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("1"))
+        self.assertEqual(result.diagnostics["buying_power_cap_qty"], "1")
+        self.assertEqual(result.diagnostics["buying_power_required_notional"], "0")
+        self.assertTrue(result.decision.params["simple_lane"]["capped_by_buying_power"])
+
+    def test_buy_cover_short_with_buying_power_caps_only_flip_to_long_excess(
+        self,
+    ) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="4", price="100"),
+            account={"buying_power": "200", "equity": "10000", "cash": "200"},
+            positions=[{"symbol": "AAPL", "qty": "1", "side": "short"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("3"))
+        self.assertEqual(result.notional, Decimal("300"))
+        self.assertEqual(result.diagnostics["buying_power_cap_qty"], "3")
+        self.assertEqual(result.diagnostics["buying_power_required_notional"], "200")
+        self.assertTrue(result.decision.params["simple_lane"]["capped_by_buying_power"])
+
+    def test_equity_order_cap_limits_large_new_exposure(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="500", price="100"),
+            account={"buying_power": "50000", "equity": "40000", "cash": "50000"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            max_order_pct_equity=Decimal("0.25"),
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("100"))
+        self.assertEqual(result.notional, Decimal("10000"))
+        self.assertEqual(result.diagnostics["equity_order_cap_notional"], "10000.00")
+        self.assertTrue(result.decision.params["simple_lane"]["capped_by_order"])
+
+    def test_equity_order_cap_rejects_missing_equity_for_new_exposure(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="1", price="100"),
+            account={"buying_power": "10000", "cash": "10000"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            max_order_pct_equity=Decimal("0.25"),
+        )
+
+        self.assertFalse(result.approved)
+        self.assertEqual(result.reject_reason, "equity_required_for_exposure_increase")
+
+    def test_symbol_cap_with_no_room_allows_only_non_increasing_quantity(self) -> None:
+        close_result = prepare_simple_decision(
+            decision=self._decision(action="sell", qty="2", price="100"),
+            account={"buying_power": "10000", "equity": "10000", "cash": "10000"},
+            positions=[{"symbol": "AAPL", "qty": "1", "side": "long"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=Decimal("0"),
+        )
+        new_exposure_result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="1", price="100"),
+            account={"buying_power": "10000", "equity": "10000", "cash": "10000"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=Decimal("0"),
+        )
+
+        self.assertTrue(close_result.approved)
+        self.assertEqual(close_result.decision.qty, Decimal("1"))
+        self.assertTrue(close_result.decision.params["simple_lane"]["capped_by_symbol"])
+        self.assertFalse(new_exposure_result.approved)
+        self.assertEqual(
+            new_exposure_result.reject_reason,
+            "max_symbol_exposure_exceeded",
+        )
+
+    def test_gross_exposure_cap_does_not_block_close_or_cover(self) -> None:
+        sell_close = prepare_simple_decision(
+            decision=self._decision(action="sell", qty="1", price="100"),
+            account={"buying_power": "0", "equity": "1000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "2", "side": "long"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            max_gross_exposure_pct_equity=Decimal("0"),
+            require_equity_for_exposure_increase=True,
+        )
+        buy_cover = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="1", price="100"),
+            account={"buying_power": "0", "equity": "1000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "2", "side": "short"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            max_gross_exposure_pct_equity=Decimal("0"),
+            require_equity_for_exposure_increase=True,
+        )
+
+        self.assertTrue(sell_close.approved)
+        self.assertTrue(buy_cover.approved)
+        self.assertFalse(sell_close.decision.params["simple_lane"]["capped_by_gross"])
+        self.assertFalse(buy_cover.decision.params["simple_lane"]["capped_by_gross"])
+
+    def test_gross_exposure_cap_rejects_missing_equity_for_new_exposure(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="1", price="100"),
+            account={"buying_power": "10000", "cash": "10000"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            max_gross_exposure_pct_equity=Decimal("1"),
+        )
+
+        self.assertFalse(result.approved)
+        self.assertEqual(result.reject_reason, "equity_required_for_exposure_increase")
+
+    def test_gross_exposure_cap_with_no_room_allows_only_closing_quantity(
+        self,
+    ) -> None:
+        close_result = prepare_simple_decision(
+            decision=self._decision(action="sell", qty="2", price="100"),
+            account={"buying_power": "10000", "equity": "1000", "cash": "10000"},
+            positions=[{"symbol": "AAPL", "qty": "1", "side": "long"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            max_gross_exposure_pct_equity=Decimal("0"),
+        )
+        new_exposure_result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="1", price="100"),
+            account={"buying_power": "10000", "equity": "1000", "cash": "10000"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            max_gross_exposure_pct_equity=Decimal("0"),
+        )
+
+        self.assertTrue(close_result.approved)
+        self.assertEqual(close_result.decision.qty, Decimal("1"))
+        self.assertTrue(close_result.decision.params["simple_lane"]["capped_by_gross"])
+        self.assertFalse(new_exposure_result.approved)
+        self.assertEqual(
+            new_exposure_result.reject_reason,
+            "max_gross_exposure_exceeded",
+        )
+
+    def test_missing_equity_rejects_new_exposure_when_required(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(action="buy", qty="1", price="100"),
+            account={"buying_power": "10000", "cash": "10000"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+            require_equity_for_exposure_increase=True,
+        )
+
+        self.assertFalse(result.approved)
+        self.assertEqual(result.reject_reason, "equity_required_for_exposure_increase")
+
     def test_short_increase_buying_power_cap_counts_only_excess_qty(self) -> None:
         result = prepare_simple_decision(
             decision=self._decision(action="sell", qty="5", price="100"),
@@ -218,6 +430,16 @@ class TestSimpleRisk(TestCase):
             ),
             Decimal("0"),
         )
+        reducing_buy = self._decision(action="buy", qty="1", price="100")
+        self.assertEqual(
+            _buying_power_required_notional(
+                decision=reducing_buy,
+                qty=Decimal("1"),
+                price=Decimal("100"),
+                current_qty=Decimal("-2"),
+            ),
+            Decimal("0"),
+        )
 
     def test_rejects_sub_min_qty_after_quantization(self) -> None:
         result = prepare_simple_decision(
@@ -262,4 +484,39 @@ class TestSimpleRisk(TestCase):
         self.assertIn(
             "observed_post_cost_expectancy_bps_missing",
             result.diagnostics["target_sizing"]["blocking_reasons"],
+        )
+
+    def test_exposure_increase_helper_and_gross_notional_fallback_edges(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _exposure_increase_qty(
+                action="hold",
+                qty=Decimal("5"),
+                current_qty=Decimal("0"),
+            ),
+            Decimal("0"),
+        )
+        self.assertEqual(
+            portfolio_gross_notional(
+                [
+                    {"symbol": "AAPL", "market_value": "125.50"},
+                    {"symbol": "AAPL", "market_value": "not-a-decimal", "qty": "2"},
+                    {"symbol": "MSFT", "qty": "10"},
+                    {"symbol": "AAPL", "qty": None},
+                    {"symbol": "AAPL", "qty": "bad"},
+                    {"symbol": "AAPL", "quantity": "-3"},
+                ],
+                "AAPL",
+                fallback_price=Decimal("10"),
+            ),
+            Decimal("175.50"),
+        )
+        self.assertEqual(
+            portfolio_gross_notional(
+                [{"symbol": "AAPL", "qty": "10"}],
+                "AAPL",
+                fallback_price=None,
+            ),
+            Decimal("0"),
         )


### PR DESCRIPTION
## Summary

- Fix simple-lane sizing so only exposure-increasing quantity consumes buying power, equity order caps, and gross exposure caps; short covers and long closes stay close-only and are not blocked by capital caps.
- Add fail-closed simple-lane equity defaults plus bounded Knative probe notional settings for live and sim.
- Add cross-DSN order-feed reconciliation that annotates live PA3SX7FYNUTF evidence with canonical TORGHUT_SIM refs without creating fake live executions or setting same-DB FK columns.
- Update source-window classification, repair CronJobs, empirical renewal ordering, and regression tests for the Jun 11 authority repair path.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_simple_risk.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/config.py app/main.py app/trading/simple_risk.py app/trading/scheduler/simple_pipeline.py app/trading/order_feed.py app/trading/revenue_repair.py app/trading/submission_council.py app/trading/hypotheses.py app/trading/jangar_continuity.py app/trading/jangar_controller_ingestion_carry.py app/trading/profit_freshness_frontier.py scripts/reconcile_cross_dsn_order_feed_links.py tests/test_simple_risk.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen python -m py_compile app/config.py app/main.py app/trading/simple_risk.py app/trading/scheduler/simple_pipeline.py app/trading/order_feed.py app/trading/revenue_repair.py app/trading/submission_council.py app/trading/hypotheses.py app/trading/jangar_continuity.py app/trading/jangar_controller_ingestion_carry.py app/trading/profit_freshness_frontier.py scripts/reconcile_cross_dsn_order_feed_links.py tests/test_simple_risk.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen python scripts/reconcile_cross_dsn_order_feed_links.py --help`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
