### PR TITLE
feat(flamingo): raise local context to native max

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -139,7 +139,7 @@ Flamingo:
 
 - Argo CD app `flamingo` is `Synced` and `Healthy`.
 - Pod `flamingo-bbb64fd75-sdmr6` is `1/1 Running` on `turin`.
-- Final launch flags include:
+- The 32K baseline launch flags included:
 
 ```text
 --max-model-len 32768 --gpu-memory-utilization 0.92 --max-num-seqs 256 --enable-prefix-caching --tool-call-parser qwen3_coder
@@ -179,6 +179,41 @@ Pi host harness:
 - `pi --provider flamingo --model qwen3-coder-flamingo --no-tools --no-session
   -p "Reply with exactly: pi-flamingo-ready"` returned `pi-flamingo-ready`.
 
+## Context Window Rungs
+
+Qwen3-Coder-Next's native context ceiling is 262,144 tokens. Flamingo's GitOps
+target is the native ceiling; the smaller rungs are retained only as rollback or
+startup-triage points if the native rollout cannot start cleanly.
+
+| Phase | vLLM `--max-model-len` | Pi `contextWindow` | Pi `maxTokens` | Status |
+| --- | ---: | ---: | ---: | --- |
+| 1 | `262144` | `245760` | `8192` | Current native GitOps target |
+| 2 | `131072` | `114688` | `8192` | Roll back here only if 256K fails startup |
+| 3 | `65536` | `57344` | `8192` | Last-resort lower-cap rollback |
+
+Pi compaction settings must stay explicit for every Flamingo rung:
+
+```json
+{
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 20000
+  }
+}
+```
+
+Required host gate:
+
+```bash
+bun run scripts/jangar/validate-pi-flamingo-compaction.ts
+```
+
+The script uses temporary `PI_CODING_AGENT_DIR` and session directories. It must
+fail if stdout, stderr, or the saved session contains a context-window HTTP
+`400`, `input_tokens`, `maximum context length`, or
+`Context overflow recovery failed`.
+
 ## Optimization Rounds
 
 Record each run with the vLLM image digest, model revision, flags, concurrency,
@@ -212,16 +247,23 @@ Initial rollout evidence:
 - `--max-num-seqs 256` keeps the sequence cap below available Mamba cache
   blocks while preserving the observed 32K-context KV-cache budget.
 
-Round 2: increase utilization and context only after Round 1 is stable.
+Round 2: native 256K context with the same utilization and sequence caps.
 
-Patch one flag at a time in Git:
+Deployed target flags:
 
 ```text
---gpu-memory-utilization 0.94
---max-model-len 65536
+--max-model-len 262144 --gpu-memory-utilization 0.92 --max-num-seqs 256 --enable-prefix-caching --tool-call-parser qwen3_coder
 ```
 
-Do not combine utilization and context increases in one rollout.
+Keep `--gpu-memory-utilization 0.92` and `--max-num-seqs 256` for this native
+context increase. Update Pi to `contextWindow: 245760`, keep
+`maxTokens: 8192`, and require the host compaction gate to record a
+`compaction` session entry without overflow recovery. YaRN or 1M-context
+experiments are intentionally out of scope for Flamingo's local default path.
+
+If 256K fails startup, roll back one cap at a time to `131072`, then `65536`,
+while keeping the same Pi budget table above and rerunning the same server and
+host gates.
 
 Round 3: MoE tuning.
 

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - --served-model-name
             - qwen3-coder-flamingo
             - --max-model-len
-            - "32768"
+            - "262144"
             - --gpu-memory-utilization
             - "0.92"
             - --max-num-seqs

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/component: model-server
 spec:
   replicas: 1
+  progressDeadlineSeconds: 14400
   strategy:
     type: Recreate
   selector:

--- a/docs/jangar/pi-agent-flamingo-host-configuration.md
+++ b/docs/jangar/pi-agent-flamingo-host-configuration.md
@@ -82,7 +82,30 @@ curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
 Expected tool-call result:
 
 ```json
-{"name":"add","arguments":"{\"a\": 7, \"b\": 35}"}
+{ "name": "add", "arguments": "{\"a\": 7, \"b\": 35}" }
+```
+
+## Client Context Budget
+
+Keep Pi's `models.json` budget below the vLLM server rung. Do not set the Pi
+client window to the exact native Qwen3-Coder-Next ceiling.
+
+| vLLM `--max-model-len` | Pi `contextWindow` | Pi `maxTokens` |
+| ---------------------- | -----------------: | -------------: |
+| `262144`               |           `245760` |         `8192` |
+| `131072`               |           `114688` |         `8192` |
+| `65536`                |            `57344` |         `8192` |
+
+Compaction must stay explicit in `settings.json` for Flamingo host runs:
+
+```json
+{
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 20000
+  }
+}
 ```
 
 ## Pi Binary Smoke
@@ -100,7 +123,12 @@ cat > "$PI_TMP_DIR/settings.json" <<'JSON'
   "defaultModel": "qwen3-coder-flamingo",
   "defaultThinkingLevel": "off",
   "quietStartup": true,
-  "enableInstallTelemetry": false
+  "enableInstallTelemetry": false,
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 20000
+  }
 }
 JSON
 
@@ -121,8 +149,8 @@ cat > "$PI_TMP_DIR/models.json" <<'JSON'
           "name": "Qwen3 Coder Flamingo",
           "reasoning": false,
           "input": ["text"],
-          "contextWindow": 32768,
-          "maxTokens": 4096,
+          "contextWindow": 245760,
+          "maxTokens": 8192,
           "cost": {
             "input": 0,
             "output": 0,
@@ -150,6 +178,30 @@ Expected output:
 
 ```text
 pi-flamingo-ready
+```
+
+## Pi Compaction Gate
+
+Run the repo-local gate from the Mac host before using Flamingo for long Pi
+sessions. It writes temporary `settings.json`, `models.json`, and session files,
+then proves a follow-up turn can use a compaction summary without falling back to
+overflow recovery.
+
+```bash
+bun run scripts/jangar/validate-pi-flamingo-compaction.ts
+```
+
+While the live server is still on the old 32K rung, run the reduced smoke
+against the same code path:
+
+```bash
+PI_FLAMINGO_SERVER_CONTEXT=32768 \
+PI_FLAMINGO_CLIENT_CONTEXT=24576 \
+PI_FLAMINGO_MAX_TOKENS=2048 \
+PI_FLAMINGO_COMPACTION_RESERVE=8192 \
+PI_FLAMINGO_KEEP_RECENT=4000 \
+PI_FLAMINGO_PROMPT_CHARS=90000 \
+bun run scripts/jangar/validate-pi-flamingo-compaction.ts
 ```
 
 ## Rollback

--- a/scripts/jangar/validate-pi-flamingo-compaction.ts
+++ b/scripts/jangar/validate-pi-flamingo-compaction.ts
@@ -1,0 +1,431 @@
+#!/usr/bin/env bun
+
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+type RunResult = {
+  args: string[]
+  code: number | null
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
+type SessionEntry = {
+  type?: string
+  message?: {
+    role?: string
+  }
+  role?: string
+  [key: string]: unknown
+}
+
+const forbiddenOutput = [
+  /maximum context length/i,
+  /\binput_tokens\b/i,
+  /Context overflow recovery failed/i,
+  /HTTP\s*400/i,
+  /\b400\b[^\n]*(context|token)/i,
+]
+
+function parseInteger(name: string, fallback: number): number {
+  const value = process.env[name]
+  if (value === undefined || value === '') {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got ${value}`)
+  }
+
+  return parsed
+}
+
+function defaultClientContext(serverContext: number): number {
+  if (serverContext >= 262144) {
+    return 245760
+  }
+
+  if (serverContext >= 131072) {
+    return 114688
+  }
+
+  if (serverContext >= 65536) {
+    return 57344
+  }
+
+  return Math.max(8192, serverContext - 8192)
+}
+
+function buildPrompt(marker: string, targetChars: number): string {
+  const prefix = [
+    `Remember this exact marker for the next turn: ${marker}`,
+    'If context is compacted, the summary must preserve that marker verbatim.',
+    'After reading the filler below, reply with exactly:',
+    `stored ${marker}`,
+    '',
+    'FILLER START',
+  ].join('\n')
+
+  const unit = [
+    `The durable validation marker is ${marker}.`,
+    'This line exists only to create enough reusable conversation history for a local Pi compaction smoke.',
+    'Do not infer any task from this filler; preserve the marker and wait for the follow-up question.',
+    '',
+  ].join('\n')
+
+  const filler = unit.repeat(Math.ceil(targetChars / unit.length)).slice(0, targetChars)
+
+  return `${prefix}\n${filler}\nFILLER END\nReply with exactly: stored ${marker}\n`
+}
+
+async function runPi(args: string[], env: NodeJS.ProcessEnv, timeoutMs: number): Promise<RunResult> {
+  return await new Promise((resolve) => {
+    const child = spawn('pi', args, {
+      cwd: process.cwd(),
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8')
+    })
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8')
+    })
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+      setTimeout(() => child.kill('SIGKILL'), 5000).unref()
+    }, timeoutMs)
+
+    child.on('close', (code) => {
+      clearTimeout(timeout)
+      resolve({ args, code, stdout, stderr, timedOut })
+    })
+  })
+}
+
+async function fetchServerContext(baseUrl: string, model: string): Promise<number | undefined> {
+  const response = await fetch(`${baseUrl.replace(/\/+$/, '')}/models`, {
+    headers: {
+      authorization: `Bearer ${process.env.PI_FLAMINGO_API_KEY ?? 'flamingo-local'}`,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`GET /v1/models failed with HTTP ${response.status}`)
+  }
+
+  const body = (await response.json()) as {
+    data?: Array<{
+      id?: string
+      max_model_len?: number
+    }>
+  }
+  const entry = body.data?.find((candidate) => candidate.id === model) ?? body.data?.[0]
+
+  return entry?.max_model_len
+}
+
+async function findJsonlFiles(path: string): Promise<string[]> {
+  const files: string[] = []
+
+  for (const entry of await readdir(path)) {
+    const child = join(path, entry)
+    const childStat = await stat(child)
+
+    if (childStat.isDirectory()) {
+      files.push(...(await findJsonlFiles(child)))
+      continue
+    }
+
+    if (entry.endsWith('.jsonl')) {
+      files.push(child)
+    }
+  }
+
+  return files
+}
+
+async function readSession(sessionDir: string): Promise<{ entries: SessionEntry[]; text: string; files: string[] }> {
+  const files = await findJsonlFiles(sessionDir)
+  const entries: SessionEntry[] = []
+  let text = ''
+
+  for (const file of files) {
+    const content = await readFile(file, 'utf8')
+    text += `\n--- ${file} ---\n${content}`
+
+    for (const line of content.split('\n')) {
+      if (line.trim() === '') {
+        continue
+      }
+
+      try {
+        entries.push(JSON.parse(line) as SessionEntry)
+      } catch {
+        // Keep the raw text check authoritative for malformed lines.
+      }
+    }
+  }
+
+  return { entries, text, files }
+}
+
+function assertNoForbiddenOutput(label: string, text: string): void {
+  const matched = forbiddenOutput.find((pattern) => pattern.test(text))
+  if (matched) {
+    throw new Error(`${label} contained forbidden overflow output matching ${matched}`)
+  }
+}
+
+function assertCompactionBeforeFinalAssistant(entries: SessionEntry[]): number {
+  const compactionIndexes = entries.flatMap((entry, index) => (entry.type === 'compaction' ? [index] : []))
+  const finalAssistantIndex = entries.findLastIndex((entry) => {
+    return entry.message?.role === 'assistant' || entry.role === 'assistant'
+  })
+
+  if (compactionIndexes.length === 0) {
+    throw new Error('session did not contain a compaction entry')
+  }
+
+  if (finalAssistantIndex === -1) {
+    throw new Error('session did not contain an assistant response')
+  }
+
+  if (!compactionIndexes.some((index) => index < finalAssistantIndex)) {
+    throw new Error('session compaction entry was not recorded before the final assistant response')
+  }
+
+  return compactionIndexes.length
+}
+
+function printHelp(): void {
+  console.log(`Usage: bun run scripts/jangar/validate-pi-flamingo-compaction.ts
+
+Environment:
+  PI_FLAMINGO_BASE_URL             OpenAI-compatible base URL (default: http://flamingo.ide-newton.ts.net/v1)
+  PI_FLAMINGO_MODEL                Model id (default: qwen3-coder-flamingo)
+  PI_FLAMINGO_API_KEY              Provider API key (default: flamingo-local)
+  PI_FLAMINGO_SERVER_CONTEXT       Expected vLLM max_model_len (default: 262144)
+  PI_FLAMINGO_CLIENT_CONTEXT       Pi models.json contextWindow (default follows rollout table)
+  PI_FLAMINGO_MAX_TOKENS           Pi models.json maxTokens (default: 8192 for 64K+, else 2048)
+  PI_FLAMINGO_COMPACTION_RESERVE   Pi compaction reserveTokens (default: 16384)
+  PI_FLAMINGO_KEEP_RECENT          Pi compaction keepRecentTokens (default: 20000)
+  PI_FLAMINGO_PROMPT_CHARS         First-turn filler size (default: threshold-sized)
+  PI_FLAMINGO_TIMEOUT_MS           Timeout per Pi turn (default: 600000)
+  PI_FLAMINGO_KEEP_TMP             Set to 1 to keep temp config/session dirs after success
+
+Current 32K live-server smoke:
+  PI_FLAMINGO_SERVER_CONTEXT=32768 PI_FLAMINGO_CLIENT_CONTEXT=24576 PI_FLAMINGO_MAX_TOKENS=2048 \\
+  PI_FLAMINGO_COMPACTION_RESERVE=8192 PI_FLAMINGO_KEEP_RECENT=4000 PI_FLAMINGO_PROMPT_CHARS=90000 \\
+  bun run scripts/jangar/validate-pi-flamingo-compaction.ts`)
+}
+
+async function main(): Promise<void> {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    printHelp()
+    return
+  }
+
+  const baseUrl = process.env.PI_FLAMINGO_BASE_URL ?? 'http://flamingo.ide-newton.ts.net/v1'
+  const provider = process.env.PI_FLAMINGO_PROVIDER ?? 'flamingo'
+  const model = process.env.PI_FLAMINGO_MODEL ?? 'qwen3-coder-flamingo'
+  const apiKey = process.env.PI_FLAMINGO_API_KEY ?? 'flamingo-local'
+  const serverContext = parseInteger('PI_FLAMINGO_SERVER_CONTEXT', 262144)
+  const clientContext = parseInteger('PI_FLAMINGO_CLIENT_CONTEXT', defaultClientContext(serverContext))
+  const maxTokens = parseInteger('PI_FLAMINGO_MAX_TOKENS', serverContext >= 65536 ? 8192 : 2048)
+  const reserveTokens = parseInteger('PI_FLAMINGO_COMPACTION_RESERVE', 16384)
+  const keepRecentTokens = parseInteger('PI_FLAMINGO_KEEP_RECENT', 20000)
+  const threshold = clientContext - reserveTokens
+  const promptChars = parseInteger('PI_FLAMINGO_PROMPT_CHARS', Math.max(12000, (threshold + 4096) * 4))
+  const timeoutMs = parseInteger('PI_FLAMINGO_TIMEOUT_MS', 600000)
+
+  if (clientContext + maxTokens > serverContext) {
+    throw new Error(
+      `client contextWindow + maxTokens must fit server context (${clientContext} + ${maxTokens} > ${serverContext})`,
+    )
+  }
+
+  if (threshold <= 0) {
+    throw new Error(`compaction threshold must be positive (${clientContext} - ${reserveTokens})`)
+  }
+
+  const reportedServerContext = await fetchServerContext(baseUrl, model)
+  if (reportedServerContext !== undefined && reportedServerContext < serverContext) {
+    throw new Error(`/v1/models reports max_model_len=${reportedServerContext}, below expected ${serverContext}`)
+  }
+
+  const tempRoot = await mkdtemp(join(tmpdir(), 'pi-flamingo-compaction-'))
+  const agentDir = join(tempRoot, 'agent')
+  const sessionDir = join(tempRoot, 'sessions')
+  const promptPath = join(tempRoot, 'first-turn.md')
+  const sessionId = randomUUID()
+  const marker = process.env.PI_FLAMINGO_MARKER ?? `flamingo-compaction-${randomUUID().slice(0, 8)}`
+  let keepTemp = process.env.PI_FLAMINGO_KEEP_TMP === '1'
+
+  try {
+    await mkdir(agentDir, { recursive: true })
+    await mkdir(sessionDir, { recursive: true })
+
+    await writeFile(
+      join(agentDir, 'settings.json'),
+      `${JSON.stringify(
+        {
+          defaultProvider: provider,
+          defaultModel: model,
+          defaultThinkingLevel: 'off',
+          quietStartup: true,
+          enableInstallTelemetry: false,
+          compaction: {
+            enabled: true,
+            reserveTokens,
+            keepRecentTokens,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    await writeFile(
+      join(agentDir, 'models.json'),
+      `${JSON.stringify(
+        {
+          providers: {
+            [provider]: {
+              baseUrl,
+              api: 'openai-completions',
+              apiKey,
+              compat: {
+                supportsDeveloperRole: false,
+                supportsReasoningEffort: false,
+              },
+              models: [
+                {
+                  id: model,
+                  name: 'Qwen3 Coder Flamingo',
+                  reasoning: false,
+                  input: ['text'],
+                  contextWindow: clientContext,
+                  maxTokens,
+                  cost: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    await writeFile(promptPath, buildPrompt(marker, promptChars))
+
+    const commonArgs = [
+      '--provider',
+      provider,
+      '--model',
+      model,
+      '--session-id',
+      sessionId,
+      '--session-dir',
+      sessionDir,
+      '--no-tools',
+      '--no-extensions',
+      '--no-skills',
+      '--no-prompt-templates',
+      '--no-themes',
+      '--no-context-files',
+      '--print',
+    ]
+    const env = {
+      ...process.env,
+      PI_CODING_AGENT_DIR: agentDir,
+      PI_CODING_AGENT_SESSION_DIR: sessionDir,
+      PI_SKIP_VERSION_CHECK: '1',
+      PI_TELEMETRY: '0',
+    }
+
+    const first = await runPi([...commonArgs, `@${promptPath}`], env, timeoutMs)
+    assertNoForbiddenOutput('first Pi turn', `${first.stdout}\n${first.stderr}`)
+    if (first.timedOut || first.code !== 0) {
+      throw new Error(
+        `first Pi turn failed with code ${first.code}${first.timedOut ? ' after timeout' : ''}\n${first.stderr}`,
+      )
+    }
+
+    const second = await runPi(
+      [...commonArgs, `What exact marker did I ask you to preserve? Reply with only ${marker}.`],
+      env,
+      timeoutMs,
+    )
+    assertNoForbiddenOutput('second Pi turn', `${second.stdout}\n${second.stderr}`)
+    if (second.timedOut || second.code !== 0) {
+      throw new Error(
+        `second Pi turn failed with code ${second.code}${second.timedOut ? ' after timeout' : ''}\n${second.stderr}`,
+      )
+    }
+
+    const session = await readSession(sessionDir)
+    assertNoForbiddenOutput('saved Pi session', session.text)
+    const compactionCount = assertCompactionBeforeFinalAssistant(session.entries)
+
+    if (!second.stdout.includes(marker)) {
+      keepTemp = true
+      throw new Error(`follow-up did not preserve marker ${marker}\nOutput:\n${second.stdout}`)
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          baseUrl,
+          model,
+          reportedServerContext,
+          serverContext,
+          clientContext,
+          maxTokens,
+          reserveTokens,
+          keepRecentTokens,
+          threshold,
+          promptChars,
+          compactionCount,
+          marker,
+          sessionFiles: session.files,
+        },
+        null,
+        2,
+      ),
+    )
+  } catch (error) {
+    keepTemp = true
+    console.error(`Pi Flamingo compaction validation failed. Temp root kept at ${tempRoot}`)
+    throw error
+  } finally {
+    if (!keepTemp) {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/scripts/jangar/validate-pi-flamingo-compaction.ts
+++ b/scripts/jangar/validate-pi-flamingo-compaction.ts
@@ -249,7 +249,7 @@ async function main(): Promise<void> {
   const reserveTokens = parseInteger('PI_FLAMINGO_COMPACTION_RESERVE', 16384)
   const keepRecentTokens = parseInteger('PI_FLAMINGO_KEEP_RECENT', 20000)
   const threshold = clientContext - reserveTokens
-  const promptChars = parseInteger('PI_FLAMINGO_PROMPT_CHARS', Math.max(12000, (threshold + 4096) * 4))
+  const promptChars = parseInteger('PI_FLAMINGO_PROMPT_CHARS', Math.max(12000, Math.ceil((threshold + 4096) * 4.7)))
   const timeoutMs = parseInteger('PI_FLAMINGO_TIMEOUT_MS', 600000)
 
   if (clientContext + maxTokens > serverContext) {


### PR DESCRIPTION
## Summary

- Raises Flamingo's vLLM server context target to Qwen3-Coder-Next's native `262144` tokens.
- Sets the Pi host client budget to `contextWindow: 245760` with `maxTokens: 8192` and explicit compaction settings.
- Adds a repo-local Pi compaction validation script that uses temporary config/session directories and fails on context overflow signatures.
- Extends the Flamingo Deployment progress deadline to allow the 74.86 GiB FP8 checkpoint and native-context startup to complete.

## Related Issues

None

## Testing

- `bunx oxfmt --check scripts/jangar/validate-pi-flamingo-compaction.ts`
- `git diff --check`
- `kustomize build argocd/applications/flamingo` rendered successfully to `/tmp/flamingo-rendered.yaml`
- `kubectl apply --dry-run=server -f /tmp/flamingo-rendered.yaml`
- `kubectl apply -f /tmp/flamingo-rendered.yaml`
- `curl -fsS http://flamingo.ide-newton.ts.net/v1/models | jq '.data[0].id, .data[0].max_model_len'`
- Chat-completions smoke against `http://flamingo.ide-newton.ts.net/v1/chat/completions` returned `flamingo-262k-ready`
- Tool-call smoke returned `{"name":"add","arguments":"{\"a\": 7, \"b\": 35}"}`
- `PI_FLAMINGO_TIMEOUT_MS=1800000 bun run scripts/jangar/validate-pi-flamingo-compaction.ts` passed with `reportedServerContext: 262144`, `clientContext: 245760`, `threshold: 229376`, and `compactionCount: 2`
- `kubectl -n flamingo logs deploy/flamingo --tail=220` showed `GPU KV cache size: 442,636 tokens`, `Maximum concurrency for 262,144 tokens per request: 1.69x`, and no context overflow or memory errors in the final scan.
- Python `urllib` check from `jangar/open-webui-0` confirmed the OpenWebUI pod sees `qwen3-coder-flamingo` with `max_model_len` `262144`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
