### PR TITLE
fix(rook-ceph): raise active recovery concurrency

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -41,6 +41,7 @@ cephClusterSpec:
       # the recreated 24 TB OSDs.
       osd_max_backfills: "3"
       osd_recovery_max_single_start: "3"
+      osd_recovery_max_active: "3"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Adds `osd_recovery_max_active: "3"` to the Rook CephCluster OSD config.
- Keeps the change alongside the existing temporary Turin recovery settings for mClock, backfills, and recovery start concurrency.
- Targets the current recovery reservation bottleneck without changing pool layout, OSD placement, or storage devices.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file("argocd/applications/rook-ceph/cluster-values.yaml"); puts "ok"'`
- `bun run lint:argocd`
- `git diff --check`
- Baseline readback before change: `kubectl --context galactic-tailscale -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s`
- Baseline readback before change: `kubectl --context galactic-tailscale -n rook-ceph exec deploy/rook-ceph-tools -- ceph pg stat`
- Baseline readback before change: `kubectl --context galactic-tailscale -n rook-ceph exec deploy/rook-ceph-tools -- ceph config dump | rg 'osd_(mclock|recovery|max_backfills)'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
