### PR TITLE
feat(flamingo): add turin blackwell model serving

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -1,0 +1,154 @@
+# Flamingo
+
+`flamingo` is the Blackwell model-serving application for coding agents. It is a
+normal Kubernetes GPU workload, not a KubeVirt VM.
+
+## Runtime
+
+- Node: `turin`
+- GPU: `NVIDIA RTX PRO 6000 Blackwell Max-Q`, advertised as `nvidia.com/gpu: 1`
+- RuntimeClass: `nvidia`
+- Server: `vllm/vllm-openai:v0.23.0-x86_64-cu129`
+- Image digest: `sha256:871762282db5bc464b5a3f0a59e41207ef25c2d95edf5f701e57a6bfc27b9496`
+- Primary model: `Qwen/Qwen3-Coder-Next-FP8`
+- Served model name: `qwen3-coder-flamingo`
+- Internal URL: `http://flamingo.flamingo.svc.cluster.local/v1`
+- Tailnet URL: `http://flamingo.ide-newton.ts.net/v1`
+
+`Qwen/Qwen3-Coder-30B-A3B-Instruct` is the fallback only if the FP8 Next model
+fails Blackwell image compatibility, OOMs at 32K context, or fails tool-call
+smoke tests.
+
+## Rollout Gates
+
+Run the KubeVirt/Talos checks separately. Flamingo does not require Talos
+reinstall, node reboot, VFIO rebinding, or GPU passthrough.
+
+Before syncing this app:
+
+```bash
+kubectl get runtimeclass nvidia nvidia-cdi nvidia-legacy
+kubectl get node turin -o json | jq '.status.allocatable["nvidia.com/gpu"], .metadata.labels["nvidia.com/gpu.product"]'
+kubectl describe node turin | sed -n '/Allocated resources:/,/Events:/p'
+```
+
+Expected:
+
+- `nvidia.com/gpu` allocatable is `1`.
+- Current allocated `nvidia.com/gpu` is `0`.
+- Product label is the Blackwell RTX PRO 6000 variant.
+
+Render before sync:
+
+```bash
+kustomize build argocd/applications/flamingo
+```
+
+After sync:
+
+```bash
+kubectl -n flamingo rollout status deploy/flamingo --timeout=4h
+kubectl -n flamingo get pod -o wide
+kubectl describe node turin | sed -n '/Allocated resources:/,/Events:/p'
+```
+
+Expected:
+
+- The `flamingo` pod runs on `turin`.
+- Node allocation shows `nvidia.com/gpu: 1`.
+- No other workload consumes the GPU.
+
+## Smoke Tests
+
+Cluster-local:
+
+```bash
+kubectl -n flamingo run flamingo-smoke \
+  --rm -i --restart=Never \
+  --image=curlimages/curl:8.11.1 \
+  --command -- sh -c '
+    curl -fsS http://flamingo.flamingo.svc.cluster.local/v1/models &&
+    curl -fsS http://flamingo.flamingo.svc.cluster.local/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d "{\"model\":\"qwen3-coder-flamingo\",\"messages\":[{\"role\":\"user\",\"content\":\"Return only the word ready.\"}],\"max_tokens\":8}"
+  '
+```
+
+Tailnet:
+
+```bash
+curl -fsS http://flamingo.ide-newton.ts.net/v1/models
+```
+
+Tool-call smoke:
+
+```bash
+curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen3-coder-flamingo",
+    "messages": [{"role": "user", "content": "Call get_repo_status for lab."}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_repo_status",
+        "description": "Return repository status.",
+        "parameters": {
+          "type": "object",
+          "properties": {"repo": {"type": "string"}},
+          "required": ["repo"]
+        }
+      }
+    }],
+    "tool_choice": "auto",
+    "max_tokens": 128
+  }' | jq '.choices[0].message.tool_calls'
+```
+
+Expected: `tool_calls` is a non-empty array and the function argument includes
+`"repo": "lab"`.
+
+## Optimization Rounds
+
+Record each run with the vLLM image digest, model revision, flags, concurrency,
+prompt/output token counts, TTFT, output tokens per second, peak GPU memory, GPU
+power draw, and any OOM or parser failures.
+
+Round 0: baseline smoke.
+
+```bash
+kubectl -n flamingo logs deploy/flamingo --tail=200
+kubectl -n flamingo exec deploy/flamingo -- nvidia-smi
+```
+
+Round 1: Qwen3-Coder-Next-FP8 at 32K context.
+
+Use the deployed flags:
+
+```text
+--max-model-len 32768 --gpu-memory-utilization 0.80 --enable-prefix-caching --tool-call-parser qwen3_coder
+```
+
+Round 2: increase utilization and context only after Round 1 is stable.
+
+Patch one flag at a time in Git:
+
+```text
+--gpu-memory-utilization 0.84
+--gpu-memory-utilization 0.88
+--max-model-len 65536
+```
+
+Do not combine utilization and context increases in one rollout.
+
+Round 3: MoE tuning.
+
+Only run this if vLLM logs indicate default MoE configuration or poor MoE
+throughput. Save generated configs outside Git unless they are proven stable,
+then mount them with `VLLM_TUNED_CONFIG_FOLDER`.
+
+Round 4: fallback comparison.
+
+Switch the model to `Qwen/Qwen3-Coder-30B-A3B-Instruct`, keep the served name
+`qwen3-coder-flamingo`, and repeat the same benchmark set. Keep Next-FP8 unless
+30B-A3B is materially more stable or faster for coding-agent tool workloads.

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flamingo
+  namespace: flamingo
+  labels:
+    app.kubernetes.io/name: flamingo
+    app.kubernetes.io/component: model-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flamingo
+      app.kubernetes.io/component: model-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: flamingo
+        app.kubernetes.io/component: model-server
+    spec:
+      runtimeClassName: nvidia
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/hostname: turin
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:v0.23.0-x86_64-cu129@sha256:871762282db5bc464b5a3f0a59e41207ef25c2d95edf5f701e57a6bfc27b9496
+          imagePullPolicy: IfNotPresent
+          args:
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --model
+            - Qwen/Qwen3-Coder-Next-FP8
+            - --served-model-name
+            - qwen3-coder-flamingo
+            - --max-model-len
+            - "32768"
+            - --gpu-memory-utilization
+            - "0.80"
+            - --enable-prefix-caching
+            - --enable-auto-tool-choice
+            - --tool-call-parser
+            - qwen3_coder
+          env:
+            - name: HF_HOME
+              value: /models/huggingface
+            - name: VLLM_CACHE_ROOT
+              value: /models/vllm
+            - name: VLLM_LOGGING_LEVEL
+              value: INFO
+          ports:
+            - name: http
+              containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 240
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 4
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: "16"
+              memory: 128Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "64"
+              memory: 256Gi
+              nvidia.com/gpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: model-cache
+              mountPath: /models
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: flamingo-model-cache
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi

--- a/argocd/applications/flamingo/kustomization.yaml
+++ b/argocd/applications/flamingo/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - tailscale-service.yaml

--- a/argocd/applications/flamingo/pvc.yaml
+++ b/argocd/applications/flamingo/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flamingo-model-cache
+  namespace: flamingo
+  labels:
+    app.kubernetes.io/name: flamingo
+    app.kubernetes.io/component: model-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: rook-ceph-block
+  resources:
+    requests:
+      storage: 256Gi

--- a/argocd/applications/flamingo/service.yaml
+++ b/argocd/applications/flamingo/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flamingo
+  namespace: flamingo
+  labels:
+    app.kubernetes.io/name: flamingo
+spec:
+  selector:
+    app.kubernetes.io/name: flamingo
+    app.kubernetes.io/component: model-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applications/flamingo/tailscale-service.yaml
+++ b/argocd/applications/flamingo/tailscale-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flamingo-tailscale
+  namespace: flamingo
+  annotations:
+    argocd.argoproj.io/ignore-healthcheck: "true"
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: flamingo
+  labels:
+    app.kubernetes.io/name: flamingo
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: flamingo
+    app.kubernetes.io/component: model-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applications/kubevirt/kustomization.yaml
+++ b/argocd/applications/kubevirt/kustomization.yaml
@@ -27,6 +27,14 @@ patches:
           argocd.argoproj.io/sync-wave: "1"
           argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       spec:
+        infra:
+          nodePlacement:
+            tolerations:
+              # Turin is a control-plane node. This only lets KubeVirt's infra
+              # DaemonSets run there; individual VM placement stays explicit.
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+                effect: NoSchedule
         configuration:
           developerConfiguration:
             featureGates:

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -132,6 +132,18 @@ spec:
                     pod-security.kubernetes.io/enforce: privileged
                     pod-security.kubernetes.io/audit: privileged
                     pod-security.kubernetes.io/warn: privileged
+              - name: flamingo
+                path: argocd/applications/flamingo
+                namespace: flamingo
+                annotations:
+                  argocd.argoproj.io/sync-wave: "2"
+                automation: manual
+                enabled: "true"
+                managedNamespaceMetadata:
+                  labels:
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
               - name: saigak
                 path: argocd/applications/saigak
                 namespace: saigak

--- a/devices/turin/README.md
+++ b/devices/turin/README.md
@@ -29,6 +29,7 @@ Docs:
 - `devices/turin/docs/cluster-join-plan.md` (join + Ceph OSD migration plan)
 - `devices/turin/docs/bmc-fan-bringup.md` (BMC and fan alert notes)
 - `devices/turin/docs/nvidia-gpu-on-talos.md` (NVIDIA driver/runtime plan)
+- `devices/turin/docs/kubevirt-on-turin.md` (KubeVirt runtime and canary checks)
 - `devices/turin/docs/ceph-recreate-three-osds.md` (destructive no-Kingston OSD recreate runbook)
 - `devices/turin/docs/rook-ceph-turin-recreate-osds-values-draft.yaml` (draft-only Rook storage node snippet; not an Argo input)
 

--- a/devices/turin/docs/kubevirt-on-turin.md
+++ b/devices/turin/docs/kubevirt-on-turin.md
@@ -1,0 +1,131 @@
+# KubeVirt On Turin
+
+Turin can host ordinary KubeVirt VMs after KubeVirt infra pods are scheduled on
+the node. This is separate from NVIDIA GPU passthrough.
+
+## Current Boundary
+
+Plain VMs require:
+
+- CPU virtualization exposed by the host (`svm` on AMD).
+- `/dev/kvm`.
+- `/dev/vhost-net`.
+- `/dev/net/tun`.
+- `virt-handler` running on the node.
+
+The live Turin readback already showed the host prerequisites. The GitOps change
+for plain VMs is to let KubeVirt infrastructure tolerate Turin's control-plane
+taint:
+
+```yaml
+spec:
+  infra:
+    nodePlacement:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+```
+
+Do not add broad workload placement. VMs that should run on Turin must opt in
+with their own `nodeSelector` and toleration.
+
+## Pre-Sync Checks
+
+```bash
+talosctl -n 100.100.244.171 read /proc/cpuinfo | rg -m 1 'svm|vmx'
+talosctl -n 100.100.244.171 ls /dev | rg 'kvm|vhost-net|vhost-vsock'
+talosctl -n 100.100.244.171 ls /dev/net | rg '^100.100.244.171 +tun$'
+kubectl get node turin -o json | jq '.spec.taints, .metadata.labels["kubevirt.io/schedulable"]'
+kubectl -n kubevirt get ds virt-handler -o json | jq '.spec.template.spec.tolerations'
+```
+
+Expected before the KubeVirt patch is synced:
+
+- KVM, vhost, and tun are present.
+- Turin has the `node-role.kubernetes.io/control-plane=NoSchedule` taint.
+- `virt-handler` does not yet run on Turin.
+
+## Post-Sync Checks
+
+```bash
+kubectl -n kubevirt rollout status ds/virt-handler --timeout=10m
+kubectl -n kubevirt get pod -o wide | rg 'virt-handler|turin'
+kubectl get node turin -o json | jq -r '.metadata.labels["kubevirt.io/schedulable"]'
+kubectl get vms,vmis --all-namespaces -o wide
+```
+
+Expected:
+
+- A `virt-handler` pod runs on Turin.
+- Turin is labeled `kubevirt.io/schedulable=true`.
+- Existing `saigak` and `openclaw` VMs stay Running on their current nodes.
+
+## Temporary Non-GPU Canary
+
+Use a canary VMI that requests no GPU, no PVC, and no host devices. Delete it
+immediately after the scheduling and boot check.
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: turin-kubevirt-canary
+  namespace: kubevirt
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: turin
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+  domain:
+    devices:
+      disks:
+        - name: containerdisk
+          disk:
+            bus: virtio
+        - name: cloudinitdisk
+          disk:
+            bus: virtio
+    resources:
+      requests:
+        memory: 512Mi
+  volumes:
+    - name: containerdisk
+      containerDisk:
+        image: quay.io/kubevirt/cirros-container-disk-demo
+    - name: cloudinitdisk
+      cloudInitNoCloud:
+        userData: |-
+          #cloud-config
+          password: turin
+          chpasswd: { expire: False }
+```
+
+Apply and clean up:
+
+```bash
+kubectl apply -f /tmp/turin-kubevirt-canary.yaml
+kubectl -n kubevirt wait vmi/turin-kubevirt-canary --for=condition=Ready --timeout=5m
+kubectl -n kubevirt get vmi turin-kubevirt-canary -o wide
+kubectl -n kubevirt delete vmi turin-kubevirt-canary --wait=true
+```
+
+## GPU Passthrough Is A Separate Project
+
+Do not mix GPU passthrough with the Flamingo Kubernetes GPU pod lane.
+
+GPU passthrough VMs would require a separate plan:
+
+- Confirm IOMMU groups and boot arguments such as `amd_iommu=on` if needed.
+- Add Talos VFIO module preload, following the `devices/altra` pattern:
+  `vfio`, `vfio_iommu_type1`, `vfio_pci`, and `irqbypass`.
+- Switch the target GPU away from the host NVIDIA driver path.
+- Configure NVIDIA GPU Operator sandbox workload mode and VFIO manager.
+- Add a Turin-specific KubeVirt `permittedHostDevices` entry for the Blackwell
+  PCI ID.
+- Stop container GPU workloads before rebinding the device.
+
+That would make the GPU unavailable to normal Kubernetes pods, so it is not part
+of Flamingo.

--- a/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
+++ b/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
@@ -1,0 +1,150 @@
+# Saigak To Flamingo GPU Pod Migration
+
+This runbook migrates completion traffic from the `saigak` KubeVirt VM to the
+`flamingo` Kubernetes GPU pod. It does not migrate embeddings.
+
+## Current Roles
+
+`saigak` is a KubeVirt `VirtualMachine` pinned to `talos-192-168-1-85`. It serves
+Ollama on port `11434` and backs several existing consumers.
+
+`flamingo` is a normal Kubernetes Deployment pinned to Turin's Blackwell GPU. It
+serves a vLLM OpenAI-compatible API on:
+
+```text
+http://flamingo.flamingo.svc.cluster.local/v1
+http://flamingo.ide-newton.ts.net/v1
+```
+
+The first served model name is:
+
+```text
+qwen3-coder-flamingo
+```
+
+## Do Not Move Embeddings Yet
+
+Keep embedding traffic on `saigak` until a separate embedding migration handles
+model choice, dimensions, index rebuilds, and database compatibility.
+
+Keep these values unchanged during this migration:
+
+```text
+OPENAI_EMBEDDING_API_BASE_URL=http://saigak.saigak.svc.cluster.local:11434/v1
+OPENAI_EMBEDDING_MODEL=qwen3-embedding-saigak:8b
+```
+
+## Completion Migration Order
+
+Move one consumer at a time, starting with the lowest-risk host-side harness.
+
+1. Host-side pi harness.
+2. Agents service canary.
+3. Bumba completion traffic.
+4. Jangar/OpenWebUI completion traffic.
+5. Torghut or other production workflows only after benchmark and tool-call
+   evidence is stable.
+
+Do not migrate multiple consumers in the same commit or rollout.
+
+## Host-Side Pi Harness
+
+Configure the harness to use:
+
+```text
+OPENAI_API_BASE_URL=http://flamingo.ide-newton.ts.net/v1
+OPENAI_COMPLETION_MODEL=qwen3-coder-flamingo
+```
+
+If the harness has a separate API key setting, use a local dummy value unless the
+client refuses empty keys:
+
+```text
+OPENAI_API_KEY=flamingo-local
+```
+
+Smoke:
+
+```bash
+curl -fsS http://flamingo.ide-newton.ts.net/v1/models
+curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"qwen3-coder-flamingo","messages":[{"role":"user","content":"Return only ready."}],"max_tokens":8}'
+```
+
+## In-Cluster Consumers
+
+Use the ClusterIP URL:
+
+```text
+OPENAI_API_BASE_URL=http://flamingo.flamingo.svc.cluster.local/v1
+OPENAI_COMPLETION_MODEL=qwen3-coder-flamingo
+```
+
+Keep embedding variables pointed at `saigak`.
+
+For apps that use one base URL for both completions and embeddings, first split
+completion and embedding configuration in that app. Do not point embedding calls
+at Flamingo until the embedding migration exists.
+
+## Rollback Values
+
+Rollback completion traffic to `saigak` with:
+
+```text
+OPENAI_API_BASE_URL=http://saigak.saigak.svc.cluster.local:11434/v1
+OPENAI_COMPLETION_MODEL=qwen3-main-saigak:30b-a3b
+```
+
+Keep embedding rollback values as:
+
+```text
+OPENAI_EMBEDDING_API_BASE_URL=http://saigak.saigak.svc.cluster.local:11434/v1
+OPENAI_EMBEDDING_MODEL=qwen3-embedding-saigak:8b
+```
+
+Rollback criteria:
+
+- Flamingo pod restarts repeatedly.
+- `/v1/models` or `/v1/chat/completions` fails.
+- Tool-call responses are not parseable by the consumer.
+- GPU memory, power, or thermal behavior is unstable under expected concurrency.
+- Completion latency regresses enough to block agent workflows.
+
+## Validation Per Consumer
+
+For each migrated consumer, record:
+
+- Commit or config change.
+- Base URL and model name.
+- Prompt used for smoke.
+- Whether tool calls parsed successfully.
+- First-token latency and end-to-end latency.
+- Any rollback command used.
+
+For Kubernetes consumers:
+
+```bash
+kubectl -n <namespace> rollout status deploy/<deployment> --timeout=10m
+kubectl -n <namespace> logs deploy/<deployment> --tail=200 | rg -i 'flamingo|qwen3-coder|error|tool'
+```
+
+For host-side consumers:
+
+```bash
+curl -fsS http://flamingo.ide-newton.ts.net/v1/models
+```
+
+## Saigak Decommission Criteria
+
+Do not decommission `saigak` until all of these are true:
+
+- No completion consumer depends on `qwen3-main-saigak:30b-a3b`.
+- Embeddings have a separately validated replacement or embeddings explicitly
+  remain on a smaller dedicated service.
+- OpenWebUI, Jangar, Bumba, Agents, Torghut, and Synthesis configs have been
+  audited.
+- `saigak` PVC contents have been backed up or declared disposable.
+- A rollback window has passed with Flamingo stable under normal agent load.
+
+Until then, keep `saigak` running as the rollback and embedding service.

--- a/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
+++ b/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
@@ -1,0 +1,116 @@
+# Turin KubeVirt And Flamingo Blackwell Serving Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable ordinary KubeVirt VM scheduling on Turin and add `flamingo`, a Kubernetes GPU pod app for Blackwell-backed coding-agent model serving.
+
+**Architecture:** KubeVirt gets only the infra placement change needed for `virt-handler` to run on Turin's control-plane-tainted node. Flamingo is a separate Argo CD application pinned to Turin's NVIDIA RuntimeClass and single Blackwell GPU, exposed through an OpenAI-compatible vLLM endpoint for host-side and future in-cluster agents.
+
+**Tech Stack:** Argo CD ApplicationSet, Kustomize, KubeVirt `v1.8.2`, Talos `v1.13.4`, NVIDIA GPU Operator runtime classes, vLLM OpenAI server, Qwen3-Coder-Next-FP8, Tailscale LoadBalancer services.
+
+---
+
+## Boundaries
+
+- Do not reboot Turin.
+- Do not reinstall or patch live Talos machine config.
+- Do not modify Ceph storage topology.
+- Do not switch Turin into GPU passthrough mode.
+- Do not migrate embeddings away from `saigak` in this change.
+- Do not repurpose the existing `saigak` KubeVirt VM for the Blackwell card.
+
+## Files
+
+- Modify: `argocd/applications/kubevirt/kustomization.yaml`
+- Modify: `argocd/applicationsets/platform.yaml`
+- Create: `argocd/applications/flamingo/kustomization.yaml`
+- Create: `argocd/applications/flamingo/deployment.yaml`
+- Create: `argocd/applications/flamingo/service.yaml`
+- Create: `argocd/applications/flamingo/tailscale-service.yaml`
+- Create: `argocd/applications/flamingo/pvc.yaml`
+- Create: `argocd/applications/flamingo/README.md`
+- Create: `devices/turin/docs/kubevirt-on-turin.md`
+- Modify: `devices/turin/README.md`
+- Create: `docs/jangar/saigak-to-flamingo-gpu-pod-migration.md`
+
+### Task 1: Save The Plan
+
+- [x] **Step 1: Add this implementation plan under `docs/superpowers/plans/`.**
+
+### Task 2: Enable KubeVirt Infra Scheduling On Turin
+
+- [x] **Step 1: Patch `KubeVirt.spec.infra.nodePlacement.tolerations`.**
+
+Only `virt-handler` placement changes. Do not add global workload node placement and do not change `permittedHostDevices`.
+
+Expected rendered KubeVirt spec includes:
+
+```yaml
+spec:
+  infra:
+    nodePlacement:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+```
+
+- [ ] **Step 2: After GitOps sync, verify `virt-handler` on Turin.**
+
+```bash
+kubectl -n kubevirt rollout status ds/virt-handler --timeout=10m
+kubectl -n kubevirt get pod -o wide | rg 'virt-handler|turin'
+kubectl get node turin -o json | jq -r '.metadata.labels["kubevirt.io/schedulable"]'
+```
+
+Expected: a `virt-handler` pod runs on `turin` and the node label is `true`.
+
+- [ ] **Step 3: Run a temporary non-GPU VMI canary pinned to Turin, then delete it.**
+
+The canary must not request GPUs, PVCs, or host devices.
+
+### Task 3: Add Flamingo
+
+- [x] **Step 1: Create the Argo CD app directory.**
+
+The app pins a vLLM Deployment to Turin, requests exactly one GPU, mounts persistent cache storage, and exposes an OpenAI-compatible endpoint.
+
+- [x] **Step 2: Register `flamingo` in the platform ApplicationSet.**
+
+The app is manual sync, wave `2`, and uses managed namespace metadata with privileged Pod Security labels for NVIDIA runtime compatibility.
+
+### Task 4: Document Migration And Operations
+
+- [x] **Step 1: Add the Turin KubeVirt runtime checklist.**
+
+Document that plain VM scheduling needs KVM, vhost, tun, and `virt-handler`, while GPU passthrough is a separate VFIO/IOMMU project.
+
+- [x] **Step 2: Add the Saigak-to-Flamingo migration runbook.**
+
+Document completion-only migration, rollback env values, validation order, and decommission criteria.
+
+### Task 5: Validate
+
+- [x] **Step 1: Render KubeVirt.**
+
+```bash
+kustomize build argocd/applications/kubevirt
+```
+
+Expected: render succeeds and includes `infra.nodePlacement.tolerations`.
+
+- [x] **Step 2: Render Flamingo.**
+
+```bash
+kustomize build argocd/applications/flamingo
+```
+
+Expected: render succeeds and includes the pinned vLLM image, GPU limit, Turin node selector, and Tailscale service.
+
+- [x] **Step 3: Render the platform ApplicationSet.**
+
+```bash
+bun run lint:argocd
+```
+
+Expected: Argo lint passes for the changed app set and applications.


### PR DESCRIPTION
## Summary

- Adds the `flamingo` Argo CD application for Turin Blackwell GPU model serving with vLLM, Qwen3-Coder-Next-FP8, pinned image digest, GPU scheduling, PVC cache, ClusterIP service, and Tailscale service.
- Allows KubeVirt infrastructure pods to tolerate Turin's control-plane taint so ordinary VMs can be scheduled there explicitly.
- Documents Turin KubeVirt runtime checks, the temporary non-GPU canary, Flamingo optimization rounds, and the completion-only Saigak migration path.

## Related Issues

None

## Testing

- `git diff --check`
- `kustomize build argocd/applications/flamingo`
- `kustomize build argocd/applications/kubevirt`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
