### PR TITLE
refactor(torghut): normalize scheduler source collection

### DIFF
--- a/services/torghut/app/trading/scheduler/source_collection.py
+++ b/services/torghut/app/trading/scheduler/source_collection.py
@@ -1,14 +1,7 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
+"""Scheduler source-collection mixin exports."""
+
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from .source_collection_modules import SimplePipelineSourceCollectionMixin
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.scheduler.source_collection_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+__all__ = ["SimplePipelineSourceCollectionMixin"]

--- a/services/torghut/app/trading/scheduler/source_collection_modules/__init__.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/__init__.py
@@ -1,74 +1,7 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
+"""Scheduler source-collection implementation modules."""
+
 from __future__ import annotations
 
-from importlib import import_module as __compat_import_module__
-import logging as __compat_logging__
-import sys as __compat_sys__
-import types as __compat_types__
+from .decision_lineage import SimplePipelineSourceCollectionMixin
 
-__compat_part_modules__: list[__compat_types__.ModuleType] = []
-
-
-class __CompatModule__(__compat_types__.ModuleType):
-    def __setattr__(self, name: str, value: object) -> None:
-        super().__setattr__(name, value)
-        for module in __compat_part_modules__:
-            module.__dict__[name] = value
-
-
-def __compat_export__(module: __compat_types__.ModuleType) -> None:
-    for name, value in module.__dict__.items():
-        if name.startswith("__"):
-            continue
-        globals()[name] = value
-
-
-__compat_module__ = __compat_import_module__(f"{__name__}.part_01_statements_80")
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_simplepipelinesourcecollectionmixinmethods"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_02_source_collection_helpers"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_module__ = __compat_import_module__(
-    f"{__name__}.part_03_simplepipelinesourcecollectionmixinmethods"
-)
-__compat_part_modules__.append(__compat_module__)
-__compat_export__(__compat_module__)
-for __compat_loaded_module__ in __compat_part_modules__:
-    __compat_loaded_module__.__dict__.update(
-        {name: value for name, value in globals().items() if not name.startswith("__")}
-    )
-
-__compat_sys__.modules[__name__].__class__ = __CompatModule__
-logger = __compat_logging__.getLogger(__name__.removesuffix("_modules"))
-for __compat_loaded_module__ in globals().get("__compat_part_modules__", ()):
-    __compat_loaded_module__.__dict__["logger"] = logger
-__all__ = [
-    name
-    for name in globals()
-    if not name.startswith("__") and not name.startswith("_CompatModule")
-]
-del __compat_module__
+__all__ = ["SimplePipelineSourceCollectionMixin"]

--- a/services/torghut/app/trading/scheduler/source_collection_modules/collection_types.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/collection_types.py
@@ -1,0 +1,159 @@
+"""Shared data structures for scheduler source collection."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal, NamedTuple, Protocol
+
+from sqlalchemy.orm import Session
+
+from ....models import Strategy
+
+
+SourceCollectionAction = Literal["buy", "sell"]
+
+
+class SourceCollectionState(NamedTuple):
+    now: datetime
+    target_symbols: set[str]
+    target_plan_targets: list[dict[str, Any]]
+    normalized_allowed: set[str]
+    bounded_sim_owner_active: bool
+
+
+class SourceCollectionTargetContext(NamedTuple):
+    target: dict[str, Any]
+    strategy: Strategy
+    symbols: list[str]
+    symbol_actions: Mapping[str, SourceCollectionAction]
+    symbol_quantities: dict[str, Decimal]
+    pair_balance_state: str
+    window_start: datetime
+    window_end: datetime
+    target_cap: Decimal
+
+
+class SourceCollectionMode(NamedTuple):
+    source_decision_mode: str
+    profit_proof_eligible: bool
+    execution_metadata: dict[str, Any]
+
+
+class SourceCollectionDecisionPayload(NamedTuple):
+    params: dict[str, Any]
+    qty: Decimal
+    timeframe: str
+
+
+class SourceCollectionDecisionRun(NamedTuple):
+    session: Session | None
+    blocked_symbols: set[str]
+    seen: set[tuple[str, str, str, str]]
+    now: datetime
+
+
+class SourceCollectionExposure(NamedTuple):
+    signed_qty: Decimal
+    latest_fill_at: datetime | None
+
+
+class SourceCollectionActiveWindowSummary(NamedTuple):
+    active_targets: list[dict[str, Any]]
+    active_windows: list[dict[str, str]]
+    window_starts: list[datetime]
+    window_ends: list[datetime]
+
+
+class SourceCollectionQuantityResolution(Protocol):
+    qty: Decimal
+    audit: Mapping[str, Any]
+    price_params: Mapping[str, Any]
+
+
+class SourceCollectionRuntime(Protocol):
+    account_label: str
+    _paper_route_target_plan_cache: (
+        tuple[set[str], str | None, list[dict[str, Any]], datetime] | None
+    )
+    _paper_route_target_plan_success_cache: (
+        tuple[set[str], list[dict[str, Any]], datetime] | None
+    )
+
+    def _trading_now(self) -> datetime: ...
+
+    def _is_market_session_open(self, now: datetime) -> bool: ...
+
+    def _live_submission_gate(
+        self,
+        *,
+        session: Session | None = None,
+    ) -> Mapping[str, Any]: ...
+
+    def _fetch_paper_route_target_plan_url(
+        self,
+        url: str,
+        *,
+        timeout_seconds: float,
+        attempts: int,
+        retry_backoff_seconds: float,
+    ) -> Mapping[str, Any]: ...
+
+    def _record_bounded_target_plan_blocker(
+        self,
+        *,
+        reason: str,
+        symbols: set[str] | None = None,
+        targets: Sequence[Mapping[str, Any]] | None = None,
+    ) -> None: ...
+
+    def _external_paper_route_target_probe_symbols_cached(
+        self,
+        *,
+        session: Session | None = None,
+        strategies: Sequence[Strategy] | None = None,
+    ) -> tuple[set[str], str | None, list[dict[str, Any]]]: ...
+
+    @staticmethod
+    def _paper_route_target_strategy(
+        target: Mapping[str, Any],
+        strategies: Sequence[Strategy],
+    ) -> Strategy | None: ...
+
+    @staticmethod
+    def _paper_route_target_strategy_symbols(strategy: Strategy) -> set[str]: ...
+
+    @staticmethod
+    def _paper_route_target_source_decision_metadata(
+        **metadata_args: Any,
+    ) -> dict[str, Any]: ...
+
+    @staticmethod
+    def _bounded_paper_route_execution_metadata(
+        **metadata_args: Any,
+    ) -> dict[str, Any]: ...
+
+    @staticmethod
+    def _paper_route_target_source_cap(
+        params: Mapping[str, Any],
+    ) -> Decimal | None: ...
+
+    def _paper_route_target_quantity_resolution(
+        self,
+        **resolution_args: Any,
+    ) -> SourceCollectionQuantityResolution | None: ...
+
+
+__all__ = [
+    "SourceCollectionActiveWindowSummary",
+    "SourceCollectionAction",
+    "SourceCollectionDecisionPayload",
+    "SourceCollectionDecisionRun",
+    "SourceCollectionExposure",
+    "SourceCollectionMode",
+    "SourceCollectionQuantityResolution",
+    "SourceCollectionRuntime",
+    "SourceCollectionState",
+    "SourceCollectionTargetContext",
+]

--- a/services/torghut/app/trading/scheduler/source_collection_modules/decision_helpers.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/decision_helpers.py
@@ -1,25 +1,48 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnusedImport=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportPrivateUsage=false, reportUnsupportedDunderAll=false
 """Source-collection helper functions split from the pipeline mixin."""
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, cast
+from typing import Any, Protocol, cast
+
+from sqlalchemy.orm import Session
 
 from ....config import settings
-from ....models import TradeDecision
-from ...models import StrategyDecision
-from ..target_plan_helpers import _optional_decimal, _safe_text
+from ...runtime_decision_authority import source_decision_mode_is_profit_proof_eligible
+from ..target_plan_helpers_modules import (
+    PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON as _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON,
+    optional_decimal as _optional_decimal,
+    paper_route_probe_lineage_from_params as _paper_route_probe_lineage_from_params,
+    safe_text as _safe_text,
+    target_bool as _target_bool,
+    target_plan_lineage as _target_plan_lineage,
+    target_symbols as _target_symbols,
+)
+from .collection_types import (
+    SourceCollectionExposure,
+    SourceCollectionMode,
+    SourceCollectionTargetContext,
+)
 
-# ruff: noqa: F401,F403,F405,F811,F821
 
-from .part_01_statements_80 import *
-from .part_02_simplepipelinesourcecollectionmixinmethods import *
+logger = logging.getLogger(__name__)
 
 
-def _source_collection_window_active(
+class FlatRepairSnapshotLookup(Protocol):
+    def __call__(
+        self,
+        *,
+        session: Session,
+        account_label: str,
+        symbol: str,
+        after: datetime | None,
+    ) -> bool: ...
+
+
+def source_collection_window_active(
     window: tuple[datetime, datetime],
     now: datetime,
 ) -> bool:
@@ -27,12 +50,12 @@ def _source_collection_window_active(
     return window_start <= now < window_end
 
 
-def _source_collection_strategy_exposure(
+def source_collection_strategy_exposure(
     rows: Sequence[Any],
-) -> _SourceCollectionExposure:
-    exposure = _SourceCollectionExposure(signed_qty=Decimal("0"), latest_fill_at=None)
+) -> SourceCollectionExposure:
+    exposure = SourceCollectionExposure(signed_qty=Decimal("0"), latest_fill_at=None)
     for row in rows:
-        exposure = _source_collection_accumulate_exposure(
+        exposure = source_collection_accumulate_exposure(
             exposure,
             side=row[0],
             filled_qty=row[1],
@@ -41,15 +64,15 @@ def _source_collection_strategy_exposure(
     return exposure
 
 
-def _source_collection_profit_proof_exposure(
+def source_collection_profit_proof_exposure(
     rows: Sequence[Any],
-) -> _SourceCollectionExposure:
-    exposure = _SourceCollectionExposure(signed_qty=Decimal("0"), latest_fill_at=None)
+) -> SourceCollectionExposure:
+    exposure = SourceCollectionExposure(signed_qty=Decimal("0"), latest_fill_at=None)
     for row in rows:
         raw_decision_json = row[2]
-        if not _source_collection_profit_row_eligible(raw_decision_json):
+        if not source_collection_profit_row_eligible(raw_decision_json):
             continue
-        exposure = _source_collection_accumulate_exposure(
+        exposure = source_collection_accumulate_exposure(
             exposure,
             side=row[0],
             filled_qty=row[1],
@@ -58,7 +81,7 @@ def _source_collection_profit_proof_exposure(
     return exposure
 
 
-def _source_collection_profit_row_eligible(raw_decision_json: object) -> bool:
+def source_collection_profit_row_eligible(raw_decision_json: object) -> bool:
     if not isinstance(raw_decision_json, Mapping):
         return False
     decision_json = cast(Mapping[str, Any], raw_decision_json)
@@ -78,13 +101,13 @@ def _source_collection_profit_row_eligible(raw_decision_json: object) -> bool:
     )
 
 
-def _source_collection_accumulate_exposure(
-    exposure: _SourceCollectionExposure,
+def source_collection_accumulate_exposure(
+    exposure: SourceCollectionExposure,
     *,
     side: object,
     filled_qty: object,
     created_at: object,
-) -> _SourceCollectionExposure:
+) -> SourceCollectionExposure:
     qty = _optional_decimal(filled_qty)
     if qty is None or qty <= 0:
         return exposure
@@ -93,7 +116,7 @@ def _source_collection_accumulate_exposure(
         signed_qty -= qty
     else:
         signed_qty += qty
-    return _SourceCollectionExposure(
+    return SourceCollectionExposure(
         signed_qty=signed_qty,
         latest_fill_at=_latest_fill_at(exposure.latest_fill_at, created_at),
     )
@@ -110,16 +133,17 @@ def _latest_fill_at(
     return current
 
 
-def _source_collection_has_unrepaired_exposure(
+def source_collection_has_unrepaired_exposure(
     *,
     session: Session,
     account_label: str,
     symbol: str,
-    exposure: _SourceCollectionExposure,
+    exposure: SourceCollectionExposure,
+    flat_repair_snapshot_lookup: FlatRepairSnapshotLookup,
 ) -> bool:
     if abs(exposure.signed_qty) <= _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON:
         return False
-    if SimplePipelineSourceCollectionMixin._paper_route_target_symbol_has_flat_repair_snapshot(
+    if flat_repair_snapshot_lookup(
         session=session,
         account_label=account_label,
         symbol=symbol,
@@ -129,7 +153,7 @@ def _source_collection_has_unrepaired_exposure(
     return True
 
 
-def _source_collection_symbols(
+def source_collection_symbols(
     target: Mapping[str, Any],
     *,
     target_symbols: set[str],
@@ -144,7 +168,7 @@ def _source_collection_symbols(
     return symbols
 
 
-def _balanced_pair_needs_short_permission(
+def balanced_pair_needs_short_permission(
     pair_balance_state: str,
     symbol_actions: Mapping[str, str],
 ) -> bool:
@@ -155,11 +179,11 @@ def _balanced_pair_needs_short_permission(
     )
 
 
-def _source_collection_simple_lane(
-    context: _SourceCollectionTargetContext,
+def source_collection_simple_lane(
+    context: SourceCollectionTargetContext,
     *,
     metadata: Mapping[str, Any],
-    mode: _SourceCollectionMode,
+    mode: SourceCollectionMode,
     action: str,
 ) -> dict[str, Any]:
     simple_lane: dict[str, Any] = {
@@ -188,13 +212,13 @@ def _source_collection_simple_lane(
     return simple_lane
 
 
-def _source_collection_params(
-    context: _SourceCollectionTargetContext,
+def source_collection_params(
+    context: SourceCollectionTargetContext,
     *,
     symbol: str,
     metadata: dict[str, Any],
     simple_lane: dict[str, Any],
-    mode: _SourceCollectionMode,
+    mode: SourceCollectionMode,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {
         "paper_route_target_plan": metadata,
@@ -225,7 +249,7 @@ def _source_collection_params(
         "final_promotion_allowed": False,
         "live_capital_routing_enabled": False,
         **mode.execution_metadata,
-        **_source_collection_bounded_execution_params(mode.execution_metadata),
+        **source_collection_bounded_execution_params(mode.execution_metadata),
         **_target_plan_lineage([dict(context.target)], symbol),
     }
     if "exit_minute_after_open" in metadata:
@@ -233,7 +257,7 @@ def _source_collection_params(
     return params
 
 
-def _source_collection_bounded_execution_params(
+def source_collection_bounded_execution_params(
     execution_metadata: Mapping[str, Any],
 ) -> dict[str, Any]:
     if not execution_metadata:
@@ -244,8 +268,8 @@ def _source_collection_bounded_execution_params(
     }
 
 
-def _source_collection_timeframe(
-    context: _SourceCollectionTargetContext,
+def source_collection_timeframe(
+    context: SourceCollectionTargetContext,
 ) -> str:
     return (
         _safe_text(context.target.get("timeframe"))
@@ -255,8 +279,8 @@ def _source_collection_timeframe(
     )
 
 
-def _log_target_notional_sizing_blocker(
-    context: _SourceCollectionTargetContext,
+def log_target_notional_sizing_blocker(
+    context: SourceCollectionTargetContext,
     *,
     symbol: str,
     blockers: object,
@@ -273,7 +297,7 @@ def _log_target_notional_sizing_blocker(
     )
 
 
-def _apply_source_collection_quantity_resolution(
+def apply_source_collection_quantity_resolution(
     *,
     metadata: dict[str, Any],
     simple_lane: dict[str, Any],
@@ -289,4 +313,17 @@ def _apply_source_collection_quantity_resolution(
     params.update(quantity_resolution.price_params)
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "FlatRepairSnapshotLookup",
+    "apply_source_collection_quantity_resolution",
+    "balanced_pair_needs_short_permission",
+    "log_target_notional_sizing_blocker",
+    "source_collection_has_unrepaired_exposure",
+    "source_collection_params",
+    "source_collection_profit_proof_exposure",
+    "source_collection_simple_lane",
+    "source_collection_strategy_exposure",
+    "source_collection_symbols",
+    "source_collection_timeframe",
+    "source_collection_window_active",
+]

--- a/services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py
@@ -1,129 +1,81 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-
 from __future__ import annotations
 
 import logging
-import os
-from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta, timezone
-from decimal import Decimal
-from typing import Any, cast
-from urllib.parse import urlsplit
-
-from sqlalchemy import desc, select  # pyright: ignore[reportUnknownVariableType]
-from sqlalchemy.orm import Session
+from collections.abc import Mapping
+from datetime import timedelta, timezone
+from typing import TYPE_CHECKING, Any, cast
 
 from ....config import settings
 from ....models import (
-    Execution,
-    PositionSnapshot,
     Strategy,
-    TradeDecision,
 )
 from ...models import StrategyDecision
-from ...paper_route_target_plan import (
-    paper_route_target_plan_from_payload,
-    paper_route_target_plan_probe_symbols,
-    paper_route_target_plan_targets,
-)
 from ...runtime_decision_authority import (
-    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
     STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
-    source_decision_mode_is_profit_proof_eligible,
 )
-from ...session_context import regular_session_open_utc_for
-from ..target_plan_helpers import (
-    _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL,
-    _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS,
-    _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON,
-    _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS,
-    _PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
-    _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS,
-    _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK,
-    _REGULAR_SESSION_MINUTES,
-    _bounded_sim_collection_blockers,
-    _bounded_sim_collection_reserves_account,
-    _bounded_sim_collection_target_with_runtime_account_audit,
-    _lineage_text_values,
-    _merge_paper_route_probe_lineage,
-    _optional_decimal,
-    _paper_route_probe_lineage_from_params,
-    _safe_text,
-    _strategy_lookup_names,
-    _target_active_in_window,
-    _target_bool,
-    _target_bounded_collection_authorized,
-    _target_has_bounded_sim_collection_source_kind,
-    _target_has_bounded_source_collection_authorization,
-    _target_lookup_names,
-    _target_missing_explicit_probe_window,
-    _target_owns_bounded_sim_collection_account,
-    _target_pair_balance_state,
-    _target_plan_has_active_bounded_sim_collection_owner,
-    _target_plan_lineage,
-    _target_probe_action,
-    _target_probe_cap,
-    _target_probe_exit_minute_after_open,
-    _target_probe_symbol_actions,
-    _target_probe_symbol_quantities,
-    _target_probe_window,
-    _target_requires_bounded_sim_collection_gate,
-    _target_runtime_account_matches,
-    _target_symbols,
-    _target_truthy,
+from ..target_plan_helpers_modules import (
+    BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS as _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS,
+    BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS as _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS,
+    BOUNDED_SIM_COLLECTION_LINEAGE_KEYS as _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS,
+    BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS as _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS,
+    REGULAR_SESSION_MINUTES as _REGULAR_SESSION_MINUTES,
+    bounded_sim_collection_blockers as _bounded_sim_collection_blockers,
+    lineage_text_values as _lineage_text_values,
+    merge_paper_route_probe_lineage as _merge_paper_route_probe_lineage,
+    safe_text as _safe_text,
+    strategy_lookup_names as _strategy_lookup_names,
+    target_bool as _target_bool,
+    target_has_bounded_sim_collection_source_kind as _target_has_bounded_sim_collection_source_kind,
+    target_lookup_names as _target_lookup_names,
+    target_plan_lineage as _target_plan_lineage,
+    target_probe_exit_minute_after_open as _target_probe_exit_minute_after_open,
+    target_probe_window as _target_probe_window,
+    target_requires_bounded_sim_collection_gate as _target_requires_bounded_sim_collection_gate,
+    target_symbols as _target_symbols,
+    target_truthy as _target_truthy,
 )
-
-# ruff: noqa: F401,F403,F405,F811,F821
-
-from .part_01_statements_80 import *
-from .part_02_simplepipelinesourcecollectionmixinmethods import *
+from .source_decisions import SimplePipelineSourceCollectionDecisionMixin
+from .target_plan_fetch import SimplePipelineSourceCollectionTargetPlanMixin
 
 
-class _SimplePipelineSourceCollectionMixinMethodsPart3:
+if TYPE_CHECKING:
+    from .collection_types import (
+        SourceCollectionRuntime as SourceCollectionRuntimeMixin,
+    )
+else:
+
+    class SourceCollectionRuntimeMixin:
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+
+class SimplePipelineSourceCollectionLineageMixin(SourceCollectionRuntimeMixin):
     def _paper_route_target_lineage_for_decision(
         self,
         decision: StrategyDecision,
         strategy: Strategy | None,
     ) -> dict[str, Any]:
-        if settings.trading_mode != "paper":
-            return {}
-        if not settings.trading_simple_paper_route_probe_enabled:
-            return {}
-        symbol = decision.symbol.strip().upper()
-        if not symbol:
+        symbol = self._paper_route_lineage_symbol(decision)
+        if symbol is None:
             return {}
         target_plan_symbols, target_plan_error, target_plan_targets = (
             self._external_paper_route_target_probe_symbols_cached()
         )
         if target_plan_error or symbol not in target_plan_symbols:
             return {}
-        matching_targets: list[dict[str, Any]] = []
-        for target in target_plan_targets:
-            target_symbols = _target_symbols(target)
-            if target_symbols and symbol not in target_symbols:
-                continue
-            if not self._target_matches_decision_strategy(target, decision, strategy):
-                continue
-            if _target_probe_window(target) is not None and not (
-                self._decision_event_in_target_window(decision, target)
-            ):
-                continue
-            matching_targets.append(dict(target))
+        matching_targets = self._paper_route_lineage_targets(
+            target_plan_targets,
+            decision=decision,
+            strategy=strategy,
+            symbol=symbol,
+        )
         if not matching_targets:
             return {}
         lineage = _target_plan_lineage(matching_targets, symbol)
-        if not any(
-            lineage.get(key)
-            for key in (
-                "source_candidate_ids",
-                "source_hypothesis_ids",
-                "paper_route_probe_lineage_targets",
-            )
-        ):
+        if not self._paper_route_lineage_has_materialized_source(lineage):
             return {}
         return {
             "mode": "paper_route_target_lineage",
@@ -132,6 +84,67 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
             "paper_route_target_plan_symbols": sorted(target_plan_symbols),
             **lineage,
         }
+
+    @staticmethod
+    def _paper_route_lineage_symbol(decision: StrategyDecision) -> str | None:
+        if settings.trading_mode != "paper":
+            return None
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return None
+        symbol = decision.symbol.strip().upper()
+        return symbol or None
+
+    def _paper_route_lineage_targets(
+        self,
+        targets: list[dict[str, Any]],
+        *,
+        decision: StrategyDecision,
+        strategy: Strategy | None,
+        symbol: str,
+    ) -> list[dict[str, Any]]:
+        matching_targets: list[dict[str, Any]] = []
+        for target in targets:
+            if self._paper_route_lineage_target_matches(
+                target,
+                decision=decision,
+                strategy=strategy,
+                symbol=symbol,
+            ):
+                matching_targets.append(dict(target))
+        return matching_targets
+
+    def _paper_route_lineage_target_matches(
+        self,
+        target: Mapping[str, Any],
+        *,
+        decision: StrategyDecision,
+        strategy: Strategy | None,
+        symbol: str,
+    ) -> bool:
+        target_symbols = _target_symbols(target)
+        if target_symbols and symbol not in target_symbols:
+            return False
+        if not self._target_matches_decision_strategy(target, decision, strategy):
+            return False
+        return _target_probe_window(
+            target
+        ) is None or self._decision_event_in_target_window(
+            decision,
+            target,
+        )
+
+    @staticmethod
+    def _paper_route_lineage_has_materialized_source(
+        lineage: Mapping[str, Any],
+    ) -> bool:
+        return any(
+            lineage.get(key)
+            for key in (
+                "source_candidate_ids",
+                "source_hypothesis_ids",
+                "paper_route_probe_lineage_targets",
+            )
+        )
 
     @staticmethod
     def _target_matches_decision_strategy(
@@ -173,28 +186,8 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
         decision: StrategyDecision,
         strategy: Strategy | None,
     ) -> Mapping[str, Any] | None:
-        if settings.trading_mode != "paper":
-            return None
-        if not settings.trading_simple_paper_route_probe_enabled:
-            return None
-        if self._paper_route_target_source_cap(decision.params) is not None:
-            return None
-        if isinstance(
-            decision.params.get("paper_route_target_plan_source_decision"), Mapping
-        ):
-            return None
-        if isinstance(decision.params.get("paper_route_probe_exit"), Mapping):
-            return None
-        existing_mode = (
-            str(decision.params.get("source_decision_mode") or "")
-            .strip()
-            .lower()
-            .replace("-", "_")
-        )
-        if existing_mode == ROUTE_ACQUISITION_SOURCE_DECISION_MODE:
-            return None
-        symbol = decision.symbol.strip().upper()
-        if not symbol:
+        symbol = self._strategy_signal_candidate_symbol(decision)
+        if symbol is None:
             return None
         target_plan_symbols, target_plan_error, target_plan_targets = (
             self._external_paper_route_target_probe_symbols_cached()
@@ -202,49 +195,110 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
         if target_plan_error or symbol not in target_plan_symbols:
             return None
         for target in target_plan_targets:
-            target_symbols = _target_symbols(target)
-            if target_symbols and symbol not in target_symbols:
-                continue
-            if not self._decision_event_in_target_window(decision, target):
-                continue
-            if not self._target_matches_decision_strategy(target, decision, strategy):
-                continue
-            if _safe_text(target.get("candidate_id")) is None:
-                continue
-            if _safe_text(target.get("hypothesis_id")) is None:
-                continue
-            if str(target.get("observed_stage") or "").strip().lower() != "paper":
-                continue
-            if not _target_has_bounded_sim_collection_source_kind(target):
-                continue
-            if _target_requires_bounded_sim_collection_gate(target):
-                blockers = _bounded_sim_collection_blockers(
-                    target,
-                    account_label=self.account_label,
-                )
-                if blockers:
-                    logger.warning(
-                        "Skipping strategy-signal paper authority because bounded SIM "
-                        "collection is not authorized strategy=%s symbol=%s blockers=%s",
-                        strategy.name if strategy is not None else decision.strategy_id,
-                        symbol,
-                        ",".join(blockers),
-                    )
-                    continue
-            if not _target_truthy(target.get("paper_probation_authorized")):
-                continue
-            return target
+            if self._strategy_signal_target_matches(
+                target,
+                decision=decision,
+                strategy=strategy,
+                symbol=symbol,
+            ):
+                return target
         return None
 
+    def _strategy_signal_candidate_symbol(
+        self,
+        decision: StrategyDecision,
+    ) -> str | None:
+        if self._strategy_signal_candidate_blocked(decision):
+            return None
+        symbol = decision.symbol.strip().upper()
+        return symbol or None
+
+    def _strategy_signal_candidate_blocked(
+        self,
+        decision: StrategyDecision,
+    ) -> bool:
+        existing_mode = (
+            str(decision.params.get("source_decision_mode") or "")
+            .strip()
+            .lower()
+            .replace("-", "_")
+        )
+        return (
+            settings.trading_mode != "paper"
+            or not settings.trading_simple_paper_route_probe_enabled
+            or self._paper_route_target_source_cap(decision.params) is not None
+            or isinstance(
+                decision.params.get("paper_route_target_plan_source_decision"),
+                Mapping,
+            )
+            or isinstance(decision.params.get("paper_route_probe_exit"), Mapping)
+            or existing_mode == ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+        )
+
+    def _strategy_signal_target_matches(
+        self,
+        target: Mapping[str, Any],
+        *,
+        decision: StrategyDecision,
+        strategy: Strategy | None,
+        symbol: str,
+    ) -> bool:
+        target_symbols = _target_symbols(target)
+        if target_symbols and symbol not in target_symbols:
+            return False
+        if not self._decision_event_in_target_window(decision, target):
+            return False
+        if not self._target_matches_decision_strategy(target, decision, strategy):
+            return False
+        if not self._strategy_signal_target_identity_complete(target):
+            return False
+        if self._strategy_signal_target_blocked(target, decision, strategy, symbol):
+            return False
+        return _target_truthy(target.get("paper_probation_authorized"))
+
     @staticmethod
+    def _strategy_signal_target_identity_complete(
+        target: Mapping[str, Any],
+    ) -> bool:
+        return (
+            _safe_text(target.get("candidate_id")) is not None
+            and _safe_text(target.get("hypothesis_id")) is not None
+            and str(target.get("observed_stage") or "").strip().lower() == "paper"
+            and _target_has_bounded_sim_collection_source_kind(target)
+        )
+
+    def _strategy_signal_target_blocked(
+        self,
+        target: Mapping[str, Any],
+        decision: StrategyDecision,
+        strategy: Strategy | None,
+        symbol: str,
+    ) -> bool:
+        if not _target_requires_bounded_sim_collection_gate(target):
+            return False
+        blockers = _bounded_sim_collection_blockers(
+            target,
+            account_label=self.account_label,
+        )
+        if not blockers:
+            return False
+        logger.warning(
+            "Skipping strategy-signal paper authority because bounded SIM "
+            "collection is not authorized strategy=%s symbol=%s blockers=%s",
+            strategy.name if strategy is not None else decision.strategy_id,
+            symbol,
+            ",".join(blockers),
+        )
+        return True
+
     def _strategy_signal_paper_metadata(
+        self,
         *,
         decision: StrategyDecision,
         target: Mapping[str, Any],
         strategy: Strategy | None,
     ) -> dict[str, Any]:
         lineage = _target_plan_lineage([dict(target)], decision.symbol)
-        window = _target_probe_window(target)
         metadata: dict[str, Any] = {
             "mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
             "source": "external_target_plan_url",
@@ -263,6 +317,16 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
         if strategy is not None:
             metadata["strategy_name"] = strategy.name
             metadata["strategy_id"] = str(strategy.id)
+        self._add_strategy_signal_identity_metadata(metadata, target)
+        self._add_strategy_signal_bounded_metadata(metadata, target)
+        self._add_strategy_signal_probe_metadata(metadata, target)
+        return metadata
+
+    @staticmethod
+    def _add_strategy_signal_identity_metadata(
+        metadata: dict[str, Any],
+        target: Mapping[str, Any],
+    ) -> None:
         for key in (
             "candidate_id",
             "hypothesis_id",
@@ -276,6 +340,12 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
             value = _safe_text(target.get(key))
             if value is not None:
                 metadata[key] = value
+
+    @staticmethod
+    def _add_strategy_signal_bounded_metadata(
+        metadata: dict[str, Any],
+        target: Mapping[str, Any],
+    ) -> None:
         for key in _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS:
             value = _safe_text(target.get(key))
             if value is not None:
@@ -302,6 +372,13 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
             value = target.get(key)
             if value is not None:
                 metadata[key] = value
+
+    @staticmethod
+    def _add_strategy_signal_probe_metadata(
+        metadata: dict[str, Any],
+        target: Mapping[str, Any],
+    ) -> None:
+        window = _target_probe_window(target)
         if window is not None:
             window_start, window_end = window
             metadata["paper_route_probe_window_start"] = window_start.isoformat()
@@ -319,7 +396,6 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
                     metadata["paper_route_probe_exit_default_reason"] = (
                         "target_plan_evidence_collection_session_close"
                     )
-        return metadata
 
     def _with_paper_route_target_lineage(
         self,
@@ -371,12 +447,15 @@ class _SimplePipelineSourceCollectionMixinMethodsPart3:
 
 
 class SimplePipelineSourceCollectionMixin(
-    _SimplePipelineSourceCollectionMixinMethodsPart1,
-    _SimplePipelineSourceCollectionMixinMethodsPart2,
-    _SimplePipelineSourceCollectionMixinMethodsPart3,
+    SimplePipelineSourceCollectionTargetPlanMixin,
+    SimplePipelineSourceCollectionDecisionMixin,
+    SimplePipelineSourceCollectionLineageMixin,
     object,
 ):
     pass
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "SimplePipelineSourceCollectionLineageMixin",
+    "SimplePipelineSourceCollectionMixin",
+]

--- a/services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py
@@ -291,8 +291,8 @@ class SimplePipelineSourceCollectionLineageMixin(SourceCollectionRuntimeMixin):
         )
         return True
 
+    @staticmethod
     def _strategy_signal_paper_metadata(
-        self,
         *,
         decision: StrategyDecision,
         target: Mapping[str, Any],
@@ -317,9 +317,18 @@ class SimplePipelineSourceCollectionLineageMixin(SourceCollectionRuntimeMixin):
         if strategy is not None:
             metadata["strategy_name"] = strategy.name
             metadata["strategy_id"] = str(strategy.id)
-        self._add_strategy_signal_identity_metadata(metadata, target)
-        self._add_strategy_signal_bounded_metadata(metadata, target)
-        self._add_strategy_signal_probe_metadata(metadata, target)
+        SimplePipelineSourceCollectionLineageMixin._add_strategy_signal_identity_metadata(
+            metadata,
+            target,
+        )
+        SimplePipelineSourceCollectionLineageMixin._add_strategy_signal_bounded_metadata(
+            metadata,
+            target,
+        )
+        SimplePipelineSourceCollectionLineageMixin._add_strategy_signal_probe_metadata(
+            metadata,
+            target,
+        )
         return metadata
 
     @staticmethod

--- a/services/torghut/app/trading/scheduler/source_collection_modules/source_decisions.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/source_decisions.py
@@ -1,16 +1,12 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, NamedTuple, cast
-from urllib.parse import urlsplit
+from typing import TYPE_CHECKING, Any, cast
 
-from sqlalchemy import desc, select  # pyright: ignore[reportUnknownVariableType]
+from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
 from ....config import settings
@@ -21,105 +17,68 @@ from ....models import (
     TradeDecision,
 )
 from ...models import StrategyDecision
-from ...paper_route_target_plan import (
-    paper_route_target_plan_from_payload,
-    paper_route_target_plan_probe_symbols,
-    paper_route_target_plan_targets,
-)
 from ...runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
-    STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
-    source_decision_mode_is_profit_proof_eligible,
 )
-from ...session_context import regular_session_open_utc_for
-from ..target_plan_helpers import (
-    _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL,
-    _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS,
-    _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON,
-    _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS,
-    _PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
-    _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS,
-    _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK,
-    _REGULAR_SESSION_MINUTES,
-    _bounded_sim_collection_blockers,
-    _bounded_sim_collection_reserves_account,
-    _bounded_sim_collection_target_with_runtime_account_audit,
-    _lineage_text_values,
-    _merge_paper_route_probe_lineage,
-    _optional_decimal,
-    _paper_route_probe_lineage_from_params,
-    _safe_text,
-    _strategy_lookup_names,
-    _target_active_in_window,
-    _target_bool,
-    _target_bounded_collection_authorized,
-    _target_has_bounded_sim_collection_source_kind,
-    _target_has_bounded_source_collection_authorization,
-    _target_lookup_names,
-    _target_missing_explicit_probe_window,
-    _target_owns_bounded_sim_collection_account,
-    _target_pair_balance_state,
-    _target_plan_has_active_bounded_sim_collection_owner,
-    _target_plan_lineage,
-    _target_probe_action,
-    _target_probe_cap,
-    _target_probe_exit_minute_after_open,
-    _target_probe_symbol_actions,
-    _target_probe_symbol_quantities,
-    _target_probe_window,
-    _target_requires_bounded_sim_collection_gate,
-    _target_runtime_account_matches,
-    _target_symbols,
-    _target_truthy,
+from ..target_plan_helpers_modules import (
+    PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK as _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK,
+    bounded_sim_collection_blockers as _bounded_sim_collection_blockers,
+    bounded_sim_collection_reserves_account as _bounded_sim_collection_reserves_account,
+    bounded_sim_collection_target_with_runtime_account_audit as _bounded_sim_collection_target_with_runtime_account_audit,
+    merge_paper_route_probe_lineage as _merge_paper_route_probe_lineage,
+    optional_decimal as _optional_decimal,
+    paper_route_probe_lineage_from_params as _paper_route_probe_lineage_from_params,
+    safe_text as _safe_text,
+    target_active_in_window as _target_active_in_window,
+    target_owns_bounded_sim_collection_account as _target_owns_bounded_sim_collection_account,
+    target_pair_balance_state as _target_pair_balance_state,
+    target_plan_has_active_bounded_sim_collection_owner as _target_plan_has_active_bounded_sim_collection_owner,
+    target_probe_action as _target_probe_action,
+    target_probe_cap as _target_probe_cap,
+    target_probe_symbol_actions as _target_probe_symbol_actions,
+    target_probe_symbol_quantities as _target_probe_symbol_quantities,
+    target_probe_window as _target_probe_window,
+    target_requires_bounded_sim_collection_gate as _target_requires_bounded_sim_collection_gate,
+    target_runtime_account_matches as _target_runtime_account_matches,
+)
+from .collection_types import (
+    SourceCollectionAction,
+    SourceCollectionDecisionPayload,
+    SourceCollectionDecisionRun,
+    SourceCollectionMode,
+    SourceCollectionState,
+    SourceCollectionTargetContext,
+)
+from .decision_helpers import (
+    apply_source_collection_quantity_resolution,
+    balanced_pair_needs_short_permission,
+    log_target_notional_sizing_blocker,
+    source_collection_has_unrepaired_exposure,
+    source_collection_params,
+    source_collection_profit_proof_exposure,
+    source_collection_simple_lane,
+    source_collection_strategy_exposure,
+    source_collection_symbols,
+    source_collection_timeframe,
+    source_collection_window_active,
 )
 
-# ruff: noqa: F401,F403,F405,F811,F821
 
-from .part_01_statements_80 import *
+if TYPE_CHECKING:
+    from .collection_types import (
+        SourceCollectionRuntime as SourceCollectionRuntimeMixin,
+    )
+else:
 
-
-class _SourceCollectionState(NamedTuple):
-    now: datetime
-    target_symbols: set[str]
-    target_plan_targets: list[dict[str, Any]]
-    normalized_allowed: set[str]
-    bounded_sim_owner_active: bool
+    class SourceCollectionRuntimeMixin:
+        pass
 
 
-class _SourceCollectionTargetContext(NamedTuple):
-    target: Mapping[str, Any]
-    strategy: Strategy
-    symbols: list[str]
-    symbol_actions: dict[str, str]
-    symbol_quantities: dict[str, Decimal]
-    pair_balance_state: str
-    window_start: datetime
-    window_end: datetime
-    target_cap: Decimal
+logger = logging.getLogger(__name__)
 
 
-class _SourceCollectionMode(NamedTuple):
-    source_decision_mode: str
-    profit_proof_eligible: bool
-    execution_metadata: dict[str, Any]
-
-
-class _SourceCollectionDecisionPayload(NamedTuple):
-    params: dict[str, Any]
-    qty: Decimal
-    timeframe: str
-
-
-class _SourceCollectionExposure(NamedTuple):
-    signed_qty: Decimal
-    latest_fill_at: datetime | None
-
-
-class _SimplePipelineSourceCollectionMixinMethodsPart2:
+class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
     def _paper_route_target_source_decisions(
         self,
         *,
@@ -162,15 +121,17 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
                     blocked_symbols,
                 )
                 continue
+            run = SourceCollectionDecisionRun(
+                session=session,
+                blocked_symbols=set(blocked_symbols),
+                seen=seen,
+                now=state.now,
+            )
             for symbol in context.symbols:
                 decision = self._paper_route_target_source_decision_for_symbol(
                     context,
                     symbol=symbol,
-                    positions=positions,
-                    session=session,
-                    blocked_symbols=blocked_symbols,
-                    seen=seen,
-                    now=state.now,
+                    run=run,
                 )
                 if decision is not None:
                     decisions.append(decision)
@@ -182,7 +143,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
         strategies: Sequence[Strategy],
         allowed_symbols: set[str],
         session: Session | None,
-    ) -> _SourceCollectionState | None:
+    ) -> SourceCollectionState | None:
         if settings.trading_mode != "paper":
             return None
         if not settings.trading_simple_paper_route_probe_enabled:
@@ -223,7 +184,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             account_label=self.account_label,
             now=now,
         )
-        return _SourceCollectionState(
+        return SourceCollectionState(
             now=now,
             target_symbols=target_symbols,
             target_plan_targets=target_plan_targets,
@@ -237,8 +198,8 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
         *,
         strategies: Sequence[Strategy],
         positions: Sequence[Mapping[str, Any]] | None,
-        state: _SourceCollectionState,
-    ) -> _SourceCollectionTargetContext | None:
+        state: SourceCollectionState,
+    ) -> SourceCollectionTargetContext | None:
         target = _bounded_sim_collection_target_with_runtime_account_audit(
             raw_target,
             positions=(
@@ -255,12 +216,12 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             return None
         if self._paper_route_target_bounded_gate_blocked(target):
             return None
-        if window is None or not _source_collection_window_active(window, state.now):
+        if window is None or not source_collection_window_active(window, state.now):
             return None
         if target_cap is None or target_cap <= 0 or strategy is None:
             return None
 
-        symbols = _source_collection_symbols(
+        symbols = source_collection_symbols(
             target,
             target_symbols=state.target_symbols,
             normalized_allowed=state.normalized_allowed,
@@ -269,33 +230,29 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
         symbol_actions = _target_probe_symbol_actions(target, symbols)
         symbol_quantities = _target_probe_symbol_quantities(target, symbols)
         pair_balance_state = _target_pair_balance_state(target, symbol_actions)
-        if self._paper_route_target_pair_gate_blocked(
-            target,
-            strategy=strategy,
-            symbols=symbols,
-            symbol_actions=symbol_actions,
-            pair_balance_state=pair_balance_state,
-            positions=positions,
-        ):
-            return None
-        window_start, window_end = window
-        return _SourceCollectionTargetContext(
+        context = SourceCollectionTargetContext(
             target=target,
             strategy=strategy,
             symbols=symbols,
             symbol_actions=symbol_actions,
             symbol_quantities=symbol_quantities,
             pair_balance_state=pair_balance_state,
-            window_start=window_start,
-            window_end=window_end,
+            window_start=window[0],
+            window_end=window[1],
             target_cap=target_cap,
         )
+        if self._paper_route_target_pair_gate_blocked(
+            context,
+            positions=positions,
+        ):
+            return None
+        return context
 
     def _paper_route_target_owner_skip(
         self,
         target: Mapping[str, Any],
         *,
-        state: _SourceCollectionState,
+        state: SourceCollectionState,
     ) -> bool:
         if not (
             state.bounded_sim_owner_active
@@ -337,44 +294,43 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
 
     def _paper_route_target_pair_gate_blocked(
         self,
-        target: Mapping[str, Any],
+        context: SourceCollectionTargetContext,
         *,
-        strategy: Strategy,
-        symbols: list[str],
-        symbol_actions: Mapping[str, str],
-        pair_balance_state: str,
         positions: Sequence[Mapping[str, Any]] | None,
     ) -> bool:
         if _target_requires_bounded_sim_collection_gate(
-            target
+            context.target
         ) and self._paper_route_target_account_has_open_exposure(positions):
             logger.warning(
                 "Skipping paper-route target source collection because account "
                 "is not flat for bounded SIM evidence strategy=%s symbols=%s",
-                strategy.name,
-                symbols,
+                context.strategy.name,
+                context.symbols,
             )
             return True
-        if pair_balance_state == "imbalanced":
+        if context.pair_balance_state == "imbalanced":
             logger.warning(
                 "Skipping imbalanced paper-route pair target strategy=%s symbols=%s actions=%s",
-                strategy.name,
-                symbols,
-                symbol_actions,
+                context.strategy.name,
+                context.symbols,
+                context.symbol_actions,
             )
             return True
-        if _balanced_pair_needs_short_permission(pair_balance_state, symbol_actions):
+        if balanced_pair_needs_short_permission(
+            context.pair_balance_state,
+            context.symbol_actions,
+        ):
             logger.warning(
                 "Skipping balanced paper-route pair target because shorts are disabled strategy=%s symbols=%s",
-                strategy.name,
-                symbols,
+                context.strategy.name,
+                context.symbols,
             )
             return True
         return False
 
     def _paper_route_target_blocked_open_exposure_symbols(
         self,
-        context: _SourceCollectionTargetContext,
+        context: SourceCollectionTargetContext,
         *,
         positions: Sequence[Mapping[str, Any]] | None,
         session: Session | None,
@@ -399,28 +355,23 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
 
     def _paper_route_target_source_decision_for_symbol(
         self,
-        context: _SourceCollectionTargetContext,
+        context: SourceCollectionTargetContext,
         *,
         symbol: str,
-        positions: Sequence[Mapping[str, Any]] | None,
-        session: Session | None,
-        blocked_symbols: list[str],
-        seen: set[tuple[str, str, str, str]],
-        now: datetime,
+        run: SourceCollectionDecisionRun,
     ) -> StrategyDecision | None:
-        del positions
         action = context.symbol_actions.get(
             symbol,
             _target_probe_action(context.target),
         )
         if action == "sell" and not settings.trading_allow_shorts:
             return None
-        if symbol in blocked_symbols:
+        if symbol in run.blocked_symbols:
             return None
         if (
-            session is not None
+            run.session is not None
             and self._paper_route_target_symbol_has_open_profit_proof_exposure(
-                session=session,
+                session=run.session,
                 strategy=context.strategy,
                 symbol=symbol,
                 account_label=self.account_label,
@@ -434,21 +385,21 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             context.window_start.isoformat(),
             action,
         )
-        if key in seen:
+        if key in run.seen:
             return None
-        seen.add(key)
+        run.seen.add(key)
         payload = self._paper_route_target_source_decision_payload(
             context,
             symbol=symbol,
             action=action,
-            now=now,
+            now=run.now,
         )
         if payload is None:
             return None
         return StrategyDecision(
             strategy_id=str(context.strategy.id),
             symbol=symbol,
-            event_ts=now,
+            event_ts=run.now,
             timeframe=payload.timeframe,
             action=action,
             qty=payload.qty,
@@ -460,24 +411,24 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
 
     def _paper_route_target_source_decision_payload(
         self,
-        context: _SourceCollectionTargetContext,
+        context: SourceCollectionTargetContext,
         *,
         symbol: str,
-        action: str,
+        action: SourceCollectionAction,
         now: datetime,
-    ) -> _SourceCollectionDecisionPayload | None:
+    ) -> SourceCollectionDecisionPayload | None:
         metadata, mode = self._paper_route_target_source_collection_metadata(
             context,
             symbol=symbol,
             action=action,
         )
-        simple_lane = _source_collection_simple_lane(
+        simple_lane = source_collection_simple_lane(
             context,
             metadata=metadata,
             mode=mode,
             action=action,
         )
-        params = _source_collection_params(
+        params = source_collection_params(
             context,
             symbol=symbol,
             metadata=metadata,
@@ -488,7 +439,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             params,
             _paper_route_probe_lineage_from_params(params),
         )
-        timeframe = _source_collection_timeframe(context)
+        timeframe = source_collection_timeframe(context)
         requested_qty = context.symbol_quantities.get(symbol, Decimal("1"))
         quantity_resolution = self._paper_route_target_quantity_resolution(
             target=context.target,
@@ -504,19 +455,19 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
         if quantity_resolution is None:
             return None
         if quantity_resolution.audit.get("sizing_source") != "target_notional":
-            _log_target_notional_sizing_blocker(
+            log_target_notional_sizing_blocker(
                 context,
                 symbol=symbol,
                 blockers=quantity_resolution.audit.get("blockers"),
             )
             return None
-        _apply_source_collection_quantity_resolution(
+        apply_source_collection_quantity_resolution(
             metadata=metadata,
             simple_lane=simple_lane,
             params=params,
             quantity_resolution=quantity_resolution,
         )
-        return _SourceCollectionDecisionPayload(
+        return SourceCollectionDecisionPayload(
             params=params,
             qty=quantity_resolution.qty,
             timeframe=timeframe,
@@ -524,18 +475,14 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
 
     def _paper_route_target_source_collection_metadata(
         self,
-        context: _SourceCollectionTargetContext,
+        context: SourceCollectionTargetContext,
         *,
         symbol: str,
-        action: str,
-    ) -> tuple[dict[str, Any], _SourceCollectionMode]:
+        action: SourceCollectionAction,
+    ) -> tuple[dict[str, Any], SourceCollectionMode]:
         metadata = self._paper_route_target_source_decision_metadata(
-            target=context.target,
-            strategy=context.strategy,
+            context=context,
             symbol=symbol,
-            window_start=context.window_start,
-            window_end=context.window_end,
-            max_notional=context.target_cap,
         )
         metadata["paper_route_probe_symbol_actions"] = dict(context.symbol_actions)
         if context.symbol_quantities:
@@ -558,20 +505,18 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
 
     def _paper_route_target_source_collection_mode(
         self,
-        context: _SourceCollectionTargetContext,
+        context: SourceCollectionTargetContext,
         *,
         metadata: dict[str, Any],
         symbol: str,
-        action: str,
-    ) -> _SourceCollectionMode:
+        action: SourceCollectionAction,
+    ) -> SourceCollectionMode:
         execution_metadata = (
             self._bounded_paper_route_execution_metadata(
-                target=context.target,
-                strategy=context.strategy,
+                context=context,
                 symbol=symbol,
                 action=action,
                 account_label=self.account_label,
-                max_notional=context.target_cap,
             )
             if _target_requires_bounded_sim_collection_gate(context.target)
             else {}
@@ -580,7 +525,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             _safe_text(execution_metadata.get("submit_path"))
             != "bounded_paper_route_collection"
         ):
-            return _SourceCollectionMode(
+            return SourceCollectionMode(
                 source_decision_mode=ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
                 profit_proof_eligible=False,
                 execution_metadata=execution_metadata,
@@ -593,7 +538,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
         metadata["bounded_paper_route_execution_policy"] = execution_metadata[
             "execution_policy"
         ]
-        return _SourceCollectionMode(
+        return SourceCollectionMode(
             source_decision_mode=BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
             profit_proof_eligible=True,
             execution_metadata=execution_metadata,
@@ -701,12 +646,15 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             )
             return True
 
-        exposure = _source_collection_strategy_exposure(rows)
-        return _source_collection_has_unrepaired_exposure(
+        exposure = source_collection_strategy_exposure(rows)
+        return source_collection_has_unrepaired_exposure(
             session=session,
             account_label=account_label,
             symbol=normalized_symbol,
             exposure=exposure,
+            flat_repair_snapshot_lookup=(
+                SimplePipelineSourceCollectionDecisionMixin._paper_route_target_symbol_has_flat_repair_snapshot
+            ),
         )
 
     @staticmethod
@@ -743,7 +691,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             positions, (bytes, bytearray, str)
         ):
             return False
-        return not SimplePipelineSourceCollectionMixin._paper_route_target_symbol_has_open_position(
+        return not SimplePipelineSourceCollectionDecisionMixin._paper_route_target_symbol_has_open_position(
             cast(Sequence[Mapping[str, Any]], positions),
             symbol,
         )
@@ -793,12 +741,15 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
             )
             return True
 
-        exposure = _source_collection_profit_proof_exposure(rows)
-        return _source_collection_has_unrepaired_exposure(
+        exposure = source_collection_profit_proof_exposure(rows)
+        return source_collection_has_unrepaired_exposure(
             session=session,
             account_label=account_label,
             symbol=normalized_symbol,
             exposure=exposure,
+            flat_repair_snapshot_lookup=(
+                SimplePipelineSourceCollectionDecisionMixin._paper_route_target_symbol_has_flat_repair_snapshot
+            ),
         )
 
     @staticmethod
@@ -835,7 +786,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
 
         filtered_positions: list[Mapping[str, Any]] = []
         for position in positions:
-            if SimplePipelineSourceCollectionMixin._paper_route_position_is_materialized_projection(
+            if SimplePipelineSourceCollectionDecisionMixin._paper_route_position_is_materialized_projection(
                 position,
                 materialized_client_order_ids,
             ):
@@ -884,4 +835,4 @@ class _SimplePipelineSourceCollectionMixinMethodsPart2:
         return False
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["SimplePipelineSourceCollectionDecisionMixin"]

--- a/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
@@ -1,5 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
-
 from __future__ import annotations
 
 import logging
@@ -7,18 +5,14 @@ import os
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
 
-from sqlalchemy import desc, select  # pyright: ignore[reportUnknownVariableType]
 from sqlalchemy.orm import Session
 
 from ....config import settings
 from ....models import (
-    Execution,
-    PositionSnapshot,
     Strategy,
-    TradeDecision,
 )
 from ...models import StrategyDecision
 from ...paper_route_target_plan import (
@@ -27,63 +21,53 @@ from ...paper_route_target_plan import (
     paper_route_target_plan_targets,
 )
 from ...runtime_decision_authority import (
-    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
-    STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
-    source_decision_mode_is_profit_proof_eligible,
 )
 from ...session_context import regular_session_open_utc_for
-from ..target_plan_helpers import (
-    _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL,
-    _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS,
-    _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS,
-    _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON,
-    _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS,
-    _PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
-    _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS,
-    _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK,
-    _REGULAR_SESSION_MINUTES,
-    _bounded_sim_collection_blockers,
-    _bounded_sim_collection_reserves_account,
-    _bounded_sim_collection_target_with_runtime_account_audit,
-    _lineage_text_values,
-    _merge_paper_route_probe_lineage,
-    _optional_decimal,
-    _paper_route_probe_lineage_from_params,
-    _safe_text,
-    _strategy_lookup_names,
-    _target_active_in_window,
-    _target_bool,
-    _target_bounded_collection_authorized,
-    _target_has_bounded_sim_collection_source_kind,
-    _target_has_bounded_source_collection_authorization,
-    _target_lookup_names,
-    _target_missing_explicit_probe_window,
-    _target_owns_bounded_sim_collection_account,
-    _target_pair_balance_state,
-    _target_plan_has_active_bounded_sim_collection_owner,
-    _target_plan_lineage,
-    _target_probe_action,
-    _target_probe_cap,
-    _target_probe_exit_minute_after_open,
-    _target_probe_symbol_actions,
-    _target_probe_symbol_quantities,
-    _target_probe_window,
-    _target_requires_bounded_sim_collection_gate,
-    _target_runtime_account_matches,
-    _target_symbols,
-    _target_truthy,
+from ..target_plan_helpers_modules import (
+    BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL as _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL,
+    PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS as _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS,
+    PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS as _PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
+    PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS as _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS,
+    REGULAR_SESSION_MINUTES as _REGULAR_SESSION_MINUTES,
+    lineage_text_values as _lineage_text_values,
+    optional_decimal as _optional_decimal,
+    safe_text as _safe_text,
+    strategy_lookup_names as _strategy_lookup_names,
+    target_bounded_collection_authorized as _target_bounded_collection_authorized,
+    target_has_bounded_source_collection_authorization as _target_has_bounded_source_collection_authorization,
+    target_lookup_names as _target_lookup_names,
+    target_missing_explicit_probe_window as _target_missing_explicit_probe_window,
+    target_plan_lineage as _target_plan_lineage,
+    target_probe_exit_minute_after_open as _target_probe_exit_minute_after_open,
+    target_probe_symbol_actions as _target_probe_symbol_actions,
+    target_probe_symbol_quantities as _target_probe_symbol_quantities,
+    target_probe_window as _target_probe_window,
+    target_requires_bounded_sim_collection_gate as _target_requires_bounded_sim_collection_gate,
+    target_symbols as _target_symbols,
+    target_truthy as _target_truthy,
+)
+from .collection_types import (
+    SourceCollectionActiveWindowSummary,
+    SourceCollectionAction,
+    SourceCollectionTargetContext,
 )
 
-# ruff: noqa: F401,F403,F405,F811,F821
+
+if TYPE_CHECKING:
+    from .collection_types import (
+        SourceCollectionRuntime as SourceCollectionRuntimeMixin,
+    )
+else:
+
+    class SourceCollectionRuntimeMixin:
+        pass
 
 
 logger = logging.getLogger(__name__)
 
 
-class _SimplePipelineSourceCollectionMixinMethodsPart1:
+class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin):
     @staticmethod
     def _paper_route_target_plan_url_points_to_current_service(url: str) -> bool:
         parsed = urlsplit(url)
@@ -207,10 +191,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
         strategies: Sequence[Strategy] | None = None,
     ) -> tuple[set[str], str | None, list[dict[str, Any]]]:
         now = self._trading_now().astimezone(timezone.utc)
-        cached = cast(
-            tuple[set[str], str | None, list[dict[str, Any]], datetime] | None,
-            getattr(self, "_paper_route_target_plan_cache", None),
-        )
+        cached = self._paper_route_target_plan_cache
         if cached is not None:
             symbols, load_error, targets, cached_at = cached
             if (
@@ -286,17 +267,46 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
             return None
 
         now = self._trading_now().astimezone(timezone.utc)
+        summary = self._active_bounded_paper_route_target_summary(
+            targets=targets,
+            symbol=symbol,
+            now=now,
+        )
+        if not summary.active_targets:
+            return None
+        gate: dict[str, object] = {
+            "mode": "paper_route_target_window_submission_gate",
+            "symbol": symbol,
+            "account_label": self.account_label,
+            "target_count": len(summary.active_targets),
+            "target_symbols": sorted(target_symbols),
+            "active_windows": summary.active_windows[:5],
+            "requires_scoped_source_decision": True,
+        }
+        if summary.window_starts and summary.window_ends:
+            gate["window_start"] = min(summary.window_starts).isoformat()
+            gate["window_end"] = max(summary.window_ends).isoformat()
+        gate.update(_target_plan_lineage(summary.active_targets, symbol))
+        return gate
+
+    @staticmethod
+    def _active_bounded_paper_route_target_summary(
+        *,
+        targets: Sequence[Mapping[str, Any]],
+        symbol: str,
+        now: datetime,
+    ) -> SourceCollectionActiveWindowSummary:
         active_targets: list[dict[str, Any]] = []
         active_windows: list[dict[str, str]] = []
         window_starts: list[datetime] = []
         window_ends: list[datetime] = []
         for target in targets:
-            if not _target_requires_bounded_sim_collection_gate(target):
-                continue
-            if symbol not in _target_symbols(target):
-                continue
             window = _target_probe_window(target)
-            if window is None:
+            if (
+                not _target_requires_bounded_sim_collection_gate(target)
+                or symbol not in _target_symbols(target)
+                or window is None
+            ):
                 continue
             window_start, window_end = window
             if now < window_start or now >= window_end:
@@ -310,22 +320,12 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
                     "window_end": window_end.isoformat(),
                 }
             )
-        if not active_targets:
-            return None
-        gate: dict[str, object] = {
-            "mode": "paper_route_target_window_submission_gate",
-            "symbol": symbol,
-            "account_label": self.account_label,
-            "target_count": len(active_targets),
-            "target_symbols": sorted(target_symbols),
-            "active_windows": active_windows[:5],
-            "requires_scoped_source_decision": True,
-        }
-        if window_starts and window_ends:
-            gate["window_start"] = min(window_starts).isoformat()
-            gate["window_end"] = max(window_ends).isoformat()
-        gate.update(_target_plan_lineage(active_targets, symbol))
-        return gate
+        return SourceCollectionActiveWindowSummary(
+            active_targets=active_targets,
+            active_windows=active_windows,
+            window_starts=window_starts,
+            window_ends=window_ends,
+        )
 
     @staticmethod
     def _paper_route_target_strategy(
@@ -387,7 +387,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
                 "enabled": bool(strategy.enabled),
                 "base_timeframe": str(strategy.base_timeframe or ""),
                 "universe_symbols": sorted(
-                    SimplePipelineSourceCollectionMixin._paper_route_target_strategy_symbols(
+                    SimplePipelineSourceCollectionTargetPlanMixin._paper_route_target_strategy_symbols(
                         strategy
                     )
                 ),
@@ -486,14 +486,79 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
 
     @staticmethod
     def _paper_route_target_source_decision_metadata(
-        *,
-        target: Mapping[str, Any],
-        strategy: Strategy,
-        symbol: str,
-        window_start: datetime,
-        window_end: datetime,
-        max_notional: Decimal,
+        **metadata_args: Any,
     ) -> dict[str, Any]:
+        context, symbol = (
+            SimplePipelineSourceCollectionTargetPlanMixin._source_collection_metadata_context(
+                metadata_args
+            )
+        )
+        return SimplePipelineSourceCollectionTargetPlanMixin._paper_route_target_source_decision_metadata_from_context(
+            context=context,
+            symbol=symbol,
+        )
+
+    @staticmethod
+    def _source_collection_metadata_context(
+        metadata_args: Mapping[str, Any],
+        *,
+        require_window: bool = True,
+    ) -> tuple[SourceCollectionTargetContext, str]:
+        raw_symbol = metadata_args.get("symbol")
+        if not isinstance(raw_symbol, str) or not raw_symbol.strip():
+            raise TypeError("symbol is required")
+        symbol = raw_symbol.strip().upper()
+        context = metadata_args.get("context")
+        if isinstance(context, SourceCollectionTargetContext):
+            return context, symbol
+        target = metadata_args.get("target")
+        strategy = metadata_args.get("strategy")
+        window_start = metadata_args.get("window_start")
+        window_end = metadata_args.get("window_end")
+        max_notional = _optional_decimal(metadata_args.get("max_notional"))
+        if not isinstance(target, Mapping):
+            raise TypeError("target is required")
+        if not isinstance(strategy, Strategy):
+            raise TypeError("strategy is required")
+        if require_window and not (
+            isinstance(window_start, datetime) and isinstance(window_end, datetime)
+        ):
+            raise TypeError("window_start and window_end are required")
+        if not isinstance(window_start, datetime):
+            window_start = datetime.fromtimestamp(0, tz=timezone.utc)
+        if not isinstance(window_end, datetime):
+            window_end = window_start
+        if max_notional is None:
+            raise TypeError("max_notional is required")
+        target_mapping = cast(Mapping[str, Any], target)
+        normalized_target: dict[str, Any] = dict(target_mapping)
+        symbols = sorted(_target_symbols(normalized_target)) or [symbol]
+        return (
+            SourceCollectionTargetContext(
+                target=normalized_target,
+                strategy=strategy,
+                symbols=symbols,
+                symbol_actions=_target_probe_symbol_actions(normalized_target, symbols),
+                symbol_quantities=_target_probe_symbol_quantities(
+                    normalized_target,
+                    symbols,
+                ),
+                pair_balance_state="not_required",
+                window_start=window_start,
+                window_end=window_end,
+                target_cap=max_notional,
+            ),
+            symbol,
+        )
+
+    @staticmethod
+    def _paper_route_target_source_decision_metadata_from_context(
+        *,
+        context: SourceCollectionTargetContext,
+        symbol: str,
+    ) -> dict[str, Any]:
+        target = context.target
+        strategy = context.strategy
         lineage = _target_plan_lineage([dict(target)], symbol)
         bounded_collection_authorized = _target_bounded_collection_authorized(target)
         target_runtime_strategy_name = (
@@ -507,10 +572,10 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
             "runtime_strategy_name": target_runtime_strategy_name,
             "strategy_lookup_names": _target_lookup_names(target),
             "paper_route_probe_symbols": sorted(_target_symbols(target)),
-            "paper_route_probe_window_start": window_start.isoformat(),
-            "paper_route_probe_window_end": window_end.isoformat(),
-            "paper_route_probe_next_session_max_notional": str(max_notional),
-            "paper_route_probe_effective_max_notional": str(max_notional),
+            "paper_route_probe_window_start": context.window_start.isoformat(),
+            "paper_route_probe_window_end": context.window_end.isoformat(),
+            "paper_route_probe_next_session_max_notional": str(context.target_cap),
+            "paper_route_probe_effective_max_notional": str(context.target_cap),
             "paper_route_probe_symbol_quantities": {
                 item_symbol: str(quantity)
                 for item_symbol, quantity in _target_probe_symbol_quantities(
@@ -561,7 +626,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
                 _safe_text(target.get("bounded_evidence_collection_scope"))
                 or "paper_route_probe_next_session_only"
             ),
-            "bounded_evidence_collection_max_notional": str(max_notional),
+            "bounded_evidence_collection_max_notional": str(context.target_cap),
             "promotion_allowed": False,
             "final_promotion_authorized": False,
             "final_authority_ok": False,
@@ -587,7 +652,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
             metadata["exit_minute_after_open"] = exit_minute
             metadata["effective_exit_minute_after_open"] = effective_exit_minute
             metadata["exit_due_at"] = (
-                window_start + timedelta(minutes=effective_exit_minute)
+                context.window_start + timedelta(minutes=effective_exit_minute)
             ).isoformat()
             if exit_defaulted:
                 metadata["paper_route_probe_exit_defaulted"] = True
@@ -607,14 +672,37 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
 
     @staticmethod
     def _bounded_paper_route_execution_metadata(
-        *,
-        target: Mapping[str, Any],
-        strategy: Strategy,
-        symbol: str,
-        action: str,
-        account_label: str | None,
-        max_notional: Decimal,
+        **metadata_args: Any,
     ) -> dict[str, Any]:
+        context, symbol = (
+            SimplePipelineSourceCollectionTargetPlanMixin._source_collection_metadata_context(
+                metadata_args,
+                require_window=False,
+            )
+        )
+        action = metadata_args.get("action")
+        if action not in {"buy", "sell"}:
+            raise TypeError("action must be buy or sell")
+        account_label = metadata_args.get("account_label")
+        return SimplePipelineSourceCollectionTargetPlanMixin._bounded_paper_route_execution_metadata_from_context(
+            context=context,
+            symbol=symbol,
+            action=cast(SourceCollectionAction, action),
+            account_label=str(account_label).strip()
+            if account_label is not None
+            else None,
+        )
+
+    @staticmethod
+    def _bounded_paper_route_execution_metadata_from_context(
+        *,
+        context: SourceCollectionTargetContext,
+        symbol: str,
+        action: SourceCollectionAction,
+        account_label: str | None,
+    ) -> dict[str, Any]:
+        target = context.target
+        strategy = context.strategy
         target_account_label = (
             _safe_text(target.get("account_label"))
             or _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
@@ -637,7 +725,7 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
             "strategy_name": strategy.name,
             "symbol": symbol,
             "side": action,
-            "max_notional": str(max_notional),
+            "max_notional": str(context.target_cap),
             "idempotency_key_basis": "trade_decision_hash_client_order_id",
             "order_feed_linkage_keys": [
                 "alpaca_account_label",
@@ -684,4 +772,4 @@ class _SimplePipelineSourceCollectionMixinMethodsPart1:
         return cap if cap is not None and cap > 0 else None
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = ["SimplePipelineSourceCollectionTargetPlanMixin"]


### PR DESCRIPTION
## Summary

- Normalizes the scheduler source-collection package by replacing generated `part_*` modules with semantic modules: `target_plan_fetch`, `source_decisions`, `decision_helpers`, `decision_lineage`, and `collection_types`.
- Replaces the dynamic source-collection facade with static imports and explicit exports, removing the changed surface from `globals().update`, `sys.modules` replacement, wildcard import, dynamic `__all__`, and file-level Ruff or Pyright suppression patterns.
- Preserves the existing `SimplePipelineSourceCollectionMixin` export plus legacy static helper call signatures used by existing scheduler tests.
- Splits the source-collection decision context into typed named tuples and helper functions so the touched package passes the focused Pylint size, design, and Torghut quality gates without suppressions.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen python -m compileall app/trading/scheduler/source_collection.py app/trading/scheduler/source_collection_modules`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/source_collection.py app/trading/scheduler/source_collection_modules`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/source_collection.py app/trading/scheduler/source_collection_modules`
- `cd services/torghut && uv run --frozen pylint app/trading/scheduler/source_collection.py app/trading/scheduler/source_collection_modules --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && uv run --frozen pylint app/trading/scheduler/source_collection.py app/trading/scheduler/source_collection_modules/*.py --disable=all --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks --score=n`
- `cd services/torghut && uv run --frozen pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-file-pyright-suppression,torghut-type-ignore,torghut-file-ruff-noqa,torghut-blanket-pylint-disable,torghut-dynamic-attribute-hook,torghut-dynamic-all,torghut-wildcard-import,torghut-custom-module-class --score=n app/trading/scheduler/source_collection.py app/trading/scheduler/source_collection_modules`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/pipeline/test_trading_pipeline_retry_profit_floor_a.py::TestTradingPipelineRetryProfitFloorA::test_strategy_signal_paper_collection_bypasses_repair_only_floor tests/pipeline/test_trading_pipeline_retry_profit_floor_b.py::TestTradingPipelineRetryProfitFloorB::test_simple_pipeline_retry_helpers_filter_invalid_rows_and_limits` (`2 passed, 1 warning`)
- `cd services/torghut && uv run --frozen pytest tests/simple_pipeline tests/pipeline/test_trading_pipeline_target_plan_source_c.py tests/submission_council/test_paper_probation_import_plan.py tests/submission_council/test_source_collection_candidates.py tests/pipeline/test_trading_pipeline_retry_profit_floor_a.py::TestTradingPipelineRetryProfitFloorA::test_strategy_signal_paper_collection_bypasses_repair_only_floor tests/pipeline/test_trading_pipeline_retry_profit_floor_b.py::TestTradingPipelineRetryProfitFloorB::test_simple_pipeline_retry_helpers_filter_invalid_rows_and_limits` (`77 passed, 1 warning`)
- `cd services/torghut && uv run --frozen python -m compileall app scripts`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
