### PR TITLE
chore(torghut): promote image 2d1e275c

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: materialize-targets
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -160,9 +160,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+                  value: sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
                 - name: TORGHUT_COMMIT
-                  value: 982f13e73e27c6987009be1d69238372a11d9b5d
+                  value: 2d1e275c1b13b0fb53630c89a03a0787e04be561
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-13T09:45:15Z"
+        client.knative.dev/updateTimestamp: "2026-06-13T10:17:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           ports:
             - name: http1
               containerPort: 8181
@@ -537,11 +537,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-483-g982f13e73
+              value: v0.596.0-485-g2d1e275c1
             - name: TORGHUT_COMMIT
-              value: 982f13e73e27c6987009be1d69238372a11d9b5d
+              value: 2d1e275c1b13b0fb53630c89a03a0787e04be561
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              value: sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-13T09:45:15Z"
+        client.knative.dev/updateTimestamp: "2026-06-13T10:17:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           ports:
             - name: http1
               containerPort: 8181
@@ -399,11 +399,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-483-g982f13e73
+              value: v0.596.0-485-g2d1e275c1
             - name: TORGHUT_COMMIT
-              value: 982f13e73e27c6987009be1d69238372a11d9b5d
+              value: 2d1e275c1b13b0fb53630c89a03a0787e04be561
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              value: sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -88,7 +88,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+                  value: sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -125,7 +125,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -197,6 +197,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+                  value: sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 982f13e73e27c6987009be1d69238372a11d9b5d
+            value: 2d1e275c1b13b0fb53630c89a03a0787e04be561
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+            value: sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1014b35be901cc89e04d12c7e5846884af4ead6b67e28fe195d3130c68073c20
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2d1e275c1b13b0fb53630c89a03a0787e04be561`
- Image tag: `2d1e275c`
- Image digest: `sha256:5bd7323f9d65bb0c580615371a4f3bcd4a1b778d72054c302807a4580af16439`