### PR TITLE
feat(anypi): improve torghut diff coverage executable-line reporting

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -265,6 +265,27 @@ def summarize_changed_coverage(
     return summary
 
 
+@dataclass(frozen=True)
+class UncoveredExecutableLine:
+    filename: str
+    line_number: int
+
+
+@dataclass(frozen=True)
+class DiffCoverageReport:
+    file_summaries: list[FileDiffCoverage]
+    uncovered_executable_lines: list[UncoveredExecutableLine]
+    ignored_changed_lines: list[UncoveredExecutableLine]
+
+    @property
+    def has_issues(self) -> bool:
+        return (
+            any(item.missing_from_coverage for item in self.file_summaries)
+            or bool(self.uncovered_executable_lines)
+            or bool(self.ignored_changed_lines)
+        )
+
+
 def _format_summary(summary: list[FileDiffCoverage]) -> str:
     lines: list[str] = []
     for item in summary:
@@ -279,6 +300,28 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
                 f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
             )
     return "\n".join(lines)
+
+
+def _format_uncovered_executable_lines(
+    lines: list[UncoveredExecutableLine],
+) -> str:
+    if not lines:
+        return ""
+    lines_str = []
+    for line in lines:
+        lines_str.append(f"  {line.filename}:{line.line_number}")
+    return "uncovered executable changed lines:\n" + "\n".join(lines_str)
+
+
+def _format_ignored_changed_lines(
+    lines: list[UncoveredExecutableLine],
+) -> str:
+    if not lines:
+        return ""
+    lines_str = []
+    for line in lines:
+        lines_str.append(f"  {line.filename}:{line.line_number}")
+    return "ignored changed lines (non-executable):\n" + "\n".join(lines_str)
 
 
 def main() -> int:
@@ -316,25 +359,66 @@ def main() -> int:
     if not changed_with_untracked:
         print("diff coverage passed: no changed Torghut Python source lines")
         return 0
-    summary = summarize_changed_coverage(
+
+    file_summaries = summarize_changed_coverage(
         changed_lines=changed_with_untracked,
         coverage_index=coverage_index,
     )
-    if not summary:
+
+    uncovered_lines = []
+    ignored_lines = []
+    for filename, lines in changed_with_untracked.items():
+        coverage_file = coverage_index.get(filename)
+        if coverage_file is None:
+            continue
+        executable_lines = _executable_source_lines(service_root / filename)
+        for line in sorted(lines):
+            if line not in coverage_file:
+                continue
+            if line in executable_lines:
+                if coverage_file[line] <= 0:
+                    uncovered_lines.append(
+                        UncoveredExecutableLine(filename=filename, line_number=line)
+                    )
+            else:
+                ignored_lines.append(
+                    UncoveredExecutableLine(filename=filename, line_number=line)
+                )
+
+    report = DiffCoverageReport(
+        file_summaries=file_summaries,
+        uncovered_executable_lines=uncovered_lines,
+        ignored_changed_lines=ignored_lines,
+    )
+
+    if not file_summaries:
         print("diff coverage passed: no changed executable Torghut Python source lines")
         return 0
 
-    total_executable = sum(item.executable_changed_lines for item in summary)
-    total_covered = sum(item.covered_lines for item in summary)
+    total_executable = sum(item.executable_changed_lines for item in file_summaries)
+    total_covered = sum(item.covered_lines for item in file_summaries)
     coverage_pct = (
         (total_covered / total_executable) * 100 if total_executable else 100.0
     )
-    print(_format_summary(summary))
+
+    print(_format_summary(file_summaries))
+    uncovered_text = _format_uncovered_executable_lines(
+        report.uncovered_executable_lines
+    )
+    if uncovered_text:
+        print("")
+        print(uncovered_text)
+    ignored_text = _format_ignored_changed_lines(report.ignored_changed_lines)
+    if ignored_text:
+        print("")
+        print(ignored_text)
     print(
         f"total changed-line coverage: {total_covered}/{total_executable} ({coverage_pct:.2f}%)"
     )
 
-    missing_files = [item.filename for item in summary if item.missing_from_coverage]
+    missing_files = [
+        item.filename for item in file_summaries if item.missing_from_coverage
+    ]
     if missing_files:
         print(
             "diff coverage failed: changed files missing from coverage.xml: "

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -10,10 +10,14 @@ from unittest.mock import call
 from unittest.mock import patch
 
 from scripts.check_diff_coverage import (
+    DiffCoverageReport,
     FileDiffCoverage,
+    UncoveredExecutableLine,
     _drop_missing_non_executable_files,
     _executable_source_lines,
     _format_summary,
+    _format_uncovered_executable_lines,
+    _format_ignored_changed_lines,
     _git,
     _git_optional,
     _include_untracked_python_files,
@@ -469,6 +473,131 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
 
         self.assertIn("missing-from-coverage", text)
         self.assertIn("missing lines: 20", text)
+
+    def test_diff_coverage_report_tracks_issues(self) -> None:
+        report = DiffCoverageReport(
+            file_summaries=[],
+            uncovered_executable_lines=[],
+            ignored_changed_lines=[],
+        )
+
+        self.assertFalse(report.has_issues)
+
+    def test_diff_coverage_report_flags_uncovered_lines_as_issues(self) -> None:
+        report = DiffCoverageReport(
+            file_summaries=[],
+            uncovered_executable_lines=[
+                UncoveredExecutableLine(filename="app/foo.py", line_number=10)
+            ],
+            ignored_changed_lines=[],
+        )
+
+        self.assertTrue(report.has_issues)
+
+    def test_diff_coverage_report_flags_ignored_lines_as_issues(self) -> None:
+        report = DiffCoverageReport(
+            file_summaries=[],
+            uncovered_executable_lines=[],
+            ignored_changed_lines=[
+                UncoveredExecutableLine(filename="app/foo.py", line_number=10)
+            ],
+        )
+
+        self.assertTrue(report.has_issues)
+
+    def test_diff_coverage_report_with_missing_coverage_file(self) -> None:
+        report = DiffCoverageReport(
+            file_summaries=[
+                FileDiffCoverage(
+                    filename="app/foo.py",
+                    executable_changed_lines=1,
+                    covered_lines=0,
+                    missing_lines=(10,),
+                    missing_from_coverage=True,
+                )
+            ],
+            uncovered_executable_lines=[],
+            ignored_changed_lines=[],
+        )
+
+        self.assertTrue(report.has_issues)
+
+    def test_format_uncovered_executable_lines_formats_stable_order(self) -> None:
+        lines = [
+            UncoveredExecutableLine(filename="app/bar.py", line_number=20),
+            UncoveredExecutableLine(filename="app/foo.py", line_number=10),
+        ]
+
+        text = _format_uncovered_executable_lines(lines)
+
+        self.assertIn("app/bar.py:20", text)
+        self.assertIn("app/foo.py:10", text)
+
+    def test_format_uncovered_executable_lines_empty_string_when_no_lines(self) -> None:
+        text = _format_uncovered_executable_lines([])
+
+        self.assertEqual(text, "")
+
+    def test_format_ignored_changed_lines_formats_stable_order(self) -> None:
+        lines = [
+            UncoveredExecutableLine(filename="app/bar.py", line_number=20),
+            UncoveredExecutableLine(filename="app/foo.py", line_number=10),
+        ]
+
+        text = _format_ignored_changed_lines(lines)
+
+        self.assertIn("app/bar.py:20", text)
+        self.assertIn("app/foo.py:10", text)
+
+    def test_format_ignored_changed_lines_empty_string_when_no_lines(self) -> None:
+        text = _format_ignored_changed_lines([])
+
+        self.assertEqual(text, "")
+
+    def test_format_uncovered_executable_lines(self) -> None:
+        lines = [
+            UncoveredExecutableLine(filename="app/foo.py", line_number=15),
+            UncoveredExecutableLine(filename="scripts/bar.py", line_number=30),
+        ]
+
+        text = _format_uncovered_executable_lines(lines)
+
+        self.assertIn("uncovered executable changed lines:", text)
+        self.assertIn("app/foo.py:15", text)
+        self.assertIn("scripts/bar.py:30", text)
+
+    def test_format_ignored_changed_lines(self) -> None:
+        lines = [
+            UncoveredExecutableLine(filename="app/foo.py", line_number=5),
+        ]
+
+        text = _format_ignored_changed_lines(lines)
+
+        self.assertIn("ignored changed lines (non-executable):", text)
+        self.assertIn("app/foo.py:5", text)
+
+    def test_summarize_changed_coverage_with_multi_file_diff(self) -> None:
+        coverage_index = {
+            "app/foo.py": {10: 1, 11: 0, 20: 0},
+            "app/bar.py": {5: 1},
+        }
+
+        summary = summarize_changed_coverage(
+            changed_lines={
+                "app/foo.py": {10, 11, 20},
+                "app/bar.py": {5, 10},
+            },
+            coverage_index=coverage_index,
+        )
+
+        self.assertEqual(len(summary), 2)
+        self.assertEqual(summary[0].filename, "app/bar.py")
+        self.assertEqual(summary[0].covered_lines, 1)
+        self.assertEqual(summary[0].executable_changed_lines, 1)
+        self.assertEqual(summary[1].filename, "app/foo.py")
+        self.assertEqual(summary[1].covered_lines, 1)
+        self.assertEqual(summary[1].executable_changed_lines, 3)
+        self.assertEqual(summary[1].missing_lines, (11, 20))
 
     @patch("scripts.check_diff_coverage._parse_args")
     @patch("scripts.check_diff_coverage._repo_root")


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-eval-torghut-minimal-20260616a.
- Prompt variant: `minimal` (`d68005d5c5147ca6`).
- Session artifact: `/workspace/.anypi/sessions/validation-repair-1-ac6e4d6c/2026-06-16T20-25-29-720Z_019ed21c-4978-7fe2-8b6b-5b72c6d194c8.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0
- CI: Pending: pull request checks have not completed yet.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
