### PR TITLE
fix(rook-ceph): raise recovery start concurrency

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -40,6 +40,7 @@ cephClusterSpec:
       # Temporarily raise recovery/backfill concurrency while Turin rebuilds
       # the recreated 24 TB OSDs.
       osd_max_backfills: "3"
+      osd_recovery_max_single_start: "3"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Raises `osd_recovery_max_single_start` from the default `1` to `3` for the temporary Turin OSD rebuild.
- Keeps the setting in the Rook Ceph GitOps config next to the existing `high_recovery_ops`, mClock recovery override, and `osd_max_backfills=3` recovery tuning.
- Targets the observed limiter where OSDs had the backfill ceiling set to `3` but were still starting recovery work one operation at a time.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph > /tmp/rook-ceph-single-start-render.yaml`
- `yq 'select(.kind == "CephCluster" and .metadata.name == "rook-ceph") | .spec.cephConfig.osd' /tmp/rook-ceph-single-start-render.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
