### PR TITLE
fix(agents): publish multi-arch runner workloads

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -59,7 +59,7 @@ jobs:
           AGENTS_BUILD_RUNNER: 'true'
           AGENTS_DOCKERFILE: services/agents/Dockerfile
           AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
-          AGENTS_IMAGE_PLATFORMS: linux/arm64
+          AGENTS_IMAGE_PLATFORMS: linux/amd64,linux/arm64
           AGENTS_RUNNER_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-codex-runner:buildcache
           AGENTS_BUILD_CACHE_MODE: max
           AGENTS_BUILD_NODE_OPTIONS: --max-old-space-size=4096

--- a/argocd/applications/agents/anypi-agent.yaml
+++ b/argocd/applications/agents/anypi-agent.yaml
@@ -15,3 +15,4 @@ spec:
   security:
     allowedSecrets:
       - github-token
+      - codex-auth

--- a/argocd/applications/agents/anypi-agent.yaml
+++ b/argocd/applications/agents/anypi-agent.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   providerRef:
     name: anypi
+  defaults:
+    systemPrompt: |
+      Controller-required placeholder. Anypi ignores this by default and uses ANYPI_PROMPT_VARIANT.
   vcsRef:
     name: github
   security:

--- a/argocd/applications/agents/anypi-agent.yaml
+++ b/argocd/applications/agents/anypi-agent.yaml
@@ -1,0 +1,12 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
+metadata:
+  name: anypi-agent
+spec:
+  providerRef:
+    name: anypi
+  vcsRef:
+    name: github
+  security:
+    allowedSecrets:
+      - github-token

--- a/argocd/applications/agents/anypi-agent.yaml
+++ b/argocd/applications/agents/anypi-agent.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   providerRef:
     name: anypi
+  defaults:
+    systemPrompt: |
+      You are Anypi, an autonomous production coding runner using the Pi SDK.
+      Work directly in the repository, make real code changes, run relevant validation, and leave the worktree changed
+      for the runner to commit, push, and open or update a pull request.
   vcsRef:
     name: github
   security:

--- a/argocd/applications/agents/anypi-agent.yaml
+++ b/argocd/applications/agents/anypi-agent.yaml
@@ -7,9 +7,16 @@ spec:
     name: anypi
   defaults:
     systemPrompt: |
-      You are Anypi, an autonomous production coding runner using the Pi SDK.
-      Work directly in the repository, make real code changes, run relevant validation, and leave the worktree changed
-      for the runner to commit, push, and open or update a pull request.
+      Act as a coding agent inside an existing repository.
+
+      Rules:
+      - Inspect repository instructions and relevant files before editing.
+      - Keep the solution focused, production-quality, and no broader than the task.
+      - Add or update tests for changed behavior.
+      - Run the checks required for touched files; fix failures and rerun them.
+      - Do not hard-code for tests, remove tests to pass, fake results, or claim success with failing checks.
+      - Do not commit, push, merge, or change branches.
+      - Keep the final response concise: changed files and validation only.
   vcsRef:
     name: github
   security:

--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -19,6 +19,7 @@ spec:
     ANYPI_SESSION_DIR: /workspace/.anypi/sessions
     ANYPI_STATUS_PATH: /workspace/.agent/status.json
     ANYPI_LOG_PATH: /workspace/.agent/runner.log
+    ANYPI_VALIDATION_REPAIR_ATTEMPTS: "2"
     AGENT_RUN_NAME: "{{agentRun.name}}"
     AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
   outputArtifacts:

--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -1,0 +1,28 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentProvider
+metadata:
+  name: anypi
+spec:
+  binary: /usr/local/bin/anypi-runner
+  adapter:
+    type: exec
+  envTemplate:
+    ANYPI_PROVIDER: flamingo
+    ANYPI_MODEL: qwen3-coder-flamingo
+    ANYPI_BASE_URL: http://flamingo.flamingo.svc.cluster.local/v1
+    ANYPI_API_KEY: flamingo-local
+    ANYPI_THINKING_LEVEL: "off"
+    ANYPI_TOOLS: all
+    ANYPI_WORKSPACE: /workspace
+    ANYPI_WORKTREE: /workspace/lab
+    ANYPI_AGENT_DIR: /workspace/.anypi
+    ANYPI_SESSION_DIR: /workspace/.anypi/sessions
+    ANYPI_STATUS_PATH: /workspace/.agent/status.json
+    ANYPI_LOG_PATH: /workspace/.agent/runner.log
+    AGENT_RUN_NAME: "{{agentRun.name}}"
+    AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
+  outputArtifacts:
+    - name: runner-log
+      path: /workspace/.agent/runner.log
+    - name: runner-status
+      path: /workspace/.agent/status.json

--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -11,6 +11,7 @@ spec:
     ANYPI_MODEL: qwen3-coder-flamingo
     ANYPI_BASE_URL: http://flamingo.flamingo.svc.cluster.local/v1
     ANYPI_API_KEY: flamingo-local
+    ANYPI_MODEL_READY_TIMEOUT_SECONDS: "1800"
     ANYPI_THINKING_LEVEL: "off"
     ANYPI_TOOLS: all
     ANYPI_WORKSPACE: /workspace

--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -19,6 +19,7 @@ spec:
     ANYPI_SESSION_DIR: /workspace/.anypi/sessions
     ANYPI_STATUS_PATH: /workspace/.agent/status.json
     ANYPI_LOG_PATH: /workspace/.agent/runner.log
+    ANYPI_NO_CHANGE_REPAIR_ATTEMPTS: "2"
     ANYPI_VALIDATION_REPAIR_ATTEMPTS: "2"
     AGENT_RUN_NAME: "{{agentRun.name}}"
     AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"

--- a/argocd/applications/agents/anypi-eval-agent.yaml
+++ b/argocd/applications/agents/anypi-eval-agent.yaml
@@ -1,10 +1,10 @@
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: Agent
 metadata:
-  name: anypi-agent
+  name: anypi-eval-agent
 spec:
   providerRef:
-    name: anypi
+    name: anypi-eval
   vcsRef:
     name: github
   security:

--- a/argocd/applications/agents/anypi-eval-agent.yaml
+++ b/argocd/applications/agents/anypi-eval-agent.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   providerRef:
     name: anypi-eval
+  defaults:
+    systemPrompt: |
+      Controller-required placeholder. Anypi ignores this by default and uses ANYPI_PROMPT_VARIANT.
   vcsRef:
     name: github
   security:

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -1,7 +1,7 @@
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentProvider
 metadata:
-  name: anypi
+  name: anypi-eval
 spec:
   binary: /usr/local/bin/anypi-runner
   adapter:
@@ -12,7 +12,7 @@ spec:
     ANYPI_BASE_URL: http://flamingo.flamingo.svc.cluster.local/v1
     ANYPI_API_KEY: flamingo-local
     ANYPI_MODEL_READY_TIMEOUT_SECONDS: "1800"
-    ANYPI_PROMPT_VARIANT: minimal
+    ANYPI_PROMPT_VARIANT: "{{parameters.promptVariant}}"
     ANYPI_ALLOW_SYSTEM_PROMPT_OVERRIDE: "false"
     ANYPI_THINKING_LEVEL: "off"
     ANYPI_TOOLS: all

--- a/argocd/applications/agents/codex-secretbinding.yaml
+++ b/argocd/applications/agents/codex-secretbinding.yaml
@@ -12,6 +12,8 @@ spec:
       name: codex-spark-smoke-agent
     - kind: Agent
       name: graf-codex-agent
+    - kind: Agent
+      name: anypi-agent
   allowedSecrets:
     - github-token
     - codex-auth

--- a/argocd/applications/agents/codex-secretbinding.yaml
+++ b/argocd/applications/agents/codex-secretbinding.yaml
@@ -14,6 +14,8 @@ spec:
       name: graf-codex-agent
     - kind: Agent
       name: anypi-agent
+    - kind: Agent
+      name: anypi-eval-agent
   allowedSecrets:
     - github-token
     - codex-auth

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - codex-spark-smoke-agent.yaml
   - codex-spark-smoke-agent-system-prompt-configmap.yaml
   - codex-spark-smoke-implspec.yaml
+  - anypi-agentprovider.yaml
+  - anypi-agent.yaml
   - codex-agentprovider.yaml
   - codex-spark-agentprovider.yaml
   - codex-agent-system-prompt-configmap.yaml

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -15,7 +15,9 @@ resources:
   - codex-spark-smoke-agent-system-prompt-configmap.yaml
   - codex-spark-smoke-implspec.yaml
   - anypi-agentprovider.yaml
+  - anypi-eval-agentprovider.yaml
   - anypi-agent.yaml
+  - anypi-eval-agent.yaml
   - codex-agentprovider.yaml
   - codex-spark-agentprovider.yaml
   - codex-agent-system-prompt-configmap.yaml

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -29,8 +29,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 4a010a93
-    digest: sha256:ba27e25e5aed4c331e4e931e29663546cfabb28eb7276e0ee905005fd8287174
+    tag: b18caf3d8
+    digest: sha256:4e1cb399c4ec0d458622e2689b02f5166bd9205b64a33fe904e5756b3d89f004
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -99,8 +99,7 @@ readinessProbe:
   timeoutSeconds: 5
 controller:
   defaultWorkload:
-    nodeSelector:
-      kubernetes.io/arch: arm64
+    nodeSelector: {}
     resources:
       requests:
         cpu: "1"

--- a/bun.lock
+++ b/bun.lock
@@ -678,6 +678,18 @@
         "bun-types": "1.3.14",
       },
     },
+    "services/anypi": {
+      "name": "@proompteng/anypi",
+      "version": "0.1.0",
+      "dependencies": {
+        "@earendil-works/pi-coding-agent": "0.79.4",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "typescript": "^6.0.3",
+        "vitest": "4.1.5",
+      },
+    },
     "services/bonjour": {
       "name": "@proompteng/bonjour",
       "version": "0.1.0",
@@ -984,6 +996,8 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
     "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
@@ -1008,6 +1022,8 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
     "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1042.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-node": "^3.972.39", "@aws-sdk/middleware-bucket-endpoint": "^3.972.10", "@aws-sdk/middleware-expect-continue": "^3.972.10", "@aws-sdk/middleware-flexible-checksums": "^3.974.16", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-location-constraint": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.37", "@aws-sdk/middleware-ssec": "^3.972.10", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.25", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/eventstream-serde-config-resolver": "^4.3.14", "@smithy/eventstream-serde-node": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-blob-browser": "^4.2.15", "@smithy/hash-node": "^4.2.14", "@smithy/hash-stream-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/md5-js": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.974.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.22", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw=="],
@@ -1030,7 +1046,11 @@
 
     "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw=="],
 
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.22", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ=="],
+
     "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.18", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A=="],
 
     "@aws-sdk/middleware-expect-continue": ["@aws-sdk/middleware-expect-continue@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ=="],
 
@@ -1050,6 +1070,8 @@
 
     "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@smithy/core": "^3.23.17", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-retry": "^4.3.6", "tslib": "^2.6.2" } }, "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A=="],
 
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Agv95NCgYyvuYUXt2PcFcOMrKCkhBFPhoH+nVMQh85RcXSCQrhAa4475plBOeomCihP26vKHT5KinVQT3iD14w=="],
+
     "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.6", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.25", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w=="],
 
     "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/config-resolver": "^4.4.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A=="],
@@ -1058,7 +1080,7 @@
 
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.25", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.37", "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw=="],
 
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1041.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
 
@@ -1290,6 +1312,14 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.4", "@earendil-works/pi-ai": "^0.79.4", "@earendil-works/pi-tui": "^0.79.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.3.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-PthzVzM5m4XH/hrU+2fVjuwuH5M4eMFWbd0NCRScH14XKpwlPc8/Fh6JDz0jQb5kTBT9oQT183YLTHVVulFL9A=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw=="],
+
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 
     "@effect/cli": ["@effect/cli@0.75.1", "", { "dependencies": { "ini": "^4.1.3", "toml": "^3.0.0", "yaml": "^2.5.0" }, "peerDependencies": { "@effect/platform": "^0.96.0", "@effect/printer": "^0.49.0", "@effect/printer-ansi": "^0.49.0", "effect": "^3.21.1" } }, "sha512-aDZ1OZzaFAb6NyBOrP+Bl52eICds5ERI9aa67LzloJELt5SCWeNwthtaEacBvvMkwVUcykJ+YHcGCkD1t47g8g=="],
@@ -1439,6 +1469,8 @@
     "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
 
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.0.5", "", { "peerDependencies": { "@tailwindcss/oxide": "^4.0.0", "tailwindcss": "^4.0.0" }, "optionalPeers": ["@tailwindcss/oxide", "tailwindcss"] }, "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
@@ -1660,6 +1692,28 @@
 
     "@lukeed/uuid": ["@lukeed/uuid@2.0.1", "", { "dependencies": { "@lukeed/csprng": "^1.1.0" } }, "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w=="],
 
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
     "@mastra/core": ["@mastra/core@1.32.1", "", { "dependencies": { "@a2a-js/sdk": "~0.3.13", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.23", "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.23", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.1", "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.8", "@ai-sdk/ui-utils-v5": "npm:@ai-sdk/ui-utils@1.2.11", "@isaacs/ttlcache": "^2.1.4", "@lukeed/uuid": "^2.0.1", "@mastra/schema-compat": "1.2.9", "@modelcontextprotocol/sdk": "^1.29.0", "@sindresorhus/slugify": "^2.2.1", "@standard-schema/spec": "^1.1.0", "ajv": "^8.18.0", "chat": "^4.24.0", "croner": "^10.0.1", "dotenv": "^17.3.1", "execa": "^9.6.1", "gray-matter": "^4.0.3", "hono": "^4.12.8", "hono-openapi": "^1.3.0", "ignore": "^7.0.5", "js-tiktoken": "^1.0.21", "json-schema": "^0.4.0", "lru-cache": "^11.2.7", "p-map": "^7.0.4", "p-retry": "^7.1.1", "picomatch": "^4.0.3", "radash": "^12.1.1", "tokenx": "^1.3.0", "ws": "^8.20.0", "xxhash-wasm": "^1.1.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-6ynJNZ9GMkLs11c9D4Ui9Z0eOP8GsAqPeMVhlnxExcdTls0ufFQSXFgwzBqtS97fot9IOA/fxDLvvW83fnsP0A=="],
 
     "@mastra/deployer": ["@mastra/deployer@1.32.1", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/preset-typescript": "^7.28.5", "@babel/traverse": "^7.29.0", "@hono/node-ws": "^1.3.0", "@mastra/server": "1.32.1", "@optimize-lodash/rollup-plugin": "^5.1.0", "@rollup/plugin-alias": "6.0.0", "@rollup/plugin-commonjs": "29.0.2", "@rollup/plugin-esm-shim": "0.1.8", "@rollup/plugin-json": "6.1.0", "@rollup/plugin-node-resolve": "16.0.3", "@rollup/plugin-virtual": "3.0.2", "@sindresorhus/slugify": "^2.2.1", "@types/babel__traverse": "^7.28.0", "empathic": "^2.0.0", "esbuild": "^0.27.4", "find-workspaces": "^0.3.1", "fs-extra": "^11.3.4", "hono": "^4.12.8", "local-pkg": "^1.1.2", "resolve-from": "^5.0.0", "resolve.exports": "^2.0.3", "rollup": "^4.59.0", "rollup-plugin-esbuild": "^6.2.1", "strip-json-comments": "^5.0.3", "tinyglobby": "^0.2.16", "typescript-paths": "^1.5.2", "ws": "^8.20.0" }, "peerDependencies": { "@mastra/core": ">=1.0.0-0 <2.0.0-0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-7y79RQVkwwfFJ1b6WVnBiXWhF4wc3dF2dHGN69Uejld2D+/TqOKCBq7RP/SO3iOWWEc01UCt5OAbXwpbEIV3mA=="],
@@ -1671,6 +1725,8 @@
     "@mastra/server": ["@mastra/server@1.32.1", "", { "dependencies": { "hono": "^4.12.8" }, "peerDependencies": { "@mastra/core": ">=1.13.2-0 <2.0.0-0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-CybYeWN2Ga+MRx2+PouMQ5ne0B9M63YtiY3XOs5RnYYifkq6k3Wv9uaDvHoLbW4wWllCUwRMeV3WEOQLGPW13g=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -2104,6 +2160,8 @@
 
     "@proompteng/agents": ["@proompteng/agents@workspace:services/agents"],
 
+    "@proompteng/anypi": ["@proompteng/anypi@workspace:services/anypi"],
+
     "@proompteng/atelier": ["@proompteng/atelier@workspace:packages/atelier"],
 
     "@proompteng/backend": ["@proompteng/backend@workspace:packages/backend"],
@@ -2423,6 +2481,8 @@
     "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
 
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
 
@@ -2842,6 +2902,8 @@
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
@@ -3058,7 +3120,7 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
 
@@ -3104,7 +3166,7 @@
 
     "boxen": ["boxen@7.0.0", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^7.0.0", "chalk": "^5.0.1", "cli-boxes": "^3.0.0", "string-width": "^5.1.2", "type-fest": "^2.13.0", "widest-line": "^4.0.1", "wrap-ansi": "^8.0.1" } }, "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg=="],
 
-    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -3119,6 +3181,8 @@
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -3480,6 +3544,8 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "echarts": ["echarts@6.0.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.0.0" } }, "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ=="],
 
     "eciesjs": ["eciesjs@0.4.17", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w=="],
@@ -3728,7 +3794,7 @@
 
     "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
 
-    "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+    "gaxios": ["gaxios@7.1.5", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg=="],
 
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
@@ -3738,7 +3804,7 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -3779,6 +3845,8 @@
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
     "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
+
+    "google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
@@ -3844,6 +3912,8 @@
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
     "hono": ["hono@4.12.17", "", {}, "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ=="],
@@ -3852,7 +3922,7 @@
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
-    "hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "hpagent": ["hpagent@1.2.0", "", {}, "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="],
 
@@ -3869,6 +3939,8 @@
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "http-status": ["http-status@2.1.0", "", {}, "sha512-O5kPr7AW7wYd/BBiOezTwnVAnmSNFY+J7hlZD2X5IOxVBetjcHAiTXhzj0gMrnojQlwy+UT1/Y3H3vJ3UlmvLA=="],
 
@@ -4150,6 +4222,8 @@
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-to-typescript": ["json-schema-to-typescript@15.0.3", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^11.5.5", "@types/json-schema": "^7.0.15", "@types/lodash": "^4.17.7", "is-glob": "^4.0.3", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "minimist": "^1.2.8", "prettier": "^3.2.5", "tinyglobby": "^0.2.9" }, "bin": { "json2ts": "dist/src/cli.js" } }, "sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA=="],
 
     "json-schema-to-zod": ["json-schema-to-zod@2.7.0", "", { "bin": { "json-schema-to-zod": "dist/cjs/cli.js" } }, "sha512-eW59l3NQ6sa3HcB+Ahf7pP6iGU7MY4we5JsPqXQ2ZcIPF8QxSg/lkY8lN0Js/AG0NjMbk+nZGUfHlceiHF+bwQ=="],
@@ -4171,6 +4245,10 @@
     "jsonpath-plus": ["jsonpath-plus@10.3.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA=="],
 
     "jsox": ["jsox@1.2.121", "", { "bin": { "jsox": "lib/cli.js" } }, "sha512-9Ag50tKhpTwS6r5wh3MJSAvpSof0UBr39Pto8OnzFT32Z/pAbxAsKHzyvsyMEHVslELvHyO/4/jaQELHk8wDcw=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "kabina": ["kabina@workspace:apps/kabina"],
 
@@ -4312,7 +4390,7 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
-    "marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "mastra": ["mastra@1.8.1", "", { "dependencies": { "@clack/prompts": "^1.1.0", "@expo/devcert": "^1.2.1", "@mastra/deployer": "^1.32.1", "@mastra/loggers": "^1.1.1", "archiver": "^7.0.1", "commander": "^14.0.3", "dotenv": "^17.3.1", "execa": "^9.6.1", "fs-extra": "^11.3.4", "get-port": "^7.1.0", "local-pkg": "^1.1.2", "openapi-fetch": "^0.17.0", "picocolors": "^1.1.1", "posthog-node": "5.17.2", "semver": "^7.7.4", "serve": "^14.2.6", "serve-handler": "^6.1.7", "shell-quote": "^1.8.3", "strip-json-comments": "^5.0.3", "yocto-spinner": "^1.1.0" }, "peerDependencies": { "@mastra/core": ">=1.1.0-0 <2.0.0-0", "zod": "^3.25.0 || ^4.0.0" }, "bin": { "mastra": "dist/index.js" } }, "sha512-pjkA54aJWn19DEOR22f3js7/73zzFN6nQBs0PfzGKnvtaAUuhSuzFEo9Z1AHD3t7dSTp140Iqr41F8hb4Z0Qyw=="],
 
@@ -4462,7 +4540,7 @@
 
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
-    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -4614,6 +4692,8 @@
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
     "openapi-fetch": ["openapi-fetch@0.17.0", "", { "dependencies": { "openapi-typescript-helpers": "^0.1.0" } }, "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
@@ -4667,6 +4747,8 @@
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
@@ -4785,6 +4867,8 @@
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -4949,6 +5033,8 @@
     "responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "rettime": ["rettime@0.7.0", "", {}, "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw=="],
 
@@ -5324,6 +5410,8 @@
 
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-essentials": ["ts-essentials@10.0.3", "", { "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-/FrVAZ76JLTWxJOERk04fm8hYENDo0PWSP3YLQKxevLwWtxemGcl5JJEzN4iqfDlRve0ckyfFaOBu4xbNH/wZw=="],
 
     "ts-jest": ["ts-jest@29.4.9", "", { "dependencies": { "bs-logger": "^0.2.6", "fast-json-stable-stringify": "^2.1.0", "handlebars": "^4.7.9", "json5": "^2.2.3", "lodash.memoize": "^4.1.2", "make-error": "^1.3.6", "semver": "^7.7.4", "type-fest": "^4.41.0", "yargs-parser": "^21.1.1" }, "peerDependencies": { "@babel/core": ">=7.0.0-beta.0 <8", "@jest/transform": "^29.0.0 || ^30.0.0", "@jest/types": "^29.0.0 || ^30.0.0", "babel-jest": "^29.0.0 || ^30.0.0", "jest": "^29.0.0 || ^30.0.0", "jest-util": "^29.0.0 || ^30.0.0", "typescript": ">=4.3 <7" }, "optionalPeers": ["@babel/core", "@jest/transform", "@jest/types", "babel-jest", "jest-util"], "bin": { "ts-jest": "cli.js" } }, "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ=="],
@@ -5355,6 +5443,8 @@
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -5622,6 +5712,50 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/core": ["@aws-sdk/core@3.974.21", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@aws-sdk/xml-builder": "^3.972.30", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.56", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.47", "@aws-sdk/credential-provider-http": "^3.972.49", "@aws-sdk/credential-provider-ini": "^3.972.54", "@aws-sdk/credential-provider-process": "^3.972.47", "@aws-sdk/credential-provider-sso": "^3.972.53", "@aws-sdk/credential-provider-web-identity": "^3.972.53", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A=="],
+
+    "@aws-sdk/client-bedrock-runtime/@smithy/core": ["@smithy/core@3.25.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A=="],
+
+    "@aws-sdk/client-bedrock-runtime/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA=="],
+
+    "@aws-sdk/client-bedrock-runtime/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1041.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw=="],
+
+    "@aws-sdk/eventstream-handler-node/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/eventstream-handler-node/@smithy/core": ["@smithy/core@3.25.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A=="],
+
+    "@aws-sdk/eventstream-handler-node/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/middleware-eventstream/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/middleware-eventstream/@smithy/core": ["@smithy/core@3.25.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A=="],
+
+    "@aws-sdk/middleware-eventstream/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/core": ["@aws-sdk/core@3.974.21", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@aws-sdk/xml-builder": "^3.972.30", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/core": ["@smithy/core@3.25.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/core": ["@aws-sdk/core@3.974.21", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@aws-sdk/xml-builder": "^3.972.30", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.21", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.21", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw=="],
+
+    "@aws-sdk/token-providers/@smithy/core": ["@smithy/core@3.25.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A=="],
+
+    "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
     "@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/core/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
@@ -5686,6 +5820,20 @@
 
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
+    "@earendil-works/pi-agent-core/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@earendil-works/pi-ai/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@earendil-works/pi-coding-agent/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "@earendil-works/pi-coding-agent/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "@earendil-works/pi-coding-agent/undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
+
+    "@earendil-works/pi-coding-agent/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@effect/experimental/@effect/platform": ["@effect/platform@0.94.2", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.15" } }, "sha512-85vdwpnK4oH/rJ3EuX/Gi2Hkt+K4HvXWr9bxCuqvty9hxyEcRxkJcqTesYrcVoQB6aULb1Za2B0MKoTbvffB3Q=="],
@@ -5713,6 +5861,12 @@
     "@floating-ui/react/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.7", "", { "dependencies": { "@floating-ui/dom": "^1.7.5" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg=="],
 
     "@floating-ui/react/@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@google/genai/p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "@google/genai/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "@google/genai/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "@grpc/proto-loader/protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
@@ -5781,6 +5935,8 @@
     "@mastra/server/hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
 
     "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "@mistralai/mistralai/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
@@ -6268,6 +6424,10 @@
 
     "cdk8s-cli/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
+    "cdk8s-plus-31/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "cdk8s-plus-33/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
     "chalk-template/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
@@ -6384,9 +6544,7 @@
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "gaxios/rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
-
-    "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "gcp-metadata/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
 
     "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -6580,6 +6738,8 @@
 
     "mlly/ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
+    "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
     "msw/graphql": ["graphql@16.12.0", "", {}, "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="],
 
     "msw/tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
@@ -6593,6 +6753,8 @@
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "node-pty/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "normalize-package-data/hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
 
     "normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
@@ -6651,6 +6813,8 @@
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "proto3-json-serializer/protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
@@ -6902,6 +7066,54 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.30", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/core/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.47", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.49", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.54", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/credential-provider-env": "^3.972.47", "@aws-sdk/credential-provider-http": "^3.972.49", "@aws-sdk/credential-provider-login": "^3.972.53", "@aws-sdk/credential-provider-process": "^3.972.47", "@aws-sdk/credential-provider-sso": "^3.972.53", "@aws-sdk/credential-provider-web-identity": "^3.972.53", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.47", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/token-providers": "3.1069.0", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@smithy/core/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@smithy/fetch-http-handler/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@smithy/node-http-handler/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.30", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.30", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.35", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/nested-clients/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/nested-clients/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg=="],
+
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@discordjs/ws/@discordjs/rest/undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
@@ -6917,6 +7129,10 @@
     "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "@earendil-works/pi-ai/@smithy/node-http-handler/@smithy/core": ["@smithy/core@3.25.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A=="],
+
+    "@earendil-works/pi-ai/@smithy/node-http-handler/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
 
     "@effect/experimental/@effect/platform/msgpackr": ["msgpackr@1.11.8", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA=="],
 
@@ -6969,6 +7185,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@floating-ui/react/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
+
+    "@google/genai/p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "@grpc/proto-loader/protobufjs/@types/node": ["@types/node@24.10.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw=="],
 
@@ -7244,6 +7462,8 @@
 
     "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
 
+    "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
     "@tailwindcss/postcss/@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
     "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.4", "", { "os": "android", "cpu": "arm64" }, "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g=="],
@@ -7410,6 +7630,8 @@
 
     "cdk8s-cli/cdk8s/yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
+    "cdk8s-cli/cdk8s-plus-33/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
     "cdk8s-cli/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "cdk8s-cli/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
@@ -7422,6 +7644,10 @@
 
     "cdk8s-cli/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
+    "cdk8s-plus-31/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "cdk8s-plus-33/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
     "chalk-template/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "chalk-template/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -7431,6 +7657,8 @@
     "cli-truncate/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "cli-truncate/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "cli-truncate/string-width/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "clipboardy/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -7572,9 +7800,9 @@
 
     "fumadocs-mdx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
-    "gaxios/rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+    "gcp-metadata/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "gcp-metadata/gaxios/rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -7758,6 +7986,8 @@
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "ora/string-width/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
     "parse5-htmlparser2-tree-adapter/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "parse5-parser-stream/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -7775,6 +8005,8 @@
     "react-select/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
 
     "react-select/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "reestr/@tailwindcss/vite/@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
@@ -8032,11 +8264,33 @@
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "wrap-ansi/string-width/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.21", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.21", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.21", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.21", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1069.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.21", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.21", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
 
     "@floating-ui/react/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
 
@@ -8051,6 +8305,8 @@
     "@jest/core/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "@jest/reporters/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "@jest/reporters/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@jest/reporters/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -8458,6 +8714,8 @@
 
     "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
+    "@redocly/openapi-core/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "@tailwindcss/postcss/@tailwindcss/node/enhanced-resolve/tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
     "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
@@ -8608,6 +8866,8 @@
 
     "app/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
+    "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
     "archiver-utils/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.4", "", {}, "sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw=="],
@@ -8616,23 +8876,27 @@
 
     "babel-jest/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
+    "cdk8s-cli/cdk8s-plus-33/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
     "cdk8s-cli/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cdk8s-cli/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "cdk8s-cli/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
+    "cdk8s-plus-31/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "cdk8s-plus-33/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "chalk-template/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "cli-truncate/slice-ansi/is-fullwidth-code-point/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "concurrently/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "gaxios/rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "gaxios/rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "gcp-metadata/gaxios/rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "gray-matter/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -8641,6 +8905,8 @@
     "jest-cli/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "jest-config/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "jest-config/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "jest-config/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -8657,6 +8923,8 @@
     "jest-runner/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "jest-runtime/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "jest-runtime/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "jest-runtime/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -8750,15 +9018,21 @@
 
     "kabina/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
+    "log-update/slice-ansi/is-fullwidth-code-point/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
     "npm-run-all/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "npm-run-all/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@1.0.0", "", {}, "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="],
 
     "npm-run-all/cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "npm-run-all/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "proto3-json-serializer/protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "react-datepicker/@floating-ui/react/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
+
+    "readdir-glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "reestr/@tailwindcss/vite/@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -8877,6 +9151,8 @@
     "reestr/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
 
     "reestr/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+
+    "serve-handler/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "slice-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
@@ -9032,6 +9308,8 @@
 
     "tanstack-router-react-example-with-trpc-react-query/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
+    "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "tsdown/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "unrun/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -9130,6 +9408,18 @@
 
     "wrap-ansi-cjs/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.35", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.35", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.35", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg=="],
+
     "@inquirer/core/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "@jest/console/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -9137,6 +9427,8 @@
     "@jest/core/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "@jest/reporters/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "@jest/reporters/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@jest/snapshot-utils/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
@@ -9334,7 +9626,11 @@
 
     "app/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
+    "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "babel-jest/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "cdk8s-cli/cdk8s-plus-33/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "cdk8s-cli/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -9344,13 +9640,17 @@
 
     "concurrently/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "gaxios/rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "gcp-metadata/gaxios/rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "gcp-metadata/gaxios/rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "jest-circus/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "jest-cli/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "jest-config/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "jest-config/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "jest-diff/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
@@ -9365,6 +9665,8 @@
     "jest-runner/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "jest-runtime/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "jest-runtime/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "jest-snapshot/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
@@ -9524,7 +9826,17 @@
 
     "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
+
     "cdk8s-cli/yargs/cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "gcp-metadata/gaxios/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "gcp-metadata/gaxios/rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "jsii-srcmak/jsii-pacmak/@jsii/check-node/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -9533,6 +9845,8 @@
     "jsii-srcmak/jsii-rosetta/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "cdk8s-cli/yargs/cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "gcp-metadata/gaxios/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "jsii-srcmak/jsii-pacmak/@jsii/check-node/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -76,7 +76,7 @@ spec:
     mode: read-write
   parameters:
     repository: proompteng/lab
-    base: main
+    base: codex/flamingo-rollout-complete
     head: codex/anypi-eval/strict-repo/runner-status-evidence-20260616
     promptVariant: strict-repo
     validationCommands: |
@@ -122,7 +122,7 @@ spec:
     mode: read-write
   parameters:
     repository: proompteng/lab
-    base: main
+    base: codex/flamingo-rollout-complete
     head: codex/anypi-eval/strict-repo/agents-docs-manifests-20260616
     promptVariant: strict-repo
     validationCommands: |

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -40,7 +40,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
+    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
     resources:
       requests:
         cpu: '2'
@@ -86,7 +86,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
+    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
     resources:
       requests:
         cpu: '2'
@@ -130,7 +130,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
+    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -40,7 +40,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
     resources:
       requests:
         cpu: '2'
@@ -86,7 +86,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
     resources:
       requests:
         cpu: '2'
@@ -130,7 +130,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -1,0 +1,141 @@
+# Templates only. Do not add this file to the Argo CD kustomization.
+#
+# Duplicate each AgentRun per prompt variant by setting:
+#   metadata.name
+#   spec.parameters.head
+#   spec.parameters.promptVariant: minimal | finish-gated | repair-loop | strict-repo
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: anypi-eval-torghut-strict-repo-20260616
+  namespace: agents
+  labels:
+    app.kubernetes.io/part-of: anypi-prompt-eval
+spec:
+  agentRef:
+    name: anypi-eval-agent
+  implementation:
+    inline:
+      summary: Improve Torghut diff coverage reporting
+      text: |
+        Improve services/torghut/scripts/check_diff_coverage.py so uncovered executable changed lines are reported
+        with actionable file:line details. Add regression tests in services/torghut/tests/test_check_diff_coverage.py.
+        Preserve existing behavior for covered lines and non-executable changed lines.
+  runtime:
+    type: job
+  ttlSecondsAfterFinished: 86400
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/anypi-eval/strict-repo/torghut-diff-coverage-20260616
+    promptVariant: strict-repo
+    validationCommands: |
+      cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
+  secrets:
+    - github-token
+  workload:
+    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    resources:
+      requests:
+        cpu: '2'
+        memory: 4Gi
+        ephemeral-storage: 12Gi
+      limits:
+        memory: 12Gi
+        ephemeral-storage: 24Gi
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: anypi-eval-runner-strict-repo-20260616
+  namespace: agents
+  labels:
+    app.kubernetes.io/part-of: anypi-prompt-eval
+spec:
+  agentRef:
+    name: anypi-eval-agent
+  implementation:
+    inline:
+      summary: Improve Anypi status evidence tests
+      text: |
+        Improve services/anypi tests so status evidence for prompt variants, validation plans, and CI checks is covered.
+        Keep the change focused on runner behavior and tests.
+  runtime:
+    type: job
+  ttlSecondsAfterFinished: 86400
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/anypi-eval/strict-repo/runner-status-evidence-20260616
+    promptVariant: strict-repo
+    validationCommands: |
+      bun run --filter @proompteng/anypi tsc
+      bun run --filter @proompteng/anypi test
+      bun run --filter @proompteng/anypi lint
+  secrets:
+    - github-token
+  workload:
+    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    resources:
+      requests:
+        cpu: '2'
+        memory: 4Gi
+        ephemeral-storage: 12Gi
+      limits:
+        memory: 12Gi
+        ephemeral-storage: 24Gi
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: anypi-eval-agents-strict-repo-20260616
+  namespace: agents
+  labels:
+    app.kubernetes.io/part-of: anypi-prompt-eval
+spec:
+  agentRef:
+    name: anypi-eval-agent
+  implementation:
+    inline:
+      summary: Improve Anypi eval documentation and manifests
+      text: |
+        Improve the Anypi eval documentation and agents manifests so prompt evaluation runs are easier to audit.
+        Keep manifests renderable and avoid changing unrelated providers.
+  runtime:
+    type: job
+  ttlSecondsAfterFinished: 86400
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/anypi-eval/strict-repo/agents-docs-manifests-20260616
+    promptVariant: strict-repo
+    validationCommands: |
+      mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml
+  secrets:
+    - github-token
+  workload:
+    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    resources:
+      requests:
+        cpu: '2'
+        memory: 4Gi
+        ephemeral-storage: 12Gi
+      limits:
+        memory: 12Gi
+        ephemeral-storage: 24Gi

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -126,7 +126,7 @@ spec:
     head: codex/anypi-eval/strict-repo/agents-docs-manifests-20260616
     promptVariant: strict-repo
     validationCommands: |
-      mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml
+      kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml
   secrets:
     - github-token
   workload:

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -40,7 +40,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
+    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
     resources:
       requests:
         cpu: '2'
@@ -86,7 +86,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
+    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
     resources:
       requests:
         cpu: '2'
@@ -130,7 +130,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
+    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -40,7 +40,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
+    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
     resources:
       requests:
         cpu: '2'
@@ -86,7 +86,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
+    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
     resources:
       requests:
         cpu: '2'
@@ -130,7 +130,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
+    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi-prompt-eval.md
+++ b/docs/agents/anypi-prompt-eval.md
@@ -1,0 +1,72 @@
+# Anypi Prompt Evaluation
+
+Status: implementation/evaluation protocol
+
+## Purpose
+
+Anypi does not promote a final system prompt by taste. Prompt variants are compared with real AgentRuns that must create
+code and tests, pass local validation, open PRs, and wait for required GitHub checks.
+
+## Variants
+
+- `minimal`: short repo-coding contract.
+- `finish-gated`: `minimal` plus explicit continue-until-validation behavior.
+- `repair-loop`: `finish-gated` plus failure-output/root-cause repair discipline.
+- `strict-repo`: `repair-loop` plus stronger AGENTS.md, no-hardcoding, no-test-weakening, no-unrelated-refactor rules.
+
+The prompt text is resolved inside `services/anypi/src/prompt.ts`. Runtime details are not model-facing.
+
+## Evaluation Matrix
+
+Run at least three substantial tasks against at least three variants. Prefer two repetitions when GPU/queue capacity is
+available. Every run must use a unique branch:
+
+```text
+codex/anypi-eval/<variant>/<task>/<yyyymmddhhmm>
+```
+
+Required task classes:
+
+- Torghut: improve executable changed-line reporting in `services/torghut/scripts/check_diff_coverage.py` and add
+  regression tests in `services/torghut/tests/test_check_diff_coverage.py`.
+- Anypi: improve runner behavior or tests under `services/anypi` with TypeScript validation.
+- Infra/docs plus code: touch `argocd/applications/agents` and docs while preserving manifest rendering and PR-template
+  compliance.
+
+## Scoring
+
+Hard gates:
+
+- AgentRun reaches `Succeeded`.
+- Worktree contains a real code/test diff.
+- Local validation passes.
+- PR is opened or updated.
+- Required GitHub checks pass.
+- Status contains `promptVariant`, `promptHash`, `validationPlan`, validation results, CI result, commit, PR URL, and
+  session path.
+- No runtime leakage in model-facing prompts; no hardcoded test hacks, removed tests, fake validation, or broad unrelated
+  refactors.
+
+Tie-breakers:
+
+- Fewer agent, validation, and CI repair attempts.
+- Lower elapsed time.
+- Smaller unrelated diff.
+- Clearer PR body and status evidence.
+
+Promotion rule: promote a variant to `anypi-agent` only after at least 80% green PR rate and zero instruction-violation
+failures. If no variant passes, leave `anypi-agent` on `minimal`, record the failures, and iterate the variants.
+
+## Current Results
+
+| Variant | Task | AgentRun | PR | Local validation | Required CI | Repairs | Decision |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| pending | pending | pending | pending | pending | pending | pending | pending |
+
+## Commands
+
+```bash
+kubectl -n agents get agentprovider anypi-eval
+kubectl -n agents get agent anypi-eval-agent
+kubectl -n agents get agentrun -l app.kubernetes.io/part-of=anypi-prompt-eval
+```

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -27,6 +27,8 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 - `ANYPI_BASE_URL`, `ANYPI_PROVIDER`, and `ANYPI_MODEL` configure the generated Pi `models.json`.
 - Sessions are persisted under `/workspace/.anypi/sessions`; the active session file path is written into
   `/workspace/.agent/status.json`.
+- `ANYPI_VALIDATION_REPAIR_ATTEMPTS=2` gives Pi two bounded repair passes when a runner-side validation command fails.
+  The runner still refuses to commit or push unless all validation commands pass.
 
 ## AgentRun Example
 
@@ -68,7 +70,7 @@ spec:
     image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
     resources:
       requests:
-        cpu: "2"
+        cpu: '2'
         memory: 4Gi
         ephemeral-storage: 12Gi
       limits:

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
 
@@ -98,7 +98,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
+    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
 
@@ -98,7 +98,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
+    image: registry.ide-newton.ts.net/lab/anypi:7a7036831@sha256:ae96478b7571b3a19d217fea217af4e584a37bb1d549cdd1e0e94348475fa706
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -27,6 +27,8 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 - `ANYPI_BASE_URL`, `ANYPI_PROVIDER`, and `ANYPI_MODEL` configure the generated Pi `models.json`.
 - Sessions are persisted under `/workspace/.anypi/sessions`; the active session file path is written into
   `/workspace/.agent/status.json`.
+- `ANYPI_MODEL_READY_TIMEOUT_SECONDS=1800` makes the runner wait for `GET /v1/models` before starting Pi, which avoids
+  empty runs while Flamingo is cold-loading the model.
 - `ANYPI_VALIDATION_REPAIR_ATTEMPTS=2` gives Pi two bounded repair passes when a runner-side validation command fails.
   The runner still refuses to commit or push unless all validation commands pass.
 - `ANYPI_NO_CHANGE_REPAIR_ATTEMPTS=2` gives Pi two bounded continuation prompts if a session exits without leaving

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,9 +9,10 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
+- Supported workload image platforms: `linux/amd64`, `linux/arm64`
 
 The provider is an Agents `exec` provider. The controller mounts `/workspace/run.json`, injects `VCS_*` and
 `GH_TOKEN/GITHUB_TOKEN`, then starts the Anypi binary directly. Anypi clones the repository, checks out the AgentRun head
@@ -98,7 +99,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:3675fe829@sha256:69e428a22540b940f2d40eed83be3bfe97bb5807bbc9d27087d366f56dfad0ad
+    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -29,6 +29,8 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
   `/workspace/.agent/status.json`.
 - `ANYPI_VALIDATION_REPAIR_ATTEMPTS=2` gives Pi two bounded repair passes when a runner-side validation command fails.
   The runner still refuses to commit or push unless all validation commands pass.
+- `ANYPI_NO_CHANGE_REPAIR_ATTEMPTS=2` gives Pi two bounded continuation prompts if a session exits without leaving
+  code changes. The run still fails if the worktree is unchanged after those attempts.
 
 ## AgentRun Example
 

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
 
@@ -95,7 +95,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    image: registry.ide-newton.ts.net/lab/anypi:05c1eeeb8@sha256:ae3f971839388448508b1784e9155313a6f5263f5b1ffe46730ae58e72dd4a75
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -25,23 +25,34 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 - `ANYPI_THINKING_LEVEL=off` is the default because Flamingo/Qwen3 Coder is served through vLLM without reasoning-effort
   support.
 - `ANYPI_BASE_URL`, `ANYPI_PROVIDER`, and `ANYPI_MODEL` configure the generated Pi `models.json`.
+- `ANYPI_PROMPT_VARIANT` selects the runner-owned system prompt candidate. Valid values are `minimal`,
+  `finish-gated`, `repair-loop`, and `strict-repo`.
+- `ANYPI_ALLOW_SYSTEM_PROMPT_OVERRIDE=false` keeps `Agent.spec.defaults.systemPrompt` or run-payload prompt drift from
+  bypassing prompt-variant evaluation.
 - Sessions are persisted under `/workspace/.anypi/sessions`; the active session file path is written into
   `/workspace/.agent/status.json`.
 - `ANYPI_MODEL_READY_TIMEOUT_SECONDS=1800` makes the runner wait for `GET /v1/models` before starting Pi, which avoids
   empty runs while Flamingo is cold-loading the model.
+- `ANYPI_VALIDATION_POLICY=append` combines inferred service checks, run-provided checks, and provider checks. The runner
+  refuses to continue when the only validation command is `git diff --check`.
 - `ANYPI_VALIDATION_REPAIR_ATTEMPTS=2` gives Pi two bounded repair passes when a runner-side validation command fails.
   The runner still refuses to commit or push unless all validation commands pass.
 - `ANYPI_NO_CHANGE_REPAIR_ATTEMPTS=2` gives Pi two bounded continuation prompts if a session exits without leaving
   code changes. The run still fails if the worktree is unchanged after those attempts.
+- `ANYPI_CI_REPAIR_ATTEMPTS=1` makes the runner wait for required GitHub checks after opening the PR and run one bounded
+  repair pass if those checks fail.
 
 ## Prompt Contract
 
-The system prompt is intentionally small and repo-focused. It does not mention Anypi, yolo mode, Kubernetes, Flamingo,
-or the Pi SDK. Runtime details stay in runner config and logs, not in the model's behavioral contract.
+The system prompt is a measured runner artifact, not a fixed Agent default. The default provider starts with `minimal`;
+`anypi-eval-agent` runs comparative variants through `ANYPI_PROMPT_VARIANT={{parameters.promptVariant}}`.
 
-The Agents controller resolves `Agent.spec.defaults.systemPrompt` into `/workspace/run.json`; Anypi passes that resolved
-prompt to Pi's `ResourceLoader`. The per-run task prompt only adds the worktree, repository refs, task text, and a short
-set of task rules. Root `AGENTS.md` is injected as repository context.
+Prompt variants are intentionally small and repo-focused. They do not mention Anypi, yolo mode, Kubernetes, Flamingo, or
+the Pi SDK. Runtime details stay in runner config and logs, not in the model's behavioral contract. Root `AGENTS.md` is
+injected as repository context.
+
+Status evidence is written to `/workspace/.agent/status.json`: `promptVariant`, `promptHash`, `validationPlan`,
+`validations`, `ci`, `ciAttempts`, `sessionFiles`, `commit`, and `pullRequest`.
 
 ## AgentRun Example
 
@@ -124,4 +135,4 @@ Do not set `spec.parameters.prompt`; the task belongs in `ImplementationSpec.spe
    ```
 
 Acceptance requires a Succeeded AgentRun, a pushed `codex/...` branch, and an opened PR containing real Torghut code and
-test changes. The runner does not auto-merge.
+test changes with required GitHub checks green. The runner does not auto-merge.

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -34,6 +34,15 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 - `ANYPI_NO_CHANGE_REPAIR_ATTEMPTS=2` gives Pi two bounded continuation prompts if a session exits without leaving
   code changes. The run still fails if the worktree is unchanged after those attempts.
 
+## Prompt Contract
+
+The system prompt is intentionally small and repo-focused. It does not mention Anypi, yolo mode, Kubernetes, Flamingo,
+or the Pi SDK. Runtime details stay in runner config and logs, not in the model's behavioral contract.
+
+The Agents controller resolves `Agent.spec.defaults.systemPrompt` into `/workspace/run.json`; Anypi passes that resolved
+prompt to Pi's `ResourceLoader`. The per-run task prompt only adds the worktree, repository refs, task text, and a short
+set of task rules. Root `AGENTS.md` is injected as repository context.
+
 ## AgentRun Example
 
 ```yaml
@@ -67,7 +76,11 @@ spec:
     validationCommands: |
       git diff --check
       cd services/torghut && uv sync --frozen --extra dev
+      cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
+      cd services/torghut && uv run --frozen pyright --project pyrightconfig.json
+      cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json
+      cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json
   secrets:
     - github-token
   workload:

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -1,0 +1,108 @@
+# Anypi
+
+Anypi is the lightweight Agents provider for running Pi as an autonomous coding harness against the self-hosted
+Flamingo model.
+
+## Runtime Contract
+
+- Provider: `anypi`
+- Agent: `anypi-agent`
+- Binary: `/usr/local/bin/anypi-runner`
+- Runtime type: `job`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>`
+- Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
+- Default model: `qwen3-coder-flamingo`
+
+The provider is an Agents `exec` provider. The controller mounts `/workspace/run.json`, injects `VCS_*` and
+`GH_TOKEN/GITHUB_TOKEN`, then starts the Anypi binary directly. Anypi clones the repository, checks out the AgentRun head
+branch, invokes Pi through the TypeScript SDK, validates the result, commits, pushes, and opens or updates a PR.
+
+## Pi SDK Configuration
+
+Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
+
+- `ANYPI_TOOLS=all` enables the full built-in coding tool set: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`.
+- `ANYPI_THINKING_LEVEL=off` is the default because Flamingo/Qwen3 Coder is served through vLLM without reasoning-effort
+  support.
+- `ANYPI_BASE_URL`, `ANYPI_PROVIDER`, and `ANYPI_MODEL` configure the generated Pi `models.json`.
+- Sessions are persisted under `/workspace/.anypi/sessions`; the active session file path is written into
+  `/workspace/.agent/status.json`.
+
+## AgentRun Example
+
+```yaml
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: anypi-torghut-quality-20260616
+  namespace: agents
+spec:
+  agentRef:
+    name: anypi-agent
+  implementation:
+    inline:
+      summary: Improve Torghut diff coverage reporting
+      text: |
+        Improve services/torghut/scripts/check_diff_coverage.py so uncovered executable changed lines are reported
+        with actionable file:line details. Add regression tests in services/torghut/tests/test_check_diff_coverage.py.
+        Run the focused tests and leave the worktree changed for the runner to commit.
+  runtime:
+    type: job
+  ttlSecondsAfterFinished: 86400
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/anypi-torghut-quality-20260616
+    validationCommands: |
+      git diff --check
+      cd services/torghut && uv sync --frozen --extra dev
+      cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
+  secrets:
+    - github-token
+  workload:
+    image: registry.ide-newton.ts.net/lab/anypi:<tag>@<digest>
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+        ephemeral-storage: 12Gi
+      limits:
+        memory: 12Gi
+        ephemeral-storage: 24Gi
+```
+
+Do not set `spec.parameters.prompt`; the task belongs in `ImplementationSpec.spec.text` or
+`spec.implementation.inline.text`.
+
+## Rollout
+
+1. Build and push:
+
+   ```bash
+   bun run build:anypi
+   docker buildx imagetools inspect registry.ide-newton.ts.net/lab/anypi:<tag>
+   ```
+
+2. Pin the resulting image digest in the validation AgentRun `spec.workload.image`.
+3. Sync `argocd/agents`.
+4. Verify:
+
+   ```bash
+   kubectl -n agents get agentprovider anypi
+   kubectl -n agents get agent anypi-agent
+   ```
+
+5. Submit the Torghut validation AgentRun and monitor:
+
+   ```bash
+   kubectl -n agents get agentrun anypi-torghut-quality-20260616
+   kubectl -n agents logs -f job/$(kubectl -n agents get job -l agents.proompteng.ai/agent-run=anypi-torghut-quality-20260616 -o jsonpath='{.items[0].metadata.name}')
+   ```
+
+Acceptance requires a Succeeded AgentRun, a pushed `codex/...` branch, and an opened PR containing real Torghut code and
+test changes. The runner does not auto-merge.

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -28,7 +28,8 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 - `ANYPI_PROMPT_VARIANT` selects the runner-owned system prompt candidate. Valid values are `minimal`,
   `finish-gated`, `repair-loop`, and `strict-repo`.
 - `ANYPI_ALLOW_SYSTEM_PROMPT_OVERRIDE=false` keeps `Agent.spec.defaults.systemPrompt` or run-payload prompt drift from
-  bypassing prompt-variant evaluation.
+  bypassing prompt-variant evaluation. The Agent still carries a controller-required placeholder `systemPrompt`; Anypi
+  logs and ignores it unless this override flag is explicitly enabled.
 - Sessions are persisted under `/workspace/.anypi/sessions`; the active session file path is written into
   `/workspace/.agent/status.json`.
 - `ANYPI_MODEL_READY_TIMEOUT_SECONDS=1800` makes the runner wait for `GET /v1/models` before starting Pi, which avoids
@@ -45,7 +46,9 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 ## Prompt Contract
 
 The system prompt is a measured runner artifact, not a fixed Agent default. The default provider starts with `minimal`;
-`anypi-eval-agent` runs comparative variants through `ANYPI_PROMPT_VARIANT={{parameters.promptVariant}}`.
+`anypi-eval-agent` runs comparative variants through `ANYPI_PROMPT_VARIANT={{parameters.promptVariant}}`. The Kubernetes
+`Agent` placeholder exists only because the Agents controller requires a `defaults.systemPrompt` field before it will
+materialize a run.
 
 Prompt variants are intentionally small and repo-focused. They do not mention Anypi, yolo mode, Kubernetes, Flamingo, or
 the Pi SDK. Runtime details stay in runner config and logs, not in the model's behavioral contract. Root `AGENTS.md` is

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "facteur:consume": "bun run packages/scripts/src/facteur/run-consumer.ts",
     "convex:reseal": "bun run packages/scripts/src/convex/reseal-secrets.ts",
     "build:torghut": "bun run packages/scripts/src/torghut/build-image.ts",
+    "build:anypi": "bun run packages/scripts/src/anypi/build-image.ts",
     "build:symphony": "bun run packages/scripts/src/symphony/build-image.ts",
     "khoshut:deploy": "bun run packages/scripts/src/khoshut/deploy-service.ts",
     "deploy:torghut-agentruns": "bun run packages/scripts/src/torghut/deploy-agentruns.ts",

--- a/packages/scripts/src/anypi/build-image.ts
+++ b/packages/scripts/src/anypi/build-image.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env bun
+
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+import { ensureCli, repoRoot, run } from '../shared/cli'
+import { buildAndPushDockerImage } from '../shared/docker'
+import { execGit } from '../shared/git'
+
+export type BuildImageOptions = {
+  registry?: string
+  repository?: string
+  tag?: string
+  context?: string
+  dockerfile?: string
+  version?: string
+  commit?: string
+  cacheRef?: string
+  platforms?: string[]
+}
+
+const parsePlatforms = (value: string | undefined): string[] | undefined => {
+  if (!value) return undefined
+  const platforms = value
+    .split(',')
+    .map((platform) => platform.trim())
+    .filter(Boolean)
+  return platforms.length > 0 ? platforms : undefined
+}
+
+const createPrunedContext = async (): Promise<{ dir: string; cleanup: () => void }> => {
+  ensureCli('bunx')
+  const dir = mkdtempSync(resolve(tmpdir(), 'anypi-prune-'))
+  const cleanup = () => rmSync(dir, { recursive: true, force: true })
+  try {
+    await run('bunx', ['turbo', 'prune', '--scope=@proompteng/anypi', '--docker', `--out-dir=${dir}`], {
+      cwd: repoRoot,
+    })
+    copyFileSync(resolve(repoRoot, 'tsconfig.base.json'), resolve(dir, 'tsconfig.base.json'))
+    return { dir, cleanup }
+  } catch (error) {
+    cleanup()
+    throw error
+  }
+}
+
+export const buildImage = async (options: BuildImageOptions = {}) => {
+  const registry = options.registry ?? process.env.ANYPI_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
+  const repository = options.repository ?? process.env.ANYPI_IMAGE_REPOSITORY ?? 'lab/anypi'
+  const tag = options.tag ?? process.env.ANYPI_IMAGE_TAG ?? execGit(['rev-parse', '--short', 'HEAD'])
+  const dockerfile = resolve(
+    repoRoot,
+    options.dockerfile ?? process.env.ANYPI_DOCKERFILE ?? 'services/anypi/Dockerfile',
+  )
+  const commit = options.commit ?? process.env.ANYPI_COMMIT ?? execGit(['rev-parse', 'HEAD'])
+  const cacheRef = options.cacheRef ?? process.env.ANYPI_BUILD_CACHE_REF ?? `${registry}/${repository}:buildcache`
+  const platforms = options.platforms ??
+    parsePlatforms(process.env.ANYPI_IMAGE_PLATFORMS) ??
+    parsePlatforms(process.env.DOCKER_IMAGE_PLATFORMS) ?? ['linux/amd64', 'linux/arm64']
+  const usePrune = options.context === undefined && process.env.ANYPI_BUILD_CONTEXT === undefined
+  let context: string
+  let cleanup: (() => void) | undefined
+
+  try {
+    if (usePrune) {
+      const pruned = await createPrunedContext()
+      context = pruned.dir
+      cleanup = pruned.cleanup
+    } else {
+      context = resolve(repoRoot, options.context ?? process.env.ANYPI_BUILD_CONTEXT ?? '.')
+    }
+    const result = await buildAndPushDockerImage({
+      registry,
+      repository,
+      tag,
+      context,
+      dockerfile,
+      buildArgs: {
+        LAB_GIT_SHA: commit,
+      },
+      cacheRef,
+      platforms,
+    })
+    return { ...result, commit, version: options.version ?? tag }
+  } finally {
+    cleanup?.()
+  }
+}
+
+if (import.meta.main) {
+  buildImage().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}
+
+export const __private = {
+  execGit,
+  parsePlatforms,
+}

--- a/services/anypi/Dockerfile
+++ b/services/anypi/Dockerfile
@@ -5,6 +5,8 @@ ARG BUN_VERSION=1.3.14
 ARG BUN_BASE_IMAGE=mirror.gcr.io/oven/bun
 ARG NODE_VERSION=24.11.1
 ARG UV_VERSION=0.11.14
+ARG HELM_VERSION=3.18.6
+ARG KUSTOMIZE_VERSION=5.8.1
 ARG LAB_GIT_SHA=dev
 
 FROM node:${NODE_VERSION}-bookworm-slim AS node-runtime
@@ -23,6 +25,8 @@ RUN --mount=type=cache,target=/root/.cache/bun \
 FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS runner
 ARG LAB_GIT_SHA
 ARG UV_VERSION
+ARG HELM_VERSION
+ARG KUSTOMIZE_VERSION
 ENV NODE_ENV=production \
   WORKSPACE=/workspace \
   WORKTREE=/workspace/lab \
@@ -55,6 +59,24 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
   rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --break-system-packages --no-cache-dir "uv==${UV_VERSION}"
+
+RUN set -eux; \
+  arch="$(dpkg --print-architecture)"; \
+  case "${arch}" in \
+    amd64) tool_arch=amd64 ;; \
+    arm64) tool_arch=arm64 ;; \
+    *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${tool_arch}.tar.gz" -o /tmp/helm.tar.gz; \
+  tar -xzf /tmp/helm.tar.gz -C /tmp; \
+  mv "/tmp/linux-${tool_arch}/helm" /usr/local/bin/helm; \
+  curl -fsSL \
+    "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${tool_arch}.tar.gz" \
+    -o /tmp/kustomize.tar.gz; \
+  tar -xzf /tmp/kustomize.tar.gz -C /usr/local/bin kustomize; \
+  rm -rf /tmp/helm.tar.gz /tmp/kustomize.tar.gz "/tmp/linux-${tool_arch}"; \
+  helm version --short; \
+  kustomize version
 
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules

--- a/services/anypi/Dockerfile
+++ b/services/anypi/Dockerfile
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+# Built from a Turbo-pruned context:
+# `bunx turbo prune --scope=@proompteng/anypi --docker --out-dir <dir>`
+ARG BUN_VERSION=1.3.14
+ARG BUN_BASE_IMAGE=mirror.gcr.io/oven/bun
+ARG NODE_VERSION=24.11.1
+ARG UV_VERSION=0.11.14
+ARG LAB_GIT_SHA=dev
+
+FROM node:${NODE_VERSION}-bookworm-slim AS node-runtime
+
+FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS deps
+WORKDIR /app
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+COPY json/ .
+COPY tsconfig.base.json ./
+RUN --mount=type=cache,target=/root/.cache/bun \
+  bun install --omit=dev --ignore-scripts --filter @proompteng/anypi
+
+FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS runner
+ARG LAB_GIT_SHA
+ARG UV_VERSION
+ENV NODE_ENV=production \
+  WORKSPACE=/workspace \
+  WORKTREE=/workspace/lab \
+  GIT_TERMINAL_PROMPT=0 \
+  BUN_INSTALL=/usr/local \
+  ANYPI_WORKSPACE=/workspace \
+  ANYPI_WORKTREE=/workspace/lab \
+  ANYPI_AGENT_DIR=/workspace/.anypi
+
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+  set -eux; \
+  apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
+  apt-get install -y -V --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    gh \
+    git \
+    jq \
+    openssh-client \
+    python3 \
+    python3-pip; \
+  rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages --no-cache-dir "uv==${UV_VERSION}"
+
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/package.json ./package.json
+COPY --from=deps /app/tsconfig.base.json ./tsconfig.base.json
+COPY full/services/anypi ./services/anypi
+COPY --from=deps /app/services/anypi/node_modules ./services/anypi/node_modules
+
+RUN mkdir -p /workspace /app/services/anypi \
+  && printf '%s\n' '#!/bin/sh' 'exec bun /app/services/anypi/src/main.ts "$@"' > /usr/local/bin/anypi-runner \
+  && chmod +x /usr/local/bin/anypi-runner \
+  && cd /app/services/anypi \
+  && bun -e "await import('@earendil-works/pi-coding-agent')" \
+  && test -x /usr/local/bin/anypi-runner \
+  && printf '%s\n' "${LAB_GIT_SHA}" > /app/services/anypi/build-sha.txt
+
+WORKDIR /workspace
+CMD ["bash"]

--- a/services/anypi/Dockerfile
+++ b/services/anypi/Dockerfile
@@ -43,6 +43,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
   apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
   apt-get install -y -V --no-install-recommends \
     bash \
+    build-essential \
     ca-certificates \
     curl \
     gh \

--- a/services/anypi/package.json
+++ b/services/anypi/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@proompteng/anypi",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun src/main.ts",
+    "test": "bunx vitest run --config vitest.config.ts",
+    "tsc": "bunx tsc --noEmit -p tsconfig.json",
+    "lint": "bunx oxfmt --check src"
+  },
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "0.79.4"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "typescript": "^6.0.3",
+    "vitest": "4.1.5"
+  },
+  "packageManager": "bun@1.3.14"
+}

--- a/services/anypi/src/command.ts
+++ b/services/anypi/src/command.ts
@@ -1,0 +1,76 @@
+import type { CommandResult } from './types'
+
+export type RunCommandOptions = {
+  cwd?: string
+  env?: Record<string, string | undefined>
+  allowFailure?: boolean
+  input?: string
+  onOutput?: (chunk: string) => void | Promise<void>
+}
+
+const buildEnv = (env?: Record<string, string | undefined>) =>
+  Object.fromEntries(
+    Object.entries(env ? { ...process.env, ...env } : process.env).filter(([, value]) => value !== undefined),
+  ) as Record<string, string>
+
+const readStream = async (
+  stream: ReadableStream<Uint8Array> | null,
+  onOutput?: (chunk: string) => void | Promise<void>,
+) => {
+  if (!stream) return ''
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let output = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    const text = decoder.decode(value, { stream: true })
+    output += text
+    await onOutput?.(text)
+  }
+  const tail = decoder.decode()
+  output += tail
+  if (tail) await onOutput?.(tail)
+  return output
+}
+
+export const runCommand = async (
+  command: string,
+  args: string[],
+  options: RunCommandOptions = {},
+): Promise<CommandResult> => {
+  const started = Date.now()
+  const subprocess = Bun.spawn([command, ...args], {
+    cwd: options.cwd,
+    env: buildEnv(options.env),
+    stdin: options.input ? 'pipe' : 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if (options.input) {
+    subprocess.stdin?.write(options.input)
+    subprocess.stdin?.end()
+  }
+  const [exitCode, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    readStream(subprocess.stdout, options.onOutput),
+    readStream(subprocess.stderr, options.onOutput),
+  ])
+  const result = {
+    command,
+    args,
+    cwd: options.cwd,
+    exitCode,
+    stdout,
+    stderr,
+    durationMs: Date.now() - started,
+  }
+  if (exitCode !== 0 && !options.allowFailure) {
+    const rendered = [command, ...args].join(' ')
+    throw new Error(`command failed (${exitCode}): ${rendered}\n${stderr || stdout}`.trim())
+  }
+  return result
+}
+
+export const runShell = async (script: string, options: RunCommandOptions = {}) =>
+  await runCommand('bash', ['-lc', script], options)

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
-import { buildAgentPrompt, resolveTaskPrompt, resolveValidationCommands } from './prompt'
+import { buildAgentPrompt, buildValidationRepairPrompt, resolveTaskPrompt, resolveValidationCommands } from './prompt'
 
 describe('Anypi config', () => {
   test('defaults to Flamingo and all Pi coding tools', () => {
@@ -11,6 +11,7 @@ describe('Anypi config', () => {
     expect(config.baseUrl).toBe('http://flamingo.flamingo.svc.cluster.local/v1')
     expect(config.thinkingLevel).toBe('off')
     expect(config.tools).toEqual([...ALL_PI_TOOL_NAMES])
+    expect(config.validationRepairAttempts).toBe(2)
   })
 
   test('renders Pi custom models.json for vLLM OpenAI-compatible serving', () => {
@@ -71,5 +72,28 @@ describe('Anypi prompt contract', () => {
         [],
       ),
     ).toEqual(['git diff --check', 'uv run pytest tests/test_check_diff_coverage.py'])
+  })
+
+  test('builds a validation repair prompt with failed command output', () => {
+    const prompt = buildValidationRepairPrompt({
+      attempt: 1,
+      maxAttempts: 2,
+      worktree: '/workspace/lab',
+      results: [
+        {
+          command: 'bash',
+          args: ['-lc', 'git diff --check'],
+          exitCode: 2,
+          stdout: 'file.py:1: trailing whitespace.',
+          stderr: '',
+          durationMs: 12,
+          ok: false,
+        },
+      ],
+    })
+    expect(prompt).toContain('Repair attempt: 1 of 2')
+    expect(prompt).toContain('git diff --check')
+    expect(prompt).toContain('trailing whitespace')
+    expect(prompt).toContain('do not remove tests')
   })
 })

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest'
+
+import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
+import { buildAgentPrompt, resolveTaskPrompt, resolveValidationCommands } from './prompt'
+
+describe('Anypi config', () => {
+  test('defaults to Flamingo and all Pi coding tools', () => {
+    const config = resolveConfig({})
+    expect(config.provider).toBe('flamingo')
+    expect(config.model).toBe('qwen3-coder-flamingo')
+    expect(config.baseUrl).toBe('http://flamingo.flamingo.svc.cluster.local/v1')
+    expect(config.thinkingLevel).toBe('off')
+    expect(config.tools).toEqual([...ALL_PI_TOOL_NAMES])
+  })
+
+  test('renders Pi custom models.json for vLLM OpenAI-compatible serving', () => {
+    const config = resolveConfig({})
+    expect(buildModelsJson(config)).toMatchObject({
+      providers: {
+        flamingo: {
+          api: 'openai-completions',
+          baseUrl: 'http://flamingo.flamingo.svc.cluster.local/v1',
+          compat: {
+            supportsDeveloperRole: false,
+            supportsReasoningEffort: false,
+          },
+          models: [{ id: 'qwen3-coder-flamingo', reasoning: false }],
+        },
+      },
+    })
+  })
+
+  test('parses validation commands from newline text or JSON', () => {
+    expect(parseCommandList('git diff --check\nbun test')).toEqual(['git diff --check', 'bun test'])
+    expect(parseCommandList('["git diff --check","bun test"]')).toEqual(['git diff --check', 'bun test'])
+  })
+})
+
+describe('Anypi prompt contract', () => {
+  test('prefers rendered run prompt over raw implementation text', () => {
+    expect(
+      resolveTaskPrompt({
+        prompt: 'rendered',
+        implementation: { text: 'raw' },
+      }),
+    ).toBe('rendered')
+  })
+
+  test('builds yolo autonomous coding instructions', () => {
+    const prompt = buildAgentPrompt(
+      {
+        prompt: 'Refactor code and add tests.',
+        vcs: { repository: 'proompteng/lab', baseBranch: 'main', headBranch: 'codex/anypi' },
+      },
+      '/workspace/lab',
+    )
+    expect(prompt).toContain('YOLO-mode autonomous coding agent')
+    expect(prompt).toContain('shell, read, edit, write, grep, find, and ls')
+    expect(prompt).toContain('Refactor code and add tests.')
+    expect(prompt).toContain('runner will validate, commit, push, and open or update the PR')
+  })
+
+  test('uses run parameters for validation commands when env commands are absent', () => {
+    expect(
+      resolveValidationCommands(
+        {
+          parameters: {
+            validationCommands: 'git diff --check\nuv run pytest tests/test_check_diff_coverage.py',
+          },
+        },
+        [],
+      ),
+    ).toEqual(['git diff --check', 'uv run pytest tests/test_check_diff_coverage.py'])
+  })
+})

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -4,11 +4,17 @@ import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } f
 import {
   buildAgentPrompt,
   buildNoChangeRepairPrompt,
+  buildSystemPrompt,
   buildValidationRepairPrompt,
   resolveTaskPrompt,
   resolveValidationCommands,
 } from './prompt'
-import { isBenignAssistantContinuationError, resolveAttemptSessionDir } from './pi-session'
+import {
+  isBenignAssistantContinuationError,
+  resolveAttemptSessionDir,
+  resolveEffectiveSystemPrompt,
+} from './pi-session'
+import { buildCommitMessage, buildPullRequestTitle, normalizeConventionalSummary } from './run'
 
 describe('Anypi config', () => {
   test('defaults to Flamingo and all Pi coding tools', () => {
@@ -66,7 +72,7 @@ describe('Anypi prompt contract', () => {
     ).toBe('rendered')
   })
 
-  test('builds yolo autonomous coding instructions', () => {
+  test('builds focused coding instructions without runtime leakage', () => {
     const prompt = buildAgentPrompt(
       {
         prompt: 'Refactor code and add tests.',
@@ -74,10 +80,34 @@ describe('Anypi prompt contract', () => {
       },
       '/workspace/lab',
     )
-    expect(prompt).toContain('YOLO-mode autonomous coding agent')
-    expect(prompt).toContain('shell, read, edit, write, grep, find, and ls')
+    expect(prompt).toContain('Use repository instructions and existing patterns')
     expect(prompt).toContain('Refactor code and add tests.')
-    expect(prompt).toContain('runner will validate, commit, push, and open or update the PR')
+    expect(prompt).toContain('Leave the final changes in the worktree')
+    expect(prompt).not.toMatch(/Anypi|YOLO|Kubernetes|Pi SDK|shell, read, edit, write/)
+  })
+
+  test('keeps the default system prompt simple and repo-focused', () => {
+    const prompt = buildSystemPrompt()
+    expect(prompt).toContain('Act as a coding agent inside an existing repository')
+    expect(prompt).toContain('Run the checks required for touched files')
+    expect(prompt).not.toMatch(/Anypi|YOLO|Kubernetes|Pi SDK|provider|Flamingo/)
+  })
+
+  test('uses resolved Agent system prompt when provided', () => {
+    expect(resolveEffectiveSystemPrompt('  custom repo prompt  ')).toBe('custom repo prompt')
+    expect(resolveEffectiveSystemPrompt()).toBe(buildSystemPrompt())
+  })
+
+  test('normalizes generated PR metadata to conventional lowercase subjects', () => {
+    expect(normalizeConventionalSummary('Improve Torghut Diff Coverage.', 'fallback')).toBe(
+      'improve torghut diff coverage',
+    )
+    expect(buildCommitMessage({ implementation: { summary: 'Improve Torghut Diff Coverage' } })).toBe(
+      'feat(anypi): improve torghut diff coverage',
+    )
+    expect(buildPullRequestTitle({ implementation: { summary: 'Improve Torghut Diff Coverage' } })).toBe(
+      'feat(anypi): improve torghut diff coverage',
+    )
   })
 
   test('uses run parameters for validation commands when env commands are absent', () => {
@@ -113,7 +143,7 @@ describe('Anypi prompt contract', () => {
     expect(prompt).toContain('Repair attempt: 1 of 2')
     expect(prompt).toContain('git diff --check')
     expect(prompt).toContain('trailing whitespace')
-    expect(prompt).toContain('do not remove tests')
+    expect(prompt).toContain('do not remove or weaken')
   })
 
   test('builds a no-change repair prompt that requires implementation', () => {

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, test } from 'vitest'
 
 import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
+import { parseCiChecks, summarizeChecks } from './git'
 import {
   buildAgentPrompt,
   buildNoChangeRepairPrompt,
   buildSystemPrompt,
   buildValidationRepairPrompt,
+  hashSystemPrompt,
+  inferValidationCommands,
+  resolvePromptVariant,
   resolveTaskPrompt,
   resolveValidationCommands,
+  resolveValidationPlan,
 } from './prompt'
 import {
   isBenignAssistantContinuationError,
@@ -23,10 +28,15 @@ describe('Anypi config', () => {
     expect(config.model).toBe('qwen3-coder-flamingo')
     expect(config.baseUrl).toBe('http://flamingo.flamingo.svc.cluster.local/v1')
     expect(config.modelReadyTimeoutSeconds).toBe(1800)
+    expect(config.promptVariant).toBe('minimal')
+    expect(config.allowSystemPromptOverride).toBe(false)
     expect(config.thinkingLevel).toBe('off')
     expect(config.tools).toEqual([...ALL_PI_TOOL_NAMES])
+    expect(config.validationPolicy).toBe('append')
     expect(config.noChangeRepairAttempts).toBe(2)
     expect(config.validationRepairAttempts).toBe(2)
+    expect(config.ciRepairAttempts).toBe(1)
+    expect(config.ciRequiredOnly).toBe(true)
   })
 
   test('renders Pi custom models.json for vLLM OpenAI-compatible serving', () => {
@@ -49,6 +59,15 @@ describe('Anypi config', () => {
   test('parses validation commands from newline text or JSON', () => {
     expect(parseCommandList('git diff --check\nbun test')).toEqual(['git diff --check', 'bun test'])
     expect(parseCommandList('["git diff --check","bun test"]')).toEqual(['git diff --check', 'bun test'])
+  })
+
+  test('normalizes prompt variants and validation policy from env', () => {
+    expect(resolvePromptVariant('strict-repo')).toBe('strict-repo')
+    expect(resolvePromptVariant('unknown')).toBe('minimal')
+    expect(resolveConfig({ ANYPI_PROMPT_VARIANT: 'repair-loop', ANYPI_VALIDATION_POLICY: 'override' })).toMatchObject({
+      promptVariant: 'repair-loop',
+      validationPolicy: 'override',
+    })
   })
 
   test('isolates persisted sessions per agent attempt', () => {
@@ -87,15 +106,27 @@ describe('Anypi prompt contract', () => {
   })
 
   test('keeps the default system prompt simple and repo-focused', () => {
-    const prompt = buildSystemPrompt()
+    const prompt = buildSystemPrompt('minimal')
     expect(prompt).toContain('Act as a coding agent inside an existing repository')
     expect(prompt).toContain('Run the checks required for touched files')
     expect(prompt).not.toMatch(/Anypi|YOLO|Kubernetes|Pi SDK|provider|Flamingo/)
+    expect(hashSystemPrompt('minimal')).toMatch(/^[a-f0-9]{16}$/)
+  })
+
+  test('builds distinct prompt variants without runtime leakage', () => {
+    expect(buildSystemPrompt('finish-gated')).toContain('Continue until the implementation')
+    expect(buildSystemPrompt('repair-loop')).toContain('fix the root cause')
+    expect(buildSystemPrompt('strict-repo')).toContain('Follow AGENTS.md')
+    for (const variant of ['minimal', 'finish-gated', 'repair-loop', 'strict-repo'] as const) {
+      expect(buildSystemPrompt(variant)).not.toMatch(/Anypi|YOLO|Kubernetes|Pi SDK|provider|Flamingo/)
+    }
   })
 
   test('uses resolved Agent system prompt when provided', () => {
-    expect(resolveEffectiveSystemPrompt('  custom repo prompt  ')).toBe('custom repo prompt')
-    expect(resolveEffectiveSystemPrompt()).toBe(buildSystemPrompt())
+    expect(resolveEffectiveSystemPrompt({ promptVariant: 'minimal' }, '  custom repo prompt  ')).toBe(
+      'custom repo prompt',
+    )
+    expect(resolveEffectiveSystemPrompt({ promptVariant: 'strict-repo' })).toBe(buildSystemPrompt('strict-repo'))
   })
 
   test('normalizes generated PR metadata to conventional lowercase subjects', () => {
@@ -121,6 +152,48 @@ describe('Anypi prompt contract', () => {
         [],
       ),
     ).toEqual(['git diff --check', 'uv run pytest tests/test_check_diff_coverage.py'])
+  })
+
+  test('infers service-aware validation and refuses only diff-check', () => {
+    expect(
+      inferValidationCommands({
+        implementation: { text: 'Improve services/anypi prompt handling and argocd/applications/agents manifests.' },
+      }),
+    ).toContain('bun run --filter @proompteng/anypi tsc')
+
+    expect(() => resolveValidationPlan({ implementation: { text: 'Change generic docs.' } }, [], 'append')).toThrow(
+      /service-aware validation/,
+    )
+  })
+
+  test('records validation sources and appends run commands', () => {
+    const plan = resolveValidationPlan(
+      {
+        implementation: { text: 'Improve services/anypi prompt handling.' },
+        parameters: { validationCommands: 'bun run --filter @proompteng/anypi test' },
+      },
+      ['bun run --filter @proompteng/anypi lint'],
+      'append',
+    )
+    expect(plan.sources).toEqual(['inferred', 'run-spec', 'env'])
+    expect(plan.commands).toContain('bun run --filter @proompteng/anypi tsc')
+    expect(plan.commands).toContain('bun run --filter @proompteng/anypi lint')
+  })
+
+  test('parses and summarizes GitHub check buckets', () => {
+    const checks = parseCiChecks(
+      JSON.stringify([
+        { name: 'lint', workflow: 'CI', bucket: 'pass', state: 'SUCCESS' },
+        { name: 'pyright', workflow: 'CI', bucket: 'fail', state: 'FAILURE', link: 'https://example.invalid' },
+      ]),
+    )
+    expect(checks[0]).toMatchObject({ name: 'lint', workflow: 'CI', bucket: 'pass' })
+    expect(summarizeChecks(checks)).toMatchObject({
+      failed: [checks[1]],
+      pending: [],
+      passed: [checks[0]],
+      summary: '1 passed/skipped, 0 pending, 1 failed/cancelled',
+    })
   })
 
   test('builds a validation repair prompt with failed command output', () => {

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -8,6 +8,7 @@ import {
   resolveTaskPrompt,
   resolveValidationCommands,
 } from './prompt'
+import { isBenignAssistantContinuationError, resolveAttemptSessionDir } from './pi-session'
 
 describe('Anypi config', () => {
   test('defaults to Flamingo and all Pi coding tools', () => {
@@ -42,6 +43,16 @@ describe('Anypi config', () => {
   test('parses validation commands from newline text or JSON', () => {
     expect(parseCommandList('git diff --check\nbun test')).toEqual(['git diff --check', 'bun test'])
     expect(parseCommandList('["git diff --check","bun test"]')).toEqual(['git diff --check', 'bun test'])
+  })
+
+  test('isolates persisted sessions per agent attempt', () => {
+    const sessionDir = resolveAttemptSessionDir('/workspace/.anypi/sessions', 'Validation repair #1')
+    expect(sessionDir).toMatch(/^\/workspace\/\.anypi\/sessions\/validation-repair-1-[a-f0-9]{8}$/)
+  })
+
+  test('recognizes the narrow assistant continuation terminal error', () => {
+    expect(isBenignAssistantContinuationError(new Error('Cannot continue from message role: assistant'))).toBe(true)
+    expect(isBenignAssistantContinuationError(new Error('rate limit'))).toBe(false)
   })
 })
 

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
-import { parseCiChecks, summarizeChecks } from './git'
+import { parseCiChecks, parsePullRequestList, summarizeChecks } from './git'
 import {
   buildAgentPrompt,
   buildNoChangeRepairPrompt,
@@ -194,6 +194,14 @@ describe('Anypi prompt contract', () => {
       passed: [checks[0]],
       summary: '1 passed/skipped, 0 pending, 1 failed/cancelled',
     })
+  })
+
+  test('parses GitHub REST pull request lookup results', () => {
+    expect(parsePullRequestList('[{"number":123,"html_url":"https://github.com/proompteng/lab/pull/123"}]')).toEqual({
+      number: 123,
+      url: 'https://github.com/proompteng/lab/pull/123',
+    })
+    expect(parsePullRequestList('[]')).toBeNull()
   })
 
   test('builds a validation repair prompt with failed command output', () => {

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -15,6 +15,7 @@ describe('Anypi config', () => {
     expect(config.provider).toBe('flamingo')
     expect(config.model).toBe('qwen3-coder-flamingo')
     expect(config.baseUrl).toBe('http://flamingo.flamingo.svc.cluster.local/v1')
+    expect(config.modelReadyTimeoutSeconds).toBe(1800)
     expect(config.thinkingLevel).toBe('off')
     expect(config.tools).toEqual([...ALL_PI_TOOL_NAMES])
     expect(config.noChangeRepairAttempts).toBe(2)

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'vitest'
 
 import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
-import { buildAgentPrompt, buildValidationRepairPrompt, resolveTaskPrompt, resolveValidationCommands } from './prompt'
+import {
+  buildAgentPrompt,
+  buildNoChangeRepairPrompt,
+  buildValidationRepairPrompt,
+  resolveTaskPrompt,
+  resolveValidationCommands,
+} from './prompt'
 
 describe('Anypi config', () => {
   test('defaults to Flamingo and all Pi coding tools', () => {
@@ -11,6 +17,7 @@ describe('Anypi config', () => {
     expect(config.baseUrl).toBe('http://flamingo.flamingo.svc.cluster.local/v1')
     expect(config.thinkingLevel).toBe('off')
     expect(config.tools).toEqual([...ALL_PI_TOOL_NAMES])
+    expect(config.noChangeRepairAttempts).toBe(2)
     expect(config.validationRepairAttempts).toBe(2)
   })
 
@@ -95,5 +102,13 @@ describe('Anypi prompt contract', () => {
     expect(prompt).toContain('git diff --check')
     expect(prompt).toContain('trailing whitespace')
     expect(prompt).toContain('do not remove tests')
+  })
+
+  test('builds a no-change repair prompt that requires implementation', () => {
+    const prompt = buildNoChangeRepairPrompt({ attempt: 1, maxAttempts: 2, worktree: '/workspace/lab' })
+    expect(prompt).toContain('completed without leaving any code changes')
+    expect(prompt).toContain('Repair attempt: 1 of 2')
+    expect(prompt).toContain('requires a real implementation')
+    expect(prompt).toContain('leave the final changes in the worktree')
   })
 })

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -160,6 +160,11 @@ describe('Anypi prompt contract', () => {
         implementation: { text: 'Improve services/anypi prompt handling and argocd/applications/agents manifests.' },
       }),
     ).toContain('bun run --filter @proompteng/anypi tsc')
+    expect(
+      inferValidationCommands({
+        implementation: { text: 'Improve argocd/applications/agents AgentProvider manifests.' },
+      }),
+    ).toContain('kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml')
 
     expect(() => resolveValidationPlan({ implementation: { text: 'Change generic docs.' } }, [], 'append')).toThrow(
       /service-aware validation/,

--- a/services/anypi/src/config.ts
+++ b/services/anypi/src/config.ts
@@ -21,6 +21,7 @@ export type AnypiConfig = {
   model: string
   baseUrl: string
   apiKey: string
+  modelReadyTimeoutSeconds: number
   thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
   contextWindow: number
   maxTokens: number
@@ -102,6 +103,7 @@ export const resolveConfig = (env: NodeJS.ProcessEnv = process.env): AnypiConfig
     model: readEnv(env, 'ANYPI_MODEL', 'qwen3-coder-flamingo'),
     baseUrl: readEnv(env, 'ANYPI_BASE_URL', 'http://flamingo.flamingo.svc.cluster.local/v1'),
     apiKey: readEnv(env, 'ANYPI_API_KEY', 'flamingo-local'),
+    modelReadyTimeoutSeconds: readNumber(env, 'ANYPI_MODEL_READY_TIMEOUT_SECONDS', 1800),
     thinkingLevel: normalizeThinkingLevel(readEnv(env, 'ANYPI_THINKING_LEVEL', 'off')),
     contextWindow: readNumber(env, 'ANYPI_CONTEXT_WINDOW', 32768),
     maxTokens: readNumber(env, 'ANYPI_MAX_TOKENS', 4096),

--- a/services/anypi/src/config.ts
+++ b/services/anypi/src/config.ts
@@ -2,7 +2,8 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
 
-import type { AgentRunnerSpecPayload, AgentRunSpecPayload } from './types'
+import { resolvePromptVariant, resolveValidationPolicy } from './prompt'
+import type { AgentRunnerSpecPayload, AgentRunSpecPayload, PromptVariant, ValidationPolicy } from './types'
 
 export const ALL_PI_TOOL_NAMES = ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'] as const
 
@@ -22,14 +23,21 @@ export type AnypiConfig = {
   baseUrl: string
   apiKey: string
   modelReadyTimeoutSeconds: number
+  promptVariant: PromptVariant
+  allowSystemPromptOverride: boolean
   thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
   contextWindow: number
   maxTokens: number
   tools: string[]
   allowNoVcs: boolean
   validationCommands: string[]
+  validationPolicy: ValidationPolicy
   noChangeRepairAttempts: number
   validationRepairAttempts: number
+  ciCheckTimeoutSeconds: number
+  ciCheckIntervalSeconds: number
+  ciRepairAttempts: number
+  ciRequiredOnly: boolean
 }
 
 const readEnv = (env: NodeJS.ProcessEnv, name: string, fallback: string) => {
@@ -104,14 +112,21 @@ export const resolveConfig = (env: NodeJS.ProcessEnv = process.env): AnypiConfig
     baseUrl: readEnv(env, 'ANYPI_BASE_URL', 'http://flamingo.flamingo.svc.cluster.local/v1'),
     apiKey: readEnv(env, 'ANYPI_API_KEY', 'flamingo-local'),
     modelReadyTimeoutSeconds: readNumber(env, 'ANYPI_MODEL_READY_TIMEOUT_SECONDS', 1800),
+    promptVariant: resolvePromptVariant(env.ANYPI_PROMPT_VARIANT),
+    allowSystemPromptOverride: readBoolean(env, 'ANYPI_ALLOW_SYSTEM_PROMPT_OVERRIDE', false),
     thinkingLevel: normalizeThinkingLevel(readEnv(env, 'ANYPI_THINKING_LEVEL', 'off')),
     contextWindow: readNumber(env, 'ANYPI_CONTEXT_WINDOW', 32768),
     maxTokens: readNumber(env, 'ANYPI_MAX_TOKENS', 4096),
     tools: parseTools(env.ANYPI_TOOLS),
     allowNoVcs: readBoolean(env, 'ANYPI_ALLOW_NO_VCS', false),
     validationCommands: parseCommandList(env.ANYPI_VALIDATION_COMMANDS),
+    validationPolicy: resolveValidationPolicy(env.ANYPI_VALIDATION_POLICY),
     noChangeRepairAttempts: readNumber(env, 'ANYPI_NO_CHANGE_REPAIR_ATTEMPTS', 2),
     validationRepairAttempts: readNumber(env, 'ANYPI_VALIDATION_REPAIR_ATTEMPTS', 2),
+    ciCheckTimeoutSeconds: readNumber(env, 'ANYPI_CI_CHECK_TIMEOUT_SECONDS', 3600),
+    ciCheckIntervalSeconds: readNumber(env, 'ANYPI_CI_CHECK_INTERVAL_SECONDS', 30),
+    ciRepairAttempts: readNumber(env, 'ANYPI_CI_REPAIR_ATTEMPTS', 1),
+    ciRequiredOnly: readBoolean(env, 'ANYPI_CI_REQUIRED_ONLY', true),
   }
 }
 

--- a/services/anypi/src/config.ts
+++ b/services/anypi/src/config.ts
@@ -1,0 +1,168 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+
+import type { AgentRunnerSpecPayload, AgentRunSpecPayload } from './types'
+
+export const ALL_PI_TOOL_NAMES = ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'] as const
+
+export type AnypiConfig = {
+  workspace: string
+  worktree: string
+  agentDir: string
+  sessionDir: string
+  authPath: string
+  modelsPath: string
+  runSpecPath: string
+  runnerSpecPath: string
+  statusPath: string
+  logPath: string
+  provider: string
+  model: string
+  baseUrl: string
+  apiKey: string
+  thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+  contextWindow: number
+  maxTokens: number
+  tools: string[]
+  allowNoVcs: boolean
+  validationCommands: string[]
+}
+
+const readEnv = (env: NodeJS.ProcessEnv, name: string, fallback: string) => {
+  const value = env[name]?.trim()
+  return value && value.length > 0 ? value : fallback
+}
+
+const readBoolean = (env: NodeJS.ProcessEnv, name: string, fallback: boolean) => {
+  const value = env[name]?.trim().toLowerCase()
+  if (!value) return fallback
+  if (['1', 'true', 'yes', 'y', 'on'].includes(value)) return true
+  if (['0', 'false', 'no', 'n', 'off'].includes(value)) return false
+  return fallback
+}
+
+const readNumber = (env: NodeJS.ProcessEnv, name: string, fallback: number) => {
+  const raw = env[name]?.trim()
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+const parseTools = (raw: string | undefined): string[] => {
+  if (!raw || raw.trim().toLowerCase() === 'all') return [...ALL_PI_TOOL_NAMES]
+  const tools = raw
+    .split(/[\s,]+/)
+    .map((tool) => tool.trim())
+    .filter(Boolean)
+  return tools.length > 0 ? [...new Set(tools)] : [...ALL_PI_TOOL_NAMES]
+}
+
+export const parseCommandList = (raw: string | undefined): string[] => {
+  if (!raw?.trim()) return []
+  const trimmed = raw.trim()
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (!Array.isArray(parsed)) throw new Error('validation command JSON must be an array')
+    return parsed.map((entry) => String(entry).trim()).filter(Boolean)
+  }
+  return trimmed
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+const normalizeThinkingLevel = (raw: string): AnypiConfig['thinkingLevel'] => {
+  if (['off', 'minimal', 'low', 'medium', 'high', 'xhigh'].includes(raw)) {
+    return raw as AnypiConfig['thinkingLevel']
+  }
+  return 'off'
+}
+
+export const resolveConfig = (env: NodeJS.ProcessEnv = process.env): AnypiConfig => {
+  const workspace = readEnv(env, 'ANYPI_WORKSPACE', '/workspace')
+  const worktree = readEnv(env, 'ANYPI_WORKTREE', resolve(workspace, 'lab'))
+  const agentDir = readEnv(env, 'ANYPI_AGENT_DIR', resolve(workspace, '.anypi'))
+  const runSpecPath = readEnv(env, 'AGENT_RUN_SPEC', resolve(workspace, 'run.json'))
+  const runnerSpecPath = readEnv(env, 'AGENT_RUNNER_SPEC_PATH', resolve(workspace, 'agent-runner.json'))
+  return {
+    workspace,
+    worktree,
+    agentDir,
+    sessionDir: readEnv(env, 'ANYPI_SESSION_DIR', resolve(agentDir, 'sessions')),
+    authPath: readEnv(env, 'ANYPI_AUTH_PATH', resolve(agentDir, 'auth.json')),
+    modelsPath: readEnv(env, 'ANYPI_MODELS_PATH', resolve(agentDir, 'models.json')),
+    runSpecPath,
+    runnerSpecPath,
+    statusPath: readEnv(env, 'ANYPI_STATUS_PATH', resolve(workspace, '.agent/status.json')),
+    logPath: readEnv(env, 'ANYPI_LOG_PATH', resolve(workspace, '.agent/runner.log')),
+    provider: readEnv(env, 'ANYPI_PROVIDER', 'flamingo'),
+    model: readEnv(env, 'ANYPI_MODEL', 'qwen3-coder-flamingo'),
+    baseUrl: readEnv(env, 'ANYPI_BASE_URL', 'http://flamingo.flamingo.svc.cluster.local/v1'),
+    apiKey: readEnv(env, 'ANYPI_API_KEY', 'flamingo-local'),
+    thinkingLevel: normalizeThinkingLevel(readEnv(env, 'ANYPI_THINKING_LEVEL', 'off')),
+    contextWindow: readNumber(env, 'ANYPI_CONTEXT_WINDOW', 32768),
+    maxTokens: readNumber(env, 'ANYPI_MAX_TOKENS', 4096),
+    tools: parseTools(env.ANYPI_TOOLS),
+    allowNoVcs: readBoolean(env, 'ANYPI_ALLOW_NO_VCS', false),
+    validationCommands: parseCommandList(env.ANYPI_VALIDATION_COMMANDS),
+  }
+}
+
+export const readJsonFile = async <T>(path: string): Promise<T> => {
+  const raw = await readFile(path, 'utf8')
+  return JSON.parse(raw) as T
+}
+
+export const loadRunSpec = async (config: AnypiConfig): Promise<AgentRunSpecPayload> =>
+  await readJsonFile<AgentRunSpecPayload>(config.runSpecPath)
+
+export const loadRunnerSpec = async (config: AnypiConfig): Promise<AgentRunnerSpecPayload | null> => {
+  try {
+    return await readJsonFile<AgentRunnerSpecPayload>(config.runnerSpecPath)
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return null
+    throw error
+  }
+}
+
+export const applyRunnerArtifacts = (config: AnypiConfig, runnerSpec: AgentRunnerSpecPayload | null): AnypiConfig => ({
+  ...config,
+  statusPath: runnerSpec?.artifacts?.statusPath ?? config.statusPath,
+  logPath: runnerSpec?.artifacts?.logPath ?? config.logPath,
+})
+
+export const buildModelsJson = (config: AnypiConfig) => ({
+  providers: {
+    [config.provider]: {
+      baseUrl: config.baseUrl,
+      api: 'openai-completions',
+      apiKey: config.apiKey,
+      compat: {
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+      },
+      models: [
+        {
+          id: config.model,
+          name: config.model,
+          reasoning: false,
+          input: ['text'],
+          contextWindow: config.contextWindow,
+          maxTokens: config.maxTokens,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+        },
+      ],
+    },
+  },
+})
+
+export const writeModelsFile = async (config: AnypiConfig) => {
+  await mkdir(dirname(config.modelsPath), { recursive: true })
+  await writeFile(config.modelsPath, `${JSON.stringify(buildModelsJson(config), null, 2)}\n`, 'utf8')
+}

--- a/services/anypi/src/config.ts
+++ b/services/anypi/src/config.ts
@@ -27,6 +27,7 @@ export type AnypiConfig = {
   tools: string[]
   allowNoVcs: boolean
   validationCommands: string[]
+  noChangeRepairAttempts: number
   validationRepairAttempts: number
 }
 
@@ -107,6 +108,7 @@ export const resolveConfig = (env: NodeJS.ProcessEnv = process.env): AnypiConfig
     tools: parseTools(env.ANYPI_TOOLS),
     allowNoVcs: readBoolean(env, 'ANYPI_ALLOW_NO_VCS', false),
     validationCommands: parseCommandList(env.ANYPI_VALIDATION_COMMANDS),
+    noChangeRepairAttempts: readNumber(env, 'ANYPI_NO_CHANGE_REPAIR_ATTEMPTS', 2),
     validationRepairAttempts: readNumber(env, 'ANYPI_VALIDATION_REPAIR_ATTEMPTS', 2),
   }
 }

--- a/services/anypi/src/config.ts
+++ b/services/anypi/src/config.ts
@@ -27,6 +27,7 @@ export type AnypiConfig = {
   tools: string[]
   allowNoVcs: boolean
   validationCommands: string[]
+  validationRepairAttempts: number
 }
 
 const readEnv = (env: NodeJS.ProcessEnv, name: string, fallback: string) => {
@@ -106,6 +107,7 @@ export const resolveConfig = (env: NodeJS.ProcessEnv = process.env): AnypiConfig
     tools: parseTools(env.ANYPI_TOOLS),
     allowNoVcs: readBoolean(env, 'ANYPI_ALLOW_NO_VCS', false),
     validationCommands: parseCommandList(env.ANYPI_VALIDATION_COMMANDS),
+    validationRepairAttempts: readNumber(env, 'ANYPI_VALIDATION_REPAIR_ATTEMPTS', 2),
   }
 }
 

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -17,6 +17,11 @@ export type GitContext = {
   pullRequestsEnabled: boolean
 }
 
+type PullRequestLookup = {
+  number: number
+  url?: string
+}
+
 const envFlag = (value: string | undefined, fallback: boolean) => {
   if (!value) return fallback
   const normalized = value.trim().toLowerCase()
@@ -28,6 +33,53 @@ const envFlag = (value: string | undefined, fallback: boolean) => {
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
 
 const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms))
+
+const repositoryOwner = (repository: string) => repository.split('/')[0]
+
+export const parsePullRequestList = (raw: string): PullRequestLookup | null => {
+  const parsed = JSON.parse(raw || '[]') as unknown
+  if (!Array.isArray(parsed)) return null
+  const [first] = parsed
+  if (!first || typeof first !== 'object') return null
+  const record = first as Record<string, unknown>
+  const number = typeof record.number === 'number' ? record.number : Number(record.number)
+  if (!Number.isFinite(number) || number <= 0) return null
+  const url = typeof record.html_url === 'string' ? record.html_url : undefined
+  return { number, url }
+}
+
+const parsePullRequestResponse = (raw: string): PullRequestLookup => {
+  const parsed = JSON.parse(raw || '{}') as Record<string, unknown>
+  const number = typeof parsed.number === 'number' ? parsed.number : Number(parsed.number)
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error('GitHub pull request response did not include a pull request number')
+  }
+  const url = typeof parsed.html_url === 'string' ? parsed.html_url : undefined
+  return { number, url }
+}
+
+const writePullRequestInput = async (payload: Record<string, unknown>) => {
+  const path = resolve('/tmp', `anypi-pr-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`)
+  await writeFile(path, `${JSON.stringify(payload)}\n`, 'utf8')
+  return path
+}
+
+const runGitHubPullRequestMutation = async (
+  git: GitContext,
+  endpoint: string,
+  method: 'POST' | 'PATCH',
+  payload: Record<string, unknown>,
+) => {
+  const inputPath = await writePullRequestInput(payload)
+  try {
+    return await runCommand('gh', ['api', endpoint, '-X', method, '--input', inputPath], {
+      cwd: git.worktree,
+      env: git.env,
+    })
+  } finally {
+    await rm(inputPath, { force: true })
+  }
+}
 
 const buildCloneUrl = (cloneBaseUrl: string, repository: string) => {
   const base = trimTrailingSlash(cloneBaseUrl || 'https://github.com')
@@ -157,49 +209,34 @@ export const createOrUpdatePullRequest = async (
   },
 ): Promise<PullRequestResult> => {
   if (!git.pullRequestsEnabled) return { enabled: false }
+  const owner = repositoryOwner(git.repository)
+  const endpoint = `repos/${git.repository}/pulls`
   const view = await runCommand(
     'gh',
-    ['pr', 'view', git.headBranch, '--repo', git.repository, '--json', 'url', '--jq', '.url'],
+    ['api', endpoint, '-X', 'GET', '-f', `head=${owner}:${git.headBranch}`, '-f', 'state=open'],
     {
       cwd: git.worktree,
       env: git.env,
       allowFailure: true,
     },
   )
-  if (view.exitCode === 0 && view.stdout.trim()) {
-    await runCommand(
-      'gh',
-      ['pr', 'edit', git.headBranch, '--repo', git.repository, '--title', input.title, '--body', input.body],
-      {
-        cwd: git.worktree,
-        env: git.env,
-      },
-    )
-    return { enabled: true, url: view.stdout.trim(), created: false }
+  const existing = view.exitCode === 0 ? parsePullRequestList(view.stdout) : null
+  if (existing) {
+    const updated = await runGitHubPullRequestMutation(git, `${endpoint}/${existing.number}`, 'PATCH', {
+      title: input.title,
+      body: input.body,
+    })
+    const parsed = parsePullRequestResponse(updated.stdout)
+    return { enabled: true, url: parsed.url ?? existing.url, created: false }
   }
-  const created = await runCommand(
-    'gh',
-    [
-      'pr',
-      'create',
-      '--repo',
-      git.repository,
-      '--base',
-      git.baseBranch,
-      '--head',
-      git.headBranch,
-      '--title',
-      input.title,
-      '--body',
-      input.body,
-    ],
-    { cwd: git.worktree, env: git.env },
-  )
-  const url = created.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => line.startsWith('http'))
-  return { enabled: true, url, created: true }
+  const created = await runGitHubPullRequestMutation(git, endpoint, 'POST', {
+    title: input.title,
+    body: input.body,
+    base: git.baseBranch,
+    head: git.headBranch,
+  })
+  const parsed = parsePullRequestResponse(created.stdout)
+  return { enabled: true, url: parsed.url, created: true }
 }
 
 export const runValidationCommands = async (

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -1,0 +1,226 @@
+import { chmod, mkdir, rm, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+import { runCommand, runShell } from './command'
+import type { AnypiConfig } from './config'
+import type { AgentRunSpecPayload, CommandResult, PullRequestResult } from './types'
+
+export type GitContext = {
+  repository: string
+  baseBranch: string
+  headBranch: string
+  cloneUrl: string
+  webUrl: string
+  worktree: string
+  env: Record<string, string | undefined>
+  writeEnabled: boolean
+  pullRequestsEnabled: boolean
+}
+
+const envFlag = (value: string | undefined, fallback: boolean) => {
+  if (!value) return fallback
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+  return fallback
+}
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
+const buildCloneUrl = (cloneBaseUrl: string, repository: string) => {
+  const base = trimTrailingSlash(cloneBaseUrl || 'https://github.com')
+  if (base.startsWith('git@')) return `${base}:${repository}.git`
+  return `${base}/${repository}.git`
+}
+
+const safeRemoveWorktree = async (workspace: string, worktree: string) => {
+  const resolvedWorkspace = resolve(workspace)
+  const resolvedWorktree = resolve(worktree)
+  if (resolvedWorktree === resolvedWorkspace || !resolvedWorktree.startsWith(`${resolvedWorkspace}/`)) {
+    throw new Error(`refusing to remove worktree outside workspace: ${resolvedWorktree}`)
+  }
+  await rm(resolvedWorktree, { recursive: true, force: true })
+}
+
+const configureAskpass = async (env: Record<string, string | undefined>) => {
+  const token = env.GH_TOKEN || env.GITHUB_TOKEN
+  if (!token) return env
+  env.GH_TOKEN ??= token
+  env.GITHUB_TOKEN ??= token
+  env.GIT_TERMINAL_PROMPT = '0'
+  env.GIT_ASKPASS_USERNAME ??= 'x-access-token'
+  if (!env.GIT_ASKPASS) {
+    const askpassPath = '/tmp/anypi-git-askpass.sh'
+    await writeFile(
+      askpassPath,
+      `#!/bin/sh
+case "$1" in
+  *Username*) printf '%s\\n' "$GIT_ASKPASS_USERNAME" ;;
+  *Password*) printf '%s\\n' "$GIT_ASKPASS_TOKEN" ;;
+  *) printf '%s\\n' "$GIT_ASKPASS_TOKEN" ;;
+esac
+`,
+      { mode: 0o700 },
+    )
+    await chmod(askpassPath, 0o700)
+    env.GIT_ASKPASS = askpassPath
+  }
+  env.GIT_ASKPASS_TOKEN = token
+  return env
+}
+
+export const resolveGitContext = async (
+  config: AnypiConfig,
+  runSpec: AgentRunSpecPayload,
+): Promise<GitContext | null> => {
+  const repository = process.env.VCS_REPOSITORY || runSpec.vcs?.repository || runSpec.repository
+  if (!repository) {
+    if (config.allowNoVcs) return null
+    throw new Error('VCS_REPOSITORY or run repository metadata is required')
+  }
+  const baseBranch = process.env.VCS_BASE_BRANCH || runSpec.vcs?.baseBranch || runSpec.base || 'main'
+  const runName = runSpec.agentRun?.name ?? 'anypi-run'
+  const headBranch = process.env.VCS_HEAD_BRANCH || runSpec.vcs?.headBranch || runSpec.head || `codex/${runName}`
+  const cloneBaseUrl = process.env.VCS_CLONE_BASE_URL || runSpec.vcs?.cloneBaseUrl || 'https://github.com'
+  const webBaseUrl = process.env.VCS_WEB_BASE_URL || runSpec.vcs?.webBaseUrl || 'https://github.com'
+  const env = await configureAskpass({ ...process.env })
+  return {
+    repository,
+    baseBranch,
+    headBranch,
+    cloneUrl: buildCloneUrl(cloneBaseUrl, repository),
+    webUrl: `${trimTrailingSlash(webBaseUrl)}/${repository}`,
+    worktree: config.worktree,
+    env,
+    writeEnabled: envFlag(process.env.VCS_WRITE_ENABLED, runSpec.vcs?.writeEnabled ?? true),
+    pullRequestsEnabled: envFlag(process.env.VCS_PULL_REQUESTS_ENABLED, runSpec.vcs?.pullRequestsEnabled ?? true),
+  }
+}
+
+export const prepareRepository = async (
+  config: AnypiConfig,
+  git: GitContext | null,
+  log: (message: string) => Promise<void>,
+) => {
+  if (!git) {
+    await mkdir(config.worktree, { recursive: true })
+    return
+  }
+  await log(`cloning ${git.repository} ${git.baseBranch} into ${git.worktree}`)
+  await safeRemoveWorktree(config.workspace, git.worktree)
+  await mkdir(dirname(git.worktree), { recursive: true })
+  await runCommand('git', ['clone', '--branch', git.baseBranch, '--single-branch', git.cloneUrl, git.worktree], {
+    cwd: config.workspace,
+    env: git.env,
+  })
+  await runCommand('git', ['checkout', '-B', git.headBranch], { cwd: git.worktree, env: git.env })
+  const authorName = process.env.VCS_COMMIT_AUTHOR_NAME || process.env.GIT_AUTHOR_NAME
+  const authorEmail = process.env.VCS_COMMIT_AUTHOR_EMAIL || process.env.GIT_AUTHOR_EMAIL
+  if (authorName) await runCommand('git', ['config', 'user.name', authorName], { cwd: git.worktree, env: git.env })
+  if (authorEmail) await runCommand('git', ['config', 'user.email', authorEmail], { cwd: git.worktree, env: git.env })
+}
+
+export const gitStatusShort = async (worktree: string, env?: Record<string, string | undefined>) =>
+  (await runCommand('git', ['status', '--short'], { cwd: worktree, env })).stdout.trim()
+
+export const countCommitsAhead = async (git: GitContext) => {
+  const result = await runShell(`git rev-list --count "origin/${git.baseBranch}..HEAD"`, {
+    cwd: git.worktree,
+    env: git.env,
+  })
+  return Number.parseInt(result.stdout.trim(), 10) || 0
+}
+
+export const commitIfNeeded = async (git: GitContext, message: string): Promise<string | null> => {
+  const status = await gitStatusShort(git.worktree, git.env)
+  if (status) {
+    await runCommand('git', ['add', '-A'], { cwd: git.worktree, env: git.env })
+    await runCommand('git', ['commit', '-m', message], { cwd: git.worktree, env: git.env })
+  }
+  const ahead = await countCommitsAhead(git)
+  if (ahead === 0) return null
+  return (await runCommand('git', ['rev-parse', 'HEAD'], { cwd: git.worktree, env: git.env })).stdout.trim()
+}
+
+export const pushBranch = async (git: GitContext) => {
+  if (!git.writeEnabled) throw new Error('VCS write mode is disabled; refusing to push')
+  await runCommand('git', ['push', '-u', 'origin', `HEAD:${git.headBranch}`], { cwd: git.worktree, env: git.env })
+}
+
+export const createOrUpdatePullRequest = async (
+  git: GitContext,
+  input: {
+    title: string
+    body: string
+  },
+): Promise<PullRequestResult> => {
+  if (!git.pullRequestsEnabled) return { enabled: false }
+  const view = await runCommand(
+    'gh',
+    ['pr', 'view', git.headBranch, '--repo', git.repository, '--json', 'url', '--jq', '.url'],
+    {
+      cwd: git.worktree,
+      env: git.env,
+      allowFailure: true,
+    },
+  )
+  if (view.exitCode === 0 && view.stdout.trim()) {
+    await runCommand(
+      'gh',
+      ['pr', 'edit', git.headBranch, '--repo', git.repository, '--title', input.title, '--body', input.body],
+      {
+        cwd: git.worktree,
+        env: git.env,
+      },
+    )
+    return { enabled: true, url: view.stdout.trim(), created: false }
+  }
+  const created = await runCommand(
+    'gh',
+    [
+      'pr',
+      'create',
+      '--repo',
+      git.repository,
+      '--base',
+      git.baseBranch,
+      '--head',
+      git.headBranch,
+      '--title',
+      input.title,
+      '--body',
+      input.body,
+    ],
+    { cwd: git.worktree, env: git.env },
+  )
+  const url = created.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('http'))
+  return { enabled: true, url, created: true }
+}
+
+export const runValidationCommands = async (
+  commands: string[],
+  git: GitContext | null,
+  worktree: string,
+  log: (message: string) => Promise<void>,
+): Promise<CommandResult[]> => {
+  const results: CommandResult[] = []
+  for (const command of commands) {
+    await log(`validation: ${command}`)
+    const result = await runShell(command, {
+      cwd: worktree,
+      env: git?.env,
+      allowFailure: true,
+      onOutput: async (chunk) => {
+        if (chunk.trim()) await log(chunk.trimEnd())
+      },
+    })
+    results.push(result)
+    if (result.exitCode !== 0) {
+      throw new Error(`validation failed (${result.exitCode}): ${command}`)
+    }
+  }
+  return results
+}

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path'
 
 import { runCommand, runShell } from './command'
 import type { AnypiConfig } from './config'
-import type { AgentRunSpecPayload, CommandResult, PullRequestResult } from './types'
+import type { AgentRunSpecPayload, CiCheck, CiWaitResult, CommandResult, PullRequestResult } from './types'
 
 export type GitContext = {
   repository: string
@@ -26,6 +26,8 @@ const envFlag = (value: string | undefined, fallback: boolean) => {
 }
 
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
+const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms))
 
 const buildCloneUrl = (cloneBaseUrl: string, repository: string) => {
   const base = trimTrailingSlash(cloneBaseUrl || 'https://github.com')
@@ -224,4 +226,112 @@ export const runValidationCommands = async (
     }
   }
   return results
+}
+
+export const parseCiChecks = (raw: string): CiCheck[] => {
+  if (!raw.trim()) return []
+  const parsed = JSON.parse(raw) as unknown
+  if (!Array.isArray(parsed)) throw new Error('gh pr checks JSON output was not an array')
+  return parsed.map((entry) => {
+    const record = entry && typeof entry === 'object' ? (entry as Record<string, unknown>) : {}
+    return {
+      name: String(record.name ?? 'unknown'),
+      workflow: record.workflow ? String(record.workflow) : undefined,
+      state: record.state ? String(record.state) : undefined,
+      bucket: record.bucket ? String(record.bucket) : undefined,
+      link: record.link ? String(record.link) : undefined,
+    }
+  })
+}
+
+export const summarizeChecks = (checks: CiCheck[]) => {
+  const failed = checks.filter((check) => ['fail', 'cancel'].includes(check.bucket ?? ''))
+  const pending = checks.filter((check) => check.bucket === 'pending')
+  const passed = checks.filter((check) => ['pass', 'skipping'].includes(check.bucket ?? ''))
+  return {
+    failed,
+    pending,
+    passed,
+    summary: `${passed.length} passed/skipped, ${pending.length} pending, ${failed.length} failed/cancelled`,
+  }
+}
+
+export const waitForPullRequestChecks = async (
+  git: GitContext,
+  options: {
+    timeoutSeconds: number
+    intervalSeconds: number
+    requiredOnly: boolean
+  },
+  log: (message: string) => Promise<void>,
+): Promise<CiWaitResult> => {
+  const started = Date.now()
+  const deadline = started + options.timeoutSeconds * 1000
+  let attempts = 0
+  let lastChecks: CiCheck[] = []
+  let lastSummary = 'checks not started'
+
+  while (Date.now() <= deadline) {
+    attempts += 1
+    const args = ['pr', 'checks', git.headBranch, '--repo', git.repository, '--json', 'name,workflow,state,bucket,link']
+    if (options.requiredOnly) args.push('--required')
+    const result = await runCommand('gh', args, {
+      cwd: git.worktree,
+      env: git.env,
+      allowFailure: true,
+    })
+
+    try {
+      lastChecks = parseCiChecks(result.stdout)
+    } catch (error) {
+      return {
+        ok: false,
+        status: 'unavailable',
+        requiredOnly: options.requiredOnly,
+        attempts,
+        durationMs: Date.now() - started,
+        checks: [],
+        summary: error instanceof Error ? error.message : String(error),
+      }
+    }
+
+    const summary = summarizeChecks(lastChecks)
+    lastSummary = summary.summary
+    await log(`ci checks: ${lastSummary}`)
+
+    if (summary.failed.length > 0) {
+      return {
+        ok: false,
+        status: 'failed',
+        requiredOnly: options.requiredOnly,
+        attempts,
+        durationMs: Date.now() - started,
+        checks: lastChecks,
+        summary: lastSummary,
+      }
+    }
+    if (summary.pending.length === 0) {
+      return {
+        ok: true,
+        status: 'passed',
+        requiredOnly: options.requiredOnly,
+        attempts,
+        durationMs: Date.now() - started,
+        checks: lastChecks,
+        summary: lastChecks.length === 0 ? 'no required checks reported' : lastSummary,
+      }
+    }
+
+    await sleep(options.intervalSeconds * 1000)
+  }
+
+  return {
+    ok: false,
+    status: 'timed-out',
+    requiredOnly: options.requiredOnly,
+    attempts,
+    durationMs: Date.now() - started,
+    checks: lastChecks,
+    summary: lastSummary,
+  }
 }

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -307,24 +307,42 @@ export const waitForPullRequestChecks = async (
   let attempts = 0
   let lastChecks: CiCheck[] = []
   let lastSummary = 'checks not started'
+  let effectiveRequiredOnly = options.requiredOnly
 
   while (Date.now() <= deadline) {
     attempts += 1
-    const args = ['pr', 'checks', git.headBranch, '--repo', git.repository, '--json', 'name,workflow,state,bucket,link']
-    if (options.requiredOnly) args.push('--required')
-    const result = await runCommand('gh', args, {
-      cwd: git.worktree,
-      env: git.env,
-      allowFailure: true,
-    })
+    const readChecks = async (requiredOnly: boolean) => {
+      const args = [
+        'pr',
+        'checks',
+        git.headBranch,
+        '--repo',
+        git.repository,
+        '--json',
+        'name,workflow,state,bucket,link',
+      ]
+      if (requiredOnly) args.push('--required')
+      return await runCommand('gh', args, {
+        cwd: git.worktree,
+        env: git.env,
+        allowFailure: true,
+      })
+    }
 
     try {
+      let result = await readChecks(effectiveRequiredOnly)
       lastChecks = parseCiChecks(result.stdout)
+      if (effectiveRequiredOnly && lastChecks.length === 0) {
+        await log('ci checks: no required checks reported; falling back to all pull request checks')
+        effectiveRequiredOnly = false
+        result = await readChecks(false)
+        lastChecks = parseCiChecks(result.stdout)
+      }
     } catch (error) {
       return {
         ok: false,
         status: 'unavailable',
-        requiredOnly: options.requiredOnly,
+        requiredOnly: effectiveRequiredOnly,
         attempts,
         durationMs: Date.now() - started,
         checks: [],
@@ -336,11 +354,16 @@ export const waitForPullRequestChecks = async (
     lastSummary = summary.summary
     await log(`ci checks: ${lastSummary}`)
 
+    if (lastChecks.length === 0) {
+      lastSummary = 'no pull request checks reported yet'
+      await sleep(options.intervalSeconds * 1000)
+      continue
+    }
     if (summary.failed.length > 0) {
       return {
         ok: false,
         status: 'failed',
-        requiredOnly: options.requiredOnly,
+        requiredOnly: effectiveRequiredOnly,
         attempts,
         durationMs: Date.now() - started,
         checks: lastChecks,
@@ -351,11 +374,11 @@ export const waitForPullRequestChecks = async (
       return {
         ok: true,
         status: 'passed',
-        requiredOnly: options.requiredOnly,
+        requiredOnly: effectiveRequiredOnly,
         attempts,
         durationMs: Date.now() - started,
         checks: lastChecks,
-        summary: lastChecks.length === 0 ? 'no required checks reported' : lastSummary,
+        summary: lastSummary,
       }
     }
 
@@ -365,7 +388,7 @@ export const waitForPullRequestChecks = async (
   return {
     ok: false,
     status: 'timed-out',
-    requiredOnly: options.requiredOnly,
+    requiredOnly: effectiveRequiredOnly,
     attempts,
     durationMs: Date.now() - started,
     checks: lastChecks,

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -219,7 +219,8 @@ export const runValidationCommands = async (
     })
     results.push(result)
     if (result.exitCode !== 0) {
-      throw new Error(`validation failed (${result.exitCode}): ${command}`)
+      await log(`validation failed (${result.exitCode}): ${command}`)
+      break
     }
   }
   return results

--- a/services/anypi/src/logger.ts
+++ b/services/anypi/src/logger.ts
@@ -1,0 +1,26 @@
+import { appendFile, mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export type Logger = {
+  info: (message: string) => Promise<void>
+  error: (message: string) => Promise<void>
+}
+
+const timestampUtc = () => new Date().toISOString()
+
+export const createLogger = async (logPath: string): Promise<Logger> => {
+  await mkdir(dirname(logPath), { recursive: true })
+  const write = async (level: 'info' | 'error', message: string) => {
+    const line = `${timestampUtc()} ${level.toUpperCase()} ${message}\n`
+    if (level === 'error') {
+      process.stderr.write(line)
+    } else {
+      process.stdout.write(line)
+    }
+    await appendFile(logPath, line, 'utf8')
+  }
+  return {
+    info: (message) => write('info', message),
+    error: (message) => write('error', message),
+  }
+}

--- a/services/anypi/src/main.ts
+++ b/services/anypi/src/main.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+
+import { runAnypi } from './run'
+
+runAnypi().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
 
 import {
   AuthStorage,
@@ -20,6 +21,22 @@ export type PiRunResult = {
   text: string
   tools: string[]
   sessionFile?: string
+}
+
+export type PiRunOptions = {
+  sessionLabel?: string
+}
+
+export const isBenignAssistantContinuationError = (error: unknown) =>
+  error instanceof Error && error.message.includes('Cannot continue from message role: assistant')
+
+export const resolveAttemptSessionDir = (sessionDir: string, sessionLabel = 'attempt') => {
+  const safeLabel = sessionLabel
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+  return join(sessionDir, `${safeLabel || 'attempt'}-${randomUUID().slice(0, 8)}`)
 }
 
 const collectAgentsFiles = async (worktree: string) => {
@@ -47,12 +64,15 @@ export const runPiAgent = async (
   config: AnypiConfig,
   prompt: string,
   log: (message: string) => Promise<void>,
+  options: PiRunOptions = {},
 ): Promise<PiRunResult> => {
   await mkdir(config.agentDir, { recursive: true })
   await mkdir(config.sessionDir, { recursive: true })
   await mkdir(dirname(config.authPath), { recursive: true })
   if (!existsSync(config.authPath)) await writeFile(config.authPath, '{}\n', 'utf8')
   await writeModelsFile(config)
+  const attemptSessionDir = resolveAttemptSessionDir(config.sessionDir, options.sessionLabel)
+  await mkdir(attemptSessionDir, { recursive: true })
 
   const authStorage = AuthStorage.create(config.authPath)
   const modelRegistry = ModelRegistry.create(authStorage, config.modelsPath)
@@ -76,11 +96,12 @@ export const runPiAgent = async (
     thinkingLevel: config.thinkingLevel,
     resourceLoader,
     tools: config.tools,
-    sessionManager: SessionManager.create(config.worktree, config.sessionDir),
+    sessionManager: SessionManager.create(config.worktree, attemptSessionDir),
     settingsManager,
   })
 
   if (modelFallbackMessage) await log(`pi model fallback: ${modelFallbackMessage}`)
+  await log(`pi session dir: ${attemptSessionDir}`)
   session.setActiveToolsByName(session.getAllTools().map((tool) => tool.name))
   await log(`pi active tools: ${session.getActiveToolNames().join(', ')}`)
 
@@ -100,7 +121,12 @@ export const runPiAgent = async (
   })
 
   try {
-    await session.prompt(prompt)
+    try {
+      await session.prompt(prompt)
+    } catch (error) {
+      if (!text.trim() || !isBenignAssistantContinuationError(error)) throw error
+      await log(`pi stopped after assistant final response: ${(error as Error).message}`)
+    }
     return {
       text,
       tools: session.getActiveToolNames(),

--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -1,0 +1,113 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import {
+  AuthStorage,
+  createAgentSession,
+  createExtensionRuntime,
+  ModelRegistry,
+  type ResourceLoader,
+  SessionManager,
+  SettingsManager,
+} from '@earendil-works/pi-coding-agent'
+
+import type { AnypiConfig } from './config'
+import { writeModelsFile } from './config'
+import { buildSystemPrompt } from './prompt'
+
+export type PiRunResult = {
+  text: string
+  tools: string[]
+  sessionFile?: string
+}
+
+const collectAgentsFiles = async (worktree: string) => {
+  const rootAgents = join(worktree, 'AGENTS.md')
+  if (!existsSync(rootAgents)) return []
+  return [{ path: rootAgents, content: await readFile(rootAgents, 'utf8') }]
+}
+
+const createResourceLoader = async (worktree: string): Promise<ResourceLoader> => {
+  const agentsFiles = await collectAgentsFiles(worktree)
+  return {
+    getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles }),
+    getSystemPrompt: () => buildSystemPrompt(),
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  }
+}
+
+export const runPiAgent = async (
+  config: AnypiConfig,
+  prompt: string,
+  log: (message: string) => Promise<void>,
+): Promise<PiRunResult> => {
+  await mkdir(config.agentDir, { recursive: true })
+  await mkdir(config.sessionDir, { recursive: true })
+  await mkdir(dirname(config.authPath), { recursive: true })
+  if (!existsSync(config.authPath)) await writeFile(config.authPath, '{}\n', 'utf8')
+  await writeModelsFile(config)
+
+  const authStorage = AuthStorage.create(config.authPath)
+  const modelRegistry = ModelRegistry.create(authStorage, config.modelsPath)
+  const model = modelRegistry.find(config.provider, config.model)
+  if (!model) throw new Error(`Pi model not found: ${config.provider}/${config.model}`)
+
+  const resourceLoader = await createResourceLoader(config.worktree)
+  const settingsManager = SettingsManager.inMemory({
+    compaction: { enabled: true },
+    retry: { enabled: true, maxRetries: 2 },
+    defaultProjectTrust: 'never',
+    quietStartup: true,
+  })
+
+  const { session, modelFallbackMessage } = await createAgentSession({
+    cwd: config.worktree,
+    agentDir: config.agentDir,
+    authStorage,
+    modelRegistry,
+    model,
+    thinkingLevel: config.thinkingLevel,
+    resourceLoader,
+    tools: config.tools,
+    sessionManager: SessionManager.create(config.worktree, config.sessionDir),
+    settingsManager,
+  })
+
+  if (modelFallbackMessage) await log(`pi model fallback: ${modelFallbackMessage}`)
+  session.setActiveToolsByName(session.getAllTools().map((tool) => tool.name))
+  await log(`pi active tools: ${session.getActiveToolNames().join(', ')}`)
+
+  let text = ''
+  const unsubscribe = session.subscribe((event) => {
+    if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
+      const delta = event.assistantMessageEvent.delta
+      text += delta
+      void log(delta)
+    }
+    if (event.type === 'tool_execution_start') {
+      void log(`tool start: ${event.toolName}`)
+    }
+    if (event.type === 'tool_execution_end') {
+      void log(`tool end: ${event.toolName}`)
+    }
+  })
+
+  try {
+    await session.prompt(prompt)
+    return {
+      text,
+      tools: session.getActiveToolNames(),
+      sessionFile: session.sessionFile,
+    }
+  } finally {
+    unsubscribe()
+    session.dispose()
+  }
+}

--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -25,6 +25,7 @@ export type PiRunResult = {
 
 export type PiRunOptions = {
   sessionLabel?: string
+  systemPrompt?: string
 }
 
 export const isBenignAssistantContinuationError = (error: unknown) =>
@@ -45,7 +46,10 @@ const collectAgentsFiles = async (worktree: string) => {
   return [{ path: rootAgents, content: await readFile(rootAgents, 'utf8') }]
 }
 
-const createResourceLoader = async (worktree: string): Promise<ResourceLoader> => {
+export const resolveEffectiveSystemPrompt = (inlineSystemPrompt?: string) =>
+  inlineSystemPrompt?.trim() || buildSystemPrompt()
+
+const createResourceLoader = async (worktree: string, systemPrompt: string): Promise<ResourceLoader> => {
   const agentsFiles = await collectAgentsFiles(worktree)
   return {
     getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
@@ -53,7 +57,7 @@ const createResourceLoader = async (worktree: string): Promise<ResourceLoader> =
     getPrompts: () => ({ prompts: [], diagnostics: [] }),
     getThemes: () => ({ themes: [], diagnostics: [] }),
     getAgentsFiles: () => ({ agentsFiles }),
-    getSystemPrompt: () => buildSystemPrompt(),
+    getSystemPrompt: () => systemPrompt,
     getAppendSystemPrompt: () => [],
     extendResources: () => {},
     reload: async () => {},
@@ -79,7 +83,8 @@ export const runPiAgent = async (
   const model = modelRegistry.find(config.provider, config.model)
   if (!model) throw new Error(`Pi model not found: ${config.provider}/${config.model}`)
 
-  const resourceLoader = await createResourceLoader(config.worktree)
+  const systemPrompt = resolveEffectiveSystemPrompt(options.systemPrompt)
+  const resourceLoader = await createResourceLoader(config.worktree, systemPrompt)
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: true },
     retry: { enabled: true, maxRetries: 2 },

--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -46,8 +46,8 @@ const collectAgentsFiles = async (worktree: string) => {
   return [{ path: rootAgents, content: await readFile(rootAgents, 'utf8') }]
 }
 
-export const resolveEffectiveSystemPrompt = (inlineSystemPrompt?: string) =>
-  inlineSystemPrompt?.trim() || buildSystemPrompt()
+export const resolveEffectiveSystemPrompt = (config: Pick<AnypiConfig, 'promptVariant'>, inlineSystemPrompt?: string) =>
+  inlineSystemPrompt?.trim() || buildSystemPrompt(config.promptVariant)
 
 const createResourceLoader = async (worktree: string, systemPrompt: string): Promise<ResourceLoader> => {
   const agentsFiles = await collectAgentsFiles(worktree)
@@ -83,7 +83,7 @@ export const runPiAgent = async (
   const model = modelRegistry.find(config.provider, config.model)
   if (!model) throw new Error(`Pi model not found: ${config.provider}/${config.model}`)
 
-  const systemPrompt = resolveEffectiveSystemPrompt(options.systemPrompt)
+  const systemPrompt = resolveEffectiveSystemPrompt(config, options.systemPrompt)
   const resourceLoader = await createResourceLoader(config.worktree, systemPrompt)
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: true },

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -84,6 +84,16 @@ Failures:
 ${failures.map(formatValidationResult).join('\n\n')}`
 }
 
+export const buildNoChangeRepairPrompt = (input: { attempt: number; maxAttempts: number; worktree: string }) =>
+  `Your previous response completed without leaving any code changes in the git worktree.
+
+Worktree: ${input.worktree}
+Repair attempt: ${input.attempt} of ${input.maxAttempts}
+
+This AgentRun requires a real implementation. Continue from the repository state now: inspect the requested files,
+edit source and tests, run relevant validation, and leave the final changes in the worktree. Do not stop with only
+analysis or a summary.`
+
 export const buildSystemPrompt = () =>
   `You are Anypi, an autonomous production coding runner.
 Be direct, use the repository instructions, inspect before editing, make coherent production changes, and verify with commands.

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -70,9 +70,7 @@ export const inferValidationCommands = (runSpec: AgentRunSpecPayload) => {
     )
   }
   if (task.includes('argocd/applications/agents') || task.includes('agentprovider') || task.includes('agentrun')) {
-    commands.push(
-      'mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml',
-    )
+    commands.push('kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml')
   }
   return dedupeCommands(commands)
 }

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -1,4 +1,18 @@
-import type { AgentRunSpecPayload, ValidationResult } from './types'
+import { createHash } from 'node:crypto'
+
+import type { AgentRunSpecPayload, PromptVariant, ValidationPlan, ValidationPolicy, ValidationResult } from './types'
+
+export const PROMPT_VARIANTS = ['minimal', 'finish-gated', 'repair-loop', 'strict-repo'] as const
+
+export const DEFAULT_PROMPT_VARIANT: PromptVariant = 'minimal'
+
+export const resolvePromptVariant = (raw: string | undefined): PromptVariant => {
+  const normalized = raw?.trim().toLowerCase()
+  if (PROMPT_VARIANTS.some((variant) => variant === normalized)) return normalized as PromptVariant
+  return DEFAULT_PROMPT_VARIANT
+}
+
+const dedupeCommands = (commands: string[]) => [...new Set(commands.map((command) => command.trim()).filter(Boolean))]
 
 export const resolveTaskPrompt = (runSpec: AgentRunSpecPayload) => {
   const candidates = [runSpec.prompt, runSpec.implementation?.text, runSpec.implementation?.summary]
@@ -9,10 +23,9 @@ export const resolveTaskPrompt = (runSpec: AgentRunSpecPayload) => {
   return JSON.stringify(runSpec, null, 2)
 }
 
-export const resolveValidationCommands = (runSpec: AgentRunSpecPayload, configuredCommands: string[]) => {
-  if (configuredCommands.length > 0) return configuredCommands
+export const parseRunValidationCommands = (runSpec: AgentRunSpecPayload) => {
   const raw = runSpec.parameters?.validationCommands
-  if (!raw?.trim()) return ['git diff --check']
+  if (!raw?.trim()) return []
   if (raw.trim().startsWith('[')) {
     const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) throw new Error('parameters.validationCommands must be a JSON array or newline list')
@@ -23,6 +36,91 @@ export const resolveValidationCommands = (runSpec: AgentRunSpecPayload, configur
     .map((entry) => entry.trim())
     .filter(Boolean)
 }
+
+const taskFingerprint = (runSpec: AgentRunSpecPayload) =>
+  [
+    runSpec.prompt,
+    runSpec.implementation?.summary,
+    runSpec.implementation?.text,
+    runSpec.goal?.objective,
+    runSpec.issueTitle,
+    runSpec.issueBody,
+  ]
+    .filter(Boolean)
+    .join('\n')
+    .toLowerCase()
+
+export const inferValidationCommands = (runSpec: AgentRunSpecPayload) => {
+  const task = taskFingerprint(runSpec)
+  const commands = ['git diff --check']
+  if (task.includes('services/torghut') || task.includes('torghut')) {
+    commands.push(
+      'cd services/torghut && uv sync --frozen --extra dev',
+      'cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations',
+      'cd services/torghut && uv run --frozen pyright --project pyrightconfig.json',
+      'cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json',
+      'cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json',
+    )
+  }
+  if (task.includes('services/anypi') || task.includes('anypi')) {
+    commands.push(
+      'bun run --filter @proompteng/anypi tsc',
+      'bun run --filter @proompteng/anypi test',
+      'bun run --filter @proompteng/anypi lint',
+    )
+  }
+  if (task.includes('argocd/applications/agents') || task.includes('agentprovider') || task.includes('agentrun')) {
+    commands.push(
+      'mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml',
+    )
+  }
+  return dedupeCommands(commands)
+}
+
+export const resolveValidationPolicy = (raw: string | undefined): ValidationPolicy =>
+  raw?.trim().toLowerCase() === 'override' ? 'override' : 'append'
+
+export const resolveValidationPlan = (
+  runSpec: AgentRunSpecPayload,
+  configuredCommands: string[],
+  policy: ValidationPolicy,
+): ValidationPlan => {
+  const inferredCommands = inferValidationCommands(runSpec)
+  const runCommands = parseRunValidationCommands(runSpec)
+  const sources: string[] = []
+  let commands: string[]
+
+  if (policy === 'override') {
+    if (configuredCommands.length > 0) {
+      commands = configuredCommands
+      sources.push('env')
+    } else if (runCommands.length > 0) {
+      commands = runCommands
+      sources.push('run-spec')
+    } else {
+      commands = inferredCommands
+      sources.push('inferred')
+    }
+  } else {
+    commands = dedupeCommands([...inferredCommands, ...runCommands, ...configuredCommands])
+    if (inferredCommands.length > 0) sources.push('inferred')
+    if (runCommands.length > 0) sources.push('run-spec')
+    if (configuredCommands.length > 0) sources.push('env')
+  }
+
+  if (commands.length <= 1 && commands[0] === 'git diff --check') {
+    throw new Error('Anypi requires service-aware validation commands; refusing to run only git diff --check')
+  }
+
+  return {
+    policy,
+    sources,
+    commands,
+  }
+}
+
+export const resolveValidationCommands = (runSpec: AgentRunSpecPayload, configuredCommands: string[]) =>
+  resolveValidationPlan(runSpec, configuredCommands, 'override').commands
 
 export const buildAgentPrompt = (runSpec: AgentRunSpecPayload, worktree: string) => {
   const task = resolveTaskPrompt(runSpec)
@@ -93,8 +191,26 @@ The task requires a real implementation. Continue from the repository state now:
 source and tests, run relevant validation, and leave the final changes in the worktree. Do not stop with only analysis
 or a summary.`
 
-export const buildSystemPrompt = () =>
-  `Act as a coding agent inside an existing repository.
+export const buildCiRepairPrompt = (input: {
+  attempt: number
+  maxAttempts: number
+  worktree: string
+  summary: string
+}) =>
+  `Pull request checks failed after the previous changes.
+
+Worktree: ${input.worktree}
+Repair attempt: ${input.attempt} of ${input.maxAttempts}
+
+Inspect the failing CI signal, reproduce the likely failure locally when possible, repair the root cause, run the
+relevant validation commands, and leave the final code changes in the worktree. Do not remove or weaken tests, fake
+results, or make unrelated refactors.
+
+CI summary:
+${input.summary}`
+
+const SYSTEM_PROMPTS: Record<PromptVariant, string> = {
+  minimal: `Act as a coding agent inside an existing repository.
 
 Rules:
 - Inspect repository instructions and relevant files before editing.
@@ -103,4 +219,47 @@ Rules:
 - Run the checks required for touched files; fix failures and rerun them.
 - Do not hard-code for tests, remove tests to pass, fake results, or claim success with failing checks.
 - Do not commit, push, merge, or change branches.
-- Keep the final response concise: changed files and validation only.`
+- Keep the final response concise: changed files and validation only.`,
+  'finish-gated': `Act as a coding agent inside an existing repository.
+
+Rules:
+- Inspect repository instructions and relevant files before editing.
+- Keep the solution focused, production-quality, and no broader than the task.
+- Add or update tests for changed behavior.
+- Run the checks required for touched files; fix failures and rerun them.
+- Continue until the implementation, tests, and validation are complete.
+- Do not hard-code for tests, remove tests to pass, fake results, or claim success with failing checks.
+- Do not commit, push, merge, or change branches.
+- Keep the final response concise: changed files and validation only.`,
+  'repair-loop': `Act as a coding agent inside an existing repository.
+
+Rules:
+- Inspect repository instructions and relevant files before editing.
+- Keep the solution focused, production-quality, and no broader than the task.
+- Add or update tests for changed behavior.
+- Run the checks required for touched files; fix failures and rerun them.
+- When a check fails, use the command output as evidence, fix the root cause, and rerun the failing check.
+- Continue until the implementation, tests, and validation are complete.
+- Do not hard-code for tests, remove tests to pass, fake results, or claim success with failing checks.
+- Do not commit, push, merge, or change branches.
+- Keep the final response concise: changed files and validation only.`,
+  'strict-repo': `Act as a coding agent inside an existing repository.
+
+Rules:
+- Inspect repository instructions and relevant files before editing.
+- Follow AGENTS.md and existing code patterns for every file you touch.
+- Keep the solution focused, production-quality, and no broader than the task.
+- Add or update tests for changed behavior.
+- Run the checks required for touched files; fix failures and rerun them.
+- When a check fails, use the command output as evidence, fix the root cause, and rerun the failing check.
+- Continue until the implementation, tests, and validation are complete.
+- Do not hard-code for tests, remove tests to pass, fake results, or claim success with failing checks.
+- Do not delete coverage, weaken assertions, skip mandatory checks, or make unrelated refactors.
+- Do not commit, push, merge, or change branches.
+- Keep the final response concise: changed files and validation only.`,
+}
+
+export const buildSystemPrompt = (variant: PromptVariant = DEFAULT_PROMPT_VARIANT) => SYSTEM_PROMPTS[variant]
+
+export const hashSystemPrompt = (variant: PromptVariant) =>
+  createHash('sha256').update(buildSystemPrompt(variant)).digest('hex').slice(0, 16)

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -1,4 +1,4 @@
-import type { AgentRunSpecPayload } from './types'
+import type { AgentRunSpecPayload, ValidationResult } from './types'
 
 export const resolveTaskPrompt = (runSpec: AgentRunSpecPayload) => {
   const candidates = [runSpec.prompt, runSpec.implementation?.text, runSpec.implementation?.summary]
@@ -46,6 +46,42 @@ Operational rules:
 
 Task:
 ${task}`
+}
+
+const trimOutput = (value: string, maxLength = 6000) => {
+  const trimmed = value.trim()
+  if (trimmed.length <= maxLength) return trimmed || 'N/A'
+  return `${trimmed.slice(0, maxLength)}\n...[truncated]`
+}
+
+const formatValidationResult = (result: ValidationResult) => `Command: \`${[result.command, ...result.args].join(' ')}\`
+Exit: ${result.exitCode}
+stdout:
+\`\`\`
+${trimOutput(result.stdout)}
+\`\`\`
+stderr:
+\`\`\`
+${trimOutput(result.stderr)}
+\`\`\``
+
+export const buildValidationRepairPrompt = (input: {
+  attempt: number
+  maxAttempts: number
+  worktree: string
+  results: ValidationResult[]
+}) => {
+  const failures = input.results.filter((result) => !result.ok)
+  return `Validation failed after your previous changes.
+
+Worktree: ${input.worktree}
+Repair attempt: ${input.attempt} of ${input.maxAttempts}
+
+Fix the repository so every validation command passes. Preserve the requested feature work, do not remove tests to make
+the suite pass, and run the failing command(s) again before stopping. Leave the final code changes in the worktree.
+
+Failures:
+${failures.map(formatValidationResult).join('\n\n')}`
 }
 
 export const buildSystemPrompt = () =>

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -1,0 +1,54 @@
+import type { AgentRunSpecPayload } from './types'
+
+export const resolveTaskPrompt = (runSpec: AgentRunSpecPayload) => {
+  const candidates = [runSpec.prompt, runSpec.implementation?.text, runSpec.implementation?.summary]
+  for (const candidate of candidates) {
+    const text = candidate?.trim()
+    if (text) return text
+  }
+  return JSON.stringify(runSpec, null, 2)
+}
+
+export const resolveValidationCommands = (runSpec: AgentRunSpecPayload, configuredCommands: string[]) => {
+  if (configuredCommands.length > 0) return configuredCommands
+  const raw = runSpec.parameters?.validationCommands
+  if (!raw?.trim()) return ['git diff --check']
+  if (raw.trim().startsWith('[')) {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) throw new Error('parameters.validationCommands must be a JSON array or newline list')
+    return parsed.map((entry) => String(entry).trim()).filter(Boolean)
+  }
+  return raw
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+export const buildAgentPrompt = (runSpec: AgentRunSpecPayload, worktree: string) => {
+  const task = resolveTaskPrompt(runSpec)
+  const parameters = runSpec.parameters ?? {}
+  const goal = runSpec.goal?.objective?.trim()
+  return `You are Anypi, a YOLO-mode autonomous coding agent running inside Kubernetes.
+
+Worktree: ${worktree}
+Repository: ${runSpec.vcs?.repository ?? runSpec.repository ?? parameters.repository ?? 'unknown'}
+Base branch: ${runSpec.vcs?.baseBranch ?? runSpec.base ?? parameters.base ?? 'main'}
+Head branch: ${runSpec.vcs?.headBranch ?? runSpec.head ?? parameters.head ?? 'codex/anypi'}
+${goal ? `Goal: ${goal}\n` : ''}
+Operational rules:
+- Work autonomously. Do not ask the user for clarification.
+- You have shell, read, edit, write, grep, find, and ls tools available.
+- Make real code and test changes when the task asks for implementation.
+- Run the most relevant validation commands yourself before stopping.
+- Do not merge. Do not delete branches.
+- Leave the final code changes in the git worktree; the Anypi runner will validate, commit, push, and open or update the PR.
+- If the task is impossible, leave a concise failure report in the final response and do not fake a diff.
+
+Task:
+${task}`
+}
+
+export const buildSystemPrompt = () =>
+  `You are Anypi, an autonomous production coding runner.
+Be direct, use the repository instructions, inspect before editing, make coherent production changes, and verify with commands.
+You are running in yolo mode with write/edit/shell tools enabled. Do not wait for approval inside the run.`

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -28,21 +28,19 @@ export const buildAgentPrompt = (runSpec: AgentRunSpecPayload, worktree: string)
   const task = resolveTaskPrompt(runSpec)
   const parameters = runSpec.parameters ?? {}
   const goal = runSpec.goal?.objective?.trim()
-  return `You are Anypi, a YOLO-mode autonomous coding agent running inside Kubernetes.
-
-Worktree: ${worktree}
+  return `Worktree: ${worktree}
 Repository: ${runSpec.vcs?.repository ?? runSpec.repository ?? parameters.repository ?? 'unknown'}
 Base branch: ${runSpec.vcs?.baseBranch ?? runSpec.base ?? parameters.base ?? 'main'}
 Head branch: ${runSpec.vcs?.headBranch ?? runSpec.head ?? parameters.head ?? 'codex/anypi'}
 ${goal ? `Goal: ${goal}\n` : ''}
-Operational rules:
-- Work autonomously. Do not ask the user for clarification.
-- You have shell, read, edit, write, grep, find, and ls tools available.
-- Make real code and test changes when the task asks for implementation.
-- Run the most relevant validation commands yourself before stopping.
-- Do not merge. Do not delete branches.
-- Leave the final code changes in the git worktree; the Anypi runner will validate, commit, push, and open or update the PR.
-- If the task is impossible, leave a concise failure report in the final response and do not fake a diff.
+Task rules:
+- Use repository instructions and existing patterns.
+- Implement the requested change directly.
+- Add or update tests when behavior changes.
+- Run the checks required for the files you touched.
+- Fix validation failures before stopping.
+- Do not commit, push, merge, delete branches, or fake results.
+- Leave the final changes in the worktree.
 
 Task:
 ${task}`
@@ -72,29 +70,37 @@ export const buildValidationRepairPrompt = (input: {
   results: ValidationResult[]
 }) => {
   const failures = input.results.filter((result) => !result.ok)
-  return `Validation failed after your previous changes.
+  return `Validation failed after the previous changes.
 
 Worktree: ${input.worktree}
 Repair attempt: ${input.attempt} of ${input.maxAttempts}
 
-Fix the repository so every validation command passes. Preserve the requested feature work, do not remove tests to make
-the suite pass, and run the failing command(s) again before stopping. Leave the final code changes in the worktree.
+Fix the repository so every validation command passes. Preserve the requested feature work, do not remove or weaken
+tests to make the suite pass, and run the failing command(s) again before stopping. Leave the final code changes in the
+worktree.
 
 Failures:
 ${failures.map(formatValidationResult).join('\n\n')}`
 }
 
 export const buildNoChangeRepairPrompt = (input: { attempt: number; maxAttempts: number; worktree: string }) =>
-  `Your previous response completed without leaving any code changes in the git worktree.
+  `The previous attempt completed without leaving any code changes in the git worktree.
 
 Worktree: ${input.worktree}
 Repair attempt: ${input.attempt} of ${input.maxAttempts}
 
-This AgentRun requires a real implementation. Continue from the repository state now: inspect the requested files,
-edit source and tests, run relevant validation, and leave the final changes in the worktree. Do not stop with only
-analysis or a summary.`
+The task requires a real implementation. Continue from the repository state now: inspect the requested files, edit
+source and tests, run relevant validation, and leave the final changes in the worktree. Do not stop with only analysis
+or a summary.`
 
 export const buildSystemPrompt = () =>
-  `You are Anypi, an autonomous production coding runner.
-Be direct, use the repository instructions, inspect before editing, make coherent production changes, and verify with commands.
-You are running in yolo mode with write/edit/shell tools enabled. Do not wait for approval inside the run.`
+  `Act as a coding agent inside an existing repository.
+
+Rules:
+- Inspect repository instructions and relevant files before editing.
+- Keep the solution focused, production-quality, and no broader than the task.
+- Add or update tests for changed behavior.
+- Run the checks required for touched files; fix failures and rerun them.
+- Do not hard-code for tests, remove tests to pass, fake results, or claim success with failing checks.
+- Do not commit, push, merge, or change branches.
+- Keep the final response concise: changed files and validation only.`

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -4,7 +4,7 @@ import { dirname } from 'node:path'
 import { applyRunnerArtifacts, loadRunnerSpec, loadRunSpec, resolveConfig, type AnypiConfig } from './config'
 import { createLogger } from './logger'
 import { runPiAgent } from './pi-session'
-import { buildAgentPrompt, resolveValidationCommands } from './prompt'
+import { buildAgentPrompt, buildValidationRepairPrompt, resolveValidationCommands } from './prompt'
 import {
   commitIfNeeded,
   countCommitsAhead,
@@ -76,8 +76,16 @@ const baseStatus = (config: AnypiConfig, runSpec: AgentRunSpecPayload, git: GitC
   providerModel: `${config.provider}/${config.model}`,
   tools: [],
   validations: [],
+  validationAttempts: 0,
   promptChars: 0,
 })
+
+const mergeTools = (left: string[], right: string[]) => [...new Set([...left, ...right])]
+
+const failedValidation = (results: ValidationResult[]) => results.find((result) => !result.ok)
+
+const formatValidationError = (result: ValidationResult) =>
+  `validation failed (${result.exitCode}): ${[result.command, ...result.args].join(' ')}`
 
 export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<AnypiStatus> => {
   let config = resolveConfig(env)
@@ -95,9 +103,12 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
     const prompt = buildAgentPrompt(runSpec, config.worktree)
     status.promptChars = prompt.length
 
-    const piResult = await runPiAgent(config, prompt, logger.info)
+    let piResult = await runPiAgent(config, prompt, logger.info)
+    let piText = piResult.text
+    const sessionFiles = piResult.sessionFile ? [piResult.sessionFile] : []
     status.tools = piResult.tools
     status.sessionFile = piResult.sessionFile
+    status.sessionFiles = sessionFiles
 
     const changed = await gitStatusShort(config.worktree, git?.env)
     const commitsAhead = git ? await countCommitsAhead(git) : 0
@@ -106,8 +117,36 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
     }
 
     const validationCommands = resolveValidationCommands(runSpec, config.validationCommands)
-    const validationResults = await runValidationCommands(validationCommands, git, config.worktree, logger.info)
-    status.validations = validationResults.map((result): ValidationResult => ({ ...result, ok: result.exitCode === 0 }))
+    let validationResults: ValidationResult[] = []
+    for (let attempt = 0; attempt <= config.validationRepairAttempts; attempt += 1) {
+      const rawResults = await runValidationCommands(validationCommands, git, config.worktree, logger.info)
+      validationResults = rawResults.map((result): ValidationResult => ({ ...result, ok: result.exitCode === 0 }))
+      status.validationAttempts = attempt + 1
+      status.validations = validationResults
+      await writeStatus(config.statusPath, status)
+
+      const failed = failedValidation(validationResults)
+      if (!failed) break
+      if (attempt >= config.validationRepairAttempts) throw new Error(formatValidationError(failed))
+
+      await logger.error(
+        `${formatValidationError(failed)}; starting validation repair ${attempt + 1}/${config.validationRepairAttempts}`,
+      )
+      const repairPrompt = buildValidationRepairPrompt({
+        attempt: attempt + 1,
+        maxAttempts: config.validationRepairAttempts,
+        worktree: config.worktree,
+        results: validationResults,
+      })
+      const repairResult = await runPiAgent(config, repairPrompt, logger.info)
+      piText = `${piText}\n\n## Validation repair ${attempt + 1}\n${repairResult.text}`
+      status.tools = mergeTools(status.tools, repairResult.tools)
+      if (repairResult.sessionFile) {
+        sessionFiles.push(repairResult.sessionFile)
+        status.sessionFile = repairResult.sessionFile
+        status.sessionFiles = sessionFiles
+      }
+    }
 
     let pullRequest: PullRequestResult | undefined
     if (git) {
@@ -117,7 +156,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       await pushBranch(git)
       pullRequest = await createOrUpdatePullRequest(git, {
         title: buildPullRequestTitle(runSpec),
-        body: buildPullRequestBody({ runSpec, status, git, piText: piResult.text }),
+        body: buildPullRequestBody({ runSpec, status, git, piText }),
       })
       status.pullRequest = pullRequest
     }

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -29,20 +29,28 @@ const toErrorMessage = (error: unknown) => (error instanceof Error ? error.messa
 
 const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms))
 
+export const normalizeConventionalSummary = (raw: string | undefined, fallback: string) => {
+  const summary = (raw?.trim() || fallback)
+    .replace(/\s+/g, ' ')
+    .replace(/[.。]+$/g, '')
+    .toLowerCase()
+  return summary.slice(0, 80)
+}
+
 const writeStatus = async (path: string, status: AnypiStatus) => {
   await mkdir(dirname(path), { recursive: true })
   await writeFile(path, `${JSON.stringify(status, null, 2)}\n`, 'utf8')
 }
 
-const buildCommitMessage = (runSpec: AgentRunSpecPayload) => {
+export const buildCommitMessage = (runSpec: AgentRunSpecPayload) => {
   const summary = runSpec.implementation?.summary?.trim() || runSpec.issueTitle?.trim() || runSpec.agentRun?.name
-  return `feat(anypi): ${summary ? summary.slice(0, 80) : 'implement agent task'}`
+  return `feat(anypi): ${normalizeConventionalSummary(summary, 'implement agent task')}`
 }
 
-const buildPullRequestTitle = (runSpec: AgentRunSpecPayload) => {
+export const buildPullRequestTitle = (runSpec: AgentRunSpecPayload) => {
   const title =
     process.env.VCS_PR_TITLE_TEMPLATE?.trim() || runSpec.issueTitle?.trim() || runSpec.implementation?.summary?.trim()
-  return title ? `feat(anypi): ${title.slice(0, 80)}` : 'feat(anypi): apply autonomous agent changes'
+  return `feat(anypi): ${normalizeConventionalSummary(title, 'apply autonomous agent changes')}`
 }
 
 const buildPullRequestBody = (input: {
@@ -163,6 +171,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       await recordPiResult(
         await runPiAgent(config, nextPrompt, logger.info, {
           sessionLabel: attempt === 0 ? 'initial' : `no-change-repair-${attempt}`,
+          systemPrompt: runSpec.systemPrompt,
         }),
         attempt === 0 ? undefined : `No-change repair ${attempt}`,
       )
@@ -204,6 +213,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       })
       const repairResult = await runPiAgent(config, repairPrompt, logger.info, {
         sessionLabel: `validation-repair-${attempt + 1}`,
+        systemPrompt: runSpec.systemPrompt,
       })
       piText = `${piText}\n\n## Validation repair ${attempt + 1}\n${repairResult.text}`
       status.tools = mergeTools(status.tools, repairResult.tools)

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -27,6 +27,8 @@ const timestampUtc = () => new Date().toISOString()
 
 const toErrorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error))
 
+const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms))
+
 const writeStatus = async (path: string, status: AnypiStatus) => {
   await mkdir(dirname(path), { recursive: true })
   await writeFile(path, `${JSON.stringify(status, null, 2)}\n`, 'utf8')
@@ -93,6 +95,33 @@ const failedValidation = (results: ValidationResult[]) => results.find((result) 
 const formatValidationError = (result: ValidationResult) =>
   `validation failed (${result.exitCode}): ${[result.command, ...result.args].join(' ')}`
 
+const waitForModelEndpoint = async (config: AnypiConfig, log: (message: string) => Promise<void>) => {
+  const modelsUrl = `${config.baseUrl.replace(/\/+$/, '')}/models`
+  const deadline = Date.now() + config.modelReadyTimeoutSeconds * 1000
+  let lastError = 'not checked'
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(modelsUrl, {
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+        },
+      })
+      if (response.ok) {
+        await log(`model endpoint ready: ${modelsUrl}`)
+        return
+      }
+      lastError = `${response.status} ${response.statusText}`.trim()
+    } catch (error) {
+      lastError = toErrorMessage(error)
+    }
+    await log(`model endpoint not ready: ${modelsUrl} (${lastError})`)
+    await sleep(10_000)
+  }
+
+  throw new Error(`model endpoint not ready after ${config.modelReadyTimeoutSeconds}s: ${modelsUrl} (${lastError})`)
+}
+
 export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<AnypiStatus> => {
   let config = resolveConfig(env)
   const runnerSpec = await loadRunnerSpec(config)
@@ -106,6 +135,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
     await writeStatus(config.statusPath, status)
     await logger.info(`starting Anypi for ${status.runName ?? 'unknown run'}`)
     await prepareRepository(config, git, logger.info)
+    await waitForModelEndpoint(config, logger.info)
     const prompt = buildAgentPrompt(runSpec, config.worktree)
     status.promptChars = prompt.length
 

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -161,7 +161,9 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
               worktree: config.worktree,
             })
       await recordPiResult(
-        await runPiAgent(config, nextPrompt, logger.info),
+        await runPiAgent(config, nextPrompt, logger.info, {
+          sessionLabel: attempt === 0 ? 'initial' : `no-change-repair-${attempt}`,
+        }),
         attempt === 0 ? undefined : `No-change repair ${attempt}`,
       )
       status.agentAttempts = attempt + 1
@@ -200,7 +202,9 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
         worktree: config.worktree,
         results: validationResults,
       })
-      const repairResult = await runPiAgent(config, repairPrompt, logger.info)
+      const repairResult = await runPiAgent(config, repairPrompt, logger.info, {
+        sessionLabel: `validation-repair-${attempt + 1}`,
+      })
       piText = `${piText}\n\n## Validation repair ${attempt + 1}\n${repairResult.text}`
       status.tools = mergeTools(status.tools, repairResult.tools)
       if (repairResult.sessionFile) {

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -1,0 +1,138 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import { applyRunnerArtifacts, loadRunnerSpec, loadRunSpec, resolveConfig, type AnypiConfig } from './config'
+import { createLogger } from './logger'
+import { runPiAgent } from './pi-session'
+import { buildAgentPrompt, resolveValidationCommands } from './prompt'
+import {
+  commitIfNeeded,
+  countCommitsAhead,
+  createOrUpdatePullRequest,
+  gitStatusShort,
+  prepareRepository,
+  pushBranch,
+  resolveGitContext,
+  runValidationCommands,
+  type GitContext,
+} from './git'
+import type { AgentRunSpecPayload, AnypiStatus, PullRequestResult, ValidationResult } from './types'
+
+const timestampUtc = () => new Date().toISOString()
+
+const toErrorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error))
+
+const writeStatus = async (path: string, status: AnypiStatus) => {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(status, null, 2)}\n`, 'utf8')
+}
+
+const buildCommitMessage = (runSpec: AgentRunSpecPayload) => {
+  const summary = runSpec.implementation?.summary?.trim() || runSpec.issueTitle?.trim() || runSpec.agentRun?.name
+  return `feat(anypi): ${summary ? summary.slice(0, 80) : 'implement agent task'}`
+}
+
+const buildPullRequestTitle = (runSpec: AgentRunSpecPayload) => {
+  const title =
+    process.env.VCS_PR_TITLE_TEMPLATE?.trim() || runSpec.issueTitle?.trim() || runSpec.implementation?.summary?.trim()
+  return title ? `feat(anypi): ${title.slice(0, 80)}` : 'feat(anypi): apply autonomous agent changes'
+}
+
+const buildPullRequestBody = (input: {
+  runSpec: AgentRunSpecPayload
+  status: AnypiStatus
+  git: GitContext
+  piText: string
+}) => {
+  const validations = input.status.validations
+    .map((result) => `- \`${[result.command, ...result.args].join(' ')}\` exit ${result.exitCode}`)
+    .join('\n')
+  return `## Summary
+Anypi generated this change using Pi SDK against Flamingo.
+
+AgentRun: ${input.status.namespace ?? 'agents'}/${input.status.runName ?? 'unknown'}
+Model: ${input.status.providerModel}
+Session: ${input.status.sessionFile ?? 'N/A'}
+
+## Validation
+${validations || 'No validation commands were configured.'}
+
+## Agent Output
+${input.piText.trim().slice(0, 6000) || 'N/A'}
+`
+}
+
+const baseStatus = (config: AnypiConfig, runSpec: AgentRunSpecPayload, git: GitContext | null): AnypiStatus => ({
+  provider: 'anypi',
+  status: 'running',
+  startedAt: timestampUtc(),
+  runName: runSpec.agentRun?.name,
+  namespace: runSpec.agentRun?.namespace,
+  repository: git?.repository,
+  baseBranch: git?.baseBranch,
+  headBranch: git?.headBranch,
+  worktree: config.worktree,
+  model: config.model,
+  providerModel: `${config.provider}/${config.model}`,
+  tools: [],
+  validations: [],
+  promptChars: 0,
+})
+
+export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<AnypiStatus> => {
+  let config = resolveConfig(env)
+  const runnerSpec = await loadRunnerSpec(config)
+  config = applyRunnerArtifacts(config, runnerSpec)
+  const logger = await createLogger(config.logPath)
+  const runSpec = await loadRunSpec(config)
+  const git = await resolveGitContext(config, runSpec)
+  const status = baseStatus(config, runSpec, git)
+
+  try {
+    await writeStatus(config.statusPath, status)
+    await logger.info(`starting Anypi for ${status.runName ?? 'unknown run'}`)
+    await prepareRepository(config, git, logger.info)
+    const prompt = buildAgentPrompt(runSpec, config.worktree)
+    status.promptChars = prompt.length
+
+    const piResult = await runPiAgent(config, prompt, logger.info)
+    status.tools = piResult.tools
+    status.sessionFile = piResult.sessionFile
+
+    const changed = await gitStatusShort(config.worktree, git?.env)
+    const commitsAhead = git ? await countCommitsAhead(git) : 0
+    if (!changed && git && commitsAhead === 0) {
+      throw new Error('Anypi completed without leaving code changes in the worktree')
+    }
+
+    const validationCommands = resolveValidationCommands(runSpec, config.validationCommands)
+    const validationResults = await runValidationCommands(validationCommands, git, config.worktree, logger.info)
+    status.validations = validationResults.map((result): ValidationResult => ({ ...result, ok: result.exitCode === 0 }))
+
+    let pullRequest: PullRequestResult | undefined
+    if (git) {
+      const commit = await commitIfNeeded(git, buildCommitMessage(runSpec))
+      if (!commit) throw new Error('Anypi produced no commits relative to the base branch')
+      status.commit = commit
+      await pushBranch(git)
+      pullRequest = await createOrUpdatePullRequest(git, {
+        title: buildPullRequestTitle(runSpec),
+        body: buildPullRequestBody({ runSpec, status, git, piText: piResult.text }),
+      })
+      status.pullRequest = pullRequest
+    }
+
+    status.status = 'succeeded'
+    status.finishedAt = timestampUtc()
+    await writeStatus(config.statusPath, status)
+    await logger.info(`Anypi finished with status ${status.status}`)
+    return status
+  } catch (error) {
+    status.status = 'failed'
+    status.finishedAt = timestampUtc()
+    status.error = toErrorMessage(error)
+    await writeStatus(config.statusPath, status)
+    await logger.error(status.error)
+    throw error
+  }
+}

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -4,7 +4,12 @@ import { dirname } from 'node:path'
 import { applyRunnerArtifacts, loadRunnerSpec, loadRunSpec, resolveConfig, type AnypiConfig } from './config'
 import { createLogger } from './logger'
 import { runPiAgent } from './pi-session'
-import { buildAgentPrompt, buildValidationRepairPrompt, resolveValidationCommands } from './prompt'
+import {
+  buildAgentPrompt,
+  buildNoChangeRepairPrompt,
+  buildValidationRepairPrompt,
+  resolveValidationCommands,
+} from './prompt'
 import {
   commitIfNeeded,
   countCommitsAhead,
@@ -76,6 +81,7 @@ const baseStatus = (config: AnypiConfig, runSpec: AgentRunSpecPayload, git: GitC
   providerModel: `${config.provider}/${config.model}`,
   tools: [],
   validations: [],
+  agentAttempts: 0,
   validationAttempts: 0,
   promptChars: 0,
 })
@@ -103,17 +109,43 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
     const prompt = buildAgentPrompt(runSpec, config.worktree)
     status.promptChars = prompt.length
 
-    let piResult = await runPiAgent(config, prompt, logger.info)
-    let piText = piResult.text
-    const sessionFiles = piResult.sessionFile ? [piResult.sessionFile] : []
-    status.tools = piResult.tools
-    status.sessionFile = piResult.sessionFile
-    status.sessionFiles = sessionFiles
+    let piText = ''
+    const sessionFiles: string[] = []
+    const recordPiResult = async (result: Awaited<ReturnType<typeof runPiAgent>>, label?: string) => {
+      piText = piText ? `${piText}\n\n${label ? `## ${label}\n` : ''}${result.text}` : result.text
+      status.tools = mergeTools(status.tools, result.tools)
+      if (result.sessionFile) {
+        sessionFiles.push(result.sessionFile)
+        status.sessionFile = result.sessionFile
+        status.sessionFiles = sessionFiles
+      }
+    }
 
-    const changed = await gitStatusShort(config.worktree, git?.env)
-    const commitsAhead = git ? await countCommitsAhead(git) : 0
-    if (!changed && git && commitsAhead === 0) {
-      throw new Error('Anypi completed without leaving code changes in the worktree')
+    for (let attempt = 0; attempt <= config.noChangeRepairAttempts; attempt += 1) {
+      const nextPrompt =
+        attempt === 0
+          ? prompt
+          : buildNoChangeRepairPrompt({
+              attempt,
+              maxAttempts: config.noChangeRepairAttempts,
+              worktree: config.worktree,
+            })
+      await recordPiResult(
+        await runPiAgent(config, nextPrompt, logger.info),
+        attempt === 0 ? undefined : `No-change repair ${attempt}`,
+      )
+      status.agentAttempts = attempt + 1
+      await writeStatus(config.statusPath, status)
+
+      const changed = await gitStatusShort(config.worktree, git?.env)
+      const commitsAhead = git ? await countCommitsAhead(git) : 0
+      if (changed || !git || commitsAhead > 0) break
+      if (attempt >= config.noChangeRepairAttempts) {
+        throw new Error('Anypi completed without leaving code changes in the worktree')
+      }
+      await logger.error(
+        `Anypi completed without leaving code changes; starting no-change repair ${attempt + 1}/${config.noChangeRepairAttempts}`,
+      )
     }
 
     const validationCommands = resolveValidationCommands(runSpec, config.validationCommands)

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -6,9 +6,11 @@ import { createLogger } from './logger'
 import { runPiAgent } from './pi-session'
 import {
   buildAgentPrompt,
+  buildCiRepairPrompt,
   buildNoChangeRepairPrompt,
   buildValidationRepairPrompt,
-  resolveValidationCommands,
+  hashSystemPrompt,
+  resolveValidationPlan,
 } from './prompt'
 import {
   commitIfNeeded,
@@ -19,9 +21,17 @@ import {
   pushBranch,
   resolveGitContext,
   runValidationCommands,
+  waitForPullRequestChecks,
   type GitContext,
 } from './git'
-import type { AgentRunSpecPayload, AnypiStatus, PullRequestResult, ValidationResult } from './types'
+import type {
+  AgentRunSpecPayload,
+  AnypiStatus,
+  CiWaitResult,
+  PullRequestResult,
+  ValidationPlan,
+  ValidationResult,
+} from './types'
 
 const timestampUtc = () => new Date().toISOString()
 
@@ -62,22 +72,50 @@ const buildPullRequestBody = (input: {
   const validations = input.status.validations
     .map((result) => `- \`${[result.command, ...result.args].join(' ')}\` exit ${result.exitCode}`)
     .join('\n')
+  const ci = input.status.ci
+    ? `${input.status.ci.status}: ${input.status.ci.summary}`
+    : 'Pending: pull request checks have not completed yet.'
   return `## Summary
-Anypi generated this change using Pi SDK against Flamingo.
 
-AgentRun: ${input.status.namespace ?? 'agents'}/${input.status.runName ?? 'unknown'}
-Model: ${input.status.providerModel}
-Session: ${input.status.sessionFile ?? 'N/A'}
+- Anypi generated this code change for ${input.status.namespace ?? 'agents'}/${input.status.runName ?? 'unknown'}.
+- Prompt variant: ${input.status.promptVariant} (${input.status.promptHash}).
+- Session artifact: ${input.status.sessionFile ?? 'N/A'}.
+
+## Related Issues
+
+None
 
 ## Validation
-${validations || 'No validation commands were configured.'}
+
+${validations || '- N/A'}
+
+CI: ${ci}
+
+## Screenshots (if applicable)
+
+N/A
+
+## Breaking Changes
+
+None
+
+## Checklist
+
+- [x] Testing section documents the exact validation performed.
+- [x] Screenshots and Breaking Changes sections are handled appropriately.
+- [x] Documentation, release notes, and follow-ups are updated or tracked.
 
 ## Agent Output
 ${input.piText.trim().slice(0, 6000) || 'N/A'}
 `
 }
 
-const baseStatus = (config: AnypiConfig, runSpec: AgentRunSpecPayload, git: GitContext | null): AnypiStatus => ({
+const baseStatus = (
+  config: AnypiConfig,
+  runSpec: AgentRunSpecPayload,
+  git: GitContext | null,
+  validationPlan: ValidationPlan,
+): AnypiStatus => ({
   provider: 'anypi',
   status: 'running',
   startedAt: timestampUtc(),
@@ -89,10 +127,14 @@ const baseStatus = (config: AnypiConfig, runSpec: AgentRunSpecPayload, git: GitC
   worktree: config.worktree,
   model: config.model,
   providerModel: `${config.provider}/${config.model}`,
+  promptVariant: config.promptVariant,
+  promptHash: hashSystemPrompt(config.promptVariant),
   tools: [],
   validations: [],
+  validationPlan,
   agentAttempts: 0,
   validationAttempts: 0,
+  ciAttempts: 0,
   promptChars: 0,
 })
 
@@ -102,6 +144,19 @@ const failedValidation = (results: ValidationResult[]) => results.find((result) 
 
 const formatValidationError = (result: ValidationResult) =>
   `validation failed (${result.exitCode}): ${[result.command, ...result.args].join(' ')}`
+
+const formatCiError = (ci: CiWaitResult) => `ci checks ${ci.status}: ${ci.summary}`
+
+const formatCiRepairSummary = (ci: CiWaitResult) => {
+  const checks = ci.checks
+    .map(
+      (check) =>
+        `- ${check.workflow ? `${check.workflow} / ` : ''}${check.name}: ${check.bucket ?? check.state ?? 'unknown'}`,
+    )
+    .slice(0, 30)
+    .join('\n')
+  return `${ci.status}: ${ci.summary}${checks ? `\n${checks}` : ''}`
+}
 
 const waitForModelEndpoint = async (config: AnypiConfig, log: (message: string) => Promise<void>) => {
   const modelsUrl = `${config.baseUrl.replace(/\/+$/, '')}/models`
@@ -137,15 +192,21 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
   const logger = await createLogger(config.logPath)
   const runSpec = await loadRunSpec(config)
   const git = await resolveGitContext(config, runSpec)
-  const status = baseStatus(config, runSpec, git)
+  const validationPlan = resolveValidationPlan(runSpec, config.validationCommands, config.validationPolicy)
+  const status = baseStatus(config, runSpec, git, validationPlan)
 
   try {
     await writeStatus(config.statusPath, status)
     await logger.info(`starting Anypi for ${status.runName ?? 'unknown run'}`)
+    await logger.info(`prompt variant: ${status.promptVariant} ${status.promptHash}`)
+    if (runSpec.systemPrompt && !config.allowSystemPromptOverride) {
+      await logger.info('run systemPrompt ignored because ANYPI_ALLOW_SYSTEM_PROMPT_OVERRIDE is false')
+    }
     await prepareRepository(config, git, logger.info)
     await waitForModelEndpoint(config, logger.info)
     const prompt = buildAgentPrompt(runSpec, config.worktree)
     status.promptChars = prompt.length
+    const systemPrompt = config.allowSystemPromptOverride ? runSpec.systemPrompt : undefined
 
     let piText = ''
     const sessionFiles: string[] = []
@@ -171,7 +232,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       await recordPiResult(
         await runPiAgent(config, nextPrompt, logger.info, {
           sessionLabel: attempt === 0 ? 'initial' : `no-change-repair-${attempt}`,
-          systemPrompt: runSpec.systemPrompt,
+          systemPrompt,
         }),
         attempt === 0 ? undefined : `No-change repair ${attempt}`,
       )
@@ -189,7 +250,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       )
     }
 
-    const validationCommands = resolveValidationCommands(runSpec, config.validationCommands)
+    const validationCommands = status.validationPlan.commands
     let validationResults: ValidationResult[] = []
     for (let attempt = 0; attempt <= config.validationRepairAttempts; attempt += 1) {
       const rawResults = await runValidationCommands(validationCommands, git, config.worktree, logger.info)
@@ -213,8 +274,9 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       })
       const repairResult = await runPiAgent(config, repairPrompt, logger.info, {
         sessionLabel: `validation-repair-${attempt + 1}`,
-        systemPrompt: runSpec.systemPrompt,
+        systemPrompt,
       })
+      status.agentAttempts += 1
       piText = `${piText}\n\n## Validation repair ${attempt + 1}\n${repairResult.text}`
       status.tools = mergeTools(status.tools, repairResult.tools)
       if (repairResult.sessionFile) {
@@ -235,6 +297,71 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
         body: buildPullRequestBody({ runSpec, status, git, piText }),
       })
       status.pullRequest = pullRequest
+      await writeStatus(config.statusPath, status)
+
+      if (pullRequest.enabled) {
+        for (let attempt = 0; attempt <= config.ciRepairAttempts; attempt += 1) {
+          const ci = await waitForPullRequestChecks(
+            git,
+            {
+              timeoutSeconds: config.ciCheckTimeoutSeconds,
+              intervalSeconds: config.ciCheckIntervalSeconds,
+              requiredOnly: config.ciRequiredOnly,
+            },
+            logger.info,
+          )
+          status.ciAttempts = attempt + 1
+          status.ci = ci
+          await writeStatus(config.statusPath, status)
+          if (ci.ok) break
+          if (attempt >= config.ciRepairAttempts) throw new Error(formatCiError(ci))
+
+          await logger.error(`${formatCiError(ci)}; starting ci repair ${attempt + 1}/${config.ciRepairAttempts}`)
+          const repairResult = await runPiAgent(
+            config,
+            buildCiRepairPrompt({
+              attempt: attempt + 1,
+              maxAttempts: config.ciRepairAttempts,
+              worktree: config.worktree,
+              summary: formatCiRepairSummary(ci),
+            }),
+            logger.info,
+            {
+              sessionLabel: `ci-repair-${attempt + 1}`,
+              systemPrompt,
+            },
+          )
+          await recordPiResult(repairResult, `CI repair ${attempt + 1}`)
+          status.agentAttempts += 1
+
+          const rawResults = await runValidationCommands(validationCommands, git, config.worktree, logger.info)
+          validationResults = rawResults.map((result): ValidationResult => ({ ...result, ok: result.exitCode === 0 }))
+          status.validationAttempts += 1
+          status.validations = validationResults
+          await writeStatus(config.statusPath, status)
+          const failed = failedValidation(validationResults)
+          if (failed) throw new Error(formatValidationError(failed))
+
+          const previousCommit: string | undefined = status.commit
+          const repairedCommit = await commitIfNeeded(git, buildCommitMessage(runSpec))
+          if (!repairedCommit || repairedCommit === previousCommit) throw new Error('CI repair produced no new commit')
+          status.commit = repairedCommit
+          await pushBranch(git)
+          pullRequest = await createOrUpdatePullRequest(git, {
+            title: buildPullRequestTitle(runSpec),
+            body: buildPullRequestBody({ runSpec, status, git, piText }),
+          })
+          status.pullRequest = pullRequest
+          await writeStatus(config.statusPath, status)
+        }
+
+        pullRequest = await createOrUpdatePullRequest(git, {
+          title: buildPullRequestTitle(runSpec),
+          body: buildPullRequestBody({ runSpec, status, git, piText }),
+        })
+        status.pullRequest = pullRequest
+        await writeStatus(config.statusPath, status)
+      }
     }
 
     status.status = 'succeeded'

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -1,5 +1,9 @@
 export type JsonRecord = Record<string, unknown>
 
+export type PromptVariant = 'minimal' | 'finish-gated' | 'repair-loop' | 'strict-repo'
+
+export type ValidationPolicy = 'append' | 'override'
+
 export type AgentRunIdentity = {
   name?: string
   namespace?: string
@@ -70,10 +74,34 @@ export type ValidationResult = CommandResult & {
   ok: boolean
 }
 
+export type ValidationPlan = {
+  policy: ValidationPolicy
+  sources: string[]
+  commands: string[]
+}
+
 export type PullRequestResult = {
   enabled: boolean
   url?: string
   created?: boolean
+}
+
+export type CiCheck = {
+  name: string
+  workflow?: string
+  state?: string
+  bucket?: string
+  link?: string
+}
+
+export type CiWaitResult = {
+  ok: boolean
+  status: 'passed' | 'failed' | 'timed-out' | 'unavailable'
+  requiredOnly: boolean
+  attempts: number
+  durationMs: number
+  checks: CiCheck[]
+  summary: string
 }
 
 export type AnypiStatus = {
@@ -89,12 +117,17 @@ export type AnypiStatus = {
   worktree?: string
   model: string
   providerModel: string
+  promptVariant: PromptVariant
+  promptHash: string
   tools: string[]
   sessionFile?: string
   sessionFiles?: string[]
   commit?: string
   pullRequest?: PullRequestResult
+  ci?: CiWaitResult
+  ciAttempts: number
   validations: ValidationResult[]
+  validationPlan: ValidationPlan
   agentAttempts: number
   validationAttempts: number
   promptChars: number

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -90,9 +90,11 @@ export type AnypiStatus = {
   providerModel: string
   tools: string[]
   sessionFile?: string
+  sessionFiles?: string[]
   commit?: string
   pullRequest?: PullRequestResult
   validations: ValidationResult[]
+  validationAttempts: number
   promptChars: number
   error?: string
 }

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -94,6 +94,7 @@ export type AnypiStatus = {
   commit?: string
   pullRequest?: PullRequestResult
   validations: ValidationResult[]
+  agentAttempts: number
   validationAttempts: number
   promptChars: number
   error?: string

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -30,6 +30,7 @@ export type AgentRunSpecPayload = {
   agentRun?: AgentRunIdentity
   implementation?: ImplementationPayload
   parameters?: Record<string, string>
+  systemPrompt?: string
   prompt?: string
   goal?: {
     objective?: string

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -1,0 +1,98 @@
+export type JsonRecord = Record<string, unknown>
+
+export type AgentRunIdentity = {
+  name?: string
+  namespace?: string
+}
+
+export type ImplementationPayload = {
+  summary?: string
+  text?: string
+}
+
+export type VcsContext = {
+  provider?: string
+  providerName?: string
+  repository?: string
+  baseBranch?: string
+  headBranch?: string
+  mode?: string
+  writeEnabled?: boolean
+  pullRequestsEnabled?: boolean
+  apiBaseUrl?: string
+  cloneBaseUrl?: string
+  webBaseUrl?: string
+  cloneProtocol?: string
+}
+
+export type AgentRunSpecPayload = {
+  provider?: string
+  agentRun?: AgentRunIdentity
+  implementation?: ImplementationPayload
+  parameters?: Record<string, string>
+  prompt?: string
+  goal?: {
+    objective?: string
+    tokenBudget?: number
+  }
+  repository?: string
+  base?: string
+  head?: string
+  issueTitle?: string
+  issueBody?: string
+  vcs?: VcsContext
+}
+
+export type AgentRunnerSpecPayload = {
+  provider?: string
+  artifacts?: {
+    statusPath?: string
+    logPath?: string
+    logRetentionSeconds?: number
+  }
+  payloads?: {
+    eventFilePath?: string
+  }
+}
+
+export type CommandResult = {
+  command: string
+  args: string[]
+  cwd?: string
+  exitCode: number
+  stdout: string
+  stderr: string
+  durationMs: number
+}
+
+export type ValidationResult = CommandResult & {
+  ok: boolean
+}
+
+export type PullRequestResult = {
+  enabled: boolean
+  url?: string
+  created?: boolean
+}
+
+export type AnypiStatus = {
+  provider: string
+  status: 'running' | 'succeeded' | 'failed'
+  startedAt: string
+  finishedAt?: string
+  runName?: string
+  namespace?: string
+  repository?: string
+  baseBranch?: string
+  headBranch?: string
+  worktree?: string
+  model: string
+  providerModel: string
+  tools: string[]
+  sessionFile?: string
+  commit?: string
+  pullRequest?: PullRequestResult
+  validations: ValidationResult[]
+  promptChars: number
+  error?: string
+}

--- a/services/anypi/tsconfig.json
+++ b/services/anypi/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/services/anypi/vitest.config.ts
+++ b/services/anypi/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- Adds prompt-evaluated Anypi runner support and eval manifests for Flamingo-backed Pi AgentRuns.
- Publishes multi-arch Anypi and default Agents runner image pins for `linux/amd64` and `linux/arm64`.
- Clears the default AgentRun workload node selector so jobs are not forced onto arm64 when their image supports multiple architectures.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/anypi tsc`
- `bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi lint`
- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-archfix-render.yaml`
- Verified rendered Agents manifests omit `AGENTS_AGENT_RUNNER_NODE_SELECTOR` and pin `registry.ide-newton.ts.net/lab/agents-codex-runner:b18caf3d8@sha256:4e1cb399c4ec0d458622e2689b02f5166bd9205b64a33fe904e5756b3d89f004`.
- Verified `registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874` has `linux/amd64` and `linux/arm64` manifests.
- Verified `registry.ide-newton.ts.net/lab/agents-codex-runner:b18caf3d8@sha256:4e1cb399c4ec0d458622e2689b02f5166bd9205b64a33fe904e5756b3d89f004` has `linux/amd64` and `linux/arm64` manifests.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
