### PR TITLE
refactor(torghut): simplify quant readiness verifier

### DIFF
--- a/services/torghut/scripts/quant_readiness_artifacts.py
+++ b/services/torghut/scripts/quant_readiness_artifacts.py
@@ -1,0 +1,400 @@
+"""Artifact validators for the Torghut quant readiness verifier."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+_MODEL_RISK_EVIDENCE_SCHEMA_VERSION = "torghut.model-risk-evidence.v1"
+
+
+def _parse_iso8601_timestamp(raw: str, *, field_name: str) -> datetime:
+    normalized = raw.strip()
+    if not normalized:
+        raise ValueError(f"{field_name}_missing")
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{field_name}_invalid") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name}_missing_timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_json_object(path: Path, *, invalid_reason: str) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(invalid_reason)
+    return cast(dict[str, Any], payload)
+
+
+def _require_keys(
+    payload: Mapping[str, Any],
+    required_keys: tuple[str, ...],
+    *,
+    missing_reason_prefix: str,
+) -> None:
+    missing = [key for key in required_keys if key not in payload]
+    if missing:
+        raise ValueError(f"{missing_reason_prefix}:{','.join(missing)}")
+
+
+def _require_mapping(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    invalid_reason: str,
+) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(invalid_reason)
+    return cast(dict[str, Any], value)
+
+
+def _require_text(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    missing_reason: str,
+) -> str:
+    value = str(payload.get(key, "")).strip()
+    if not value:
+        raise ValueError(missing_reason)
+    return value
+
+
+def _require_true(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    failed_reason: str,
+) -> None:
+    if not bool(payload.get(key, False)):
+        raise ValueError(failed_reason)
+
+
+def _load_gate_trace(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("gate_report_payload_invalid")
+    payload_map = cast(dict[str, Any], payload)
+    provenance = payload_map.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError("gate_report_missing_provenance")
+    provenance_map = cast(dict[str, Any], provenance)
+    gate_trace = str(provenance_map.get("gate_report_trace_id", "")).strip()
+    recommendation_trace = str(
+        provenance_map.get("recommendation_trace_id", "")
+    ).strip()
+    if not gate_trace:
+        raise ValueError("gate_report_trace_id_missing")
+    if not recommendation_trace:
+        raise ValueError("recommendation_trace_id_missing")
+    return {
+        "gate_report_trace_id": gate_trace,
+        "recommendation_trace_id": recommendation_trace,
+    }
+
+
+def _load_profitability_proof(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("profitability_proof_invalid")
+    payload_map = cast(dict[str, Any], payload)
+    required_root_keys = (
+        "hypothesis",
+        "window_days",
+        "statistics",
+        "risk_controls",
+    )
+    missing = [key for key in required_root_keys if key not in payload_map]
+    if missing:
+        raise ValueError(f"profitability_proof_missing_keys:{','.join(missing)}")
+
+    raw_statistics = payload_map.get("statistics")
+    if not isinstance(raw_statistics, dict):
+        raise ValueError("profitability_proof_statistics_invalid")
+    statistics = cast(dict[str, Any], raw_statistics)
+
+    effect_size = statistics.get("effect_size")
+    if not isinstance(effect_size, (int, float)):
+        raise ValueError("profitability_proof_effect_size_invalid")
+
+    sample_size = payload_map.get("sample_size")
+    if not isinstance(sample_size, int) or sample_size < 1:
+        raise ValueError("profitability_proof_sample_size_invalid")
+
+    p_value = statistics.get("p_value")
+    if not isinstance(p_value, (int, float)) or not 0 <= float(p_value) <= 1:
+        raise ValueError("profitability_proof_p_value_invalid")
+
+    raw_risk_controls = payload_map.get("risk_controls")
+    if not isinstance(raw_risk_controls, dict):
+        raise ValueError("profitability_proof_risk_controls_invalid")
+    risk_controls = cast(dict[str, Any], raw_risk_controls)
+
+    drawdown_delta = risk_controls.get("max_drawdown_delta")
+    if not isinstance(drawdown_delta, (int, float)):
+        raise ValueError("profitability_proof_risk_controls_drawdown_invalid")
+
+    window_days = payload_map.get("window_days")
+    if not isinstance(window_days, (int, float)) or window_days <= 0:
+        raise ValueError("profitability_proof_window_days_invalid")
+
+    hypothesis = str(payload_map.get("hypothesis", "")).strip()
+    if not hypothesis:
+        raise ValueError("profitability_proof_hypothesis_missing")
+
+    return {
+        "hypothesis": hypothesis,
+        "sample_size": sample_size,
+        "window_days": float(window_days),
+        "effect_size": float(effect_size),
+        "p_value": float(p_value),
+        "drawdown_delta": float(drawdown_delta),
+        "risk_controls": risk_controls,
+    }
+
+
+def _load_incident_evidence(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("incident_payload_invalid")
+    payload_map = cast(dict[str, Any], payload)
+    required_keys = (
+        "triggered_at",
+        "reasons",
+        "rollback_hooks",
+        "safety_snapshot",
+        "provenance",
+        "verification",
+    )
+    missing = [key for key in required_keys if key not in payload_map]
+    if missing:
+        raise ValueError(f"incident_payload_missing_keys:{','.join(missing)}")
+    rollback_hooks = payload_map.get("rollback_hooks")
+    if not isinstance(rollback_hooks, dict):
+        raise ValueError("incident_payload_rollback_hooks_invalid")
+    reasons = payload_map.get("reasons")
+    if not isinstance(reasons, list) or not reasons:
+        raise ValueError("incident_payload_reasons_invalid")
+    if not bool(rollback_hooks.get("order_submission_blocked", False)):
+        raise ValueError("incident_payload_order_block_missing")
+    verification = payload_map.get("verification")
+    if not isinstance(verification, dict):
+        raise ValueError("incident_payload_verification_invalid")
+    if not bool(verification.get("incident_evidence_complete", False)):
+        raise ValueError("incident_payload_verification_failed")
+    return payload_map
+
+
+def _load_control_plane_contract(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("control_plane_contract_invalid")
+    payload_map = cast(dict[str, Any], payload)
+    required_keys = (
+        "contract_version",
+        "signal_continuity_state",
+        "signal_continuity_alert_active",
+        "signal_continuity_promotion_block_total",
+        "last_autonomy_recommendation_trace_id",
+        "domain_telemetry_event_total",
+        "domain_telemetry_dropped_total",
+        "alpha_readiness_hypotheses_total",
+        "alpha_readiness_shadow_total",
+        "alpha_readiness_blocked_total",
+        "alpha_readiness_dependency_quorum_decision",
+    )
+    missing = [key for key in required_keys if key not in payload_map]
+    if missing:
+        raise ValueError(f"control_plane_contract_missing_keys:{','.join(missing)}")
+    if payload_map.get("contract_version") != "torghut.quant-producer.v1":
+        raise ValueError("control_plane_contract_version_invalid")
+    telemetry_events = payload_map.get("domain_telemetry_event_total")
+    if not isinstance(telemetry_events, dict):
+        raise ValueError("control_plane_contract_domain_telemetry_events_invalid")
+    telemetry_drops = payload_map.get("domain_telemetry_dropped_total")
+    if not isinstance(telemetry_drops, dict):
+        raise ValueError("control_plane_contract_domain_telemetry_dropped_invalid")
+    dependency_quorum_decision = str(
+        payload_map.get("alpha_readiness_dependency_quorum_decision", "")
+    ).strip()
+    if dependency_quorum_decision not in {"allow", "delay", "block", "unknown"}:
+        raise ValueError(
+            "control_plane_contract_alpha_readiness_dependency_quorum_invalid"
+        )
+    return payload_map
+
+
+def _validate_model_risk_generated_at(
+    payload: Mapping[str, Any],
+    *,
+    now: datetime,
+    max_age_hours: int,
+) -> tuple[datetime, float]:
+    generated_at_raw = payload.get("generated_at")
+    if not isinstance(generated_at_raw, str):
+        raise ValueError("model_risk_evidence_package_generated_at_invalid")
+    generated_at = _parse_iso8601_timestamp(
+        generated_at_raw,
+        field_name="model_risk_evidence_package_generated_at",
+    )
+    age_hours = (now - generated_at).total_seconds() / 3600.0
+    if age_hours < 0:
+        raise ValueError("model_risk_evidence_package_generated_at_future")
+    if age_hours > max(1, int(max_age_hours)):
+        raise ValueError("model_risk_evidence_package_stale")
+    return generated_at, age_hours
+
+
+def _model_risk_promotion_summary(payload: Mapping[str, Any]) -> dict[str, str]:
+    promotion = _require_mapping(
+        payload,
+        "promotion",
+        invalid_reason="model_risk_evidence_package_promotion_invalid",
+    )
+    return {
+        "promotion_gate_report_trace_id": _require_text(
+            promotion,
+            "gate_report_trace_id",
+            missing_reason="model_risk_evidence_package_gate_trace_missing",
+        ),
+        "promotion_recommendation_trace_id": _require_text(
+            promotion,
+            "recommendation_trace_id",
+            missing_reason="model_risk_evidence_package_recommendation_trace_missing",
+        ),
+    }
+
+
+def _model_risk_rollback_summary(payload: Mapping[str, Any]) -> dict[str, str]:
+    rollback = _require_mapping(
+        payload,
+        "rollback",
+        invalid_reason="model_risk_evidence_package_rollback_invalid",
+    )
+    _require_true(
+        rollback,
+        "incident_evidence_complete",
+        failed_reason="model_risk_evidence_package_rollback_incomplete",
+    )
+    return {
+        "rollback_incident_evidence_path": _require_text(
+            rollback,
+            "incident_evidence_path",
+            missing_reason="model_risk_evidence_package_rollback_incident_path_missing",
+        )
+    }
+
+
+def _model_risk_drift_summary(payload: Mapping[str, Any]) -> dict[str, str]:
+    drift = _require_mapping(
+        payload,
+        "drift",
+        invalid_reason="model_risk_evidence_package_drift_invalid",
+    )
+    _require_true(
+        drift,
+        "evidence_continuity_passed",
+        failed_reason="model_risk_evidence_package_drift_not_passed",
+    )
+    return {
+        "drift_evidence_continuity_report_path": _require_text(
+            drift,
+            "evidence_continuity_report_path",
+            missing_reason="model_risk_evidence_package_drift_report_missing",
+        )
+    }
+
+
+def _model_risk_runbook_summary(payload: Mapping[str, Any]) -> dict[str, str]:
+    runbook = _require_mapping(
+        payload,
+        "runbook_drill",
+        invalid_reason="model_risk_evidence_package_runbook_invalid",
+    )
+    rehearsal_at_raw = _require_text(
+        runbook,
+        "rehearsal_at",
+        missing_reason="model_risk_evidence_package_runbook_rehearsal_missing",
+    )
+    _parse_iso8601_timestamp(
+        rehearsal_at_raw,
+        field_name="model_risk_evidence_package_rehearsal_at",
+    )
+    _require_true(
+        runbook,
+        "emergency_stop_rehearsed",
+        failed_reason="model_risk_evidence_package_runbook_rehearsal_not_passed",
+    )
+    return {"runbook_rehearsal_at": rehearsal_at_raw}
+
+
+def _model_risk_legacy_summary(payload: Mapping[str, Any]) -> dict[str, str]:
+    legacy_disposition = _require_mapping(
+        payload,
+        "legacy_gap_disposition",
+        invalid_reason="model_risk_evidence_package_legacy_disposition_invalid",
+    )
+    _require_true(
+        legacy_disposition,
+        "signed_disposition_complete",
+        failed_reason="model_risk_evidence_package_legacy_disposition_incomplete",
+    )
+    return {
+        "legacy_mapping_path": _require_text(
+            legacy_disposition,
+            "mapping_path",
+            missing_reason="model_risk_evidence_package_legacy_mapping_missing",
+        )
+    }
+
+
+def _load_model_risk_evidence_package(
+    path: Path,
+    *,
+    now: datetime,
+    max_age_hours: int,
+) -> dict[str, Any]:
+    payload_map = _load_json_object(
+        path,
+        invalid_reason="model_risk_evidence_package_invalid",
+    )
+    required_keys = (
+        "schema_version",
+        "generated_at",
+        "promotion",
+        "rollback",
+        "drift",
+        "runbook_drill",
+        "legacy_gap_disposition",
+    )
+    _require_keys(
+        payload_map,
+        required_keys,
+        missing_reason_prefix="model_risk_evidence_package_missing_keys",
+    )
+    schema_version = str(payload_map.get("schema_version", "")).strip()
+    if schema_version != _MODEL_RISK_EVIDENCE_SCHEMA_VERSION:
+        raise ValueError("model_risk_evidence_package_schema_version_invalid")
+    generated_at, age_hours = _validate_model_risk_generated_at(
+        payload_map,
+        now=now,
+        max_age_hours=max_age_hours,
+    )
+
+    return {
+        "schema_version": schema_version,
+        "generated_at": generated_at.isoformat(),
+        "age_hours": round(age_hours, 4),
+        **_model_risk_promotion_summary(payload_map),
+        **_model_risk_rollback_summary(payload_map),
+        **_model_risk_drift_summary(payload_map),
+        **_model_risk_runbook_summary(payload_map),
+        **_model_risk_legacy_summary(payload_map),
+    }

--- a/services/torghut/scripts/verify_quant_readiness.py
+++ b/services/torghut/scripts/verify_quant_readiness.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Mapping, cast
 
 from sqlalchemy import and_, func, or_, select
+from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
 from app.models import (
@@ -21,360 +23,196 @@ from app.models import (
     ResearchStressMetrics,
     TradeDecision,
 )
-
-_MODEL_RISK_EVIDENCE_SCHEMA_VERSION = "torghut.model-risk-evidence.v1"
-
-
-def _parse_iso8601_timestamp(raw: str, *, field_name: str) -> datetime:
-    normalized = raw.strip()
-    if not normalized:
-        raise ValueError(f"{field_name}_missing")
-    if normalized.endswith("Z"):
-        normalized = f"{normalized[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError as exc:
-        raise ValueError(f"{field_name}_invalid") from exc
-    if parsed.tzinfo is None:
-        raise ValueError(f"{field_name}_missing_timezone")
-    return parsed.astimezone(timezone.utc)
+from scripts.quant_readiness_artifacts import (
+    _load_control_plane_contract,
+    _load_gate_trace,
+    _load_incident_evidence,
+    _load_model_risk_evidence_package,
+    _load_profitability_proof,
+)
 
 
-def _load_gate_trace(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("gate_report_payload_invalid")
-    payload_map = cast(dict[str, Any], payload)
-    provenance = payload_map.get("provenance")
-    if not isinstance(provenance, dict):
-        raise ValueError("gate_report_missing_provenance")
-    provenance_map = cast(dict[str, Any], provenance)
-    gate_trace = str(provenance_map.get("gate_report_trace_id", "")).strip()
-    recommendation_trace = str(
-        provenance_map.get("recommendation_trace_id", "")
-    ).strip()
-    if not gate_trace:
-        raise ValueError("gate_report_trace_id_missing")
-    if not recommendation_trace:
-        raise ValueError("recommendation_trace_id_missing")
-    return {
-        "gate_report_trace_id": gate_trace,
-        "recommendation_trace_id": recommendation_trace,
-    }
+@dataclass(frozen=True)
+class AcceptanceWindowCounts:
+    non_skipped_runs: int
+    trade_decisions: int
+    executions: int
+    full_chain_runs: int
+    route_total: int
+    missing_route_rows: int
+    route_fallback_rows: int
+    advisor_eligible_rows: int
+    advisor_payload_rows: int
 
 
-def _load_profitability_proof(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("profitability_proof_invalid")
-    payload_map = cast(dict[str, Any], payload)
-    required_root_keys = (
-        "hypothesis",
-        "window_days",
-        "statistics",
-        "risk_controls",
+@dataclass(frozen=True)
+class AcceptanceWindowThresholds:
+    min_non_skipped_runs: int
+    min_trade_decisions: int
+    min_executions: int
+    min_full_chain_runs: int
+    min_route_coverage_ratio: float
+    min_execution_advisor_coverage_ratio: float
+    max_route_fallback_ratio: float
+
+
+@dataclass(frozen=True)
+class ReadinessCounts:
+    missing_route_count: int
+    total_route_count: int
+    fallback_route_count: int
+    invalid_fallback_reason_count: int
+    missing_research_trace_count: int
+    non_skipped_runs: int
+    trade_decisions: int
+    advisor_eligible_rows: int
+    advisor_payload_rows: int
+    executions: int
+    full_chain_runs: int
+
+
+@dataclass(frozen=True)
+class ReadinessThresholds:
+    max_missing_provenance: int
+    max_invalid_fallback_reason: int
+    max_missing_research_traces: int
+    max_model_risk_evidence_age_hours: int
+    acceptance: AcceptanceWindowThresholds
+
+
+def _safe_ratio(numerator: int, denominator: int, *, default: float = 0.0) -> float:
+    if denominator <= 0:
+        return default
+    return max(0.0, numerator / denominator)
+
+
+def _acceptance_counts_from_values(values: Mapping[str, Any]) -> AcceptanceWindowCounts:
+    return AcceptanceWindowCounts(
+        non_skipped_runs=int(values["non_skipped_runs"]),
+        trade_decisions=int(values["trade_decisions"]),
+        executions=int(values["executions"]),
+        full_chain_runs=int(values["full_chain_runs"]),
+        route_total=int(values["route_total"]),
+        missing_route_rows=int(values["missing_route_rows"]),
+        route_fallback_rows=int(values["route_fallback_rows"]),
+        advisor_eligible_rows=int(values["advisor_eligible_rows"]),
+        advisor_payload_rows=int(values["advisor_payload_rows"]),
     )
-    missing = [key for key in required_root_keys if key not in payload_map]
-    if missing:
-        raise ValueError(f"profitability_proof_missing_keys:{','.join(missing)}")
-
-    raw_statistics = payload_map.get("statistics")
-    if not isinstance(raw_statistics, dict):
-        raise ValueError("profitability_proof_statistics_invalid")
-    statistics = cast(dict[str, Any], raw_statistics)
-
-    effect_size = statistics.get("effect_size")
-    if not isinstance(effect_size, (int, float)):
-        raise ValueError("profitability_proof_effect_size_invalid")
-
-    sample_size = payload_map.get("sample_size")
-    if not isinstance(sample_size, int) or sample_size < 1:
-        raise ValueError("profitability_proof_sample_size_invalid")
-
-    p_value = statistics.get("p_value")
-    if not isinstance(p_value, (int, float)) or not 0 <= float(p_value) <= 1:
-        raise ValueError("profitability_proof_p_value_invalid")
-
-    raw_risk_controls = payload_map.get("risk_controls")
-    if not isinstance(raw_risk_controls, dict):
-        raise ValueError("profitability_proof_risk_controls_invalid")
-    risk_controls = cast(dict[str, Any], raw_risk_controls)
-
-    drawdown_delta = risk_controls.get("max_drawdown_delta")
-    if not isinstance(drawdown_delta, (int, float)):
-        raise ValueError("profitability_proof_risk_controls_drawdown_invalid")
-
-    window_days = payload_map.get("window_days")
-    if not isinstance(window_days, (int, float)) or window_days <= 0:
-        raise ValueError("profitability_proof_window_days_invalid")
-
-    hypothesis = str(payload_map.get("hypothesis", "")).strip()
-    if not hypothesis:
-        raise ValueError("profitability_proof_hypothesis_missing")
-
-    return {
-        "hypothesis": hypothesis,
-        "sample_size": sample_size,
-        "window_days": float(window_days),
-        "effect_size": float(effect_size),
-        "p_value": float(p_value),
-        "drawdown_delta": float(drawdown_delta),
-        "risk_controls": risk_controls,
-    }
 
 
-def _load_incident_evidence(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("incident_payload_invalid")
-    payload_map = cast(dict[str, Any], payload)
-    required_keys = (
-        "triggered_at",
-        "reasons",
-        "rollback_hooks",
-        "safety_snapshot",
-        "provenance",
-        "verification",
+def _acceptance_thresholds_from_values(
+    values: Mapping[str, Any],
+) -> AcceptanceWindowThresholds:
+    return AcceptanceWindowThresholds(
+        min_non_skipped_runs=int(values["min_non_skipped_runs"]),
+        min_trade_decisions=int(values["min_trade_decisions"]),
+        min_executions=int(values["min_executions"]),
+        min_full_chain_runs=int(values["min_full_chain_runs"]),
+        min_route_coverage_ratio=float(values["min_route_coverage_ratio"]),
+        min_execution_advisor_coverage_ratio=float(
+            values["min_execution_advisor_coverage_ratio"]
+        ),
+        max_route_fallback_ratio=float(values["max_route_fallback_ratio"]),
     )
-    missing = [key for key in required_keys if key not in payload_map]
-    if missing:
-        raise ValueError(f"incident_payload_missing_keys:{','.join(missing)}")
-    rollback_hooks = payload_map.get("rollback_hooks")
-    if not isinstance(rollback_hooks, dict):
-        raise ValueError("incident_payload_rollback_hooks_invalid")
-    reasons = payload_map.get("reasons")
-    if not isinstance(reasons, list) or not reasons:
-        raise ValueError("incident_payload_reasons_invalid")
-    if not bool(rollback_hooks.get("order_submission_blocked", False)):
-        raise ValueError("incident_payload_order_block_missing")
-    verification = payload_map.get("verification")
-    if not isinstance(verification, dict):
-        raise ValueError("incident_payload_verification_invalid")
-    if not bool(verification.get("incident_evidence_complete", False)):
-        raise ValueError("incident_payload_verification_failed")
-    return payload_map
 
 
-def _load_control_plane_contract(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("control_plane_contract_invalid")
-    payload_map = cast(dict[str, Any], payload)
-    required_keys = (
-        "contract_version",
-        "signal_continuity_state",
-        "signal_continuity_alert_active",
-        "signal_continuity_promotion_block_total",
-        "last_autonomy_recommendation_trace_id",
-        "domain_telemetry_event_total",
-        "domain_telemetry_dropped_total",
-        "alpha_readiness_hypotheses_total",
-        "alpha_readiness_shadow_total",
-        "alpha_readiness_blocked_total",
-        "alpha_readiness_dependency_quorum_decision",
+def _acceptance_counts_from_readiness(
+    counts: ReadinessCounts,
+) -> AcceptanceWindowCounts:
+    return AcceptanceWindowCounts(
+        non_skipped_runs=counts.non_skipped_runs,
+        trade_decisions=counts.trade_decisions,
+        executions=counts.executions,
+        full_chain_runs=counts.full_chain_runs,
+        route_total=counts.total_route_count,
+        missing_route_rows=counts.missing_route_count,
+        route_fallback_rows=counts.fallback_route_count,
+        advisor_eligible_rows=counts.advisor_eligible_rows,
+        advisor_payload_rows=counts.advisor_payload_rows,
     )
-    missing = [key for key in required_keys if key not in payload_map]
-    if missing:
-        raise ValueError(f"control_plane_contract_missing_keys:{','.join(missing)}")
-    if payload_map.get("contract_version") != "torghut.quant-producer.v1":
-        raise ValueError("control_plane_contract_version_invalid")
-    telemetry_events = payload_map.get("domain_telemetry_event_total")
-    if not isinstance(telemetry_events, dict):
-        raise ValueError("control_plane_contract_domain_telemetry_events_invalid")
-    telemetry_drops = payload_map.get("domain_telemetry_dropped_total")
-    if not isinstance(telemetry_drops, dict):
-        raise ValueError("control_plane_contract_domain_telemetry_dropped_invalid")
-    dependency_quorum_decision = str(
-        payload_map.get("alpha_readiness_dependency_quorum_decision", "")
-    ).strip()
-    if dependency_quorum_decision not in {"allow", "delay", "block", "unknown"}:
-        raise ValueError(
-            "control_plane_contract_alpha_readiness_dependency_quorum_invalid"
-        )
-    return payload_map
 
 
-def _load_model_risk_evidence_package(
-    path: Path,
+def _acceptance_window_passed(
+    counts: AcceptanceWindowCounts,
+    thresholds: AcceptanceWindowThresholds,
     *,
-    now: datetime,
-    max_age_hours: int,
+    route_coverage_ratio: float,
+    route_fallback_ratio: float,
+    execution_advisor_coverage_ratio: float,
+) -> bool:
+    return (
+        counts.non_skipped_runs >= thresholds.min_non_skipped_runs
+        and counts.trade_decisions >= thresholds.min_trade_decisions
+        and counts.executions >= thresholds.min_executions
+        and counts.full_chain_runs >= thresholds.min_full_chain_runs
+        and route_coverage_ratio >= thresholds.min_route_coverage_ratio
+        and route_fallback_ratio <= thresholds.max_route_fallback_ratio
+        and execution_advisor_coverage_ratio
+        >= thresholds.min_execution_advisor_coverage_ratio
+    )
+
+
+def _format_acceptance_window(
+    counts: AcceptanceWindowCounts,
+    thresholds: AcceptanceWindowThresholds,
 ) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("model_risk_evidence_package_invalid")
-    payload_map = cast(dict[str, Any], payload)
-    required_keys = (
-        "schema_version",
-        "generated_at",
-        "promotion",
-        "rollback",
-        "drift",
-        "runbook_drill",
-        "legacy_gap_disposition",
+    route_coverage_ratio = _safe_ratio(
+        counts.route_total - counts.missing_route_rows,
+        counts.route_total,
     )
-    missing = [key for key in required_keys if key not in payload_map]
-    if missing:
-        raise ValueError(
-            f"model_risk_evidence_package_missing_keys:{','.join(missing)}"
-        )
-    schema_version = str(payload_map.get("schema_version", "")).strip()
-    if schema_version != _MODEL_RISK_EVIDENCE_SCHEMA_VERSION:
-        raise ValueError("model_risk_evidence_package_schema_version_invalid")
-    generated_at_raw = payload_map.get("generated_at")
-    if not isinstance(generated_at_raw, str):
-        raise ValueError("model_risk_evidence_package_generated_at_invalid")
-    generated_at = _parse_iso8601_timestamp(
-        generated_at_raw,
-        field_name="model_risk_evidence_package_generated_at",
+    route_fallback_ratio = _safe_ratio(
+        counts.route_fallback_rows,
+        counts.route_total,
     )
-    age_delta_hours = (now - generated_at).total_seconds() / 3600.0
-    if age_delta_hours < 0:
-        raise ValueError("model_risk_evidence_package_generated_at_future")
-    age_hours = age_delta_hours
-    if age_hours > max(1, int(max_age_hours)):
-        raise ValueError("model_risk_evidence_package_stale")
-
-    promotion_raw = payload_map.get("promotion")
-    if not isinstance(promotion_raw, dict):
-        raise ValueError("model_risk_evidence_package_promotion_invalid")
-    promotion = cast(dict[str, Any], promotion_raw)
-    gate_trace = str(promotion.get("gate_report_trace_id", "")).strip()
-    recommendation_trace = str(promotion.get("recommendation_trace_id", "")).strip()
-    if not gate_trace:
-        raise ValueError("model_risk_evidence_package_gate_trace_missing")
-    if not recommendation_trace:
-        raise ValueError("model_risk_evidence_package_recommendation_trace_missing")
-
-    rollback_raw = payload_map.get("rollback")
-    if not isinstance(rollback_raw, dict):
-        raise ValueError("model_risk_evidence_package_rollback_invalid")
-    rollback = cast(dict[str, Any], rollback_raw)
-    incident_evidence_path = str(rollback.get("incident_evidence_path", "")).strip()
-    if not incident_evidence_path:
-        raise ValueError("model_risk_evidence_package_rollback_incident_path_missing")
-    if not bool(rollback.get("incident_evidence_complete", False)):
-        raise ValueError("model_risk_evidence_package_rollback_incomplete")
-
-    drift_raw = payload_map.get("drift")
-    if not isinstance(drift_raw, dict):
-        raise ValueError("model_risk_evidence_package_drift_invalid")
-    drift = cast(dict[str, Any], drift_raw)
-    continuity_path = str(drift.get("evidence_continuity_report_path", "")).strip()
-    if not continuity_path:
-        raise ValueError("model_risk_evidence_package_drift_report_missing")
-    if not bool(drift.get("evidence_continuity_passed", False)):
-        raise ValueError("model_risk_evidence_package_drift_not_passed")
-
-    runbook_raw = payload_map.get("runbook_drill")
-    if not isinstance(runbook_raw, dict):
-        raise ValueError("model_risk_evidence_package_runbook_invalid")
-    runbook = cast(dict[str, Any], runbook_raw)
-    rehearsal_at_raw = str(runbook.get("rehearsal_at", "")).strip()
-    if not rehearsal_at_raw:
-        raise ValueError("model_risk_evidence_package_runbook_rehearsal_missing")
-    _parse_iso8601_timestamp(
-        rehearsal_at_raw,
-        field_name="model_risk_evidence_package_rehearsal_at",
-    )
-    if not bool(runbook.get("emergency_stop_rehearsed", False)):
-        raise ValueError("model_risk_evidence_package_runbook_rehearsal_not_passed")
-
-    legacy_raw = payload_map.get("legacy_gap_disposition")
-    if not isinstance(legacy_raw, dict):
-        raise ValueError("model_risk_evidence_package_legacy_disposition_invalid")
-    legacy_disposition = cast(dict[str, Any], legacy_raw)
-    mapping_path = str(legacy_disposition.get("mapping_path", "")).strip()
-    if not mapping_path:
-        raise ValueError("model_risk_evidence_package_legacy_mapping_missing")
-    if not bool(legacy_disposition.get("signed_disposition_complete", False)):
-        raise ValueError("model_risk_evidence_package_legacy_disposition_incomplete")
-
-    return {
-        "schema_version": schema_version,
-        "generated_at": generated_at.isoformat(),
-        "age_hours": round(age_hours, 4),
-        "promotion_gate_report_trace_id": gate_trace,
-        "promotion_recommendation_trace_id": recommendation_trace,
-        "rollback_incident_evidence_path": incident_evidence_path,
-        "drift_evidence_continuity_report_path": continuity_path,
-        "runbook_rehearsal_at": rehearsal_at_raw,
-        "legacy_mapping_path": mapping_path,
-    }
-
-
-def _evaluate_acceptance_window(
-    *,
-    non_skipped_runs: int,
-    trade_decisions: int,
-    executions: int,
-    full_chain_runs: int,
-    route_total: int,
-    missing_route_rows: int,
-    route_fallback_rows: int,
-    advisor_eligible_rows: int,
-    advisor_payload_rows: int,
-    min_non_skipped_runs: int,
-    min_trade_decisions: int,
-    min_executions: int,
-    min_full_chain_runs: int,
-    min_route_coverage_ratio: float,
-    min_execution_advisor_coverage_ratio: float,
-    max_route_fallback_ratio: float,
-) -> dict[str, Any]:
-    route_coverage_ratio = (
-        max(0.0, (route_total - missing_route_rows) / route_total)
-        if route_total > 0
-        else 0.0
-    )
-    route_fallback_ratio = (
-        max(0.0, route_fallback_rows / route_total) if route_total > 0 else 0.0
-    )
-    execution_advisor_coverage_ratio = (
-        max(0.0, advisor_payload_rows / advisor_eligible_rows)
-        if advisor_eligible_rows > 0
-        else 1.0
-    )
-    passed = (
-        non_skipped_runs >= min_non_skipped_runs
-        and trade_decisions >= min_trade_decisions
-        and executions >= min_executions
-        and full_chain_runs >= min_full_chain_runs
-        and route_coverage_ratio >= min_route_coverage_ratio
-        and route_fallback_ratio <= max_route_fallback_ratio
-        and execution_advisor_coverage_ratio >= min_execution_advisor_coverage_ratio
+    execution_advisor_coverage_ratio = _safe_ratio(
+        counts.advisor_payload_rows,
+        counts.advisor_eligible_rows,
+        default=1.0,
     )
     return {
-        "passed": passed,
+        "passed": _acceptance_window_passed(
+            counts,
+            thresholds,
+            route_coverage_ratio=route_coverage_ratio,
+            route_fallback_ratio=route_fallback_ratio,
+            execution_advisor_coverage_ratio=execution_advisor_coverage_ratio,
+        ),
         "lookback": {
-            "non_skipped_runs": non_skipped_runs,
-            "trade_decisions": trade_decisions,
-            "executions": executions,
-            "full_chain_runs": full_chain_runs,
-            "route_total": route_total,
-            "missing_route_rows": missing_route_rows,
+            "non_skipped_runs": counts.non_skipped_runs,
+            "trade_decisions": counts.trade_decisions,
+            "executions": counts.executions,
+            "full_chain_runs": counts.full_chain_runs,
+            "route_total": counts.route_total,
+            "missing_route_rows": counts.missing_route_rows,
             "route_coverage_ratio": round(route_coverage_ratio, 6),
-            "route_fallback_rows": route_fallback_rows,
+            "route_fallback_rows": counts.route_fallback_rows,
             "route_fallback_ratio": round(route_fallback_ratio, 6),
-            "execution_advisor_eligible_rows": advisor_eligible_rows,
-            "execution_advisor_payload_rows": advisor_payload_rows,
+            "execution_advisor_eligible_rows": counts.advisor_eligible_rows,
+            "execution_advisor_payload_rows": counts.advisor_payload_rows,
             "execution_advisor_coverage_ratio": round(
                 execution_advisor_coverage_ratio, 6
             ),
         },
         "thresholds": {
-            "min_non_skipped_runs": min_non_skipped_runs,
-            "min_trade_decisions": min_trade_decisions,
-            "min_executions": min_executions,
-            "min_full_chain_runs": min_full_chain_runs,
-            "min_route_coverage_ratio": min_route_coverage_ratio,
-            "max_route_fallback_ratio": max_route_fallback_ratio,
-            "min_execution_advisor_coverage_ratio": min_execution_advisor_coverage_ratio,
+            "min_non_skipped_runs": thresholds.min_non_skipped_runs,
+            "min_trade_decisions": thresholds.min_trade_decisions,
+            "min_executions": thresholds.min_executions,
+            "min_full_chain_runs": thresholds.min_full_chain_runs,
+            "min_route_coverage_ratio": thresholds.min_route_coverage_ratio,
+            "max_route_fallback_ratio": thresholds.max_route_fallback_ratio,
+            "min_execution_advisor_coverage_ratio": thresholds.min_execution_advisor_coverage_ratio,
         },
     }
 
 
-def main() -> None:
+def _evaluate_acceptance_window(**values: Any) -> dict[str, Any]:
+    return _format_acceptance_window(
+        _acceptance_counts_from_values(values),
+        _acceptance_thresholds_from_values(values),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Verify Torghut autonomous quant readiness controls."
     )
@@ -475,165 +313,19 @@ def main() -> None:
         default=0.99,
         help="Minimum execution_advisor payload coverage ratio on rows that include microstructure_state.",
     )
-    args = parser.parse_args()
+    return parser
 
-    now = datetime.now(timezone.utc)
-    lookback_hours = max(1, int(args.lookback_hours))
-    lookback_start = now - timedelta(hours=lookback_hours)
 
-    with SessionLocal() as session:
-        missing_route_query = select(func.count(Execution.id)).where(
-            and_(
-                Execution.created_at >= lookback_start,
-                or_(
-                    Execution.execution_expected_adapter.is_(None),
-                    and_(
-                        Execution.execution_expected_adapter.is_not(None),
-                        func.btrim(Execution.execution_expected_adapter) == "",
-                    ),
-                    Execution.execution_actual_adapter.is_(None),
-                    and_(
-                        Execution.execution_actual_adapter.is_not(None),
-                        func.btrim(Execution.execution_actual_adapter) == "",
-                    ),
-                ),
-            )
-        )
-        missing_route_count = session.execute(missing_route_query).scalar_one()
-
-        total_route_count = session.execute(
-            select(func.count(Execution.id)).where(
-                Execution.created_at >= lookback_start
-            )
-        ).scalar_one()
-        fallback_route_count = session.execute(
-            select(func.count(Execution.id)).where(
-                and_(
-                    Execution.created_at >= lookback_start,
-                    Execution.execution_fallback_count > 0,
-                )
-            )
-        ).scalar_one()
-
-        invalid_fallback_reason_count = session.execute(
-            select(func.count(Execution.id)).where(
-                and_(
-                    Execution.created_at >= lookback_start,
-                    Execution.execution_fallback_count > 0,
-                    or_(
-                        Execution.execution_fallback_reason.is_(None),
-                        and_(
-                            Execution.execution_fallback_reason.is_not(None),
-                            func.btrim(Execution.execution_fallback_reason) == "",
-                        ),
-                    ),
-                )
-            )
-        ).scalar_one()
-
-        missing_research_trace_count = session.execute(
-            select(func.count(ResearchRun.id)).where(
-                and_(
-                    ResearchRun.created_at >= lookback_start,
-                    ResearchRun.status != "skipped",
-                    or_(
-                        ResearchRun.gate_report_trace_id.is_(None),
-                        and_(
-                            ResearchRun.gate_report_trace_id.is_not(None),
-                            func.btrim(ResearchRun.gate_report_trace_id) == "",
-                        ),
-                        ResearchRun.recommendation_trace_id.is_(None),
-                        and_(
-                            ResearchRun.recommendation_trace_id.is_not(None),
-                            func.btrim(ResearchRun.recommendation_trace_id) == "",
-                        ),
-                    ),
-                )
-            )
-        ).scalar_one()
-
-        non_skipped_runs = session.execute(
-            select(func.count(ResearchRun.id)).where(
-                and_(
-                    ResearchRun.created_at >= lookback_start,
-                    ResearchRun.status != "skipped",
-                )
-            )
-        ).scalar_one()
-
-        trade_decisions = session.execute(
-            select(func.count(TradeDecision.id)).where(
-                TradeDecision.created_at >= lookback_start
-            )
-        ).scalar_one()
-        advisor_coverage = session.execute(
-            select(
-                func.count(TradeDecision.id).filter(
-                    func.jsonb_typeof(
-                        TradeDecision.decision_json["params"]["microstructure_state"]
-                    )
-                    == "object"
-                ),
-                func.count(TradeDecision.id).filter(
-                    and_(
-                        func.jsonb_typeof(
-                            TradeDecision.decision_json["params"][
-                                "microstructure_state"
-                            ]
-                        )
-                        == "object",
-                        func.jsonb_typeof(
-                            TradeDecision.decision_json["params"]["execution_advisor"]
-                        )
-                        == "object",
-                    )
-                ),
-            ).where(TradeDecision.created_at >= lookback_start)
-        ).one()
-        advisor_eligible_rows = int(advisor_coverage[0] or 0)
-        advisor_payload_rows = int(advisor_coverage[1] or 0)
-
-        executions = session.execute(
-            select(func.count(Execution.id)).where(
-                Execution.created_at >= lookback_start
-            )
-        ).scalar_one()
-
-        full_chain_runs = session.execute(
-            select(func.count(func.distinct(ResearchRun.run_id)))
-            .select_from(ResearchRun)
-            .join(ResearchCandidate, ResearchCandidate.run_id == ResearchRun.run_id)
-            .join(
-                ResearchFoldMetrics,
-                ResearchFoldMetrics.candidate_id == ResearchCandidate.candidate_id,
-            )
-            .join(
-                ResearchStressMetrics,
-                ResearchStressMetrics.candidate_id == ResearchCandidate.candidate_id,
-            )
-            .join(
-                ResearchPromotion,
-                ResearchPromotion.candidate_id == ResearchCandidate.candidate_id,
-            )
-            .where(
-                and_(
-                    ResearchRun.created_at >= lookback_start,
-                    ResearchRun.status != "skipped",
-                )
-            )
-        ).scalar_one()
-
-    checks: dict[str, Any] = {
-        "acceptance_window": _evaluate_acceptance_window(
-            non_skipped_runs=int(non_skipped_runs),
-            trade_decisions=int(trade_decisions),
-            executions=int(executions),
-            full_chain_runs=int(full_chain_runs),
-            route_total=int(total_route_count),
-            missing_route_rows=int(missing_route_count),
-            route_fallback_rows=int(fallback_route_count),
-            advisor_eligible_rows=advisor_eligible_rows,
-            advisor_payload_rows=advisor_payload_rows,
+def _readiness_thresholds_from_args(args: argparse.Namespace) -> ReadinessThresholds:
+    return ReadinessThresholds(
+        max_missing_provenance=int(args.max_missing_provenance),
+        max_invalid_fallback_reason=int(args.max_invalid_fallback_reason),
+        max_missing_research_traces=int(args.max_missing_research_traces),
+        max_model_risk_evidence_age_hours=max(
+            1,
+            int(args.max_model_risk_evidence_age_hours),
+        ),
+        acceptance=AcceptanceWindowThresholds(
             min_non_skipped_runs=max(1, int(args.min_non_skipped_runs)),
             min_trade_decisions=max(1, int(args.min_trade_decisions)),
             min_executions=max(1, int(args.min_executions)),
@@ -645,148 +337,409 @@ def main() -> None:
                 float(args.min_execution_advisor_coverage_ratio),
             ),
         ),
-        "execution_route_provenance": {
-            "missing_rows": int(missing_route_count),
-            "threshold": args.max_missing_provenance,
-            "passed": int(missing_route_count) <= args.max_missing_provenance,
-        },
-        "execution_route_fallback_ratio": {
-            "fallback_rows": int(fallback_route_count),
-            "route_total": int(total_route_count),
-            "ratio": (
-                round(int(fallback_route_count) / int(total_route_count), 6)
-                if int(total_route_count) > 0
-                else 0.0
+    )
+
+
+def _missing_text(column: Any) -> Any:
+    return or_(column.is_(None), and_(column.is_not(None), func.btrim(column) == ""))
+
+
+def _count_rows(session: Session, query: Any) -> int:
+    return int(session.execute(query).scalar_one())
+
+
+def _count_missing_route_rows(session: Session, lookback_start: datetime) -> int:
+    return _count_rows(
+        session,
+        select(func.count(Execution.id)).where(
+            and_(
+                Execution.created_at >= lookback_start,
+                or_(
+                    _missing_text(Execution.execution_expected_adapter),
+                    _missing_text(Execution.execution_actual_adapter),
+                ),
+            )
+        ),
+    )
+
+
+def _count_total_route_rows(session: Session, lookback_start: datetime) -> int:
+    return _count_rows(
+        session,
+        select(func.count(Execution.id)).where(Execution.created_at >= lookback_start),
+    )
+
+
+def _count_fallback_route_rows(session: Session, lookback_start: datetime) -> int:
+    return _count_rows(
+        session,
+        select(func.count(Execution.id)).where(
+            and_(
+                Execution.created_at >= lookback_start,
+                Execution.execution_fallback_count > 0,
+            )
+        ),
+    )
+
+
+def _count_invalid_fallback_reason_rows(
+    session: Session,
+    lookback_start: datetime,
+) -> int:
+    return _count_rows(
+        session,
+        select(func.count(Execution.id)).where(
+            and_(
+                Execution.created_at >= lookback_start,
+                Execution.execution_fallback_count > 0,
+                _missing_text(Execution.execution_fallback_reason),
+            )
+        ),
+    )
+
+
+def _count_missing_research_trace_rows(
+    session: Session,
+    lookback_start: datetime,
+) -> int:
+    return _count_rows(
+        session,
+        select(func.count(ResearchRun.id)).where(
+            and_(
+                ResearchRun.created_at >= lookback_start,
+                ResearchRun.status != "skipped",
+                or_(
+                    _missing_text(ResearchRun.gate_report_trace_id),
+                    _missing_text(ResearchRun.recommendation_trace_id),
+                ),
+            )
+        ),
+    )
+
+
+def _count_non_skipped_runs(session: Session, lookback_start: datetime) -> int:
+    return _count_rows(
+        session,
+        select(func.count(ResearchRun.id)).where(
+            and_(
+                ResearchRun.created_at >= lookback_start,
+                ResearchRun.status != "skipped",
+            )
+        ),
+    )
+
+
+def _count_trade_decisions(session: Session, lookback_start: datetime) -> int:
+    return _count_rows(
+        session,
+        select(func.count(TradeDecision.id)).where(
+            TradeDecision.created_at >= lookback_start
+        ),
+    )
+
+
+def _load_execution_advisor_coverage(
+    session: Session,
+    lookback_start: datetime,
+) -> tuple[int, int]:
+    advisor_coverage = session.execute(
+        select(
+            func.count(TradeDecision.id).filter(
+                func.jsonb_typeof(
+                    TradeDecision.decision_json["params"]["microstructure_state"]
+                )
+                == "object"
             ),
-            "threshold": max(0.0, float(args.max_route_fallback_ratio)),
-            "passed": (
-                (int(fallback_route_count) / int(total_route_count))
-                <= max(0.0, float(args.max_route_fallback_ratio))
-                if int(total_route_count) > 0
-                else True
+            func.count(TradeDecision.id).filter(
+                and_(
+                    func.jsonb_typeof(
+                        TradeDecision.decision_json["params"]["microstructure_state"]
+                    )
+                    == "object",
+                    func.jsonb_typeof(
+                        TradeDecision.decision_json["params"]["execution_advisor"]
+                    )
+                    == "object",
+                )
             ),
-        },
-        "execution_advisor_provenance": {
-            "microstructure_rows": advisor_eligible_rows,
-            "execution_advisor_rows": advisor_payload_rows,
-            "coverage_ratio": (
-                round(advisor_payload_rows / advisor_eligible_rows, 6)
-                if advisor_eligible_rows > 0
-                else 1.0
+        ).where(TradeDecision.created_at >= lookback_start)
+    ).one()
+    return int(advisor_coverage[0] or 0), int(advisor_coverage[1] or 0)
+
+
+def _count_executions(session: Session, lookback_start: datetime) -> int:
+    return _count_rows(
+        session,
+        select(func.count(Execution.id)).where(Execution.created_at >= lookback_start),
+    )
+
+
+def _count_full_chain_runs(session: Session, lookback_start: datetime) -> int:
+    return _count_rows(
+        session,
+        select(func.count(func.distinct(ResearchRun.run_id)))
+        .select_from(ResearchRun)
+        .join(ResearchCandidate, ResearchCandidate.run_id == ResearchRun.run_id)
+        .join(
+            ResearchFoldMetrics,
+            ResearchFoldMetrics.candidate_id == ResearchCandidate.candidate_id,
+        )
+        .join(
+            ResearchStressMetrics,
+            ResearchStressMetrics.candidate_id == ResearchCandidate.candidate_id,
+        )
+        .join(
+            ResearchPromotion,
+            ResearchPromotion.candidate_id == ResearchCandidate.candidate_id,
+        )
+        .where(
+            and_(
+                ResearchRun.created_at >= lookback_start,
+                ResearchRun.status != "skipped",
+            )
+        ),
+    )
+
+
+def _load_readiness_counts(lookback_start: datetime) -> ReadinessCounts:
+    with SessionLocal() as session:
+        advisor_eligible_rows, advisor_payload_rows = _load_execution_advisor_coverage(
+            session,
+            lookback_start,
+        )
+        return ReadinessCounts(
+            missing_route_count=_count_missing_route_rows(session, lookback_start),
+            total_route_count=_count_total_route_rows(session, lookback_start),
+            fallback_route_count=_count_fallback_route_rows(session, lookback_start),
+            invalid_fallback_reason_count=_count_invalid_fallback_reason_rows(
+                session,
+                lookback_start,
             ),
-            "threshold": max(0.0, float(args.min_execution_advisor_coverage_ratio)),
-            "passed": (
-                (advisor_payload_rows / advisor_eligible_rows)
-                >= max(0.0, float(args.min_execution_advisor_coverage_ratio))
-                if advisor_eligible_rows > 0
-                else True
+            missing_research_trace_count=_count_missing_research_trace_rows(
+                session,
+                lookback_start,
             ),
-        },
-        "execution_fallback_reason": {
-            "missing_rows": int(invalid_fallback_reason_count),
-            "threshold": args.max_invalid_fallback_reason,
-            "passed": int(invalid_fallback_reason_count)
-            <= args.max_invalid_fallback_reason,
-        },
-        "research_trace_provenance": {
-            "missing_rows": int(missing_research_trace_count),
-            "threshold": args.max_missing_research_traces,
-            "passed": int(missing_research_trace_count)
-            <= args.max_missing_research_traces,
-        },
+            non_skipped_runs=_count_non_skipped_runs(session, lookback_start),
+            trade_decisions=_count_trade_decisions(session, lookback_start),
+            advisor_eligible_rows=advisor_eligible_rows,
+            advisor_payload_rows=advisor_payload_rows,
+            executions=_count_executions(session, lookback_start),
+            full_chain_runs=_count_full_chain_runs(session, lookback_start),
+        )
+
+
+def _count_threshold_check(missing_rows: int, threshold: int) -> dict[str, Any]:
+    return {
+        "missing_rows": missing_rows,
+        "threshold": threshold,
+        "passed": missing_rows <= threshold,
     }
 
+
+def _route_fallback_ratio_check(
+    counts: ReadinessCounts,
+    thresholds: ReadinessThresholds,
+) -> dict[str, Any]:
+    ratio = _safe_ratio(counts.fallback_route_count, counts.total_route_count)
+    return {
+        "fallback_rows": counts.fallback_route_count,
+        "route_total": counts.total_route_count,
+        "ratio": round(ratio, 6),
+        "threshold": thresholds.acceptance.max_route_fallback_ratio,
+        "passed": ratio <= thresholds.acceptance.max_route_fallback_ratio,
+    }
+
+
+def _execution_advisor_provenance_check(
+    counts: ReadinessCounts,
+    thresholds: ReadinessThresholds,
+) -> dict[str, Any]:
+    coverage_ratio = _safe_ratio(
+        counts.advisor_payload_rows,
+        counts.advisor_eligible_rows,
+        default=1.0,
+    )
+    return {
+        "microstructure_rows": counts.advisor_eligible_rows,
+        "execution_advisor_rows": counts.advisor_payload_rows,
+        "coverage_ratio": round(coverage_ratio, 6),
+        "threshold": thresholds.acceptance.min_execution_advisor_coverage_ratio,
+        "passed": coverage_ratio
+        >= thresholds.acceptance.min_execution_advisor_coverage_ratio,
+    }
+
+
+def _build_core_checks(
+    counts: ReadinessCounts,
+    thresholds: ReadinessThresholds,
+) -> dict[str, Any]:
+    return {
+        "acceptance_window": _format_acceptance_window(
+            _acceptance_counts_from_readiness(counts),
+            thresholds.acceptance,
+        ),
+        "execution_route_provenance": _count_threshold_check(
+            counts.missing_route_count,
+            thresholds.max_missing_provenance,
+        ),
+        "execution_route_fallback_ratio": _route_fallback_ratio_check(
+            counts,
+            thresholds,
+        ),
+        "execution_advisor_provenance": _execution_advisor_provenance_check(
+            counts,
+            thresholds,
+        ),
+        "execution_fallback_reason": _count_threshold_check(
+            counts.invalid_fallback_reason_count,
+            thresholds.max_invalid_fallback_reason,
+        ),
+        "research_trace_provenance": _count_threshold_check(
+            counts.missing_research_trace_count,
+            thresholds.max_missing_research_traces,
+        ),
+    }
+
+
+def _add_governance_trace_check(checks: dict[str, Any], path: Path) -> None:
+    trace_payload = _load_gate_trace(path)
+    checks["governance_trace"] = {
+        "artifact": str(path),
+        "gate_report_trace_id": trace_payload["gate_report_trace_id"],
+        "recommendation_trace_id": trace_payload["recommendation_trace_id"],
+        "passed": True,
+    }
+
+
+def _add_rollback_incident_check(checks: dict[str, Any], path: Path) -> None:
+    incident_payload = _load_incident_evidence(path)
+    checks["rollback_incident_evidence"] = {
+        "artifact": str(path),
+        "triggered_at": incident_payload.get("triggered_at"),
+        "reason_count": len(cast(list[Any], incident_payload.get("reasons", []))),
+        "passed": True,
+    }
+
+
+def _add_profitability_evidence_check(checks: dict[str, Any], path: Path) -> None:
+    proof_payload = _load_profitability_proof(path)
+    checks["profitability_evidence"] = {
+        "artifact": str(path),
+        "hypothesis": proof_payload.get("hypothesis"),
+        "sample_size": proof_payload.get("sample_size"),
+        "window_days": proof_payload.get("window_days"),
+        "effect_size": proof_payload.get("effect_size"),
+        "p_value": proof_payload.get("p_value"),
+        "drawdown_delta": proof_payload.get("drawdown_delta"),
+        "passed": True,
+    }
+
+
+def _add_control_plane_contract_check(checks: dict[str, Any], path: Path) -> None:
+    contract_payload = _load_control_plane_contract(path)
+    checks["control_plane_contract"] = {
+        "artifact": str(path),
+        "contract_version": contract_payload.get("contract_version"),
+        "last_autonomy_recommendation_trace_id": contract_payload.get(
+            "last_autonomy_recommendation_trace_id"
+        ),
+        "domain_telemetry_event_total": contract_payload.get(
+            "domain_telemetry_event_total"
+        ),
+        "domain_telemetry_dropped_total": contract_payload.get(
+            "domain_telemetry_dropped_total"
+        ),
+        "passed": True,
+    }
+
+
+def _add_model_risk_evidence_check(
+    checks: dict[str, Any],
+    path: Path,
+    *,
+    now: datetime,
+    max_age_hours: int,
+) -> None:
+    package_payload = _load_model_risk_evidence_package(
+        path,
+        now=now,
+        max_age_hours=max_age_hours,
+    )
+    checks["model_risk_evidence_package"] = {
+        "artifact": str(path),
+        **package_payload,
+        "passed": True,
+    }
+
+
+def _add_optional_artifact_checks(
+    checks: dict[str, Any],
+    args: argparse.Namespace,
+    *,
+    now: datetime,
+    thresholds: ReadinessThresholds,
+) -> None:
     if args.gate_report:
-        checks["governance_trace"] = {
-            "artifact": str(args.gate_report),
-            "passed": False,
-        }
-        trace_payload = _load_gate_trace(args.gate_report)
-        checks["governance_trace"] = {
-            "artifact": str(args.gate_report),
-            "gate_report_trace_id": trace_payload["gate_report_trace_id"],
-            "recommendation_trace_id": trace_payload["recommendation_trace_id"],
-            "passed": True,
-        }
-
+        _add_governance_trace_check(checks, args.gate_report)
     if args.incident_evidence:
-        checks["rollback_incident_evidence"] = {
-            "artifact": str(args.incident_evidence),
-            "passed": False,
-        }
-        incident_payload = _load_incident_evidence(args.incident_evidence)
-        checks["rollback_incident_evidence"] = {
-            "artifact": str(args.incident_evidence),
-            "triggered_at": incident_payload.get("triggered_at"),
-            "reason_count": len(cast(list[Any], incident_payload.get("reasons", []))),
-            "passed": True,
-        }
-
+        _add_rollback_incident_check(checks, args.incident_evidence)
     if args.profitability_proof:
-        checks["profitability_evidence"] = {
-            "artifact": str(args.profitability_proof),
-            "passed": False,
-        }
-        proof_payload = _load_profitability_proof(args.profitability_proof)
-        checks["profitability_evidence"] = {
-            "artifact": str(args.profitability_proof),
-            "hypothesis": proof_payload.get("hypothesis"),
-            "sample_size": proof_payload.get("sample_size"),
-            "window_days": proof_payload.get("window_days"),
-            "effect_size": proof_payload.get("effect_size"),
-            "p_value": proof_payload.get("p_value"),
-            "drawdown_delta": proof_payload.get("drawdown_delta"),
-            "passed": True,
-        }
-
+        _add_profitability_evidence_check(checks, args.profitability_proof)
     if args.control_plane_contract:
-        checks["control_plane_contract"] = {
-            "artifact": str(args.control_plane_contract),
-            "passed": False,
-        }
-        contract_payload = _load_control_plane_contract(args.control_plane_contract)
-        checks["control_plane_contract"] = {
-            "artifact": str(args.control_plane_contract),
-            "contract_version": contract_payload.get("contract_version"),
-            "last_autonomy_recommendation_trace_id": contract_payload.get(
-                "last_autonomy_recommendation_trace_id"
-            ),
-            "domain_telemetry_event_total": contract_payload.get(
-                "domain_telemetry_event_total"
-            ),
-            "domain_telemetry_dropped_total": contract_payload.get(
-                "domain_telemetry_dropped_total"
-            ),
-            "passed": True,
-        }
-
+        _add_control_plane_contract_check(checks, args.control_plane_contract)
     if args.model_risk_evidence_package:
-        checks["model_risk_evidence_package"] = {
-            "artifact": str(args.model_risk_evidence_package),
-            "passed": False,
-        }
-        package_payload = _load_model_risk_evidence_package(
+        _add_model_risk_evidence_check(
+            checks,
             args.model_risk_evidence_package,
             now=now,
-            max_age_hours=max(1, int(args.max_model_risk_evidence_age_hours)),
+            max_age_hours=thresholds.max_model_risk_evidence_age_hours,
         )
-        checks["model_risk_evidence_package"] = {
-            "artifact": str(args.model_risk_evidence_package),
-            **package_payload,
-            "passed": True,
-        }
 
+
+def _build_readiness_payload(
+    *,
+    now: datetime,
+    lookback_start: datetime,
+    lookback_hours: int,
+    checks: Mapping[str, Any],
+) -> dict[str, Any]:
     all_passed = all(bool(item.get("passed")) for item in checks.values())
-    payload = {
+    return {
         "ok": all_passed,
         "evaluated_at": now.isoformat(),
         "lookback_start": lookback_start.isoformat(),
         "lookback_hours": lookback_hours,
         "checks": checks,
     }
+
+
+def _emit_readiness_payload(payload: Mapping[str, Any]) -> None:
     print(json.dumps(payload, indent=2))
-    if not all_passed:
+    if not bool(payload.get("ok")):
         raise SystemExit(1)
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    now = datetime.now(timezone.utc)
+    lookback_hours = max(1, int(args.lookback_hours))
+    lookback_start = now - timedelta(hours=lookback_hours)
+    thresholds = _readiness_thresholds_from_args(args)
+    checks = _build_core_checks(_load_readiness_counts(lookback_start), thresholds)
+    _add_optional_artifact_checks(
+        checks,
+        args,
+        now=now,
+        thresholds=thresholds,
+    )
+    _emit_readiness_payload(
+        _build_readiness_payload(
+            now=now,
+            lookback_start=lookback_start,
+            lookback_hours=lookback_hours,
+            checks=checks,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/test_verify_quant_readiness.py
+++ b/services/torghut/tests/test_verify_quant_readiness.py
@@ -1,20 +1,173 @@
 from __future__ import annotations
 
+import argparse
+import io
 import json
 import tempfile
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 
 from scripts.verify_quant_readiness import (
+    AcceptanceWindowThresholds,
+    ReadinessCounts,
+    ReadinessThresholds,
+    _add_optional_artifact_checks,
+    _build_core_checks,
+    _build_readiness_payload,
+    _emit_readiness_payload,
     _evaluate_acceptance_window,
     _load_control_plane_contract,
     _load_gate_trace,
+    _load_incident_evidence,
+    _load_readiness_counts,
     _load_model_risk_evidence_package,
+    _load_profitability_proof,
+    main,
 )
+from scripts.quant_readiness_artifacts import _parse_iso8601_timestamp
+
+
+class _FakeExecuteResult:
+    def __init__(
+        self,
+        *,
+        scalar: int | None = None,
+        row: tuple[int, int] | None = None,
+    ) -> None:
+        self._scalar = scalar
+        self._row = row
+
+    def scalar_one(self) -> int:
+        if self._scalar is None:
+            raise AssertionError("fake scalar result was not configured")
+        return self._scalar
+
+    def one(self) -> tuple[int, int]:
+        if self._row is None:
+            raise AssertionError("fake row result was not configured")
+        return self._row
+
+
+class _FakeSession:
+    def __init__(self, results: list[_FakeExecuteResult]) -> None:
+        self.results = results
+        self.queries: list[object] = []
+
+    def execute(self, query: object) -> _FakeExecuteResult:
+        self.queries.append(query)
+        if not self.results:
+            raise AssertionError("unexpected extra query")
+        return self.results.pop(0)
+
+
+class _FakeSessionContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self.session = session
+
+    def __enter__(self) -> _FakeSession:
+        return self.session
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def _readiness_thresholds() -> ReadinessThresholds:
+    return ReadinessThresholds(
+        max_missing_provenance=0,
+        max_invalid_fallback_reason=0,
+        max_missing_research_traces=0,
+        max_model_risk_evidence_age_hours=24,
+        acceptance=AcceptanceWindowThresholds(
+            min_non_skipped_runs=1,
+            min_trade_decisions=1,
+            min_executions=1,
+            min_full_chain_runs=1,
+            min_route_coverage_ratio=0.95,
+            min_execution_advisor_coverage_ratio=0.85,
+            max_route_fallback_ratio=0.25,
+        ),
+    )
+
+
+def _model_risk_payload(now: datetime) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.model-risk-evidence.v1",
+        "generated_at": now.isoformat(),
+        "promotion": {
+            "gate_report_trace_id": "gate-trace-1",
+            "recommendation_trace_id": "rec-trace-1",
+        },
+        "rollback": {
+            "incident_evidence_complete": True,
+            "incident_evidence_path": "/tmp/rollback.json",
+        },
+        "drift": {
+            "evidence_continuity_passed": True,
+            "evidence_continuity_report_path": "/tmp/evidence.json",
+        },
+        "runbook_drill": {
+            "emergency_stop_rehearsed": True,
+            "rehearsal_at": now.isoformat(),
+        },
+        "legacy_gap_disposition": {
+            "signed_disposition_complete": True,
+            "mapping_path": "docs/torghut/design-system/v6/14-legacy-gap-disposition-map-2026-03-03.md",
+        },
+    }
+
+
+def _control_plane_payload() -> dict[str, object]:
+    return {
+        "contract_version": "torghut.quant-producer.v1",
+        "signal_continuity_state": "signals_present",
+        "signal_continuity_alert_active": False,
+        "signal_continuity_promotion_block_total": 0,
+        "last_autonomy_recommendation_trace_id": "trace-1",
+        "domain_telemetry_event_total": {"torghut.autonomy.cycle_completed": 2},
+        "domain_telemetry_dropped_total": {"disabled": 2},
+        "alpha_readiness_hypotheses_total": 3,
+        "alpha_readiness_shadow_total": 2,
+        "alpha_readiness_blocked_total": 1,
+        "alpha_readiness_dependency_quorum_decision": "unknown",
+    }
+
+
+def _profitability_payload() -> dict[str, object]:
+    return {
+        "hypothesis": "alpha proof",
+        "sample_size": 12,
+        "window_days": 30,
+        "statistics": {"effect_size": 1.2, "p_value": 0.04},
+        "risk_controls": {"max_drawdown_delta": 0.1},
+    }
+
+
+def _incident_payload(now: datetime) -> dict[str, object]:
+    return {
+        "triggered_at": now.isoformat(),
+        "reasons": ["manual-stop"],
+        "rollback_hooks": {"order_submission_blocked": True},
+        "safety_snapshot": {},
+        "provenance": {},
+        "verification": {"incident_evidence_complete": True},
+    }
 
 
 class TestVerifyQuantReadiness(TestCase):
+    def _assert_loader_rejects(
+        self,
+        loader: Callable[[Path], object],
+        payload: object,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "payload.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                loader(path)
+
     def test_load_gate_trace_reads_required_trace_ids(self) -> None:
         payload = {
             "provenance": {
@@ -38,6 +191,23 @@ class TestVerifyQuantReadiness(TestCase):
             )
             with self.assertRaises(ValueError):
                 _load_gate_trace(path)
+
+    def test_parse_iso8601_rejects_invalid_timestamp_shapes(self) -> None:
+        self.assertEqual(
+            _parse_iso8601_timestamp("2026-03-03T20:00:00Z", field_name="field"),
+            datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc),
+        )
+        for raw in ("", "not-a-time", "2026-03-03T20:00:00"):
+            with self.assertRaises(ValueError):
+                _parse_iso8601_timestamp(raw, field_name="field")
+
+    def test_load_gate_trace_rejects_invalid_payload_shapes(self) -> None:
+        self._assert_loader_rejects(_load_gate_trace, [])
+        self._assert_loader_rejects(_load_gate_trace, {"provenance": []})
+        self._assert_loader_rejects(
+            _load_gate_trace,
+            {"provenance": {"recommendation_trace_id": "rec-1"}},
+        )
 
     def test_acceptance_window_passes_when_thresholds_met(self) -> None:
         result = _evaluate_acceptance_window(
@@ -135,20 +305,101 @@ class TestVerifyQuantReadiness(TestCase):
         lookback = result["lookback"]
         self.assertEqual(lookback["route_fallback_ratio"], 0.4)
 
+    def test_load_readiness_counts_wires_query_results(self) -> None:
+        fake_session = _FakeSession(
+            [
+                _FakeExecuteResult(row=(8, 7)),
+                _FakeExecuteResult(scalar=1),
+                _FakeExecuteResult(scalar=10),
+                _FakeExecuteResult(scalar=2),
+                _FakeExecuteResult(scalar=0),
+                _FakeExecuteResult(scalar=0),
+                _FakeExecuteResult(scalar=3),
+                _FakeExecuteResult(scalar=6),
+                _FakeExecuteResult(scalar=5),
+                _FakeExecuteResult(scalar=2),
+            ]
+        )
+        with patch(
+            "scripts.verify_quant_readiness.SessionLocal",
+            return_value=_FakeSessionContext(fake_session),
+        ):
+            counts = _load_readiness_counts(datetime(2026, 3, 3, tzinfo=timezone.utc))
+
+        self.assertEqual(counts.missing_route_count, 1)
+        self.assertEqual(counts.total_route_count, 10)
+        self.assertEqual(counts.advisor_eligible_rows, 8)
+        self.assertEqual(counts.full_chain_runs, 2)
+        self.assertEqual(len(fake_session.queries), 10)
+
+    def test_core_checks_and_payload_preserve_readiness_shape(self) -> None:
+        counts = ReadinessCounts(
+            missing_route_count=0,
+            total_route_count=10,
+            fallback_route_count=2,
+            invalid_fallback_reason_count=0,
+            missing_research_trace_count=0,
+            non_skipped_runs=3,
+            trade_decisions=6,
+            advisor_eligible_rows=8,
+            advisor_payload_rows=7,
+            executions=5,
+            full_chain_runs=2,
+        )
+        checks = _build_core_checks(counts, _readiness_thresholds())
+        now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
+        payload = _build_readiness_payload(
+            now=now,
+            lookback_start=now - timedelta(hours=24),
+            lookback_hours=24,
+            checks=checks,
+        )
+
+        self.assertTrue(payload["ok"])
+        self.assertTrue(checks["acceptance_window"]["passed"])
+        self.assertEqual(checks["execution_route_fallback_ratio"]["ratio"], 0.2)
+        self.assertEqual(
+            checks["execution_advisor_provenance"]["coverage_ratio"],
+            0.875,
+        )
+
+    def test_main_emits_default_readiness_payload(self) -> None:
+        counts = ReadinessCounts(
+            missing_route_count=0,
+            total_route_count=10,
+            fallback_route_count=0,
+            invalid_fallback_reason_count=0,
+            missing_research_trace_count=0,
+            non_skipped_runs=2,
+            trade_decisions=2,
+            advisor_eligible_rows=2,
+            advisor_payload_rows=2,
+            executions=2,
+            full_chain_runs=1,
+        )
+        with (
+            patch(
+                "scripts.verify_quant_readiness._load_readiness_counts",
+                return_value=counts,
+            ),
+            patch("sys.argv", ["verify_quant_readiness.py"]),
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["lookback_hours"], 24)
+
+    def test_emit_readiness_payload_exits_when_checks_fail(self) -> None:
+        with (
+            patch("sys.stdout", new_callable=io.StringIO),
+            self.assertRaises(SystemExit),
+        ):
+            _emit_readiness_payload({"ok": False, "checks": {}})
+
     def test_load_control_plane_contract_requires_wave6_keys(self) -> None:
-        payload = {
-            "contract_version": "torghut.quant-producer.v1",
-            "signal_continuity_state": "signals_present",
-            "signal_continuity_alert_active": False,
-            "signal_continuity_promotion_block_total": 0,
-            "last_autonomy_recommendation_trace_id": "trace-1",
-            "domain_telemetry_event_total": {"torghut.autonomy.cycle_completed": 2},
-            "domain_telemetry_dropped_total": {"disabled": 2},
-            "alpha_readiness_hypotheses_total": 3,
-            "alpha_readiness_shadow_total": 2,
-            "alpha_readiness_blocked_total": 1,
-            "alpha_readiness_dependency_quorum_decision": "unknown",
-        }
+        payload = _control_plane_payload()
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "control-plane-contract.json"
             path.write_text(json.dumps(payload), encoding="utf-8")
@@ -165,32 +416,56 @@ class TestVerifyQuantReadiness(TestCase):
             with self.assertRaises(ValueError):
                 _load_control_plane_contract(path)
 
+    def test_load_control_plane_contract_rejects_invalid_shapes(self) -> None:
+        valid = _control_plane_payload()
+        invalid_cases: list[object] = [
+            [],
+            valid | {"contract_version": "bad"},
+            valid | {"domain_telemetry_event_total": []},
+            valid | {"domain_telemetry_dropped_total": []},
+            valid | {"alpha_readiness_dependency_quorum_decision": "bad"},
+        ]
+        for payload in invalid_cases:
+            with self.subTest(payload=payload):
+                self._assert_loader_rejects(_load_control_plane_contract, payload)
+
+    def test_load_profitability_proof_rejects_invalid_shapes(self) -> None:
+        valid = _profitability_payload()
+        invalid_cases: list[object] = [
+            [],
+            {"hypothesis": "alpha proof"},
+            valid | {"statistics": []},
+            valid | {"statistics": {"effect_size": "bad", "p_value": 0.04}},
+            valid | {"sample_size": 0},
+            valid | {"statistics": {"effect_size": 1.2, "p_value": 2}},
+            valid | {"risk_controls": []},
+            valid | {"risk_controls": {"max_drawdown_delta": "bad"}},
+            valid | {"window_days": 0},
+            valid | {"hypothesis": ""},
+        ]
+        for payload in invalid_cases:
+            with self.subTest(payload=payload):
+                self._assert_loader_rejects(_load_profitability_proof, payload)
+
+    def test_load_incident_evidence_rejects_invalid_shapes(self) -> None:
+        now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
+        valid = _incident_payload(now)
+        invalid_cases: list[object] = [
+            [],
+            {"triggered_at": now.isoformat()},
+            valid | {"rollback_hooks": []},
+            valid | {"reasons": []},
+            valid | {"rollback_hooks": {"order_submission_blocked": False}},
+            valid | {"verification": []},
+            valid | {"verification": {"incident_evidence_complete": False}},
+        ]
+        for payload in invalid_cases:
+            with self.subTest(payload=payload):
+                self._assert_loader_rejects(_load_incident_evidence, payload)
+
     def test_load_model_risk_evidence_package_passes_when_complete(self) -> None:
         now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
-        payload = {
-            "schema_version": "torghut.model-risk-evidence.v1",
-            "generated_at": now.isoformat(),
-            "promotion": {
-                "gate_report_trace_id": "gate-trace-1",
-                "recommendation_trace_id": "rec-trace-1",
-            },
-            "rollback": {
-                "incident_evidence_complete": True,
-                "incident_evidence_path": "/tmp/rollback.json",
-            },
-            "drift": {
-                "evidence_continuity_passed": True,
-                "evidence_continuity_report_path": "/tmp/evidence.json",
-            },
-            "runbook_drill": {
-                "emergency_stop_rehearsed": True,
-                "rehearsal_at": now.isoformat(),
-            },
-            "legacy_gap_disposition": {
-                "signed_disposition_complete": True,
-                "mapping_path": "docs/torghut/design-system/v6/14-legacy-gap-disposition-map-2026-03-03.md",
-            },
-        }
+        payload = _model_risk_payload(now)
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "model-risk-evidence.json"
             path.write_text(json.dumps(payload), encoding="utf-8")
@@ -208,30 +483,7 @@ class TestVerifyQuantReadiness(TestCase):
     def test_load_model_risk_evidence_package_rejects_stale_payload(self) -> None:
         now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
         stale = now - timedelta(hours=72)
-        payload = {
-            "schema_version": "torghut.model-risk-evidence.v1",
-            "generated_at": stale.isoformat(),
-            "promotion": {
-                "gate_report_trace_id": "gate-trace-1",
-                "recommendation_trace_id": "rec-trace-1",
-            },
-            "rollback": {
-                "incident_evidence_complete": True,
-                "incident_evidence_path": "/tmp/rollback.json",
-            },
-            "drift": {
-                "evidence_continuity_passed": True,
-                "evidence_continuity_report_path": "/tmp/evidence.json",
-            },
-            "runbook_drill": {
-                "emergency_stop_rehearsed": True,
-                "rehearsal_at": now.isoformat(),
-            },
-            "legacy_gap_disposition": {
-                "signed_disposition_complete": True,
-                "mapping_path": "docs/torghut/design-system/v6/14-legacy-gap-disposition-map-2026-03-03.md",
-            },
-        }
+        payload = _model_risk_payload(now) | {"generated_at": stale.isoformat()}
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "model-risk-evidence.json"
             path.write_text(json.dumps(payload), encoding="utf-8")
@@ -241,30 +493,7 @@ class TestVerifyQuantReadiness(TestCase):
     def test_load_model_risk_evidence_package_rejects_future_generated_at(self) -> None:
         now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
         future = now + timedelta(hours=2)
-        payload = {
-            "schema_version": "torghut.model-risk-evidence.v1",
-            "generated_at": future.isoformat(),
-            "promotion": {
-                "gate_report_trace_id": "gate-trace-1",
-                "recommendation_trace_id": "rec-trace-1",
-            },
-            "rollback": {
-                "incident_evidence_complete": True,
-                "incident_evidence_path": "/tmp/rollback.json",
-            },
-            "drift": {
-                "evidence_continuity_passed": True,
-                "evidence_continuity_report_path": "/tmp/evidence.json",
-            },
-            "runbook_drill": {
-                "emergency_stop_rehearsed": True,
-                "rehearsal_at": now.isoformat(),
-            },
-            "legacy_gap_disposition": {
-                "signed_disposition_complete": True,
-                "mapping_path": "docs/torghut/design-system/v6/14-legacy-gap-disposition-map-2026-03-03.md",
-            },
-        }
+        payload = _model_risk_payload(now) | {"generated_at": future.isoformat()}
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "model-risk-evidence.json"
             path.write_text(json.dumps(payload), encoding="utf-8")
@@ -275,32 +504,112 @@ class TestVerifyQuantReadiness(TestCase):
         self,
     ) -> None:
         now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
-        payload = {
-            "schema_version": "torghut.model-risk-evidence.v2",
-            "generated_at": now.isoformat(),
-            "promotion": {
-                "gate_report_trace_id": "gate-trace-1",
-                "recommendation_trace_id": "rec-trace-1",
-            },
-            "rollback": {
-                "incident_evidence_complete": True,
-                "incident_evidence_path": "/tmp/rollback.json",
-            },
-            "drift": {
-                "evidence_continuity_passed": True,
-                "evidence_continuity_report_path": "/tmp/evidence.json",
-            },
-            "runbook_drill": {
-                "emergency_stop_rehearsed": True,
-                "rehearsal_at": now.isoformat(),
-            },
-            "legacy_gap_disposition": {
-                "signed_disposition_complete": True,
-                "mapping_path": "docs/torghut/design-system/v6/14-legacy-gap-disposition-map-2026-03-03.md",
-            },
+        payload = _model_risk_payload(now) | {
+            "schema_version": "torghut.model-risk-evidence.v2"
         }
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "model-risk-evidence.json"
             path.write_text(json.dumps(payload), encoding="utf-8")
             with self.assertRaises(ValueError):
                 _load_model_risk_evidence_package(path, now=now, max_age_hours=24)
+
+    def test_load_model_risk_evidence_package_rejects_invalid_nested_shapes(
+        self,
+    ) -> None:
+        now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
+        valid = _model_risk_payload(now)
+        invalid_cases: list[object] = [
+            [],
+            {"schema_version": "torghut.model-risk-evidence.v1"},
+            valid | {"generated_at": 123},
+            valid | {"promotion": []},
+            valid | {"promotion": {"gate_report_trace_id": ""}},
+            valid | {"rollback": {"incident_evidence_path": "/tmp/rollback.json"}},
+            valid | {"drift": {"evidence_continuity_passed": False}},
+            valid | {"runbook_drill": {"rehearsal_at": ""}},
+            valid | {"legacy_gap_disposition": {"signed_disposition_complete": False}},
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            for index, payload in enumerate(invalid_cases):
+                path = base / f"model-risk-{index}.json"
+                path.write_text(json.dumps(payload), encoding="utf-8")
+                with self.subTest(payload=payload), self.assertRaises(ValueError):
+                    _load_model_risk_evidence_package(
+                        path,
+                        now=now,
+                        max_age_hours=24,
+                    )
+
+    def test_optional_artifact_checks_add_passed_summaries(self) -> None:
+        now = datetime(2026, 3, 3, 20, 0, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            gate_path = base / "gate.json"
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "provenance": {
+                            "gate_report_trace_id": "gate-1",
+                            "recommendation_trace_id": "rec-1",
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            incident_path = base / "incident.json"
+            incident_path.write_text(
+                json.dumps(
+                    {
+                        "triggered_at": now.isoformat(),
+                        "reasons": ["manual-stop"],
+                        "rollback_hooks": {"order_submission_blocked": True},
+                        "safety_snapshot": {},
+                        "provenance": {},
+                        "verification": {"incident_evidence_complete": True},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            proof_path = base / "proof.json"
+            proof_path.write_text(
+                json.dumps(_profitability_payload()),
+                encoding="utf-8",
+            )
+            contract_path = base / "contract.json"
+            contract_path.write_text(
+                json.dumps(_control_plane_payload()),
+                encoding="utf-8",
+            )
+            model_risk_path = base / "model-risk.json"
+            model_risk_path.write_text(
+                json.dumps(_model_risk_payload(now)),
+                encoding="utf-8",
+            )
+
+            checks: dict[str, object] = {}
+            args = argparse.Namespace(
+                gate_report=gate_path,
+                incident_evidence=incident_path,
+                profitability_proof=proof_path,
+                control_plane_contract=contract_path,
+                model_risk_evidence_package=model_risk_path,
+            )
+            _add_optional_artifact_checks(
+                checks,
+                args,
+                now=now,
+                thresholds=_readiness_thresholds(),
+            )
+
+        self.assertEqual(
+            set(checks),
+            {
+                "governance_trace",
+                "rollback_incident_evidence",
+                "profitability_evidence",
+                "control_plane_contract",
+                "model_risk_evidence_package",
+            },
+        )
+        self.assertTrue(all(bool(item["passed"]) for item in checks.values()))


### PR DESCRIPTION
## Summary

- Split Torghut quant readiness artifact/schema validation into `scripts/quant_readiness_artifacts.py` while preserving imports through `scripts.verify_quant_readiness`.
- Reworked the quant readiness verifier around explicit counts/threshold data containers and focused helpers for DB reads, core checks, optional artifacts, payload building, and CLI emission.
- Added focused tests for validator failures, readiness count wiring, core payload shape, optional artifacts, and the CLI smoke path.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen python -m compileall app scripts`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pylint scripts/verify_quant_readiness.py scripts/quant_readiness_artifacts.py --disable=all --enable=too-many-lines,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements --score=n`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_verify_quant_readiness.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_verify_quant_readiness.py --cov=scripts.verify_quant_readiness --cov=scripts.quant_readiness_artifacts --cov-branch --cov-report=term-missing -q`
- `cd services/torghut && uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml`
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
