### PR TITLE
fix(rook-ceph): enable mclock recovery profile

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -31,6 +31,12 @@ cephClusterSpec:
       osd_pool_default_min_size: "1"
       mon_data_avail_warn: "20"
     osd:
+      # Use Ceph's mClock recovery-biased profile while Turin rebuilds
+      # the recreated 24 TB OSDs.
+      osd_mclock_profile: "high_recovery_ops"
+      # Allow the temporary recovery/backfill limits below to take effect
+      # while the OSDs run with the mClock scheduler.
+      osd_mclock_override_recovery_settings: "true"
       # Temporarily raise recovery/backfill concurrency while Turin rebuilds
       # the recreated 24 TB OSDs.
       osd_max_backfills: "3"


### PR DESCRIPTION
## Summary

- Sets Rook Ceph OSDs to the `high_recovery_ops` mClock profile while Turin rebuilds recreated 24 TB OSDs.
- Enables `osd_mclock_override_recovery_settings` so the existing temporary `osd_max_backfills=3` limit can take effect under `mclock_scheduler`.
- Keeps the change scoped to `argocd/applications/rook-ceph/cluster-values.yaml` for GitOps rollout.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph > /tmp/rook-ceph-mclock-render.yaml`
- `yq 'select(.kind == "CephCluster" and .metadata.name == "rook-ceph") | .spec.cephConfig.osd' /tmp/rook-ceph-mclock-render.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
