### PR TITLE
docs(flamingo): finalize blackwell rollout

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -108,6 +108,56 @@ curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
 Expected: `tool_calls` is a non-empty array and the function argument includes
 `"repo": "lab"`.
 
+## Rollout Evidence
+
+Recorded on 2026-06-16 after syncing the merged GitOps revisions.
+
+KubeVirt:
+
+- `virt-handler-cmn8v` is `1/1 Running` on `turin`.
+- `turin` has `kubevirt.io/schedulable=true`.
+- Existing `saigak` and `openclaw` VMIs remained `Running`.
+- A temporary `turin-kubevirt-canary` VMI pinned to `turin` reached `Running`
+  and was deleted after the check.
+
+Storage:
+
+- `rook-ceph.rbd.csi.ceph.com` and `rook-ceph.cephfs.csi.ceph.com` are both
+  registered on `CSINode/turin`.
+- The `flamingo-model-cache` PVC is bound to `rook-ceph-block` and attached on
+  `turin`.
+- The wider Ceph cluster remained in recovery during this rollout; no Ceph OSD,
+  CRUSH, or Talos storage mutation was performed for Flamingo.
+
+Flamingo:
+
+- Argo CD app `flamingo` is `Synced` and `Healthy`.
+- Pod `flamingo-bbb64fd75-sdmr6` is `1/1 Running` on `turin`.
+- Final launch flags include:
+
+```text
+--max-model-len 32768 --gpu-memory-utilization 0.92 --max-num-seqs 256 --enable-prefix-caching --tool-call-parser qwen3_coder
+```
+
+- `/v1/models` works through both
+  `http://flamingo.flamingo.svc.cluster.local/v1` and
+  `http://flamingo.ide-newton.ts.net/v1`.
+- Cluster-local chat smoke returned `cluster-ready`.
+- Tailnet chat smoke returned `flamingo-ready` with HTTP `200`.
+- Tailnet tool-call smoke returned a structured `add` function call with
+  arguments `{"a": 7, "b": 35}`.
+- `nvidia-smi` while idle after load reported
+  `90458 MiB / 97887 MiB`, `49 C`, and `15.30 W`.
+- vLLM reported `406,910` GPU KV-cache tokens and `12.42x` maximum concurrency
+  for 32,768-token requests.
+
+OpenWebUI:
+
+- OpenWebUI is configured with Flamingo first in `OPENAI_API_BASE_URLS` and the
+  Jangar gateway second as a rollback path.
+- `DEFAULT_MODELS` is `qwen3-coder-flamingo`.
+- `ENABLE_OLLAMA_API=true` keeps Saigak's Ollama endpoint available separately.
+
 ## Optimization Rounds
 
 Record each run with the vLLM image digest, model revision, flags, concurrency,
@@ -157,6 +207,15 @@ Round 3: MoE tuning.
 Only run this if vLLM logs indicate default MoE configuration or poor MoE
 throughput. Save generated configs outside Git unless they are proven stable,
 then mount them with `VLLM_TUNED_CONFIG_FOLDER`.
+
+Current logs show vLLM using the default MoE config for this Blackwell SKU:
+
+```text
+Using default MoE config. Performance might be sub-optimal!
+```
+
+Treat a tuned MoE config as the next optimization change after this stable
+serving rollout. Do not combine MoE tuning with another memory/context increase.
 
 Round 4: fallback comparison.
 

--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -29,7 +29,7 @@ serviceAccount:
   create: true
   name: open-webui
 
-openaiBaseApiUrl: http://jangar.jangar.svc.cluster.local/openai/v1
+openaiBaseApiUrl: http://flamingo.flamingo.svc.cluster.local/v1
 
 databaseUrl: ""
 
@@ -48,8 +48,14 @@ extraEnvVars:
   # Disable TLS when calling the HTTP-only Jangar OpenAI gateway
   - name: AIOHTTP_CLIENT_SESSION_SSL
     value: "false"
+  # Keep Flamingo first so new chats default to the Blackwell vLLM endpoint.
+  # Keep the Jangar gateway second as a rollback/hosted-model path.
+  - name: OPENAI_API_BASE_URLS
+    value: "http://flamingo.flamingo.svc.cluster.local/v1;http://jangar.jangar.svc.cluster.local/openai/v1"
+  - name: OPENAI_API_KEYS
+    value: ";"
   - name: DEFAULT_MODELS
-    value: gpt-5.5
+    value: qwen3-coder-flamingo
   - name: WEBUI_AUTH
     value: "false"
   - name: ENABLE_SIGNUP

--- a/docs/jangar/pi-agent-flamingo-host-configuration.md
+++ b/docs/jangar/pi-agent-flamingo-host-configuration.md
@@ -1,0 +1,100 @@
+# Pi Agent Flamingo Host Configuration
+
+Use this when running a host-side Pi/agent harness against the Turin Blackwell
+GPU pod.
+
+## Endpoint
+
+Use the Tailscale endpoint from the host:
+
+```text
+http://flamingo.ide-newton.ts.net/v1
+```
+
+Use the ClusterIP endpoint only from Kubernetes pods:
+
+```text
+http://flamingo.flamingo.svc.cluster.local/v1
+```
+
+## Host Environment
+
+Set the OpenAI-compatible completion endpoint and model. Keep both base-url
+aliases if the local harness supports either spelling.
+
+```bash
+export OPENAI_API_BASE_URL=http://flamingo.ide-newton.ts.net/v1
+export OPENAI_BASE_URL=http://flamingo.ide-newton.ts.net/v1
+export OPENAI_API_KEY=flamingo-local
+export OPENAI_COMPLETION_MODEL=qwen3-coder-flamingo
+export OPENAI_MODEL=qwen3-coder-flamingo
+```
+
+Do not move embeddings to Flamingo in this step. If the harness uses embedding
+configuration, keep it on Saigak:
+
+```bash
+export OPENAI_EMBEDDING_API_BASE_URL=http://saigak.saigak.svc.cluster.local:11434/v1
+export OPENAI_EMBEDDING_MODEL=qwen3-embedding-saigak:8b
+```
+
+## Smoke
+
+Run these from the host before pointing long-running agents at the model:
+
+```bash
+curl -fsS http://flamingo.ide-newton.ts.net/v1/models
+
+curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"qwen3-coder-flamingo","messages":[{"role":"user","content":"Reply with exactly: flamingo-ready"}],"max_tokens":16,"temperature":0}'
+```
+
+Tool-call smoke:
+
+```bash
+curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen3-coder-flamingo",
+    "messages": [{"role": "user", "content": "Use the provided tool to add 7 and 35. Do not answer directly."}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "add",
+        "description": "Add two integers.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "a": {"type": "integer"},
+            "b": {"type": "integer"}
+          },
+          "required": ["a", "b"]
+        }
+      }
+    }],
+    "tool_choice": "auto",
+    "max_tokens": 128,
+    "temperature": 0
+  }'
+```
+
+Expected tool-call result:
+
+```json
+{"name":"add","arguments":"{\"a\": 7, \"b\": 35}"}
+```
+
+## Rollback
+
+For completion rollback to Saigak/Jangar-compatible routing:
+
+```bash
+export OPENAI_API_BASE_URL=http://saigak.saigak.svc.cluster.local:11434/v1
+export OPENAI_BASE_URL=http://saigak.saigak.svc.cluster.local:11434/v1
+export OPENAI_COMPLETION_MODEL=qwen3-main-saigak:30b-a3b
+export OPENAI_MODEL=qwen3-main-saigak:30b-a3b
+```
+
+Rollback if Flamingo is not reachable, tool calls are not structured, or the
+GPU pod is restarting under agent load.

--- a/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
+++ b/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
@@ -39,9 +39,9 @@ OPENAI_EMBEDDING_MODEL=qwen3-embedding-saigak:8b
 Move one consumer at a time, starting with the lowest-risk host-side harness.
 
 1. Host-side pi harness.
-2. Agents service canary.
-3. Bumba completion traffic.
-4. Jangar/OpenWebUI completion traffic.
+2. Jangar/OpenWebUI completion traffic.
+3. Agents service canary.
+4. Bumba completion traffic.
 5. Torghut or other production workflows only after benchmark and tool-call
    evidence is stable.
 
@@ -49,19 +49,25 @@ Do not migrate multiple consumers in the same commit or rollout.
 
 ## Host-Side Pi Harness
 
-Configure the harness to use:
+Configure the harness to use the OpenAI-compatible endpoint:
 
 ```text
 OPENAI_API_BASE_URL=http://flamingo.ide-newton.ts.net/v1
+OPENAI_BASE_URL=http://flamingo.ide-newton.ts.net/v1
 OPENAI_COMPLETION_MODEL=qwen3-coder-flamingo
+OPENAI_MODEL=qwen3-coder-flamingo
 ```
 
-If the harness has a separate API key setting, use a local dummy value unless the
-client refuses empty keys:
+If the harness has a separate API key setting, use a local dummy value. vLLM does
+not require a real key on this endpoint, but many OpenAI-compatible clients
+refuse an empty one:
 
 ```text
 OPENAI_API_KEY=flamingo-local
 ```
+
+Do not point embedding settings at Flamingo. If the host has embedding variables,
+leave them on `saigak` until the embedding migration is designed.
 
 Smoke:
 
@@ -86,6 +92,34 @@ Keep embedding variables pointed at `saigak`.
 For apps that use one base URL for both completions and embeddings, first split
 completion and embedding configuration in that app. Do not point embedding calls
 at Flamingo until the embedding migration exists.
+
+## OpenWebUI
+
+OpenWebUI is the first in-cluster UI consumer migrated to Flamingo. The GitOps
+values keep Flamingo first and the Jangar gateway second:
+
+```text
+OPENAI_API_BASE_URLS=http://flamingo.flamingo.svc.cluster.local/v1;http://jangar.jangar.svc.cluster.local/openai/v1
+OPENAI_API_KEYS=;
+DEFAULT_MODELS=qwen3-coder-flamingo
+ENABLE_OLLAMA_API=true
+OLLAMA_BASE_URLS=http://saigak.saigak.svc.cluster.local:11434
+```
+
+Validation:
+
+```bash
+argocd --core app sync jangar --timeout 900
+kubectl -n jangar rollout status statefulset/open-webui --timeout=10m
+kubectl -n jangar exec open-webui-0 -- printenv OPENAI_API_BASE_URLS DEFAULT_MODELS OLLAMA_BASE_URLS
+```
+
+Rollback by restoring:
+
+```text
+OPENAI_API_BASE_URL=http://jangar.jangar.svc.cluster.local/openai/v1
+DEFAULT_MODELS=gpt-5.5
+```
 
 ## Rollback Values
 


### PR DESCRIPTION
## Summary

- Configure OpenWebUI with Flamingo as the first OpenAI-compatible completion endpoint and the Jangar gateway as rollback.
- Record live Turin/KubeVirt/Rook/Flamingo rollout evidence, including chat and tool-call smoke results.
- Add host-side Pi agent configuration docs for the Flamingo Tailscale endpoint.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/flamingo`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar | rg -n -C 4 "OPENAI_API_BASE_URLS|OPENAI_API_KEYS|OPENAI_API_BASE_URL|DEFAULT_MODELS|OLLAMA_BASE_URLS"`
- `bun run lint:argocd`
- `git diff --check`
- `kustomize build argocd/applications/flamingo | kubectl apply --dry-run=server -f -`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar | kubectl apply --dry-run=server -f -`
- Live pre-PR smoke: `curl -fsS http://flamingo.ide-newton.ts.net/v1/models`
- Live pre-PR smoke: cluster-local `/v1/models` and `/v1/chat/completions` via `kubectl -n flamingo run ... curlimages/curl:8.11.1`
- Live pre-PR smoke: Tailscale chat completion returned `flamingo-ready` with HTTP 200.
- Live pre-PR smoke: Tailscale tool-call completion returned function `add` with arguments `{"a": 7, "b": 35}`.

## Breaking Changes

OpenWebUI's default model changes from `gpt-5.5` to `qwen3-coder-flamingo`. The Jangar gateway remains configured as a secondary OpenAI-compatible endpoint and Saigak remains available through the OpenWebUI Ollama integration.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
