### PR TITLE
fix(torghut): preserve proof target symbols

### DIFF
--- a/services/torghut/app/trading/proofs/service.py
+++ b/services/torghut/app/trading/proofs/service.py
@@ -7,8 +7,10 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from ...models import Strategy
 from .account_state import load_account_state
 from .health import build_health_payload
 from .ledger import load_runtime_ledger
@@ -32,6 +34,7 @@ from .targets import (
     isoformat,
     latest_closed_regular_equities_session_window,
     next_regular_equities_session_window,
+    proof_target_strategy_lookup_names_from_payloads,
     select_proof_targets,
 )
 
@@ -50,12 +53,18 @@ def build_proofs_payload(
 ) -> ProofsPayload:
     resolved_generated_at = generated_at or datetime.now(timezone.utc)
     bounded_limit = max(1, min(int(limit or DEFAULT_PROOFS_LIMIT), MAX_PROOFS_LIMIT))
+    strategy_universe_by_name = _load_strategy_universe_by_name(
+        session,
+        live_submission_gate=live_submission_gate,
+        route_reacquisition_book=route_reacquisition_book,
+    )
     targets = select_proof_targets(
         live_submission_gate=live_submission_gate,
         route_reacquisition_book=route_reacquisition_book,
         limit=bounded_limit,
         window=window,
         generated_at=resolved_generated_at,
+        strategy_universe_by_name=strategy_universe_by_name,
     )
     proofs = [
         _build_proof(
@@ -97,6 +106,28 @@ def build_proofs_payload(
             "reason": "proof_collection_only",
             "blockers": ["live_runtime_ledger_authority_required"],
         },
+    }
+
+
+def _load_strategy_universe_by_name(
+    session: Session,
+    *,
+    live_submission_gate: Mapping[str, Any],
+    route_reacquisition_book: Mapping[str, Any],
+) -> dict[str, object]:
+    names = proof_target_strategy_lookup_names_from_payloads(
+        live_submission_gate=live_submission_gate,
+        route_reacquisition_book=route_reacquisition_book,
+    )
+    if not names:
+        return {}
+    rows = session.execute(
+        select(Strategy.name, Strategy.universe_symbols).where(Strategy.name.in_(names))
+    ).all()
+    return {
+        str(name): universe_symbols
+        for name, universe_symbols in rows
+        if str(name or "").strip()
     }
 
 

--- a/services/torghut/app/trading/proofs/targets.py
+++ b/services/torghut/app/trading/proofs/targets.py
@@ -183,13 +183,12 @@ def select_proof_targets(
     limit: int,
     window: ProofWindowSelector,
     generated_at: datetime,
+    strategy_universe_by_name: Mapping[str, object] | None = None,
 ) -> list[ProofTarget]:
-    plan = mapping_value(
-        live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
+    raw_targets = _proof_target_mappings(
+        live_submission_gate=live_submission_gate,
+        route_reacquisition_book=route_reacquisition_book,
     )
-    raw_targets = mapping_items(plan.get("targets"))
-    if not raw_targets:
-        raw_targets = mapping_items(route_reacquisition_book.get("targets"))
 
     selected_start, selected_end = selected_window_bounds(
         "latest_closed" if window == "latest_closed" else "next",
@@ -203,6 +202,7 @@ def select_proof_targets(
             selector=window,
             selected_start=selected_start,
             selected_end=selected_end,
+            strategy_universe_by_name=strategy_universe_by_name or {},
         )
         if target is None:
             continue
@@ -221,6 +221,7 @@ def proof_target_from_mapping(
     selector: ProofWindowSelector,
     selected_start: datetime,
     selected_end: datetime,
+    strategy_universe_by_name: Mapping[str, object] | None = None,
 ) -> ProofTarget | None:
     raw = {str(key): value for key, value in target.items()}
     if selector == "auto":
@@ -244,6 +245,13 @@ def proof_target_from_mapping(
             *symbol_quantities.keys(),
         }
     )
+    if not symbols and strategy_universe_by_name:
+        strategy_symbols: set[str] = set()
+        for name in proof_target_strategy_lookup_names(raw):
+            strategy_symbols.update(_symbol_values(strategy_universe_by_name.get(name)))
+        symbols = sorted(strategy_symbols)
+    if not symbols:
+        return None
     account_label = text_value(raw.get("account_label")) or PROOFS_RUNTIME_ACCOUNT_LABEL
     strategy_name = text_value(raw.get("strategy_name"))
     runtime_strategy_name = (
@@ -270,6 +278,58 @@ def proof_target_from_mapping(
         window_start=window_start,
         window_end=window_end,
     )
+
+
+def proof_target_strategy_lookup_names(target: Mapping[str, Any]) -> tuple[str, ...]:
+    names: list[str] = []
+    for raw_value in (
+        target.get("strategy_lookup_names"),
+        target.get("runtime_strategy_name"),
+        target.get("strategy_name"),
+    ):
+        values: Sequence[object]
+        if isinstance(raw_value, Sequence) and not isinstance(
+            raw_value,
+            (str, bytes, bytearray),
+        ):
+            values = cast(Sequence[object], raw_value)
+        else:
+            values = (raw_value,)
+        for value in values:
+            name = str(value or "").strip()
+            if name and name not in names:
+                names.append(name)
+    return tuple(names)
+
+
+def proof_target_strategy_lookup_names_from_payloads(
+    *,
+    live_submission_gate: Mapping[str, Any],
+    route_reacquisition_book: Mapping[str, Any],
+) -> tuple[str, ...]:
+    names: list[str] = []
+    for target in _proof_target_mappings(
+        live_submission_gate=live_submission_gate,
+        route_reacquisition_book=route_reacquisition_book,
+    ):
+        for name in proof_target_strategy_lookup_names(target):
+            if name not in names:
+                names.append(name)
+    return tuple(names)
+
+
+def _proof_target_mappings(
+    *,
+    live_submission_gate: Mapping[str, Any],
+    route_reacquisition_book: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    plan = mapping_value(
+        live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
+    )
+    raw_targets = mapping_items(plan.get("targets"))
+    if not raw_targets:
+        raw_targets = mapping_items(route_reacquisition_book.get("targets"))
+    return raw_targets
 
 
 def _symbol_values(value: object) -> set[str]:

--- a/services/torghut/tests/test_proofs_service.py
+++ b/services/torghut/tests/test_proofs_service.py
@@ -91,6 +91,34 @@ def test_build_proofs_payload_reports_no_target() -> None:
     assert payload["promotion_authority"]["allowed"] is False
 
 
+def test_build_proofs_payload_fills_missing_symbols_from_strategy_universe() -> None:
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    window_end = datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc)
+    target = _target(window_start, window_end)
+    target.pop("paper_route_probe_symbols")
+    target.pop("paper_route_probe_symbol_actions")
+
+    with _session() as session:
+        session.add(
+            Strategy(
+                name="pairs-v1",
+                description="proof fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=[" amzn ", "", "AAPL", "AMZN"],
+            )
+        )
+        session.commit()
+        payload = _build(
+            session,
+            target=target,
+            generated_at=window_start - timedelta(minutes=1),
+        )
+
+    assert payload["proofs"][0]["symbols"] == ["AAPL", "AMZN"]
+
+
 def test_build_proofs_payload_waiting_and_collecting_states() -> None:
     window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
     window_end = datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_proofs_targets.py
+++ b/services/torghut/tests/test_proofs_targets.py
@@ -52,6 +52,60 @@ def test_select_proof_targets_dedupes_identity_window() -> None:
     assert targets[0].symbols == ("AAPL", "AMZN")
 
 
+def test_select_proof_targets_uses_strategy_universe_when_target_symbols_missing() -> (
+    None
+):
+    generated_at = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+
+    targets = select_proof_targets(
+        live_submission_gate={
+            "runtime_ledger_paper_probation_import_plan": {
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "candidate-1",
+                        "runtime_strategy_name": "pairs-v1",
+                        "account_label": "TORGHUT_SIM",
+                    }
+                ]
+            }
+        },
+        route_reacquisition_book={},
+        limit=20,
+        window="next",
+        generated_at=generated_at,
+        strategy_universe_by_name={"pairs-v1": [" amzn ", "", "AAPL", "AMZN"]},
+    )
+
+    assert len(targets) == 1
+    assert targets[0].symbols == ("AAPL", "AMZN")
+
+
+def test_select_proof_targets_skips_symbolless_targets() -> None:
+    generated_at = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+
+    targets = select_proof_targets(
+        live_submission_gate={
+            "runtime_ledger_paper_probation_import_plan": {
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "candidate-1",
+                        "runtime_strategy_name": "missing-symbols-v1",
+                        "account_label": "TORGHUT_SIM",
+                    }
+                ]
+            }
+        },
+        route_reacquisition_book={},
+        limit=20,
+        window="next",
+        generated_at=generated_at,
+    )
+
+    assert targets == []
+
+
 def test_target_plan_parser_accepts_proofs_payload() -> None:
     plan = paper_route_target_plan_from_payload(
         {


### PR DESCRIPTION
## Summary

- Restores canonical `/trading/proofs` paper-route target symbols when source targets only carry strategy identity.
- Loads the strategy universe from the Torghut database as the fallback symbol scope before building proof targets.
- Skips proof targets that still have no auditable symbol scope so post-deploy evidence cannot pass on empty symbol envelopes.

## Related Issues

Refs #10780.

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_proofs_targets.py tests/test_proofs_service.py tests/test_trading_proofs_api.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/proofs tests/test_proofs_targets.py tests/test_proofs_service.py tests/test_trading_proofs_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/proofs tests/test_proofs_targets.py tests/test_proofs_service.py tests/test_trading_proofs_api.py`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
