### PR TITLE
fix(rook-ceph): allow csi plugins on turin

### DIFF
--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -42,3 +42,9 @@ csi:
   provisionerReplicas: 2
   pluginPriorityClassName: system-node-critical
   provisionerPriorityClassName: system-cluster-critical
+  # Turin is intentionally a control-plane node and needs CSI nodeplugins so
+  # GPU workloads pinned there can mount rook-ceph-block PVCs.
+  pluginTolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule


### PR DESCRIPTION
## Summary

- Add a Rook CSI plugin toleration for Turin's control-plane taint.
- Allows RBD/CephFS CSI nodeplugin DaemonSets to run on Turin.
- Unblocks GPU pods pinned to Turin from mounting `rook-ceph-block` PVCs.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph` with output saved to `/tmp/rook-ceph-render.yaml`
- `rg -n "pluginTolerations|node-role.kubernetes.io/control-plane|kind: OperatorConfig|name: rook-ceph-operator-config" /tmp/rook-ceph-render.yaml -C 4`
- `bun run lint:argocd`
- `kubectl apply --server-side --force-conflicts --dry-run=server -f /tmp/rook-ceph-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
