### PR TITLE
test(torghut): make flatten position imports explicit

### DIFF
--- a/services/torghut/tests/flatten_paper_account_positions/support.py
+++ b/services/torghut/tests/flatten_paper_account_positions/support.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-# ruff: noqa: F401
-
 import json
 import sys
 from contextlib import redirect_stdout
@@ -216,4 +214,39 @@ class _TestFlattenPaperAccountPositionsBase(TestCase):
     pass
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "Any",
+    "Base",
+    "Decimal",
+    "Execution",
+    "ExecutionOrderEvent",
+    "FakeBytesResponse",
+    "FakeFlattenClient",
+    "FakeHttpResponse",
+    "FakeSessionContext",
+    "MissingOrderIdFlattenClient",
+    "RejectingFlattenClient",
+    "SequencedFlattenClient",
+    "Session",
+    "SimpleNamespace",
+    "Strategy",
+    "StrategyDecision",
+    "StringIO",
+    "TestCase",
+    "TradeDecision",
+    "_TestFlattenPaperAccountPositionsBase",
+    "_memory_session",
+    "_source_decision",
+    "_source_strategy",
+    "cast",
+    "create_engine",
+    "datetime",
+    "flatten_paper_account_positions",
+    "flatten_script",
+    "json",
+    "patch",
+    "redirect_stdout",
+    "select",
+    "sys",
+    "timezone",
+]

--- a/services/torghut/tests/flatten_paper_account_positions/test_cli_snapshot_guards.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_cli_snapshot_guards.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
-from tests.flatten_paper_account_positions.support import *
+from tests.flatten_paper_account_positions.support import (
+    FakeFlattenClient,
+    SimpleNamespace,
+    StringIO,
+    _TestFlattenPaperAccountPositionsBase,
+    datetime,
+    flatten_script,
+    json,
+    patch,
+    redirect_stdout,
+    sys,
+    timezone,
+)
 
 
 class TestFlattenPaperAccountCliSnapshotGuards(_TestFlattenPaperAccountPositionsBase):

--- a/services/torghut/tests/flatten_paper_account_positions/test_flatten_orders.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_flatten_orders.py
@@ -1,7 +1,30 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
-from tests.flatten_paper_account_positions.support import *
+from tests.flatten_paper_account_positions.support import (
+    Any,
+    Decimal,
+    Execution,
+    ExecutionOrderEvent,
+    FakeFlattenClient,
+    MissingOrderIdFlattenClient,
+    RejectingFlattenClient,
+    SequencedFlattenClient,
+    SimpleNamespace,
+    Strategy,
+    StrategyDecision,
+    TradeDecision,
+    _TestFlattenPaperAccountPositionsBase,
+    _memory_session,
+    _source_decision,
+    _source_strategy,
+    cast,
+    datetime,
+    flatten_paper_account_positions,
+    flatten_script,
+    patch,
+    select,
+    timezone,
+)
 
 
 class TestFlattenPaperAccountFlattenOrders(_TestFlattenPaperAccountPositionsBase):

--- a/services/torghut/tests/flatten_paper_account_positions/test_target_plan_readback.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_target_plan_readback.py
@@ -1,7 +1,21 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
-from tests.flatten_paper_account_positions.support import *
+from tests.flatten_paper_account_positions.support import (
+    FakeBytesResponse,
+    FakeFlattenClient,
+    FakeHttpResponse,
+    FakeSessionContext,
+    SimpleNamespace,
+    StringIO,
+    _TestFlattenPaperAccountPositionsBase,
+    datetime,
+    flatten_script,
+    json,
+    patch,
+    redirect_stdout,
+    sys,
+    timezone,
+)
 
 
 class TestFlattenPaperAccountTargetPlanReadback(_TestFlattenPaperAccountPositionsBase):


### PR DESCRIPTION
## Summary

- Replaces flatten position test wildcard support imports with explicit imports.
- Converts the flatten test support module from dynamic `__all__` to a static export list.
- Removes the remaining Ruff suppression comments from the flatten position test split.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check tests/test_flatten_paper_account_positions.py tests/flatten_paper_account_positions`
- `cd services/torghut && uv run --frozen ruff check tests/test_flatten_paper_account_positions.py tests/flatten_paper_account_positions`
- `cd services/torghut && uv run --frozen pytest tests/flatten_paper_account_positions -q`
- `rg -n "ruff: noqa|import \*|test_part_|Part[0-9]|part_[0-9]" services/torghut/tests/test_flatten_paper_account_positions.py services/torghut/tests/flatten_paper_account_positions` -> no matches
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
