### PR TITLE
refactor(torghut): normalize config and metrics modules

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1,14 +1,21 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public configuration surface for the Torghut service."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from .config_modules.part_01_statements_20 import (
+    FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD,
+    TradingAccountLane,
+    urlopen,
+)
+from .config_modules.part_07_settingsmethodspart2 import Settings, get_settings
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.config_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+settings = get_settings()
+
+__all__ = [
+    "FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD",
+    "Settings",
+    "TradingAccountLane",
+    "get_settings",
+    "settings",
+    "urlopen",
+]

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from .config_modules.part_01_statements_20 import (
+from .config_modules import (
     FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD,
+    Settings,
     TradingAccountLane,
+    get_settings,
     urlopen,
 )
-from .config_modules.part_07_settingsmethodspart2 import Settings, get_settings
 
 settings = get_settings()
 

--- a/services/torghut/app/config_modules/__init__.py
+++ b/services/torghut/app/config_modules/__init__.py
@@ -1,96 +1,21 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Configuration package exports for the Torghut service."""
+
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405,F821
+from .common import (
+    FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD,
+    TradingAccountLane,
+    urlopen,
+)
+from .settings import Settings, get_settings
 
-from importlib import import_module as __compat_import_module__
-import logging as __compat_logging__
-import sys as __compat_sys__
-import types as __compat_types__
-
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
-
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_20")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_02_settingsfieldspart1")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_03_settingsfieldspart2")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_04_settingsfieldspart3")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_05_settingsfieldspart4")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_06_settingsmethodspart1")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_07_settingsmethodspart2")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 settings = get_settings()
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__["settings"] = settings
-logger = __compat_logging__.getLogger(__name__.removesuffix("_modules"))
-for __compat_loaded_module__ in globals().get("__compat_part_modules__", ()):
-    __compat_loaded_module__.__dict__["logger"] = logger
+
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD",
+    "Settings",
+    "TradingAccountLane",
+    "get_settings",
+    "settings",
+    "urlopen",
 ]
-del __compat_module__

--- a/services/torghut/app/config_modules/autonomy_execution_fields.py
+++ b/services/torghut/app/config_modules/autonomy_execution_fields.py
@@ -1,30 +1,14 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-"""Application configuration for the torghut service."""
+"""Autonomy, drift, universe, execution, and simulation settings."""
 
-import json
-import logging
 import tempfile
-import os
-from decimal import Decimal
-from functools import lru_cache
-from http.client import HTTPConnection, HTTPSConnection
 from pathlib import Path
-import string
-from typing import Any, List, Literal, Optional, cast
-from urllib.parse import urlsplit
+from typing import Literal, Optional
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from ..logging_config import configure_logging
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_20 import *
-from .part_02_settingsfieldspart1 import *
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings
 
 
-class _SettingsFieldsPart2(BaseSettings):
+class AutonomyExecutionSettingsFields(BaseSettings):
     trading_autonomy_artifact_dir: str = Field(
         default=str(Path(tempfile.gettempdir()) / "torghut-autonomy"),
         alias="TRADING_AUTONOMY_ARTIFACT_DIR",
@@ -675,4 +659,4 @@ class _SettingsFieldsPart2(BaseSettings):
     )
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["AutonomyExecutionSettingsFields"]

--- a/services/torghut/app/config_modules/common.py
+++ b/services/torghut/app/config_modules/common.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
 from http.client import HTTPConnection, HTTPSConnection
@@ -164,6 +166,9 @@ class _HttpResponseHandle:
         return False
 
 
+FeatureFlagUrlopen = Callable[[_HttpRequest, float], _HttpResponseHandle]
+
+
 def urlopen(request: _HttpRequest, timeout: float) -> _HttpResponseHandle:
     connection, request_path = _http_connection_for_url(
         request.full_url,
@@ -178,6 +183,14 @@ def urlopen(request: _HttpRequest, timeout: float) -> _HttpResponseHandle:
         connection.close()
         raise
     return _HttpResponseHandle(connection, response)
+
+
+def _feature_flag_urlopen() -> FeatureFlagUrlopen:
+    config_module = sys.modules.get("app.config")
+    candidate = getattr(config_module, "urlopen", None) if config_module else None
+    if callable(candidate):
+        return cast(FeatureFlagUrlopen, candidate)
+    return urlopen
 
 
 def _build_boolean_feature_flag_request(
@@ -247,7 +260,7 @@ def resolve_boolean_feature_flag(
 ) -> tuple[bool, bool]:
     http_request, timeout_seconds = _build_boolean_feature_flag_request(request)
     try:
-        with urlopen(http_request, timeout_seconds) as response:
+        with _feature_flag_urlopen()(http_request, timeout_seconds) as response:
             return _parse_boolean_feature_flag_response(
                 request=request,
                 status=int(getattr(response, "status", 200)),

--- a/services/torghut/app/config_modules/common.py
+++ b/services/torghut/app/config_modules/common.py
@@ -1,25 +1,16 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-"""Application configuration for the torghut service."""
+"""Shared configuration helpers for the Torghut service."""
 
 import json
 import logging
-import tempfile
-import os
-from decimal import Decimal
+from dataclasses import dataclass
 from functools import lru_cache
 from http.client import HTTPConnection, HTTPSConnection
-from pathlib import Path
-import string
-from typing import Any, List, Literal, Optional, cast
+from typing import Any, Literal, Optional, cast
 from urllib.parse import urlsplit
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel
 
 from ..logging_config import configure_logging
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
 
 configure_logging()
 
@@ -72,7 +63,7 @@ FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD: dict[str, str] = {
     "posthog_enabled": "torghut_posthog_enabled",
 }
 
-_LLM_COMMITTEE_ROLES = {
+LLM_COMMITTEE_ROLES = {
     "researcher",
     "risk_critic",
     "execution_critic",
@@ -91,8 +82,18 @@ class TradingAccountLane(BaseModel):
     enabled: bool = True
 
 
+@dataclass(frozen=True)
+class BooleanFeatureFlagRequest:
+    endpoint: str
+    namespace_key: str
+    entity_id: str
+    flag_key: str
+    default_value: bool
+    timeout_ms: int
+
+
 @lru_cache(maxsize=1)
-def _dspy_bootstrap_artifact_hash() -> str | None:
+def dspy_bootstrap_artifact_hash() -> str | None:
     try:
         from ..trading.llm.dspy_programs.runtime import DSPyReviewRuntime
     except Exception:
@@ -179,73 +180,101 @@ def urlopen(request: _HttpRequest, timeout: float) -> _HttpResponseHandle:
     return _HttpResponseHandle(connection, response)
 
 
-def _resolve_boolean_feature_flag(
-    *,
-    endpoint: str,
-    namespace_key: str,
-    entity_id: str,
-    flag_key: str,
-    default_value: bool,
-    timeout_ms: int,
-) -> tuple[bool, bool]:
+def _build_boolean_feature_flag_request(
+    request: BooleanFeatureFlagRequest,
+) -> tuple[_HttpRequest, float]:
     payload = json.dumps(
         {
-            "namespaceKey": namespace_key,
-            "flagKey": flag_key,
-            "entityId": entity_id,
+            "namespaceKey": request.namespace_key,
+            "flagKey": request.flag_key,
+            "entityId": request.entity_id,
             "context": {},
         }
     ).encode("utf-8")
-    request_url = f"{endpoint.rstrip('/')}/evaluate/v1/boolean"
-    timeout_seconds = max(timeout_ms, 1) / 1000.0
-    request = _HttpRequest(
-        full_url=request_url,
-        method="POST",
-        data=payload,
-        headers={
-            "accept": "application/json",
-            "content-type": "application/json",
-        },
+    request_url = f"{request.endpoint.rstrip('/')}/evaluate/v1/boolean"
+    timeout_seconds = max(request.timeout_ms, 1) / 1000.0
+    return (
+        _HttpRequest(
+            full_url=request_url,
+            method="POST",
+            data=payload,
+            headers={
+                "accept": "application/json",
+                "content-type": "application/json",
+            },
+        ),
+        timeout_seconds,
     )
+
+
+def _feature_flag_default(request: BooleanFeatureFlagRequest) -> tuple[bool, bool]:
+    return request.default_value, False
+
+
+def _parse_boolean_feature_flag_response(
+    *,
+    request: BooleanFeatureFlagRequest,
+    status: int,
+    body_bytes: bytes,
+) -> tuple[bool, bool]:
+    if status < 200 or status >= 300:
+        logger.warning(
+            "Feature flag resolve HTTP failure for key=%s status=%s; using default.",
+            request.flag_key,
+            status,
+        )
+        return _feature_flag_default(request)
+    raw_body = json.loads(body_bytes.decode("utf-8"))
+    if not isinstance(raw_body, dict):
+        logger.warning(
+            "Feature flag resolve invalid response for key=%s; using default.",
+            request.flag_key,
+        )
+        return _feature_flag_default(request)
+    body = cast(dict[str, object], raw_body)
+    enabled = body.get("enabled")
+    if not isinstance(enabled, bool):
+        logger.warning(
+            "Feature flag resolve missing boolean `enabled` for key=%s; using default.",
+            request.flag_key,
+        )
+        return _feature_flag_default(request)
+    return enabled, True
+
+
+def resolve_boolean_feature_flag(
+    request: BooleanFeatureFlagRequest,
+) -> tuple[bool, bool]:
+    http_request, timeout_seconds = _build_boolean_feature_flag_request(request)
     try:
-        with urlopen(request, timeout_seconds) as response:
-            status = int(getattr(response, "status", 200))
-            if status < 200 or status >= 300:
-                logger.warning(
-                    "Feature flag resolve HTTP failure for key=%s status=%s; using default.",
-                    flag_key,
-                    status,
-                )
-                return default_value, False
-            raw_body = json.loads(response.read().decode("utf-8"))
-            if not isinstance(raw_body, dict):
-                logger.warning(
-                    "Feature flag resolve invalid response for key=%s; using default.",
-                    flag_key,
-                )
-                return default_value, False
-            body = cast(dict[str, object], raw_body)
-            enabled = body.get("enabled")
-            if not isinstance(enabled, bool):
-                logger.warning(
-                    "Feature flag resolve missing boolean `enabled` for key=%s; using default.",
-                    flag_key,
-                )
-                return default_value, False
-            return enabled, True
+        with urlopen(http_request, timeout_seconds) as response:
+            return _parse_boolean_feature_flag_response(
+                request=request,
+                status=int(getattr(response, "status", 200)),
+                body_bytes=response.read(),
+            )
     except ValueError:
         logger.warning(
             "Feature flag resolve invalid endpoint for key=%s endpoint=%s; using default.",
-            flag_key,
-            endpoint,
+            request.flag_key,
+            request.endpoint,
         )
-        return default_value, False
+        return _feature_flag_default(request)
     except Exception:
         logger.warning(
-            "Feature flag resolve failed for key=%s; using default.", flag_key
+            "Feature flag resolve failed for key=%s; using default.", request.flag_key
         )
-        return default_value, False
-    return default_value, False
+        return _feature_flag_default(request)
+    return _feature_flag_default(request)
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD",
+    "LLM_COMMITTEE_ROLES",
+    "BooleanFeatureFlagRequest",
+    "TradingAccountLane",
+    "dspy_bootstrap_artifact_hash",
+    "logger",
+    "resolve_boolean_feature_flag",
+    "urlopen",
+]

--- a/services/torghut/app/config_modules/llm_fields.py
+++ b/services/torghut/app/config_modules/llm_fields.py
@@ -1,32 +1,12 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-"""Application configuration for the torghut service."""
+"""LLM rollout, committee, and DSPy runtime settings."""
 
-import json
-import logging
-import tempfile
-import os
-from decimal import Decimal
-from functools import lru_cache
-from http.client import HTTPConnection, HTTPSConnection
-from pathlib import Path
-import string
-from typing import Any, List, Literal, Optional, cast
-from urllib.parse import urlsplit
+from typing import Literal, Optional
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from ..logging_config import configure_logging
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_20 import *
-from .part_02_settingsfieldspart1 import *
-from .part_03_settingsfieldspart2 import *
-from .part_04_settingsfieldspart3 import *
-
-
-class _SettingsFieldsPart4(BaseSettings):
+class LlmSettingsFields(BaseSettings):
     llm_rollout_stage: Literal[
         "stage0",
         "stage1",
@@ -164,4 +144,4 @@ class _SettingsFieldsPart4(BaseSettings):
     )
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["LlmSettingsFields"]

--- a/services/torghut/app/config_modules/normalization.py
+++ b/services/torghut/app/config_modules/normalization.py
@@ -1,33 +1,34 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-"""Application configuration for the torghut service."""
+"""Settings normalization and validation mixins."""
 
 import json
-import logging
-import tempfile
 import os
-from decimal import Decimal
-from functools import lru_cache
-from http.client import HTTPConnection, HTTPSConnection
-from pathlib import Path
-import string
-from typing import Any, List, Literal, Optional, cast
+from typing import Literal, Optional, cast
 from urllib.parse import urlsplit
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from ..logging_config import configure_logging
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_20 import *
-from .part_02_settingsfieldspart1 import *
-from .part_03_settingsfieldspart2 import *
-from .part_04_settingsfieldspart3 import *
-from .part_05_settingsfieldspart4 import *
+from .common import (
+    BooleanFeatureFlagRequest,
+    FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD,
+    logger,
+    resolve_boolean_feature_flag,
+)
+from .autonomy_execution_fields import AutonomyExecutionSettingsFields
+from .llm_fields import LlmSettingsFields
+from .runtime_risk_fields import RuntimeRiskSettingsFields
+from .service_fields import CoreSettingsFields
 
 
-class _SettingsMethodsPart1:
+def validate_fragility_map(name: str, values: dict[str, float]) -> None:
+    for state, value in values.items():
+        if value < 0 or value > 1:
+            raise ValueError(f"{name}[{state}] must be within [0, 1]")
+
+
+class SettingsNormalizationMixin(
+    CoreSettingsFields,
+    AutonomyExecutionSettingsFields,
+    RuntimeRiskSettingsFields,
+    LlmSettingsFields,
+):
     def _apply_feature_flag_overrides(self) -> None:
         if not self.trading_feature_flags_enabled:
             return
@@ -49,13 +50,15 @@ class _SettingsMethodsPart1:
         self.trading_feature_flags_entity_id = entity_id
         for field_name, flag_key in FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD.items():
             default_value = bool(getattr(self, field_name))
-            resolved, success = _resolve_boolean_feature_flag(
-                endpoint=endpoint,
-                namespace_key=namespace_key,
-                entity_id=entity_id,
-                flag_key=flag_key,
-                default_value=default_value,
-                timeout_ms=self.trading_feature_flags_timeout_ms,
+            resolved, success = resolve_boolean_feature_flag(
+                BooleanFeatureFlagRequest(
+                    endpoint=endpoint,
+                    namespace_key=namespace_key,
+                    entity_id=entity_id,
+                    flag_key=flag_key,
+                    default_value=default_value,
+                    timeout_ms=self.trading_feature_flags_timeout_ms,
+                )
             )
             setattr(self, field_name, resolved)
             if not success:
@@ -662,19 +665,19 @@ class _SettingsMethodsPart1:
             raise ValueError(
                 "TRADING_FRAGILITY thresholds must satisfy elevated <= stress <= crisis"
             )
-        _validate_fragility_map(
+        validate_fragility_map(
             "TRADING_FRAGILITY_STATE_BUDGET_MULTIPLIERS",
             self.trading_fragility_state_budget_multipliers,
         )
-        _validate_fragility_map(
+        validate_fragility_map(
             "TRADING_FRAGILITY_STATE_CAPACITY_MULTIPLIERS",
             self.trading_fragility_state_capacity_multipliers,
         )
-        _validate_fragility_map(
+        validate_fragility_map(
             "TRADING_FRAGILITY_STATE_PARTICIPATION_CLAMPS",
             self.trading_fragility_state_participation_clamps,
         )
-        _validate_fragility_map(
+        validate_fragility_map(
             "TRADING_FRAGILITY_STATE_ABSTAIN_BIAS",
             self.trading_fragility_state_abstain_bias,
         )
@@ -683,6 +686,67 @@ class _SettingsMethodsPart1:
             for key, value in self.trading_allocator_symbol_correlation_groups.items()
             if str(key).strip() and str(value).strip()
         }
+
+    @property
+    def llm_live_fail_open_requested(self) -> bool:
+        return self.llm_live_fail_open_requested_for_stage(self.llm_rollout_stage)
+
+    def llm_live_fail_open_requested_for_stage(self, rollout_stage: str) -> bool:
+        if self.trading_mode != "live":
+            return False
+        normalized_stage = self._normalize_rollout_stage(rollout_stage)
+        if normalized_stage in {"stage1", "stage2"}:
+            return (
+                self.llm_effective_fail_mode(rollout_stage=normalized_stage)
+                == "pass_through"
+            )
+        return self.llm_effective_fail_mode() == "pass_through"
+
+    def llm_effective_fail_mode_for_current_rollout(
+        self,
+    ) -> Literal["veto", "pass_through"]:
+        rollout_stage = self._normalize_rollout_stage(self.llm_rollout_stage)
+        if rollout_stage in {"stage1", "stage2"}:
+            return self.llm_effective_fail_mode(rollout_stage=rollout_stage)
+        return self.llm_effective_fail_mode()
+
+    def llm_effective_fail_mode(
+        self, *, rollout_stage: Optional[str] = None
+    ) -> Literal["veto", "pass_through"]:
+        if rollout_stage == "stage1":
+            if self.llm_fail_mode_enforcement == "strict_veto":
+                return "veto"
+            return "pass_through"
+
+        if rollout_stage == "stage2":
+            return "pass_through"
+
+        if self.llm_fail_mode_enforcement == "strict_veto":
+            return "veto"
+        return self.llm_fail_mode
+
+    @staticmethod
+    def _normalize_rollout_stage(stage: str) -> str:
+        if stage.startswith("stage0"):
+            return "stage0"
+        if stage.startswith("stage1"):
+            return "stage1"
+        if stage.startswith("stage2"):
+            return "stage2"
+        if stage.startswith("stage3"):
+            return "stage3"
+        return "stage3"
+
+    @staticmethod
+    def _matches_model_version_lock(model: str, version_lock: str) -> bool:
+        if not version_lock:
+            return False
+        if model == version_lock:
+            return True
+        if "@" in version_lock:
+            locked_model = version_lock.split("@", 1)[0].strip()
+            return bool(locked_model) and model == locked_model
+        return False
 
     def _validate_llm_settings(self) -> None:
         if (
@@ -758,4 +822,4 @@ class _SettingsMethodsPart1:
         )
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["SettingsNormalizationMixin", "validate_fragility_map"]

--- a/services/torghut/app/config_modules/runtime_risk_fields.py
+++ b/services/torghut/app/config_modules/runtime_risk_fields.py
@@ -1,31 +1,13 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-"""Application configuration for the torghut service."""
+"""Runtime risk, allocator, readiness, and integration settings."""
 
-import json
-import logging
-import tempfile
-import os
 from decimal import Decimal
-from functools import lru_cache
-from http.client import HTTPConnection, HTTPSConnection
-from pathlib import Path
-import string
-from typing import Any, List, Literal, Optional, cast
-from urllib.parse import urlsplit
+from typing import Literal, Optional
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from ..logging_config import configure_logging
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_20 import *
-from .part_02_settingsfieldspart1 import *
-from .part_03_settingsfieldspart2 import *
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings
 
 
-class _SettingsFieldsPart3(BaseSettings):
+class RuntimeRiskSettingsFields(BaseSettings):
     trading_runtime_regime_confidence_thresholds_by_entropy_band: dict[
         str, tuple[float, float]
     ] = Field(
@@ -668,4 +650,4 @@ class _SettingsFieldsPart3(BaseSettings):
     llm_shadow_mode: bool = Field(default=False, alias="LLM_SHADOW_MODE")
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["RuntimeRiskSettingsFields"]

--- a/services/torghut/app/config_modules/service_fields.py
+++ b/services/torghut/app/config_modules/service_fields.py
@@ -1,29 +1,14 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-"""Application configuration for the torghut service."""
+"""Core service and trading connectivity settings."""
 
-import json
-import logging
-import tempfile
-import os
-from decimal import Decimal
-from functools import lru_cache
-from http.client import HTTPConnection, HTTPSConnection
-from pathlib import Path
-import string
-from typing import Any, List, Literal, Optional, cast
-from urllib.parse import urlsplit
+from __future__ import annotations
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import Literal, Optional
 
-from ..logging_config import configure_logging
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_20 import *
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings
 
 
-class _SettingsFieldsPart1(BaseSettings):
+class CoreSettingsFields(BaseSettings):
     """Environment-backed settings."""
 
     app_env: Literal["dev", "stage", "prod"] = Field(
@@ -671,4 +656,4 @@ class _SettingsFieldsPart1(BaseSettings):
     )
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["CoreSettingsFields"]

--- a/services/torghut/app/config_modules/settings.py
+++ b/services/torghut/app/config_modules/settings.py
@@ -1,34 +1,25 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-"""Application configuration for the torghut service."""
+"""Concrete Torghut settings model and derived accessors."""
 
 import json
-import logging
-import tempfile
 import os
-from decimal import Decimal
 from functools import lru_cache
-from http.client import HTTPConnection, HTTPSConnection
-from pathlib import Path
 import string
-from typing import Any, List, Literal, Optional, cast
+from typing import Any, List, cast
 from urllib.parse import urlsplit
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import ValidationError
+from pydantic_settings import SettingsConfigDict
 
-from ..logging_config import configure_logging
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_20 import *
-from .part_02_settingsfieldspart1 import *
-from .part_03_settingsfieldspart2 import *
-from .part_04_settingsfieldspart3 import *
-from .part_05_settingsfieldspart4 import *
-from .part_06_settingsmethodspart1 import *
+from .common import (
+    LLM_COMMITTEE_ROLES,
+    TradingAccountLane,
+    dspy_bootstrap_artifact_hash,
+    logger,
+)
+from .normalization import SettingsNormalizationMixin
 
 
-class _SettingsMethodsPart2:
+class SettingsAccessorsMixin(SettingsNormalizationMixin):
     def _validate_tigerbeetle_settings(self) -> None:
         if self.tigerbeetle_cluster_id <= 0:
             raise ValueError("TORGHUT_TIGERBEETLE_CLUSTER_ID must be > 0")
@@ -377,54 +368,62 @@ class _SettingsMethodsPart2:
             if item.strip()
         ]
 
-    def llm_dspy_live_runtime_gate(self) -> tuple[bool, tuple[str, ...]]:
-        normalized_stage = self._normalize_rollout_stage(self.llm_rollout_stage)
-        reasons: list[str] = []
-
+    def _append_dspy_runtime_mode_reasons(
+        self, reasons: list[str], normalized_stage: str
+    ) -> None:
         if self.trading_mode != "live":
             reasons.append("dspy_live_requires_live_trading_mode")
         if self.llm_dspy_runtime_mode != "active":
             reasons.append("dspy_live_runtime_mode_not_active")
         if normalized_stage != "stage3":
             reasons.append("dspy_live_rollout_stage_not_stage3")
+
+    def _append_dspy_jangar_url_reasons(self, reasons: list[str]) -> None:
         if not self.jangar_base_url:
             reasons.append("dspy_jangar_base_url_missing")
-        else:
-            parsed_base_url = urlsplit(self.jangar_base_url)
-            normalized_base_path = parsed_base_url.path.rstrip("/")
-            if not parsed_base_url.scheme:
-                reasons.append("dspy_jangar_base_url_invalid")
-            elif parsed_base_url.scheme not in {"http", "https"}:
-                reasons.append("dspy_jangar_base_url_invalid")
-            elif not parsed_base_url.hostname:
-                reasons.append("dspy_jangar_base_url_invalid")
-            elif parsed_base_url.query or parsed_base_url.fragment:
-                reasons.append("dspy_jangar_base_url_invalid")
-            elif normalized_base_path and normalized_base_path not in (
-                "/openai/v1",
-                "/openai/v1/chat/completions",
-            ):
-                reasons.append("dspy_jangar_base_url_invalid")
+            return
 
+        parsed_base_url = urlsplit(self.jangar_base_url)
+        normalized_base_path = parsed_base_url.path.rstrip("/")
+        if not parsed_base_url.scheme:
+            reasons.append("dspy_jangar_base_url_invalid")
+        elif parsed_base_url.scheme not in {"http", "https"}:
+            reasons.append("dspy_jangar_base_url_invalid")
+        elif not parsed_base_url.hostname:
+            reasons.append("dspy_jangar_base_url_invalid")
+        elif parsed_base_url.query or parsed_base_url.fragment:
+            reasons.append("dspy_jangar_base_url_invalid")
+        elif normalized_base_path and normalized_base_path not in (
+            "/openai/v1",
+            "/openai/v1/chat/completions",
+        ):
+            reasons.append("dspy_jangar_base_url_invalid")
+
+    def _append_dspy_artifact_reasons(self, reasons: list[str]) -> None:
         if not self.llm_dspy_artifact_hash:
             reasons.append("dspy_artifact_hash_missing")
-        else:
-            normalized_hash = self.llm_dspy_artifact_hash.strip().lower()
-            if len(normalized_hash) != 64:
-                reasons.append("dspy_artifact_hash_invalid_length")
-            elif any(ch not in string.hexdigits for ch in normalized_hash):
-                reasons.append("dspy_artifact_hash_not_hex")
-            elif (
-                normalized_hash == (_dspy_bootstrap_artifact_hash() or "")
-                and self.llm_dspy_runtime_mode == "active"
-            ):
-                reasons.append("dspy_bootstrap_artifact_forbidden")
+            return
 
+        normalized_hash = self.llm_dspy_artifact_hash.strip().lower()
+        if len(normalized_hash) != 64:
+            reasons.append("dspy_artifact_hash_invalid_length")
+        elif any(ch not in string.hexdigits for ch in normalized_hash):
+            reasons.append("dspy_artifact_hash_not_hex")
+        elif (
+            normalized_hash == (dspy_bootstrap_artifact_hash() or "")
+            and self.llm_dspy_runtime_mode == "active"
+        ):
+            reasons.append("dspy_bootstrap_artifact_forbidden")
+
+    def _append_dspy_model_inventory_reasons(self, reasons: list[str]) -> None:
         if not self.llm_allowed_models:
             reasons.append("llm_model_inventory_missing")
         elif self.llm_model not in self.llm_allowed_models:
             reasons.append("llm_model_not_in_inventory")
 
+    def _append_dspy_stage_evidence_reasons(
+        self, reasons: list[str], normalized_stage: str
+    ) -> None:
         if normalized_stage in {"stage2", "stage3"}:
             if not self.llm_evaluation_report:
                 reasons.append("llm_evaluation_report_missing")
@@ -439,16 +438,27 @@ class _SettingsMethodsPart2:
             ):
                 reasons.append("llm_model_version_lock_mismatch")
 
+    def _append_dspy_committee_reasons(self, reasons: list[str]) -> None:
         if not self.llm_committee_enabled:
             reasons.append("llm_committee_disabled")
         if self.llm_committee_roles and not all(
-            role in _LLM_COMMITTEE_ROLES for role in self.llm_committee_roles
+            role in LLM_COMMITTEE_ROLES for role in self.llm_committee_roles
         ):
             reasons.append("llm_committee_roles_invalid")
         if self.llm_committee_mandatory_roles and not all(
-            role in _LLM_COMMITTEE_ROLES for role in self.llm_committee_mandatory_roles
+            role in LLM_COMMITTEE_ROLES for role in self.llm_committee_mandatory_roles
         ):
             reasons.append("llm_committee_mandatory_roles_invalid")
+
+    def llm_dspy_live_runtime_gate(self) -> tuple[bool, tuple[str, ...]]:
+        normalized_stage = self._normalize_rollout_stage(self.llm_rollout_stage)
+        reasons: list[str] = []
+        self._append_dspy_runtime_mode_reasons(reasons, normalized_stage)
+        self._append_dspy_jangar_url_reasons(reasons)
+        self._append_dspy_artifact_reasons(reasons)
+        self._append_dspy_model_inventory_reasons(reasons)
+        self._append_dspy_stage_evidence_reasons(reasons, normalized_stage)
+        self._append_dspy_committee_reasons(reasons)
 
         migration_allowed, migration_reasons = self.llm_dspy_cutover_migration_guard()
         if not migration_allowed:
@@ -486,76 +496,9 @@ class _SettingsMethodsPart2:
         allowed, _ = self.llm_dspy_live_runtime_gate()
         return allowed
 
-    @property
-    def llm_live_fail_open_requested(self) -> bool:
-        return self.llm_live_fail_open_requested_for_stage(self.llm_rollout_stage)
-
-    def llm_live_fail_open_requested_for_stage(self, rollout_stage: str) -> bool:
-        if self.trading_mode != "live":
-            return False
-        normalized_stage = self._normalize_rollout_stage(rollout_stage)
-        if normalized_stage in {"stage1", "stage2"}:
-            return (
-                self.llm_effective_fail_mode(rollout_stage=normalized_stage)
-                == "pass_through"
-            )
-        return self.llm_effective_fail_mode() == "pass_through"
-
-    def llm_effective_fail_mode_for_current_rollout(
-        self,
-    ) -> Literal["veto", "pass_through"]:
-        rollout_stage = self._normalize_rollout_stage(self.llm_rollout_stage)
-        if rollout_stage in {"stage1", "stage2"}:
-            return self.llm_effective_fail_mode(rollout_stage=rollout_stage)
-        return self.llm_effective_fail_mode()
-
-    def llm_effective_fail_mode(
-        self, *, rollout_stage: Optional[str] = None
-    ) -> Literal["veto", "pass_through"]:
-        if rollout_stage == "stage1":
-            if self.llm_fail_mode_enforcement == "strict_veto":
-                return "veto"
-            return "pass_through"
-
-        if rollout_stage == "stage2":
-            return "pass_through"
-
-        if self.llm_fail_mode_enforcement == "strict_veto":
-            return "veto"
-        return self.llm_fail_mode
-
-    @staticmethod
-    def _normalize_rollout_stage(stage: str) -> str:
-        if stage.startswith("stage0"):
-            return "stage0"
-        if stage.startswith("stage1"):
-            return "stage1"
-        if stage.startswith("stage2"):
-            return "stage2"
-        if stage.startswith("stage3"):
-            return "stage3"
-        return "stage3"
-
-    @staticmethod
-    def _matches_model_version_lock(model: str, version_lock: str) -> bool:
-        if not version_lock:
-            return False
-        if model == version_lock:
-            return True
-        if "@" in version_lock:
-            locked_model = version_lock.split("@", 1)[0].strip()
-            return bool(locked_model) and model == locked_model
-        return False
-
 
 class Settings(
-    _SettingsFieldsPart1,
-    _SettingsFieldsPart2,
-    _SettingsFieldsPart3,
-    _SettingsFieldsPart4,
-    _SettingsMethodsPart1,
-    _SettingsMethodsPart2,
-    BaseSettings,
+    SettingsAccessorsMixin,
 ):
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -565,17 +508,11 @@ class Settings(
     )
 
 
-def _validate_fragility_map(name: str, values: dict[str, float]) -> None:
-    for state, value in values.items():
-        if value < 0 or value > 1:
-            raise ValueError(f"{name}[{state}] must be within [0, 1]")
-
-
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
     """Return a cached Settings instance so values are loaded once."""
 
-    return Settings()  # type: ignore[call-arg]
+    return Settings()
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["Settings", "get_settings"]

--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -1,14 +1,7 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Prometheus-formatted metrics for Torghut trading counters."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from .metrics_modules import render_trading_metrics
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.metrics_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+__all__ = ["render_trading_metrics"]

--- a/services/torghut/app/metrics_modules/__init__.py
+++ b/services/torghut/app/metrics_modules/__init__.py
@@ -1,49 +1,7 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Metrics rendering helpers for Torghut."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from .renderers import render_trading_metrics
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
-
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_escape_label_value")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_render_forecast_route_selection_total_map"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
-del __compat_module__
+__all__ = ["render_trading_metrics"]

--- a/services/torghut/app/metrics_modules/core.py
+++ b/services/torghut/app/metrics_modules/core.py
@@ -1,13 +1,9 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Prometheus-formatted metrics for Torghut trading counters."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from decimal import Decimal
-from typing import cast
-
-# ruff: noqa: F401,F403,F405,F811,F821
 
 
 def _escape_label_value(value: str | int | float) -> str:
@@ -15,7 +11,7 @@ def _escape_label_value(value: str | int | float) -> str:
     return text.replace("\\", "\\\\").replace('"', '\\"')
 
 
-def _render_labeled_metric(
+def render_labeled_metric(
     metric_name: str,
     labels: Mapping[str, str],
     value: int | float,
@@ -28,7 +24,7 @@ def _render_labeled_metric(
     return [f"{metric_name}{{{label_text}}} {value}"]
 
 
-def _coerce_int(value: object) -> int:
+def coerce_int(value: object) -> int:
     if isinstance(value, bool):
         return int(value)
     if isinstance(value, int):
@@ -40,7 +36,7 @@ def _coerce_int(value: object) -> int:
     return 0
 
 
-_SIMPLE_MAP_METRICS: dict[str, tuple[str, str, str, str, str]] = {
+SIMPLE_MAP_METRICS: dict[str, tuple[str, str, str, str, str]] = {
     "execution_requests_total": (
         "torghut_trading_execution_requests_total",
         "Count of execution requests by adapter.",
@@ -379,14 +375,14 @@ _SIMPLE_MAP_METRICS: dict[str, tuple[str, str, str, str, str]] = {
     ),
 }
 
-_STRATEGY_RUNTIME_METRICS: dict[str, tuple[str, str]] = {
+STRATEGY_RUNTIME_METRICS: dict[str, tuple[str, str]] = {
     "strategy_events_total": ("torghut_trading_strategy_events_total", "counter"),
     "strategy_intents_total": ("torghut_trading_strategy_intents_total", "counter"),
     "strategy_errors_total": ("torghut_trading_strategy_errors_total", "counter"),
     "strategy_latency_ms": ("torghut_trading_strategy_latency_ms", "gauge"),
 }
 
-_SERVICE_LABEL_GAUGES: dict[str, tuple[str, str]] = {
+SERVICE_LABEL_GAUGES: dict[str, tuple[str, str]] = {
     "signal_lag_seconds": (
         "torghut_trading_signal_lag_seconds",
         "Latest signal ingestion lag in seconds.",
@@ -429,7 +425,7 @@ _SERVICE_LABEL_GAUGES: dict[str, tuple[str, str]] = {
     ),
 }
 
-_DIRECT_GAUGES: dict[str, tuple[str, str]] = {
+DIRECT_GAUGES: dict[str, tuple[str, str]] = {
     "feature_staleness_ms_p95": (
         "torghut_trading_feature_staleness_ms_p95",
         "Feature staleness p95 for the latest ingest batch.",
@@ -480,7 +476,7 @@ _DIRECT_GAUGES: dict[str, tuple[str, str]] = {
     ),
 }
 
-_AUTONOMY_WINDOW_GAUGES: dict[str, tuple[str, str]] = {
+AUTONOMY_WINDOW_GAUGES: dict[str, tuple[str, str]] = {
     "calibration_coverage_error": (
         "torghut_trading_calibration_coverage_error",
         "Absolute conformal coverage error for the latest autonomy window.",
@@ -495,14 +491,14 @@ _AUTONOMY_WINDOW_GAUGES: dict[str, tuple[str, str]] = {
     ),
 }
 
-_EVIDENCE_CONTINUITY_KEYS = {
+EVIDENCE_CONTINUITY_KEYS = {
     "evidence_continuity_last_checked_ts_seconds",
     "evidence_continuity_last_success_ts_seconds",
     "evidence_continuity_last_failed_runs",
 }
 
 
-def _metric_headers(metric_name: str, help_text: str, metric_type: str) -> list[str]:
+def metric_headers(metric_name: str, help_text: str, metric_type: str) -> list[str]:
     return [f"# HELP {metric_name} {help_text}", f"# TYPE {metric_name} {metric_type}"]
 
 
@@ -516,7 +512,7 @@ def _parse_metric_value(value: object, numeric_kind: str) -> int | float | None:
     return None
 
 
-def _sorted_metric_items(
+def sorted_metric_items(
     values: Mapping[str, object],
     *,
     numeric_kind: str,
@@ -530,17 +526,17 @@ def _sorted_metric_items(
     return sorted(items)
 
 
-def _render_simple_map_metric(key: str, values: Mapping[str, object]) -> list[str]:
-    metric_name, help_text, metric_type, label_name, numeric_kind = _SIMPLE_MAP_METRICS[
+def render_simple_map_metric(key: str, values: Mapping[str, object]) -> list[str]:
+    metric_name, help_text, metric_type, label_name, numeric_kind = SIMPLE_MAP_METRICS[
         key
     ]
-    lines = _metric_headers(metric_name, help_text, metric_type)
-    for label, numeric_value in _sorted_metric_items(
+    lines = metric_headers(metric_name, help_text, metric_type)
+    for label, numeric_value in sorted_metric_items(
         values,
         numeric_kind=numeric_kind,
     ):
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={label_name: label},
                 value=numeric_value,
@@ -549,20 +545,20 @@ def _render_simple_map_metric(key: str, values: Mapping[str, object]) -> list[st
     return lines
 
 
-def _render_execution_fallback_total_map(values: Mapping[str, object]) -> list[str]:
+def render_execution_fallback_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_execution_fallback_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of execution fallbacks by adapter transition.",
         "counter",
     )
-    for transition, count in _sorted_metric_items(values, numeric_kind="int"):
+    for transition, count in sorted_metric_items(values, numeric_kind="int"):
         expected_adapter = "unknown"
         actual_adapter = "unknown"
         if "->" in transition:
             expected_adapter, actual_adapter = transition.split("->", 1)
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"from": expected_adapter, "to": actual_adapter},
                 value=count,
@@ -571,20 +567,20 @@ def _render_execution_fallback_total_map(values: Mapping[str, object]) -> list[s
     return lines
 
 
-def _render_lean_failure_taxonomy_total_map(values: Mapping[str, object]) -> list[str]:
+def render_lean_failure_taxonomy_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_lean_failure_taxonomy_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of LEAN failures by operation and taxonomy.",
         "counter",
     )
-    for label, count in _sorted_metric_items(values, numeric_kind="int"):
+    for label, count in sorted_metric_items(values, numeric_kind="int"):
         operation = "unknown"
         taxonomy = "unknown"
         if ":" in label:
             operation, taxonomy = label.split(":", 1)
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"operation": operation, "taxonomy": taxonomy},
                 value=count,
@@ -593,11 +589,11 @@ def _render_lean_failure_taxonomy_total_map(values: Mapping[str, object]) -> lis
     return lines
 
 
-def _render_route_provenance_map(values: Mapping[str, object]) -> list[str]:
-    total = _coerce_int(values.get("total"))
-    missing = _coerce_int(values.get("missing"))
-    unknown = _coerce_int(values.get("unknown"))
-    mismatch = _coerce_int(values.get("mismatch"))
+def render_route_provenance_map(values: Mapping[str, object]) -> list[str]:
+    total = coerce_int(values.get("total"))
+    missing = coerce_int(values.get("missing"))
+    unknown = coerce_int(values.get("unknown"))
+    mismatch = coerce_int(values.get("mismatch"))
     lines: list[str] = []
     ratio_metrics: list[tuple[str, str]] = [
         ("coverage_ratio", "torghut_trading_route_provenance_coverage_ratio"),
@@ -606,7 +602,7 @@ def _render_route_provenance_map(values: Mapping[str, object]) -> list[str]:
     ]
     for source_key, metric_name in ratio_metrics:
         lines.extend(
-            _metric_headers(
+            metric_headers(
                 metric_name,
                 "Route provenance continuity ratio for recent executions.",
                 "gauge",
@@ -615,7 +611,7 @@ def _render_route_provenance_map(values: Mapping[str, object]) -> list[str]:
         ratio = values.get(source_key)
         if isinstance(ratio, (int, float, Decimal)):
             lines.extend(
-                _render_labeled_metric(
+                render_labeled_metric(
                     metric_name=metric_name,
                     labels={},
                     value=float(ratio),
@@ -644,9 +640,9 @@ def _render_route_provenance_map(values: Mapping[str, object]) -> list[str]:
         ),
     ]
     for metric_name, metric_value, help_text in count_metrics:
-        lines.extend(_metric_headers(metric_name, help_text, "gauge"))
+        lines.extend(metric_headers(metric_name, help_text, "gauge"))
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={},
                 value=metric_value,
@@ -655,20 +651,20 @@ def _render_route_provenance_map(values: Mapping[str, object]) -> list[str]:
     return lines
 
 
-def _render_universe_resolution_total_map(values: Mapping[str, object]) -> list[str]:
+def render_universe_resolution_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_universe_resolution_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of universe resolution outcomes by status and reason.",
         "counter",
     )
-    for key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for key, count in sorted_metric_items(values, numeric_kind="int"):
         status = "unknown"
         reason = "unknown"
         if "|" in key:
             status, reason = key.split("|", 1)
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"status": status, "reason": reason},
                 value=count,
@@ -677,9 +673,9 @@ def _render_universe_resolution_total_map(values: Mapping[str, object]) -> list[
     return lines
 
 
-def _render_forecast_calibration_error_map(values: Mapping[str, object]) -> list[str]:
+def render_forecast_calibration_error_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_forecast_calibration_error"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Forecast calibration error by model family, symbol, and horizon.",
         "gauge",
@@ -700,7 +696,7 @@ def _render_forecast_calibration_error_map(values: Mapping[str, object]) -> list
         except (ValueError, TypeError):
             continue
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={
                     "model_family": family,
@@ -711,6 +707,3 @@ def _render_forecast_calibration_error_map(values: Mapping[str, object]) -> list
             )
         )
     return lines
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]

--- a/services/torghut/app/metrics_modules/renderers.py
+++ b/services/torghut/app/metrics_modules/renderers.py
@@ -1,33 +1,47 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Prometheus-formatted metrics for Torghut trading counters."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from decimal import Decimal
 from typing import cast
 
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_escape_label_value import *
+from .core import (
+    AUTONOMY_WINDOW_GAUGES,
+    DIRECT_GAUGES,
+    EVIDENCE_CONTINUITY_KEYS,
+    SERVICE_LABEL_GAUGES,
+    SIMPLE_MAP_METRICS,
+    STRATEGY_RUNTIME_METRICS,
+    coerce_int,
+    metric_headers,
+    render_execution_fallback_total_map,
+    render_forecast_calibration_error_map,
+    render_labeled_metric,
+    render_lean_failure_taxonomy_total_map,
+    render_route_provenance_map,
+    render_simple_map_metric,
+    render_universe_resolution_total_map,
+    sorted_metric_items,
+)
 
 
 def _render_forecast_route_selection_total_map(
     values: Mapping[str, object],
 ) -> list[str]:
     metric_name = "torghut_forecast_route_selection_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of forecast route selections by model family and route key.",
         "counter",
     )
-    for route_key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for route_key, count in sorted_metric_items(values, numeric_kind="int"):
         parts = route_key.split("|", 1)
         if len(parts) != 2:
             continue
         family, route_label = parts
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={
                     "model_family": family,
@@ -41,11 +55,11 @@ def _render_forecast_route_selection_total_map(
 
 def _render_llm_committee_verdict_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_llm_committee_verdict_total"
-    lines = _metric_headers(metric_name, "Count of committee role verdicts.", "counter")
-    for label, count in _sorted_metric_items(values, numeric_kind="int"):
+    lines = metric_headers(metric_name, "Count of committee role verdicts.", "counter")
+    for label, count in sorted_metric_items(values, numeric_kind="int"):
         role, verdict = (label.split(":", 1) + ["unknown"])[:2]
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"role": role, "verdict": verdict},
                 value=count,
@@ -56,12 +70,12 @@ def _render_llm_committee_verdict_total_map(values: Mapping[str, object]) -> lis
 
 def _render_allocator_multiplier_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_allocation_multiplier_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Allocator multiplier applications by regime and fragility state.",
         "counter",
     )
-    for label, count in _sorted_metric_items(values, numeric_kind="int"):
+    for label, count in sorted_metric_items(values, numeric_kind="int"):
         parts = label.rsplit("|", 2)
         if len(parts) == 3:
             regime, fragility_state, multiplier = parts
@@ -73,7 +87,7 @@ def _render_allocator_multiplier_total_map(values: Mapping[str, object]) -> list
             fragility_state = "elevated"
             multiplier = "unknown"
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={
                     "regime": regime,
@@ -88,12 +102,12 @@ def _render_allocator_multiplier_total_map(values: Mapping[str, object]) -> list
 
 def _render_qty_resolution_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_qty_resolution_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of quantity-resolution outcomes by stage, outcome, and reason.",
         "counter",
     )
-    for key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for key, count in sorted_metric_items(values, numeric_kind="int"):
         stage = "unknown"
         outcome = "unknown"
         reason = "unknown"
@@ -101,7 +115,7 @@ def _render_qty_resolution_total_map(values: Mapping[str, object]) -> list[str]:
         if len(parts) == 3:
             stage, outcome, reason = parts
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"stage": stage, "outcome": outcome, "reason": reason},
                 value=count,
@@ -112,19 +126,19 @@ def _render_qty_resolution_total_map(values: Mapping[str, object]) -> list[str]:
 
 def _render_sell_inventory_context_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_sell_inventory_context_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of sell inventory context observations by stage and context.",
         "counter",
     )
-    for key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for key, count in sorted_metric_items(values, numeric_kind="int"):
         stage = "unknown"
         context = "unknown"
         parts = key.split("|", 1)
         if len(parts) == 2:
             stage, context = parts
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"stage": stage, "context": context},
                 value=count,
@@ -135,19 +149,19 @@ def _render_sell_inventory_context_total_map(values: Mapping[str, object]) -> li
 
 def _render_execution_local_reject_total_map(values: Mapping[str, object]) -> list[str]:
     metric_name = "torghut_trading_execution_local_reject_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of local execution rejects by code and reason.",
         "counter",
     )
-    for key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for key, count in sorted_metric_items(values, numeric_kind="int"):
         code = "unknown"
         reason = "unknown"
         parts = key.split("|", 1)
         if len(parts) == 2:
             code, reason = parts
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"code": code, "reason": reason},
                 value=count,
@@ -160,12 +174,12 @@ def _render_execution_submit_attempt_total_map(
     values: Mapping[str, object],
 ) -> list[str]:
     metric_name = "torghut_trading_execution_submit_attempt_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of execution submit attempts by adapter, side, and asset class.",
         "counter",
     )
-    for key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for key, count in sorted_metric_items(values, numeric_kind="int"):
         adapter = "unknown"
         side = "unknown"
         asset_class = "unknown"
@@ -173,7 +187,7 @@ def _render_execution_submit_attempt_total_map(
         if len(parts) == 3:
             adapter, side, asset_class = parts
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={
                     "adapter": adapter,
@@ -190,19 +204,19 @@ def _render_execution_submit_result_total_map(
     values: Mapping[str, object],
 ) -> list[str]:
     metric_name = "torghut_trading_execution_submit_result_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of execution submit results by status and adapter.",
         "counter",
     )
-    for key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for key, count in sorted_metric_items(values, numeric_kind="int"):
         status = "unknown"
         adapter = "unknown"
         parts = key.split("|", 1)
         if len(parts) == 2:
             status, adapter = parts
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"status": status, "adapter": adapter},
                 value=count,
@@ -258,7 +272,7 @@ def _render_tca_summary_map(values: Mapping[str, object]) -> list[str]:
         numeric_value = float(metric_value)
         metric_type = "counter" if summary_key == "order_count" else "gauge"
         lines.extend(
-            _metric_headers(
+            metric_headers(
                 metric_name,
                 f"Torghut TCA summary metric {summary_key}.",
                 metric_type,
@@ -269,11 +283,11 @@ def _render_tca_summary_map(values: Mapping[str, object]) -> list[str]:
 
 
 def _render_strategy_runtime_map(key: str, values: Mapping[str, object]) -> list[str]:
-    metric_name, metric_type = _STRATEGY_RUNTIME_METRICS[key]
-    lines = _metric_headers(metric_name, f"Strategy runtime metric {key}.", metric_type)
-    for strategy_id, count in _sorted_metric_items(values, numeric_kind="int"):
+    metric_name, metric_type = STRATEGY_RUNTIME_METRICS[key]
+    lines = metric_headers(metric_name, f"Strategy runtime metric {key}.", metric_type)
+    for strategy_id, count in sorted_metric_items(values, numeric_kind="int"):
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"strategy_id": strategy_id},
                 value=count,
@@ -286,15 +300,15 @@ def _render_strategy_intent_suppression_total_map(
     values: Mapping[str, object],
 ) -> list[str]:
     metric_name = "torghut_trading_strategy_intent_suppression_total"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         "Count of runtime intents suppressed before decision creation.",
         "counter",
     )
-    for key, count in _sorted_metric_items(values, numeric_kind="int"):
+    for key, count in sorted_metric_items(values, numeric_kind="int"):
         strategy_id, reason = (key.split("|", 1) + ["unknown"])[:2]
         lines.extend(
-            _render_labeled_metric(
+            render_labeled_metric(
                 metric_name=metric_name,
                 labels={"strategy_id": strategy_id, "reason": reason or "unknown"},
                 value=count,
@@ -304,28 +318,28 @@ def _render_strategy_intent_suppression_total_map(
 
 
 _SPECIAL_MAP_RENDERERS = {
-    "execution_fallback_total": _render_execution_fallback_total_map,
+    "execution_fallback_total": render_execution_fallback_total_map,
     "execution_local_reject_total": _render_execution_local_reject_total_map,
     "execution_submit_attempt_total": _render_execution_submit_attempt_total_map,
     "execution_submit_result_total": _render_execution_submit_result_total_map,
     "strategy_intent_suppression_total": _render_strategy_intent_suppression_total_map,
-    "lean_failure_taxonomy_total": _render_lean_failure_taxonomy_total_map,
-    "route_provenance": _render_route_provenance_map,
-    "forecast_calibration_error": _render_forecast_calibration_error_map,
+    "lean_failure_taxonomy_total": render_lean_failure_taxonomy_total_map,
+    "route_provenance": render_route_provenance_map,
+    "forecast_calibration_error": render_forecast_calibration_error_map,
     "forecast_route_selection_total": _render_forecast_route_selection_total_map,
     "llm_committee_verdict_total": _render_llm_committee_verdict_total_map,
     "allocator_multiplier_total": _render_allocator_multiplier_total_map,
     "qty_resolution_total": _render_qty_resolution_total_map,
     "sell_inventory_context_total": _render_sell_inventory_context_total_map,
-    "universe_resolution_total": _render_universe_resolution_total_map,
+    "universe_resolution_total": render_universe_resolution_total_map,
     "tca_summary": _render_tca_summary_map,
 }
 
 
 def _render_mapping_metric(key: str, values: Mapping[str, object]) -> list[str]:
-    if key in _SIMPLE_MAP_METRICS:
-        return _render_simple_map_metric(key, values)
-    if key in _STRATEGY_RUNTIME_METRICS:
+    if key in SIMPLE_MAP_METRICS:
+        return render_simple_map_metric(key, values)
+    if key in STRATEGY_RUNTIME_METRICS:
         return _render_strategy_runtime_map(key, values)
     renderer = _SPECIAL_MAP_RENDERERS.get(key)
     if renderer is None:
@@ -333,132 +347,192 @@ def _render_mapping_metric(key: str, values: Mapping[str, object]) -> list[str]:
     return renderer(values)
 
 
-def _render_scalar_metric(
-    key: str,
+ScalarRenderer = Callable[[str, int | float, Mapping[str, object]], list[str]]
+
+
+def _render_service_label_scalar(
+    metric_name: str,
+    help_text: str,
+    value: int | float,
+) -> list[str]:
+    lines = metric_headers(metric_name, help_text, "gauge")
+    lines.extend(
+        render_labeled_metric(
+            metric_name=metric_name,
+            labels={"service": "torghut"},
+            value=value,
+        )
+    )
+    return lines
+
+
+def _render_direct_gauge_scalar(
+    metric_name: str, help_text: str, value: int | float
+) -> list[str]:
+    lines = metric_headers(metric_name, help_text, "gauge")
+    lines.append(f"{metric_name} {value}")
+    return lines
+
+
+def _render_evidence_continuity_scalar(key: str, value: int | float) -> list[str]:
+    metric_name = f"torghut_trading_{key}"
+    lines = metric_headers(
+        metric_name,
+        f"Torghut trading metric {key.replace('_', ' ')}.",
+        "gauge",
+    )
+    lines.append(f"{metric_name} {value}")
+    return lines
+
+
+def _render_autonomy_window_scalar(
+    metric_name: str, help_text: str, value: int | float
+) -> list[str]:
+    lines = metric_headers(metric_name, help_text, "gauge")
+    lines.extend(
+        render_labeled_metric(
+            metric_name=metric_name,
+            labels={"symbol": "all", "horizon": "autonomy"},
+            value=value,
+        )
+    )
+    return lines
+
+
+def _render_llm_committee_veto_alignment_scalar(
+    _key: str,
     value: int | float,
     metrics: Mapping[str, object],
 ) -> list[str]:
-    service_spec = _SERVICE_LABEL_GAUGES.get(key)
-    if service_spec is not None:
-        metric_name, help_text = service_spec
-        lines = _metric_headers(metric_name, help_text, "gauge")
-        lines.extend(
-            _render_labeled_metric(
-                metric_name=metric_name,
-                labels={"service": "torghut"},
-                value=value,
-            )
-        )
-        return lines
-
-    direct_spec = _DIRECT_GAUGES.get(key)
-    if direct_spec is not None:
-        metric_name, help_text = direct_spec
-        lines = _metric_headers(metric_name, help_text, "gauge")
-        lines.append(f"{metric_name} {value}")
-        return lines
-
-    if key in _EVIDENCE_CONTINUITY_KEYS:
-        metric_name = f"torghut_trading_{key}"
-        lines = _metric_headers(
-            metric_name,
-            f"Torghut trading metric {key.replace('_', ' ')}.",
+    metric_name = "torghut_trading_llm_committee_veto_alignment_total"
+    rate_name = "torghut_trading_llm_committee_veto_alignment_rate"
+    veto_total = coerce_int(metrics.get("llm_committee_veto_total"))
+    lines = metric_headers(
+        metric_name,
+        "Count of committee vetoes aligned with deterministic veto outcomes.",
+        "counter",
+    )
+    lines.append(f"{metric_name} {value}")
+    lines.extend(
+        metric_headers(
+            rate_name,
+            "Ratio of committee vetoes aligned with deterministic veto outcomes.",
             "gauge",
         )
-        lines.append(f"{metric_name} {value}")
-        return lines
+    )
+    rate = float(value) / veto_total if veto_total > 0 else 1.0
+    lines.append(f"{rate_name} {rate}")
+    return lines
 
-    autonomy_spec = _AUTONOMY_WINDOW_GAUGES.get(key)
-    if autonomy_spec is not None:
-        metric_name, help_text = autonomy_spec
-        lines = _metric_headers(metric_name, help_text, "gauge")
-        lines.extend(
-            _render_labeled_metric(
-                metric_name=metric_name,
-                labels={"symbol": "all", "horizon": "autonomy"},
-                value=value,
-            )
-        )
-        return lines
 
-    if key == "llm_committee_veto_alignment_total":
-        metric_name = "torghut_trading_llm_committee_veto_alignment_total"
-        rate_name = "torghut_trading_llm_committee_veto_alignment_rate"
-        veto_total = _coerce_int(metrics.get("llm_committee_veto_total"))
-        lines = _metric_headers(
-            metric_name,
-            "Count of committee vetoes aligned with deterministic veto outcomes.",
-            "counter",
-        )
-        lines.append(f"{metric_name} {value}")
-        lines.extend(
-            _metric_headers(
-                rate_name,
-                "Ratio of committee vetoes aligned with deterministic veto outcomes.",
-                "gauge",
-            )
-        )
-        rate = float(value) / veto_total if veto_total > 0 else 1.0
-        lines.append(f"{rate_name} {rate}")
-        return lines
-
-    if key == "orders_rejected_total":
-        submitted_total = _coerce_int(metrics.get("orders_submitted_total"))
-        total = submitted_total + int(value)
-        clean_ratio = float(submitted_total) / total if total > 0 else 1.0
-        reject_ratio = float(value) / total if total > 0 else 0.0
-        lines = _metric_headers(
-            "torghut_trading_execution_clean_ratio",
-            "Ratio of submitted orders to total submit/reject outcomes.",
+def _render_orders_rejected_scalar(
+    _key: str,
+    value: int | float,
+    metrics: Mapping[str, object],
+) -> list[str]:
+    submitted_total = coerce_int(metrics.get("orders_submitted_total"))
+    total = submitted_total + int(value)
+    clean_ratio = float(submitted_total) / total if total > 0 else 1.0
+    reject_ratio = float(value) / total if total > 0 else 0.0
+    lines = metric_headers(
+        "torghut_trading_execution_clean_ratio",
+        "Ratio of submitted orders to total submit/reject outcomes.",
+        "gauge",
+    )
+    lines.append(f"torghut_trading_execution_clean_ratio {clean_ratio}")
+    lines.extend(
+        metric_headers(
+            "torghut_trading_execution_reject_ratio",
+            "Ratio of rejected orders to total submit/reject outcomes.",
             "gauge",
         )
-        lines.append(f"torghut_trading_execution_clean_ratio {clean_ratio}")
-        lines.extend(
-            _metric_headers(
-                "torghut_trading_execution_reject_ratio",
-                "Ratio of rejected orders to total submit/reject outcomes.",
-                "gauge",
-            )
-        )
-        lines.append(f"torghut_trading_execution_reject_ratio {reject_ratio}")
-        lines.extend(
-            _metric_headers(
-                "torghut_trading_orders_rejected_total",
-                "Torghut trading metric orders rejected total.",
-                "counter",
-            )
-        )
-        lines.append(f"torghut_trading_orders_rejected_total {value}")
-        return lines
-
-    if key == "signal_batch_order_violation_total":
-        metric_name = "torghut_trading_signal_batch_order_violation_total"
-        lines = _metric_headers(
-            metric_name,
-            "Count of signal batch ordering violations detected by the feature-quality gate.",
+    )
+    lines.append(f"torghut_trading_execution_reject_ratio {reject_ratio}")
+    lines.extend(
+        metric_headers(
+            "torghut_trading_orders_rejected_total",
+            "Torghut trading metric orders rejected total.",
             "counter",
         )
-        lines.append(f"{metric_name} {value}")
-        return lines
+    )
+    lines.append(f"torghut_trading_orders_rejected_total {value}")
+    return lines
 
-    if key == "execution_validation_mismatch_total":
-        metric_name = "torghut_trading_execution_validation_mismatch_total"
-        lines = _metric_headers(
-            metric_name,
-            "Count of mismatches between earlier quantity planning and execution validation.",
-            "counter",
-        )
-        lines.append(f"{metric_name} {value}")
-        return lines
 
+def _render_signal_batch_order_violation_scalar(
+    _key: str,
+    value: int | float,
+    _metrics: Mapping[str, object],
+) -> list[str]:
+    metric_name = "torghut_trading_signal_batch_order_violation_total"
+    lines = metric_headers(
+        metric_name,
+        "Count of signal batch ordering violations detected by the feature-quality gate.",
+        "counter",
+    )
+    lines.append(f"{metric_name} {value}")
+    return lines
+
+
+def _render_execution_validation_mismatch_scalar(
+    _key: str,
+    value: int | float,
+    _metrics: Mapping[str, object],
+) -> list[str]:
+    metric_name = "torghut_trading_execution_validation_mismatch_total"
+    lines = metric_headers(
+        metric_name,
+        "Count of mismatches between earlier quantity planning and execution validation.",
+        "counter",
+    )
+    lines.append(f"{metric_name} {value}")
+    return lines
+
+
+def _render_default_scalar(key: str, value: int | float) -> list[str]:
     metric_name = f"torghut_trading_{key}"
-    lines = _metric_headers(
+    lines = metric_headers(
         metric_name,
         f"Torghut trading metric {key.replace('_', ' ')}.",
         "counter",
     )
     lines.append(f"{metric_name} {value}")
     return lines
+
+
+_SPECIAL_SCALAR_RENDERERS: dict[str, ScalarRenderer] = {
+    "llm_committee_veto_alignment_total": _render_llm_committee_veto_alignment_scalar,
+    "orders_rejected_total": _render_orders_rejected_scalar,
+    "signal_batch_order_violation_total": _render_signal_batch_order_violation_scalar,
+    "execution_validation_mismatch_total": _render_execution_validation_mismatch_scalar,
+}
+
+
+def _render_scalar_metric(
+    key: str,
+    value: int | float,
+    metrics: Mapping[str, object],
+) -> list[str]:
+    service_spec = SERVICE_LABEL_GAUGES.get(key)
+    if service_spec is not None:
+        return _render_service_label_scalar(*service_spec, value)
+
+    direct_spec = DIRECT_GAUGES.get(key)
+    if direct_spec is not None:
+        return _render_direct_gauge_scalar(*direct_spec, value)
+
+    if key in EVIDENCE_CONTINUITY_KEYS:
+        return _render_evidence_continuity_scalar(key, value)
+
+    autonomy_spec = AUTONOMY_WINDOW_GAUGES.get(key)
+    if autonomy_spec is not None:
+        return _render_autonomy_window_scalar(*autonomy_spec, value)
+
+    renderer = _SPECIAL_SCALAR_RENDERERS.get(key)
+    if renderer is not None:
+        return renderer(key, value, metrics)
+
+    return _render_default_scalar(key, value)
 
 
 def render_trading_metrics(metrics: Mapping[str, object]) -> str:
@@ -476,6 +550,3 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
 
 
 __all__ = ["render_trading_metrics"]
-
-
-__all__ = [name for name in globals() if not name.startswith("__")]


### PR DESCRIPTION
## Summary

- Removes dynamic `globals().update` and `sys.modules` facade behavior from `app.config`, `app.config_modules`, `app.metrics`, and `app.metrics_modules`.
- Renames generated config and metrics `part_*` modules to semantic modules with explicit imports and exports.
- Drops file-level Pyright/Ruff suppressions and wildcard imports from the cleaned config and metrics lanes, then restructures mixins/helpers so strict Pyright and focused Pylint design checks pass without suppressions.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen python -m compileall app scripts`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen python scripts/check_refactor_quality.py`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pylint app/config.py app/config_modules app/metrics.py app/metrics_modules --disable=all --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks --score=n`
- `cd services/torghut && uv run --frozen pytest tests/test_metrics.py tests/test_llm_guardrails.py tests/test_time_source.py tests/test_market_context.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
