### PR TITLE
fix(flamingo): increase vllm gpu memory budget

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -126,16 +126,24 @@ Round 1: Qwen3-Coder-Next-FP8 at 32K context.
 Use the deployed flags:
 
 ```text
---max-model-len 32768 --gpu-memory-utilization 0.80 --enable-prefix-caching --tool-call-parser qwen3_coder
+--max-model-len 32768 --gpu-memory-utilization 0.92 --enable-prefix-caching --tool-call-parser qwen3_coder
 ```
+
+Initial rollout evidence:
+
+- `0.80` reached model load but failed before serving with
+  `ValueError: No available memory for the cache blocks`.
+- The Blackwell card reported about `97.9 GiB` total memory and vLLM held about
+  `77.5 GiB` after loading the FP8 checkpoint.
+- `0.92` is the first tuned setting for 32K context so vLLM has room for KV
+  cache while still leaving a small safety margin below full device memory.
 
 Round 2: increase utilization and context only after Round 1 is stable.
 
 Patch one flag at a time in Git:
 
 ```text
---gpu-memory-utilization 0.84
---gpu-memory-utilization 0.88
+--gpu-memory-utilization 0.94
 --max-model-len 65536
 ```
 

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - --max-model-len
             - "32768"
             - --gpu-memory-utilization
-            - "0.80"
+            - "0.92"
             - --enable-prefix-caching
             - --enable-auto-tool-choice
             - --tool-call-parser


### PR DESCRIPTION
## Summary

- Raise Flamingo vLLM `gpu_memory_utilization` from `0.80` to `0.92`.
- Keep Qwen3-Coder-Next-FP8 at 32K context and retain the existing OpenAI-compatible serving flags.
- Record the observed `0.80` startup failure and Blackwell memory evidence in the Flamingo README.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/flamingo` with output saved to `/tmp/flamingo-render.yaml`
- `rg -n "gpu-memory-utilization|0.92|Qwen3-Coder" /tmp/flamingo-render.yaml argocd/applications/flamingo/README.md -C 2`
- `bun run lint:argocd`
- `kubectl apply --server-side --force-conflicts --dry-run=server -f /tmp/flamingo-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
