### PR TITLE
fix(rook-ceph): allow turin osd placement

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -42,6 +42,10 @@ cephClusterSpec:
   # Keep talos-192-168-1-194 as control-plane only (mon node, no OSDs).
   placement:
     mon:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
@@ -52,6 +56,18 @@ cephClusterSpec:
                     - talos-192-168-1-85
                     - talos-192-168-1-194
                     - turin
+    # Turin is a control-plane node with local OSD disks, so Rook needs the
+    # same taint tolerance for both the prepare job and the OSD daemons.
+    prepareosd:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+    osd:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
 
   mgr:
     count: 2


### PR DESCRIPTION
## Summary

- Adds control-plane taint tolerations for Rook monitor, OSD prepare, and OSD daemon placement.
- Allows Rook to schedule the `rook-ceph-osd-prepare-turin` job and replacement OSD daemons on the `turin` control-plane node.
- Keeps storage scoped to the existing explicit by-id devices; no broad device discovery is enabled.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file("argocd/applications/rook-ceph/cluster-values.yaml"); puts "cluster-values yaml ok"'`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-rendered-placement.yaml`
- `ruby -e 'require "yaml"; YAML.load_stream(File.read("/tmp/rook-ceph-rendered-placement.yaml")); puts "render ok"'`
- `git diff --check`
- `bun run lint:argocd`
- Live validation: rendered `CephCluster` placement was applied to unblock the already-approved Turin OSD migration.
- Live validation: Rook created `rook-ceph-osd-prepare-turin` on node `turin`, and new `rook-ceph-osd-0`, `rook-ceph-osd-1`, and `rook-ceph-osd-2` pods are running on `turin`.
- Live validation: `ceph osd tree` shows OSDs `0`, `1`, and `2` under `turin`, OSDs `3`, `4`, and `5` under `talos-192-168-1-85`, and the empty old `talos-192-168-1-203` CRUSH bucket was removed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This makes the previously merged Turin OSD replacement configuration schedulable on the tainted control-plane node.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
