### PR TITLE
fix(anypi): render template-backed eval PRs

### DIFF
--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -1,29 +1,37 @@
-# Templates only. Do not add this file to the Argo CD kustomization.
+# Apply this file as one batch to schedule five substantial Anypi prompt-eval AgentRuns concurrently.
+# Do not add this file to the Argo CD kustomization; these are evaluation runs, not steady-state resources.
 #
-# Duplicate each AgentRun per prompt variant by setting:
-#   metadata.name
-#   spec.parameters.head
-#   spec.parameters.promptVariant: minimal | finish-gated | repair-loop | strict-repo
+# Batch contract:
+# - Five AgentRuns start together with unique branches.
+# - The batch covers at least three prompt variants and all required task classes.
+# - Runtime node selectors force both amd64 and arm64 runner coverage for the multi-arch Anypi image.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-torghut-strict-repo-20260616
+  name: anypi-eval-torghut-minimal-20260616a
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
+    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/prompt-variant: minimal
+    anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
   agentRef:
     name: anypi-eval-agent
   implementation:
     inline:
-      summary: Improve Torghut diff coverage reporting
+      summary: Improve Torghut diff coverage executable-line reporting
       text: |
-        Improve services/torghut/scripts/check_diff_coverage.py so uncovered executable changed lines are reported
-        with actionable file:line details. Add regression tests in services/torghut/tests/test_check_diff_coverage.py.
-        Preserve existing behavior for covered lines and non-executable changed lines.
+        Improve services/torghut/scripts/check_diff_coverage.py so uncovered executable changed lines are reported with
+        actionable file:line details, stable ordering, and clear separation between executable and ignored changed lines.
+        Add regression tests in services/torghut/tests/test_check_diff_coverage.py that cover multi-file diffs and
+        uncovered executable lines. Preserve existing behavior for covered lines and non-executable changed lines.
   runtime:
     type: job
+    config:
+      nodeSelector:
+        kubernetes.io/arch: amd64
   ttlSecondsAfterFinished: 86400
   vcsRef:
     name: github
@@ -33,8 +41,8 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/strict-repo/torghut-diff-coverage-20260616
-    promptVariant: strict-repo
+    head: codex/anypi-eval/minimal/torghut-diff-coverage-20260616a
+    promptVariant: minimal
     validationCommands: |
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
   secrets:
@@ -43,7 +51,7 @@ spec:
     image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
     resources:
       requests:
-        cpu: '2'
+        cpu: "2"
         memory: 4Gi
         ephemeral-storage: 12Gi
       limits:
@@ -53,21 +61,29 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-runner-strict-repo-20260616
+  name: anypi-eval-torghut-repair-20260616a
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
+    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/prompt-variant: repair-loop
+    anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
   agentRef:
     name: anypi-eval-agent
   implementation:
     inline:
-      summary: Improve Anypi status evidence tests
+      summary: Improve Torghut diff coverage diagnostic grouping
       text: |
-        Improve services/anypi tests so status evidence for prompt variants, validation plans, and CI checks is covered.
-        Keep the change focused on runner behavior and tests.
+        Improve services/torghut/scripts/check_diff_coverage.py reporting so uncovered executable changed lines are grouped
+        by file with concise counts, sorted line numbers, and enough context to decide the next test to write. Add or update
+        regression tests in services/torghut/tests/test_check_diff_coverage.py. Keep the diff focused on the reporting path
+        and preserve existing coverage accounting semantics.
   runtime:
     type: job
+    config:
+      nodeSelector:
+        kubernetes.io/arch: arm64
   ttlSecondsAfterFinished: 86400
   vcsRef:
     name: github
@@ -76,8 +92,112 @@ spec:
     mode: read-write
   parameters:
     repository: proompteng/lab
-    base: codex/flamingo-rollout-complete
-    head: codex/anypi-eval/strict-repo/runner-status-evidence-20260616
+    base: main
+    head: codex/anypi-eval/repair-loop/torghut-diff-coverage-20260616a
+    promptVariant: repair-loop
+    validationCommands: |
+      cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
+  secrets:
+    - github-token
+  workload:
+    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+        ephemeral-storage: 12Gi
+      limits:
+        memory: 12Gi
+        ephemeral-storage: 24Gi
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: anypi-eval-runner-finish-20260616a
+  namespace: agents
+  labels:
+    app.kubernetes.io/part-of: anypi-prompt-eval
+    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/prompt-variant: finish-gated
+    anypi.proompteng.ai/task: anypi-status-evidence
+spec:
+  agentRef:
+    name: anypi-eval-agent
+  implementation:
+    inline:
+      summary: Improve Anypi status evidence for prompt evaluation
+      text: |
+        Improve services/anypi so prompt-evaluation status evidence is easier to audit after an AgentRun. Add focused
+        TypeScript tests that verify status metadata includes prompt variant/hash, validation plan sources, validation
+        attempts, CI attempts, session artifact paths, and PR metadata. Keep runtime details out of model-facing prompts.
+  runtime:
+    type: job
+    config:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+  ttlSecondsAfterFinished: 86400
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/anypi-eval/finish-gated/runner-status-evidence-20260616a
+    promptVariant: finish-gated
+    validationCommands: |
+      bun run --filter @proompteng/anypi tsc
+      bun run --filter @proompteng/anypi test
+      bun run --filter @proompteng/anypi lint
+  secrets:
+    - github-token
+  workload:
+    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+        ephemeral-storage: 12Gi
+      limits:
+        memory: 12Gi
+        ephemeral-storage: 24Gi
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: anypi-eval-runner-strict-20260616a
+  namespace: agents
+  labels:
+    app.kubernetes.io/part-of: anypi-prompt-eval
+    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/prompt-variant: strict-repo
+    anypi.proompteng.ai/task: anypi-ci-watcher
+spec:
+  agentRef:
+    name: anypi-eval-agent
+  implementation:
+    inline:
+      summary: Improve Anypi CI watcher regression coverage
+      text: |
+        Improve services/anypi CI watcher coverage with regression tests for required-check fallback, pending-check timeout
+        summaries, failed-check repair signals, and PR body testing output. Keep the implementation focused on runner
+        behavior and do not weaken validation or CI gates.
+  runtime:
+    type: job
+    config:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+  ttlSecondsAfterFinished: 86400
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/anypi-eval/strict-repo/runner-ci-watcher-20260616a
     promptVariant: strict-repo
     validationCommands: |
       bun run --filter @proompteng/anypi tsc
@@ -89,7 +209,7 @@ spec:
     image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
     resources:
       requests:
-        cpu: '2'
+        cpu: "2"
         memory: 4Gi
         ephemeral-storage: 12Gi
       limits:
@@ -99,21 +219,28 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-agents-strict-repo-20260616
+  name: anypi-eval-agents-repair-20260616a
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
+    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/prompt-variant: repair-loop
+    anypi.proompteng.ai/task: agents-docs-manifests
 spec:
   agentRef:
     name: anypi-eval-agent
   implementation:
     inline:
-      summary: Improve Anypi eval documentation and manifests
+      summary: Improve Agents Anypi evaluation docs and manifest validation
       text: |
-        Improve the Anypi eval documentation and agents manifests so prompt evaluation runs are easier to audit.
-        Keep manifests renderable and avoid changing unrelated providers.
+        Improve the Anypi evaluation documentation and Agents manifests so prompt-eval batches are easier to audit and less
+        likely to produce invalid AgentRuns. Include code or manifest validation changes where useful, preserve Argo render
+        behavior, and ensure PR-template requirements remain explicit. Do not change unrelated providers.
   runtime:
     type: job
+    config:
+      nodeSelector:
+        kubernetes.io/arch: amd64
   ttlSecondsAfterFinished: 86400
   vcsRef:
     name: github
@@ -122,9 +249,9 @@ spec:
     mode: read-write
   parameters:
     repository: proompteng/lab
-    base: codex/flamingo-rollout-complete
-    head: codex/anypi-eval/strict-repo/agents-docs-manifests-20260616
-    promptVariant: strict-repo
+    base: main
+    head: codex/anypi-eval/repair-loop/agents-docs-manifests-20260616a
+    promptVariant: repair-loop
     validationCommands: |
       kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml
   secrets:
@@ -133,7 +260,7 @@ spec:
     image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
     resources:
       requests:
-        cpu: '2'
+        cpu: "2"
         memory: 4Gi
         ephemeral-storage: 12Gi
       limits:

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -48,7 +48,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
     resources:
       requests:
         cpu: "2"
@@ -100,7 +100,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
     resources:
       requests:
         cpu: "2"
@@ -153,7 +153,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
     resources:
       requests:
         cpu: "2"
@@ -206,7 +206,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
     resources:
       requests:
         cpu: "2"
@@ -257,7 +257,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
     resources:
       requests:
         cpu: "2"

--- a/docs/agents/anypi-prompt-eval.md
+++ b/docs/agents/anypi-prompt-eval.md
@@ -18,8 +18,9 @@ The prompt text is resolved inside `services/anypi/src/prompt.ts`. Runtime detai
 
 ## Evaluation Matrix
 
-Run at least three substantial tasks against at least three variants. Prefer two repetitions when GPU/queue capacity is
-available. Every run must use a unique branch:
+Run at least three substantial tasks against at least three variants. Evaluation batches should schedule five AgentRuns at
+the same time when the cluster has runner capacity, then collect results from all five before deciding the next batch. Every
+run must use a unique branch:
 
 ```text
 codex/anypi-eval/<variant>/<task>/<yyyymmddhhmm>
@@ -32,6 +33,10 @@ Required task classes:
 - Anypi: improve runner behavior or tests under `services/anypi` with TypeScript validation.
 - Infra/docs plus code: touch `argocd/applications/agents` and docs while preserving manifest rendering and PR-template
   compliance.
+
+The ready-to-apply batch template is `docs/agents/anypi-prompt-eval-agentruns.yaml`. Apply it as one file so the five runs
+start concurrently. The template pins the multi-arch Anypi image and uses `runtime.config.nodeSelector` to force coverage on
+both `amd64` and `arm64` nodes.
 
 ## Scoring
 
@@ -69,4 +74,5 @@ failures. If no variant passes, leave `anypi-agent` on `minimal`, record the fai
 kubectl -n agents get agentprovider anypi-eval
 kubectl -n agents get agent anypi-eval-agent
 kubectl -n agents get agentrun -l app.kubernetes.io/part-of=anypi-prompt-eval
+kubectl apply -f docs/agents/anypi-prompt-eval-agentruns.yaml
 ```

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`
@@ -101,7 +101,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:b18caf3d8@sha256:101b15a3323213c45d29665d9855a67e07a132b13b366107f307476dcb96b874
+    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -17,6 +17,8 @@ Flamingo model.
 The provider is an Agents `exec` provider. The controller mounts `/workspace/run.json`, injects `VCS_*` and
 `GH_TOKEN/GITHUB_TOKEN`, then starts the Anypi binary directly. Anypi clones the repository, checks out the AgentRun head
 branch, invokes Pi through the TypeScript SDK, validates the result, commits, pushes, and opens or updates a PR.
+PR bodies are rendered from the target repository's `.github/PULL_REQUEST_TEMPLATE.md` when present, with every template
+section filled and validation commands copied from runner status.
 
 ## Pi SDK Configuration
 

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -19,7 +19,7 @@ import {
   resolveAttemptSessionDir,
   resolveEffectiveSystemPrompt,
 } from './pi-session'
-import { buildCommitMessage, buildPullRequestTitle, normalizeConventionalSummary } from './run'
+import { buildCommitMessage, buildPullRequestTitle, normalizeConventionalSummary, renderPullRequestBody } from './run'
 
 describe('Anypi config', () => {
   test('defaults to Flamingo and all Pi coding tools', () => {
@@ -139,6 +139,94 @@ describe('Anypi prompt contract', () => {
     expect(buildPullRequestTitle({ implementation: { summary: 'Improve Torghut Diff Coverage' } })).toBe(
       'feat(anypi): improve torghut diff coverage',
     )
+  })
+
+  test('renders PR bodies from the repository template without placeholders', () => {
+    const body = renderPullRequestBody({
+      runSpec: { implementation: { summary: 'Improve Anypi PR body rendering' } },
+      status: {
+        provider: 'anypi',
+        status: 'running',
+        startedAt: '2026-06-16T00:00:00.000Z',
+        runName: 'anypi-eval-runner-repair-20260616',
+        namespace: 'agents',
+        model: 'qwen3-coder-flamingo',
+        providerModel: 'flamingo/qwen3-coder-flamingo',
+        promptVariant: 'repair-loop',
+        promptHash: '0123456789abcdef',
+        tools: ['bash', 'edit'],
+        sessionFile: '/workspace/.anypi/sessions/initial/session.json',
+        validations: [
+          {
+            command: 'bash',
+            args: ['-lc', 'bun run --filter @proompteng/anypi test'],
+            exitCode: 0,
+            stdout: '',
+            stderr: '',
+            durationMs: 42,
+            ok: true,
+          },
+        ],
+        validationPlan: {
+          policy: 'append',
+          sources: ['inferred', 'run-spec'],
+          commands: ['bun run --filter @proompteng/anypi test'],
+        },
+        agentAttempts: 1,
+        validationAttempts: 1,
+        ciAttempts: 1,
+        promptChars: 1200,
+        ci: {
+          ok: true,
+          status: 'passed',
+          requiredOnly: true,
+          attempts: 3,
+          durationMs: 3000,
+          checks: [],
+          summary: '2 passed/skipped, 0 pending, 0 failed/cancelled',
+        },
+      },
+      git: {
+        repository: 'proompteng/lab',
+        baseBranch: 'main',
+        headBranch: 'codex/anypi-eval/runner',
+        cloneUrl: 'https://github.com/proompteng/lab.git',
+        webUrl: 'https://github.com/proompteng/lab',
+        worktree: '/workspace/lab',
+        env: {},
+        writeEnabled: true,
+        pullRequestsEnabled: true,
+      },
+      piText: 'implemented',
+      template: `## Summary
+
+<!-- 3-5 concise bullets describing what changed. -->
+
+## Related Issues
+
+## Testing
+
+## Screenshots (if applicable)
+
+## Breaking Changes
+
+## Checklist
+
+- [ ] Testing section documents the exact validation performed (or \`N/A\` with justification).
+- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
+- [ ] Documentation, release notes, and follow-ups are updated or tracked.
+`,
+    })
+
+    expect(body).toContain('## Summary')
+    expect(body).toContain('## Testing')
+    expect(body).toContain('Prompt variant: `repair-loop` (`0123456789abcdef`)')
+    expect(body).toContain('bun run --filter @proompteng/anypi test')
+    expect(body).toContain('- CI: passed: 2 passed/skipped, 0 pending, 0 failed/cancelled')
+    expect(body).toContain('- [x] Testing section documents the exact validation performed.')
+    expect(body).not.toContain('<!--')
+    expect(body).not.toContain('[ ]')
+    expect(body).not.toMatch(/TODO|TBD|<\.\.\.>/)
   })
 
   test('uses run parameters for validation commands when env commands are absent', () => {

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname } from 'node:path'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 
 import { applyRunnerArtifacts, loadRunnerSpec, loadRunSpec, resolveConfig, type AnypiConfig } from './config'
 import { createLogger } from './logger'
@@ -63,52 +63,88 @@ export const buildPullRequestTitle = (runSpec: AgentRunSpecPayload) => {
   return `feat(anypi): ${normalizeConventionalSummary(title, 'apply autonomous agent changes')}`
 }
 
-const buildPullRequestBody = (input: {
+const DEFAULT_PULL_REQUEST_HEADINGS = [
+  'Summary',
+  'Related Issues',
+  'Testing',
+  'Screenshots (if applicable)',
+  'Breaking Changes',
+  'Checklist',
+]
+
+const extractPullRequestHeadings = (template: string | undefined) => {
+  const headings = [...(template ?? '').matchAll(/^##\s+(.+?)\s*$/gm)]
+    .map((match) => match[1]?.trim())
+    .filter((heading): heading is string => Boolean(heading))
+  return headings.length > 0 ? headings : DEFAULT_PULL_REQUEST_HEADINGS
+}
+
+const normalizeHeading = (heading: string) => heading.toLowerCase().replace(/\s+/g, ' ').trim()
+
+const validationSummary = (status: AnypiStatus) => {
+  const validations = status.validations
+    .map((result) => `- \`${[result.command, ...result.args].join(' ')}\` exit ${result.exitCode}`)
+    .join('\n')
+  const ci = status.ci
+    ? `${status.ci.status}: ${status.ci.summary}`
+    : 'Pending: pull request checks have not completed yet.'
+  return `${validations || '- N/A'}\n- CI: ${ci}`
+}
+
+export const renderPullRequestBody = (input: {
   runSpec: AgentRunSpecPayload
   status: AnypiStatus
   git: GitContext
   piText: string
+  template?: string
 }) => {
-  const validations = input.status.validations
-    .map((result) => `- \`${[result.command, ...result.args].join(' ')}\` exit ${result.exitCode}`)
-    .join('\n')
-  const ci = input.status.ci
-    ? `${input.status.ci.status}: ${input.status.ci.summary}`
-    : 'Pending: pull request checks have not completed yet.'
-  return `## Summary
+  const sections = new Map([
+    [
+      'summary',
+      [
+        `- Generated for ${input.status.namespace ?? 'agents'}/${input.status.runName ?? 'unknown'}.`,
+        `- Prompt variant: \`${input.status.promptVariant}\` (\`${input.status.promptHash}\`).`,
+        `- Session artifact: \`${input.status.sessionFile ?? 'N/A'}\`.`,
+      ].join('\n'),
+    ],
+    ['related issues', 'None'],
+    ['testing', validationSummary(input.status)],
+    ['screenshots (if applicable)', 'N/A'],
+    ['breaking changes', 'None'],
+    [
+      'checklist',
+      [
+        '- [x] Testing section documents the exact validation performed.',
+        '- [x] Screenshots and Breaking Changes sections are handled appropriately.',
+        '- [x] Documentation, release notes, and follow-ups are updated or tracked.',
+      ].join('\n'),
+    ],
+  ])
 
-- Anypi generated this code change for ${input.status.namespace ?? 'agents'}/${input.status.runName ?? 'unknown'}.
-- Prompt variant: ${input.status.promptVariant} (${input.status.promptHash}).
-- Session artifact: ${input.status.sessionFile ?? 'N/A'}.
-
-## Related Issues
-
-None
-
-## Validation
-
-${validations || '- N/A'}
-
-CI: ${ci}
-
-## Screenshots (if applicable)
-
-N/A
-
-## Breaking Changes
-
-None
-
-## Checklist
-
-- [x] Testing section documents the exact validation performed.
-- [x] Screenshots and Breaking Changes sections are handled appropriately.
-- [x] Documentation, release notes, and follow-ups are updated or tracked.
-
-## Agent Output
-${input.piText.trim().slice(0, 6000) || 'N/A'}
-`
+  return `${extractPullRequestHeadings(input.template)
+    .map((heading) => `## ${heading}\n\n${sections.get(normalizeHeading(heading)) ?? 'N/A'}`)
+    .join('\n\n')}\n`
 }
+
+const loadPullRequestTemplate = async (worktree: string) => {
+  try {
+    return await readFile(join(worktree, '.github/PULL_REQUEST_TEMPLATE.md'), 'utf8')
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return undefined
+    throw error
+  }
+}
+
+const buildPullRequestBody = async (input: {
+  runSpec: AgentRunSpecPayload
+  status: AnypiStatus
+  git: GitContext
+  piText: string
+}) =>
+  renderPullRequestBody({
+    ...input,
+    template: await loadPullRequestTemplate(input.git.worktree),
+  })
 
 const baseStatus = (
   config: AnypiConfig,
@@ -294,7 +330,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       await pushBranch(git)
       pullRequest = await createOrUpdatePullRequest(git, {
         title: buildPullRequestTitle(runSpec),
-        body: buildPullRequestBody({ runSpec, status, git, piText }),
+        body: await buildPullRequestBody({ runSpec, status, git, piText }),
       })
       status.pullRequest = pullRequest
       await writeStatus(config.statusPath, status)
@@ -349,7 +385,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
           await pushBranch(git)
           pullRequest = await createOrUpdatePullRequest(git, {
             title: buildPullRequestTitle(runSpec),
-            body: buildPullRequestBody({ runSpec, status, git, piText }),
+            body: await buildPullRequestBody({ runSpec, status, git, piText }),
           })
           status.pullRequest = pullRequest
           await writeStatus(config.statusPath, status)
@@ -357,7 +393,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
 
         pullRequest = await createOrUpdatePullRequest(git, {
           title: buildPullRequestTitle(runSpec),
-          body: buildPullRequestBody({ runSpec, status, git, piText }),
+          body: await buildPullRequestBody({ runSpec, status, git, piText }),
         })
         status.pullRequest = pullRequest
         await writeStatus(config.statusPath, status)


### PR DESCRIPTION
## Summary

- Renders Anypi PR bodies from `.github/PULL_REQUEST_TEMPLATE.md` headings with concrete, filled sections.
- Adds a five-AgentRun prompt-eval batch covering multiple prompt variants and both amd64/arm64 runner scheduling.
- Pins the eval batch and Anypi docs to the pushed multi-arch `anypi:292c28dc` image digest.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/anypi tsc`
- `bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi lint`
- `kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `kubectl apply --dry-run=server -f docs/agents/anypi-prompt-eval-agentruns.yaml`
- `ANYPI_IMAGE_TAG=292c28dc ANYPI_IMAGE_PLATFORMS=linux/amd64,linux/arm64 bun run build:anypi`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/anypi:292c28dc`
- `docker run --rm --platform linux/amd64 registry.ide-newton.ts.net/lab/anypi:292c28dc /bin/sh -lc 'uname -m && test -x /usr/local/bin/anypi-runner && cat /app/services/anypi/build-sha.txt'`
- `docker run --rm --platform linux/arm64 registry.ide-newton.ts.net/lab/anypi:292c28dc /bin/sh -lc 'uname -m && test -x /usr/local/bin/anypi-runner && cat /app/services/anypi/build-sha.txt'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
