### PR TITLE
fix(nvidia): enable turin device plugin

### DIFF
--- a/argocd/applications/nvidia-gpu-operator/values.yaml
+++ b/argocd/applications/nvidia-gpu-operator/values.yaml
@@ -10,6 +10,15 @@ operator:
   # Talos uses containerd.
   defaultRuntime: containerd
 
+daemonsets:
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+
 # Do not attempt to install host NVIDIA drivers/toolkit on Talos.
 driver:
   enabled: false
@@ -17,8 +26,12 @@ driver:
 toolkit:
   enabled: false
 
-# No container workloads use the GPU on the host.
+# Turin uses Talos NVIDIA system extensions for the host driver/toolkit. The
+# device plugin only advertises that already-loaded GPU to Kubernetes.
 devicePlugin:
+  enabled: true
+
+migManager:
   enabled: false
 
 # This image is amd64-only; disable it on arm64 nodes.


### PR DESCRIPTION
## Summary

- Enables the NVIDIA device plugin in the GPU Operator values so Turin can advertise the Talos-provided NVIDIA GPU to Kubernetes.
- Keeps GPU Operator host driver and toolkit installation disabled because Talos owns those pieces through system extensions.
- Adds the control-plane taint toleration to GPU Operator daemonsets so the device-plugin path can run on Turin.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file("argocd/applications/nvidia-gpu-operator/values.yaml"); puts "nvidia values yaml ok"'`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/nvidia-gpu-operator >/tmp/nvidia-gpu-operator-rendered.yaml`
- Rendered ClusterPolicy inspection confirmed `driver.enabled=false`, `toolkit.enabled=false`, `devicePlugin.enabled=true`, `migManager.enabled=false`, and daemonset tolerations for `nvidia.com/gpu` and `node-role.kubernetes.io/control-plane`.
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This enables Kubernetes device-plugin advertisement for nodes labeled by the NVIDIA GPU Operator while keeping Talos-owned driver/toolkit installation disabled.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
