### PR TITLE
fix(torghut): raise renewal memory limit

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -27,11 +27,11 @@ spec:
               resources:
                 requests:
                   cpu: 100m
-                  memory: 256Mi
+                  memory: 512Mi
                   ephemeral-storage: 256Mi
                 limits:
                   cpu: "1"
-                  memory: 1Gi
+                  memory: 2Gi
                   ephemeral-storage: 2Gi
               command:
                 - /bin/bash


### PR DESCRIPTION
## Summary

- Increase `torghut-empirical-promotion-renewal` memory request from `256Mi` to `512Mi`.
- Increase the renewal memory limit from `1Gi` to `2Gi` after the rollout smoke hit an OOM kill during proof renewal.
- Leave the renewal command sequence, proof gates, image, and promotion behavior unchanged.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
