### PR TITLE
chore(symphony): promote image e874f7df

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-04T08:49:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-16T07:05:11Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "05ba6f5b"
-    digest: sha256:21874a01097eae0dc8a12b2bedcecab4532dbbe7d32506d7b8c76b1c83cec778
+    newTag: "e874f7df"
+    digest: sha256:1bd8cfa6d44e34a40dcf96b52d191ca9ec0725b0d3ef4be98866df5645837d44

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-04T08:49:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-16T07:05:11Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "05ba6f5b"
-    digest: sha256:21874a01097eae0dc8a12b2bedcecab4532dbbe7d32506d7b8c76b1c83cec778
+    newTag: "e874f7df"
+    digest: sha256:1bd8cfa6d44e34a40dcf96b52d191ca9ec0725b0d3ef4be98866df5645837d44

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-04T08:49:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-16T07:05:11Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "05ba6f5b"
-    digest: sha256:21874a01097eae0dc8a12b2bedcecab4532dbbe7d32506d7b8c76b1c83cec778
+    newTag: "e874f7df"
+    digest: sha256:1bd8cfa6d44e34a40dcf96b52d191ca9ec0725b0d3ef4be98866df5645837d44


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `e874f7dfe87110a837f8f58d1e70780f3bc80e80`
- Image tag: `e874f7df`
- Image digest: `sha256:1bd8cfa6d44e34a40dcf96b52d191ca9ec0725b0d3ef4be98866df5645837d44`