### PR TITLE
refactor(torghut): reduce pylint design hotspots

### DIFF
--- a/services/torghut/app/trading/quantity_rules.py
+++ b/services/torghut/app/trading/quantity_rules.py
@@ -178,15 +178,14 @@ def fractional_equities_enabled_for_trade(
     normalized_action = action.strip().lower()
     if normalized_action == "buy":
         return True
-    if normalized_action != "sell":
-        return False
-    if position_qty is None:
-        return False
-    if position_qty <= 0:
-        return False
-    if requested_qty is None or requested_qty <= 0:
-        return True
-    return requested_qty <= position_qty
+    return (
+        normalized_action == "sell"
+        and position_qty is not None
+        and position_qty > 0
+        and (
+            requested_qty is None or requested_qty <= 0 or requested_qty <= position_qty
+        )
+    )
 
 
 __all__ = [

--- a/services/torghut/app/trading/quote_quality.py
+++ b/services/torghut/app/trading/quote_quality.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -62,6 +62,18 @@ class QuoteQualityStatus:
         }
 
 
+@dataclass(frozen=True)
+class _QuoteQualityContext:
+    signal: SignalEnvelope
+    policy: QuoteQualityPolicy
+    price: Decimal | None
+    bid: Decimal | None
+    ask: Decimal | None
+    source: str | None
+    quote_age_seconds: Decimal | None
+    has_snapshot_fallback: bool
+
+
 class SignalQuoteQualityTracker:
     """Track last executable prices and reject non-executable quote states."""
 
@@ -90,153 +102,135 @@ def assess_signal_quote_quality(
     previous_price: Decimal | None,
     policy: QuoteQualityPolicy | None = None,
 ) -> QuoteQualityStatus:
-    effective_policy = policy or QuoteQualityPolicy()
-    price = _extract_price(signal)
-    bid = _extract_bid(signal)
-    ask = _extract_ask(signal)
-    source = _extract_quote_source(signal)
-    quote_age_seconds = _signal_quote_age_seconds(signal)
-    has_snapshot_fallback = _has_quote_snapshot_fallback(signal) or source is not None
-    if price is None and bid is None and ask is None and not has_snapshot_fallback:
-        return _status(
+    context = _quote_quality_context(signal=signal, policy=policy)
+    reason = _base_quote_reject_reason(context)
+    if reason is not None:
+        return _status_from_context(context, valid=False, reason=reason)
+
+    spread_bps = _signal_spread_bps(signal=signal, price=context.price)
+    reason = _policy_quote_reject_reason(context, spread_bps)
+    if reason is not None:
+        return _status_from_context(
+            context,
             valid=False,
-            reason="absent_snapshot_fallback",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if price is None or price <= 0:
-        return _status(
-            valid=False,
-            reason="non_positive_price",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if bid is None and ask is None:
-        return _status(
-            valid=False,
-            reason="missing_executable_quote",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if bid is None:
-        return _status(
-            valid=False,
-            reason="missing_bid",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if ask is None:
-        return _status(
-            valid=False,
-            reason="missing_ask",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if bid <= 0:
-        return _status(
-            valid=False,
-            reason="non_positive_bid",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if ask <= 0:
-        return _status(
-            valid=False,
-            reason="non_positive_ask",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if ask < bid:
-        return _status(
-            valid=False,
-            reason="crossed_quote",
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
+            reason=reason,
+            spread_bps=spread_bps,
         )
 
-    spread_bps = _signal_spread_bps(signal=signal, price=price)
-    if (
-        quote_age_seconds is not None
-        and effective_policy.max_executable_quote_age_seconds is not None
-        and quote_age_seconds
-        > Decimal(str(effective_policy.max_executable_quote_age_seconds))
-    ):
-        return _status(
-            valid=False,
-            reason="stale_quote",
-            spread_bps=spread_bps,
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-    if (
-        spread_bps is not None
-        and spread_bps > effective_policy.max_executable_spread_bps
-    ):
-        return _status(
-            valid=False,
-            reason="spread_bps_exceeded",
-            spread_bps=spread_bps,
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
-        )
-
-    jump_bps = _signal_mid_jump_bps(price=price, reference_price=previous_price)
-    if (
-        jump_bps is not None
-        and jump_bps > effective_policy.max_quote_mid_jump_bps
-        and spread_bps is not None
-        and spread_bps > effective_policy.max_jump_with_wide_spread_bps
-    ):
-        return _status(
+    jump_bps = _signal_mid_jump_bps(
+        price=context.price,
+        reference_price=previous_price,
+    )
+    if _has_wide_spread_midpoint_jump(context, spread_bps, jump_bps):
+        return _status_from_context(
+            context,
             valid=False,
             reason="wide_spread_midpoint_jump",
             spread_bps=spread_bps,
             jump_bps=jump_bps,
-            quote_age_seconds=quote_age_seconds,
-            source=source,
-            price=price,
-            bid=bid,
-            ask=ask,
         )
-    return _status(
+    return _status_from_context(
+        context,
         valid=True,
         spread_bps=spread_bps,
         jump_bps=jump_bps,
-        quote_age_seconds=quote_age_seconds,
+    )
+
+
+def _quote_quality_context(
+    *,
+    signal: SignalEnvelope,
+    policy: QuoteQualityPolicy | None,
+) -> _QuoteQualityContext:
+    source = _extract_quote_source(signal)
+    return _QuoteQualityContext(
+        signal=signal,
+        policy=policy or QuoteQualityPolicy(),
+        price=_extract_price(signal),
+        bid=_extract_bid(signal),
+        ask=_extract_ask(signal),
         source=source,
-        price=price,
-        bid=bid,
-        ask=ask,
+        quote_age_seconds=_signal_quote_age_seconds(signal),
+        has_snapshot_fallback=_has_quote_snapshot_fallback(signal)
+        or source is not None,
+    )
+
+
+def _base_quote_reject_reason(context: _QuoteQualityContext) -> str | None:
+    checks: tuple[tuple[Callable[[], bool], str], ...] = (
+        (
+            lambda: (
+                context.price is None
+                and context.bid is None
+                and context.ask is None
+                and not context.has_snapshot_fallback
+            ),
+            "absent_snapshot_fallback",
+        ),
+        (lambda: context.price is None or context.price <= 0, "non_positive_price"),
+        (
+            lambda: context.bid is None and context.ask is None,
+            "missing_executable_quote",
+        ),
+        (lambda: context.bid is None, "missing_bid"),
+        (lambda: context.ask is None, "missing_ask"),
+        (lambda: cast(Decimal, context.bid) <= 0, "non_positive_bid"),
+        (lambda: cast(Decimal, context.ask) <= 0, "non_positive_ask"),
+        (
+            lambda: cast(Decimal, context.ask) < cast(Decimal, context.bid),
+            "crossed_quote",
+        ),
+    )
+    return next((reason for failed, reason in checks if failed()), None)
+
+
+def _policy_quote_reject_reason(
+    context: _QuoteQualityContext,
+    spread_bps: Decimal | None,
+) -> str | None:
+    if (
+        context.quote_age_seconds is not None
+        and context.policy.max_executable_quote_age_seconds is not None
+        and context.quote_age_seconds
+        > Decimal(str(context.policy.max_executable_quote_age_seconds))
+    ):
+        return "stale_quote"
+    if spread_bps is not None and spread_bps > context.policy.max_executable_spread_bps:
+        return "spread_bps_exceeded"
+    return None
+
+
+def _has_wide_spread_midpoint_jump(
+    context: _QuoteQualityContext,
+    spread_bps: Decimal | None,
+    jump_bps: Decimal | None,
+) -> bool:
+    return (
+        jump_bps is not None
+        and jump_bps > context.policy.max_quote_mid_jump_bps
+        and spread_bps is not None
+        and spread_bps > context.policy.max_jump_with_wide_spread_bps
+    )
+
+
+def _status_from_context(
+    context: _QuoteQualityContext,
+    *,
+    valid: bool,
+    reason: str | None = None,
+    spread_bps: Decimal | None = None,
+    jump_bps: Decimal | None = None,
+) -> QuoteQualityStatus:
+    return _status(
+        valid=valid,
+        reason=reason,
+        spread_bps=spread_bps,
+        jump_bps=jump_bps,
+        quote_age_seconds=context.quote_age_seconds,
+        source=context.source,
+        price=context.price,
+        bid=context.bid,
+        ask=context.ask,
     )
 
 

--- a/services/torghut/app/trading/regime.py
+++ b/services/torghut/app/trading/regime.py
@@ -75,21 +75,12 @@ def _classify_volatility(
     prices: list[Decimal],
 ) -> VolatilityBucket:
     if volatilities:
-        avg_vol = _decimal_mean(volatilities)
-        if avg_vol < Decimal("0.01"):
-            return "low"
-        if avg_vol < Decimal("0.03"):
-            return "mid"
-        return "high"
+        return _volatility_bucket_from_average(_decimal_mean(volatilities))
 
     price_vol = _average_abs_pct_change(prices)
     if price_vol is None:
         return "unknown"
-    if price_vol < Decimal("0.002"):
-        return "low"
-    if price_vol < Decimal("0.01"):
-        return "mid"
-    return "high"
+    return _price_volatility_bucket(price_vol)
 
 
 def _classify_trend(
@@ -97,26 +88,50 @@ def _classify_trend(
     macd_diffs: list[Decimal],
 ) -> TrendBucket:
     if len(prices) >= 2:
-        start = prices[0]
-        end = prices[-1]
-        if start == 0:
-            return "unknown"
-        change = (end - start) / start
-        if change >= Decimal("0.002"):
-            return "up"
-        if change <= Decimal("-0.002"):
-            return "down"
-        return "flat"
+        return _trend_bucket_from_price_change(prices[0], prices[-1])
 
     if macd_diffs:
-        avg_macd = _decimal_mean(macd_diffs)
-        if avg_macd >= Decimal("0.05"):
-            return "up"
-        if avg_macd <= Decimal("-0.05"):
-            return "down"
-        return "flat"
+        return _trend_bucket_from_average_macd(_decimal_mean(macd_diffs))
 
     return "unknown"
+
+
+def _volatility_bucket_from_average(avg_volatility: Decimal) -> VolatilityBucket:
+    if avg_volatility < Decimal("0.01"):
+        return "low"
+    if avg_volatility < Decimal("0.03"):
+        return "mid"
+    return "high"
+
+
+def _price_volatility_bucket(price_volatility: Decimal) -> VolatilityBucket:
+    if price_volatility < Decimal("0.002"):
+        return "low"
+    if price_volatility < Decimal("0.01"):
+        return "mid"
+    return "high"
+
+
+def _trend_bucket_from_price_change(
+    start: Decimal,
+    end: Decimal,
+) -> TrendBucket:
+    if start == 0:
+        return "unknown"
+    change = (end - start) / start
+    if change >= Decimal("0.002"):
+        return "up"
+    if change <= Decimal("-0.002"):
+        return "down"
+    return "flat"
+
+
+def _trend_bucket_from_average_macd(avg_macd: Decimal) -> TrendBucket:
+    if avg_macd >= Decimal("0.05"):
+        return "up"
+    if avg_macd <= Decimal("-0.05"):
+        return "down"
+    return "flat"
 
 
 def _classify_liquidity(

--- a/services/torghut/app/trading/simple_risk.py
+++ b/services/torghut/app/trading/simple_risk.py
@@ -29,6 +29,62 @@ class SimpleRiskPreparation:
     diagnostics: dict[str, Any] | None = None
 
 
+@dataclass(frozen=True)
+class _SimpleRiskRequest:
+    decision: StrategyDecision
+    account: dict[str, str]
+    positions: list[dict[str, Any]]
+    fractional_equities_enabled: bool
+    allow_shorts: bool
+    max_notional_per_order: Decimal | None
+    max_notional_per_symbol: Decimal | None
+    buying_power_reserve_bps: Decimal
+    max_order_pct_equity: Decimal | None
+    max_gross_exposure_pct_equity: Decimal | None
+    require_equity_for_exposure_increase: bool
+
+
+@dataclass(frozen=True)
+class _SimpleRiskContext:
+    decision: StrategyDecision
+    price: Decimal
+    current_qty: Decimal
+    resolution: QuantityResolution
+    min_qty: Decimal
+    quantized_qty: Decimal
+    normalized_action: str
+    exposure_increase_qty: Decimal
+    non_increasing_qty_allowance: Decimal
+    diagnostics: dict[str, Any]
+
+    @property
+    def enforce_exposure(self) -> bool:
+        return self.exposure_increase_qty > 0
+
+    @property
+    def short_increasing(self) -> bool:
+        return (
+            self.normalized_action == "sell"
+            and self.exposure_increase_qty > Decimal("0")
+        )
+
+
+@dataclass
+class _SimpleRiskCaps:
+    adjusted_qty: Decimal
+    capped_by_order: bool = False
+    capped_by_symbol: bool = False
+    capped_by_gross: bool = False
+    capped_by_buying_power: bool = False
+    buying_power: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class _SimpleRiskFinal:
+    notional: Decimal
+    buying_power_required: Decimal
+
+
 def position_qty_for_symbol(
     positions: list[dict[str, Any]],
     symbol: str,
@@ -99,6 +155,83 @@ def prepare_simple_decision(
     max_gross_exposure_pct_equity: Decimal | None = None,
     require_equity_for_exposure_increase: bool = False,
 ) -> SimpleRiskPreparation:
+    return _prepare_simple_risk_request(
+        _SimpleRiskRequest(
+            decision=decision,
+            account=account,
+            positions=positions,
+            fractional_equities_enabled=fractional_equities_enabled,
+            allow_shorts=allow_shorts,
+            max_notional_per_order=max_notional_per_order,
+            max_notional_per_symbol=max_notional_per_symbol,
+            buying_power_reserve_bps=buying_power_reserve_bps,
+            max_order_pct_equity=max_order_pct_equity,
+            max_gross_exposure_pct_equity=max_gross_exposure_pct_equity,
+            require_equity_for_exposure_increase=require_equity_for_exposure_increase,
+        )
+    )
+
+
+def _prepare_simple_risk_request(
+    request: _SimpleRiskRequest,
+) -> SimpleRiskPreparation:
+    context, rejection = _build_simple_risk_context(
+        decision=request.decision,
+        positions=request.positions,
+        fractional_equities_enabled=request.fractional_equities_enabled,
+        allow_shorts=request.allow_shorts,
+    )
+    if rejection is not None:
+        return rejection
+    if context is None:
+        raise RuntimeError("simple_risk_context_missing")
+
+    rejection = _initial_simple_risk_rejection(
+        context=context,
+        account=request.account,
+        allow_shorts=request.allow_shorts,
+        require_equity_for_exposure_increase=(
+            request.require_equity_for_exposure_increase
+        ),
+        max_order_pct_equity=request.max_order_pct_equity,
+        max_gross_exposure_pct_equity=request.max_gross_exposure_pct_equity,
+    )
+    if rejection is not None:
+        return rejection
+
+    caps = _apply_simple_risk_caps(
+        context=context,
+        account=request.account,
+        positions=request.positions,
+        buying_power_reserve_bps=request.buying_power_reserve_bps,
+        max_notional_per_order=request.max_notional_per_order,
+        max_notional_per_symbol=request.max_notional_per_symbol,
+        max_order_pct_equity=request.max_order_pct_equity,
+        max_gross_exposure_pct_equity=request.max_gross_exposure_pct_equity,
+    )
+    rejection = _final_quantity_rejection(context=context, caps=caps)
+    if rejection is not None:
+        return rejection
+
+    final = _build_simple_risk_final(context=context, caps=caps)
+    rejection = _buying_power_rejection(
+        context=context,
+        caps=caps,
+        final=final,
+        buying_power_reserve_bps=request.buying_power_reserve_bps,
+    )
+    if rejection is not None:
+        return rejection
+    return _approved_simple_risk(context=context, caps=caps, final=final)
+
+
+def _build_simple_risk_context(
+    *,
+    decision: StrategyDecision,
+    positions: list[dict[str, Any]],
+    fractional_equities_enabled: bool,
+    allow_shorts: bool,
+) -> tuple[_SimpleRiskContext | None, SimpleRiskPreparation | None]:
     price = _extract_decision_price(decision)
     current_qty = position_qty_for_symbol(positions, decision.symbol)
     resolution = resolve_quantity_resolution(
@@ -124,11 +257,9 @@ def prepare_simple_decision(
         "min_qty": str(min_qty),
         "quantity_resolution": resolution.to_payload(),
     }
-
     if price is None or price <= 0:
         diagnostics["price"] = None if price is None else str(price)
-        return SimpleRiskPreparation(
-            approved=False,
+        return None, _rejected_simple_risk_preparation(
             decision=decision,
             quantity_resolution=resolution,
             notional=None,
@@ -137,318 +268,459 @@ def prepare_simple_decision(
         )
 
     diagnostics["price"] = str(price)
-    raw_target_sizing = decision.params.get("target_sizing")
-    if isinstance(raw_target_sizing, Mapping):
-        target_sizing = target_sizing_payload(
-            cast(Mapping[str, Any], raw_target_sizing)
-        )
-        diagnostics["target_sizing"] = target_sizing
-        if target_sizing["blocking_reasons"]:
-            return SimpleRiskPreparation(
-                approved=False,
-                decision=decision,
-                quantity_resolution=resolution,
-                notional=price * quantized_qty if quantized_qty > 0 else Decimal("0"),
-                reject_reason="target_sizing_blocked",
-                diagnostics=diagnostics,
-            )
-
-    if quantized_qty <= 0 or quantized_qty < min_qty:
-        return SimpleRiskPreparation(
-            approved=False,
-            decision=decision,
-            quantity_resolution=resolution,
-            notional=price * quantized_qty if quantized_qty > 0 else Decimal("0"),
-            reject_reason="qty_below_min_after_clamp",
-            diagnostics=diagnostics,
-        )
-    if not qty_has_valid_increment(
-        decision.symbol,
-        quantized_qty,
-        fractional_equities_enabled=resolution.fractional_allowed,
-    ):
-        return SimpleRiskPreparation(
-            approved=False,
-            decision=decision,
-            quantity_resolution=resolution,
-            notional=price * quantized_qty,
-            reject_reason="invalid_qty_increment",
-            diagnostics=diagnostics,
-        )
-
     normalized_action = decision.action.strip().lower()
     exposure_increase_qty = _exposure_increase_qty(
         action=normalized_action,
         qty=quantized_qty,
         current_qty=current_qty,
     )
-    non_increasing_qty_allowance = quantized_qty - exposure_increase_qty
-    diagnostics["current_qty"] = str(current_qty)
-    diagnostics["exposure_increase_qty"] = str(exposure_increase_qty)
-    diagnostics["non_increasing_qty_allowance"] = str(non_increasing_qty_allowance)
-    short_increasing = normalized_action == "sell" and exposure_increase_qty > 0
-    if short_increasing and not allow_shorts:
-        return SimpleRiskPreparation(
-            approved=False,
-            decision=decision,
-            quantity_resolution=resolution,
-            notional=price * quantized_qty,
-            reject_reason="shorting_not_allowed_for_asset",
-            diagnostics=diagnostics,
-        )
-
-    enforce_exposure = exposure_increase_qty > 0
-    adjusted_qty = quantized_qty
-    capped_by_order = False
-    capped_by_symbol = False
-    capped_by_gross = False
-    capped_by_buying_power = False
-    buying_power: Decimal | None = None
-    equity = _resolve_decimal(account.get("equity"))
-    diagnostics["equity"] = str(equity) if equity is not None else None
-    if require_equity_for_exposure_increase and enforce_exposure and equity is None:
-        return SimpleRiskPreparation(
-            approved=False,
-            decision=decision,
-            quantity_resolution=resolution,
-            notional=price * quantized_qty,
-            reject_reason="equity_required_for_exposure_increase",
-            diagnostics=diagnostics,
-        )
-
-    if (
-        enforce_exposure
-        and max_notional_per_order is not None
-        and max_notional_per_order >= 0
-    ):
-        order_cap_qty = _cap_qty_by_new_exposure_notional(
+    return (
+        _SimpleRiskContext(
             decision=decision,
             price=price,
             current_qty=current_qty,
-            cap_notional=max_notional_per_order,
-            fractional_equities_enabled=resolution.fractional_allowed,
-        )
-        if order_cap_qty < adjusted_qty:
-            adjusted_qty = order_cap_qty
-            capped_by_order = True
-
-    if (
-        enforce_exposure
-        and max_order_pct_equity is not None
-        and max_order_pct_equity >= 0
-    ):
-        if equity is None:
-            return SimpleRiskPreparation(
-                approved=False,
-                decision=decision,
-                quantity_resolution=resolution,
-                notional=price * quantized_qty,
-                reject_reason="equity_required_for_exposure_increase",
-                diagnostics=diagnostics,
-            )
-        equity_order_cap_notional = equity * max_order_pct_equity
-        diagnostics["max_order_pct_equity"] = str(max_order_pct_equity)
-        diagnostics["equity_order_cap_notional"] = str(equity_order_cap_notional)
-        order_cap_qty = _cap_qty_by_new_exposure_notional(
-            decision=decision,
-            price=price,
-            current_qty=current_qty,
-            cap_notional=equity_order_cap_notional,
-            fractional_equities_enabled=resolution.fractional_allowed,
-        )
-        if order_cap_qty < adjusted_qty:
-            adjusted_qty = order_cap_qty
-            capped_by_order = True
-
-    if (
-        enforce_exposure
-        and max_notional_per_symbol is not None
-        and max_notional_per_symbol >= 0
-    ):
-        current_abs_value = abs(
-            position_value_for_symbol(
-                positions,
-                decision.symbol,
-                fallback_price=price,
-            )
-        )
-        remaining_notional = max_notional_per_symbol - current_abs_value
-        diagnostics["current_symbol_abs_notional"] = str(current_abs_value)
-        diagnostics["remaining_symbol_notional_room"] = str(remaining_notional)
-        if remaining_notional <= 0:
-            symbol_cap_qty = _non_increasing_qty_allowance(
-                action=normalized_action,
-                current_qty=current_qty,
-            )
-            adjusted_qty = min(adjusted_qty, symbol_cap_qty)
-            capped_by_symbol = True
-        else:
-            symbol_cap_qty = _cap_qty_by_new_exposure_notional(
-                decision=decision,
-                price=price,
-                current_qty=current_qty,
-                cap_notional=remaining_notional,
-                fractional_equities_enabled=resolution.fractional_allowed,
-            )
-            if symbol_cap_qty < adjusted_qty:
-                adjusted_qty = symbol_cap_qty
-                capped_by_symbol = True
-
-    if (
-        enforce_exposure
-        and max_gross_exposure_pct_equity is not None
-        and max_gross_exposure_pct_equity >= 0
-    ):
-        if equity is None:
-            return SimpleRiskPreparation(
-                approved=False,
-                decision=decision,
-                quantity_resolution=resolution,
-                notional=price * quantized_qty,
-                reject_reason="equity_required_for_exposure_increase",
-                diagnostics=diagnostics,
-            )
-        current_gross_notional = portfolio_gross_notional(
-            positions,
-            decision.symbol,
-            fallback_price=price,
-        )
-        gross_cap_notional = equity * max_gross_exposure_pct_equity
-        remaining_gross_notional = gross_cap_notional - current_gross_notional
-        diagnostics["max_gross_exposure_pct_equity"] = str(
-            max_gross_exposure_pct_equity
-        )
-        diagnostics["current_gross_notional"] = str(current_gross_notional)
-        diagnostics["gross_cap_notional"] = str(gross_cap_notional)
-        diagnostics["remaining_gross_notional_room"] = str(remaining_gross_notional)
-        if remaining_gross_notional <= 0:
-            gross_cap_qty = _non_increasing_qty_allowance(
-                action=normalized_action,
-                current_qty=current_qty,
-            )
-        else:
-            gross_cap_qty = _cap_qty_by_new_exposure_notional(
-                decision=decision,
-                price=price,
-                current_qty=current_qty,
-                cap_notional=remaining_gross_notional,
-                fractional_equities_enabled=resolution.fractional_allowed,
-            )
-        if gross_cap_qty < adjusted_qty:
-            adjusted_qty = gross_cap_qty
-            capped_by_gross = True
-
-    if enforce_exposure:
-        buying_power = _resolve_decimal(account.get("buying_power"))
-        diagnostics["buying_power"] = (
-            str(buying_power) if buying_power is not None else None
-        )
-        if buying_power is not None:
-            effective_buying_power = _buying_power_after_reserve(
-                buying_power=buying_power,
-                reserve_bps=buying_power_reserve_bps,
-            )
-            diagnostics["buying_power_reserve_bps"] = str(buying_power_reserve_bps)
-            diagnostics["buying_power_after_reserve"] = str(effective_buying_power)
-            buying_power_cap_qty = _buying_power_cap_qty(
-                decision=decision,
-                price=price,
-                buying_power=max(effective_buying_power, Decimal("0")),
-                current_qty=current_qty,
-                fractional_allowed=resolution.fractional_allowed,
-            )
-            diagnostics["buying_power_cap_qty"] = str(buying_power_cap_qty)
-            if buying_power_cap_qty < adjusted_qty:
-                adjusted_qty = buying_power_cap_qty
-                capped_by_buying_power = True
-
-    diagnostics["final_qty"] = str(adjusted_qty)
-    if adjusted_qty <= 0 or adjusted_qty < min_qty:
-        reject_reason = "qty_below_min_after_clamp"
-        if capped_by_symbol:
-            reject_reason = "max_symbol_exposure_exceeded"
-        elif capped_by_gross:
-            reject_reason = "max_gross_exposure_exceeded"
-        elif capped_by_buying_power:
-            reject_reason = "insufficient_buying_power"
-        elif capped_by_order:
-            reject_reason = "max_notional_exceeded"
-        return SimpleRiskPreparation(
-            approved=False,
-            decision=decision,
-            quantity_resolution=resolution,
-            notional=price * adjusted_qty if adjusted_qty > 0 else Decimal("0"),
-            reject_reason=reject_reason,
+            resolution=resolution,
+            min_qty=min_qty,
+            quantized_qty=quantized_qty,
+            normalized_action=normalized_action,
+            exposure_increase_qty=exposure_increase_qty,
+            non_increasing_qty_allowance=quantized_qty - exposure_increase_qty,
             diagnostics=diagnostics,
+        ),
+        None,
+    )
+
+
+def _initial_simple_risk_rejection(
+    *,
+    context: _SimpleRiskContext,
+    account: dict[str, str],
+    allow_shorts: bool,
+    require_equity_for_exposure_increase: bool,
+    max_order_pct_equity: Decimal | None,
+    max_gross_exposure_pct_equity: Decimal | None,
+) -> SimpleRiskPreparation | None:
+    target_sizing_rejection = _target_sizing_rejection(context)
+    if target_sizing_rejection is not None:
+        return target_sizing_rejection
+    if context.quantized_qty <= 0 or context.quantized_qty < context.min_qty:
+        return _rejected_simple_risk_preparation(
+            decision=context.decision,
+            quantity_resolution=context.resolution,
+            notional=_positive_notional(context.price, context.quantized_qty),
+            reject_reason="qty_below_min_after_clamp",
+            diagnostics=context.diagnostics,
         )
     if not qty_has_valid_increment(
-        decision.symbol,
-        adjusted_qty,
-        fractional_equities_enabled=resolution.fractional_allowed,
+        context.decision.symbol,
+        context.quantized_qty,
+        fractional_equities_enabled=context.resolution.fractional_allowed,
     ):
-        return SimpleRiskPreparation(
-            approved=False,
-            decision=decision,
-            quantity_resolution=resolution,
-            notional=price * adjusted_qty,
+        return _rejected_simple_risk_preparation(
+            decision=context.decision,
+            quantity_resolution=context.resolution,
+            notional=context.price * context.quantized_qty,
             reject_reason="invalid_qty_increment",
-            diagnostics=diagnostics,
+            diagnostics=context.diagnostics,
         )
+    if context.short_increasing and not allow_shorts:
+        return _rejected_simple_risk_preparation(
+            decision=context.decision,
+            quantity_resolution=context.resolution,
+            notional=context.price * context.quantized_qty,
+            reject_reason="shorting_not_allowed_for_asset",
+            diagnostics=context.diagnostics,
+        )
+    equity = _resolve_equity(context, account)
+    if _equity_required_for_exposure(
+        context=context,
+        equity=equity,
+        require_equity_for_exposure_increase=require_equity_for_exposure_increase,
+        max_order_pct_equity=max_order_pct_equity,
+        max_gross_exposure_pct_equity=max_gross_exposure_pct_equity,
+    ):
+        return _rejected_simple_risk_preparation(
+            decision=context.decision,
+            quantity_resolution=context.resolution,
+            notional=context.price * context.quantized_qty,
+            reject_reason="equity_required_for_exposure_increase",
+            diagnostics=context.diagnostics,
+        )
+    return None
 
-    notional = price * adjusted_qty
-    diagnostics["final_notional"] = str(notional)
-    buying_power_required = _buying_power_required_notional(
-        decision=decision,
-        qty=adjusted_qty,
-        price=price,
-        current_qty=current_qty,
+
+def _target_sizing_rejection(
+    context: _SimpleRiskContext,
+) -> SimpleRiskPreparation | None:
+    raw_target_sizing = context.decision.params.get("target_sizing")
+    if not isinstance(raw_target_sizing, Mapping):
+        return None
+    target_sizing = target_sizing_payload(cast(Mapping[str, Any], raw_target_sizing))
+    context.diagnostics["target_sizing"] = target_sizing
+    if not target_sizing["blocking_reasons"]:
+        return None
+    return _rejected_simple_risk_preparation(
+        decision=context.decision,
+        quantity_resolution=context.resolution,
+        notional=_positive_notional(context.price, context.quantized_qty),
+        reject_reason="target_sizing_blocked",
+        diagnostics=context.diagnostics,
     )
-    diagnostics["buying_power_required_notional"] = str(buying_power_required)
-    if not enforce_exposure:
-        diagnostics.setdefault("buying_power_cap_qty", str(adjusted_qty))
-    if enforce_exposure:
-        effective_buying_power = (
-            _buying_power_after_reserve(
-                buying_power=buying_power,
-                reserve_bps=buying_power_reserve_bps,
-            )
-            if buying_power is not None
-            else None
-        )
-        if (
-            effective_buying_power is not None
-            and buying_power_required > effective_buying_power
-        ):
-            return SimpleRiskPreparation(
-                approved=False,
-                decision=decision,
-                quantity_resolution=resolution,
-                notional=notional,
-                reject_reason="insufficient_buying_power",
-                diagnostics=diagnostics,
-            )
 
-    params = dict(decision.params)
+
+def _equity_required_for_exposure(
+    *,
+    context: _SimpleRiskContext,
+    equity: Decimal | None,
+    require_equity_for_exposure_increase: bool,
+    max_order_pct_equity: Decimal | None,
+    max_gross_exposure_pct_equity: Decimal | None,
+) -> bool:
+    if not context.enforce_exposure or equity is not None:
+        return False
+    return (
+        require_equity_for_exposure_increase
+        or _non_negative_limit(max_order_pct_equity)
+        or _non_negative_limit(max_gross_exposure_pct_equity)
+    )
+
+
+def _resolve_equity(
+    context: _SimpleRiskContext,
+    account: dict[str, str],
+) -> Decimal | None:
+    equity = _resolve_decimal(account.get("equity"))
+    context.diagnostics["equity"] = str(equity) if equity is not None else None
+    return equity
+
+
+def _apply_simple_risk_caps(
+    *,
+    context: _SimpleRiskContext,
+    account: dict[str, str],
+    positions: list[dict[str, Any]],
+    buying_power_reserve_bps: Decimal,
+    max_notional_per_order: Decimal | None,
+    max_notional_per_symbol: Decimal | None,
+    max_order_pct_equity: Decimal | None,
+    max_gross_exposure_pct_equity: Decimal | None,
+) -> _SimpleRiskCaps:
+    caps = _SimpleRiskCaps(adjusted_qty=context.quantized_qty)
+    if context.enforce_exposure:
+        equity = _resolve_equity(context, account)
+        _apply_order_notional_cap(context, caps, max_notional_per_order)
+        _apply_equity_order_cap(context, caps, equity, max_order_pct_equity)
+        _apply_symbol_notional_cap(context, caps, positions, max_notional_per_symbol)
+        _apply_gross_exposure_cap(
+            context,
+            caps,
+            positions,
+            equity,
+            max_gross_exposure_pct_equity,
+        )
+        _apply_buying_power_cap(
+            context,
+            caps,
+            account=account,
+            buying_power_reserve_bps=buying_power_reserve_bps,
+        )
+    context.diagnostics["final_qty"] = str(caps.adjusted_qty)
+    return caps
+
+
+def _apply_order_notional_cap(
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+    max_notional_per_order: Decimal | None,
+) -> None:
+    if not _non_negative_limit(max_notional_per_order):
+        return
+    order_cap_qty = _cap_qty_by_new_exposure_notional(
+        decision=context.decision,
+        price=context.price,
+        current_qty=context.current_qty,
+        cap_notional=cast(Decimal, max_notional_per_order),
+        fractional_equities_enabled=context.resolution.fractional_allowed,
+    )
+    if order_cap_qty < caps.adjusted_qty:
+        caps.adjusted_qty = order_cap_qty
+        caps.capped_by_order = True
+
+
+def _apply_equity_order_cap(
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+    equity: Decimal | None,
+    max_order_pct_equity: Decimal | None,
+) -> None:
+    if equity is None or not _non_negative_limit(max_order_pct_equity):
+        return
+    equity_order_cap_notional = equity * cast(Decimal, max_order_pct_equity)
+    context.diagnostics["max_order_pct_equity"] = str(max_order_pct_equity)
+    context.diagnostics["equity_order_cap_notional"] = str(equity_order_cap_notional)
+    order_cap_qty = _cap_qty_by_new_exposure_notional(
+        decision=context.decision,
+        price=context.price,
+        current_qty=context.current_qty,
+        cap_notional=equity_order_cap_notional,
+        fractional_equities_enabled=context.resolution.fractional_allowed,
+    )
+    if order_cap_qty < caps.adjusted_qty:
+        caps.adjusted_qty = order_cap_qty
+        caps.capped_by_order = True
+
+
+def _apply_symbol_notional_cap(
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+    positions: list[dict[str, Any]],
+    max_notional_per_symbol: Decimal | None,
+) -> None:
+    if not _non_negative_limit(max_notional_per_symbol):
+        return
+    current_abs_value = abs(
+        position_value_for_symbol(
+            positions,
+            context.decision.symbol,
+            fallback_price=context.price,
+        )
+    )
+    remaining_notional = cast(Decimal, max_notional_per_symbol) - current_abs_value
+    context.diagnostics["current_symbol_abs_notional"] = str(current_abs_value)
+    context.diagnostics["remaining_symbol_notional_room"] = str(remaining_notional)
+    symbol_cap_qty = (
+        _non_increasing_qty_allowance(
+            action=context.normalized_action,
+            current_qty=context.current_qty,
+        )
+        if remaining_notional <= 0
+        else _cap_qty_by_new_exposure_notional(
+            decision=context.decision,
+            price=context.price,
+            current_qty=context.current_qty,
+            cap_notional=remaining_notional,
+            fractional_equities_enabled=context.resolution.fractional_allowed,
+        )
+    )
+    if symbol_cap_qty < caps.adjusted_qty:
+        caps.adjusted_qty = symbol_cap_qty
+        caps.capped_by_symbol = True
+
+
+def _apply_gross_exposure_cap(
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+    positions: list[dict[str, Any]],
+    equity: Decimal | None,
+    max_gross_exposure_pct_equity: Decimal | None,
+) -> None:
+    if equity is None or not _non_negative_limit(max_gross_exposure_pct_equity):
+        return
+    current_gross_notional = portfolio_gross_notional(
+        positions,
+        context.decision.symbol,
+        fallback_price=context.price,
+    )
+    gross_cap_notional = equity * cast(Decimal, max_gross_exposure_pct_equity)
+    remaining_gross_notional = gross_cap_notional - current_gross_notional
+    context.diagnostics["max_gross_exposure_pct_equity"] = str(
+        max_gross_exposure_pct_equity
+    )
+    context.diagnostics["current_gross_notional"] = str(current_gross_notional)
+    context.diagnostics["gross_cap_notional"] = str(gross_cap_notional)
+    context.diagnostics["remaining_gross_notional_room"] = str(remaining_gross_notional)
+    gross_cap_qty = (
+        _non_increasing_qty_allowance(
+            action=context.normalized_action,
+            current_qty=context.current_qty,
+        )
+        if remaining_gross_notional <= 0
+        else _cap_qty_by_new_exposure_notional(
+            decision=context.decision,
+            price=context.price,
+            current_qty=context.current_qty,
+            cap_notional=remaining_gross_notional,
+            fractional_equities_enabled=context.resolution.fractional_allowed,
+        )
+    )
+    if gross_cap_qty < caps.adjusted_qty:
+        caps.adjusted_qty = gross_cap_qty
+        caps.capped_by_gross = True
+
+
+def _apply_buying_power_cap(
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+    *,
+    account: dict[str, str],
+    buying_power_reserve_bps: Decimal,
+) -> None:
+    caps.buying_power = _resolve_decimal(account.get("buying_power"))
+    context.diagnostics["buying_power"] = (
+        str(caps.buying_power) if caps.buying_power is not None else None
+    )
+    if caps.buying_power is None:
+        return
+    effective_buying_power = _buying_power_after_reserve(
+        buying_power=caps.buying_power,
+        reserve_bps=buying_power_reserve_bps,
+    )
+    context.diagnostics["buying_power_reserve_bps"] = str(buying_power_reserve_bps)
+    context.diagnostics["buying_power_after_reserve"] = str(effective_buying_power)
+    buying_power_cap_qty = _buying_power_cap_qty(
+        decision=context.decision,
+        price=context.price,
+        buying_power=max(effective_buying_power, Decimal("0")),
+        current_qty=context.current_qty,
+        fractional_allowed=context.resolution.fractional_allowed,
+    )
+    context.diagnostics["buying_power_cap_qty"] = str(buying_power_cap_qty)
+    if buying_power_cap_qty < caps.adjusted_qty:
+        caps.adjusted_qty = buying_power_cap_qty
+        caps.capped_by_buying_power = True
+
+
+def _final_quantity_rejection(
+    *,
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+) -> SimpleRiskPreparation | None:
+    if caps.adjusted_qty <= 0 or caps.adjusted_qty < context.min_qty:
+        return _rejected_simple_risk_preparation(
+            decision=context.decision,
+            quantity_resolution=context.resolution,
+            notional=_positive_notional(context.price, caps.adjusted_qty),
+            reject_reason=_quantity_reject_reason(caps),
+            diagnostics=context.diagnostics,
+        )
+    if qty_has_valid_increment(
+        context.decision.symbol,
+        caps.adjusted_qty,
+        fractional_equities_enabled=context.resolution.fractional_allowed,
+    ):
+        return None
+    return _rejected_simple_risk_preparation(
+        decision=context.decision,
+        quantity_resolution=context.resolution,
+        notional=context.price * caps.adjusted_qty,
+        reject_reason="invalid_qty_increment",
+        diagnostics=context.diagnostics,
+    )
+
+
+def _build_simple_risk_final(
+    *,
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+) -> _SimpleRiskFinal:
+    notional = context.price * caps.adjusted_qty
+    context.diagnostics["final_notional"] = str(notional)
+    buying_power_required = _buying_power_required_notional(
+        decision=context.decision,
+        qty=caps.adjusted_qty,
+        price=context.price,
+        current_qty=context.current_qty,
+    )
+    context.diagnostics["buying_power_required_notional"] = str(buying_power_required)
+    if not context.enforce_exposure:
+        context.diagnostics.setdefault("buying_power_cap_qty", str(caps.adjusted_qty))
+    return _SimpleRiskFinal(
+        notional=notional,
+        buying_power_required=buying_power_required,
+    )
+
+
+def _buying_power_rejection(
+    *,
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+    final: _SimpleRiskFinal,
+    buying_power_reserve_bps: Decimal,
+) -> SimpleRiskPreparation | None:
+    if not context.enforce_exposure or caps.buying_power is None:
+        return None
+    effective_buying_power = _buying_power_after_reserve(
+        buying_power=caps.buying_power,
+        reserve_bps=buying_power_reserve_bps,
+    )
+    if final.buying_power_required <= effective_buying_power:
+        return None
+    return _rejected_simple_risk_preparation(
+        decision=context.decision,
+        quantity_resolution=context.resolution,
+        notional=final.notional,
+        reject_reason="insufficient_buying_power",
+        diagnostics=context.diagnostics,
+    )
+
+
+def _approved_simple_risk(
+    *,
+    context: _SimpleRiskContext,
+    caps: _SimpleRiskCaps,
+    final: _SimpleRiskFinal,
+) -> SimpleRiskPreparation:
+    params = dict(context.decision.params)
     params["execution_lane"] = "simple"
     params["submit_path"] = "direct_alpaca"
     params["simple_lane"] = {
-        "requested_qty": str(decision.qty),
-        "final_qty": str(adjusted_qty),
-        "price": str(price),
-        "notional": str(notional),
-        "quantity_resolution": resolution.to_payload(),
-        "capped_by_order": capped_by_order,
-        "capped_by_symbol": capped_by_symbol,
-        "capped_by_gross": capped_by_gross,
-        "capped_by_buying_power": capped_by_buying_power,
+        "requested_qty": str(context.decision.qty),
+        "final_qty": str(caps.adjusted_qty),
+        "price": str(context.price),
+        "notional": str(final.notional),
+        "quantity_resolution": context.resolution.to_payload(),
+        "capped_by_order": caps.capped_by_order,
+        "capped_by_symbol": caps.capped_by_symbol,
+        "capped_by_gross": caps.capped_by_gross,
+        "capped_by_buying_power": caps.capped_by_buying_power,
     }
     return SimpleRiskPreparation(
         approved=True,
-        decision=decision.model_copy(update={"qty": adjusted_qty, "params": params}),
-        quantity_resolution=resolution,
+        decision=context.decision.model_copy(
+            update={"qty": caps.adjusted_qty, "params": params}
+        ),
+        quantity_resolution=context.resolution,
+        notional=final.notional,
+        diagnostics=context.diagnostics,
+    )
+
+
+def _rejected_simple_risk_preparation(
+    *,
+    decision: StrategyDecision,
+    quantity_resolution: QuantityResolution,
+    notional: Decimal | None,
+    reject_reason: str,
+    diagnostics: dict[str, Any],
+) -> SimpleRiskPreparation:
+    return SimpleRiskPreparation(
+        approved=False,
+        decision=decision,
+        quantity_resolution=quantity_resolution,
         notional=notional,
+        reject_reason=reject_reason,
         diagnostics=diagnostics,
     )
+
+
+def _positive_notional(price: Decimal, qty: Decimal) -> Decimal:
+    return price * qty if qty > 0 else Decimal("0")
+
+
+def _non_negative_limit(limit: Decimal | None) -> bool:
+    return limit is not None and limit >= 0
+
+
+def _quantity_reject_reason(caps: _SimpleRiskCaps) -> str:
+    if caps.capped_by_symbol:
+        return "max_symbol_exposure_exceeded"
+    if caps.capped_by_gross:
+        return "max_gross_exposure_exceeded"
+    if caps.capped_by_buying_power:
+        return "insufficient_buying_power"
+    if caps.capped_by_order:
+        return "max_notional_exceeded"
+    return "qty_below_min_after_clamp"
 
 
 def _extract_decision_price(decision: StrategyDecision) -> Decimal | None:

--- a/services/torghut/scripts/analyze_historical_simulation_modules/part_01_statements_35.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/part_01_statements_35.py
@@ -8,6 +8,7 @@ import argparse
 import csv
 import json
 from collections import Counter, defaultdict, deque
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -37,6 +38,31 @@ from scripts.start_historical_simulation import (
 
 
 REPORT_SCHEMA_VERSION = "torghut.simulation-report.v1"
+
+
+@dataclass(frozen=True)
+class _ExecutionFill:
+    symbol: str
+    side: str
+    qty: Decimal
+    price: Decimal
+
+
+@dataclass
+class _FifoPnlState:
+    long_lots: dict[str, deque[dict[str, Decimal]]] = field(
+        default_factory=lambda: defaultdict(deque)
+    )
+    short_lots: dict[str, deque[dict[str, Decimal]]] = field(
+        default_factory=lambda: defaultdict(deque)
+    )
+    realized_total: Decimal = Decimal("0")
+    execution_notional_total: Decimal = Decimal("0")
+    open_lot_count: int = 0
+    realized_by_symbol: dict[str, Decimal] = field(
+        default_factory=lambda: defaultdict(lambda: Decimal("0"))
+    )
+    trade_rows: list[dict[str, Any]] = field(default_factory=list)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -88,22 +114,29 @@ def _to_list_of_strings(value: Any) -> list[str]:
 
 
 def _as_decimal(value: Any) -> Decimal | None:
-    if value is None:
-        return None
     if isinstance(value, Decimal):
         return value
+    text = _decimal_input_text(value)
+    if text is None:
+        return None
+    try:
+        return Decimal(text)
+    except Exception:
+        return None
+
+
+def _decimal_input_text(value: Any) -> str | None:
+    if value is None:
+        return None
     if isinstance(value, bool):
-        return Decimal(int(value))
+        return str(int(value))
     if isinstance(value, (int, float)):
-        return Decimal(str(value))
+        return str(value)
     if isinstance(value, str):
         stripped = value.strip()
         if not stripped:
             return None
-        try:
-            return Decimal(stripped)
-        except Exception:
-            return None
+        return stripped
     return None
 
 
@@ -223,55 +256,95 @@ def _build_last_price_map(
     tca_rows: list[dict[str, Any]],
     execution_rows: list[dict[str, Any]],
 ) -> dict[str, Decimal]:
+    prices = _last_prices_from_clickhouse(
+        clickhouse_config=clickhouse_config,
+        price_table=price_table,
+    )
+    if prices:
+        return prices
+    prices = _last_prices_from_tca_rows(tca_rows)
+    if prices:
+        return prices
+    return _last_prices_from_execution_rows(execution_rows)
+
+
+def _last_prices_from_clickhouse(
+    *,
+    clickhouse_config: ClickHouseRuntimeConfig | None,
+    price_table: str,
+) -> dict[str, Decimal]:
+    if clickhouse_config is None or not clickhouse_config.http_url or not price_table:
+        return {}
+    for close_field in ("close", "c"):
+        prices = _last_prices_from_clickhouse_field(
+            clickhouse_config=clickhouse_config,
+            price_table=price_table,
+            close_field=close_field,
+        )
+        if prices:
+            return prices
+    return {}
+
+
+def _last_prices_from_clickhouse_field(
+    *,
+    clickhouse_config: ClickHouseRuntimeConfig,
+    price_table: str,
+    close_field: str,
+) -> dict[str, Decimal]:
+    query = (
+        f"SELECT symbol, toString(argMax({close_field}, event_ts)) "
+        f"FROM {price_table} "
+        f"GROUP BY symbol FORMAT TabSeparated"
+    )
+    try:
+        status, body = _http_clickhouse_query(config=clickhouse_config, query=query)
+    except Exception:
+        return {}
+    if not (200 <= status < 300 and body):
+        return {}
+    return _last_prices_from_tab_separated_body(body)
+
+
+def _last_prices_from_tab_separated_body(body: str) -> dict[str, Decimal]:
     prices: dict[str, Decimal] = {}
-    if clickhouse_config is not None and clickhouse_config.http_url and price_table:
-        for close_field in ("close", "c"):
-            query = (
-                f"SELECT symbol, toString(argMax({close_field}, event_ts)) "
-                f"FROM {price_table} "
-                f"GROUP BY symbol FORMAT TabSeparated"
-            )
-            try:
-                status, body = _http_clickhouse_query(
-                    config=clickhouse_config, query=query
-                )
-            except Exception:
-                status = 0
-                body = ""
-            if not (200 <= status < 300 and body):
-                continue
-            for line in body.splitlines():
-                parts = line.split("\t")
-                if len(parts) != 2:
-                    continue
-                symbol = parts[0].strip()
-                price = _as_decimal(parts[1])
-                if symbol and price is not None:
-                    prices[symbol] = price
-            if prices:
-                break
+    for line in body.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        symbol = parts[0].strip()
+        price = _as_decimal(parts[1])
+        if symbol and price is not None:
+            prices[symbol] = price
+    return prices
 
-    if not prices:
-        for row in reversed(tca_rows):
-            symbol = _as_text(row.get("symbol"))
-            if not symbol or symbol in prices:
-                continue
-            avg_fill_price = _as_decimal(row.get("avg_fill_price"))
-            arrival_price = _as_decimal(row.get("arrival_price"))
-            if avg_fill_price is not None:
-                prices[symbol] = avg_fill_price
-            elif arrival_price is not None:
-                prices[symbol] = arrival_price
 
-    if not prices:
-        for row in reversed(execution_rows):
-            symbol = _as_text(row.get("symbol"))
-            if not symbol or symbol in prices:
-                continue
-            avg_fill_price = _as_decimal(row.get("avg_fill_price"))
-            if avg_fill_price is not None:
-                prices[symbol] = avg_fill_price
+def _last_prices_from_tca_rows(tca_rows: list[dict[str, Any]]) -> dict[str, Decimal]:
+    prices: dict[str, Decimal] = {}
+    for row in reversed(tca_rows):
+        symbol = _as_text(row.get("symbol"))
+        if not symbol or symbol in prices:
+            continue
+        avg_fill_price = _as_decimal(row.get("avg_fill_price"))
+        arrival_price = _as_decimal(row.get("arrival_price"))
+        if avg_fill_price is not None:
+            prices[symbol] = avg_fill_price
+        elif arrival_price is not None:
+            prices[symbol] = arrival_price
+    return prices
 
+
+def _last_prices_from_execution_rows(
+    execution_rows: list[dict[str, Any]],
+) -> dict[str, Decimal]:
+    prices: dict[str, Decimal] = {}
+    for row in reversed(execution_rows):
+        symbol = _as_text(row.get("symbol"))
+        if not symbol or symbol in prices:
+            continue
+        avg_fill_price = _as_decimal(row.get("avg_fill_price"))
+        if avg_fill_price is not None:
+            prices[symbol] = avg_fill_price
     return prices
 
 
@@ -280,112 +353,182 @@ def _fifo_trade_pnl(
     *,
     last_prices: Mapping[str, Decimal],
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    long_lots: dict[str, deque[dict[str, Decimal]]] = defaultdict(deque)
-    short_lots: dict[str, deque[dict[str, Decimal]]] = defaultdict(deque)
-    open_lot_count = 0
-    realized_total = Decimal("0")
-    execution_notional_total = Decimal("0")
-    realized_by_symbol: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
-    trade_rows: list[dict[str, Any]] = []
-
+    state = _FifoPnlState()
     for row in executions:
-        symbol = _as_text(row.get("symbol"))
-        side = (_as_text(row.get("side")) or "").lower()
-        qty = _as_decimal(row.get("filled_qty"))
-        price = _as_decimal(row.get("avg_fill_price"))
-        if (
-            symbol is None
-            or side not in {"buy", "sell"}
-            or qty is None
-            or price is None
-        ):
+        fill = _execution_fill_from_row(row)
+        if fill is None:
             continue
-        if qty <= 0:
-            continue
+        _apply_fifo_fill(state=state, fill=fill, source_row=row)
 
-        remaining = qty
-        realized_for_execution = Decimal("0")
-        execution_notional_total += qty * price
+    unrealized_total = _fifo_unrealized_total(state=state, last_prices=last_prices)
+    return _fifo_pnl_payload(state, unrealized_total), state.trade_rows
 
-        if side == "buy":
-            shorts = short_lots[symbol]
-            while remaining > 0 and shorts:
-                lot = shorts[0]
-                close_qty = min(remaining, lot["qty"])
-                realized = (lot["price"] - price) * close_qty
-                realized_total += realized
-                realized_by_symbol[symbol] += realized
-                realized_for_execution += realized
-                lot["qty"] -= close_qty
-                remaining -= close_qty
-                if lot["qty"] <= 0:
-                    shorts.popleft()
-            if remaining > 0:
-                long_lots[symbol].append({"qty": remaining, "price": price})
-        else:
-            longs = long_lots[symbol]
-            while remaining > 0 and longs:
-                lot = longs[0]
-                close_qty = min(remaining, lot["qty"])
-                realized = (price - lot["price"]) * close_qty
-                realized_total += realized
-                realized_by_symbol[symbol] += realized
-                realized_for_execution += realized
-                lot["qty"] -= close_qty
-                remaining -= close_qty
-                if lot["qty"] <= 0:
-                    longs.popleft()
-            if remaining > 0:
-                short_lots[symbol].append({"qty": remaining, "price": price})
 
-        trade_rows.append(
-            {
-                "execution_id": str(row.get("id") or ""),
-                "trade_decision_id": str(row.get("trade_decision_id") or ""),
-                "symbol": symbol,
-                "side": side,
-                "filled_qty": _decimal_to_str(qty),
-                "avg_fill_price": _decimal_to_str(price),
-                "realized_pnl_contribution": _decimal_to_str(realized_for_execution),
-                "created_at": str(row.get("created_at") or ""),
-            }
+def _execution_fill_from_row(row: dict[str, Any]) -> _ExecutionFill | None:
+    symbol = _as_text(row.get("symbol"))
+    side = (_as_text(row.get("side")) or "").lower()
+    qty = _as_decimal(row.get("filled_qty"))
+    price = _as_decimal(row.get("avg_fill_price"))
+    if symbol is None or side not in {"buy", "sell"}:
+        return None
+    if qty is None or price is None or qty <= 0:
+        return None
+    return _ExecutionFill(symbol=symbol, side=side, qty=qty, price=price)
+
+
+def _apply_fifo_fill(
+    *,
+    state: _FifoPnlState,
+    fill: _ExecutionFill,
+    source_row: dict[str, Any],
+) -> None:
+    state.execution_notional_total += fill.qty * fill.price
+    if fill.side == "buy":
+        remaining, realized_for_execution = _close_fifo_lots(
+            state=state,
+            fill=fill,
+            lots=state.short_lots[fill.symbol],
+            closes_short=True,
         )
+        if remaining > 0:
+            state.long_lots[fill.symbol].append({"qty": remaining, "price": fill.price})
+    else:
+        remaining, realized_for_execution = _close_fifo_lots(
+            state=state,
+            fill=fill,
+            lots=state.long_lots[fill.symbol],
+            closes_short=False,
+        )
+        if remaining > 0:
+            state.short_lots[fill.symbol].append(
+                {"qty": remaining, "price": fill.price}
+            )
+    state.trade_rows.append(_fifo_trade_row(source_row, fill, realized_for_execution))
 
-    unrealized_total = Decimal("0")
-    for symbol, lots in long_lots.items():
+
+def _close_fifo_lots(
+    *,
+    state: _FifoPnlState,
+    fill: _ExecutionFill,
+    lots: deque[dict[str, Decimal]],
+    closes_short: bool,
+) -> tuple[Decimal, Decimal]:
+    remaining = fill.qty
+    realized_for_execution = Decimal("0")
+    while remaining > 0 and lots:
+        lot = lots[0]
+        close_qty = min(remaining, lot["qty"])
+        realized = _realized_fifo_delta(fill=fill, lot=lot, closes_short=closes_short)
+        realized *= close_qty
+        state.realized_total += realized
+        state.realized_by_symbol[fill.symbol] += realized
+        realized_for_execution += realized
+        lot["qty"] -= close_qty
+        remaining -= close_qty
+        if lot["qty"] <= 0:
+            lots.popleft()
+    return remaining, realized_for_execution
+
+
+def _realized_fifo_delta(
+    *,
+    fill: _ExecutionFill,
+    lot: dict[str, Decimal],
+    closes_short: bool,
+) -> Decimal:
+    if closes_short:
+        return lot["price"] - fill.price
+    return fill.price - lot["price"]
+
+
+def _fifo_trade_row(
+    source_row: dict[str, Any],
+    fill: _ExecutionFill,
+    realized_for_execution: Decimal,
+) -> dict[str, Any]:
+    return {
+        "execution_id": str(source_row.get("id") or ""),
+        "trade_decision_id": str(source_row.get("trade_decision_id") or ""),
+        "symbol": fill.symbol,
+        "side": fill.side,
+        "filled_qty": _decimal_to_str(fill.qty),
+        "avg_fill_price": _decimal_to_str(fill.price),
+        "realized_pnl_contribution": _decimal_to_str(realized_for_execution),
+        "created_at": str(source_row.get("created_at") or ""),
+    }
+
+
+def _fifo_unrealized_total(
+    *,
+    state: _FifoPnlState,
+    last_prices: Mapping[str, Decimal],
+) -> Decimal:
+    long_total, long_count = _fifo_unrealized_lots(
+        lots_by_symbol=state.long_lots,
+        last_prices=last_prices,
+        short=False,
+    )
+    short_total, short_count = _fifo_unrealized_lots(
+        lots_by_symbol=state.short_lots,
+        last_prices=last_prices,
+        short=True,
+    )
+    state.open_lot_count = long_count + short_count
+    return long_total + short_total
+
+
+def _fifo_unrealized_lots(
+    *,
+    lots_by_symbol: Mapping[str, deque[dict[str, Decimal]]],
+    last_prices: Mapping[str, Decimal],
+    short: bool,
+) -> tuple[Decimal, int]:
+    total = Decimal("0")
+    count = 0
+    for symbol, lots in lots_by_symbol.items():
         last = last_prices.get(symbol)
         if last is None:
             continue
         for lot in lots:
-            unrealized_total += (last - lot["price"]) * lot["qty"]
-            open_lot_count += 1
-    for symbol, lots in short_lots.items():
-        last = last_prices.get(symbol)
-        if last is None:
-            continue
-        for lot in lots:
-            unrealized_total += (lot["price"] - last) * lot["qty"]
-            open_lot_count += 1
+            total += _unrealized_lot_delta(lot=lot, last=last, short=short)
+            count += 1
+    return total, count
 
-    gross_total = realized_total + unrealized_total
-    by_symbol_payload = [
+
+def _unrealized_lot_delta(
+    *,
+    lot: dict[str, Decimal],
+    last: Decimal,
+    short: bool,
+) -> Decimal:
+    if short:
+        return (lot["price"] - last) * lot["qty"]
+    return (last - lot["price"]) * lot["qty"]
+
+
+def _fifo_pnl_payload(
+    state: _FifoPnlState,
+    unrealized_total: Decimal,
+) -> dict[str, Any]:
+    gross_total = state.realized_total + unrealized_total
+    return {
+        "realized_pnl": state.realized_total,
+        "unrealized_pnl": unrealized_total,
+        "gross_pnl": gross_total,
+        "execution_notional_total": state.execution_notional_total,
+        "open_lot_count": state.open_lot_count,
+        "realized_by_symbol": _realized_by_symbol_payload(state),
+    }
+
+
+def _realized_by_symbol_payload(state: _FifoPnlState) -> list[dict[str, Any]]:
+    return [
         {
             "symbol": symbol,
             "realized_pnl": _decimal_to_str(value),
         }
-        for symbol, value in sorted(realized_by_symbol.items())
+        for symbol, value in sorted(state.realized_by_symbol.items())
     ]
-    return (
-        {
-            "realized_pnl": realized_total,
-            "unrealized_pnl": unrealized_total,
-            "gross_pnl": gross_total,
-            "execution_notional_total": execution_notional_total,
-            "open_lot_count": open_lot_count,
-            "realized_by_symbol": by_symbol_payload,
-        },
-        trade_rows,
-    )
 
 
 def _csv_write(path: Path, rows_payload: list[dict[str, Any]]) -> None:

--- a/services/torghut/tests/test_regime_classifier.py
+++ b/services/torghut/tests/test_regime_classifier.py
@@ -164,6 +164,31 @@ class TestRegimeClassifier(TestCase):
         self.assertEqual(one, two)
         self.assertEqual(two, three)
 
+    def test_regime_classifier_uses_macd_trend_when_price_history_is_short(
+        self,
+    ) -> None:
+        cases = [
+            (Decimal("0.08"), "vol=unknown|trend=up|liq=unknown"),
+            (Decimal("-0.08"), "vol=unknown|trend=down|liq=unknown"),
+            (Decimal("0.01"), "vol=unknown|trend=flat|liq=unknown"),
+        ]
+
+        for macd_delta, expected_label in cases:
+            with self.subTest(macd_delta=macd_delta):
+                regime = classify_regime(
+                    [
+                        self._decision(
+                            0,
+                            price=Decimal("100"),
+                            volatility=None,
+                            macd=macd_delta,
+                            macd_signal=Decimal("0"),
+                        )
+                    ]
+                )
+
+                self.assertEqual(regime.label(), expected_label)
+
     @staticmethod
     def _decision(
         minute_offset: int,


### PR DESCRIPTION
## Summary

- Refactors Torghut risk/quote/regime helper hotspots into smaller focused functions while preserving existing public call surfaces.
- Splits the historical simulation analysis price/FIFO helpers into typed fill/state helpers to remove local complexity without changing report outputs.
- Adds targeted regime coverage for the MACD fallback trend path introduced by the refactor.
- Keeps the enforced Pylint file-length gate green; touched design-complexity Pylint scope is clean.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen python -m compileall app scripts`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pylint app/trading/simple_risk.py app/trading/quote_quality.py app/trading/regime.py app/trading/quantity_rules.py scripts/analyze_historical_simulation_modules/part_01_statements_35.py --disable=all --enable=too-many-branches,too-many-locals,too-many-return-statements,too-many-statements --score=n`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_simple_risk.py tests/test_quote_quality.py tests/test_quote_quality_properties.py tests/property/test_quote_quality_properties.py tests/test_regime_classifier.py tests/property/test_quantity_rules_properties.py tests/test_analyze_historical_simulation.py --cov --cov-branch --cov-report=term-missing --cov-report=xml --cov-fail-under=0`
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (90.38%)
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_health_dependency.py tests/api/test_trading_api_simple_lane_profit_floor.py -q`
- `git diff --check`
- `bun run lint:argocd`

Diagnostic only: `cd services/torghut && uv run --frozen pytest -n auto --cov --cov-branch --cov-report=term-missing --cov-report=xml` completed with 5110 passed and 5 xdist/shared-state API health failures; the failing files passed in the serial rerun above.

## Screenshots (if applicable)

N/A - backend/service refactor only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
