### PR TITLE
docs(turin): fix kubevirt canary architecture

### DIFF
--- a/devices/turin/docs/kubevirt-on-turin.md
+++ b/devices/turin/docs/kubevirt-on-turin.md
@@ -66,7 +66,9 @@ Expected:
 
 ## Temporary Non-GPU Canary
 
-Use a canary VMI that requests no GPU, no PVC, and no host devices. Delete it
+Use a canary VMI that requests no GPU, no PVC, and no host devices. Set
+`architecture: amd64`; otherwise KubeVirt can default the guest architecture from
+existing components and leave the launcher pod unschedulable on Turin. Delete it
 immediately after the scheduling and boot check.
 
 ```yaml
@@ -76,7 +78,9 @@ metadata:
   name: turin-kubevirt-canary
   namespace: kubevirt
 spec:
+  architecture: amd64
   nodeSelector:
+    kubernetes.io/arch: amd64
     kubernetes.io/hostname: turin
   tolerations:
     - key: node-role.kubernetes.io/control-plane

--- a/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
+++ b/docs/superpowers/plans/2026-06-15-turin-kubevirt-flamingo-blackwell-serving.md
@@ -67,7 +67,7 @@ Expected: a `virt-handler` pod runs on `turin` and the node label is `true`.
 
 - [ ] **Step 3: Run a temporary non-GPU VMI canary pinned to Turin, then delete it.**
 
-The canary must not request GPUs, PVCs, or host devices.
+The canary must set `architecture: amd64` and must not request GPUs, PVCs, or host devices.
 
 ### Task 3: Add Flamingo
 


### PR DESCRIPTION
## Summary

- Documents that the Turin KubeVirt canary must set `architecture: amd64`.
- Adds the matching `kubernetes.io/arch: amd64` node selector to the canary example.
- Updates the saved implementation plan so future runs do not repeat the unschedulable arm64 default.

## Related Issues

None

## Testing

- `git diff --check`
- Live canary evidence before this doc fix: VMI with `architecture: amd64` reached Running/Ready on `turin` and was deleted.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
