### PR TITLE
refactor(torghut): normalize trading helper exports

### DIFF
--- a/services/torghut/app/trading/alpha/lane.py
+++ b/services/torghut/app/trading/alpha/lane.py
@@ -1,14 +1,67 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public exports for Torghut lane."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from importlib import import_module
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.alpha.lane_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_impl = import_module("app.trading.alpha.lane_modules")
+
+AlphaLaneResult = getattr(_impl, "AlphaLaneResult")
+_StageManifestRecord = getattr(_impl, "_StageManifestRecord")
+_ALPHA_LANE_SCHEMA_VERSION = getattr(_impl, "_ALPHA_LANE_SCHEMA_VERSION")
+_STAGE_CANDIDATE_GENERATION = getattr(_impl, "_STAGE_CANDIDATE_GENERATION")
+_STAGE_EVALUATION = getattr(_impl, "_STAGE_EVALUATION")
+_STAGE_RECOMMENDATION = getattr(_impl, "_STAGE_RECOMMENDATION")
+_stable_hash = getattr(_impl, "_stable_hash")
+_sha256_path = getattr(_impl, "_sha256_path")
+_artifact_hashes = getattr(_impl, "_artifact_hashes")
+_readable_iteration_number = getattr(_impl, "_readable_iteration_number")
+_coerce_str = getattr(_impl, "_coerce_str")
+_coalesce_alpha_inputs = getattr(_impl, "_coalesce_alpha_inputs")
+_to_decimal = getattr(_impl, "_to_decimal")
+_normalize_prices = getattr(_impl, "_normalize_prices")
+_frame_signature = getattr(_impl, "_frame_signature")
+_coerce_promotion_target = getattr(_impl, "_coerce_promotion_target")
+_coerce_jsonable = getattr(_impl, "_coerce_jsonable")
+_persist_prices = getattr(_impl, "_persist_prices")
+_write_json = getattr(_impl, "_write_json")
+_decimal_or_none = getattr(_impl, "_decimal_or_none")
+_read_policy_payload = getattr(_impl, "_read_policy_payload")
+_evaluate_candidate = getattr(_impl, "_evaluate_candidate")
+_write_stage_manifest = getattr(_impl, "_write_stage_manifest")
+_build_stage_lineage_payload = getattr(_impl, "_build_stage_lineage_payload")
+_write_iteration_notes = getattr(_impl, "_write_iteration_notes")
+_persist_strategy_factory_results = getattr(_impl, "_persist_strategy_factory_results")
+run_alpha_discovery_lane = getattr(_impl, "run_alpha_discovery_lane")
+
+__all__ = [
+    "AlphaLaneResult",
+    "_StageManifestRecord",
+    "_ALPHA_LANE_SCHEMA_VERSION",
+    "_STAGE_CANDIDATE_GENERATION",
+    "_STAGE_EVALUATION",
+    "_STAGE_RECOMMENDATION",
+    "_stable_hash",
+    "_sha256_path",
+    "_artifact_hashes",
+    "_readable_iteration_number",
+    "_coerce_str",
+    "_coalesce_alpha_inputs",
+    "_to_decimal",
+    "_normalize_prices",
+    "_frame_signature",
+    "_coerce_promotion_target",
+    "_coerce_jsonable",
+    "_persist_prices",
+    "_write_json",
+    "_decimal_or_none",
+    "_read_policy_payload",
+    "_evaluate_candidate",
+    "_write_stage_manifest",
+    "_build_stage_lineage_payload",
+    "_write_iteration_notes",
+    "_persist_strategy_factory_results",
+    "run_alpha_discovery_lane",
+]
+
+del _impl

--- a/services/torghut/app/trading/alpha/lane_modules/__init__.py
+++ b/services/torghut/app/trading/alpha/lane_modules/__init__.py
@@ -1,59 +1,67 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Public exports for app.trading.alpha.lane_modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+_impl = import_module(f"{__name__}.part_03_run_alpha_discovery_lane")
 
+AlphaLaneResult = getattr(_impl, "AlphaLaneResult")
+_StageManifestRecord = getattr(_impl, "_StageManifestRecord")
+_ALPHA_LANE_SCHEMA_VERSION = getattr(_impl, "_ALPHA_LANE_SCHEMA_VERSION")
+_STAGE_CANDIDATE_GENERATION = getattr(_impl, "_STAGE_CANDIDATE_GENERATION")
+_STAGE_EVALUATION = getattr(_impl, "_STAGE_EVALUATION")
+_STAGE_RECOMMENDATION = getattr(_impl, "_STAGE_RECOMMENDATION")
+_stable_hash = getattr(_impl, "_stable_hash")
+_sha256_path = getattr(_impl, "_sha256_path")
+_artifact_hashes = getattr(_impl, "_artifact_hashes")
+_readable_iteration_number = getattr(_impl, "_readable_iteration_number")
+_coerce_str = getattr(_impl, "_coerce_str")
+_coalesce_alpha_inputs = getattr(_impl, "_coalesce_alpha_inputs")
+_to_decimal = getattr(_impl, "_to_decimal")
+_normalize_prices = getattr(_impl, "_normalize_prices")
+_frame_signature = getattr(_impl, "_frame_signature")
+_coerce_promotion_target = getattr(_impl, "_coerce_promotion_target")
+_coerce_jsonable = getattr(_impl, "_coerce_jsonable")
+_persist_prices = getattr(_impl, "_persist_prices")
+_write_json = getattr(_impl, "_write_json")
+_decimal_or_none = getattr(_impl, "_decimal_or_none")
+_read_policy_payload = getattr(_impl, "_read_policy_payload")
+_evaluate_candidate = getattr(_impl, "_evaluate_candidate")
+_write_stage_manifest = getattr(_impl, "_write_stage_manifest")
+_build_stage_lineage_payload = getattr(_impl, "_build_stage_lineage_payload")
+_write_iteration_notes = getattr(_impl, "_write_iteration_notes")
+_persist_strategy_factory_results = getattr(_impl, "_persist_strategy_factory_results")
+run_alpha_discovery_lane = getattr(_impl, "run_alpha_discovery_lane")
 
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_alphalaneresult")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_persist_strategy_factory_results"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_03_run_alpha_discovery_lane"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "AlphaLaneResult",
+    "_StageManifestRecord",
+    "_ALPHA_LANE_SCHEMA_VERSION",
+    "_STAGE_CANDIDATE_GENERATION",
+    "_STAGE_EVALUATION",
+    "_STAGE_RECOMMENDATION",
+    "_stable_hash",
+    "_sha256_path",
+    "_artifact_hashes",
+    "_readable_iteration_number",
+    "_coerce_str",
+    "_coalesce_alpha_inputs",
+    "_to_decimal",
+    "_normalize_prices",
+    "_frame_signature",
+    "_coerce_promotion_target",
+    "_coerce_jsonable",
+    "_persist_prices",
+    "_write_json",
+    "_decimal_or_none",
+    "_read_policy_payload",
+    "_evaluate_candidate",
+    "_write_stage_manifest",
+    "_build_stage_lineage_payload",
+    "_write_iteration_notes",
+    "_persist_strategy_factory_results",
+    "run_alpha_discovery_lane",
 ]
-del __compat_module__
+
+del _impl

--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -1,14 +1,85 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public exports for Torghut autoresearch."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from importlib import import_module
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.discovery.autoresearch_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_impl = import_module("app.trading.discovery.autoresearch_modules")
+
+_SCHEMA_VERSION = getattr(_impl, "_SCHEMA_VERSION")
+_mapping = getattr(_impl, "_mapping")
+_string = getattr(_impl, "_string")
+_string_list = getattr(_impl, "_string_list")
+_coerce_decimal = getattr(_impl, "_coerce_decimal")
+_json_clone = getattr(_impl, "_json_clone")
+_stable_value_key = getattr(_impl, "_stable_value_key")
+_dedupe_preserve_order = getattr(_impl, "_dedupe_preserve_order")
+_current_grid_value = getattr(_impl, "_current_grid_value")
+_decimal_from_candidate = getattr(_impl, "_decimal_from_candidate")
+_format_numeric_like = getattr(_impl, "_format_numeric_like")
+StrategyObjective = getattr(_impl, "StrategyObjective")
+SnapshotPolicy = getattr(_impl, "SnapshotPolicy")
+ProposalModelPolicy = getattr(_impl, "ProposalModelPolicy")
+ReplayBudget = getattr(_impl, "ReplayBudget")
+RuntimeClosurePolicy = getattr(_impl, "RuntimeClosurePolicy")
+ResearchClaim = getattr(_impl, "ResearchClaim")
+ResearchSource = getattr(_impl, "ResearchSource")
+MutationSpace = getattr(_impl, "MutationSpace")
+FamilyAutoresearchPlan = getattr(_impl, "FamilyAutoresearchPlan")
+StrategyAutoresearchProgram = getattr(_impl, "StrategyAutoresearchProgram")
+_load_mutation_space = getattr(_impl, "_load_mutation_space")
+_resolve_program_path = getattr(_impl, "_resolve_program_path")
+_resolve_seed_sweep_path = getattr(_impl, "_resolve_seed_sweep_path")
+_load_runtime_closure_policy = getattr(_impl, "_load_runtime_closure_policy")
+load_strategy_autoresearch_program = getattr(
+    _impl, "load_strategy_autoresearch_program"
+)
+apply_program_objective = getattr(_impl, "apply_program_objective")
+_resolved_mutation_values = getattr(_impl, "_resolved_mutation_values")
+build_mutated_sweep_config = getattr(_impl, "build_mutated_sweep_config")
+_objective_start_equity = getattr(_impl, "_objective_start_equity")
+_objective_total_net_pnl = getattr(_impl, "_objective_total_net_pnl")
+_objective_drawdown_passes = getattr(_impl, "_objective_drawdown_passes")
+candidate_meets_objective = getattr(_impl, "candidate_meets_objective")
+stable_payload_hash = getattr(_impl, "stable_payload_hash")
+run_id = getattr(_impl, "run_id")
+
+__all__ = [
+    "_SCHEMA_VERSION",
+    "_mapping",
+    "_string",
+    "_string_list",
+    "_coerce_decimal",
+    "_json_clone",
+    "_stable_value_key",
+    "_dedupe_preserve_order",
+    "_current_grid_value",
+    "_decimal_from_candidate",
+    "_format_numeric_like",
+    "StrategyObjective",
+    "SnapshotPolicy",
+    "ProposalModelPolicy",
+    "ReplayBudget",
+    "RuntimeClosurePolicy",
+    "ResearchClaim",
+    "ResearchSource",
+    "MutationSpace",
+    "FamilyAutoresearchPlan",
+    "StrategyAutoresearchProgram",
+    "_load_mutation_space",
+    "_resolve_program_path",
+    "_resolve_seed_sweep_path",
+    "_load_runtime_closure_policy",
+    "load_strategy_autoresearch_program",
+    "apply_program_objective",
+    "_resolved_mutation_values",
+    "build_mutated_sweep_config",
+    "_objective_start_equity",
+    "_objective_total_net_pnl",
+    "_objective_drawdown_passes",
+    "candidate_meets_objective",
+    "stable_payload_hash",
+    "run_id",
+]
+
+del _impl

--- a/services/torghut/app/trading/discovery/autoresearch_modules/__init__.py
+++ b/services/torghut/app/trading/discovery/autoresearch_modules/__init__.py
@@ -1,49 +1,85 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Public exports for app.trading.discovery.autoresearch_modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+_impl = import_module(f"{__name__}.part_02_load_strategy_autoresearch_program")
 
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_21")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_load_strategy_autoresearch_program"
+_SCHEMA_VERSION = getattr(_impl, "_SCHEMA_VERSION")
+_mapping = getattr(_impl, "_mapping")
+_string = getattr(_impl, "_string")
+_string_list = getattr(_impl, "_string_list")
+_coerce_decimal = getattr(_impl, "_coerce_decimal")
+_json_clone = getattr(_impl, "_json_clone")
+_stable_value_key = getattr(_impl, "_stable_value_key")
+_dedupe_preserve_order = getattr(_impl, "_dedupe_preserve_order")
+_current_grid_value = getattr(_impl, "_current_grid_value")
+_decimal_from_candidate = getattr(_impl, "_decimal_from_candidate")
+_format_numeric_like = getattr(_impl, "_format_numeric_like")
+StrategyObjective = getattr(_impl, "StrategyObjective")
+SnapshotPolicy = getattr(_impl, "SnapshotPolicy")
+ProposalModelPolicy = getattr(_impl, "ProposalModelPolicy")
+ReplayBudget = getattr(_impl, "ReplayBudget")
+RuntimeClosurePolicy = getattr(_impl, "RuntimeClosurePolicy")
+ResearchClaim = getattr(_impl, "ResearchClaim")
+ResearchSource = getattr(_impl, "ResearchSource")
+MutationSpace = getattr(_impl, "MutationSpace")
+FamilyAutoresearchPlan = getattr(_impl, "FamilyAutoresearchPlan")
+StrategyAutoresearchProgram = getattr(_impl, "StrategyAutoresearchProgram")
+_load_mutation_space = getattr(_impl, "_load_mutation_space")
+_resolve_program_path = getattr(_impl, "_resolve_program_path")
+_resolve_seed_sweep_path = getattr(_impl, "_resolve_seed_sweep_path")
+_load_runtime_closure_policy = getattr(_impl, "_load_runtime_closure_policy")
+load_strategy_autoresearch_program = getattr(
+    _impl, "load_strategy_autoresearch_program"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
+apply_program_objective = getattr(_impl, "apply_program_objective")
+_resolved_mutation_values = getattr(_impl, "_resolved_mutation_values")
+build_mutated_sweep_config = getattr(_impl, "build_mutated_sweep_config")
+_objective_start_equity = getattr(_impl, "_objective_start_equity")
+_objective_total_net_pnl = getattr(_impl, "_objective_total_net_pnl")
+_objective_drawdown_passes = getattr(_impl, "_objective_drawdown_passes")
+candidate_meets_objective = getattr(_impl, "candidate_meets_objective")
+stable_payload_hash = getattr(_impl, "stable_payload_hash")
+run_id = getattr(_impl, "run_id")
 
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "_SCHEMA_VERSION",
+    "_mapping",
+    "_string",
+    "_string_list",
+    "_coerce_decimal",
+    "_json_clone",
+    "_stable_value_key",
+    "_dedupe_preserve_order",
+    "_current_grid_value",
+    "_decimal_from_candidate",
+    "_format_numeric_like",
+    "StrategyObjective",
+    "SnapshotPolicy",
+    "ProposalModelPolicy",
+    "ReplayBudget",
+    "RuntimeClosurePolicy",
+    "ResearchClaim",
+    "ResearchSource",
+    "MutationSpace",
+    "FamilyAutoresearchPlan",
+    "StrategyAutoresearchProgram",
+    "_load_mutation_space",
+    "_resolve_program_path",
+    "_resolve_seed_sweep_path",
+    "_load_runtime_closure_policy",
+    "load_strategy_autoresearch_program",
+    "apply_program_objective",
+    "_resolved_mutation_values",
+    "build_mutated_sweep_config",
+    "_objective_start_equity",
+    "_objective_total_net_pnl",
+    "_objective_drawdown_passes",
+    "candidate_meets_objective",
+    "stable_payload_hash",
+    "run_id",
 ]
-del __compat_module__
+
+del _impl

--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -1,14 +1,217 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public exports for Torghut evidence bundles."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from importlib import import_module
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.discovery.evidence_bundles_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_impl = import_module("app.trading.discovery.evidence_bundles_modules")
+
+EVIDENCE_BUNDLE_SCHEMA_VERSION = getattr(_impl, "EVIDENCE_BUNDLE_SCHEMA_VERSION")
+VALID_COST_CALIBRATION_STATUSES = getattr(_impl, "VALID_COST_CALIBRATION_STATUSES")
+MARKET_IMPACT_STRESS_COST_BPS = getattr(_impl, "MARKET_IMPACT_STRESS_COST_BPS")
+DELAY_ADJUSTED_DEPTH_STRESS_MS = getattr(_impl, "DELAY_ADJUSTED_DEPTH_STRESS_MS")
+DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS = getattr(
+    _impl, "DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS"
+)
+DELAY_ADJUSTED_DEPTH_STRESS_COST_BPS = getattr(
+    _impl, "DELAY_ADJUSTED_DEPTH_STRESS_COST_BPS"
+)
+MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT = getattr(
+    _impl, "MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT"
+)
+REPLAY_ACTIVITY_SCORECARD_KEYS = getattr(_impl, "REPLAY_ACTIVITY_SCORECARD_KEYS")
+MARKET_IMPACT_SCORECARD_KEYS = getattr(_impl, "MARKET_IMPACT_SCORECARD_KEYS")
+CONFORMAL_COST_BUFFER_SCORECARD_KEYS = getattr(
+    _impl, "CONFORMAL_COST_BUFFER_SCORECARD_KEYS"
+)
+DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS = getattr(
+    _impl, "DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS"
+)
+FILL_SURVIVAL_SCORECARD_KEYS = getattr(_impl, "FILL_SURVIVAL_SCORECARD_KEYS")
+RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS = getattr(
+    _impl, "RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS"
+)
+BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS = getattr(
+    _impl, "BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS"
+)
+ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS = getattr(
+    _impl, "ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS"
+)
+OFI_RESPONSE_HORIZON_SCORECARD_KEYS = getattr(
+    _impl, "OFI_RESPONSE_HORIZON_SCORECARD_KEYS"
+)
+ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS = getattr(
+    _impl, "ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS"
+)
+STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS = getattr(
+    _impl, "STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS"
+)
+_stable_hash = getattr(_impl, "_stable_hash")
+_mapping = getattr(_impl, "_mapping")
+_string = getattr(_impl, "_string")
+_int = getattr(_impl, "_int")
+_decimal = getattr(_impl, "_decimal")
+_bool = getattr(_impl, "_bool")
+_decimal_mapping_total = getattr(_impl, "_decimal_mapping_total")
+_int_mapping = getattr(_impl, "_int_mapping")
+_frontier_replay_config = getattr(_impl, "_frontier_replay_config")
+_frontier_replay_params = getattr(_impl, "_frontier_replay_params")
+_frontier_strategy_overrides = getattr(_impl, "_frontier_strategy_overrides")
+_string_list = getattr(_impl, "_string_list")
+_order_type_execution_metrics = getattr(_impl, "_order_type_execution_metrics")
+_order_lifecycle_metrics = getattr(_impl, "_order_lifecycle_metrics")
+_order_type_ablation_metrics = getattr(_impl, "_order_type_ablation_metrics")
+_artifact_refs_from_scorecard = getattr(_impl, "_artifact_refs_from_scorecard")
+_runtime_ledger_lineage_handoff = getattr(_impl, "_runtime_ledger_lineage_handoff")
+_runtime_ledger_lineage_handoff_blockers = getattr(
+    _impl, "_runtime_ledger_lineage_handoff_blockers"
+)
+_p10 = getattr(_impl, "_p10")
+_delay_depth_fillability = getattr(_impl, "_delay_depth_fillability")
+_sum_mapping_int_values = getattr(_impl, "_sum_mapping_int_values")
+_is_synthetic_dataset_snapshot = getattr(_impl, "_is_synthetic_dataset_snapshot")
+_freshness_status_from_validation_status = getattr(
+    _impl, "_freshness_status_from_validation_status"
+)
+_scorecard_with_freshness_lineage = getattr(_impl, "_scorecard_with_freshness_lineage")
+_decomposition_symbol_contribution_shares = getattr(
+    _impl, "_decomposition_symbol_contribution_shares"
+)
+_decomposition_activity_counts = getattr(_impl, "_decomposition_activity_counts")
+_enrich_scorecard_with_replay_stress_metrics = getattr(
+    _impl, "_enrich_scorecard_with_replay_stress_metrics"
+)
+CandidateEvidenceBundle = getattr(_impl, "CandidateEvidenceBundle")
+evidence_bundle_id_for_payload = getattr(_impl, "evidence_bundle_id_for_payload")
+evidence_bundle_from_frontier_candidate = getattr(
+    _impl, "evidence_bundle_from_frontier_candidate"
+)
+evidence_bundle_from_payload = getattr(_impl, "evidence_bundle_from_payload")
+_requires_promotion_proof = getattr(_impl, "_requires_promotion_proof")
+_delay_depth_survival_blockers = getattr(_impl, "_delay_depth_survival_blockers")
+_has_artifact_ref = getattr(_impl, "_has_artifact_ref")
+_order_type_execution_validation_required = getattr(
+    _impl, "_order_type_execution_validation_required"
+)
+_order_type_execution_blockers = getattr(_impl, "_order_type_execution_blockers")
+_market_impact_stress_blockers = getattr(_impl, "_market_impact_stress_blockers")
+_implementation_uncertainty_blockers = getattr(
+    _impl, "_implementation_uncertainty_blockers"
+)
+_implementation_risk_backtest_stability_required = getattr(
+    _impl, "_implementation_risk_backtest_stability_required"
+)
+_implementation_risk_backtest_stability_blockers = getattr(
+    _impl, "_implementation_risk_backtest_stability_blockers"
+)
+_bootstrap_robust_optimization_required = getattr(
+    _impl, "_bootstrap_robust_optimization_required"
+)
+_bootstrap_robust_optimization_blockers = getattr(
+    _impl, "_bootstrap_robust_optimization_blockers"
+)
+_adaptive_signal_falsification_required = getattr(
+    _impl, "_adaptive_signal_falsification_required"
+)
+_scorecard_or_null_comparator_value = getattr(
+    _impl, "_scorecard_or_null_comparator_value"
+)
+_adaptive_signal_falsification_blockers = getattr(
+    _impl, "_adaptive_signal_falsification_blockers"
+)
+_ofi_response_horizon_required = getattr(_impl, "_ofi_response_horizon_required")
+_route_tca_present = getattr(_impl, "_route_tca_present")
+_ofi_response_horizon_blockers = getattr(_impl, "_ofi_response_horizon_blockers")
+_alpha_decay_predictability_required = getattr(
+    _impl, "_alpha_decay_predictability_required"
+)
+_alpha_decay_predictability_blockers = getattr(
+    _impl, "_alpha_decay_predictability_blockers"
+)
+_stochastic_liquidity_resilience_required = getattr(
+    _impl, "_stochastic_liquidity_resilience_required"
+)
+_stochastic_liquidity_resilience_blockers = getattr(
+    _impl, "_stochastic_liquidity_resilience_blockers"
+)
+_conformal_tail_risk_blockers = getattr(_impl, "_conformal_tail_risk_blockers")
+evidence_bundle_blockers = getattr(_impl, "evidence_bundle_blockers")
+evidence_bundle_is_valid = getattr(_impl, "evidence_bundle_is_valid")
+
+__all__ = [
+    "EVIDENCE_BUNDLE_SCHEMA_VERSION",
+    "VALID_COST_CALIBRATION_STATUSES",
+    "MARKET_IMPACT_STRESS_COST_BPS",
+    "DELAY_ADJUSTED_DEPTH_STRESS_MS",
+    "DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS",
+    "DELAY_ADJUSTED_DEPTH_STRESS_COST_BPS",
+    "MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT",
+    "REPLAY_ACTIVITY_SCORECARD_KEYS",
+    "MARKET_IMPACT_SCORECARD_KEYS",
+    "CONFORMAL_COST_BUFFER_SCORECARD_KEYS",
+    "DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS",
+    "FILL_SURVIVAL_SCORECARD_KEYS",
+    "RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS",
+    "BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS",
+    "ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS",
+    "OFI_RESPONSE_HORIZON_SCORECARD_KEYS",
+    "ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS",
+    "STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS",
+    "_stable_hash",
+    "_mapping",
+    "_string",
+    "_int",
+    "_decimal",
+    "_bool",
+    "_decimal_mapping_total",
+    "_int_mapping",
+    "_frontier_replay_config",
+    "_frontier_replay_params",
+    "_frontier_strategy_overrides",
+    "_string_list",
+    "_order_type_execution_metrics",
+    "_order_lifecycle_metrics",
+    "_order_type_ablation_metrics",
+    "_artifact_refs_from_scorecard",
+    "_runtime_ledger_lineage_handoff",
+    "_runtime_ledger_lineage_handoff_blockers",
+    "_p10",
+    "_delay_depth_fillability",
+    "_sum_mapping_int_values",
+    "_is_synthetic_dataset_snapshot",
+    "_freshness_status_from_validation_status",
+    "_scorecard_with_freshness_lineage",
+    "_decomposition_symbol_contribution_shares",
+    "_decomposition_activity_counts",
+    "_enrich_scorecard_with_replay_stress_metrics",
+    "CandidateEvidenceBundle",
+    "evidence_bundle_id_for_payload",
+    "evidence_bundle_from_frontier_candidate",
+    "evidence_bundle_from_payload",
+    "_requires_promotion_proof",
+    "_delay_depth_survival_blockers",
+    "_has_artifact_ref",
+    "_order_type_execution_validation_required",
+    "_order_type_execution_blockers",
+    "_market_impact_stress_blockers",
+    "_implementation_uncertainty_blockers",
+    "_implementation_risk_backtest_stability_required",
+    "_implementation_risk_backtest_stability_blockers",
+    "_bootstrap_robust_optimization_required",
+    "_bootstrap_robust_optimization_blockers",
+    "_adaptive_signal_falsification_required",
+    "_scorecard_or_null_comparator_value",
+    "_adaptive_signal_falsification_blockers",
+    "_ofi_response_horizon_required",
+    "_route_tca_present",
+    "_ofi_response_horizon_blockers",
+    "_alpha_decay_predictability_required",
+    "_alpha_decay_predictability_blockers",
+    "_stochastic_liquidity_resilience_required",
+    "_stochastic_liquidity_resilience_blockers",
+    "_conformal_tail_risk_blockers",
+    "evidence_bundle_blockers",
+    "evidence_bundle_is_valid",
+]
+
+del _impl

--- a/services/torghut/app/trading/discovery/evidence_bundles_modules/__init__.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles_modules/__init__.py
@@ -1,79 +1,217 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Public exports for app.trading.discovery.evidence_bundles_modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+_impl = import_module(f"{__name__}.part_05_evidence_bundle_blockers")
 
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_12")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_runtime_ledger_lineage_handoff_blockers"
+EVIDENCE_BUNDLE_SCHEMA_VERSION = getattr(_impl, "EVIDENCE_BUNDLE_SCHEMA_VERSION")
+VALID_COST_CALIBRATION_STATUSES = getattr(_impl, "VALID_COST_CALIBRATION_STATUSES")
+MARKET_IMPACT_STRESS_COST_BPS = getattr(_impl, "MARKET_IMPACT_STRESS_COST_BPS")
+DELAY_ADJUSTED_DEPTH_STRESS_MS = getattr(_impl, "DELAY_ADJUSTED_DEPTH_STRESS_MS")
+DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS = getattr(
+    _impl, "DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_03_evidence_bundle_from_frontier_candidate"
+DELAY_ADJUSTED_DEPTH_STRESS_COST_BPS = getattr(
+    _impl, "DELAY_ADJUSTED_DEPTH_STRESS_COST_BPS"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_04_implementation_risk_backtest_stability_blo"
+MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT = getattr(
+    _impl, "MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_05_evidence_bundle_blockers"
+REPLAY_ACTIVITY_SCORECARD_KEYS = getattr(_impl, "REPLAY_ACTIVITY_SCORECARD_KEYS")
+MARKET_IMPACT_SCORECARD_KEYS = getattr(_impl, "MARKET_IMPACT_SCORECARD_KEYS")
+CONFORMAL_COST_BUFFER_SCORECARD_KEYS = getattr(
+    _impl, "CONFORMAL_COST_BUFFER_SCORECARD_KEYS"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
+DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS = getattr(
+    _impl, "DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS"
+)
+FILL_SURVIVAL_SCORECARD_KEYS = getattr(_impl, "FILL_SURVIVAL_SCORECARD_KEYS")
+RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS = getattr(
+    _impl, "RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS"
+)
+BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS = getattr(
+    _impl, "BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS"
+)
+ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS = getattr(
+    _impl, "ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS"
+)
+OFI_RESPONSE_HORIZON_SCORECARD_KEYS = getattr(
+    _impl, "OFI_RESPONSE_HORIZON_SCORECARD_KEYS"
+)
+ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS = getattr(
+    _impl, "ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS"
+)
+STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS = getattr(
+    _impl, "STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS"
+)
+_stable_hash = getattr(_impl, "_stable_hash")
+_mapping = getattr(_impl, "_mapping")
+_string = getattr(_impl, "_string")
+_int = getattr(_impl, "_int")
+_decimal = getattr(_impl, "_decimal")
+_bool = getattr(_impl, "_bool")
+_decimal_mapping_total = getattr(_impl, "_decimal_mapping_total")
+_int_mapping = getattr(_impl, "_int_mapping")
+_frontier_replay_config = getattr(_impl, "_frontier_replay_config")
+_frontier_replay_params = getattr(_impl, "_frontier_replay_params")
+_frontier_strategy_overrides = getattr(_impl, "_frontier_strategy_overrides")
+_string_list = getattr(_impl, "_string_list")
+_order_type_execution_metrics = getattr(_impl, "_order_type_execution_metrics")
+_order_lifecycle_metrics = getattr(_impl, "_order_lifecycle_metrics")
+_order_type_ablation_metrics = getattr(_impl, "_order_type_ablation_metrics")
+_artifact_refs_from_scorecard = getattr(_impl, "_artifact_refs_from_scorecard")
+_runtime_ledger_lineage_handoff = getattr(_impl, "_runtime_ledger_lineage_handoff")
+_runtime_ledger_lineage_handoff_blockers = getattr(
+    _impl, "_runtime_ledger_lineage_handoff_blockers"
+)
+_p10 = getattr(_impl, "_p10")
+_delay_depth_fillability = getattr(_impl, "_delay_depth_fillability")
+_sum_mapping_int_values = getattr(_impl, "_sum_mapping_int_values")
+_is_synthetic_dataset_snapshot = getattr(_impl, "_is_synthetic_dataset_snapshot")
+_freshness_status_from_validation_status = getattr(
+    _impl, "_freshness_status_from_validation_status"
+)
+_scorecard_with_freshness_lineage = getattr(_impl, "_scorecard_with_freshness_lineage")
+_decomposition_symbol_contribution_shares = getattr(
+    _impl, "_decomposition_symbol_contribution_shares"
+)
+_decomposition_activity_counts = getattr(_impl, "_decomposition_activity_counts")
+_enrich_scorecard_with_replay_stress_metrics = getattr(
+    _impl, "_enrich_scorecard_with_replay_stress_metrics"
+)
+CandidateEvidenceBundle = getattr(_impl, "CandidateEvidenceBundle")
+evidence_bundle_id_for_payload = getattr(_impl, "evidence_bundle_id_for_payload")
+evidence_bundle_from_frontier_candidate = getattr(
+    _impl, "evidence_bundle_from_frontier_candidate"
+)
+evidence_bundle_from_payload = getattr(_impl, "evidence_bundle_from_payload")
+_requires_promotion_proof = getattr(_impl, "_requires_promotion_proof")
+_delay_depth_survival_blockers = getattr(_impl, "_delay_depth_survival_blockers")
+_has_artifact_ref = getattr(_impl, "_has_artifact_ref")
+_order_type_execution_validation_required = getattr(
+    _impl, "_order_type_execution_validation_required"
+)
+_order_type_execution_blockers = getattr(_impl, "_order_type_execution_blockers")
+_market_impact_stress_blockers = getattr(_impl, "_market_impact_stress_blockers")
+_implementation_uncertainty_blockers = getattr(
+    _impl, "_implementation_uncertainty_blockers"
+)
+_implementation_risk_backtest_stability_required = getattr(
+    _impl, "_implementation_risk_backtest_stability_required"
+)
+_implementation_risk_backtest_stability_blockers = getattr(
+    _impl, "_implementation_risk_backtest_stability_blockers"
+)
+_bootstrap_robust_optimization_required = getattr(
+    _impl, "_bootstrap_robust_optimization_required"
+)
+_bootstrap_robust_optimization_blockers = getattr(
+    _impl, "_bootstrap_robust_optimization_blockers"
+)
+_adaptive_signal_falsification_required = getattr(
+    _impl, "_adaptive_signal_falsification_required"
+)
+_scorecard_or_null_comparator_value = getattr(
+    _impl, "_scorecard_or_null_comparator_value"
+)
+_adaptive_signal_falsification_blockers = getattr(
+    _impl, "_adaptive_signal_falsification_blockers"
+)
+_ofi_response_horizon_required = getattr(_impl, "_ofi_response_horizon_required")
+_route_tca_present = getattr(_impl, "_route_tca_present")
+_ofi_response_horizon_blockers = getattr(_impl, "_ofi_response_horizon_blockers")
+_alpha_decay_predictability_required = getattr(
+    _impl, "_alpha_decay_predictability_required"
+)
+_alpha_decay_predictability_blockers = getattr(
+    _impl, "_alpha_decay_predictability_blockers"
+)
+_stochastic_liquidity_resilience_required = getattr(
+    _impl, "_stochastic_liquidity_resilience_required"
+)
+_stochastic_liquidity_resilience_blockers = getattr(
+    _impl, "_stochastic_liquidity_resilience_blockers"
+)
+_conformal_tail_risk_blockers = getattr(_impl, "_conformal_tail_risk_blockers")
+evidence_bundle_blockers = getattr(_impl, "evidence_bundle_blockers")
+evidence_bundle_is_valid = getattr(_impl, "evidence_bundle_is_valid")
 
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "EVIDENCE_BUNDLE_SCHEMA_VERSION",
+    "VALID_COST_CALIBRATION_STATUSES",
+    "MARKET_IMPACT_STRESS_COST_BPS",
+    "DELAY_ADJUSTED_DEPTH_STRESS_MS",
+    "DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS",
+    "DELAY_ADJUSTED_DEPTH_STRESS_COST_BPS",
+    "MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT",
+    "REPLAY_ACTIVITY_SCORECARD_KEYS",
+    "MARKET_IMPACT_SCORECARD_KEYS",
+    "CONFORMAL_COST_BUFFER_SCORECARD_KEYS",
+    "DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS",
+    "FILL_SURVIVAL_SCORECARD_KEYS",
+    "RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS",
+    "BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS",
+    "ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS",
+    "OFI_RESPONSE_HORIZON_SCORECARD_KEYS",
+    "ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS",
+    "STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS",
+    "_stable_hash",
+    "_mapping",
+    "_string",
+    "_int",
+    "_decimal",
+    "_bool",
+    "_decimal_mapping_total",
+    "_int_mapping",
+    "_frontier_replay_config",
+    "_frontier_replay_params",
+    "_frontier_strategy_overrides",
+    "_string_list",
+    "_order_type_execution_metrics",
+    "_order_lifecycle_metrics",
+    "_order_type_ablation_metrics",
+    "_artifact_refs_from_scorecard",
+    "_runtime_ledger_lineage_handoff",
+    "_runtime_ledger_lineage_handoff_blockers",
+    "_p10",
+    "_delay_depth_fillability",
+    "_sum_mapping_int_values",
+    "_is_synthetic_dataset_snapshot",
+    "_freshness_status_from_validation_status",
+    "_scorecard_with_freshness_lineage",
+    "_decomposition_symbol_contribution_shares",
+    "_decomposition_activity_counts",
+    "_enrich_scorecard_with_replay_stress_metrics",
+    "CandidateEvidenceBundle",
+    "evidence_bundle_id_for_payload",
+    "evidence_bundle_from_frontier_candidate",
+    "evidence_bundle_from_payload",
+    "_requires_promotion_proof",
+    "_delay_depth_survival_blockers",
+    "_has_artifact_ref",
+    "_order_type_execution_validation_required",
+    "_order_type_execution_blockers",
+    "_market_impact_stress_blockers",
+    "_implementation_uncertainty_blockers",
+    "_implementation_risk_backtest_stability_required",
+    "_implementation_risk_backtest_stability_blockers",
+    "_bootstrap_robust_optimization_required",
+    "_bootstrap_robust_optimization_blockers",
+    "_adaptive_signal_falsification_required",
+    "_scorecard_or_null_comparator_value",
+    "_adaptive_signal_falsification_blockers",
+    "_ofi_response_horizon_required",
+    "_route_tca_present",
+    "_ofi_response_horizon_blockers",
+    "_alpha_decay_predictability_required",
+    "_alpha_decay_predictability_blockers",
+    "_stochastic_liquidity_resilience_required",
+    "_stochastic_liquidity_resilience_blockers",
+    "_conformal_tail_risk_blockers",
+    "evidence_bundle_blockers",
+    "evidence_bundle_is_valid",
 ]
-del __compat_module__
+
+del _impl

--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -1,14 +1,247 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public exports for Torghut executable alpha receipts."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from importlib import import_module
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.executable_alpha_receipts_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_impl = import_module("app.trading.executable_alpha_receipts_modules")
+
+CAPITAL_REPLAY_BOARD_SCHEMA_VERSION = getattr(
+    _impl, "CAPITAL_REPLAY_BOARD_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION"
+)
+_EXECUTABLE_ALPHA_REPAIR_DESIGN_REF = getattr(
+    _impl, "_EXECUTABLE_ALPHA_REPAIR_DESIGN_REF"
+)
+_EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF = getattr(
+    _impl, "_EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF"
+)
+_EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET = getattr(
+    _impl, "_EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET"
+)
+_EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET = getattr(
+    _impl, "_EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET"
+)
+_NO_DELTA_RELEASE_CONDITIONS = getattr(_impl, "_NO_DELTA_RELEASE_CONDITIONS")
+GraduationState = getattr(_impl, "GraduationState")
+_DEFAULT_FRESHNESS_SECONDS = getattr(_impl, "_DEFAULT_FRESHNESS_SECONDS")
+_LIVE_AAPL_HYPOTHESIS = getattr(_impl, "_LIVE_AAPL_HYPOTHESIS")
+_SIM_NVDA_HYPOTHESIS = getattr(_impl, "_SIM_NVDA_HYPOTHESIS")
+_BREADTH_HYPOTHESIS = getattr(_impl, "_BREADTH_HYPOTHESIS")
+_REPAIR_REASON_CLASSES = getattr(_impl, "_REPAIR_REASON_CLASSES")
+_REPAIR_CLASS_RANK = getattr(_impl, "_REPAIR_CLASS_RANK")
+_VALIDATION_COMMANDS_BY_CLASS = getattr(_impl, "_VALIDATION_COMMANDS_BY_CLASS")
+_FEATURE_OR_DRIFT_REPAIR_REASONS = getattr(_impl, "_FEATURE_OR_DRIFT_REPAIR_REASONS")
+_POST_COST_REPAIR_REASONS = getattr(_impl, "_POST_COST_REPAIR_REASONS")
+_CLOSED_SESSION_REPAIR_REASONS = getattr(_impl, "_CLOSED_SESSION_REPAIR_REASONS")
+_ALPHA_RUNTIME_REPLAY_CLASS = getattr(_impl, "_ALPHA_RUNTIME_REPLAY_CLASS")
+_RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS = getattr(
+    _impl, "_RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS"
+)
+_RUNTIME_LEDGER_PAPER_PROBATION_REASON = getattr(
+    _impl, "_RUNTIME_LEDGER_PAPER_PROBATION_REASON"
+)
+_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS = getattr(
+    _impl, "_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS"
+)
+_ZERO_RUNTIME_EVIDENCE_REASONS = getattr(_impl, "_ZERO_RUNTIME_EVIDENCE_REASONS")
+_HARD_ALPHA_ECONOMIC_REASONS = getattr(_impl, "_HARD_ALPHA_ECONOMIC_REASONS")
+_ALPHA_RUNTIME_REPAIR_REASONS = getattr(_impl, "_ALPHA_RUNTIME_REPAIR_REASONS")
+_text = getattr(_impl, "_text")
+_int = getattr(_impl, "_int")
+_float = getattr(_impl, "_float")
+_mapping = getattr(_impl, "_mapping")
+_sequence = getattr(_impl, "_sequence")
+_string_list = getattr(_impl, "_string_list")
+_stable_hash = getattr(_impl, "_stable_hash")
+_route_records = getattr(_impl, "_route_records")
+_route_board_rows = getattr(_impl, "_route_board_rows")
+_find_by_symbol = getattr(_impl, "_find_by_symbol")
+_first_with_state = getattr(_impl, "_first_with_state")
+_proof_window = getattr(_impl, "_proof_window")
+_reason_list_from_target = getattr(_impl, "_reason_list_from_target")
+_repair_class_for_target = getattr(_impl, "_repair_class_for_target")
+_top_alpha_repair = getattr(_impl, "_top_alpha_repair")
+_receipt_by_hypothesis = getattr(_impl, "_receipt_by_hypothesis")
+_targets_from_alpha_readiness = getattr(_impl, "_targets_from_alpha_readiness")
+_expected_gate_delta = getattr(_impl, "_expected_gate_delta")
+_required_input_refs = getattr(_impl, "_required_input_refs")
+_receipt_revenue_lane_rank = getattr(_impl, "_receipt_revenue_lane_rank")
+_receipt_target_key = getattr(_impl, "_receipt_target_key")
+_executable_alpha_repair_receipt = getattr(_impl, "_executable_alpha_repair_receipt")
+build_executable_alpha_repair_receipts = getattr(
+    _impl, "build_executable_alpha_repair_receipts"
+)
+_zero_notional = getattr(_impl, "_zero_notional")
+_top_queue_item = getattr(_impl, "_top_queue_item")
+_repair_receipt_reason_codes = getattr(_impl, "_repair_receipt_reason_codes")
+_selected_repair_receipt = getattr(_impl, "_selected_repair_receipt")
+_parse_datetime = getattr(_impl, "_parse_datetime")
+_routeable_candidate_count_from_evidence = getattr(
+    _impl, "_routeable_candidate_count_from_evidence"
+)
+_alpha_target_reason_codes = getattr(_impl, "_alpha_target_reason_codes")
+_required_after_receipts = getattr(_impl, "_required_after_receipts")
+_before_routeable_candidate_count = getattr(_impl, "_before_routeable_candidate_count")
+_settlement_state = getattr(_impl, "_settlement_state")
+_build_executable_alpha_settlement_slot = getattr(
+    _impl, "_build_executable_alpha_settlement_slot"
+)
+_no_delta_debt_from_settlement_slot = getattr(
+    _impl, "_no_delta_debt_from_settlement_slot"
+)
+_primary_remaining_blocker = getattr(_impl, "_primary_remaining_blocker")
+build_executable_alpha_settlement_slots = getattr(
+    _impl, "build_executable_alpha_settlement_slots"
+)
+compact_executable_alpha_settlement_slots = getattr(
+    _impl, "compact_executable_alpha_settlement_slots"
+)
+_graduation_state = getattr(_impl, "_graduation_state")
+_market_context_blockers = getattr(_impl, "_market_context_blockers")
+_quant_blockers = getattr(_impl, "_quant_blockers")
+_empirical_blockers = getattr(_impl, "_empirical_blockers")
+_tca_guardrail_blockers = getattr(_impl, "_tca_guardrail_blockers")
+_capital_blockers = getattr(_impl, "_capital_blockers")
+_before_refs = getattr(_impl, "_before_refs")
+_required_after_refs = getattr(_impl, "_required_after_refs")
+_guardrails = getattr(_impl, "_guardrails")
+_live_gate_evaluated_hypotheses = getattr(_impl, "_live_gate_evaluated_hypotheses")
+_alpha_runtime_repair_reason_codes = getattr(
+    _impl, "_alpha_runtime_repair_reason_codes"
+)
+_alpha_runtime_replay_key = getattr(_impl, "_alpha_runtime_replay_key")
+_top_alpha_runtime_replay_target = getattr(_impl, "_top_alpha_runtime_replay_target")
+_runtime_ledger_repair_candidates = getattr(_impl, "_runtime_ledger_repair_candidates")
+_runtime_ledger_repair_key = getattr(_impl, "_runtime_ledger_repair_key")
+_top_runtime_ledger_economic_repair_candidate = getattr(
+    _impl, "_top_runtime_ledger_economic_repair_candidate"
+)
+_alpha_runtime_confidence = getattr(_impl, "_alpha_runtime_confidence")
+_runtime_ledger_paper_probation_eligible = getattr(
+    _impl, "_runtime_ledger_paper_probation_eligible"
+)
+_runtime_ledger_economic_repair_item = getattr(
+    _impl, "_runtime_ledger_economic_repair_item"
+)
+_alpha_runtime_blockers = getattr(_impl, "_alpha_runtime_blockers")
+_alpha_runtime_replay_item = getattr(_impl, "_alpha_runtime_replay_item")
+_replay_item = getattr(_impl, "_replay_item")
+_candidate_replays = getattr(_impl, "_candidate_replays")
+_receipt_for_replay = getattr(_impl, "_receipt_for_replay")
+build_capital_replay_projection = getattr(_impl, "build_capital_replay_projection")
+
+__all__ = [
+    "CAPITAL_REPLAY_BOARD_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION",
+    "_EXECUTABLE_ALPHA_REPAIR_DESIGN_REF",
+    "_EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF",
+    "_EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET",
+    "_EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET",
+    "_NO_DELTA_RELEASE_CONDITIONS",
+    "GraduationState",
+    "_DEFAULT_FRESHNESS_SECONDS",
+    "_LIVE_AAPL_HYPOTHESIS",
+    "_SIM_NVDA_HYPOTHESIS",
+    "_BREADTH_HYPOTHESIS",
+    "_REPAIR_REASON_CLASSES",
+    "_REPAIR_CLASS_RANK",
+    "_VALIDATION_COMMANDS_BY_CLASS",
+    "_FEATURE_OR_DRIFT_REPAIR_REASONS",
+    "_POST_COST_REPAIR_REASONS",
+    "_CLOSED_SESSION_REPAIR_REASONS",
+    "_ALPHA_RUNTIME_REPLAY_CLASS",
+    "_RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS",
+    "_RUNTIME_LEDGER_PAPER_PROBATION_REASON",
+    "_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS",
+    "_ZERO_RUNTIME_EVIDENCE_REASONS",
+    "_HARD_ALPHA_ECONOMIC_REASONS",
+    "_ALPHA_RUNTIME_REPAIR_REASONS",
+    "_text",
+    "_int",
+    "_float",
+    "_mapping",
+    "_sequence",
+    "_string_list",
+    "_stable_hash",
+    "_route_records",
+    "_route_board_rows",
+    "_find_by_symbol",
+    "_first_with_state",
+    "_proof_window",
+    "_reason_list_from_target",
+    "_repair_class_for_target",
+    "_top_alpha_repair",
+    "_receipt_by_hypothesis",
+    "_targets_from_alpha_readiness",
+    "_expected_gate_delta",
+    "_required_input_refs",
+    "_receipt_revenue_lane_rank",
+    "_receipt_target_key",
+    "_executable_alpha_repair_receipt",
+    "build_executable_alpha_repair_receipts",
+    "_zero_notional",
+    "_top_queue_item",
+    "_repair_receipt_reason_codes",
+    "_selected_repair_receipt",
+    "_parse_datetime",
+    "_routeable_candidate_count_from_evidence",
+    "_alpha_target_reason_codes",
+    "_required_after_receipts",
+    "_before_routeable_candidate_count",
+    "_settlement_state",
+    "_build_executable_alpha_settlement_slot",
+    "_no_delta_debt_from_settlement_slot",
+    "_primary_remaining_blocker",
+    "build_executable_alpha_settlement_slots",
+    "compact_executable_alpha_settlement_slots",
+    "_graduation_state",
+    "_market_context_blockers",
+    "_quant_blockers",
+    "_empirical_blockers",
+    "_tca_guardrail_blockers",
+    "_capital_blockers",
+    "_before_refs",
+    "_required_after_refs",
+    "_guardrails",
+    "_live_gate_evaluated_hypotheses",
+    "_alpha_runtime_repair_reason_codes",
+    "_alpha_runtime_replay_key",
+    "_top_alpha_runtime_replay_target",
+    "_runtime_ledger_repair_candidates",
+    "_runtime_ledger_repair_key",
+    "_top_runtime_ledger_economic_repair_candidate",
+    "_alpha_runtime_confidence",
+    "_runtime_ledger_paper_probation_eligible",
+    "_runtime_ledger_economic_repair_item",
+    "_alpha_runtime_blockers",
+    "_alpha_runtime_replay_item",
+    "_replay_item",
+    "_candidate_replays",
+    "_receipt_for_replay",
+    "build_capital_replay_projection",
+]
+
+del _impl

--- a/services/torghut/app/trading/executable_alpha_receipts_modules/__init__.py
+++ b/services/torghut/app/trading/executable_alpha_receipts_modules/__init__.py
@@ -1,65 +1,247 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Public exports for app.trading.executable_alpha_receipts_modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+_impl = import_module(f"{__name__}.part_04_candidate_replays")
 
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_14")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_build_executable_alpha_repair_receipts"
+CAPITAL_REPLAY_BOARD_SCHEMA_VERSION = getattr(
+    _impl, "CAPITAL_REPLAY_BOARD_SCHEMA_VERSION"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
+EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION = getattr(
+    _impl, "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION"
+)
+_EXECUTABLE_ALPHA_REPAIR_DESIGN_REF = getattr(
+    _impl, "_EXECUTABLE_ALPHA_REPAIR_DESIGN_REF"
+)
+_EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF = getattr(
+    _impl, "_EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF"
+)
+_EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET = getattr(
+    _impl, "_EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET"
+)
+_EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET = getattr(
+    _impl, "_EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET"
+)
+_NO_DELTA_RELEASE_CONDITIONS = getattr(_impl, "_NO_DELTA_RELEASE_CONDITIONS")
+GraduationState = getattr(_impl, "GraduationState")
+_DEFAULT_FRESHNESS_SECONDS = getattr(_impl, "_DEFAULT_FRESHNESS_SECONDS")
+_LIVE_AAPL_HYPOTHESIS = getattr(_impl, "_LIVE_AAPL_HYPOTHESIS")
+_SIM_NVDA_HYPOTHESIS = getattr(_impl, "_SIM_NVDA_HYPOTHESIS")
+_BREADTH_HYPOTHESIS = getattr(_impl, "_BREADTH_HYPOTHESIS")
+_REPAIR_REASON_CLASSES = getattr(_impl, "_REPAIR_REASON_CLASSES")
+_REPAIR_CLASS_RANK = getattr(_impl, "_REPAIR_CLASS_RANK")
+_VALIDATION_COMMANDS_BY_CLASS = getattr(_impl, "_VALIDATION_COMMANDS_BY_CLASS")
+_FEATURE_OR_DRIFT_REPAIR_REASONS = getattr(_impl, "_FEATURE_OR_DRIFT_REPAIR_REASONS")
+_POST_COST_REPAIR_REASONS = getattr(_impl, "_POST_COST_REPAIR_REASONS")
+_CLOSED_SESSION_REPAIR_REASONS = getattr(_impl, "_CLOSED_SESSION_REPAIR_REASONS")
+_ALPHA_RUNTIME_REPLAY_CLASS = getattr(_impl, "_ALPHA_RUNTIME_REPLAY_CLASS")
+_RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS = getattr(
+    _impl, "_RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS"
+)
+_RUNTIME_LEDGER_PAPER_PROBATION_REASON = getattr(
+    _impl, "_RUNTIME_LEDGER_PAPER_PROBATION_REASON"
+)
+_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS = getattr(
+    _impl, "_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS"
+)
+_ZERO_RUNTIME_EVIDENCE_REASONS = getattr(_impl, "_ZERO_RUNTIME_EVIDENCE_REASONS")
+_HARD_ALPHA_ECONOMIC_REASONS = getattr(_impl, "_HARD_ALPHA_ECONOMIC_REASONS")
+_ALPHA_RUNTIME_REPAIR_REASONS = getattr(_impl, "_ALPHA_RUNTIME_REPAIR_REASONS")
+_text = getattr(_impl, "_text")
+_int = getattr(_impl, "_int")
+_float = getattr(_impl, "_float")
+_mapping = getattr(_impl, "_mapping")
+_sequence = getattr(_impl, "_sequence")
+_string_list = getattr(_impl, "_string_list")
+_stable_hash = getattr(_impl, "_stable_hash")
+_route_records = getattr(_impl, "_route_records")
+_route_board_rows = getattr(_impl, "_route_board_rows")
+_find_by_symbol = getattr(_impl, "_find_by_symbol")
+_first_with_state = getattr(_impl, "_first_with_state")
+_proof_window = getattr(_impl, "_proof_window")
+_reason_list_from_target = getattr(_impl, "_reason_list_from_target")
+_repair_class_for_target = getattr(_impl, "_repair_class_for_target")
+_top_alpha_repair = getattr(_impl, "_top_alpha_repair")
+_receipt_by_hypothesis = getattr(_impl, "_receipt_by_hypothesis")
+_targets_from_alpha_readiness = getattr(_impl, "_targets_from_alpha_readiness")
+_expected_gate_delta = getattr(_impl, "_expected_gate_delta")
+_required_input_refs = getattr(_impl, "_required_input_refs")
+_receipt_revenue_lane_rank = getattr(_impl, "_receipt_revenue_lane_rank")
+_receipt_target_key = getattr(_impl, "_receipt_target_key")
+_executable_alpha_repair_receipt = getattr(_impl, "_executable_alpha_repair_receipt")
+build_executable_alpha_repair_receipts = getattr(
+    _impl, "build_executable_alpha_repair_receipts"
+)
+_zero_notional = getattr(_impl, "_zero_notional")
+_top_queue_item = getattr(_impl, "_top_queue_item")
+_repair_receipt_reason_codes = getattr(_impl, "_repair_receipt_reason_codes")
+_selected_repair_receipt = getattr(_impl, "_selected_repair_receipt")
+_parse_datetime = getattr(_impl, "_parse_datetime")
+_routeable_candidate_count_from_evidence = getattr(
+    _impl, "_routeable_candidate_count_from_evidence"
+)
+_alpha_target_reason_codes = getattr(_impl, "_alpha_target_reason_codes")
+_required_after_receipts = getattr(_impl, "_required_after_receipts")
+_before_routeable_candidate_count = getattr(_impl, "_before_routeable_candidate_count")
+_settlement_state = getattr(_impl, "_settlement_state")
+_build_executable_alpha_settlement_slot = getattr(
+    _impl, "_build_executable_alpha_settlement_slot"
+)
+_no_delta_debt_from_settlement_slot = getattr(
+    _impl, "_no_delta_debt_from_settlement_slot"
+)
+_primary_remaining_blocker = getattr(_impl, "_primary_remaining_blocker")
+build_executable_alpha_settlement_slots = getattr(
+    _impl, "build_executable_alpha_settlement_slots"
+)
+compact_executable_alpha_settlement_slots = getattr(
+    _impl, "compact_executable_alpha_settlement_slots"
+)
+_graduation_state = getattr(_impl, "_graduation_state")
+_market_context_blockers = getattr(_impl, "_market_context_blockers")
+_quant_blockers = getattr(_impl, "_quant_blockers")
+_empirical_blockers = getattr(_impl, "_empirical_blockers")
+_tca_guardrail_blockers = getattr(_impl, "_tca_guardrail_blockers")
+_capital_blockers = getattr(_impl, "_capital_blockers")
+_before_refs = getattr(_impl, "_before_refs")
+_required_after_refs = getattr(_impl, "_required_after_refs")
+_guardrails = getattr(_impl, "_guardrails")
+_live_gate_evaluated_hypotheses = getattr(_impl, "_live_gate_evaluated_hypotheses")
+_alpha_runtime_repair_reason_codes = getattr(
+    _impl, "_alpha_runtime_repair_reason_codes"
+)
+_alpha_runtime_replay_key = getattr(_impl, "_alpha_runtime_replay_key")
+_top_alpha_runtime_replay_target = getattr(_impl, "_top_alpha_runtime_replay_target")
+_runtime_ledger_repair_candidates = getattr(_impl, "_runtime_ledger_repair_candidates")
+_runtime_ledger_repair_key = getattr(_impl, "_runtime_ledger_repair_key")
+_top_runtime_ledger_economic_repair_candidate = getattr(
+    _impl, "_top_runtime_ledger_economic_repair_candidate"
+)
+_alpha_runtime_confidence = getattr(_impl, "_alpha_runtime_confidence")
+_runtime_ledger_paper_probation_eligible = getattr(
+    _impl, "_runtime_ledger_paper_probation_eligible"
+)
+_runtime_ledger_economic_repair_item = getattr(
+    _impl, "_runtime_ledger_economic_repair_item"
+)
+_alpha_runtime_blockers = getattr(_impl, "_alpha_runtime_blockers")
+_alpha_runtime_replay_item = getattr(_impl, "_alpha_runtime_replay_item")
+_replay_item = getattr(_impl, "_replay_item")
+_candidate_replays = getattr(_impl, "_candidate_replays")
+_receipt_for_replay = getattr(_impl, "_receipt_for_replay")
+build_capital_replay_projection = getattr(_impl, "build_capital_replay_projection")
 
-__compat_module__ = __compat_import_module__(f"{__name__}.part_03_required_after_refs")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_04_candidate_replays")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "CAPITAL_REPLAY_BOARD_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION",
+    "_EXECUTABLE_ALPHA_REPAIR_DESIGN_REF",
+    "_EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF",
+    "_EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET",
+    "_EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET",
+    "_NO_DELTA_RELEASE_CONDITIONS",
+    "GraduationState",
+    "_DEFAULT_FRESHNESS_SECONDS",
+    "_LIVE_AAPL_HYPOTHESIS",
+    "_SIM_NVDA_HYPOTHESIS",
+    "_BREADTH_HYPOTHESIS",
+    "_REPAIR_REASON_CLASSES",
+    "_REPAIR_CLASS_RANK",
+    "_VALIDATION_COMMANDS_BY_CLASS",
+    "_FEATURE_OR_DRIFT_REPAIR_REASONS",
+    "_POST_COST_REPAIR_REASONS",
+    "_CLOSED_SESSION_REPAIR_REASONS",
+    "_ALPHA_RUNTIME_REPLAY_CLASS",
+    "_RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS",
+    "_RUNTIME_LEDGER_PAPER_PROBATION_REASON",
+    "_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS",
+    "_ZERO_RUNTIME_EVIDENCE_REASONS",
+    "_HARD_ALPHA_ECONOMIC_REASONS",
+    "_ALPHA_RUNTIME_REPAIR_REASONS",
+    "_text",
+    "_int",
+    "_float",
+    "_mapping",
+    "_sequence",
+    "_string_list",
+    "_stable_hash",
+    "_route_records",
+    "_route_board_rows",
+    "_find_by_symbol",
+    "_first_with_state",
+    "_proof_window",
+    "_reason_list_from_target",
+    "_repair_class_for_target",
+    "_top_alpha_repair",
+    "_receipt_by_hypothesis",
+    "_targets_from_alpha_readiness",
+    "_expected_gate_delta",
+    "_required_input_refs",
+    "_receipt_revenue_lane_rank",
+    "_receipt_target_key",
+    "_executable_alpha_repair_receipt",
+    "build_executable_alpha_repair_receipts",
+    "_zero_notional",
+    "_top_queue_item",
+    "_repair_receipt_reason_codes",
+    "_selected_repair_receipt",
+    "_parse_datetime",
+    "_routeable_candidate_count_from_evidence",
+    "_alpha_target_reason_codes",
+    "_required_after_receipts",
+    "_before_routeable_candidate_count",
+    "_settlement_state",
+    "_build_executable_alpha_settlement_slot",
+    "_no_delta_debt_from_settlement_slot",
+    "_primary_remaining_blocker",
+    "build_executable_alpha_settlement_slots",
+    "compact_executable_alpha_settlement_slots",
+    "_graduation_state",
+    "_market_context_blockers",
+    "_quant_blockers",
+    "_empirical_blockers",
+    "_tca_guardrail_blockers",
+    "_capital_blockers",
+    "_before_refs",
+    "_required_after_refs",
+    "_guardrails",
+    "_live_gate_evaluated_hypotheses",
+    "_alpha_runtime_repair_reason_codes",
+    "_alpha_runtime_replay_key",
+    "_top_alpha_runtime_replay_target",
+    "_runtime_ledger_repair_candidates",
+    "_runtime_ledger_repair_key",
+    "_top_runtime_ledger_economic_repair_candidate",
+    "_alpha_runtime_confidence",
+    "_runtime_ledger_paper_probation_eligible",
+    "_runtime_ledger_economic_repair_item",
+    "_alpha_runtime_blockers",
+    "_alpha_runtime_replay_item",
+    "_replay_item",
+    "_candidate_replays",
+    "_receipt_for_replay",
+    "build_capital_replay_projection",
 ]
-del __compat_module__
+
+del _impl

--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -1,14 +1,179 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public exports for Torghut profit freshness frontier."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from importlib import import_module
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.profit_freshness_frontier_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_impl = import_module("app.trading.profit_freshness_frontier_modules")
+
+PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION = getattr(
+    _impl, "PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION"
+)
+_FRESHNESS_SECONDS = getattr(_impl, "_FRESHNESS_SECONDS")
+_CURRENT_STATES = getattr(_impl, "_CURRENT_STATES")
+_ROUTE_SETTLED_ROW_STATES = getattr(_impl, "_ROUTE_SETTLED_ROW_STATES")
+_BAD_STATES = getattr(_impl, "_BAD_STATES")
+_DIMENSION_EXPECTED_BPS = getattr(_impl, "_DIMENSION_EXPECTED_BPS")
+_DIMENSION_REPAIR_COST = getattr(_impl, "_DIMENSION_REPAIR_COST")
+_REPAIR_COST_PENALTY = getattr(_impl, "_REPAIR_COST_PENALTY")
+_DIMENSION_ACTION = getattr(_impl, "_DIMENSION_ACTION")
+_DIMENSION_REPAIR_CLASSES = getattr(_impl, "_DIMENSION_REPAIR_CLASSES")
+_DAILY_NET_PNL_UNLOCK_KEYS = getattr(_impl, "_DAILY_NET_PNL_UNLOCK_KEYS")
+_DIMENSION_SUCCESS = getattr(_impl, "_DIMENSION_SUCCESS")
+_REPAIRABLE_DIMENSIONS = getattr(_impl, "_REPAIRABLE_DIMENSIONS")
+_ROUTEABILITY_ONLY_TCA_REASON_CODES = getattr(
+    _impl, "_ROUTEABILITY_ONLY_TCA_REASON_CODES"
+)
+_ROUTEABILITY_ONLY_TCA_REASON_PREFIXES = getattr(
+    _impl, "_ROUTEABILITY_ONLY_TCA_REASON_PREFIXES"
+)
+_NONBLOCKING_JANGAR_RELIABILITY_REASONS = getattr(
+    _impl, "_NONBLOCKING_JANGAR_RELIABILITY_REASONS"
+)
+_NONBLOCKING_QUANT_HEALTH_REASONS = getattr(_impl, "_NONBLOCKING_QUANT_HEALTH_REASONS")
+_ROUTEABILITY_TCA_REPAIR_LOT_TYPES = getattr(
+    _impl, "_ROUTEABILITY_TCA_REPAIR_LOT_TYPES"
+)
+_ROUTEABILITY_TCA_REPAIR_ACTION = getattr(_impl, "_ROUTEABILITY_TCA_REPAIR_ACTION")
+_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES = getattr(
+    _impl, "_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES"
+)
+_ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS = getattr(
+    _impl, "_ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS"
+)
+_ALPHA_FEATURE_REPLAY_REASON_CODES = getattr(
+    _impl, "_ALPHA_FEATURE_REPLAY_REASON_CODES"
+)
+_ALPHA_FEATURE_REPLAY_PRIORITY_BONUS = getattr(
+    _impl, "_ALPHA_FEATURE_REPLAY_PRIORITY_BONUS"
+)
+_ALPHA_FEATURE_ROUTEABILITY_PRIORITY_BONUS = getattr(
+    _impl, "_ALPHA_FEATURE_ROUTEABILITY_PRIORITY_BONUS"
+)
+_ALPHA_READINESS_ROUTEABILITY_REASON_CODES = getattr(
+    _impl, "_ALPHA_READINESS_ROUTEABILITY_REASON_CODES"
+)
+_mapping = getattr(_impl, "_mapping")
+_sequence = getattr(_impl, "_sequence")
+_text = getattr(_impl, "_text")
+_decimal = getattr(_impl, "_decimal")
+_decimal_text = getattr(_impl, "_decimal_text")
+_int = getattr(_impl, "_int")
+_float = getattr(_impl, "_float")
+_bool = getattr(_impl, "_bool")
+_unique = getattr(_impl, "_unique")
+_strings = getattr(_impl, "_strings")
+_symbols = getattr(_impl, "_symbols")
+_stable_ref = getattr(_impl, "_stable_ref")
+_timestamp = getattr(_impl, "_timestamp")
+_state_from_reasons = getattr(_impl, "_state_from_reasons")
+_hypothesis_items = getattr(_impl, "_hypothesis_items")
+_hypothesis_summary = getattr(_impl, "_hypothesis_summary")
+_hypothesis_ids_for_reasons = getattr(_impl, "_hypothesis_ids_for_reasons")
+_reason_total = getattr(_impl, "_reason_total")
+_dimension = getattr(_impl, "_dimension")
+_proof_dimension = getattr(_impl, "_proof_dimension")
+_market_domain_states = getattr(_impl, "_market_domain_states")
+_market_dimension = getattr(_impl, "_market_dimension")
+_signal_dimension = getattr(_impl, "_signal_dimension")
+_empirical_dimension = getattr(_impl, "_empirical_dimension")
+_hypothesis_dimension = getattr(_impl, "_hypothesis_dimension")
+_route_rows = getattr(_impl, "_route_rows")
+_route_symbols = getattr(_impl, "_route_symbols")
+_routeability_only_tca_reason = getattr(_impl, "_routeability_only_tca_reason")
+_tca_dimension = getattr(_impl, "_tca_dimension")
+_route_readiness_dimension = getattr(_impl, "_route_readiness_dimension")
+_is_routeability_tca_repair_reason = getattr(
+    _impl, "_is_routeability_tca_repair_reason"
+)
+_route_readiness_action = getattr(_impl, "_route_readiness_action")
+_zero_notional_action = getattr(_impl, "_zero_notional_action")
+_schema_dimension = getattr(_impl, "_schema_dimension")
+_jangar_dimension = getattr(_impl, "_jangar_dimension")
+_confidence_for_state = getattr(_impl, "_confidence_for_state")
+_routeability_confidence = getattr(_impl, "_routeability_confidence")
+_jangar_confidence = getattr(_impl, "_jangar_confidence")
+_packet_dimension = getattr(_impl, "_packet_dimension")
+_packet_hypothesis_refs = getattr(_impl, "_packet_hypothesis_refs")
+_packet_symbols = getattr(_impl, "_packet_symbols")
+_daily_net_pnl_unlock = getattr(_impl, "_daily_net_pnl_unlock")
+_expected_daily_net_pnl_unlock = getattr(_impl, "_expected_daily_net_pnl_unlock")
+_target_notional_rankings = getattr(_impl, "_target_notional_rankings")
+_repair_lot = getattr(_impl, "_repair_lot")
+build_profit_freshness_frontier = getattr(_impl, "build_profit_freshness_frontier")
+
+__all__ = [
+    "PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION",
+    "_FRESHNESS_SECONDS",
+    "_CURRENT_STATES",
+    "_ROUTE_SETTLED_ROW_STATES",
+    "_BAD_STATES",
+    "_DIMENSION_EXPECTED_BPS",
+    "_DIMENSION_REPAIR_COST",
+    "_REPAIR_COST_PENALTY",
+    "_DIMENSION_ACTION",
+    "_DIMENSION_REPAIR_CLASSES",
+    "_DAILY_NET_PNL_UNLOCK_KEYS",
+    "_DIMENSION_SUCCESS",
+    "_REPAIRABLE_DIMENSIONS",
+    "_ROUTEABILITY_ONLY_TCA_REASON_CODES",
+    "_ROUTEABILITY_ONLY_TCA_REASON_PREFIXES",
+    "_NONBLOCKING_JANGAR_RELIABILITY_REASONS",
+    "_NONBLOCKING_QUANT_HEALTH_REASONS",
+    "_ROUTEABILITY_TCA_REPAIR_LOT_TYPES",
+    "_ROUTEABILITY_TCA_REPAIR_ACTION",
+    "_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES",
+    "_ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS",
+    "_ALPHA_FEATURE_REPLAY_REASON_CODES",
+    "_ALPHA_FEATURE_REPLAY_PRIORITY_BONUS",
+    "_ALPHA_FEATURE_ROUTEABILITY_PRIORITY_BONUS",
+    "_ALPHA_READINESS_ROUTEABILITY_REASON_CODES",
+    "_mapping",
+    "_sequence",
+    "_text",
+    "_decimal",
+    "_decimal_text",
+    "_int",
+    "_float",
+    "_bool",
+    "_unique",
+    "_strings",
+    "_symbols",
+    "_stable_ref",
+    "_timestamp",
+    "_state_from_reasons",
+    "_hypothesis_items",
+    "_hypothesis_summary",
+    "_hypothesis_ids_for_reasons",
+    "_reason_total",
+    "_dimension",
+    "_proof_dimension",
+    "_market_domain_states",
+    "_market_dimension",
+    "_signal_dimension",
+    "_empirical_dimension",
+    "_hypothesis_dimension",
+    "_route_rows",
+    "_route_symbols",
+    "_routeability_only_tca_reason",
+    "_tca_dimension",
+    "_route_readiness_dimension",
+    "_is_routeability_tca_repair_reason",
+    "_route_readiness_action",
+    "_zero_notional_action",
+    "_schema_dimension",
+    "_jangar_dimension",
+    "_confidence_for_state",
+    "_routeability_confidence",
+    "_jangar_confidence",
+    "_packet_dimension",
+    "_packet_hypothesis_refs",
+    "_packet_symbols",
+    "_daily_net_pnl_unlock",
+    "_expected_daily_net_pnl_unlock",
+    "_target_notional_rankings",
+    "_repair_lot",
+    "build_profit_freshness_frontier",
+]
+
+del _impl

--- a/services/torghut/app/trading/profit_freshness_frontier_modules/__init__.py
+++ b/services/torghut/app/trading/profit_freshness_frontier_modules/__init__.py
@@ -1,57 +1,179 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Public exports for app.trading.profit_freshness_frontier_modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+_impl = import_module(f"{__name__}.part_03_build_profit_freshness_frontier")
 
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_18")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_02_tca_dimension")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_03_build_profit_freshness_frontier"
+PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION = getattr(
+    _impl, "PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
+_FRESHNESS_SECONDS = getattr(_impl, "_FRESHNESS_SECONDS")
+_CURRENT_STATES = getattr(_impl, "_CURRENT_STATES")
+_ROUTE_SETTLED_ROW_STATES = getattr(_impl, "_ROUTE_SETTLED_ROW_STATES")
+_BAD_STATES = getattr(_impl, "_BAD_STATES")
+_DIMENSION_EXPECTED_BPS = getattr(_impl, "_DIMENSION_EXPECTED_BPS")
+_DIMENSION_REPAIR_COST = getattr(_impl, "_DIMENSION_REPAIR_COST")
+_REPAIR_COST_PENALTY = getattr(_impl, "_REPAIR_COST_PENALTY")
+_DIMENSION_ACTION = getattr(_impl, "_DIMENSION_ACTION")
+_DIMENSION_REPAIR_CLASSES = getattr(_impl, "_DIMENSION_REPAIR_CLASSES")
+_DAILY_NET_PNL_UNLOCK_KEYS = getattr(_impl, "_DAILY_NET_PNL_UNLOCK_KEYS")
+_DIMENSION_SUCCESS = getattr(_impl, "_DIMENSION_SUCCESS")
+_REPAIRABLE_DIMENSIONS = getattr(_impl, "_REPAIRABLE_DIMENSIONS")
+_ROUTEABILITY_ONLY_TCA_REASON_CODES = getattr(
+    _impl, "_ROUTEABILITY_ONLY_TCA_REASON_CODES"
+)
+_ROUTEABILITY_ONLY_TCA_REASON_PREFIXES = getattr(
+    _impl, "_ROUTEABILITY_ONLY_TCA_REASON_PREFIXES"
+)
+_NONBLOCKING_JANGAR_RELIABILITY_REASONS = getattr(
+    _impl, "_NONBLOCKING_JANGAR_RELIABILITY_REASONS"
+)
+_NONBLOCKING_QUANT_HEALTH_REASONS = getattr(_impl, "_NONBLOCKING_QUANT_HEALTH_REASONS")
+_ROUTEABILITY_TCA_REPAIR_LOT_TYPES = getattr(
+    _impl, "_ROUTEABILITY_TCA_REPAIR_LOT_TYPES"
+)
+_ROUTEABILITY_TCA_REPAIR_ACTION = getattr(_impl, "_ROUTEABILITY_TCA_REPAIR_ACTION")
+_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES = getattr(
+    _impl, "_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES"
+)
+_ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS = getattr(
+    _impl, "_ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS"
+)
+_ALPHA_FEATURE_REPLAY_REASON_CODES = getattr(
+    _impl, "_ALPHA_FEATURE_REPLAY_REASON_CODES"
+)
+_ALPHA_FEATURE_REPLAY_PRIORITY_BONUS = getattr(
+    _impl, "_ALPHA_FEATURE_REPLAY_PRIORITY_BONUS"
+)
+_ALPHA_FEATURE_ROUTEABILITY_PRIORITY_BONUS = getattr(
+    _impl, "_ALPHA_FEATURE_ROUTEABILITY_PRIORITY_BONUS"
+)
+_ALPHA_READINESS_ROUTEABILITY_REASON_CODES = getattr(
+    _impl, "_ALPHA_READINESS_ROUTEABILITY_REASON_CODES"
+)
+_mapping = getattr(_impl, "_mapping")
+_sequence = getattr(_impl, "_sequence")
+_text = getattr(_impl, "_text")
+_decimal = getattr(_impl, "_decimal")
+_decimal_text = getattr(_impl, "_decimal_text")
+_int = getattr(_impl, "_int")
+_float = getattr(_impl, "_float")
+_bool = getattr(_impl, "_bool")
+_unique = getattr(_impl, "_unique")
+_strings = getattr(_impl, "_strings")
+_symbols = getattr(_impl, "_symbols")
+_stable_ref = getattr(_impl, "_stable_ref")
+_timestamp = getattr(_impl, "_timestamp")
+_state_from_reasons = getattr(_impl, "_state_from_reasons")
+_hypothesis_items = getattr(_impl, "_hypothesis_items")
+_hypothesis_summary = getattr(_impl, "_hypothesis_summary")
+_hypothesis_ids_for_reasons = getattr(_impl, "_hypothesis_ids_for_reasons")
+_reason_total = getattr(_impl, "_reason_total")
+_dimension = getattr(_impl, "_dimension")
+_proof_dimension = getattr(_impl, "_proof_dimension")
+_market_domain_states = getattr(_impl, "_market_domain_states")
+_market_dimension = getattr(_impl, "_market_dimension")
+_signal_dimension = getattr(_impl, "_signal_dimension")
+_empirical_dimension = getattr(_impl, "_empirical_dimension")
+_hypothesis_dimension = getattr(_impl, "_hypothesis_dimension")
+_route_rows = getattr(_impl, "_route_rows")
+_route_symbols = getattr(_impl, "_route_symbols")
+_routeability_only_tca_reason = getattr(_impl, "_routeability_only_tca_reason")
+_tca_dimension = getattr(_impl, "_tca_dimension")
+_route_readiness_dimension = getattr(_impl, "_route_readiness_dimension")
+_is_routeability_tca_repair_reason = getattr(
+    _impl, "_is_routeability_tca_repair_reason"
+)
+_route_readiness_action = getattr(_impl, "_route_readiness_action")
+_zero_notional_action = getattr(_impl, "_zero_notional_action")
+_schema_dimension = getattr(_impl, "_schema_dimension")
+_jangar_dimension = getattr(_impl, "_jangar_dimension")
+_confidence_for_state = getattr(_impl, "_confidence_for_state")
+_routeability_confidence = getattr(_impl, "_routeability_confidence")
+_jangar_confidence = getattr(_impl, "_jangar_confidence")
+_packet_dimension = getattr(_impl, "_packet_dimension")
+_packet_hypothesis_refs = getattr(_impl, "_packet_hypothesis_refs")
+_packet_symbols = getattr(_impl, "_packet_symbols")
+_daily_net_pnl_unlock = getattr(_impl, "_daily_net_pnl_unlock")
+_expected_daily_net_pnl_unlock = getattr(_impl, "_expected_daily_net_pnl_unlock")
+_target_notional_rankings = getattr(_impl, "_target_notional_rankings")
+_repair_lot = getattr(_impl, "_repair_lot")
+build_profit_freshness_frontier = getattr(_impl, "build_profit_freshness_frontier")
 
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION",
+    "_FRESHNESS_SECONDS",
+    "_CURRENT_STATES",
+    "_ROUTE_SETTLED_ROW_STATES",
+    "_BAD_STATES",
+    "_DIMENSION_EXPECTED_BPS",
+    "_DIMENSION_REPAIR_COST",
+    "_REPAIR_COST_PENALTY",
+    "_DIMENSION_ACTION",
+    "_DIMENSION_REPAIR_CLASSES",
+    "_DAILY_NET_PNL_UNLOCK_KEYS",
+    "_DIMENSION_SUCCESS",
+    "_REPAIRABLE_DIMENSIONS",
+    "_ROUTEABILITY_ONLY_TCA_REASON_CODES",
+    "_ROUTEABILITY_ONLY_TCA_REASON_PREFIXES",
+    "_NONBLOCKING_JANGAR_RELIABILITY_REASONS",
+    "_NONBLOCKING_QUANT_HEALTH_REASONS",
+    "_ROUTEABILITY_TCA_REPAIR_LOT_TYPES",
+    "_ROUTEABILITY_TCA_REPAIR_ACTION",
+    "_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES",
+    "_ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS",
+    "_ALPHA_FEATURE_REPLAY_REASON_CODES",
+    "_ALPHA_FEATURE_REPLAY_PRIORITY_BONUS",
+    "_ALPHA_FEATURE_ROUTEABILITY_PRIORITY_BONUS",
+    "_ALPHA_READINESS_ROUTEABILITY_REASON_CODES",
+    "_mapping",
+    "_sequence",
+    "_text",
+    "_decimal",
+    "_decimal_text",
+    "_int",
+    "_float",
+    "_bool",
+    "_unique",
+    "_strings",
+    "_symbols",
+    "_stable_ref",
+    "_timestamp",
+    "_state_from_reasons",
+    "_hypothesis_items",
+    "_hypothesis_summary",
+    "_hypothesis_ids_for_reasons",
+    "_reason_total",
+    "_dimension",
+    "_proof_dimension",
+    "_market_domain_states",
+    "_market_dimension",
+    "_signal_dimension",
+    "_empirical_dimension",
+    "_hypothesis_dimension",
+    "_route_rows",
+    "_route_symbols",
+    "_routeability_only_tca_reason",
+    "_tca_dimension",
+    "_route_readiness_dimension",
+    "_is_routeability_tca_repair_reason",
+    "_route_readiness_action",
+    "_zero_notional_action",
+    "_schema_dimension",
+    "_jangar_dimension",
+    "_confidence_for_state",
+    "_routeability_confidence",
+    "_jangar_confidence",
+    "_packet_dimension",
+    "_packet_hypothesis_refs",
+    "_packet_symbols",
+    "_daily_net_pnl_unlock",
+    "_expected_daily_net_pnl_unlock",
+    "_target_notional_rankings",
+    "_repair_lot",
+    "build_profit_freshness_frontier",
 ]
-del __compat_module__
+
+del _impl

--- a/services/torghut/app/trading/scheduler/state.py
+++ b/services/torghut/app/trading/scheduler/state.py
@@ -1,14 +1,27 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public exports for Torghut state."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from importlib import import_module
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.scheduler.state_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_impl = import_module("app.trading.scheduler.state_modules")
+
+_normalize_reason_metric = getattr(_impl, "_normalize_reason_metric")
+_split_reason_codes = getattr(_impl, "_split_reason_codes")
+_optional_decimal = getattr(_impl, "_optional_decimal")
+RuntimeUncertaintyGateAction = getattr(_impl, "RuntimeUncertaintyGateAction")
+RuntimeUncertaintyGate = getattr(_impl, "RuntimeUncertaintyGate")
+TradingMetrics = getattr(_impl, "TradingMetrics")
+TradingState = getattr(_impl, "TradingState")
+
+__all__ = [
+    "_normalize_reason_metric",
+    "_split_reason_codes",
+    "_optional_decimal",
+    "RuntimeUncertaintyGateAction",
+    "RuntimeUncertaintyGate",
+    "TradingMetrics",
+    "TradingState",
+]
+
+del _impl

--- a/services/torghut/app/trading/scheduler/state_modules/__init__.py
+++ b/services/torghut/app/trading/scheduler/state_modules/__init__.py
@@ -1,51 +1,27 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Public exports for app.trading.scheduler.state_modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+_impl = import_module(f"{__name__}.part_02_tradingmetricsmethodspart1")
 
+_normalize_reason_metric = getattr(_impl, "_normalize_reason_metric")
+_split_reason_codes = getattr(_impl, "_split_reason_codes")
+_optional_decimal = getattr(_impl, "_optional_decimal")
+RuntimeUncertaintyGateAction = getattr(_impl, "RuntimeUncertaintyGateAction")
+RuntimeUncertaintyGate = getattr(_impl, "RuntimeUncertaintyGate")
+TradingMetrics = getattr(_impl, "TradingMetrics")
+TradingState = getattr(_impl, "TradingState")
 
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_01_normalize_reason_metric"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_tradingmetricsmethodspart1"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "_normalize_reason_metric",
+    "_split_reason_codes",
+    "_optional_decimal",
+    "RuntimeUncertaintyGateAction",
+    "RuntimeUncertaintyGate",
+    "TradingMetrics",
+    "TradingState",
 ]
-del __compat_module__
+
+del _impl

--- a/services/torghut/app/trading/session_context.py
+++ b/services/torghut/app/trading/session_context.py
@@ -1,14 +1,87 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Public exports for Torghut session context."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from importlib import import_module
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.session_context_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_impl = import_module("app.trading.session_context_modules")
+
+US_EQUITIES_TIMEZONE = getattr(_impl, "US_EQUITIES_TIMEZONE")
+REGULAR_OPEN_LOCAL = getattr(_impl, "REGULAR_OPEN_LOCAL")
+REGULAR_CLOSE_LOCAL = getattr(_impl, "REGULAR_CLOSE_LOCAL")
+DEFAULT_OPENING_RANGE_MINUTES = getattr(_impl, "DEFAULT_OPENING_RANGE_MINUTES")
+DEFAULT_RECENT_WINDOW = getattr(_impl, "DEFAULT_RECENT_WINDOW")
+DEFAULT_PRICE_HISTORY_WINDOW = getattr(_impl, "DEFAULT_PRICE_HISTORY_WINDOW")
+DEFAULT_POSITION_IN_RANGE = getattr(_impl, "DEFAULT_POSITION_IN_RANGE")
+_MARKET_TZ = getattr(_impl, "_MARKET_TZ")
+nyse_full_day_holidays = getattr(_impl, "nyse_full_day_holidays")
+is_regular_equities_session_date = getattr(_impl, "is_regular_equities_session_date")
+iter_regular_equities_session_dates = getattr(
+    _impl, "iter_regular_equities_session_dates"
+)
+most_recent_regular_equities_session_date = getattr(
+    _impl, "most_recent_regular_equities_session_date"
+)
+_easter_date = getattr(_impl, "_easter_date")
+_nth_weekday = getattr(_impl, "_nth_weekday")
+_last_weekday = getattr(_impl, "_last_weekday")
+_observed_fixed_holiday = getattr(_impl, "_observed_fixed_holiday")
+regular_session_open_utc_for = getattr(_impl, "regular_session_open_utc_for")
+regular_session_close_utc_for = getattr(_impl, "regular_session_close_utc_for")
+_regular_session_boundary_utc_for = getattr(_impl, "_regular_session_boundary_utc_for")
+regular_session_minutes_elapsed = getattr(_impl, "regular_session_minutes_elapsed")
+_extract_price = getattr(_impl, "_extract_price")
+_extract_spread_bps = getattr(_impl, "_extract_spread_bps")
+_extract_imbalance_pressure = getattr(_impl, "_extract_imbalance_pressure")
+_extract_microprice_bias_bps = getattr(_impl, "_extract_microprice_bias_bps")
+_bps_delta = getattr(_impl, "_bps_delta")
+_recent_return_bps = getattr(_impl, "_recent_return_bps")
+_mean_decimal = getattr(_impl, "_mean_decimal")
+_max_decimal = getattr(_impl, "_max_decimal")
+_average_decimal = getattr(_impl, "_average_decimal")
+_ratio_decimal = getattr(_impl, "_ratio_decimal")
+_rank_universe_size = getattr(_impl, "_rank_universe_size")
+_percentile_rank = getattr(_impl, "_percentile_rank")
+_session_minutes_elapsed = getattr(_impl, "_session_minutes_elapsed")
+_SymbolSessionState = getattr(_impl, "_SymbolSessionState")
+SessionContextTracker = getattr(_impl, "SessionContextTracker")
+
+__all__ = [
+    "US_EQUITIES_TIMEZONE",
+    "REGULAR_OPEN_LOCAL",
+    "REGULAR_CLOSE_LOCAL",
+    "DEFAULT_OPENING_RANGE_MINUTES",
+    "DEFAULT_RECENT_WINDOW",
+    "DEFAULT_PRICE_HISTORY_WINDOW",
+    "DEFAULT_POSITION_IN_RANGE",
+    "_MARKET_TZ",
+    "nyse_full_day_holidays",
+    "is_regular_equities_session_date",
+    "iter_regular_equities_session_dates",
+    "most_recent_regular_equities_session_date",
+    "_easter_date",
+    "_nth_weekday",
+    "_last_weekday",
+    "_observed_fixed_holiday",
+    "regular_session_open_utc_for",
+    "regular_session_close_utc_for",
+    "_regular_session_boundary_utc_for",
+    "regular_session_minutes_elapsed",
+    "_extract_price",
+    "_extract_spread_bps",
+    "_extract_imbalance_pressure",
+    "_extract_microprice_bias_bps",
+    "_bps_delta",
+    "_recent_return_bps",
+    "_mean_decimal",
+    "_max_decimal",
+    "_average_decimal",
+    "_ratio_decimal",
+    "_rank_universe_size",
+    "_percentile_rank",
+    "_session_minutes_elapsed",
+    "_SymbolSessionState",
+    "SessionContextTracker",
+]
+
+del _impl

--- a/services/torghut/app/trading/session_context_modules/__init__.py
+++ b/services/torghut/app/trading/session_context_modules/__init__.py
@@ -1,49 +1,87 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Public exports for app.trading.session_context_modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from importlib import import_module
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
+_impl = import_module(f"{__name__}.part_02_sessioncontexttracker")
 
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_21")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_sessioncontexttracker"
+US_EQUITIES_TIMEZONE = getattr(_impl, "US_EQUITIES_TIMEZONE")
+REGULAR_OPEN_LOCAL = getattr(_impl, "REGULAR_OPEN_LOCAL")
+REGULAR_CLOSE_LOCAL = getattr(_impl, "REGULAR_CLOSE_LOCAL")
+DEFAULT_OPENING_RANGE_MINUTES = getattr(_impl, "DEFAULT_OPENING_RANGE_MINUTES")
+DEFAULT_RECENT_WINDOW = getattr(_impl, "DEFAULT_RECENT_WINDOW")
+DEFAULT_PRICE_HISTORY_WINDOW = getattr(_impl, "DEFAULT_PRICE_HISTORY_WINDOW")
+DEFAULT_POSITION_IN_RANGE = getattr(_impl, "DEFAULT_POSITION_IN_RANGE")
+_MARKET_TZ = getattr(_impl, "_MARKET_TZ")
+nyse_full_day_holidays = getattr(_impl, "nyse_full_day_holidays")
+is_regular_equities_session_date = getattr(_impl, "is_regular_equities_session_date")
+iter_regular_equities_session_dates = getattr(
+    _impl, "iter_regular_equities_session_dates"
 )
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
+most_recent_regular_equities_session_date = getattr(
+    _impl, "most_recent_regular_equities_session_date"
+)
+_easter_date = getattr(_impl, "_easter_date")
+_nth_weekday = getattr(_impl, "_nth_weekday")
+_last_weekday = getattr(_impl, "_last_weekday")
+_observed_fixed_holiday = getattr(_impl, "_observed_fixed_holiday")
+regular_session_open_utc_for = getattr(_impl, "regular_session_open_utc_for")
+regular_session_close_utc_for = getattr(_impl, "regular_session_close_utc_for")
+_regular_session_boundary_utc_for = getattr(_impl, "_regular_session_boundary_utc_for")
+regular_session_minutes_elapsed = getattr(_impl, "regular_session_minutes_elapsed")
+_extract_price = getattr(_impl, "_extract_price")
+_extract_spread_bps = getattr(_impl, "_extract_spread_bps")
+_extract_imbalance_pressure = getattr(_impl, "_extract_imbalance_pressure")
+_extract_microprice_bias_bps = getattr(_impl, "_extract_microprice_bias_bps")
+_bps_delta = getattr(_impl, "_bps_delta")
+_recent_return_bps = getattr(_impl, "_recent_return_bps")
+_mean_decimal = getattr(_impl, "_mean_decimal")
+_max_decimal = getattr(_impl, "_max_decimal")
+_average_decimal = getattr(_impl, "_average_decimal")
+_ratio_decimal = getattr(_impl, "_ratio_decimal")
+_rank_universe_size = getattr(_impl, "_rank_universe_size")
+_percentile_rank = getattr(_impl, "_percentile_rank")
+_session_minutes_elapsed = getattr(_impl, "_session_minutes_elapsed")
+_SymbolSessionState = getattr(_impl, "_SymbolSessionState")
+SessionContextTracker = getattr(_impl, "SessionContextTracker")
 
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
 __all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
+    "US_EQUITIES_TIMEZONE",
+    "REGULAR_OPEN_LOCAL",
+    "REGULAR_CLOSE_LOCAL",
+    "DEFAULT_OPENING_RANGE_MINUTES",
+    "DEFAULT_RECENT_WINDOW",
+    "DEFAULT_PRICE_HISTORY_WINDOW",
+    "DEFAULT_POSITION_IN_RANGE",
+    "_MARKET_TZ",
+    "nyse_full_day_holidays",
+    "is_regular_equities_session_date",
+    "iter_regular_equities_session_dates",
+    "most_recent_regular_equities_session_date",
+    "_easter_date",
+    "_nth_weekday",
+    "_last_weekday",
+    "_observed_fixed_holiday",
+    "regular_session_open_utc_for",
+    "regular_session_close_utc_for",
+    "_regular_session_boundary_utc_for",
+    "regular_session_minutes_elapsed",
+    "_extract_price",
+    "_extract_spread_bps",
+    "_extract_imbalance_pressure",
+    "_extract_microprice_bias_bps",
+    "_bps_delta",
+    "_recent_return_bps",
+    "_mean_decimal",
+    "_max_decimal",
+    "_average_decimal",
+    "_ratio_decimal",
+    "_rank_universe_size",
+    "_percentile_rank",
+    "_session_minutes_elapsed",
+    "_SymbolSessionState",
+    "SessionContextTracker",
 ]
-del __compat_module__
+
+del _impl


### PR DESCRIPTION
## Summary

- Replaces dynamic `globals().update`/`sys.modules` facades in seven Torghut trading helper export surfaces with explicit public exports.
- Removes blanket file-level Pyright suppressions from those wrappers and their matching `_modules/__init__.py` package exports.
- Keeps implementation part files unchanged; modules with patch-target, script-import, or cross-part coupling remain for later semantic refactor PRs instead of adding compatibility shims.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app/trading/alpha app/trading/discovery app/trading/executable_alpha_receipts.py app/trading/executable_alpha_receipts_modules app/trading/profit_freshness_frontier.py app/trading/profit_freshness_frontier_modules app/trading/revenue_repair.py app/trading/revenue_repair_modules app/trading/scheduler/state.py app/trading/scheduler/state_modules app/trading/session_context.py app/trading/session_context_modules`
- `uv run --frozen pytest tests/test_alpha_lane.py tests/test_mlx_autoresearch.py tests/test_executable_alpha_repair_receipts.py tests/test_executable_alpha_receipts.py tests/test_repair_bid_settlement.py tests/test_metrics.py tests/test_session_context.py tests/property/test_session_context_properties.py tests/stateful/test_session_context_state_machine.py tests/test_adaptive_signal_falsification_stress.py tests/autoresearch_runner/test_feedback_evidence.py` (`130 passed, 1 warning`)
- `uv run --frozen pytest tests/build_revenue_repair_digest/test_part_01.py tests/build_revenue_repair_digest/test_part_02.py tests/test_build_revenue_repair_digest.py` (`18 passed, 1 warning`)
- exact local shard 1 selection from `.github/workflows/torghut-ci.yml` with `uv run --frozen pytest -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report=` (`1363 passed, 48 warnings`)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/check_refactor_quality.py`
- `uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- changed-file Pylint design gate for the 14 modified Python files with `too-many-arguments`, `too-many-positional-arguments`, `too-many-branches`, `too-many-locals`, `too-many-return-statements`, `too-many-statements`, and `too-many-nested-blocks` enabled
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
