### PR TITLE
refactor(torghut): normalize trading runtime roots

### DIFF
--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -1,14 +1,84 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from .execution_policy_modules.part_01_statements_29 import (
+    ADAPTIVE_EXECUTION_SECONDS_MAX,
+    ADAPTIVE_EXECUTION_SECONDS_MIN,
+    ADAPTIVE_PARTICIPATION_RATE_FLOOR,
+    DEFAULT_EXECUTION_SECONDS,
+    HIGH_CONVICTION_BREAKOUT_CONTINUATION_RANK_MIN,
+    HIGH_CONVICTION_BREAKOUT_MICROPRICE_BPS_MIN,
+    HIGH_CONVICTION_MARKET_SPREAD_BPS_MAX,
+    HIGH_CONVICTION_WASHOUT_MICROPRICE_BPS_MIN,
+    HIGH_CONVICTION_WASHOUT_REVERSAL_RANK_MIN,
+    MICROSTRUCTURE_COMPRESSED_RATE_SCALE,
+    MICROSTRUCTURE_CRUMBLING_QUOTE_EXECUTION_SCALE,
+    MICROSTRUCTURE_CRUMBLING_QUOTE_PROBABILITY_PRESSURE,
+    MICROSTRUCTURE_CRUMBLING_QUOTE_RATE_SCALE,
+    MICROSTRUCTURE_DEPTH_USD_PRESSURE,
+    MICROSTRUCTURE_EXECUTION_SCALE_EPSILON,
+    MICROSTRUCTURE_EXECUTION_SCALE_MAX,
+    MICROSTRUCTURE_EXECUTION_SCALE_MIN,
+    MICROSTRUCTURE_HAZARD_PRESSURE,
+    MICROSTRUCTURE_HAZARD_RATE_SCALE,
+    MICROSTRUCTURE_HIGH_SPREAD_RATE_SCALE,
+    MICROSTRUCTURE_LATENCY_PRESSURE_MS,
+    MICROSTRUCTURE_LOW_DEPTH_RATE_SCALE,
+    MICROSTRUCTURE_PARTICIPATION_FLOOR,
+    MICROSTRUCTURE_PRESSURE_EXECUTION_SCALE,
+    MICROSTRUCTURE_SPREAD_BPS_PRESSURE,
+    MICROSTRUCTURE_STRESSED_RATE_SCALE,
+    MICROSTRUCTURE_STRESS_EXECUTION_SCALE,
+    AdaptiveExecutionApplication,
+    ExecutionPolicyConfig,
+    ExecutionPolicyOutcome,
+)
+from .execution_policy_modules.part_02_executionpolicy import ExecutionPolicy
+from .execution_policy_modules import (
+    part_03_should_keep_market_order_for_high_convicti as _execution_policy_helpers,
+)
+from .execution_policy_modules.part_03_should_keep_market_order_for_high_convicti import (
+    should_retry_order_error,
+)
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.execution_policy_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+_near_touch_limit_price = getattr(_execution_policy_helpers, "_near_touch_limit_price")
+_should_keep_market_order_for_high_conviction_entry = getattr(
+    _execution_policy_helpers,
+    "_should_keep_market_order_for_high_conviction_entry",
+)
+
+__all__ = [
+    "ADAPTIVE_EXECUTION_SECONDS_MAX",
+    "ADAPTIVE_EXECUTION_SECONDS_MIN",
+    "ADAPTIVE_PARTICIPATION_RATE_FLOOR",
+    "DEFAULT_EXECUTION_SECONDS",
+    "HIGH_CONVICTION_BREAKOUT_CONTINUATION_RANK_MIN",
+    "HIGH_CONVICTION_BREAKOUT_MICROPRICE_BPS_MIN",
+    "HIGH_CONVICTION_MARKET_SPREAD_BPS_MAX",
+    "HIGH_CONVICTION_WASHOUT_MICROPRICE_BPS_MIN",
+    "HIGH_CONVICTION_WASHOUT_REVERSAL_RANK_MIN",
+    "MICROSTRUCTURE_COMPRESSED_RATE_SCALE",
+    "MICROSTRUCTURE_CRUMBLING_QUOTE_EXECUTION_SCALE",
+    "MICROSTRUCTURE_CRUMBLING_QUOTE_PROBABILITY_PRESSURE",
+    "MICROSTRUCTURE_CRUMBLING_QUOTE_RATE_SCALE",
+    "MICROSTRUCTURE_DEPTH_USD_PRESSURE",
+    "MICROSTRUCTURE_EXECUTION_SCALE_EPSILON",
+    "MICROSTRUCTURE_EXECUTION_SCALE_MAX",
+    "MICROSTRUCTURE_EXECUTION_SCALE_MIN",
+    "MICROSTRUCTURE_HAZARD_PRESSURE",
+    "MICROSTRUCTURE_HAZARD_RATE_SCALE",
+    "MICROSTRUCTURE_HIGH_SPREAD_RATE_SCALE",
+    "MICROSTRUCTURE_LATENCY_PRESSURE_MS",
+    "MICROSTRUCTURE_LOW_DEPTH_RATE_SCALE",
+    "MICROSTRUCTURE_PARTICIPATION_FLOOR",
+    "MICROSTRUCTURE_PRESSURE_EXECUTION_SCALE",
+    "MICROSTRUCTURE_SPREAD_BPS_PRESSURE",
+    "MICROSTRUCTURE_STRESSED_RATE_SCALE",
+    "MICROSTRUCTURE_STRESS_EXECUTION_SCALE",
+    "AdaptiveExecutionApplication",
+    "ExecutionPolicy",
+    "ExecutionPolicyConfig",
+    "ExecutionPolicyOutcome",
+    "_near_touch_limit_price",
+    "_should_keep_market_order_for_high_conviction_entry",
+    "should_retry_order_error",
+]

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -1,14 +1,45 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from .order_feed_modules.part_01_statements_32 import (
+    EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION,
+    HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
+    ORDER_FEED_SOURCE_REVISION,
+    NormalizationResult,
+    NormalizedOrderEvent,
+    OrderFeedIngestor,
+)
+from .order_feed_modules.part_03_normalize_order_feed_record import (
+    apply_order_event_to_execution,
+    latest_order_event_for_execution,
+    link_order_events_to_execution,
+    merge_execution_raw_order_update,
+    normalize_order_feed_record,
+    persist_order_event,
+)
+from .order_feed_modules.part_04_repair_order_feed_execution_links import (
+    backfill_order_feed_events_from_executions,
+    backfill_order_feed_source_windows,
+    repair_order_feed_execution_links,
+    repair_order_feed_execution_states,
+    repair_order_feed_fill_deltas,
+)
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.order_feed_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+__all__ = [
+    "EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION",
+    "HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION",
+    "ORDER_FEED_SOURCE_REVISION",
+    "NormalizationResult",
+    "NormalizedOrderEvent",
+    "OrderFeedIngestor",
+    "apply_order_event_to_execution",
+    "backfill_order_feed_events_from_executions",
+    "backfill_order_feed_source_windows",
+    "latest_order_event_for_execution",
+    "link_order_events_to_execution",
+    "merge_execution_raw_order_update",
+    "normalize_order_feed_record",
+    "persist_order_event",
+    "repair_order_feed_execution_links",
+    "repair_order_feed_execution_states",
+    "repair_order_feed_fill_deltas",
+]

--- a/services/torghut/app/trading/portfolio.py
+++ b/services/torghut/app/trading/portfolio.py
@@ -1,14 +1,67 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from .portfolio_modules.part_01_statements_26 import (
+    ALLOCATOR_CLIP_CORRELATION_CAPACITY,
+    ALLOCATOR_CLIP_GROSS_EXPOSURE,
+    ALLOCATOR_CLIP_STRATEGY_BUDGET,
+    ALLOCATOR_CLIP_SYMBOL_BUDGET,
+    ALLOCATOR_CLIP_SYMBOL_CAPACITY,
+    ALLOCATOR_REGIME_LOW_CONFIDENCE,
+    ALLOCATOR_REJECT_CORRELATION_CAPACITY,
+    ALLOCATOR_REJECT_GROSS_EXPOSURE,
+    ALLOCATOR_REJECT_NO_PRICE,
+    ALLOCATOR_REJECT_QTY_BELOW_MIN,
+    ALLOCATOR_REJECT_STRATEGY_BUDGET,
+    ALLOCATOR_REJECT_SYMBOL_BUDGET,
+    ALLOCATOR_REJECT_SYMBOL_CAPACITY,
+    ALLOCATOR_REJECT_ZERO_QTY,
+    ALLOCATOR_STRATEGY_FACTORY_BASELINE_FAIL,
+    ALLOCATOR_STRATEGY_FACTORY_OBSERVE_ONLY,
+    ALLOCATOR_STRATEGY_FACTORY_PAPER_ONLY,
+    ALLOCATOR_STRATEGY_FACTORY_UNCALIBRATED,
+    AggregatedIntent,
+    AllocationConfig,
+    AllocationResult,
+    IntentAggregator,
+    PortfolioSizer,
+    PortfolioSizingConfig,
+    PortfolioSizingResult,
+)
+from .portfolio_modules.part_02_portfolioallocator import PortfolioAllocator
+from .portfolio_modules.part_03_sizer_from_settings import (
+    allocator_from_settings,
+    fragility_monitor_from_settings,
+    sizer_from_settings,
+)
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.portfolio_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+__all__ = [
+    "ALLOCATOR_CLIP_CORRELATION_CAPACITY",
+    "ALLOCATOR_CLIP_GROSS_EXPOSURE",
+    "ALLOCATOR_CLIP_STRATEGY_BUDGET",
+    "ALLOCATOR_CLIP_SYMBOL_BUDGET",
+    "ALLOCATOR_CLIP_SYMBOL_CAPACITY",
+    "ALLOCATOR_REGIME_LOW_CONFIDENCE",
+    "ALLOCATOR_REJECT_CORRELATION_CAPACITY",
+    "ALLOCATOR_REJECT_GROSS_EXPOSURE",
+    "ALLOCATOR_REJECT_NO_PRICE",
+    "ALLOCATOR_REJECT_QTY_BELOW_MIN",
+    "ALLOCATOR_REJECT_STRATEGY_BUDGET",
+    "ALLOCATOR_REJECT_SYMBOL_BUDGET",
+    "ALLOCATOR_REJECT_SYMBOL_CAPACITY",
+    "ALLOCATOR_REJECT_ZERO_QTY",
+    "ALLOCATOR_STRATEGY_FACTORY_BASELINE_FAIL",
+    "ALLOCATOR_STRATEGY_FACTORY_OBSERVE_ONLY",
+    "ALLOCATOR_STRATEGY_FACTORY_PAPER_ONLY",
+    "ALLOCATOR_STRATEGY_FACTORY_UNCALIBRATED",
+    "AggregatedIntent",
+    "AllocationConfig",
+    "AllocationResult",
+    "IntentAggregator",
+    "PortfolioAllocator",
+    "PortfolioSizer",
+    "PortfolioSizingConfig",
+    "PortfolioSizingResult",
+    "allocator_from_settings",
+    "fragility_monitor_from_settings",
+    "sizer_from_settings",
+]

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -1,14 +1,138 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from app.strategies.catalog import extract_catalog_metadata
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.strategy_runtime_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+from .strategy_runtime_modules import (
+    part_01_empty_meta as _empty_meta_helpers,
+    part_02_evaluate_microbar_cross_sectional as _microbar_evaluator_helpers,
+    part_03_coerce_plugin_result as _plugin_result_helpers,
+)
+from .strategy_runtime_modules.part_02_evaluate_microbar_cross_sectional import (
+    AggregatedIntent,
+    PluginEvaluationResult,
+    RuntimeDecision,
+    RuntimeErrorRecord,
+    RuntimeEvaluation,
+    RuntimeObservation,
+    StrategyContext,
+    StrategyDefinition,
+    StrategyIntent,
+    StrategyPlugin,
+)
+from .strategy_runtime_modules.part_03_coerce_plugin_result import (
+    IntentAggregator,
+    IntradayTsmomPlugin,
+    LegacyMacdRsiPlugin,
+    MomentumPullbackLongPlugin,
+    StrategyRegistry,
+)
+from .strategy_runtime_modules.part_04_breakoutcontinuationlongplugin import (
+    BreakoutContinuationLongPlugin,
+    MeanReversionExhaustionShortPlugin,
+    MeanReversionReboundLongPlugin,
+    MicrobarCrossSectionalLongPlugin,
+    MicrobarCrossSectionalPairsPlugin,
+    MicrobarCrossSectionalShortPlugin,
+    WashoutReboundLongPlugin,
+)
+from .strategy_runtime_modules.part_05_latedaycontinuationlongplugin import (
+    EndOfDayReversalLongPlugin,
+    LateDayContinuationLongPlugin,
+    StrategyRuntime,
+)
+from .strategy_specs import (
+    build_compiled_strategy_artifacts,
+    strategy_type_supports_spec_v2,
+)
+
+_microbar_entry_window_minutes = getattr(
+    _empty_meta_helpers,
+    "_microbar_entry_window_minutes",
+)
+_microbar_exit_minute_after_open = getattr(
+    _empty_meta_helpers,
+    "_microbar_exit_minute_after_open",
+)
+_microbar_minutes_elapsed = getattr(
+    _empty_meta_helpers,
+    "_microbar_minutes_elapsed",
+)
+_microbar_pair_max_legs = getattr(
+    _empty_meta_helpers,
+    "_microbar_pair_max_legs",
+)
+_microbar_pair_rank_thresholds = getattr(
+    _empty_meta_helpers,
+    "_microbar_pair_rank_thresholds",
+)
+_microbar_pair_side_count = getattr(
+    _empty_meta_helpers,
+    "_microbar_pair_side_count",
+)
+_microbar_rank_thresholds = getattr(
+    _empty_meta_helpers,
+    "_microbar_rank_thresholds",
+)
+_microbar_rank_universe_size = getattr(
+    _empty_meta_helpers,
+    "_microbar_rank_universe_size",
+)
+_microbar_required_features = getattr(
+    _empty_meta_helpers,
+    "_microbar_required_features",
+)
+_microbar_universe_size = getattr(
+    _empty_meta_helpers,
+    "_microbar_universe_size",
+)
+_evaluate_microbar_cross_sectional = getattr(
+    _microbar_evaluator_helpers,
+    "_evaluate_microbar_cross_sectional",
+)
+_trace_suppression_reason = getattr(
+    _plugin_result_helpers,
+    "_trace_suppression_reason",
+)
+
+__all__ = [
+    "AggregatedIntent",
+    "BreakoutContinuationLongPlugin",
+    "EndOfDayReversalLongPlugin",
+    "IntentAggregator",
+    "IntradayTsmomPlugin",
+    "LateDayContinuationLongPlugin",
+    "LegacyMacdRsiPlugin",
+    "MeanReversionExhaustionShortPlugin",
+    "MeanReversionReboundLongPlugin",
+    "MicrobarCrossSectionalLongPlugin",
+    "MicrobarCrossSectionalPairsPlugin",
+    "MicrobarCrossSectionalShortPlugin",
+    "MomentumPullbackLongPlugin",
+    "PluginEvaluationResult",
+    "RuntimeDecision",
+    "RuntimeErrorRecord",
+    "RuntimeEvaluation",
+    "RuntimeObservation",
+    "StrategyContext",
+    "StrategyDefinition",
+    "StrategyIntent",
+    "StrategyPlugin",
+    "StrategyRegistry",
+    "StrategyRuntime",
+    "WashoutReboundLongPlugin",
+    "_evaluate_microbar_cross_sectional",
+    "_microbar_entry_window_minutes",
+    "_microbar_exit_minute_after_open",
+    "_microbar_minutes_elapsed",
+    "_microbar_pair_max_legs",
+    "_microbar_pair_rank_thresholds",
+    "_microbar_pair_side_count",
+    "_microbar_rank_thresholds",
+    "_microbar_rank_universe_size",
+    "_microbar_required_features",
+    "_microbar_universe_size",
+    "_trace_suppression_reason",
+    "build_compiled_strategy_artifacts",
+    "extract_catalog_metadata",
+    "strategy_type_supports_spec_v2",
+]

--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -1,14 +1,51 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportPrivateUsage=false
 from __future__ import annotations
 
-from importlib import import_module as _import_module
-import sys as _sys
+from .tca_modules.part_01_statements_27 import (
+    ADAPTIVE_DEGRADE_FALLBACK_BPS,
+    ADAPTIVE_EXECUTION_SLOWDOWN,
+    ADAPTIVE_EXECUTION_SPEEDUP,
+    ADAPTIVE_MAX_SHORTFALL,
+    ADAPTIVE_MAX_SLIPPAGE_BPS,
+    ADAPTIVE_MIN_EXPECTED_SHORTFALL_COVERAGE,
+    ADAPTIVE_MIN_SAMPLE_SIZE,
+    ADAPTIVE_PARTICIPATION_RELAX,
+    ADAPTIVE_PARTICIPATION_TIGHTEN,
+    ADAPTIVE_TARGET_SLIPPAGE_BPS,
+    ADAPTIVE_LOOKBACK_WINDOW,
+    EXECUTION_TCA_COST_LINEAGE_SCHEMA_VERSION,
+    POST_COST_PNL_BASIS,
+    AdaptiveExecutionPolicyDecision,
+    upsert_execution_tca_metric,
+)
+from .tca_modules.part_02_observed_broker_order_policy_hash import (
+    build_tca_gate_inputs,
+    refresh_execution_tca_metrics,
+)
+from .tca_modules.part_03_execution_lineage_summary import (
+    derive_adaptive_execution_policy,
+)
+from .tigerbeetle_journal_modules.part_04_tigerbeetleledgerjournal import (
+    TigerBeetleLedgerJournal,
+)
 
-_module_name = __name__
-_parent_name, _, _module_attr = _module_name.rpartition(".")
-_impl = _import_module("app.trading.tca_modules")
-globals().update(_impl.__dict__)
-_sys.modules[_module_name] = _impl
-_parent = _sys.modules.get(_parent_name)
-if _parent is not None:
-    setattr(_parent, _module_attr, _impl)
+__all__ = [
+    "ADAPTIVE_DEGRADE_FALLBACK_BPS",
+    "ADAPTIVE_EXECUTION_SLOWDOWN",
+    "ADAPTIVE_EXECUTION_SPEEDUP",
+    "ADAPTIVE_MAX_SHORTFALL",
+    "ADAPTIVE_MAX_SLIPPAGE_BPS",
+    "ADAPTIVE_MIN_EXPECTED_SHORTFALL_COVERAGE",
+    "ADAPTIVE_MIN_SAMPLE_SIZE",
+    "ADAPTIVE_PARTICIPATION_RELAX",
+    "ADAPTIVE_PARTICIPATION_TIGHTEN",
+    "ADAPTIVE_TARGET_SLIPPAGE_BPS",
+    "ADAPTIVE_LOOKBACK_WINDOW",
+    "EXECUTION_TCA_COST_LINEAGE_SCHEMA_VERSION",
+    "POST_COST_PNL_BASIS",
+    "AdaptiveExecutionPolicyDecision",
+    "TigerBeetleLedgerJournal",
+    "build_tca_gate_inputs",
+    "derive_adaptive_execution_policy",
+    "refresh_execution_tca_metrics",
+    "upsert_execution_tca_metric",
+]

--- a/services/torghut/tests/order_feed/support.py
+++ b/services/torghut/tests/order_feed/support.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-# ruff: noqa: F401
-
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -29,7 +27,7 @@ from app.models import (
     TigerBeetleTransferRef,
     TradeDecision,
 )
-from app.trading import order_feed as order_feed_module
+from app.trading import order_feed_modules as order_feed_module
 from app.trading.tigerbeetle_client import FakeTigerBeetleClient
 from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION,
@@ -236,4 +234,58 @@ class OrderFeedTestCase(TestCase):
         return execution
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "Base",
+    "Decimal",
+    "EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION",
+    "Execution",
+    "ExecutionOrderEvent",
+    "ExecutionTCAMetric",
+    "FakeConsumer",
+    "FakeManualConsumer",
+    "FakeManualConsumerWithoutEndSeek",
+    "FakeRecord",
+    "FakeTigerBeetleClient",
+    "HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION",
+    "NormalizedOrderEvent",
+    "ORDER_FEED_SOURCE_REVISION",
+    "OrderFeedConsumerCursor",
+    "OrderFeedIngestor",
+    "OrderFeedSourceWindow",
+    "OrderFeedTestCase",
+    "RejectedSignalOutcomeEvent",
+    "SOURCE_TYPE_EXECUTION",
+    "SOURCE_TYPE_EXECUTION_ORDER_EVENT",
+    "Session",
+    "SimpleNamespace",
+    "Strategy",
+    "TRANSFER_KIND_EXECUTION_FILL",
+    "TRANSFER_KIND_FILL_POST",
+    "TestCase",
+    "TigerBeetleReconciliationRun",
+    "TigerBeetleTransferRef",
+    "TopicPartition",
+    "TradeDecision",
+    "apply_order_event_to_execution",
+    "backfill_order_feed_events_from_executions",
+    "backfill_order_feed_source_windows",
+    "create_engine",
+    "dataclass",
+    "datetime",
+    "func",
+    "latest_order_event_for_execution",
+    "link_order_events_to_execution",
+    "merge_execution_raw_order_update",
+    "normalize_order_feed_record",
+    "order_feed_module",
+    "patch",
+    "persist_order_event",
+    "repair_order_feed_execution_links",
+    "repair_order_feed_execution_states",
+    "repair_order_feed_fill_deltas",
+    "select",
+    "settings",
+    "timedelta",
+    "timezone",
+    "uuid",
+]

--- a/services/torghut/tests/order_feed/test_order_feed_backfill_and_cursor_a.py
+++ b/services/torghut/tests/order_feed/test_order_feed_backfill_and_cursor_a.py
@@ -1,7 +1,32 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
-from tests.order_feed.support import *
+from tests.order_feed.support import (
+    ORDER_FEED_SOURCE_REVISION,
+    Decimal,
+    Execution,
+    ExecutionOrderEvent,
+    FakeConsumer,
+    FakeManualConsumer,
+    FakeRecord,
+    OrderFeedConsumerCursor,
+    OrderFeedIngestor,
+    OrderFeedSourceWindow,
+    OrderFeedTestCase,
+    Session,
+    SimpleNamespace,
+    backfill_order_feed_events_from_executions,
+    datetime,
+    func,
+    order_feed_module,
+    patch,
+    repair_order_feed_execution_links,
+    repair_order_feed_execution_states,
+    repair_order_feed_fill_deltas,
+    select,
+    settings,
+    timedelta,
+    timezone,
+)
 
 
 class TestOrderFeedBackfillAndCursorA(OrderFeedTestCase):
@@ -732,7 +757,10 @@ class TestOrderFeedBackfillAndCursorA(OrderFeedTestCase):
 
         with Session(self.engine) as session:
             with patch(
-                "app.trading.order_feed.persist_order_event",
+                (
+                    "app.trading.order_feed_modules.part_01_statements_32"
+                    ".persist_order_event"
+                ),
                 side_effect=RuntimeError("store failed"),
             ):
                 counters = ingestor.ingest_once(session)
@@ -766,7 +794,10 @@ class TestOrderFeedBackfillAndCursorA(OrderFeedTestCase):
         with Session(self.engine) as session:
             self._seed_execution(session)
             with patch(
-                "app.trading.order_feed.apply_order_event_to_execution",
+                (
+                    "app.trading.order_feed_modules.part_01_statements_32"
+                    ".apply_order_event_to_execution"
+                ),
                 side_effect=RuntimeError("apply failed"),
             ):
                 counters = ingestor.ingest_once(session)

--- a/services/torghut/tests/order_feed/test_order_feed_core.py
+++ b/services/torghut/tests/order_feed/test_order_feed_core.py
@@ -1,7 +1,40 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
-from tests.order_feed.support import *
+from tests.order_feed.support import (
+    SOURCE_TYPE_EXECUTION,
+    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    TRANSFER_KIND_EXECUTION_FILL,
+    TRANSFER_KIND_FILL_POST,
+    Decimal,
+    Execution,
+    ExecutionOrderEvent,
+    ExecutionTCAMetric,
+    FakeConsumer,
+    FakeRecord,
+    FakeTigerBeetleClient,
+    NormalizedOrderEvent,
+    OrderFeedIngestor,
+    OrderFeedSourceWindow,
+    OrderFeedTestCase,
+    RejectedSignalOutcomeEvent,
+    Session,
+    Strategy,
+    TigerBeetleReconciliationRun,
+    TigerBeetleTransferRef,
+    TradeDecision,
+    apply_order_event_to_execution,
+    datetime,
+    latest_order_event_for_execution,
+    merge_execution_raw_order_update,
+    normalize_order_feed_record,
+    order_feed_module,
+    patch,
+    persist_order_event,
+    select,
+    settings,
+    timedelta,
+    timezone,
+)
 
 
 class TestOrderFeedCore(OrderFeedTestCase):
@@ -301,7 +334,10 @@ class TestOrderFeedCore(OrderFeedTestCase):
                 default_account_label="paper",
             )
             with patch(
-                "app.trading.order_feed.reconcile_tigerbeetle_transfers",
+                (
+                    "app.trading.order_feed_modules.part_01_statements_32"
+                    ".reconcile_tigerbeetle_transfers"
+                ),
                 side_effect=RuntimeError("reconcile failed"),
             ):
                 with self.assertLogs(order_feed_module.logger, level="WARNING"):
@@ -601,7 +637,12 @@ class TestOrderFeedCore(OrderFeedTestCase):
         with Session(self.engine) as session:
             execution = self._seed_execution(session)
 
-            with patch("app.trading.order_feed.upsert_execution_tca_metric") as upsert:
+            with patch(
+                (
+                    "app.trading.order_feed_modules.part_01_statements_32"
+                    ".upsert_execution_tca_metric"
+                )
+            ) as upsert:
                 counters = ingestor.ingest_once(session)
                 session.refresh(execution)
 

--- a/services/torghut/tests/order_feed/test_order_feed_cursor_and_retries.py
+++ b/services/torghut/tests/order_feed/test_order_feed_cursor_and_retries.py
@@ -1,7 +1,30 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
-from tests.order_feed.support import *
+from tests.order_feed.support import (
+    ORDER_FEED_SOURCE_REVISION,
+    Decimal,
+    ExecutionOrderEvent,
+    FakeConsumer,
+    FakeRecord,
+    NormalizedOrderEvent,
+    OrderFeedConsumerCursor,
+    OrderFeedIngestor,
+    OrderFeedSourceWindow,
+    OrderFeedTestCase,
+    Session,
+    SimpleNamespace,
+    datetime,
+    normalize_order_feed_record,
+    order_feed_module,
+    patch,
+    persist_order_event,
+    repair_order_feed_fill_deltas,
+    select,
+    settings,
+    timedelta,
+    timezone,
+    uuid,
+)
 
 
 class TestOrderFeedCursorAndRetries(OrderFeedTestCase):
@@ -22,7 +45,10 @@ class TestOrderFeedCursorAndRetries(OrderFeedTestCase):
             first_consumer = FakeConsumer([record])
             first_ingestor = OrderFeedIngestor(consumer_factory=lambda: first_consumer)
             with patch(
-                "app.trading.order_feed.apply_order_event_to_execution",
+                (
+                    "app.trading.order_feed_modules.part_01_statements_32"
+                    ".apply_order_event_to_execution"
+                ),
                 side_effect=RuntimeError("apply failed"),
             ):
                 first_counters = first_ingestor.ingest_once(session)
@@ -241,7 +267,10 @@ class TestOrderFeedCursorAndRetries(OrderFeedTestCase):
 
         with Session(self.engine) as session:
             with patch(
-                "app.trading.order_feed.persist_order_event",
+                (
+                    "app.trading.order_feed_modules.part_01_statements_32"
+                    ".persist_order_event"
+                ),
                 side_effect=RuntimeError("store failed"),
             ):
                 counters = ingestor.ingest_once(session)

--- a/services/torghut/tests/tca_adaptive_policy/support.py
+++ b/services/torghut/tests/tca_adaptive_policy/support.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-# ruff: noqa: F401
-
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import cast
@@ -12,7 +10,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.models import Base, Execution, ExecutionTCAMetric, Strategy, TradeDecision
-from app.trading import tca as tca_module
+from app.trading import tca_modules as tca_module
 from app.trading.tca import (
     build_tca_gate_inputs,
     derive_adaptive_execution_policy,
@@ -209,4 +207,27 @@ class _TestAdaptiveExecutionPolicyDerivationBase(TestCase):
         session.commit()
 
 
-__all__ = [name for name in globals() if not name.startswith("__")]
+__all__ = [
+    "Base",
+    "Decimal",
+    "Execution",
+    "ExecutionTCAMetric",
+    "Session",
+    "Strategy",
+    "TestCase",
+    "TradeDecision",
+    "_TestAdaptiveExecutionPolicyDerivationBase",
+    "build_tca_gate_inputs",
+    "cast",
+    "create_engine",
+    "datetime",
+    "derive_adaptive_execution_policy",
+    "patch",
+    "refresh_execution_tca_metrics",
+    "select",
+    "sessionmaker",
+    "tca_module",
+    "timedelta",
+    "timezone",
+    "upsert_execution_tca_metric",
+]

--- a/services/torghut/tests/tca_adaptive_policy/test_adaptive_policy_derivation.py
+++ b/services/torghut/tests/tca_adaptive_policy/test_adaptive_policy_derivation.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
-from tests.tca_adaptive_policy.support import *
+from tests.tca_adaptive_policy.support import (
+    Decimal,
+    Execution,
+    ExecutionTCAMetric,
+    TradeDecision,
+    _TestAdaptiveExecutionPolicyDerivationBase,
+    build_tca_gate_inputs,
+    cast,
+    datetime,
+    derive_adaptive_execution_policy,
+    patch,
+    refresh_execution_tca_metrics,
+    select,
+    tca_module,
+    timezone,
+    upsert_execution_tca_metric,
+)
 
 
 class TestAdaptiveExecutionPolicyDerivationPart1(
@@ -362,7 +377,10 @@ class TestAdaptiveExecutionPolicyDerivationPart1(
                 patch.object(tca_module.settings, "tigerbeetle_journal_enabled", True),
                 patch.object(tca_module.settings, "tigerbeetle_required", False),
                 patch(
-                    "app.trading.tca.TigerBeetleLedgerJournal.journal_execution",
+                    (
+                        "app.trading.tca_modules.part_01_statements_27"
+                        ".TigerBeetleLedgerJournal.journal_execution"
+                    ),
                     side_effect=RuntimeError("journal failed"),
                 ),
             ):
@@ -383,7 +401,10 @@ class TestAdaptiveExecutionPolicyDerivationPart1(
                 patch.object(tca_module.settings, "tigerbeetle_journal_enabled", True),
                 patch.object(tca_module.settings, "tigerbeetle_required", True),
                 patch(
-                    "app.trading.tca.TigerBeetleLedgerJournal.journal_execution",
+                    (
+                        "app.trading.tca_modules.part_01_statements_27"
+                        ".TigerBeetleLedgerJournal.journal_execution"
+                    ),
                     side_effect=RuntimeError("journal failed"),
                 ),
             ):

--- a/services/torghut/tests/test_tca_adaptive_policy.py
+++ b/services/torghut/tests/test_tca_adaptive_policy.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-# ruff: noqa: F401,F403,F405
+"""Compatibility module for the split TCA adaptive policy tests."""
+
 __test__ = False
-from tests.tca_adaptive_policy.support import *
-from tests.tca_adaptive_policy.test_part_01 import *
-from tests.tca_adaptive_policy.test_part_02 import *


### PR DESCRIPTION
## Summary

- Replaced the `app.trading` root module-replacement facades for order feed, TCA, execution policy, portfolio, and strategy runtime with normal explicit export modules.
- Removed blanket root Pyright disables, `globals().update`, and `sys.modules` replacement from that trading runtime surface.
- Migrated affected order-feed and TCA tests away from root monkeypatch propagation, cleaned support exports, and renamed the adaptive-policy test away from `test_part_01.py`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && .venv/bin/python -m compileall app scripts`
- `cd services/torghut && .venv/bin/ruff format --check app tests scripts migrations`
- `cd services/torghut && .venv/bin/ruff check app tests scripts migrations`
- `cd services/torghut && .venv/bin/pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n`
- `cd services/torghut && .venv/bin/pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-file-pyright-suppression,torghut-type-ignore,torghut-file-ruff-noqa,torghut-blanket-pylint-disable,torghut-dynamic-attribute-hook,torghut-dynamic-all,torghut-wildcard-import,torghut-custom-module-class --score=n app/trading/order_feed.py app/trading/tca.py app/trading/execution_policy.py app/trading/portfolio.py app/trading/strategy_runtime.py tests/order_feed/support.py tests/order_feed/test_order_feed_core.py tests/order_feed/test_order_feed_cursor_and_retries.py tests/order_feed/test_order_feed_backfill_and_cursor_a.py tests/tca_adaptive_policy/support.py tests/tca_adaptive_policy/test_adaptive_policy_derivation.py`
- `cd services/torghut && .venv/bin/pylint app/trading/order_feed.py app/trading/tca.py app/trading/execution_policy.py app/trading/portfolio.py app/trading/strategy_runtime.py --disable=all --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks --score=n`
- `cd services/torghut && .venv/bin/pyright --project pyrightconfig.json`
- `cd services/torghut && .venv/bin/pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && .venv/bin/pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && .venv/bin/pytest tests/order_feed tests/tca_adaptive_policy tests/test_execution_tca.py tests/execution_policy tests/portfolio_sizing tests/strategy_runtime tests/test_run_local_simple_lane_replay.py tests/test_strategy_specs.py -q` (`333 passed, 1 warning`)
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
