### PR TITLE
refactor(torghut): rename analyzer modules semantically

### DIFF
--- a/services/torghut/scripts/analyze_historical_simulation_modules/__init__.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/__init__.py
@@ -21,7 +21,7 @@ def __compat_export__(module: __compat_types__.ModuleType) -> None:
         globals()[name] = value
 
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_35")
+__compat_module__ = __compat_import_module__(f"{__name__}.report_helpers")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:
@@ -29,7 +29,7 @@ for __compat_loaded_module__ in __compat_part_modules__:
         {name: value for name, value in globals().items() if not name.startswith("__")}
     )
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_02_build_report")
+__compat_module__ = __compat_import_module__(f"{__name__}.report_builder")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:

--- a/services/torghut/scripts/analyze_historical_simulation_modules/report_builder.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/report_builder.py
@@ -28,7 +28,7 @@ from scripts.start_historical_simulation import (
     _validate_window_policy,
 )
 
-from .part_01_statements_35 import (
+from .report_helpers import (
     REPORT_SCHEMA_VERSION,
     _as_decimal,
     _build_last_price_map,

--- a/services/torghut/scripts/analyze_historical_simulation_modules/report_helpers.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/report_helpers.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, LiteralString, Mapping
 
 import psycopg
 from psycopg import rows
@@ -188,9 +188,12 @@ def _parse_optional_ts(value: str | None) -> datetime | None:
         return None
 
 
-def _query_rows(conn: psycopg.Connection[Any], query: str) -> list[dict[str, Any]]:
+def _query_rows(
+    conn: psycopg.Connection[Any],
+    query: LiteralString,
+) -> list[dict[str, Any]]:
     with conn.cursor(row_factory=rows.dict_row) as cursor:
-        cursor.execute(query)  # pyright: ignore[reportCallIssue]
+        cursor.execute(query)
         payload = cursor.fetchall()
     return [{str(k): v for k, v in item.items()} for item in payload]
 

--- a/services/torghut/tests/test_analyze_historical_simulation.py
+++ b/services/torghut/tests/test_analyze_historical_simulation.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -14,11 +15,49 @@ from scripts.analyze_historical_simulation import (
     _build_report,
     _extract_run_scope_decisions,
     _fifo_trade_pnl,
+    _query_rows,
 )
 from scripts.start_historical_simulation import ClickHouseRuntimeConfig
 
 
 class TestAnalyzeHistoricalSimulation(TestCase):
+    def test_query_rows_executes_literal_query_and_normalizes_keys(self) -> None:
+        class FakeCursor:
+            def __init__(self) -> None:
+                self.executed_queries: list[object] = []
+
+            def __enter__(self) -> "FakeCursor":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def execute(self, query: object) -> None:
+                self.executed_queries.append(query)
+
+            def fetchall(self) -> list[dict[object, object]]:
+                return [{"id": "decision-1", 2: Decimal("1.25")}]
+
+        class FakeConnection:
+            def __init__(self) -> None:
+                self.cursor_instance = FakeCursor()
+                self.row_factory: object | None = None
+
+            def cursor(self, *, row_factory: object) -> FakeCursor:
+                self.row_factory = row_factory
+                return self.cursor_instance
+
+        conn = FakeConnection()
+
+        rows = _query_rows(cast(Any, conn), "SELECT id, value FROM trade_decisions")
+
+        self.assertEqual(
+            conn.cursor_instance.executed_queries,
+            ["SELECT id, value FROM trade_decisions"],
+        )
+        self.assertIsNotNone(conn.row_factory)
+        self.assertEqual(rows, [{"id": "decision-1", "2": Decimal("1.25")}])
+
     def test_build_last_price_map_uses_lane_specific_price_table(self) -> None:
         captured_queries: list[str] = []
 


### PR DESCRIPTION
## Summary

- Renames analyzer implementation modules from generated `part_*` filenames to `report_helpers.py` and `report_builder.py`.
- Updates analyzer compatibility loader/imports to use semantic module names while keeping the original wrapper surface.
- Replaces the remaining inline Pyright ignore on the SQL query helper with a `LiteralString` query type.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen python -m compileall scripts/analyze_historical_simulation.py scripts/analyze_historical_simulation_modules`
- `cd services/torghut && uv run --frozen ruff format --check scripts/analyze_historical_simulation.py scripts/analyze_historical_simulation_modules tests/test_analyze_historical_simulation.py`
- `cd services/torghut && uv run --frozen ruff check scripts/analyze_historical_simulation.py scripts/analyze_historical_simulation_modules tests/test_analyze_historical_simulation.py`
- `cd services/torghut && uv run --frozen pytest tests/test_analyze_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pytest tests/test_analyze_historical_simulation.py --cov --cov-branch --cov-report=xml --cov-fail-under=0 -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `rg -n "part_[0-9]|pyright:|ruff: noqa|pylint: disable" services/torghut/scripts/analyze_historical_simulation.py services/torghut/scripts/analyze_historical_simulation_modules` -> no matches
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
