### PR TITLE
refactor(torghut): remove analyzer lint suppressions

### DIFF
--- a/services/torghut/scripts/analyze_historical_simulation.py
+++ b/services/torghut/scripts/analyze_historical_simulation.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as _import_module

--- a/services/torghut/scripts/analyze_historical_simulation_modules/__init__.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/__init__.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as __compat_import_module__
@@ -39,9 +38,4 @@ for __compat_loaded_module__ in __compat_part_modules__:
     )
 
 __compat_sys__.modules[__name__].__class__ = __CompatModule__
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
 del __compat_module__

--- a/services/torghut/scripts/analyze_historical_simulation_modules/part_01_statements_35.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/part_01_statements_35.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Generate a production-ready statistical report for a historical simulation run."""
 
@@ -7,7 +6,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-from collections import Counter, defaultdict, deque
+from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -21,21 +20,10 @@ from scripts.start_historical_simulation import (
     ClickHouseRuntimeConfig,
     _as_mapping,
     _as_text,
-    _build_clickhouse_runtime_config,
-    _build_postgres_runtime_config,
-    _build_resources,
-    _default_simulation_postgres_db,
     _http_clickhouse_query,
-    _load_manifest,
     _parse_rfc3339_timestamp,
-    _resolve_window_bounds,
-    _safe_float,
     _safe_int,
-    _validate_window_policy,
 )
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
 
 REPORT_SCHEMA_VERSION = "torghut.simulation-report.v1"
 
@@ -648,4 +636,43 @@ def _render_markdown(report: Mapping[str, Any]) -> str:
     )
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "REPORT_SCHEMA_VERSION",
+    "_ExecutionFill",
+    "_FifoPnlState",
+    "_parse_args",
+    "_to_mapping",
+    "_to_list_of_strings",
+    "_as_decimal",
+    "_decimal_input_text",
+    "_decimal_to_str",
+    "_json_default",
+    "_percentile",
+    "_mean",
+    "_load_json",
+    "_parse_optional_ts",
+    "_query_rows",
+    "_extract_simulation_context",
+    "_extract_signal_event_ts",
+    "_extract_run_scope_decisions",
+    "_build_last_price_map",
+    "_last_prices_from_clickhouse",
+    "_last_prices_from_clickhouse_field",
+    "_last_prices_from_tab_separated_body",
+    "_last_prices_from_tca_rows",
+    "_last_prices_from_execution_rows",
+    "_fifo_trade_pnl",
+    "_execution_fill_from_row",
+    "_apply_fifo_fill",
+    "_close_fifo_lots",
+    "_realized_fifo_delta",
+    "_fifo_trade_row",
+    "_fifo_unrealized_total",
+    "_fifo_unrealized_lots",
+    "_unrealized_lot_delta",
+    "_fifo_pnl_payload",
+    "_realized_by_symbol_payload",
+    "_csv_write",
+    "_collect_clickhouse_stats",
+    "_render_markdown",
+]

--- a/services/torghut/scripts/analyze_historical_simulation_modules/part_02_build_report.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/part_02_build_report.py
@@ -1,20 +1,17 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Generate a production-ready statistical report for a historical simulation run."""
 
 from __future__ import annotations
 
 import argparse
-import csv
 import json
-from collections import Counter, defaultdict, deque
+from collections import Counter
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 import psycopg
-from psycopg import rows
 
 from scripts.start_historical_simulation import (
     ClickHouseRuntimeConfig,
@@ -24,18 +21,33 @@ from scripts.start_historical_simulation import (
     _build_postgres_runtime_config,
     _build_resources,
     _default_simulation_postgres_db,
-    _http_clickhouse_query,
     _load_manifest,
-    _parse_rfc3339_timestamp,
     _resolve_window_bounds,
     _safe_float,
     _safe_int,
     _validate_window_policy,
 )
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_35 import *
+from .part_01_statements_35 import (
+    REPORT_SCHEMA_VERSION,
+    _as_decimal,
+    _build_last_price_map,
+    _collect_clickhouse_stats,
+    _csv_write,
+    _decimal_to_str,
+    _extract_run_scope_decisions,
+    _extract_signal_event_ts,
+    _fifo_trade_pnl,
+    _json_default,
+    _load_json,
+    _mean,
+    _parse_args,
+    _percentile,
+    _query_rows,
+    _render_markdown,
+    _to_list_of_strings,
+    _to_mapping,
+)
 
 
 def _build_report(args: argparse.Namespace) -> dict[str, Any]:
@@ -739,4 +751,24 @@ if __name__ == "__main__":
     main()
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "_as_decimal",
+    "_build_last_price_map",
+    "_build_report",
+    "_collect_clickhouse_stats",
+    "_csv_write",
+    "_decimal_to_str",
+    "_extract_run_scope_decisions",
+    "_extract_signal_event_ts",
+    "_fifo_trade_pnl",
+    "_json_default",
+    "_load_json",
+    "_mean",
+    "_parse_args",
+    "_percentile",
+    "_query_rows",
+    "_render_markdown",
+    "_to_list_of_strings",
+    "_to_mapping",
+    "main",
+]


### PR DESCRIPTION
## Summary

- Removed the blanket Pyright disable from `scripts/analyze_historical_simulation.py`.
- Removed analyzer-package Pyright suppressions and broad Ruff suppressions from the split implementation modules.
- Replaced hidden star-import leakage with explicit imports and static exports where needed, while preserving existing analyzer patch/import compatibility.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_analyze_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen python -m compileall scripts/analyze_historical_simulation.py scripts/analyze_historical_simulation_modules`
- `cd services/torghut && uv run --frozen ruff format --check scripts/analyze_historical_simulation.py scripts/analyze_historical_simulation_modules tests/test_analyze_historical_simulation.py`
- `cd services/torghut && uv run --frozen ruff check scripts/analyze_historical_simulation.py scripts/analyze_historical_simulation_modules tests/test_analyze_historical_simulation.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd /Users/gregkonush/.codex/worktrees/ccea/lab && git diff --check`

## Screenshots (if applicable)

N/A - Python static-analysis cleanup only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
