### PR TITLE
fix(kubevirt): encode virt-handler patch as json

### DIFF
--- a/argocd/applications/kubevirt/kustomization.yaml
+++ b/argocd/applications/kubevirt/kustomization.yaml
@@ -32,16 +32,7 @@ patches:
             - resourceType: DaemonSet
               resourceName: virt-handler
               type: strategic
-              patch: |-
-                spec:
-                  template:
-                    spec:
-                      tolerations:
-                        - key: CriticalAddonsOnly
-                          operator: Exists
-                        - key: node-role.kubernetes.io/control-plane
-                          operator: Exists
-                          effect: NoSchedule
+              patch: '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly","operator":"Exists"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
         configuration:
           developerConfiguration:
             featureGates:

--- a/devices/turin/docs/kubevirt-on-turin.md
+++ b/devices/turin/docs/kubevirt-on-turin.md
@@ -24,20 +24,14 @@ spec:
       - resourceType: DaemonSet
         resourceName: virt-handler
         type: strategic
-        patch: |-
-          spec:
-            template:
-              spec:
-                tolerations:
-                  - key: CriticalAddonsOnly
-                    operator: Exists
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-                    effect: NoSchedule
+        patch: '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly","operator":"Exists"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
 ```
 
 Do not add broad KubeVirt workload placement. VMs that should run on Turin must
 opt in with their own `nodeSelector` and toleration.
+
+KubeVirt validates `customizeComponents.patches[].patch` as JSON even when the
+patch type is `strategic`. Do not use YAML block syntax for this field.
 
 ## Pre-Sync Checks
 

--- a/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
+++ b/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
@@ -52,16 +52,7 @@ spec:
       - resourceType: DaemonSet
         resourceName: virt-handler
         type: strategic
-        patch: |-
-          spec:
-            template:
-              spec:
-                tolerations:
-                  - key: CriticalAddonsOnly
-                    operator: Exists
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-                    effect: NoSchedule
+        patch: '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly","operator":"Exists"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
 ```
 
 - [ ] **Step 2: After GitOps sync, verify `virt-handler` on Turin.**


### PR DESCRIPTION
## Summary

- Encodes the KubeVirt `virt-handler` customization patch as JSON, which the KubeVirt admission webhook requires even for strategic patches.
- Keeps the Turin control-plane toleration scoped to the `virt-handler` DaemonSet.
- Updates the Turin KubeVirt runbook and saved implementation plan with the accepted patch format.

## Related Issues

None

## Testing

- `git diff --check`
- `kustomize build argocd/applications/kubevirt`
- `kubectl apply --server-side --force-conflicts --dry-run=server -f /tmp/kubevirt-render3.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
