### PR TITLE
fix(anypi): require json-capable gh checks

### DIFF
--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -9,11 +9,11 @@
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-torghut-minimal-20260616b
+  name: anypi-eval-torghut-minimal-20260616c
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616b"
+    anypi.proompteng.ai/eval-batch: "20260616c"
     anypi.proompteng.ai/prompt-variant: minimal
     anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
@@ -41,14 +41,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/minimal/torghut-diff-coverage-20260616b
+    head: codex/anypi-eval/minimal/torghut-diff-coverage-20260616c
     promptVariant: minimal
     validationCommands: |
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
+    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
     resources:
       requests:
         cpu: "2"
@@ -61,11 +61,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-torghut-repair-20260616b
+  name: anypi-eval-torghut-repair-20260616c
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616b"
+    anypi.proompteng.ai/eval-batch: "20260616c"
     anypi.proompteng.ai/prompt-variant: repair-loop
     anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
@@ -93,14 +93,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/repair-loop/torghut-diff-coverage-20260616b
+    head: codex/anypi-eval/repair-loop/torghut-diff-coverage-20260616c
     promptVariant: repair-loop
     validationCommands: |
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
+    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
     resources:
       requests:
         cpu: "2"
@@ -113,11 +113,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-runner-finish-20260616b
+  name: anypi-eval-runner-finish-20260616c
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616b"
+    anypi.proompteng.ai/eval-batch: "20260616c"
     anypi.proompteng.ai/prompt-variant: finish-gated
     anypi.proompteng.ai/task: anypi-status-evidence
 spec:
@@ -144,7 +144,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/finish-gated/runner-status-evidence-20260616b
+    head: codex/anypi-eval/finish-gated/runner-status-evidence-20260616c
     promptVariant: finish-gated
     validationCommands: |
       bun run --filter @proompteng/anypi tsc
@@ -153,7 +153,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
+    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
     resources:
       requests:
         cpu: "2"
@@ -166,11 +166,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-runner-strict-20260616b
+  name: anypi-eval-runner-strict-20260616c
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616b"
+    anypi.proompteng.ai/eval-batch: "20260616c"
     anypi.proompteng.ai/prompt-variant: strict-repo
     anypi.proompteng.ai/task: anypi-ci-watcher
 spec:
@@ -197,7 +197,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/strict-repo/runner-ci-watcher-20260616b
+    head: codex/anypi-eval/strict-repo/runner-ci-watcher-20260616c
     promptVariant: strict-repo
     validationCommands: |
       bun run --filter @proompteng/anypi tsc
@@ -206,7 +206,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
+    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
     resources:
       requests:
         cpu: "2"
@@ -219,11 +219,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-agents-repair-20260616b
+  name: anypi-eval-agents-repair-20260616c
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616b"
+    anypi.proompteng.ai/eval-batch: "20260616c"
     anypi.proompteng.ai/prompt-variant: repair-loop
     anypi.proompteng.ai/task: agents-docs-manifests
 spec:
@@ -250,14 +250,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/repair-loop/agents-docs-manifests-20260616b
+    head: codex/anypi-eval/repair-loop/agents-docs-manifests-20260616c
     promptVariant: repair-loop
     validationCommands: |
       kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
+    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
     resources:
       requests:
         cpu: "2"

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -9,11 +9,11 @@
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-torghut-minimal-20260616a
+  name: anypi-eval-torghut-minimal-20260616b
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/eval-batch: "20260616b"
     anypi.proompteng.ai/prompt-variant: minimal
     anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
@@ -41,14 +41,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/minimal/torghut-diff-coverage-20260616a
+    head: codex/anypi-eval/minimal/torghut-diff-coverage-20260616b
     promptVariant: minimal
     validationCommands: |
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
+    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
     resources:
       requests:
         cpu: "2"
@@ -61,11 +61,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-torghut-repair-20260616a
+  name: anypi-eval-torghut-repair-20260616b
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/eval-batch: "20260616b"
     anypi.proompteng.ai/prompt-variant: repair-loop
     anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
@@ -93,14 +93,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/repair-loop/torghut-diff-coverage-20260616a
+    head: codex/anypi-eval/repair-loop/torghut-diff-coverage-20260616b
     promptVariant: repair-loop
     validationCommands: |
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
+    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
     resources:
       requests:
         cpu: "2"
@@ -113,11 +113,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-runner-finish-20260616a
+  name: anypi-eval-runner-finish-20260616b
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/eval-batch: "20260616b"
     anypi.proompteng.ai/prompt-variant: finish-gated
     anypi.proompteng.ai/task: anypi-status-evidence
 spec:
@@ -144,7 +144,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/finish-gated/runner-status-evidence-20260616a
+    head: codex/anypi-eval/finish-gated/runner-status-evidence-20260616b
     promptVariant: finish-gated
     validationCommands: |
       bun run --filter @proompteng/anypi tsc
@@ -153,7 +153,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
+    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
     resources:
       requests:
         cpu: "2"
@@ -166,11 +166,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-runner-strict-20260616a
+  name: anypi-eval-runner-strict-20260616b
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/eval-batch: "20260616b"
     anypi.proompteng.ai/prompt-variant: strict-repo
     anypi.proompteng.ai/task: anypi-ci-watcher
 spec:
@@ -197,7 +197,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/strict-repo/runner-ci-watcher-20260616a
+    head: codex/anypi-eval/strict-repo/runner-ci-watcher-20260616b
     promptVariant: strict-repo
     validationCommands: |
       bun run --filter @proompteng/anypi tsc
@@ -206,7 +206,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
+    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
     resources:
       requests:
         cpu: "2"
@@ -219,11 +219,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-agents-repair-20260616a
+  name: anypi-eval-agents-repair-20260616b
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616a"
+    anypi.proompteng.ai/eval-batch: "20260616b"
     anypi.proompteng.ai/prompt-variant: repair-loop
     anypi.proompteng.ai/task: agents-docs-manifests
 spec:
@@ -240,7 +240,7 @@ spec:
     type: job
     config:
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
   ttlSecondsAfterFinished: 86400
   vcsRef:
     name: github
@@ -250,14 +250,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/repair-loop/agents-docs-manifests-20260616a
+    head: codex/anypi-eval/repair-loop/agents-docs-manifests-20260616b
     promptVariant: repair-loop
     validationCommands: |
       kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
+    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
     resources:
       requests:
         cpu: "2"

--- a/docs/agents/anypi-prompt-eval-agentruns.yaml
+++ b/docs/agents/anypi-prompt-eval-agentruns.yaml
@@ -9,11 +9,11 @@
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-torghut-minimal-20260616c
+  name: anypi-eval-torghut-minimal-20260616d
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616c"
+    anypi.proompteng.ai/eval-batch: "20260616d"
     anypi.proompteng.ai/prompt-variant: minimal
     anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
@@ -41,14 +41,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/minimal/torghut-diff-coverage-20260616c
+    head: codex/anypi-eval/minimal/torghut-diff-coverage-20260616d
     promptVariant: minimal
     validationCommands: |
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
+    image: registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66
     resources:
       requests:
         cpu: "2"
@@ -61,11 +61,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-torghut-repair-20260616c
+  name: anypi-eval-torghut-repair-20260616d
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616c"
+    anypi.proompteng.ai/eval-batch: "20260616d"
     anypi.proompteng.ai/prompt-variant: repair-loop
     anypi.proompteng.ai/task: torghut-diff-coverage
 spec:
@@ -93,14 +93,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/repair-loop/torghut-diff-coverage-20260616c
+    head: codex/anypi-eval/repair-loop/torghut-diff-coverage-20260616d
     promptVariant: repair-loop
     validationCommands: |
       cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
+    image: registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66
     resources:
       requests:
         cpu: "2"
@@ -113,11 +113,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-runner-finish-20260616c
+  name: anypi-eval-runner-finish-20260616d
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616c"
+    anypi.proompteng.ai/eval-batch: "20260616d"
     anypi.proompteng.ai/prompt-variant: finish-gated
     anypi.proompteng.ai/task: anypi-status-evidence
 spec:
@@ -144,7 +144,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/finish-gated/runner-status-evidence-20260616c
+    head: codex/anypi-eval/finish-gated/runner-status-evidence-20260616d
     promptVariant: finish-gated
     validationCommands: |
       bun run --filter @proompteng/anypi tsc
@@ -153,7 +153,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
+    image: registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66
     resources:
       requests:
         cpu: "2"
@@ -166,11 +166,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-runner-strict-20260616c
+  name: anypi-eval-runner-strict-20260616d
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616c"
+    anypi.proompteng.ai/eval-batch: "20260616d"
     anypi.proompteng.ai/prompt-variant: strict-repo
     anypi.proompteng.ai/task: anypi-ci-watcher
 spec:
@@ -197,7 +197,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/strict-repo/runner-ci-watcher-20260616c
+    head: codex/anypi-eval/strict-repo/runner-ci-watcher-20260616d
     promptVariant: strict-repo
     validationCommands: |
       bun run --filter @proompteng/anypi tsc
@@ -206,7 +206,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
+    image: registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66
     resources:
       requests:
         cpu: "2"
@@ -219,11 +219,11 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: anypi-eval-agents-repair-20260616c
+  name: anypi-eval-agents-repair-20260616d
   namespace: agents
   labels:
     app.kubernetes.io/part-of: anypi-prompt-eval
-    anypi.proompteng.ai/eval-batch: "20260616c"
+    anypi.proompteng.ai/eval-batch: "20260616d"
     anypi.proompteng.ai/prompt-variant: repair-loop
     anypi.proompteng.ai/task: agents-docs-manifests
 spec:
@@ -250,14 +250,14 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/anypi-eval/repair-loop/agents-docs-manifests-20260616c
+    head: codex/anypi-eval/repair-loop/agents-docs-manifests-20260616d
     promptVariant: repair-loop
     validationCommands: |
       kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
+    image: registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66
     resources:
       requests:
         cpu: "2"

--- a/docs/agents/anypi-prompt-eval.md
+++ b/docs/agents/anypi-prompt-eval.md
@@ -66,7 +66,8 @@ failures. If no variant passes, leave `anypi-agent` on `minimal`, record the fai
 
 | Variant | Task | AgentRun | PR | Local validation | Required CI | Repairs | Decision |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| pending | pending | pending | pending | pending | pending | pending | pending |
+| mixed | five-run batch | `20260616a` | `#10911`, `#10912`, `#10913` before invalidation | Some local validations passed | Invalid measurement: image had `gh` 2.46.0 without `pr checks --json`, so the runner saw zero checks while GitHub had failures | Not scored | Do not promote from this batch |
+| pending | five-run batch | `20260616b` | pending | pending | pending | pending | Scheduled with `registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0` |
 
 ## Commands
 

--- a/docs/agents/anypi-prompt-eval.md
+++ b/docs/agents/anypi-prompt-eval.md
@@ -68,7 +68,8 @@ failures. If no variant passes, leave `anypi-agent` on `minimal`, record the fai
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | mixed | five-run batch | `20260616a` | `#10911`, `#10912`, `#10913` before invalidation | Some local validations passed | Invalid measurement: image had `gh` 2.46.0 without `pr checks --json`, so the runner saw zero checks while GitHub had failures | Not scored | Do not promote from this batch |
 | mixed | five-run batch | `20260616b` | `#10918`, `#10919`, `#10920`, `#10921` before invalidation | Some local validations passed | Invalid measurement: the required-check probe reported no checks as unavailable before falling back to all PR checks, so CI repair behavior was not scored | Not scored | Do not promote from this batch |
-| pending | five-run batch | `20260616c` | pending | pending | pending | pending | Scheduled with `registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba` |
+| mixed | five-run batch | `20260616c` | `#10922` before invalidation | Targeted Torghut validation passed before CI wait | Invalid measurement: all-checks probe before GitHub created checks was still treated as unavailable instead of pending/retryable | Not scored | Do not promote from this batch |
+| pending | five-run batch | `20260616d` | pending | pending | pending | pending | Scheduled with `registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66` |
 
 ## Commands
 

--- a/docs/agents/anypi-prompt-eval.md
+++ b/docs/agents/anypi-prompt-eval.md
@@ -67,7 +67,8 @@ failures. If no variant passes, leave `anypi-agent` on `minimal`, record the fai
 | Variant | Task | AgentRun | PR | Local validation | Required CI | Repairs | Decision |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | mixed | five-run batch | `20260616a` | `#10911`, `#10912`, `#10913` before invalidation | Some local validations passed | Invalid measurement: image had `gh` 2.46.0 without `pr checks --json`, so the runner saw zero checks while GitHub had failures | Not scored | Do not promote from this batch |
-| pending | five-run batch | `20260616b` | pending | pending | pending | pending | Scheduled with `registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0` |
+| mixed | five-run batch | `20260616b` | `#10918`, `#10919`, `#10920`, `#10921` before invalidation | Some local validations passed | Invalid measurement: the required-check probe reported no checks as unavailable before falling back to all PR checks, so CI repair behavior was not scored | Not scored | Do not promote from this batch |
+| pending | five-run batch | `20260616c` | pending | pending | pending | pending | Scheduled with `registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba` |
 
 ## Commands
 

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`
@@ -102,7 +102,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
+    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,10 +9,11 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`
+- GitHub CLI: `gh` must support `pr checks --json`; the image pins `gh` 2.94.0 for both platforms.
 
 The provider is an Agents `exec` provider. The controller mounts `/workspace/run.json`, injects `VCS_*` and
 `GH_TOKEN/GITHUB_TOKEN`, then starts the Anypi binary directly. Anypi clones the repository, checks out the AgentRun head
@@ -101,7 +102,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:292c28dc@sha256:391acae8dc4e34dcf46e6d84a38bb40d6f907e9bf4e6d7b7dab53f44f1008ff0
+    image: registry.ide-newton.ts.net/lab/anypi:7c86cfdd7@sha256:31b16040a32f6e3e92ef06198cc7e006e4dc8e6d2bcc26ddaab5babc47cfd3d0
     resources:
       requests:
         cpu: '2'

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Required workload image: `registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba`
+- Required workload image: `registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen3-coder-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`
@@ -102,7 +102,7 @@ spec:
   secrets:
     - github-token
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:218106f21@sha256:4500e6de7532ebbcac541c26f8da3306013a7b0034553c53ca00ba1943cf89ba
+    image: registry.ide-newton.ts.net/lab/anypi:fc4a51679@sha256:3dd2c28b9426f0530f2661fbb2b30bc96ff43f54bef74c02f5fce5ba9ecf3a66
     resources:
       requests:
         cpu: '2'

--- a/services/anypi/Dockerfile
+++ b/services/anypi/Dockerfile
@@ -5,6 +5,7 @@ ARG BUN_VERSION=1.3.14
 ARG BUN_BASE_IMAGE=mirror.gcr.io/oven/bun
 ARG NODE_VERSION=24.11.1
 ARG UV_VERSION=0.11.14
+ARG GH_VERSION=2.94.0
 ARG HELM_VERSION=3.18.6
 ARG KUSTOMIZE_VERSION=5.8.1
 ARG LAB_GIT_SHA=dev
@@ -25,6 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/bun \
 FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS runner
 ARG LAB_GIT_SHA
 ARG UV_VERSION
+ARG GH_VERSION
 ARG HELM_VERSION
 ARG KUSTOMIZE_VERSION
 ENV NODE_ENV=production \
@@ -50,7 +52,6 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     build-essential \
     ca-certificates \
     curl \
-    gh \
     git \
     jq \
     openssh-client \
@@ -70,11 +71,16 @@ RUN set -eux; \
   curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${tool_arch}.tar.gz" -o /tmp/helm.tar.gz; \
   tar -xzf /tmp/helm.tar.gz -C /tmp; \
   mv "/tmp/linux-${tool_arch}/helm" /usr/local/bin/helm; \
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${tool_arch}.tar.gz" -o /tmp/gh.tar.gz; \
+  tar -xzf /tmp/gh.tar.gz -C /tmp; \
+  mv "/tmp/gh_${GH_VERSION}_linux_${tool_arch}/bin/gh" /usr/local/bin/gh; \
   curl -fsSL \
     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${tool_arch}.tar.gz" \
     -o /tmp/kustomize.tar.gz; \
   tar -xzf /tmp/kustomize.tar.gz -C /usr/local/bin kustomize; \
-  rm -rf /tmp/helm.tar.gz /tmp/kustomize.tar.gz "/tmp/linux-${tool_arch}"; \
+  rm -rf /tmp/gh.tar.gz /tmp/helm.tar.gz /tmp/kustomize.tar.gz "/tmp/gh_${GH_VERSION}_linux_${tool_arch}" "/tmp/linux-${tool_arch}"; \
+  gh --version; \
+  gh pr checks --help | grep -- '--json'; \
   helm version --short; \
   kustomize version
 

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
-import { parseCiChecks, parsePullRequestList, summarizeChecks } from './git'
+import { parseCiChecks, parseCiChecksResult, parsePullRequestList, summarizeChecks } from './git'
 import {
   buildAgentPrompt,
   buildNoChangeRepairPrompt,
@@ -287,6 +287,19 @@ describe('Anypi prompt contract', () => {
       passed: [checks[0]],
       summary: '1 passed/skipped, 0 pending, 1 failed/cancelled',
     })
+  })
+
+  test('rejects unsupported GitHub check command output instead of treating it as no checks', () => {
+    expect(() =>
+      parseCiChecksResult({
+        command: 'gh',
+        args: ['pr', 'checks', 'branch', '--json', 'name,workflow,state,bucket,link'],
+        exitCode: 1,
+        stdout: '',
+        stderr: 'unknown flag: --json',
+        durationMs: 12,
+      }),
+    ).toThrow(/gh pr checks failed.*unknown flag: --json/)
   })
 
   test('parses GitHub REST pull request lookup results', () => {

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'vitest'
 
 import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
-import { parseCiChecks, parseCiChecksResult, parsePullRequestList, summarizeChecks } from './git'
+import {
+  isNoRequiredChecksResult,
+  parseCiChecks,
+  parseCiChecksResult,
+  parsePullRequestList,
+  summarizeChecks,
+} from './git'
 import {
   buildAgentPrompt,
   buildNoChangeRepairPrompt,
@@ -290,6 +296,27 @@ describe('Anypi prompt contract', () => {
   })
 
   test('rejects unsupported GitHub check command output instead of treating it as no checks', () => {
+    expect(
+      isNoRequiredChecksResult({
+        command: 'gh',
+        args: ['pr', 'checks', 'branch', '--required', '--json', 'name,workflow,state,bucket,link'],
+        exitCode: 1,
+        stdout: '',
+        stderr: "no checks reported on the 'codex/example' branch",
+        durationMs: 12,
+      }),
+    ).toBe(true)
+    expect(
+      isNoRequiredChecksResult({
+        command: 'gh',
+        args: ['pr', 'checks', 'branch', '--json', 'name,workflow,state,bucket,link'],
+        exitCode: 1,
+        stdout: '',
+        stderr: 'unknown flag: --json',
+        durationMs: 12,
+      }),
+    ).toBe(false)
+
     expect(() =>
       parseCiChecksResult({
         command: 'gh',

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
 import {
+  isNoChecksReportedResult,
   isNoRequiredChecksResult,
   parseCiChecks,
   parseCiChecksResult,
@@ -296,6 +297,16 @@ describe('Anypi prompt contract', () => {
   })
 
   test('rejects unsupported GitHub check command output instead of treating it as no checks', () => {
+    expect(
+      isNoChecksReportedResult({
+        command: 'gh',
+        args: ['pr', 'checks', 'branch', '--json', 'name,workflow,state,bucket,link'],
+        exitCode: 1,
+        stdout: '',
+        stderr: "no checks reported on the 'codex/example' branch",
+        durationMs: 12,
+      }),
+    ).toBe(true)
     expect(
       isNoRequiredChecksResult({
         command: 'gh',

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -289,6 +289,11 @@ export const parseCiChecksResult = (result: CommandResult): CiCheck[] => {
   return parseCiChecks(result.stdout)
 }
 
+export const isNoRequiredChecksResult = (result: CommandResult) => {
+  if (result.exitCode === 0) return false
+  return /no checks reported/i.test(`${result.stderr}\n${result.stdout}`)
+}
+
 export const summarizeChecks = (checks: CiCheck[]) => {
   const failed = checks.filter((check) => ['fail', 'cancel'].includes(check.bucket ?? ''))
   const pending = checks.filter((check) => check.bucket === 'pending')
@@ -339,7 +344,7 @@ export const waitForPullRequestChecks = async (
 
     try {
       let result = await readChecks(effectiveRequiredOnly)
-      lastChecks = parseCiChecksResult(result)
+      lastChecks = effectiveRequiredOnly && isNoRequiredChecksResult(result) ? [] : parseCiChecksResult(result)
       if (effectiveRequiredOnly && lastChecks.length === 0) {
         await log('ci checks: no required checks reported; falling back to all pull request checks')
         effectiveRequiredOnly = false

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -289,10 +289,12 @@ export const parseCiChecksResult = (result: CommandResult): CiCheck[] => {
   return parseCiChecks(result.stdout)
 }
 
-export const isNoRequiredChecksResult = (result: CommandResult) => {
+export const isNoChecksReportedResult = (result: CommandResult) => {
   if (result.exitCode === 0) return false
   return /no checks reported/i.test(`${result.stderr}\n${result.stdout}`)
 }
+
+export const isNoRequiredChecksResult = isNoChecksReportedResult
 
 export const summarizeChecks = (checks: CiCheck[]) => {
   const failed = checks.filter((check) => ['fail', 'cancel'].includes(check.bucket ?? ''))
@@ -344,13 +346,12 @@ export const waitForPullRequestChecks = async (
 
     try {
       let result = await readChecks(effectiveRequiredOnly)
-      lastChecks = effectiveRequiredOnly && isNoRequiredChecksResult(result) ? [] : parseCiChecksResult(result)
-      if (effectiveRequiredOnly && lastChecks.length === 0) {
+      if (effectiveRequiredOnly && isNoChecksReportedResult(result)) {
         await log('ci checks: no required checks reported; falling back to all pull request checks')
         effectiveRequiredOnly = false
         result = await readChecks(false)
-        lastChecks = parseCiChecksResult(result)
       }
+      lastChecks = isNoChecksReportedResult(result) ? [] : parseCiChecksResult(result)
     } catch (error) {
       return {
         ok: false,

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -281,6 +281,14 @@ export const parseCiChecks = (raw: string): CiCheck[] => {
   })
 }
 
+export const parseCiChecksResult = (result: CommandResult): CiCheck[] => {
+  if (result.exitCode !== 0) {
+    const output = (result.stderr || result.stdout || 'no output').trim()
+    throw new Error(`gh pr checks failed (${result.exitCode}): ${output}`)
+  }
+  return parseCiChecks(result.stdout)
+}
+
 export const summarizeChecks = (checks: CiCheck[]) => {
   const failed = checks.filter((check) => ['fail', 'cancel'].includes(check.bucket ?? ''))
   const pending = checks.filter((check) => check.bucket === 'pending')
@@ -331,12 +339,12 @@ export const waitForPullRequestChecks = async (
 
     try {
       let result = await readChecks(effectiveRequiredOnly)
-      lastChecks = parseCiChecks(result.stdout)
+      lastChecks = parseCiChecksResult(result)
       if (effectiveRequiredOnly && lastChecks.length === 0) {
         await log('ci checks: no required checks reported; falling back to all pull request checks')
         effectiveRequiredOnly = false
         result = await readChecks(false)
-        lastChecks = parseCiChecks(result.stdout)
+        lastChecks = parseCiChecksResult(result)
       }
     } catch (error) {
       return {


### PR DESCRIPTION
## Summary

- Pins GitHub CLI 2.94.0 in the Anypi runner image for amd64 and arm64 so `gh pr checks --json` is available.
- Makes the CI watcher treat nonzero `gh pr checks` output as an unavailable CI signal instead of polling empty checks forever.
- Pins the corrected multi-arch Anypi image in docs and the prompt-eval AgentRun batch, and records the invalidated 20260616a batch.

## Related Issues

N/A

## Testing

- `bun run --filter @proompteng/anypi tsc`
- `bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi lint`
- `kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `kubectl apply --dry-run=server -f docs/agents/anypi-prompt-eval-agentruns.yaml`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/anypi:7c86cfdd7`
- amd64 and arm64 `docker run` smoke checks verified build SHA and `gh pr checks --json` support.

## Screenshots (if applicable)

N/A

## Breaking Changes

N/A

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
