### PR TITLE
fix(torghut): bound renewal empirical row load

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -20,6 +20,7 @@ from zoneinfo import ZoneInfo
 import psycopg
 import yaml
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
 from app.models import AutoresearchEpoch, VNextEmpiricalJobRun
@@ -2250,6 +2251,30 @@ def _latest_authoritative_rows(
     return latest
 
 
+def _load_latest_empirical_job_rows(session: Session) -> list[VNextEmpiricalJobRun]:
+    """Load only the latest row for each empirical job type.
+
+    The renewal job only needs the most recent row per job type; reading the
+    full empirical job history can materialize years of JSON payloads in the
+    CronJob container.
+    """
+
+    rows: list[VNextEmpiricalJobRun] = []
+    for job_type in EMPIRICAL_JOB_TYPES:
+        row = session.scalars(
+            select(VNextEmpiricalJobRun)
+            .where(VNextEmpiricalJobRun.job_type == job_type)
+            .order_by(
+                VNextEmpiricalJobRun.created_at.desc(),
+                VNextEmpiricalJobRun.id.desc(),
+            )
+            .limit(1)
+        ).first()
+        if row is not None:
+            rows.append(row)
+    return rows
+
+
 def build_renewal_manifest(
     *,
     latest: Mapping[str, VNextEmpiricalJobRun],
@@ -3543,17 +3568,8 @@ def main() -> int:
     )
 
     with SessionLocal() as session:
-        rows = (
-            session.execute(
-                select(VNextEmpiricalJobRun).order_by(
-                    VNextEmpiricalJobRun.created_at.desc()
-                )
-            )
-            .scalars()
-            .all()
-        )
         manifest = build_renewal_manifest(
-            latest=_latest_authoritative_rows(rows),
+            latest=_latest_authoritative_rows(_load_latest_empirical_job_rows(session)),
             run_id=run_id,
             strategy_spec_ref=args.strategy_spec_ref,
             runtime_version_ref=_runtime_version_ref(),

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -2090,12 +2090,12 @@ class TestLiveConfigManifestContract(TestCase):
             {
                 "requests": {
                     "cpu": "100m",
-                    "memory": "256Mi",
+                    "memory": "512Mi",
                     "ephemeral-storage": "256Mi",
                 },
                 "limits": {
                     "cpu": "1",
-                    "memory": "1Gi",
+                    "memory": "2Gi",
                     "ephemeral-storage": "2Gi",
                 },
             },

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -8,7 +8,13 @@ from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import VNextEmpiricalJobRun
 from app.trading.empirical_jobs import (
+    EMPIRICAL_JOB_TYPES,
     build_empirical_benchmark_parity_report,
     build_empirical_foundation_router_parity_report,
     promote_janus_payload_to_empirical,
@@ -289,6 +295,82 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             "latest_empirical_jobs_missing:foundation_router_parity,janus_event_car,janus_hgrm_reward",
         ):
             renewal._latest_authoritative_rows(cast(Any, rows))
+
+    def test_load_latest_empirical_job_rows_reads_latest_per_job_type(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        VNextEmpiricalJobRun.__table__.create(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        old_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)
+        new_at = datetime(2026, 5, 19, 8, 13, tzinfo=timezone.utc)
+
+        with session_local() as session:
+            for job_type in EMPIRICAL_JOB_TYPES:
+                session.add(
+                    VNextEmpiricalJobRun(
+                        run_id=f"old-{job_type}",
+                        candidate_id="candidate-old",
+                        job_name=f"{job_type}-old",
+                        job_type=job_type,
+                        job_run_id=f"{job_type}-old",
+                        status="completed",
+                        authority="empirical",
+                        promotion_authority_eligible=True,
+                        dataset_snapshot_ref="snapshot-old",
+                        artifact_refs=[],
+                        payload_json={"marker": "old"},
+                        created_at=old_at,
+                        updated_at=old_at,
+                    )
+                )
+                session.add(
+                    VNextEmpiricalJobRun(
+                        run_id=f"new-{job_type}",
+                        candidate_id="candidate-new",
+                        job_name=f"{job_type}-new",
+                        job_type=job_type,
+                        job_run_id=f"{job_type}-new",
+                        status="completed",
+                        authority="empirical",
+                        promotion_authority_eligible=True,
+                        dataset_snapshot_ref="snapshot-new",
+                        artifact_refs=[],
+                        payload_json={"marker": "new"},
+                        created_at=new_at,
+                        updated_at=new_at,
+                    )
+                )
+            session.add(
+                VNextEmpiricalJobRun(
+                    run_id="irrelevant",
+                    candidate_id="candidate-new",
+                    job_name="irrelevant",
+                    job_type="irrelevant",
+                    job_run_id="irrelevant-new",
+                    status="completed",
+                    authority="empirical",
+                    promotion_authority_eligible=True,
+                    dataset_snapshot_ref="snapshot-new",
+                    artifact_refs=[],
+                    payload_json={"marker": "irrelevant"},
+                    created_at=new_at,
+                    updated_at=new_at,
+                )
+            )
+            session.commit()
+
+            rows = renewal._load_latest_empirical_job_rows(session)
+
+        self.assertEqual({row.job_type for row in rows}, set(EMPIRICAL_JOB_TYPES))
+        self.assertEqual({row.payload_json["marker"] for row in rows}, {"new"})
+        self.assertEqual(
+            {row.job_run_id for row in rows},
+            {f"{job_type}-new" for job_type in EMPIRICAL_JOB_TYPES},
+        )
 
     def test_runtime_version_ref_prefers_runtime_digest(self) -> None:
         with patch.dict(


### PR DESCRIPTION
## Summary

- Bounds empirical renewal metadata reads to the newest row per empirical job type.
- Preserves the existing fail-closed latest-authoritative-row checks.
- Adds a regression test proving stale historical rows and irrelevant job types are not selected.
- Updates the renewal CronJob manifest contract to match the already-rolled 512Mi/2Gi resource envelope.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_run_empirical_promotion_jobs.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
