### PR TITLE
chore(jangar): promote image e874f7df

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-04T08:48:19Z
+    deploy.knative.dev/rollout: 2026-06-16T07:10:41Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 05ba6f5b4696318762d885ea18961b9b3f093a20
+              value: e874f7dfe87110a837f8f58d1e70780f3bc80e80
             - name: JANGAR_GITOPS_REVISION
-              value: 05ba6f5b4696318762d885ea18961b9b3f093a20
+              value: e874f7dfe87110a837f8f58d1e70780f3bc80e80
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26940431928"
+              value: "27600394009"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:d4f643c39e0f486a1604cec81e9a86b69f47d5dd83f1b128bdedce480aa96fd1
+              value: sha256:543e7dce38f6d1d5278b196281477c6068235ef7815180d249ee4062cce31002
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 05ba6f5b4696318762d885ea18961b9b3f093a20
+              value: e874f7dfe87110a837f8f58d1e70780f3bc80e80
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:d4f643c39e0f486a1604cec81e9a86b69f47d5dd83f1b128bdedce480aa96fd1
+              value: sha256:543e7dce38f6d1d5278b196281477c6068235ef7815180d249ee4062cce31002
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 05ba6f5b
-    digest: sha256:d4f643c39e0f486a1604cec81e9a86b69f47d5dd83f1b128bdedce480aa96fd1
+    newTag: e874f7df
+    digest: sha256:543e7dce38f6d1d5278b196281477c6068235ef7815180d249ee4062cce31002


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `e874f7dfe87110a837f8f58d1e70780f3bc80e80`
- Image tag: `e874f7df`
- Image digest: `sha256:543e7dce38f6d1d5278b196281477c6068235ef7815180d249ee4062cce31002`
- Source CI run: `27600394009`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates