### PR TITLE
fix(kubevirt): target virt-handler on turin

### DIFF
--- a/argocd/applications/kubevirt/kustomization.yaml
+++ b/argocd/applications/kubevirt/kustomization.yaml
@@ -27,14 +27,21 @@ patches:
           argocd.argoproj.io/sync-wave: "1"
           argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       spec:
-        infra:
-          nodePlacement:
-            tolerations:
-              # Turin is a control-plane node. This only lets KubeVirt's infra
-              # DaemonSets run there; individual VM placement stays explicit.
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-                effect: NoSchedule
+        customizeComponents:
+          patches:
+            - resourceType: DaemonSet
+              resourceName: virt-handler
+              type: strategic
+              patch: |-
+                spec:
+                  template:
+                    spec:
+                      tolerations:
+                        - key: CriticalAddonsOnly
+                          operator: Exists
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: Exists
+                          effect: NoSchedule
         configuration:
           developerConfiguration:
             featureGates:

--- a/devices/turin/docs/kubevirt-on-turin.md
+++ b/devices/turin/docs/kubevirt-on-turin.md
@@ -14,21 +14,30 @@ Plain VMs require:
 - `virt-handler` running on the node.
 
 The live Turin readback already showed the host prerequisites. The GitOps change
-for plain VMs is to let KubeVirt infrastructure tolerate Turin's control-plane
-taint:
+for plain VMs is a KubeVirt component customization that lets only
+`virt-handler` tolerate Turin's control-plane taint:
 
 ```yaml
 spec:
-  infra:
-    nodePlacement:
-      tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule
+  customizeComponents:
+    patches:
+      - resourceType: DaemonSet
+        resourceName: virt-handler
+        type: strategic
+        patch: |-
+          spec:
+            template:
+              spec:
+                tolerations:
+                  - key: CriticalAddonsOnly
+                    operator: Exists
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                    effect: NoSchedule
 ```
 
-Do not add broad workload placement. VMs that should run on Turin must opt in
-with their own `nodeSelector` and toleration.
+Do not add broad KubeVirt workload placement. VMs that should run on Turin must
+opt in with their own `nodeSelector` and toleration.
 
 ## Pre-Sync Checks
 

--- a/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
+++ b/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
@@ -4,7 +4,7 @@
 
 **Goal:** Enable ordinary KubeVirt VM scheduling on Turin and add `flamingo`, a Kubernetes GPU pod app for Blackwell-backed coding-agent model serving.
 
-**Architecture:** KubeVirt gets only the infra placement change needed for `virt-handler` to run on Turin's control-plane-tainted node. Flamingo is a separate Argo CD application pinned to Turin's NVIDIA RuntimeClass and single Blackwell GPU, exposed through an OpenAI-compatible vLLM endpoint for host-side and future in-cluster agents.
+**Architecture:** KubeVirt gets only the component customization needed for `virt-handler` to run on Turin's control-plane-tainted node. Flamingo is a separate Argo CD application pinned to Turin's NVIDIA RuntimeClass and single Blackwell GPU, exposed through an OpenAI-compatible vLLM endpoint for host-side and future in-cluster agents.
 
 **Tech Stack:** Argo CD ApplicationSet, Kustomize, KubeVirt `v1.8.2`, Talos `v1.13.4`, NVIDIA GPU Operator runtime classes, vLLM OpenAI server, Qwen3-Coder-Next-FP8, Tailscale LoadBalancer services.
 
@@ -39,7 +39,7 @@
 
 ### Task 2: Enable KubeVirt Infra Scheduling On Turin
 
-- [x] **Step 1: Patch `KubeVirt.spec.infra.nodePlacement.tolerations`.**
+- [x] **Step 1: Patch `virt-handler` tolerations through `KubeVirt.spec.customizeComponents.patches`.**
 
 Only `virt-handler` placement changes. Do not add global workload node placement and do not change `permittedHostDevices`.
 
@@ -47,12 +47,21 @@ Expected rendered KubeVirt spec includes:
 
 ```yaml
 spec:
-  infra:
-    nodePlacement:
-      tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule
+  customizeComponents:
+    patches:
+      - resourceType: DaemonSet
+        resourceName: virt-handler
+        type: strategic
+        patch: |-
+          spec:
+            template:
+              spec:
+                tolerations:
+                  - key: CriticalAddonsOnly
+                    operator: Exists
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                    effect: NoSchedule
 ```
 
 - [ ] **Step 2: After GitOps sync, verify `virt-handler` on Turin.**


### PR DESCRIPTION
## Summary

- Replaces the ineffective KubeVirt infra node placement change with a `customizeComponents` strategic patch for the `virt-handler` DaemonSet.
- Preserves the existing `CriticalAddonsOnly` toleration and adds Turin's control-plane taint toleration only to `virt-handler`.
- Updates the Turin KubeVirt runbook and saved implementation plan to match the supported KubeVirt customization path.

## Related Issues

None

## Testing

- `git diff --check`
- `kustomize build argocd/applications/kubevirt`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
