### PR TITLE
fix(nvidia): correct turin cdi roots

### DIFF
--- a/argocd/applications/nvidia-gpu-operator/turin-nvidia-device-plugin.yaml
+++ b/argocd/applications/nvidia-gpu-operator/turin-nvidia-device-plugin.yaml
@@ -64,6 +64,9 @@ spec:
         - name: nvidia-device-plugin
           image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
           imagePullPolicy: IfNotPresent
+          args:
+            - --nvidia-driver-root=/
+            - --nvidia-dev-root=/
           env:
             - name: PASS_DEVICE_SPECS
               value: "true"
@@ -77,8 +80,8 @@ spec:
               value: all
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: all
-            - name: NVIDIA_DRIVER_ROOT
-              value: /usr/local
+            - name: NVIDIA_DEV_ROOT
+              value: /
             - name: MIG_STRATEGY
               value: single
             - name: CDI_ENABLED


### PR DESCRIPTION
## Summary

- Corrects the Turin standalone NVIDIA device-plugin CDI roots so host device paths resolve under `/dev`.
- Keeps the Talos NVIDIA userspace discovery working through the mounted host root at `/driver-root`.
- Preserves the scoped Turin-only device plugin added in the prior PR.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file("argocd/applications/nvidia-gpu-operator/turin-nvidia-device-plugin.yaml"); puts "turin nvidia device plugin yaml ok"'`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/nvidia-gpu-operator >/tmp/nvidia-gpu-operator-cdi-root-rendered.yaml`
- Rendered daemonset inspection confirmed `--nvidia-driver-root=/`, `--nvidia-dev-root=/`, and `NVIDIA_DEV_ROOT=/`.
- `git diff --check`
- `bun run lint:argocd`
- Live smoke test passed on Turin: `nvidia-smi -L` reported `NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
