### PR TITLE
feat(anypi): improve torghut diff coverage reporting

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -275,9 +275,10 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
             f"lines covered ({coverage_pct:.2f}%){suffix}"
         )
         if item.missing_lines:
-            lines.append(
-                f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
+            missing_details = ", ".join(
+                f"{item.filename}:{line}" for line in item.missing_lines
             )
+            lines.append(f"  missing lines: {missing_details}")
     return "\n".join(lines)
 
 

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -468,7 +468,66 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         )
 
         self.assertIn("missing-from-coverage", text)
-        self.assertIn("missing lines: 20", text)
+        self.assertIn("missing lines: scripts/check_diff_coverage.py:20", text)
+
+    def test_format_summary_reports_uncovered_lines_with_fileline_details(self) -> None:
+        """Uncovered executable changed lines are reported with actionable file:line details."""
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="app/trading/foo.py",
+                    executable_changed_lines=2,
+                    covered_lines=0,
+                    missing_lines=(11, 12),
+                )
+            ]
+        )
+
+        # Verify actionable file:line details are included
+        self.assertIn("app/trading/foo.py:11", text)
+        self.assertIn("app/trading/foo.py:12", text)
+        self.assertIn("missing lines:", text)
+
+    def test_format_summary_multiple_files_show_fileline_for_each(self) -> None:
+        """Each file's missing lines are reported with their respective file:line details."""
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="app/trading/foo.py",
+                    executable_changed_lines=1,
+                    covered_lines=0,
+                    missing_lines=(11,),
+                ),
+                FileDiffCoverage(
+                    filename="scripts/new_tool.py",
+                    executable_changed_lines=1,
+                    covered_lines=0,
+                    missing_lines=(1,),
+                ),
+            ]
+        )
+
+        # Each file should have its own file:line details
+        self.assertIn("app/trading/foo.py:11", text)
+        self.assertIn("scripts/new_tool.py:1", text)
+        self.assertEqual(text.count("missing lines:"), 2)
+
+    def test_format_summary_covered_lines_not_in_missing(self) -> None:
+        """Covered lines do not appear in the missing lines output."""
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="app/trading/foo.py",
+                    executable_changed_lines=2,
+                    covered_lines=1,
+                    missing_lines=(12,),
+                )
+            ]
+        )
+
+        # Line 11 is covered, should not be in missing
+        self.assertNotIn("11", text)
+        self.assertIn("12", text)
 
     @patch("scripts.check_diff_coverage._parse_args")
     @patch("scripts.check_diff_coverage._repo_root")


### PR DESCRIPTION
## Summary

- Anypi generated this code change for agents/anypi-eval-repair-torghut-20260616053250.
- Prompt variant: repair-loop (cc10bb81ae0f003f).
- Session artifact: /workspace/.anypi/sessions/initial-7b0230d0/2026-06-16T05-33-50-670Z_019eceeb-f4ce-7c5f-a6bd-0a455898c4e9.jsonl.

## Related Issues

None

## Validation

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0

CI: Pending: pull request checks have not completed yet.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.

## Agent Output
I'll start by examining the current implementation of the diff coverage checker and its tests to understand the existing behavior.

Now I understand the current behavior. The issue is that the script currently reports missing lines in a generic format without actionable file:line details. The task asks to improve the script so uncovered executable changed lines are reported with actionable file:line details.

Looking at the current output format in `_format_summary`, I can see it shows:
- `filename: covered/total lines covered (percentage)`
- `  missing lines: line1, line2, ...`

The improvement needed is to show the actual file:line details for uncovered executable changed lines. Let me check if there are any specific tests for the format_summary function that I need to consider.

Looking at the existing test `test_format_summary_includes_missing_from_coverage_suffix`, it expects the format to include "missing-from-coverage" and "missing lines: 20". I need to preserve this behavior while improving the output to include the actionable file:line details.

Let me analyze what changes are needed:

1. The output should include the file:line details for each uncovered line
2. The format should be something like `filename:line` for each uncovered line
3. This should be in addition to or replacing the current "missing lines" format

Let me implement the changes:

Now let me run the existing tests to make sure my change doesn't break anything:

The tests are Python tests, not Bun tests. Let me run them with pytest:

Let me check the Python setup in the torghut service:

Let me use uv to run the tests:

Let me check if pytest is installed:

Let me try a different approach - let me check if there's a way to run tests:

Let me try to directly run Python tests using the system Python:

The test is failing because the output format has changed. Now I see `scripts/check_diff_coverage.py:20` instead of just `20`. I need to update the test to match the new expected format. Let me first verify my understanding of what the task wants:

Looking at the error, the output now shows `scripts/check_diff_coverage.py:20` which is the actionable file:line format that the task requested. I need to update the tests to reflect this change.

Let me update the test:

Now let me run the test again:

Now let me run all the tests in the test file to make sure nothing else broke:

All 32 tests pass. Now I need to add regression tests for the improved behavior. Let me add tests to verify that:
1. Uncovered executable changed lines are reported with actionable file:line details
2. The format includes the filename and line number

Let me add regression tests:

Now let me run all the tests again to make sure the new tests pass:

All 35 tests pass (32 original + 3 new). Now let me verify the script behavior with a real example by running it on the actual codebase:

The new format now shows `app/trading/foo.py:11, app/trading/foo.py:13` instead of just `11, 13`, which provides actionable file:line details. Let me also verify that the existing tests that check the output are still passing and that non-executable changed lines are still handled correctly:

Now let me check if there's a way to run validation checks for the Python service:

Let me check if there are Python-specific linting or validation scripts for torghut:

Let me check if there's a CI/CD workflow for torghut:

Let me look for Python tests or linting in the CI workflows:

I can see the CI runs `check_diff_coverage.py` in the `lint-and-tests` job. Let me verify my changes work correctly by looking at what other tests exist and making sure my changes don't break any integration tests. Let me check if there are any tests that specifically test the script output:

Good, the script is only run in CI and the tests are in `test_check_diff_coverage.py`. Let me verify the script syntax is correct and run a quick validation:

Now let me check if there's pyright validation for the torghut service that I need to pass:

Now let me check if there are any other places in the codebase that might reference the format of the missing lines output:

Good, the format is only used in the test file and the script itself. Let me now verify that the PR workflow should work with my changes by looking at the git diff:

Let me run all tests one more time to make sure everything is working:

All tests pass. Now let me verify the script works as expected with a real-world scenario by examining the expected output format:

The output now shows actionable file:line details like `app/trading/session_context.py:42` instead of just `42`. This makes it much easier for developers to quickly identify and fix uncovered lines.

Now let me verify that I haven't introduced any regressions by checking that non-executable changed lines are still handled correctly:

Excellent! The non-executable changed lines are still correctly skipped (as shown by the empty summary list). Let me also verify that the covered lines behavior is preserved:

The covered lines behavior is preserved - when all lines are covered, there's no "missing lines" output. Let me also run the final validation by checking if the script can be imported without errors:

Now let me check if there are any other validation checks I should run for this service. Let me look at the CI workflow again to see what other checks exist:

Let me verify that the changes I made don't break the format check:

Let me now create a summary of the changes and verify everything one final time:

Let me run the tests one more time to ensure everything passes:

All 35 tests pass. Let me verify the changes one final time by reviewing the diff:

The changes are complete. Let me summarize what was done:

## Summary of Changes

### 1. Improved `services/torghut/scripts/check_diff_coverage.py`

**Change**: Updated the `_format_summary` function to report uncovered executable changed lines with actionable file:line details.

**Before**:
```
missing lines: 20, 21
```

**Aft
