### PR TITLE
docs(flamingo): record ui and pi smokes

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -157,6 +157,21 @@ OpenWebUI:
   Jangar gateway second as a rollback path.
 - `DEFAULT_MODELS` is `qwen3-coder-flamingo`.
 - `ENABLE_OLLAMA_API=true` keeps Saigak's Ollama endpoint available separately.
+- Playwright UI smoke loaded `http://openwebui.ide-newton.ts.net`, observed
+  selected model `qwen3-coder-flamingo`, submitted `Respond with exactly:
+  openwebui-flamingo-ready`, and the page rendered `openwebui-flamingo-ready`.
+- The captured OpenWebUI request used `POST /api/chat/completions` with
+  `"model":"qwen3-coder-flamingo"` and upstream `urlIdx: 0`.
+- Flamingo logs showed OpenWebUI pod IP `10.244.5.2` calling
+  `GET /v1/models` and `POST /v1/chat/completions` with HTTP `200`.
+
+Pi host harness:
+
+- Host-side `pi` smoke used an isolated temporary `PI_CODING_AGENT_DIR` with a
+  `flamingo` OpenAI-compatible provider pointed at
+  `http://flamingo.ide-newton.ts.net/v1`.
+- `pi --provider flamingo --model qwen3-coder-flamingo --no-tools --no-session
+  -p "Reply with exactly: pi-flamingo-ready"` returned `pi-flamingo-ready`.
 
 ## Optimization Rounds
 

--- a/docs/jangar/pi-agent-flamingo-host-configuration.md
+++ b/docs/jangar/pi-agent-flamingo-host-configuration.md
@@ -85,6 +85,73 @@ Expected tool-call result:
 {"name":"add","arguments":"{\"a\": 7, \"b\": 35}"}
 ```
 
+## Pi Binary Smoke
+
+The host `pi` binary supports custom OpenAI-compatible providers through
+`models.json`. For a no-mutation smoke, create a temporary Pi config directory
+instead of editing `~/.pi/agent`.
+
+```bash
+PI_TMP_DIR="$(mktemp -d /tmp/pi-flamingo-smoke.XXXXXX)"
+
+cat > "$PI_TMP_DIR/settings.json" <<'JSON'
+{
+  "defaultProvider": "flamingo",
+  "defaultModel": "qwen3-coder-flamingo",
+  "defaultThinkingLevel": "off",
+  "quietStartup": true,
+  "enableInstallTelemetry": false
+}
+JSON
+
+cat > "$PI_TMP_DIR/models.json" <<'JSON'
+{
+  "providers": {
+    "flamingo": {
+      "baseUrl": "http://flamingo.ide-newton.ts.net/v1",
+      "api": "openai-completions",
+      "apiKey": "flamingo-local",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        {
+          "id": "qwen3-coder-flamingo",
+          "name": "Qwen3 Coder Flamingo",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 32768,
+          "maxTokens": 4096,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        }
+      ]
+    }
+  }
+}
+JSON
+
+PI_CODING_AGENT_DIR="$PI_TMP_DIR" \
+PI_SKIP_VERSION_CHECK=1 \
+PI_TELEMETRY=0 \
+pi --provider flamingo \
+  --model qwen3-coder-flamingo \
+  --no-tools \
+  --no-session \
+  -p "Reply with exactly: pi-flamingo-ready"
+```
+
+Expected output:
+
+```text
+pi-flamingo-ready
+```
+
 ## Rollback
 
 For completion rollback to Saigak/Jangar-compatible routing:


### PR DESCRIPTION
## Summary

- Record the Playwright OpenWebUI smoke that selected `qwen3-coder-flamingo` and rendered `openwebui-flamingo-ready`.
- Record Flamingo log evidence showing OpenWebUI called vLLM `/v1/models` and `/v1/chat/completions` with HTTP 200.
- Document the isolated temporary-config `pi` smoke for the host-side Flamingo provider.

## Related Issues

None

## Testing

- `git diff --check`
- Playwright UI smoke against `http://openwebui.ide-newton.ts.net` submitted `Respond with exactly: openwebui-flamingo-ready` and observed `openwebui-flamingo-ready`.
- `kubectl -n flamingo logs deploy/flamingo --tail=80 | rg -n "POST /v1/chat/completions|openwebui|10\\.244\\.5|200 OK|GET /v1/models"`
- `PI_CODING_AGENT_DIR="$PI_TMP_DIR" PI_SKIP_VERSION_CHECK=1 PI_TELEMETRY=0 pi --provider flamingo --model qwen3-coder-flamingo --no-tools --no-session -p "Reply with exactly: pi-flamingo-ready"`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
