### PR TITLE
refactor(torghut): rename ta replay modules

### DIFF
--- a/services/torghut/scripts/ta_replay_runner.py
+++ b/services/torghut/scripts/ta_replay_runner.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as _import_module

--- a/services/torghut/scripts/ta_replay_runner_modules/__init__.py
+++ b/services/torghut/scripts/ta_replay_runner_modules/__init__.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-from importlib import import_module
-import sys
-import types
-
 from .replay_core import (
     APPLY_CONFIRMATION_PHRASE,
     CLICKHOUSE_TA_TTL_DAYS,
@@ -62,36 +58,6 @@ from .replay_orchestration import (
     main,
     parse_args,
 )
-
-_IMPLEMENTATION_MODULES = [
-    import_module(f"{__name__}.replay_core"),
-    import_module(f"{__name__}.replay_orchestration"),
-]
-
-
-class _CompatModule(types.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in _IMPLEMENTATION_MODULES:
-            module.__dict__[name] = value
-
-
-def _export_module(module: types.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-for _module in _IMPLEMENTATION_MODULES:
-    _export_module(_module)
-
-for _module in _IMPLEMENTATION_MODULES:
-    _module.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-sys.modules[__name__].__class__ = _CompatModule
 
 __all__ = (
     "APPLY_CONFIRMATION_PHRASE",

--- a/services/torghut/scripts/ta_replay_runner_modules/__init__.py
+++ b/services/torghut/scripts/ta_replay_runner_modules/__init__.py
@@ -1,47 +1,151 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
+import sys
+import types
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+from .replay_core import (
+    APPLY_CONFIRMATION_PHRASE,
+    CLICKHOUSE_TA_TTL_DAYS,
+    DEFAULT_KAFKA_RETENTION_TOPICS,
+    DERIVED_TA_TOPIC_ROLES,
+    FAILED_RUN_STATES,
+    MILLISECONDS_PER_DAY,
+    RAW_REPLAY_SOURCE_TOPIC_ROLES,
+    SUPPORTED_NAMESPACE,
+    TA_CONFIGMAP,
+    TA_DEPLOYMENT,
+    ReplayState,
+    _build_plan_report,
+    _clickhouse_basic_auth,
+    _clickhouse_query,
+    _day_gap_query,
+    _kafka_topic_config,
+    _kafka_topic_items_by_name,
+    _kafka_topic_ready_status,
+    _kubectl_binary,
+    _kubectl_get_kafka_topics_json,
+    _kubectl_get_ta_config_json,
+    _kubectl_get_ta_deployment_json,
+    _kubectl_merge_patch,
+    _load_clickhouse_coverage,
+    _load_state,
+    _parse_int,
+    _parse_int_field,
+    _parse_kafka_retention_topic_overrides,
+    _parse_retention_ms,
+    _parse_tsv_with_names,
+    _plan_command,
+    _print_plan_text,
+    _required_calendar_days_from_trading_days,
+    _require_kubectl,
+    _require_supported_namespace,
+    _retention_days,
+    _run_kubectl,
+    _table_coverage_query,
+    _topic_role_has_blocker,
+    _validate_apply_preconditions,
+    _validate_plan_args,
+)
+from .replay_orchestration import (
+    _apply_plan,
+    _build_replay_feasibility,
+    _final_status,
+    _handle_apply_mode,
+    _handle_plan_mode,
+    _handle_verify_mode,
+    _load_kafka_retention,
+    _role_blockers,
+    _string_list,
+    _summary_int,
+    _verify_state,
+    main,
+    parse_args,
+)
+
+_IMPLEMENTATION_MODULES = [
+    import_module(f"{__name__}.replay_core"),
+    import_module(f"{__name__}.replay_orchestration"),
+]
 
 
-class __CompatModule__(__compat_types__.ModuleType):
+class _CompatModule(types.ModuleType):
     def __setattr__(self, name: str, value: object) -> None:
         super().__setattr__(name, value)
-        for module in __compat_part_modules__:
+        for module in _IMPLEMENTATION_MODULES:
             module.__dict__[name] = value
 
 
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
+def _export_module(module: types.ModuleType) -> None:
     for name, value in module.__dict__.items():
         if name.startswith("__"):
             continue
         globals()[name] = value
 
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_20")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
+for _module in _IMPLEMENTATION_MODULES:
+    _export_module(_module)
+
+for _module in _IMPLEMENTATION_MODULES:
+    _module.__dict__.update(
         {name: value for name, value in globals().items() if not name.startswith("__")}
     )
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_02_load_kafka_retention")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
+sys.modules[__name__].__class__ = _CompatModule
 
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
-del __compat_module__
+__all__ = (
+    "APPLY_CONFIRMATION_PHRASE",
+    "CLICKHOUSE_TA_TTL_DAYS",
+    "DEFAULT_KAFKA_RETENTION_TOPICS",
+    "DERIVED_TA_TOPIC_ROLES",
+    "FAILED_RUN_STATES",
+    "MILLISECONDS_PER_DAY",
+    "RAW_REPLAY_SOURCE_TOPIC_ROLES",
+    "ReplayState",
+    "SUPPORTED_NAMESPACE",
+    "TA_CONFIGMAP",
+    "TA_DEPLOYMENT",
+    "_apply_plan",
+    "_build_plan_report",
+    "_build_replay_feasibility",
+    "_clickhouse_basic_auth",
+    "_clickhouse_query",
+    "_day_gap_query",
+    "_final_status",
+    "_handle_apply_mode",
+    "_handle_plan_mode",
+    "_handle_verify_mode",
+    "_kafka_topic_config",
+    "_kafka_topic_items_by_name",
+    "_kafka_topic_ready_status",
+    "_kubectl_binary",
+    "_kubectl_get_kafka_topics_json",
+    "_kubectl_get_ta_config_json",
+    "_kubectl_get_ta_deployment_json",
+    "_kubectl_merge_patch",
+    "_load_clickhouse_coverage",
+    "_load_kafka_retention",
+    "_load_state",
+    "_parse_int",
+    "_parse_int_field",
+    "_parse_kafka_retention_topic_overrides",
+    "_parse_retention_ms",
+    "_parse_tsv_with_names",
+    "_plan_command",
+    "_print_plan_text",
+    "_required_calendar_days_from_trading_days",
+    "_require_kubectl",
+    "_require_supported_namespace",
+    "_retention_days",
+    "_role_blockers",
+    "_run_kubectl",
+    "_string_list",
+    "_summary_int",
+    "_table_coverage_query",
+    "_topic_role_has_blocker",
+    "_validate_apply_preconditions",
+    "_validate_plan_args",
+    "_verify_state",
+    "main",
+    "parse_args",
+)

--- a/services/torghut/scripts/ta_replay_runner_modules/replay_core.py
+++ b/services/torghut/scripts/ta_replay_runner_modules/replay_core.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Execute the standardized Torghut TA replay rollout workflow."""
 
@@ -16,8 +15,6 @@ from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 import yaml
-
-# ruff: noqa: F401,F403,F405,F811,F821
 
 
 TA_CONFIGMAP = "torghut-ta-config"
@@ -647,6 +644,3 @@ def _topic_role_has_blocker(blocker: str, role: str) -> bool:
         or blocker.startswith(f"kafka_topic_missing:{role}:")
         or blocker.startswith(f"kafka_topic_not_ready:{role}:")
     )
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/scripts/ta_replay_runner_modules/replay_orchestration.py
+++ b/services/torghut/scripts/ta_replay_runner_modules/replay_orchestration.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Execute the standardized Torghut TA replay rollout workflow."""
 
@@ -7,19 +6,37 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
-import subprocess
-from base64 import b64encode
-from dataclasses import dataclass
 from typing import Any, Mapping
-from urllib.error import URLError
-from urllib.request import Request, urlopen
 
-import yaml
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_20 import *
+from .replay_core import (
+    APPLY_CONFIRMATION_PHRASE,
+    CLICKHOUSE_TA_TTL_DAYS,
+    DERIVED_TA_TOPIC_ROLES,
+    FAILED_RUN_STATES,
+    RAW_REPLAY_SOURCE_TOPIC_ROLES,
+    TA_CONFIGMAP,
+    TA_DEPLOYMENT,
+    ReplayState,
+    _build_plan_report,
+    _kafka_topic_config,
+    _kafka_topic_items_by_name,
+    _kafka_topic_ready_status,
+    _kubectl_get_kafka_topics_json,
+    _kubectl_merge_patch,
+    _load_clickhouse_coverage,
+    _load_state,
+    _parse_kafka_retention_topic_overrides,
+    _parse_retention_ms,
+    _plan_command,
+    _print_plan_text,
+    _required_calendar_days_from_trading_days,
+    _require_kubectl,
+    _require_supported_namespace,
+    _retention_days,
+    _topic_role_has_blocker,
+    _validate_apply_preconditions,
+    _validate_plan_args,
+)
 
 
 def _load_kafka_retention(args: argparse.Namespace) -> dict[str, Any] | None:
@@ -707,6 +724,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/tests/test_ta_replay_runner.py
+++ b/services/torghut/tests/test_ta_replay_runner.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from urllib.error import URLError
 
 from scripts import ta_replay_runner as runner
+from scripts.ta_replay_runner_modules import replay_core, replay_orchestration
 
 
 _TABLE_COVERAGE_TSV = """table_name\tdays\tfirst_day\tlast_day\trows
@@ -196,7 +197,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self,
     ) -> None:
         with patch.object(
-            runner,
+            replay_core,
             "_clickhouse_query",
             side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
         ):
@@ -218,7 +219,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self,
     ) -> None:
         with patch.object(
-            runner,
+            replay_orchestration,
             "_kubectl_get_kafka_topics_json",
             return_value=_KAFKA_TOPICS_JSON,
         ):
@@ -254,7 +255,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             ]
         }
         with patch.object(
-            runner,
+            replay_orchestration,
             "_kubectl_get_kafka_topics_json",
             return_value=payload,
         ):
@@ -293,7 +294,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
 
     def test_kafka_retention_helpers_cover_kubectl_and_json_edges(self) -> None:
         with patch.object(
-            runner,
+            replay_core,
             "_run_kubectl",
             return_value=CompletedProcess(
                 args=[], returncode=0, stdout='{"items": []}'
@@ -343,7 +344,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self,
     ) -> None:
         with patch.object(
-            runner,
+            replay_orchestration,
             "_kubectl_get_kafka_topics_json",
             return_value=_KAFKA_TOPICS_JSON,
         ):
@@ -363,7 +364,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
     def test_plan_json_embeds_coverage_preflight(self) -> None:
         output = io.StringIO()
         with patch.object(
-            runner,
+            replay_core,
             "_clickhouse_query",
             side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
         ):
@@ -388,7 +389,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
     def test_plan_json_embeds_kafka_retention_preflight(self) -> None:
         output = io.StringIO()
         with patch.object(
-            runner,
+            replay_orchestration,
             "_kubectl_get_kafka_topics_json",
             return_value=_KAFKA_TOPICS_JSON,
         ):
@@ -542,13 +543,13 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self.assertIn("do_not_start_ta_replay_until_preflight_passes", text)
 
     def test_replay_state_and_plan_helpers_cover_edge_branches(self) -> None:
-        with patch.object(runner.shutil, "which", return_value=None):
+        with patch.object(replay_core.shutil, "which", return_value=None):
             with self.assertRaisesRegex(SystemExit, "kubectl not found"):
                 runner._require_kubectl()
             with self.assertRaisesRegex(SystemExit, "kubectl not found"):
                 runner._kubectl_binary()
 
-        with patch.object(runner.shutil, "which", return_value="/usr/bin/kubectl"):
+        with patch.object(replay_core.shutil, "which", return_value="/usr/bin/kubectl"):
             runner._require_kubectl()
             self.assertEqual(runner._kubectl_binary(), "/usr/bin/kubectl")
 
@@ -602,9 +603,11 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             },
             "status": {"jobStatus": {"state": "RUNNING"}},
         }
-        with patch.object(runner, "_kubectl_get_ta_config_json", return_value=config):
+        with patch.object(
+            replay_core, "_kubectl_get_ta_config_json", return_value=config
+        ):
             with patch.object(
-                runner, "_kubectl_get_ta_deployment_json", return_value=deployment
+                replay_core, "_kubectl_get_ta_deployment_json", return_value=deployment
             ):
                 state = runner._load_state("torghut")
 
@@ -614,17 +617,19 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self.assertEqual(state.flink_restart_nonce, 8)
         self.assertEqual(state.flink_status_state, "RUNNING")
 
-        with patch.object(runner, "_kubectl_get_ta_config_json", return_value={}):
+        with patch.object(replay_core, "_kubectl_get_ta_config_json", return_value={}):
             with self.assertRaisesRegex(SystemExit, "configmap data"):
                 runner._load_state("torghut")
         with patch.object(
-            runner, "_kubectl_get_ta_config_json", return_value={"data": {}}
+            replay_core, "_kubectl_get_ta_config_json", return_value={"data": {}}
         ):
             with self.assertRaisesRegex(SystemExit, "TA_GROUP_ID missing"):
                 runner._load_state("torghut")
-        with patch.object(runner, "_kubectl_get_ta_config_json", return_value=config):
+        with patch.object(
+            replay_core, "_kubectl_get_ta_config_json", return_value=config
+        ):
             with patch.object(
-                runner, "_kubectl_get_ta_deployment_json", return_value={}
+                replay_core, "_kubectl_get_ta_deployment_json", return_value={}
             ):
                 with self.assertRaisesRegex(SystemExit, "flinkdeployment spec"):
                     runner._load_state("torghut")
@@ -638,11 +643,13 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             mode="plan",
             confirm="",
         )
-        with patch.object(runner, "parse_args", return_value=base_args):
-            with patch.object(runner, "_require_kubectl"):
-                with patch.object(runner, "_load_state", return_value=self._state()):
+        with patch.object(replay_orchestration, "parse_args", return_value=base_args):
+            with patch.object(replay_orchestration, "_require_kubectl"):
+                with patch.object(
+                    replay_orchestration, "_load_state", return_value=self._state()
+                ):
                     with patch.object(
-                        runner, "_handle_plan_mode", return_value=4
+                        replay_orchestration, "_handle_plan_mode", return_value=4
                     ) as handle_plan:
                         self.assertEqual(runner.main(), 4)
         handle_plan.assert_called_once()
@@ -655,11 +662,13 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             mode="verify",
             confirm="",
         )
-        with patch.object(runner, "parse_args", return_value=verify_args):
-            with patch.object(runner, "_require_kubectl"):
-                with patch.object(runner, "_load_state", return_value=self._state()):
+        with patch.object(replay_orchestration, "parse_args", return_value=verify_args):
+            with patch.object(replay_orchestration, "_require_kubectl"):
+                with patch.object(
+                    replay_orchestration, "_load_state", return_value=self._state()
+                ):
                     with patch.object(
-                        runner, "_handle_verify_mode", return_value=5
+                        replay_orchestration, "_handle_verify_mode", return_value=5
                     ) as handle_verify:
                         self.assertEqual(runner.main(), 5)
         handle_verify.assert_called_once()
@@ -672,11 +681,13 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             mode="apply",
             confirm=runner.APPLY_CONFIRMATION_PHRASE,
         )
-        with patch.object(runner, "parse_args", return_value=apply_args):
-            with patch.object(runner, "_require_kubectl"):
-                with patch.object(runner, "_load_state", return_value=self._state()):
+        with patch.object(replay_orchestration, "parse_args", return_value=apply_args):
+            with patch.object(replay_orchestration, "_require_kubectl"):
+                with patch.object(
+                    replay_orchestration, "_load_state", return_value=self._state()
+                ):
                     with patch.object(
-                        runner, "_handle_apply_mode", return_value=6
+                        replay_orchestration, "_handle_apply_mode", return_value=6
                     ) as handle_apply:
                         self.assertEqual(runner.main(), 6)
         handle_apply.assert_called_once()
@@ -689,8 +700,10 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             mode="apply",
             confirm="",
         )
-        with patch.object(runner, "parse_args", return_value=unconfirmed_apply_args):
-            with patch.object(runner, "_require_kubectl"):
+        with patch.object(
+            replay_orchestration, "parse_args", return_value=unconfirmed_apply_args
+        ):
+            with patch.object(replay_orchestration, "_require_kubectl"):
                 with self.assertRaisesRegex(SystemExit, "requires --confirm"):
                     runner.main()
 
@@ -705,7 +718,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         )
         output = io.StringIO()
         with patch.object(
-            runner,
+            replay_core,
             "_clickhouse_query",
             side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
         ):
@@ -738,8 +751,12 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         def capture_patch(kind: str, name: str, patch: dict[str, object]) -> None:
             patches.append((kind, name, patch))
 
-        with patch.object(runner, "_kubectl_merge_patch", side_effect=capture_patch):
-            with patch.object(runner, "_load_state", return_value=applied_state):
+        with patch.object(
+            replay_orchestration, "_kubectl_merge_patch", side_effect=capture_patch
+        ):
+            with patch.object(
+                replay_orchestration, "_load_state", return_value=applied_state
+            ):
                 with redirect_stdout(output):
                     exit_code = runner._handle_apply_mode(
                         args=self._args(
@@ -763,11 +780,13 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
     def test_apply_mode_blocks_before_patching_when_feasibility_rejects(self) -> None:
         output = io.StringIO()
         with patch.object(
-            runner,
+            replay_orchestration,
             "_kubectl_get_kafka_topics_json",
             return_value=_KAFKA_TOPICS_JSON,
         ):
-            with patch.object(runner, "_kubectl_merge_patch") as merge_patch:
+            with patch.object(
+                replay_orchestration, "_kubectl_merge_patch"
+            ) as merge_patch:
                 with redirect_stdout(output):
                     exit_code = runner._handle_apply_mode(
                         args=self._args(
@@ -805,7 +824,9 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             def read(self) -> bytes:
                 return b"ok"
 
-        with patch.object(runner, "urlopen", return_value=FakeResponse()) as urlopen:
+        with patch.object(
+            replay_core, "urlopen", return_value=FakeResponse()
+        ) as urlopen:
             result = runner._clickhouse_query(
                 http_url="http://clickhouse.test:8123",
                 username="torghut",
@@ -824,7 +845,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         )
         self.assertEqual(urlopen.call_args.kwargs["timeout"], 1)
 
-        with patch.object(runner, "urlopen", side_effect=URLError("refused")):
+        with patch.object(replay_core, "urlopen", side_effect=URLError("refused")):
             with self.assertRaisesRegex(
                 RuntimeError, "clickhouse_coverage_query_failed"
             ):
@@ -853,7 +874,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
 
         with patch.dict(os.environ, {"TA_CLICKHOUSE_PASSWORD": "from-env"}):
             with patch.object(
-                runner,
+                replay_core,
                 "_clickhouse_query",
                 side_effect=[
                     "table_name\tdays\tfirst_day\tlast_day\trows\nta_signals\tbad\t\t\t0\n",


### PR DESCRIPTION
## Summary

- Renames the TA replay generated split modules to semantic implementation files: `replay_core.py` and `replay_orchestration.py`.
- Removes blanket Pyright disables, Ruff suppression comments, wildcard imports, generated `part_*` runtime module names, dynamic module `__all__` generation, and compatibility module mutation from the TA replay runtime package.
- Keeps the original `scripts/ta_replay_runner.py` entrypoint stable while tests patch the concrete implementation modules directly.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check scripts/ta_replay_runner.py scripts/ta_replay_runner_modules tests/test_ta_replay_runner.py tests/test_ta_replay_retention_contract.py`
- `cd services/torghut && uv run --frozen ruff check scripts/ta_replay_runner.py scripts/ta_replay_runner_modules tests/test_ta_replay_runner.py tests/test_ta_replay_retention_contract.py`
- `cd services/torghut && uv run --frozen python -m compileall scripts/ta_replay_runner.py scripts/ta_replay_runner_modules`
- `cd services/torghut && uv run --frozen pytest tests/test_ta_replay_runner.py tests/test_ta_replay_retention_contract.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pytest tests/test_analyze_historical_simulation.py tests/flatten_paper_account_positions tests/test_build_historical_profitability_proof.py tests/test_ta_replay_runner.py tests/test_ta_replay_retention_contract.py -q --cov --cov-branch --cov-report=xml --cov-fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
