### PR TITLE
refactor(torghut): rename tigerbeetle journal modules

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
 from importlib import import_module as _import_module

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -1,16 +1,65 @@
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from app.trading.tigerbeetle_ledger_model import TRANSFER_KIND_RUNTIME_NET_PNL
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("scripts.journal_tigerbeetle_order_events_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+from scripts.journal_tigerbeetle_order_events_modules import (
+    DEFAULT_SOURCES,
+    SOURCE_TYPE_EXECUTION,
+    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    _attach_runtime_bucket_journal_payload,
+    _completed_progress_batch_from_timeout,
+    _fresh_reconciliation_for_empty_selection,
+    _journal_progress_events,
+    _journal_source_batch,
+    _last_journal_payload,
+    _parse_sources,
+    _payload,
+    _payload_int_matches,
+    _payload_mapping,
+    _progress_int,
+    _runtime_ref_matches_signed_bucket,
+    _safe_payload_allows_success,
+    _select_unlinked_events,
+    _select_unlinked_executions,
+    _select_unlinked_runtime_buckets,
+    _select_unlinked_tca_metrics,
+    _sqlalchemy_dsn,
+    _write_supervised_output,
+    build_order_event_transfer_plan,
+    main,
+)
+
+__all__ = (
+    "DEFAULT_SOURCES",
+    "SOURCE_TYPE_EXECUTION",
+    "SOURCE_TYPE_EXECUTION_ORDER_EVENT",
+    "SOURCE_TYPE_EXECUTION_TCA_METRIC",
+    "SOURCE_TYPE_RUNTIME_LEDGER_BUCKET",
+    "TRANSFER_KIND_RUNTIME_NET_PNL",
+    "_attach_runtime_bucket_journal_payload",
+    "_completed_progress_batch_from_timeout",
+    "_fresh_reconciliation_for_empty_selection",
+    "_journal_progress_events",
+    "_journal_source_batch",
+    "_last_journal_payload",
+    "_parse_sources",
+    "_payload",
+    "_payload_int_matches",
+    "_payload_mapping",
+    "_progress_int",
+    "_runtime_ref_matches_signed_bucket",
+    "_safe_payload_allows_success",
+    "_select_unlinked_events",
+    "_select_unlinked_executions",
+    "_select_unlinked_runtime_buckets",
+    "_select_unlinked_tca_metrics",
+    "_sqlalchemy_dsn",
+    "_write_supervised_output",
+    "build_order_event_transfer_plan",
+    "main",
+)
 
 if __name__ == "__main__":
-    raise SystemExit(_impl.main())
+    raise SystemExit(main())

--- a/services/torghut/scripts/journal_tigerbeetle_order_events_modules/__init__.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events_modules/__init__.py
@@ -1,57 +1,62 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from app.trading.tigerbeetle_ledger_model import TRANSFER_KIND_RUNTIME_NET_PNL
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
-
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_50")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_attach_runtime_bucket_journal_payload"
+from .cli import main
+from .journal_core import (
+    DEFAULT_SOURCES,
+    SOURCE_TYPE_EXECUTION,
+    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    _attach_runtime_bucket_journal_payload,
+    _journal_source_batch,
+    _parse_sources,
+    _payload_int_matches,
+    _payload_mapping,
+    _runtime_ref_matches_signed_bucket,
+    _select_unlinked_events,
+    _select_unlinked_executions,
+    _select_unlinked_runtime_buckets,
+    _select_unlinked_tca_metrics,
+    _sqlalchemy_dsn,
+    build_order_event_transfer_plan,
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
+from .journal_payloads import (
+    _completed_progress_batch_from_timeout,
+    _fresh_reconciliation_for_empty_selection,
+    _journal_progress_events,
+    _last_journal_payload,
+    _payload,
+    _progress_int,
+    _safe_payload_allows_success,
+)
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_03_main")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
-del __compat_module__
+__all__ = (
+    "DEFAULT_SOURCES",
+    "SOURCE_TYPE_EXECUTION",
+    "SOURCE_TYPE_EXECUTION_ORDER_EVENT",
+    "SOURCE_TYPE_EXECUTION_TCA_METRIC",
+    "SOURCE_TYPE_RUNTIME_LEDGER_BUCKET",
+    "TRANSFER_KIND_RUNTIME_NET_PNL",
+    "_attach_runtime_bucket_journal_payload",
+    "_completed_progress_batch_from_timeout",
+    "_fresh_reconciliation_for_empty_selection",
+    "_journal_progress_events",
+    "_journal_source_batch",
+    "_last_journal_payload",
+    "_parse_sources",
+    "_payload",
+    "_payload_int_matches",
+    "_payload_mapping",
+    "_progress_int",
+    "_runtime_ref_matches_signed_bucket",
+    "_safe_payload_allows_success",
+    "_select_unlinked_events",
+    "_select_unlinked_executions",
+    "_select_unlinked_runtime_buckets",
+    "_select_unlinked_tca_metrics",
+    "_sqlalchemy_dsn",
+    "build_order_event_transfer_plan",
+    "main",
+)

--- a/services/torghut/scripts/journal_tigerbeetle_order_events_modules/__init__.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events_modules/__init__.py
@@ -30,6 +30,7 @@ from .journal_payloads import (
     _payload,
     _progress_int,
     _safe_payload_allows_success,
+    _write_supervised_output,
 )
 
 __all__ = (
@@ -57,6 +58,7 @@ __all__ = (
     "_select_unlinked_runtime_buckets",
     "_select_unlinked_tca_metrics",
     "_sqlalchemy_dsn",
+    "_write_supervised_output",
     "build_order_event_transfer_plan",
     "main",
 )

--- a/services/torghut/scripts/journal_tigerbeetle_order_events_modules/cli.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events_modules/cli.py
@@ -1,57 +1,45 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Journal existing order-feed events into TigerBeetle and persist reconciliation."""
 
 from __future__ import annotations
 
-import argparse
 import json
 import os
-import subprocess
-import sys
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal
-from typing import Any, cast
+from typing import Any
 
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.config import Settings
-from app.models import (
-    Execution,
-    ExecutionOrderEvent,
-    ExecutionTCAMetric,
-    StrategyRuntimeLedgerBucket,
-    TigerBeetleTransferRef,
-)
 from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION,
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-    TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
     TigerBeetleLedgerJournal,
-    build_runtime_ledger_bucket_transfer_plan,
-    build_order_event_transfer_plan,
-    tigerbeetle_runtime_ledger_journal_payload,
-)
-from app.trading.tigerbeetle_client import TigerBeetleClientTimeoutError
-from app.trading.tigerbeetle_ledger_model import (
-    TRANSFER_KIND_EXECUTION_COST,
-    TRANSFER_KIND_EXECUTION_FILL,
-    TRANSFER_KIND_RUNTIME_NET_PNL,
 )
 from app.trading.tigerbeetle_reconcile import (
-    latest_tigerbeetle_reconciliation_payload,
     reconcile_tigerbeetle_transfers,
 )
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_50 import *
-from .part_02_attach_runtime_bucket_journal_payload import *
+from .journal_core import (
+    _batch_requested_stop,
+    _journal_source_batch,
+    _parse_args,
+    _parse_sources,
+    _reset_session_identity_map,
+    _select_unlinked_events,
+    _select_unlinked_executions,
+    _select_unlinked_runtime_buckets,
+    _select_unlinked_tca_metrics,
+    _sqlalchemy_dsn,
+)
+from .journal_payloads import (
+    _fresh_reconciliation_for_empty_selection,
+    _payload,
+    _run_supervised_worker,
+)
 
 
 def main() -> int:
@@ -295,6 +283,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/scripts/journal_tigerbeetle_order_events_modules/journal_core.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events_modules/journal_core.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Journal existing order-feed events into TigerBeetle and persist reconciliation."""
 
@@ -6,8 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import subprocess
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -15,8 +12,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, cast
 
-from sqlalchemy import create_engine, select
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import select
 
 from app.config import Settings
 from app.models import (
@@ -32,7 +28,6 @@ from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
     TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
-    TigerBeetleLedgerJournal,
     build_runtime_ledger_bucket_transfer_plan,
     build_order_event_transfer_plan,
     tigerbeetle_runtime_ledger_journal_payload,
@@ -43,12 +38,6 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_EXECUTION_FILL,
     TRANSFER_KIND_RUNTIME_NET_PNL,
 )
-from app.trading.tigerbeetle_reconcile import (
-    latest_tigerbeetle_reconciliation_payload,
-    reconcile_tigerbeetle_transfers,
-)
-
-# ruff: noqa: F401,F403,F405,F811,F821
 
 
 DEFAULT_SOURCES = (
@@ -454,6 +443,65 @@ def _runtime_ref_matches_signed_bucket(
     )
 
 
+def _attach_runtime_bucket_journal_payload(
+    row: StrategyRuntimeLedgerBucket,
+    ref: TigerBeetleTransferRef,
+) -> None:
+    journal_payload = tigerbeetle_runtime_ledger_journal_payload(
+        bucket=row,
+        ref=ref,
+        status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
+    )
+    existing_payload = (
+        dict(row.payload_json) if isinstance(row.payload_json, dict) else {}
+    )
+    source_refs = [
+        str(item)
+        for item in existing_payload.get("source_refs", [])
+        if str(item).strip()
+    ]
+    raw_journal_source_refs = journal_payload.get("source_refs")
+    journal_source_refs = (
+        cast(Sequence[object], raw_journal_source_refs)
+        if isinstance(raw_journal_source_refs, Sequence)
+        and not isinstance(raw_journal_source_refs, (str, bytes, bytearray))
+        else ()
+    )
+    for source_ref in journal_source_refs:
+        if isinstance(source_ref, str) and source_ref not in source_refs:
+            source_refs.append(source_ref)
+    source_row_counts = (
+        dict(existing_payload.get("source_row_counts", {}))
+        if isinstance(existing_payload.get("source_row_counts"), dict)
+        else {}
+    )
+    source_row_counts["tigerbeetle_transfer_refs"] = 1
+    row.payload_json = {
+        **existing_payload,
+        "source_refs": source_refs,
+        "source_row_counts": source_row_counts,
+        "tigerbeetle_journal_parity": journal_payload,
+        "tigerbeetle": journal_payload,
+        "tigerbeetle_account_ids": journal_payload["account_ids"],
+        "tigerbeetle_account_keys": journal_payload["account_keys"],
+        "tigerbeetle_transfer_ids": journal_payload["transfer_ids"],
+        "tigerbeetle_non_authority_blockers": journal_payload["authority_blockers"],
+    }
+
+
+def _error_summary(exc: Exception) -> str:
+    message = str(exc).strip()
+    if len(message) > 160:
+        message = f"{message[:157]}..."
+    return f"{type(exc).__name__}:{message}"
+
+
+def _reset_session_identity_map(session: Any) -> None:
+    expunge_all = getattr(session, "expunge_all", None)
+    if callable(expunge_all):
+        expunge_all()
+
+
 def _journal_source_batch(
     session: Any,
     *,
@@ -720,6 +768,3 @@ def _batch_requested_stop(batch: Mapping[str, Any]) -> bool:
     return bool(batch.get("stopped_early")) and bool(
         str(batch.get("stop_reason") or "")
     )
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/scripts/journal_tigerbeetle_order_events_modules/journal_payloads.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events_modules/journal_payloads.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python3
 """Journal existing order-feed events into TigerBeetle and persist reconciliation."""
 
@@ -10,106 +9,21 @@ import os
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal
 from typing import Any, cast
 
-from sqlalchemy import create_engine, select
-from sqlalchemy.orm import sessionmaker
-
 from app.config import Settings
-from app.models import (
-    Execution,
-    ExecutionOrderEvent,
-    ExecutionTCAMetric,
-    StrategyRuntimeLedgerBucket,
-    TigerBeetleTransferRef,
-)
-from app.trading.tigerbeetle_journal import (
-    SOURCE_TYPE_EXECUTION,
-    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
-    SOURCE_TYPE_EXECUTION_TCA_METRIC,
-    SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-    TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
-    TigerBeetleLedgerJournal,
-    build_runtime_ledger_bucket_transfer_plan,
-    build_order_event_transfer_plan,
-    tigerbeetle_runtime_ledger_journal_payload,
-)
-from app.trading.tigerbeetle_client import TigerBeetleClientTimeoutError
-from app.trading.tigerbeetle_ledger_model import (
-    TRANSFER_KIND_EXECUTION_COST,
-    TRANSFER_KIND_EXECUTION_FILL,
-    TRANSFER_KIND_RUNTIME_NET_PNL,
-)
 from app.trading.tigerbeetle_reconcile import (
     latest_tigerbeetle_reconciliation_payload,
-    reconcile_tigerbeetle_transfers,
 )
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_50 import *
-
-
-def _attach_runtime_bucket_journal_payload(
-    row: StrategyRuntimeLedgerBucket,
-    ref: TigerBeetleTransferRef,
-) -> None:
-    journal_payload = tigerbeetle_runtime_ledger_journal_payload(
-        bucket=row,
-        ref=ref,
-        status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
-    )
-    existing_payload = (
-        dict(row.payload_json) if isinstance(row.payload_json, dict) else {}
-    )
-    source_refs = [
-        str(item)
-        for item in existing_payload.get("source_refs", [])
-        if str(item).strip()
-    ]
-    raw_journal_source_refs = journal_payload.get("source_refs")
-    journal_source_refs = (
-        cast(Sequence[object], raw_journal_source_refs)
-        if isinstance(raw_journal_source_refs, Sequence)
-        and not isinstance(raw_journal_source_refs, (str, bytes, bytearray))
-        else ()
-    )
-    for source_ref in journal_source_refs:
-        if isinstance(source_ref, str) and source_ref not in source_refs:
-            source_refs.append(source_ref)
-    source_row_counts = (
-        dict(existing_payload.get("source_row_counts", {}))
-        if isinstance(existing_payload.get("source_row_counts"), dict)
-        else {}
-    )
-    source_row_counts["tigerbeetle_transfer_refs"] = 1
-    row.payload_json = {
-        **existing_payload,
-        "source_refs": source_refs,
-        "source_row_counts": source_row_counts,
-        "tigerbeetle_journal_parity": journal_payload,
-        "tigerbeetle": journal_payload,
-        "tigerbeetle_account_ids": journal_payload["account_ids"],
-        "tigerbeetle_account_keys": journal_payload["account_keys"],
-        "tigerbeetle_transfer_ids": journal_payload["transfer_ids"],
-        "tigerbeetle_non_authority_blockers": journal_payload["authority_blockers"],
-    }
-
-
-def _error_summary(exc: Exception) -> str:
-    message = str(exc).strip()
-    if len(message) > 160:
-        message = f"{message[:157]}..."
-    return f"{type(exc).__name__}:{message}"
-
-
-def _reset_session_identity_map(session: Any) -> None:
-    expunge_all = getattr(session, "expunge_all", None)
-    if callable(expunge_all):
-        expunge_all()
+from .journal_core import (
+    DEFAULT_JOURNAL_BATCH_CHUNK_SIZE,
+    INFRASTRUCTURE_RECONCILIATION_BLOCKERS,
+    MAX_JOURNAL_BATCH_CHUNK_SIZE,
+    _emit_progress,
+    _parse_sources,
+)
 
 
 def _fresh_reconciliation_for_empty_selection(
@@ -691,6 +605,3 @@ def _run_supervised_worker(args: argparse.Namespace, *, started_at: datetime) ->
         if source_exit_code:
             exit_code = 1
     return exit_code
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/tests/journal_tigerbeetle_order_events/support.py
+++ b/services/torghut/tests/journal_tigerbeetle_order_events/support.py
@@ -51,6 +51,11 @@ from app.trading.tigerbeetle_client import (
     TigerBeetleClientTimeoutError,
 )
 from scripts import journal_tigerbeetle_order_events as script
+from scripts.journal_tigerbeetle_order_events_modules import cli as script_cli
+from scripts.journal_tigerbeetle_order_events_modules import journal_core as script_core
+from scripts.journal_tigerbeetle_order_events_modules import (
+    journal_payloads as script_payloads,
+)
 from scripts import run_tigerbeetle_journal_cron as cron_runner
 
 

--- a/services/torghut/tests/journal_tigerbeetle_order_events/test_part_01.py
+++ b/services/torghut/tests/journal_tigerbeetle_order_events/test_part_01.py
@@ -209,7 +209,7 @@ class TestJournalTigerBeetleOrderEventsScriptPart1(
                 ],
             ),
             patch(
-                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                "scripts.journal_tigerbeetle_order_events_modules.journal_payloads.subprocess.run",
                 side_effect=subprocess.TimeoutExpired(
                     cmd=["python", "journal_tigerbeetle_order_events.py"],
                     timeout=0.01,
@@ -420,7 +420,7 @@ class TestJournalTigerBeetleOrderEventsScriptPart1(
                 ],
             ),
             patch(
-                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                "scripts.journal_tigerbeetle_order_events_modules.journal_payloads.subprocess.run",
                 side_effect=subprocess.TimeoutExpired(
                     cmd=["python", "journal_tigerbeetle_order_events.py"],
                     timeout=0.01,
@@ -501,7 +501,7 @@ class TestJournalTigerBeetleOrderEventsScriptPart1(
                 ],
             ),
             patch(
-                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                "scripts.journal_tigerbeetle_order_events_modules.journal_payloads.subprocess.run",
                 side_effect=subprocess.TimeoutExpired(
                     cmd=["python", "journal_tigerbeetle_order_events.py"],
                     timeout=0.01,
@@ -555,7 +555,7 @@ class TestJournalTigerBeetleOrderEventsScriptPart1(
                 ],
             ),
             patch(
-                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                "scripts.journal_tigerbeetle_order_events_modules.journal_payloads.subprocess.run",
                 side_effect=[
                     subprocess.CompletedProcess(
                         args=["python", "journal_tigerbeetle_order_events.py"],
@@ -648,7 +648,7 @@ class TestJournalTigerBeetleOrderEventsScriptPart1(
                 ],
             ),
             patch(
-                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                "scripts.journal_tigerbeetle_order_events_modules.journal_payloads.subprocess.run",
                 return_value=subprocess.CompletedProcess(
                     args=["python", "journal_tigerbeetle_order_events.py"],
                     returncode=1,
@@ -719,7 +719,7 @@ class TestJournalTigerBeetleOrderEventsScriptPart1(
                 ],
             ),
             patch(
-                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                "scripts.journal_tigerbeetle_order_events_modules.journal_payloads.subprocess.run",
                 return_value=subprocess.CompletedProcess(
                     args=["python", "journal_tigerbeetle_order_events.py"],
                     returncode=1,

--- a/services/torghut/tests/journal_tigerbeetle_order_events/test_part_03.py
+++ b/services/torghut/tests/journal_tigerbeetle_order_events/test_part_03.py
@@ -442,9 +442,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart3(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": True},
                 ) as reconcile,
@@ -505,8 +505,10 @@ class TestJournalTigerBeetleOrderEventsScriptPart3(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
-                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script_cli, "reconcile_tigerbeetle_transfers"
+                ) as reconcile,
                 redirect_stdout(stdout),
             ):
                 exit_code = script.main()
@@ -551,8 +553,10 @@ class TestJournalTigerBeetleOrderEventsScriptPart3(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
-                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script_cli, "reconcile_tigerbeetle_transfers"
+                ) as reconcile,
                 redirect_stdout(stdout),
             ):
                 exit_code = script.main()
@@ -600,9 +604,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart3(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": True, "status": "ok"},
                 ) as reconcile,
@@ -658,9 +662,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart3(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={
                         "ok": True,
@@ -735,8 +739,10 @@ class TestJournalTigerBeetleOrderEventsScriptPart3(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
-                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script_cli, "reconcile_tigerbeetle_transfers"
+                ) as reconcile,
                 redirect_stdout(stdout),
             ):
                 exit_code = script.main()

--- a/services/torghut/tests/journal_tigerbeetle_order_events/test_part_04.py
+++ b/services/torghut/tests/journal_tigerbeetle_order_events/test_part_04.py
@@ -33,7 +33,7 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                 payload = {**base_payload, **override}
                 session = object()
                 with patch.object(
-                    script,
+                    script_payloads,
                     "latest_tigerbeetle_reconciliation_payload",
                     return_value=payload,
                 ) as latest:
@@ -73,8 +73,10 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
-                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script_cli, "reconcile_tigerbeetle_transfers"
+                ) as reconcile,
                 redirect_stdout(stdout),
             ):
                 exit_code = script.main()
@@ -124,14 +126,14 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": True},
                 ),
                 patch.object(
-                    script,
+                    script_core,
                     "build_order_event_transfer_plan",
                     side_effect=build_plan_with_failure,
                 ),
@@ -172,9 +174,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": False},
                 ),
@@ -224,9 +226,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": True},
                 ) as reconcile,
@@ -273,9 +275,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": False},
                 ),
@@ -313,9 +315,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": False, "blockers": ["missing"]},
                 ),
@@ -358,9 +360,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={
                         "ok": False,
@@ -421,9 +423,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": True, "blockers": []},
                 ),
@@ -466,9 +468,9 @@ class TestJournalTigerBeetleOrderEventsScriptPart4(
                         "--json",
                     ],
                 ),
-                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
                 patch.object(
-                    script,
+                    script_cli,
                     "reconcile_tigerbeetle_transfers",
                     return_value={
                         "ok": False,


### PR DESCRIPTION
## Summary

- Renames the TigerBeetle order-event journal generated split modules to semantic files: `journal_core.py`, `journal_payloads.py`, and `cli.py`.
- Removes blanket Pyright disables, Ruff suppression comments, wildcard imports, generated `part_*` runtime module names, dynamic package mutation, and top-level `sys.modules` swapping from the journal entrypoint/package.
- Keeps the original `scripts/journal_tigerbeetle_order_events.py` import surface stable with explicit exports, including `_write_supervised_output` for the cron runner.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py::RunTigerBeetleJournalCronTest::test_run_command_replays_output_and_normalizes_safe_payload -q` (1 passed)
- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/journal_tigerbeetle_order_events -q` (70 passed)
- `cd services/torghut && uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py scripts/journal_tigerbeetle_order_events_modules scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/journal_tigerbeetle_order_events`
- `cd services/torghut && uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py scripts/journal_tigerbeetle_order_events_modules scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/journal_tigerbeetle_order_events`
- `cd services/torghut && uv run --frozen python -m compileall scripts/journal_tigerbeetle_order_events.py scripts/journal_tigerbeetle_order_events_modules`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
