### PR TITLE
revert(torghut): rollback failed promotion 7152297a60ca9dade339ece96cf7a32fb6a21324

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -27,11 +27,11 @@ spec:
               resources:
                 requests:
                   cpu: 100m
-                  memory: 512Mi
+                  memory: 256Mi
                   ephemeral-storage: 256Mi
                 limits:
                   cpu: "1"
-                  memory: 2Gi
+                  memory: 1Gi
                   ephemeral-storage: 2Gi
               command:
                 - /bin/bash


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `7152297a60ca9dade339ece96cf7a32fb6a21324`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/27390294733`
- Rollback source: `HEAD^` manifests from the failed run checkout