### PR TITLE
fix(torghut): avoid loading decision payloads in census

### DIFF
--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -351,7 +351,17 @@ def _load_session_rows(
     source_account_label = _source_account_label(identity)
     account_labels = sorted({identity.account_label, source_account_label})
     decision_stmt = (
-        select(TradeDecision, Strategy.name)
+        select(
+            TradeDecision.id.label("id"),
+            TradeDecision.strategy_id.label("strategy_id"),
+            Strategy.name.label("strategy_name"),
+            TradeDecision.alpaca_account_label.label("alpaca_account_label"),
+            TradeDecision.symbol.label("symbol"),
+            TradeDecision.status.label("status"),
+            TradeDecision.decision_hash.label("decision_hash"),
+            TradeDecision.created_at.label("created_at"),
+            TradeDecision.executed_at.label("executed_at"),
+        )
         .join(Strategy, TradeDecision.strategy_id == Strategy.id)
         .where(TradeDecision.alpaca_account_label == identity.account_label)
         .where(Strategy.name == identity.runtime_strategy_name)
@@ -361,11 +371,9 @@ def _load_session_rows(
         decision_stmt = decision_stmt.where(TradeDecision.created_at >= started_at)
     if ended_at is not None:
         decision_stmt = decision_stmt.where(TradeDecision.created_at < ended_at)
-    decision_pairs = list(session.execute(decision_stmt).all())
-    decisions = [
-        _decision_row(row, strategy_name) for row, strategy_name in decision_pairs
-    ]
-    decision_ids = {str(row.id) for row, _strategy_name in decision_pairs}
+    decision_rows = list(session.execute(decision_stmt).mappings().all())
+    decisions = [_decision_projection_row(row) for row in decision_rows]
+    decision_ids = {str(row["id"]) for row in decision_rows}
 
     execution_stmt = (
         select(Execution)
@@ -2094,6 +2102,20 @@ def _decision_row(row: TradeDecision, strategy_name: str | None) -> dict[str, ob
         "decision_hash": row.decision_hash,
         "created_at": row.created_at,
         "executed_at": row.executed_at,
+    }
+
+
+def _decision_projection_row(row: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "id": str(row["id"]),
+        "strategy_id": str(row["strategy_id"]),
+        "strategy_name": row.get("strategy_name"),
+        "alpaca_account_label": row.get("alpaca_account_label"),
+        "symbol": row.get("symbol"),
+        "status": row.get("status"),
+        "decision_hash": row.get("decision_hash"),
+        "created_at": row.get("created_at"),
+        "executed_at": row.get("executed_at"),
     }
 
 

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -221,6 +221,9 @@ class _FakeResult:
     def __init__(self, rows: list[object]) -> None:
         self._rows = rows
 
+    def mappings(self) -> "_FakeResult":
+        return self
+
     def all(self) -> list[object]:
         return self._rows
 
@@ -325,7 +328,19 @@ def test_load_session_rows_adds_linked_source_account_windows() -> None:
         created_at=datetime(2026, 5, 1, 15, tzinfo=timezone.utc),
     )
     session = _FakeReadSession(
-        decision_pairs=[(decision, DEFAULT_HPAIRS_RUNTIME_STRATEGY)],
+        decision_pairs=[
+            {
+                "id": decision.id,
+                "strategy_id": decision.strategy_id,
+                "strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+                "alpaca_account_label": decision.alpaca_account_label,
+                "symbol": decision.symbol,
+                "status": decision.status,
+                "decision_hash": decision.decision_hash,
+                "created_at": decision.created_at,
+                "executed_at": decision.executed_at,
+            }
+        ],
         scalar_results=[[execution], [event], [], []],
     )
 
@@ -1234,8 +1249,23 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
     )
 
     class ExecuteResult:
-        def all(self) -> list[tuple[SimpleNamespace, str]]:
-            return [(decision, DEFAULT_HPAIRS_RUNTIME_STRATEGY)]
+        def mappings(self) -> "ExecuteResult":
+            return self
+
+        def all(self) -> list[dict[str, object]]:
+            return [
+                {
+                    "id": decision.id,
+                    "strategy_id": decision.strategy_id,
+                    "strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+                    "alpaca_account_label": decision.alpaca_account_label,
+                    "symbol": decision.symbol,
+                    "status": decision.status,
+                    "decision_hash": decision.decision_hash,
+                    "created_at": decision.created_at,
+                    "executed_at": decision.executed_at,
+                }
+            ]
 
     class ScalarResult:
         def __init__(self, rows: list[SimpleNamespace]) -> None:
@@ -1250,6 +1280,7 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
 
         def execute(self, statement: object) -> ExecuteResult:
             assert statement is not None
+            assert "decision_json" not in str(statement)
             return ExecuteResult()
 
         def scalars(self, statement: object) -> ScalarResult:


### PR DESCRIPTION
## Summary

- Project H-PAIRS census trade decisions to only the columns used by the source-proof report.
- Keep large `decision_json` payloads out of the renewal census read path that OOMKilled the CronJob.
- Update the census loader regression test to fail if `decision_json` re-enters the projected SELECT.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py`
- `uv run --frozen ruff format --check scripts/audit_hpairs_source_proof_census.py tests/test_audit_hpairs_source_proof_census.py`
- `uv run --frozen ruff check scripts/audit_hpairs_source_proof_census.py tests/test_audit_hpairs_source_proof_census.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
