### PR TITLE
chore(jangar): upgrade openwebui

### DIFF
--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -31,7 +31,7 @@ resources:
 helmCharts:
   - name: open-webui
     repo: https://helm.openwebui.com
-    version: 14.2.0
+    version: 14.8.0
     releaseName: jangar-openwebui
     namespace: jangar
     valuesFile: openwebui-values.yaml

--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -20,7 +20,7 @@ websocket:
     enabled: false
 
 image:
-  tag: v0.9.2
+  tag: v0.9.6
 
 openaiApiKey: ""
 


### PR DESCRIPTION
## Summary

- Upgrade the Jangar Open WebUI Helm chart from 14.2.0 to 14.8.0.
- Pin the Open WebUI image tag from v0.9.2 to v0.9.6, the current latest GitHub release.
- Keep existing Jangar database, Redis websocket, Ollama, and persistence settings unchanged.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar-openwebui-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/jangar-openwebui-render.yaml`
- `rg -n "helm.sh/chart: open-webui-14.8.0|ghcr.io/open-webui/open-webui:v0.9.6|kind: Namespace" /tmp/jangar-openwebui-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
