### PR TITLE
refactor(torghut): normalize historical proof exports

### DIFF
--- a/services/torghut/scripts/build_historical_profitability_proof.py
+++ b/services/torghut/scripts/build_historical_profitability_proof.py
@@ -1,16 +1,22 @@
+#!/usr/bin/env python3
+"""CLI entrypoint for historical profitability proof artifacts."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from scripts.build_historical_profitability_proof_modules import (
+    HistoricalRunSummary,
+    ProfitabilityProofGatePolicy,
+    build_historical_profitability_bundle,
+    main,
+)
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("scripts.build_historical_profitability_proof_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+__all__ = [
+    "HistoricalRunSummary",
+    "ProfitabilityProofGatePolicy",
+    "build_historical_profitability_bundle",
+    "main",
+]
+
 
 if __name__ == "__main__":
-    raise SystemExit(_impl.main())
+    raise SystemExit(main())

--- a/services/torghut/scripts/build_historical_profitability_proof_modules/__init__.py
+++ b/services/torghut/scripts/build_historical_profitability_proof_modules/__init__.py
@@ -1,41 +1,13 @@
+"""Historical profitability proof package API."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import sys as __compat_sys__
-import types as __compat_types__
+from .proof_bundle import build_historical_profitability_bundle, main
+from .proof_core import HistoricalRunSummary, ProfitabilityProofGatePolicy
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
-
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.proof_core")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(f"{__name__}.proof_bundle")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
-del __compat_module__
+__all__ = [
+    "HistoricalRunSummary",
+    "ProfitabilityProofGatePolicy",
+    "build_historical_profitability_bundle",
+    "main",
+]

--- a/services/torghut/tests/test_build_historical_profitability_proof.py
+++ b/services/torghut/tests/test_build_historical_profitability_proof.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import runpy
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -12,14 +13,30 @@ from unittest.mock import patch
 import yaml
 
 from scripts.build_historical_profitability_proof import (
-    _load_json,
-    _load_yaml,
     build_historical_profitability_bundle,
     main,
+)
+from scripts.build_historical_profitability_proof_modules.proof_core import (
+    _load_json,
+    _load_yaml,
 )
 
 
 class TestBuildHistoricalProfitabilityProof(TestCase):
+    def test_cli_entrypoint_delegates_to_main(self) -> None:
+        with patch(
+            "scripts.build_historical_profitability_proof_modules.main",
+            return_value=7,
+        ) as mocked_main:
+            with self.assertRaises(SystemExit) as raised:
+                runpy.run_path(
+                    "scripts/build_historical_profitability_proof.py",
+                    run_name="__main__",
+                )
+
+        self.assertEqual(raised.exception.code, 7)
+        mocked_main.assert_called_once_with()
+
     def test_builds_profitable_bundle_from_historical_runs(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Replaces the historical profitability proof CLI facade with explicit public imports.
- Replaces the proof package initializer's dynamic compat module with a normal package API.
- Moves loader unit-test coverage to the concrete proof core module and covers the CLI entrypoint branch.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts`
- `cd services/torghut && uv run --frozen python scripts/check_refactor_quality.py`
- `cd services/torghut && uv run --frozen pytest tests/test_build_historical_profitability_proof.py`
- `cd services/torghut && uv run --frozen pytest tests/test_build_historical_profitability_proof.py --cov --cov-branch --cov-report=xml --cov-fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
