### PR TITLE
refactor(torghut): rename hpairs liveness modules

### DIFF
--- a/services/torghut/scripts/audit_hpairs_signal_liveness.py
+++ b/services/torghut/scripts/audit_hpairs_signal_liveness.py
@@ -1,17 +1,34 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from scripts.audit_hpairs_signal_liveness_modules import (
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    DEFAULT_OBSERVED_STAGE,
+    HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION,
+    NEXT_ACTIONS,
+    AuditExpectations,
+    build_liveness_report,
+    main,
+    parse_args,
+    stable_json,
+)
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("scripts.audit_hpairs_signal_liveness_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+__all__ = (
+    "DEFAULT_HPAIRS_ACCOUNT_LABEL",
+    "DEFAULT_HPAIRS_CANDIDATE_ID",
+    "DEFAULT_HPAIRS_HYPOTHESIS_ID",
+    "DEFAULT_HPAIRS_RUNTIME_STRATEGY",
+    "DEFAULT_OBSERVED_STAGE",
+    "HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION",
+    "NEXT_ACTIONS",
+    "AuditExpectations",
+    "build_liveness_report",
+    "main",
+    "parse_args",
+    "stable_json",
+)
 
 if __name__ == "__main__":
-    raise SystemExit(_impl.main())
+    raise SystemExit(main())

--- a/services/torghut/scripts/audit_hpairs_signal_liveness_modules/__init__.py
+++ b/services/torghut/scripts/audit_hpairs_signal_liveness_modules/__init__.py
@@ -1,47 +1,91 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from .liveness_core import (
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    DEFAULT_OBSERVED_STAGE,
+    HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION,
+    NEXT_ACTIONS,
+    AuditExpectations,
+    _availability_for_symbol,
+    _availability_report,
+    _bool_or_none,
+    _candidate_identity,
+    _first_mapping_from_keys,
+    _first_value_from_keys,
+    _float_or_none,
+    _json_default,
+    _mapping,
+    _merge_inputs,
+    _normalize_symbols,
+    _read_json_path,
+    _read_status_url,
+    _runtime_materialization_count,
+    _runtime_materialization_report,
+    _sequence,
+    _signal_drift_readiness_report,
+    _signal_threshold_report,
+    _symbol_payload,
+    _symbols_from_target,
+    _target_from_source,
+    _target_matches,
+    _text,
+    _unique_text_items,
+    stable_json,
+)
+from .veto_report import (
+    _choose_next_action,
+    _flag_report,
+    _load_cli_source,
+    _nested_flag_containers,
+    _veto_report,
+    build_liveness_report,
+    main,
+    parse_args,
+)
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
-
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_21")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_02_veto_report")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
-del __compat_module__
+__all__ = (
+    "DEFAULT_HPAIRS_ACCOUNT_LABEL",
+    "DEFAULT_HPAIRS_CANDIDATE_ID",
+    "DEFAULT_HPAIRS_HYPOTHESIS_ID",
+    "DEFAULT_HPAIRS_RUNTIME_STRATEGY",
+    "DEFAULT_OBSERVED_STAGE",
+    "HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION",
+    "NEXT_ACTIONS",
+    "AuditExpectations",
+    "_availability_for_symbol",
+    "_availability_report",
+    "_bool_or_none",
+    "_candidate_identity",
+    "_choose_next_action",
+    "_first_mapping_from_keys",
+    "_first_value_from_keys",
+    "_flag_report",
+    "_float_or_none",
+    "_json_default",
+    "_load_cli_source",
+    "_mapping",
+    "_merge_inputs",
+    "_nested_flag_containers",
+    "_normalize_symbols",
+    "_read_json_path",
+    "_read_status_url",
+    "_runtime_materialization_count",
+    "_runtime_materialization_report",
+    "_sequence",
+    "_signal_drift_readiness_report",
+    "_signal_threshold_report",
+    "_symbol_payload",
+    "_symbols_from_target",
+    "_target_from_source",
+    "_target_matches",
+    "_text",
+    "_unique_text_items",
+    "_veto_report",
+    "build_liveness_report",
+    "main",
+    "parse_args",
+    "stable_json",
+)

--- a/services/torghut/scripts/audit_hpairs_signal_liveness_modules/liveness_core.py
+++ b/services/torghut/scripts/audit_hpairs_signal_liveness_modules/liveness_core.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python
 """Read-only H-PAIRS signal/route liveness diagnostics.
 
@@ -9,17 +8,13 @@ mutates database/cluster state.
 
 from __future__ import annotations
 
-import argparse
 import json
-import sys
 import urllib.error
 import urllib.request
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
-
-# ruff: noqa: F401,F403,F405,F811,F821
 
 
 DEFAULT_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
@@ -679,6 +674,3 @@ def _runtime_materialization_report(
             or source.get("recent_window")
         ),
     }
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/scripts/audit_hpairs_signal_liveness_modules/veto_report.py
+++ b/services/torghut/scripts/audit_hpairs_signal_liveness_modules/veto_report.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 #!/usr/bin/env python
 """Read-only H-PAIRS signal/route liveness diagnostics.
 
@@ -14,14 +13,38 @@ import json
 import sys
 import urllib.error
 import urllib.request
-from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
-from pathlib import Path
+from collections.abc import Mapping, Sequence
 from typing import cast
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_21 import *
+from .liveness_core import (
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    DEFAULT_OBSERVED_STAGE,
+    HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION,
+    AuditExpectations,
+    _availability_report,
+    _bool_or_none,
+    _candidate_identity,
+    _first_mapping_from_keys,
+    _mapping,
+    _merge_inputs,
+    _normalize_symbols,
+    _read_json_path,
+    _read_status_url,
+    _runtime_materialization_report,
+    _symbol_payload,
+    _symbols_from_target,
+    _signal_drift_readiness_report,
+    _signal_threshold_report,
+    _target_from_source,
+    _unique_text_items,
+    _EVIDENCE_COLLECTION_KEYS,
+    _ROUTE_FLAG_KEYS,
+    _SIMPLE_SUBMIT_KEYS,
+    stable_json,
+)
 
 
 def _veto_report(
@@ -391,6 +414,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/tests/test_audit_hpairs_signal_liveness.py
+++ b/services/torghut/tests/test_audit_hpairs_signal_liveness.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from scripts import audit_hpairs_signal_liveness as audit
+from scripts.audit_hpairs_signal_liveness_modules import liveness_core, veto_report
 
 
 def _base_fixture() -> dict[str, object]:
@@ -391,21 +392,21 @@ def test_paper_route_probe_symbols_drive_market_data_liveness() -> None:
 
 
 def test_helper_normalizers_cover_non_fixture_shapes(tmp_path: Path) -> None:
-    assert audit._text(123) == "123"
-    assert audit._bool_or_none("enabled") is True
-    assert audit._bool_or_none("disabled") is False
-    assert audit._bool_or_none(1) is True
-    assert audit._float_or_none("") is None
-    assert audit._float_or_none("bad") is None
-    assert audit._unique_text_items({"a": 1, "b": 2}) == ["a", "b"]
-    assert audit._unique_text_items(7) == ["7"]
-    assert audit._unique_text_items(["x", "x", None]) == ["x"]
-    assert audit.stable_json({"value": object()}).endswith("\n")
+    assert liveness_core._text(123) == "123"
+    assert liveness_core._bool_or_none("enabled") is True
+    assert liveness_core._bool_or_none("disabled") is False
+    assert liveness_core._bool_or_none(1) is True
+    assert liveness_core._float_or_none("") is None
+    assert liveness_core._float_or_none("bad") is None
+    assert liveness_core._unique_text_items({"a": 1, "b": 2}) == ["a", "b"]
+    assert liveness_core._unique_text_items(7) == ["7"]
+    assert liveness_core._unique_text_items(["x", "x", None]) == ["x"]
+    assert liveness_core.stable_json({"value": object()}).endswith("\n")
 
     non_object = tmp_path / "array.json"
     non_object.write_text("[]")
     try:
-        audit._read_json_path(non_object)
+        liveness_core._read_json_path(non_object)
     except ValueError as exc:
         assert "must contain a JSON object" in str(exc)
     else:  # pragma: no cover - defensive assertion branch
@@ -436,7 +437,7 @@ def test_cli_inputs_support_overrides_status_url_errors_and_fail_on_blockers(
         assert timeout == 0.25
         return _FakeResponse()
 
-    monkeypatch.setattr(audit.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(liveness_core.urllib.request, "urlopen", _fake_urlopen)
     args = audit.parse_args(
         [
             "--fixture-json",
@@ -449,7 +450,7 @@ def test_cli_inputs_support_overrides_status_url_errors_and_fail_on_blockers(
             "0.25",
         ]
     )
-    merged = audit._load_cli_source(args)
+    merged = veto_report._load_cli_source(args)
     assert merged["target"] == {"account_label": "ALPACA_PAPER"}
     assert merged["status"] == {"simple_lane": {"submit_enabled": False}}
 

--- a/services/torghut/tests/test_audit_hpairs_signal_liveness.py
+++ b/services/torghut/tests/test_audit_hpairs_signal_liveness.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import runpy
 from pathlib import Path
 
 from scripts import audit_hpairs_signal_liveness as audit
+from scripts import audit_hpairs_signal_liveness_modules as audit_modules
 from scripts.audit_hpairs_signal_liveness_modules import liveness_core, veto_report
 
 
@@ -259,6 +261,22 @@ def test_ready_fixture_classifies_ready_to_submit_sim_order(
     assert payload["blocker_codes"] == []
     assert payload["ready_to_submit_sim_order"] is True
     assert "H-PAIRS liveness READY" in captured.err
+
+
+def test_cli_module_entrypoint_exits_with_main_result(monkeypatch: object) -> None:
+    def _fake_main() -> int:
+        return 17
+
+    monkeypatch.setattr(audit_modules, "main", _fake_main)
+    audit_path = audit.__file__
+    assert audit_path is not None
+
+    try:
+        runpy.run_path(audit_path, run_name="__main__")
+    except SystemExit as exc:
+        assert exc.code == 17
+    else:  # pragma: no cover - entrypoint must raise SystemExit
+        raise AssertionError("expected CLI entrypoint to raise SystemExit")
 
 
 def _expectations() -> audit.AuditExpectations:


### PR DESCRIPTION
## Summary

- Renames the generated H-PAIRS signal-liveness module files to semantic modules: `liveness_core.py` and `veto_report.py`.
- Replaces the package and script compatibility shims with explicit imports/exports; no dynamic module mutation remains in this slice.
- Updates tests to cover helper internals through concrete implementation modules instead of relying on leaked wrapper state.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check scripts/audit_hpairs_signal_liveness.py scripts/audit_hpairs_signal_liveness_modules tests/test_audit_hpairs_signal_liveness.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/audit_hpairs_signal_liveness.py scripts/audit_hpairs_signal_liveness_modules tests/test_audit_hpairs_signal_liveness.py`
- `cd services/torghut && uv run --frozen python -m compileall scripts/audit_hpairs_signal_liveness.py scripts/audit_hpairs_signal_liveness_modules`
- `cd services/torghut && uv run --frozen pytest tests/test_audit_hpairs_signal_liveness.py -q` (18 passed)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pytest tests/test_analyze_historical_simulation.py tests/flatten_paper_account_positions tests/test_build_historical_profitability_proof.py tests/test_ta_replay_runner.py tests/test_ta_replay_retention_contract.py tests/test_journal_tigerbeetle_order_events.py tests/journal_tigerbeetle_order_events tests/test_run_tigerbeetle_journal_cron.py tests/test_audit_hpairs_signal_liveness.py -q --cov --cov-branch --cov-report=xml --cov-fail-under=0` (161 passed)
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (95.95%)
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
