### PR TITLE
refactor(torghut): rename profit proof modules

### DIFF
--- a/services/torghut/scripts/build_historical_profitability_proof.py
+++ b/services/torghut/scripts/build_historical_profitability_proof.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as _import_module

--- a/services/torghut/scripts/build_historical_profitability_proof_modules/__init__.py
+++ b/services/torghut/scripts/build_historical_profitability_proof_modules/__init__.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as __compat_import_module__
@@ -22,7 +21,7 @@ def __compat_export__(module: __compat_types__.ModuleType) -> None:
         globals()[name] = value
 
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_24")
+__compat_module__ = __compat_import_module__(f"{__name__}.proof_core")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:
@@ -30,9 +29,7 @@ for __compat_loaded_module__ in __compat_part_modules__:
         {name: value for name, value in globals().items() if not name.startswith("__")}
     )
 
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_build_zero_baseline_payload"
-)
+__compat_module__ = __compat_import_module__(f"{__name__}.proof_bundle")
 __compat_part_modules__.append(__compat_module__)
 __compat_export__(__compat_module__)
 for __compat_loaded_module__ in __compat_part_modules__:
@@ -41,9 +38,4 @@ for __compat_loaded_module__ in __compat_part_modules__:
     )
 
 __compat_sys__.modules[__name__].__class__ = __CompatModule__
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
 del __compat_module__

--- a/services/torghut/scripts/build_historical_profitability_proof_modules/proof_bundle.py
+++ b/services/torghut/scripts/build_historical_profitability_proof_modules/proof_bundle.py
@@ -1,20 +1,14 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Build profitability proof artifacts from historical simulation run directories."""
 
 from __future__ import annotations
 
-import argparse
-import csv
-import hashlib
 import json
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping
 
-import yaml
 
 from app.trading.evaluation import (
     build_profitability_evidence_v4,
@@ -22,9 +16,33 @@ from app.trading.evaluation import (
     validate_profitability_evidence_v4,
 )
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_24 import *
+from .proof_core import (
+    _DEFAULT_BASELINE_ID,
+    _DEFAULT_EXTENDED_MAX_DRAWDOWN_PCT_EQUITY,
+    _DEFAULT_MAX_BEST_DAY_SHARE,
+    _DEFAULT_MAX_DRAWDOWN_PCT_EQUITY,
+    _DEFAULT_MIN_ACTIVE_DAY_RATIO,
+    _DEFAULT_MIN_POSITIVE_DAY_RATIO,
+    _DEFAULT_MIN_SAMPLE_SIZE,
+    _DEFAULT_MIN_TOTAL_NET_PNL_TO_DRAWDOWN_RATIO,
+    _DEFAULT_START_EQUITY,
+    _DEFAULT_TARGET_NET_PNL_PER_DAY,
+    _PROFITABILITY_PROOF_SCHEMA_VERSION,
+    HistoricalRunSummary,
+    _as_decimal,
+    _as_dict,
+    _as_int,
+    _as_list,
+    _as_text,
+    _build_report_payload,
+    _load_run_summary,
+    _parse_args,
+    _proof_gate_policy,
+    _proof_gate_summary,
+    _require_consistent_lineage,
+    _sha256_json,
+    _stable_hash_payload,
+)
 
 
 def _build_zero_baseline_payload(trading_days: list[str]) -> dict[str, object]:
@@ -400,6 +418,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/scripts/build_historical_profitability_proof_modules/proof_core.py
+++ b/services/torghut/scripts/build_historical_profitability_proof_modules/proof_core.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Build profitability proof artifacts from historical simulation run directories."""
 
@@ -9,20 +8,11 @@ import csv
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping
 
 import yaml
-
-from app.trading.evaluation import (
-    build_profitability_evidence_v4,
-    execute_profitability_benchmark_v4,
-    validate_profitability_evidence_v4,
-)
-
-# ruff: noqa: F401,F403,F405,F811,F821
 
 
 _SERVICE_ROOT = Path(__file__).resolve().parent.parent
@@ -686,6 +676,3 @@ def _build_report_payload(
             },
         },
     }
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]


### PR DESCRIPTION
## Summary

- Renames `build_historical_profitability_proof_modules` from generated `part_*` files to semantic `proof_core.py` and `proof_bundle.py` modules.
- Removes blanket Pyright disables from the wrapper and implementation package.
- Replaces the implementation wildcard import with explicit dependencies and drops dynamic `__all__` scaffolding.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check scripts/build_historical_profitability_proof.py scripts/build_historical_profitability_proof_modules tests/test_build_historical_profitability_proof.py`
- `cd services/torghut && uv run --frozen ruff check scripts/build_historical_profitability_proof.py scripts/build_historical_profitability_proof_modules tests/test_build_historical_profitability_proof.py`
- `rg -n "part_[0-9]|pyright:|ruff: noqa|pylint: disable|import \*" services/torghut/scripts/build_historical_profitability_proof.py services/torghut/scripts/build_historical_profitability_proof_modules` -> no matches
- `cd services/torghut && uv run --frozen python -m compileall scripts/build_historical_profitability_proof.py scripts/build_historical_profitability_proof_modules`
- `cd services/torghut && uv run --frozen pytest tests/test_build_historical_profitability_proof.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pytest tests/test_analyze_historical_simulation.py tests/flatten_paper_account_positions tests/test_build_historical_profitability_proof.py -q --cov --cov-branch --cov-report=xml --cov-fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
