### PR TITLE
test(torghut): rename flatten position tests

### DIFF
--- a/services/torghut/scripts/analyze_historical_simulation_modules/__init__.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/__init__.py
@@ -21,7 +21,7 @@ def __compat_export__(module: __compat_types__.ModuleType) -> None:
         globals()[name] = value
 
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_35")
+__compat_module__ = __compat_import_module__(f"{__name__}.report_helpers")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:
@@ -29,7 +29,7 @@ for __compat_loaded_module__ in __compat_part_modules__:
         {name: value for name, value in globals().items() if not name.startswith("__")}
     )
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_02_build_report")
+__compat_module__ = __compat_import_module__(f"{__name__}.report_builder")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:

--- a/services/torghut/scripts/analyze_historical_simulation_modules/report_builder.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/report_builder.py
@@ -28,7 +28,7 @@ from scripts.start_historical_simulation import (
     _validate_window_policy,
 )
 
-from .part_01_statements_35 import (
+from .report_helpers import (
     REPORT_SCHEMA_VERSION,
     _as_decimal,
     _build_last_price_map,

--- a/services/torghut/scripts/analyze_historical_simulation_modules/report_helpers.py
+++ b/services/torghut/scripts/analyze_historical_simulation_modules/report_helpers.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, LiteralString, Mapping
 
 import psycopg
 from psycopg import rows
@@ -188,9 +188,12 @@ def _parse_optional_ts(value: str | None) -> datetime | None:
         return None
 
 
-def _query_rows(conn: psycopg.Connection[Any], query: str) -> list[dict[str, Any]]:
+def _query_rows(
+    conn: psycopg.Connection[Any],
+    query: LiteralString,
+) -> list[dict[str, Any]]:
     with conn.cursor(row_factory=rows.dict_row) as cursor:
-        cursor.execute(query)  # pyright: ignore[reportCallIssue]
+        cursor.execute(query)
         payload = cursor.fetchall()
     return [{str(k): v for k, v in item.items()} for item in payload]
 

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as _import_module

--- a/services/torghut/scripts/flatten_paper_account_positions_modules/__init__.py
+++ b/services/torghut/scripts/flatten_paper_account_positions_modules/__init__.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as __compat_import_module__
@@ -22,7 +21,7 @@ def __compat_export__(module: __compat_types__.ModuleType) -> None:
         globals()[name] = value
 
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_35")
+__compat_module__ = __compat_import_module__(f"{__name__}.flatten_core")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:
@@ -30,7 +29,7 @@ for __compat_loaded_module__ in __compat_part_modules__:
         {name: value for name, value in globals().items() if not name.startswith("__")}
     )
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_02_position_payload")
+__compat_module__ = __compat_import_module__(f"{__name__}.lineage_execution")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:
@@ -38,7 +37,7 @@ for __compat_loaded_module__ in __compat_part_modules__:
         {name: value for name, value in globals().items() if not name.startswith("__")}
     )
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_03_main")
+__compat_module__ = __compat_import_module__(f"{__name__}.cli")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:
@@ -47,9 +46,4 @@ for __compat_loaded_module__ in __compat_part_modules__:
     )
 
 __compat_sys__.modules[__name__].__class__ = __CompatModule__
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
 del __compat_module__

--- a/services/torghut/scripts/flatten_paper_account_positions_modules/cli.py
+++ b/services/torghut/scripts/flatten_paper_account_positions_modules/cli.py
@@ -1,42 +1,31 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Flatten the Torghut paper account so runtime proof windows start clean."""
 
 from __future__ import annotations
 
-import argparse
-import hashlib
 import json
-import os
-import time
-import urllib.error
-import urllib.request
-from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
-from sqlalchemy import create_engine, select
-from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
 from app.alpaca_client import TorghutAlpacaClient
-from app.config import settings
-from app.db import SessionLocal
-from app.models import Execution, Strategy, TradeDecision, coerce_json_payload
-from app.snapshots import snapshot_account_and_positions, sync_order_to_db
+from app.snapshots import snapshot_account_and_positions
 from app.trading.firewall import OrderFirewall
-from app.trading.runtime_decision_authority import (
-    source_decision_mode_is_profit_proof_eligible,
+
+from .flatten_core import (
+    DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS,
+    DEFAULT_MAX_GROSS_MARKET_VALUE,
+    DEFAULT_POLL_SECONDS,
+    TERMINAL_CLEAN_STATUSES,
+    _as_mapping,
+    _decimal,
+    _parse_args,
+    _session_factory_from_env,
+    _target_plan_readback_pending_clean_window_baseline_only,
+    read_target_plan_clean_window_readback,
 )
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_35 import *
-from .part_02_position_payload import *
+from .lineage_execution import flatten_paper_account_positions
 
 
 def main() -> int:
@@ -144,6 +133,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/scripts/flatten_paper_account_positions_modules/flatten_core.py
+++ b/services/torghut/scripts/flatten_paper_account_positions_modules/flatten_core.py
@@ -1,40 +1,25 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Flatten the Torghut paper account so runtime proof windows start clean."""
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
-import time
 import urllib.error
 import urllib.request
 from collections.abc import Mapping, Sequence
-from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
-from typing import Any, Protocol, cast
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
 
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
-from app.alpaca_client import TorghutAlpacaClient
 from app.config import settings
 from app.db import SessionLocal
-from app.models import Execution, Strategy, TradeDecision, coerce_json_payload
-from app.snapshots import snapshot_account_and_positions, sync_order_to_db
-from app.trading.firewall import OrderFirewall
-from app.trading.runtime_decision_authority import (
-    source_decision_mode_is_profit_proof_eligible,
-)
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
 
 DEFAULT_ACCOUNT_LABEL = "TORGHUT_SIM"
 
@@ -685,6 +670,3 @@ def _normalize_positions(
             )
         )
     return sorted(normalized, key=lambda item: item.symbol)
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/scripts/flatten_paper_account_positions_modules/lineage_execution.py
+++ b/services/torghut/scripts/flatten_paper_account_positions_modules/lineage_execution.py
@@ -1,41 +1,39 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Flatten the Torghut paper account so runtime proof windows start clean."""
 
 from __future__ import annotations
 
-import argparse
 import hashlib
-import json
-import os
 import time
-import urllib.error
-import urllib.request
 from collections.abc import Mapping, Sequence
-from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
-from typing import Any, Protocol, cast
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, cast
 
-from sqlalchemy import create_engine, select
-from sqlalchemy.engine import Engine
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
-from app.alpaca_client import TorghutAlpacaClient
-from app.config import settings
-from app.db import SessionLocal
 from app.models import Execution, Strategy, TradeDecision, coerce_json_payload
-from app.snapshots import snapshot_account_and_positions, sync_order_to_db
-from app.trading.firewall import OrderFirewall
+from app.snapshots import sync_order_to_db
 from app.trading.runtime_decision_authority import (
     source_decision_mode_is_profit_proof_eligible,
 )
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_35 import *
+from .flatten_core import (
+    DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS,
+    DEFAULT_POLL_SECONDS,
+    DEFAULT_WAIT_FLAT_SECONDS,
+    FLATTEN_CLEANUP_STRATEGY_NAME,
+    FLATTEN_CLOSE_DECISION_SCHEMA_VERSION,
+    LINEAGE_LINKED_STATUS,
+    LINEAGE_PERSIST_FAILED_STATUS,
+    LINEAGE_UNLINKED_STATUS,
+    FlattenPosition,
+    PaperFlattenClient,
+    _normalize_positions,
+)
 
 
 def _position_payload(position: FlattenPosition) -> dict[str, str | None]:
@@ -720,6 +718,3 @@ def flatten_paper_account_positions(
         "submitted_order_count": len(submitted_orders),
         "submitted_orders": submitted_orders,
     }
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/tests/flatten_paper_account_positions/test_cli_snapshot_guards.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_cli_snapshot_guards.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from tests.flatten_paper_account_positions.support import *
 
 
-class TestFlattenPaperAccountPositionsPart3(_TestFlattenPaperAccountPositionsBase):
+class TestFlattenPaperAccountCliSnapshotGuards(_TestFlattenPaperAccountPositionsBase):
     def test_pending_baseline_allowance_predicate_fails_closed_edges(self) -> None:
         self.assertFalse(
             flatten_script._target_plan_readback_pending_clean_window_baseline_only(

--- a/services/torghut/tests/flatten_paper_account_positions/test_flatten_orders.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_flatten_orders.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from tests.flatten_paper_account_positions.support import *
 
 
-class TestFlattenPaperAccountPositionsPart1(_TestFlattenPaperAccountPositionsBase):
+class TestFlattenPaperAccountFlattenOrders(_TestFlattenPaperAccountPositionsBase):
     def test_dry_run_reports_close_orders_without_mutating(self) -> None:
         client = FakeFlattenClient(
             [

--- a/services/torghut/tests/flatten_paper_account_positions/test_target_plan_readback.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_target_plan_readback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from tests.flatten_paper_account_positions.support import *
 
 
-class TestFlattenPaperAccountPositionsPart2(_TestFlattenPaperAccountPositionsBase):
+class TestFlattenPaperAccountTargetPlanReadback(_TestFlattenPaperAccountPositionsBase):
     def test_parse_args_accepts_explicit_guardrails(self) -> None:
         argv = [
             "flatten_paper_account_positions.py",

--- a/services/torghut/tests/test_analyze_historical_simulation.py
+++ b/services/torghut/tests/test_analyze_historical_simulation.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -14,11 +15,49 @@ from scripts.analyze_historical_simulation import (
     _build_report,
     _extract_run_scope_decisions,
     _fifo_trade_pnl,
+    _query_rows,
 )
 from scripts.start_historical_simulation import ClickHouseRuntimeConfig
 
 
 class TestAnalyzeHistoricalSimulation(TestCase):
+    def test_query_rows_executes_literal_query_and_normalizes_keys(self) -> None:
+        class FakeCursor:
+            def __init__(self) -> None:
+                self.executed_queries: list[object] = []
+
+            def __enter__(self) -> "FakeCursor":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def execute(self, query: object) -> None:
+                self.executed_queries.append(query)
+
+            def fetchall(self) -> list[dict[object, object]]:
+                return [{"id": "decision-1", 2: Decimal("1.25")}]
+
+        class FakeConnection:
+            def __init__(self) -> None:
+                self.cursor_instance = FakeCursor()
+                self.row_factory: object | None = None
+
+            def cursor(self, *, row_factory: object) -> FakeCursor:
+                self.row_factory = row_factory
+                return self.cursor_instance
+
+        conn = FakeConnection()
+
+        rows = _query_rows(cast(Any, conn), "SELECT id, value FROM trade_decisions")
+
+        self.assertEqual(
+            conn.cursor_instance.executed_queries,
+            ["SELECT id, value FROM trade_decisions"],
+        )
+        self.assertIsNotNone(conn.row_factory)
+        self.assertEqual(rows, [{"id": "decision-1", "2": Decimal("1.25")}])
+
     def test_build_last_price_map_uses_lane_specific_price_table(self) -> None:
         captured_queries: list[str] = []
 

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -1,8 +1,3 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
 __test__ = False
-from tests.flatten_paper_account_positions.support import *
-from tests.flatten_paper_account_positions.test_part_01 import *
-from tests.flatten_paper_account_positions.test_part_02 import *
-from tests.flatten_paper_account_positions.test_part_03 import *


### PR DESCRIPTION
## Summary

- Renames the `flatten_paper_account_positions` split tests from generated `test_part_*` files to semantic test modules.
- Renames the split test classes to describe the covered behavior instead of part numbers.
- Removes the no-op top-level test wrapper wildcard imports now that the real split files are collected directly.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check tests/test_flatten_paper_account_positions.py tests/flatten_paper_account_positions`
- `cd services/torghut && uv run --frozen ruff check tests/test_flatten_paper_account_positions.py tests/flatten_paper_account_positions`
- `cd services/torghut && uv run --frozen pytest tests/flatten_paper_account_positions -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `rg -n "test_part_|Part[0-9]|part_[0-9]" services/torghut/tests/test_flatten_paper_account_positions.py services/torghut/tests/flatten_paper_account_positions` -> no matches
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
