### PR TITLE
fix(rook-ceph): manage backfill concurrency

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -30,6 +30,10 @@ cephClusterSpec:
       osd_pool_default_size: "2"
       osd_pool_default_min_size: "1"
       mon_data_avail_warn: "20"
+    osd:
+      # Temporarily raise recovery/backfill concurrency while Turin rebuilds
+      # the recreated 24 TB OSDs.
+      osd_max_backfills: "3"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Adds `osd_max_backfills: "3"` to the GitOps-managed Rook CephCluster `cephConfig`.
- Keeps the Turin recovery/backfill concurrency change owned by Argo CD instead of live-only Ceph CLI state.
- Scopes the change to Rook/Ceph OSD recovery behavior; no storage topology or OSD device mappings are changed.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph > /tmp/rook-ceph-render.yaml`
- `yq 'select(.kind == "CephCluster" and .metadata.name == "rook-ceph") | .spec.cephConfig' /tmp/rook-ceph-render.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
