### PR TITLE
fix(torghut): run journal worker as package module

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events_modules/journal_payloads.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events_modules/journal_payloads.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
@@ -26,6 +25,15 @@ from .journal_core import (
 )
 
 
+def _has_text_items(value: object) -> bool:
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return any(str(item).strip() for item in value)
+    return bool(value)
+
+
 def _fresh_reconciliation_for_empty_selection(
     session: Any,
     *,
@@ -38,28 +46,18 @@ def _fresh_reconciliation_for_empty_selection(
     )
     if latest is None:
         return None
-    if not bool(latest.get("ok")):
-        return None
-    if str(latest.get("status") or "") != "ok":
-        return None
-    if bool(latest.get("reconciliation_stale")):
-        return None
     max_age_seconds = int(latest.get("reconciliation_max_age_seconds") or 0)
-    if max_age_seconds <= 0:
-        return None
-    raw_blockers = latest.get("blockers")
-    if isinstance(raw_blockers, Sequence) and not isinstance(
-        raw_blockers,
-        (str, bytes, bytearray),
-    ):
-        if any(str(item).strip() for item in raw_blockers):
-            return None
-    elif raw_blockers:
-        return None
-    if not bool(latest.get("client_lookup_ok", True)):
-        return None
     latest_account_label = latest.get("account_label")
-    if account_label and latest_account_label != account_label:
+    blocked = (
+        not bool(latest.get("ok"))
+        or str(latest.get("status") or "") != "ok"
+        or bool(latest.get("reconciliation_stale"))
+        or max_age_seconds <= 0
+        or _has_text_items(latest.get("blockers"))
+        or not bool(latest.get("client_lookup_ok", True))
+        or bool(account_label and latest_account_label != account_label)
+    )
+    if blocked:
         return None
     return {
         "ok": True,
@@ -312,7 +310,8 @@ def _args_for_source(
 def _supervised_worker_argv(source: str | None = None) -> list[str]:
     return [
         sys.executable,
-        os.path.abspath(__file__),
+        "-m",
+        "scripts.journal_tigerbeetle_order_events",
         *_with_source_arg(sys.argv[1:], source),
         "--supervised-worker",
     ]
@@ -380,10 +379,8 @@ def _completed_progress_batch_from_timeout(
     *,
     worker_args: argparse.Namespace,
 ) -> dict[str, Any] | None:
-    if not bool(getattr(worker_args, "skip_reconcile", False)):
-        return None
     sources = _parse_sources(getattr(worker_args, "sources", "all"))
-    if len(sources) != 1:
+    if not bool(getattr(worker_args, "skip_reconcile", False)) or len(sources) != 1:
         return None
     source = sources[0]
     events = _journal_progress_events(text)
@@ -400,14 +397,13 @@ def _completed_progress_batch_from_timeout(
     journaled = _progress_int(complete.get("journaled"))
     skipped = _progress_int(complete.get("skipped"))
     failed = _progress_int(complete.get("failed"))
-    if failed != 0:
-        return None
-    if (
-        bool(complete.get("stopped_early"))
+    incomplete_progress = (
+        failed != 0
+        or bool(complete.get("stopped_early"))
         or str(complete.get("stop_reason") or "").strip()
-    ):
-        return None
-    if journaled + skipped + failed != selected:
+        or journaled + skipped + failed != selected
+    )
+    if incomplete_progress:
         return None
     chunk_events = [
         event
@@ -474,27 +470,17 @@ def _payload_from_completed_timeout_progress(
 def _safe_payload_allows_success(payload: Mapping[str, Any] | None) -> bool:
     if not payload:
         return False
-    if payload.get("schema_version") != "torghut.tigerbeetle-journal-order-events.v1":
-        return False
-    if bool(payload.get("exit_nonzero", True)):
-        return False
-    if bool(payload.get("promotion_authority", True)):
-        return False
-    if bool(payload.get("overrides_runtime_ledger_authority", True)):
-        return False
-    if int(payload.get("failed") or 0) != 0:
-        return False
-    for key in ("hard_failure_reasons", "stop_reasons"):
-        raw_value = payload.get(key)
-        if isinstance(raw_value, Sequence) and not isinstance(
-            raw_value,
-            (str, bytes, bytearray),
-        ):
-            if any(str(item).strip() for item in raw_value):
-                return False
-        elif raw_value:
-            return False
-    return True
+    return (
+        payload.get("schema_version") == "torghut.tigerbeetle-journal-order-events.v1"
+        and not bool(payload.get("exit_nonzero", True))
+        and not bool(payload.get("promotion_authority", True))
+        and not bool(payload.get("overrides_runtime_ledger_authority", True))
+        and int(payload.get("failed") or 0) == 0
+        and not any(
+            _has_text_items(payload.get(key))
+            for key in ("hard_failure_reasons", "stop_reasons")
+        )
+    )
 
 
 def _normalize_supervised_returncode(

--- a/services/torghut/tests/journal_tigerbeetle_order_events/test_payload_and_supervision.py
+++ b/services/torghut/tests/journal_tigerbeetle_order_events/test_payload_and_supervision.py
@@ -13,9 +13,11 @@ from tests.journal_tigerbeetle_order_events.support import (
     json,
     os,
     patch,
+    Path,
     redirect_stderr,
     redirect_stdout,
     script,
+    script_payloads,
     subprocess,
     sys,
     timezone,
@@ -284,6 +286,54 @@ class TestJournalPayloadAndSupervision(_TestJournalTigerBeetleOrderEventsScriptB
 
         self.assertEqual(events, [json.loads(progress)])
         self.assertEqual(script._progress_int("not-an-int"), 0)
+
+    def test_supervised_worker_argv_uses_package_entrypoint(self) -> None:
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "journal_tigerbeetle_order_events.py",
+                "--dsn-env",
+                "DB_DSN",
+                "--sources",
+                "execution,execution_tca_metric",
+                "--supervised-worker",
+            ],
+        ):
+            argv = script_payloads._supervised_worker_argv(script.SOURCE_TYPE_EXECUTION)
+
+        self.assertEqual(
+            argv[:3],
+            [sys.executable, "-m", "scripts.journal_tigerbeetle_order_events"],
+        )
+        self.assertNotIn("journal_payloads.py", " ".join(argv))
+        self.assertEqual(argv.count("--supervised-worker"), 1)
+        self.assertEqual(
+            argv[argv.index("--sources") + 1],
+            script.SOURCE_TYPE_EXECUTION,
+        )
+
+    def test_module_entrypoint_help_imports_with_package_context(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.journal_tigerbeetle_order_events",
+                "--help",
+            ],
+            cwd=Path(__file__).resolve().parents[2],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+        combined_output = f"{completed.stdout}\n{completed.stderr}"
+        self.assertEqual(completed.returncode, 0, combined_output)
+        self.assertIn(
+            "Journal unlinked Torghut order-feed lifecycle events", combined_output
+        )
+        self.assertNotIn("ImportError", combined_output)
 
     def test_completed_timeout_progress_rejects_untrusted_progress(self) -> None:
         def worker_args(

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -89,6 +89,57 @@ class RunTigerBeetleJournalCronTest(TestCase):
             5000,
         )
 
+    def test_live_and_sim_presets_build_journal_script_commands(self) -> None:
+        with patch(
+            "scripts.run_tigerbeetle_journal_cron.sys.argv",
+            ["run_tigerbeetle_journal_cron.py", "--preset", "live", "--json"],
+        ):
+            live_args = runner._parse_args()
+
+        live_command = runner._commands_for_preset(live_args)[0]
+        live_argv = runner._argv_for_command(
+            live_command,
+            json_output=True,
+            supervise_timeout_seconds=float(live_args.supervise_timeout_seconds),
+        )
+
+        self.assertEqual(live_argv[0], runner.sys.executable)
+        self.assertTrue(live_argv[1].endswith("journal_tigerbeetle_order_events.py"))
+        self.assertEqual(live_argv[live_argv.index("--dsn-env") + 1], "DB_DSN")
+        self.assertEqual(
+            live_argv[live_argv.index("--sources") + 1],
+            SOURCE_TYPE_EXECUTION,
+        )
+        self.assertIn("--supervise-timeout-seconds", live_argv)
+        self.assertIn("--json", live_argv)
+
+        with patch(
+            "scripts.run_tigerbeetle_journal_cron.sys.argv",
+            ["run_tigerbeetle_journal_cron.py", "--preset", "sim", "--json"],
+        ):
+            sim_args = runner._parse_args()
+
+        sim_command = runner._commands_for_preset(sim_args)[0]
+        sim_argv = runner._argv_for_command(
+            sim_command,
+            json_output=True,
+            supervise_timeout_seconds=float(sim_args.supervise_timeout_seconds),
+        )
+
+        self.assertEqual(sim_argv[0], runner.sys.executable)
+        self.assertTrue(sim_argv[1].endswith("journal_tigerbeetle_order_events.py"))
+        self.assertEqual(sim_argv[sim_argv.index("--dsn-env") + 1], "SIM_DB_DSN")
+        self.assertEqual(
+            sim_argv[sim_argv.index("--account-label") + 1],
+            "TORGHUT_SIM",
+        )
+        self.assertEqual(
+            sim_argv[sim_argv.index("--sources") + 1],
+            SOURCE_TYPE_EXECUTION,
+        )
+        self.assertIn("--supervise-timeout-seconds", sim_argv)
+        self.assertIn("--json", sim_argv)
+
     def test_default_live_execution_slices_drain_source_ref_backlog(self) -> None:
         with patch(
             "scripts.run_tigerbeetle_journal_cron.sys.argv",


### PR DESCRIPTION
## Summary

- Fixes the TigerBeetle journal supervised worker launch so it runs the package entrypoint with `python -m scripts.journal_tigerbeetle_order_events`.
- Adds regression coverage for the supervised worker argv/import path and live/sim CronJob runner command construction.
- Preserves existing GitOps CronJob commands; the Torghut release workflow should promote a new image digest after this lands.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen python -m compileall app scripts`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && repo_root=$(git rev-parse --show-toplevel); base=$(git merge-base origin/main HEAD); changed_python=(); while IFS= read -r python_file; do changed_python+=("$python_file"); done < <(git -C "$repo_root" diff --name-only --diff-filter=ACMR "$base...HEAD" -- services/torghut/app services/torghut/scripts | sed 's#^services/torghut/##' | grep -E '^(app|scripts)/.*\.py$' || true); if [ "${#changed_python[@]}" -eq 0 ]; then echo "No changed Torghut app/script Python files"; else uv run --frozen pylint "${changed_python[@]}" --disable=all --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks --score=n; fi`
- `cd services/torghut && uv run --frozen --extra dev pytest tests/journal_tigerbeetle_order_events/test_payload_and_supervision.py tests/test_run_tigerbeetle_journal_cron.py -q`
- `cd services/torghut && uv run --frozen --extra dev pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --extra dev pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --extra dev pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `cd services/torghut && uv run --frozen --extra dev python -m scripts.journal_tigerbeetle_order_events --help`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no docs changes were required for this import-path regression.
