### PR TITLE
feat(anypi): improve torghut diff coverage executable-line reporting

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -27,6 +27,7 @@ class FileDiffCoverage:
     executable_changed_lines: int
     covered_lines: int
     missing_lines: tuple[int, ...]
+    ignored_lines: tuple[int, ...]
     missing_from_coverage: bool = False
 
     @property
@@ -232,34 +233,52 @@ def summarize_changed_coverage(
     *,
     changed_lines: dict[str, set[int]],
     coverage_index: dict[str, dict[int, int]],
+    executable_lines: dict[str, set[int]] | None = None,
 ) -> list[FileDiffCoverage]:
     summary: list[FileDiffCoverage] = []
     for filename in sorted(changed_lines):
         changed = sorted(changed_lines[filename])
         line_hits = coverage_index.get(filename)
+        exec_lines = (
+            executable_lines.get(filename, set()) if executable_lines else set()
+        )
         if line_hits is None:
+            ignored = tuple(line for line in changed if line not in exec_lines)
             summary.append(
                 FileDiffCoverage(
                     filename=filename,
                     executable_changed_lines=len(changed),
                     covered_lines=0,
                     missing_lines=tuple(changed),
+                    ignored_lines=ignored,
                     missing_from_coverage=True,
                 )
             )
             continue
         executable_changed = sorted(line for line in changed if line in line_hits)
         if not executable_changed:
+            ignored = tuple(line for line in changed if line not in exec_lines)
+            summary.append(
+                FileDiffCoverage(
+                    filename=filename,
+                    executable_changed_lines=0,
+                    covered_lines=0,
+                    missing_lines=(),
+                    ignored_lines=ignored,
+                )
+            )
             continue
         missing = tuple(
             line for line in executable_changed if line_hits.get(line, 0) <= 0
         )
+        ignored = tuple(line for line in changed if line not in exec_lines)
         summary.append(
             FileDiffCoverage(
                 filename=filename,
                 executable_changed_lines=len(executable_changed),
                 covered_lines=len(executable_changed) - len(missing),
                 missing_lines=missing,
+                ignored_lines=ignored,
             )
         )
     return summary
@@ -272,11 +291,15 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
         suffix = " missing-from-coverage" if item.missing_from_coverage else ""
         lines.append(
             f"{item.filename}: {item.covered_lines}/{item.executable_changed_lines} "
-            f"lines covered ({coverage_pct:.2f}%){suffix}"
+            f"lines covered ({coverage_pct:.2f}%)" + suffix
         )
         if item.missing_lines:
             lines.append(
-                f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
+                f"  uncovered executable lines: {', '.join(str(line) for line in item.missing_lines)}"
+            )
+        if item.ignored_lines:
+            lines.append(
+                f"  ignored non-executable lines: {', '.join(str(line) for line in item.ignored_lines)}"
             )
     return "\n".join(lines)
 
@@ -316,9 +339,15 @@ def main() -> int:
     if not changed_with_untracked:
         print("diff coverage passed: no changed Torghut Python source lines")
         return 0
+    executable_lines = {
+        filename: _executable_source_lines(service_root / filename)
+        for filename in changed_with_untracked
+        if filename in coverage_index
+    }
     summary = summarize_changed_coverage(
         changed_lines=changed_with_untracked,
         coverage_index=coverage_index,
+        executable_lines=executable_lines,
     )
     if not summary:
         print("diff coverage passed: no changed executable Torghut Python source lines")

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -462,7 +462,9 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         self.assertEqual(summary[0].ignored_lines, (90,))
         self.assertFalse(summary[0].missing_from_coverage)
 
-    def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
+    def test_format_summary_includes_missing_from_coverage_suffix_old_format(
+        self,
+    ) -> None:
         text = _format_summary(
             [
                 FileDiffCoverage(
@@ -470,13 +472,14 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
                     executable_changed_lines=2,
                     covered_lines=1,
                     missing_lines=(20,),
+                    ignored_lines=(),
                     missing_from_coverage=True,
                 )
             ]
         )
 
         self.assertIn("missing-from-coverage", text)
-        self.assertIn("missing lines: 20", text)
+        self.assertIn("uncovered executable lines: 20", text)
 
     @patch("scripts.check_diff_coverage._parse_args")
     @patch("scripts.check_diff_coverage._repo_root")
@@ -664,23 +667,6 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         self.assertIn("ignored non-executable lines: 90, 91", text)
         self.assertIn("scripts/new_tool.py: 2/2 lines covered", text)
         self.assertIn("ignored non-executable lines: 4, 5", text)
-
-    def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
-        text = _format_summary(
-            [
-                FileDiffCoverage(
-                    filename="scripts/check_diff_coverage.py",
-                    executable_changed_lines=2,
-                    covered_lines=1,
-                    missing_lines=(20,),
-                    ignored_lines=(),
-                    missing_from_coverage=True,
-                )
-            ]
-        )
-
-        self.assertIn("missing-from-coverage", text)
-        self.assertIn("uncovered executable lines: 20", text)
 
     def test_summarize_changed_coverage_reports_multi_file_diffs_sorted(self) -> None:
         summary = summarize_changed_coverage(

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -38,6 +38,7 @@ class TestCheckDiffCoverage(TestCase):
             executable_changed_lines=0,
             covered_lines=0,
             missing_lines=(),
+            ignored_lines=(),
         )
 
         self.assertEqual(item.coverage_ratio, 1.0)
@@ -450,9 +451,16 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         summary = summarize_changed_coverage(
             changed_lines={"app/trading/foo.py": {90}},
             coverage_index={"app/trading/foo.py": {11: 1, 12: 0}},
+            executable_lines={"app/trading/foo.py": {11, 12}},
         )
 
-        self.assertEqual(summary, [])
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0].filename, "app/trading/foo.py")
+        self.assertEqual(summary[0].executable_changed_lines, 0)
+        self.assertEqual(summary[0].covered_lines, 0)
+        self.assertEqual(summary[0].missing_lines, ())
+        self.assertEqual(summary[0].ignored_lines, (90,))
+        self.assertFalse(summary[0].missing_from_coverage)
 
     def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
         text = _format_summary(
@@ -628,3 +636,141 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         exit_code = main()
 
         self.assertEqual(exit_code, 0)
+
+    def test_format_summary_separates_uncovered_executable_from_ignored_lines(
+        self,
+    ) -> None:
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="app/trading/foo.py",
+                    executable_changed_lines=3,
+                    covered_lines=1,
+                    missing_lines=(11, 13),
+                    ignored_lines=(90, 91),
+                ),
+                FileDiffCoverage(
+                    filename="scripts/new_tool.py",
+                    executable_changed_lines=2,
+                    covered_lines=2,
+                    missing_lines=(),
+                    ignored_lines=(4, 5),
+                ),
+            ]
+        )
+
+        self.assertIn("app/trading/foo.py: 1/3 lines covered", text)
+        self.assertIn("uncovered executable lines: 11, 13", text)
+        self.assertIn("ignored non-executable lines: 90, 91", text)
+        self.assertIn("scripts/new_tool.py: 2/2 lines covered", text)
+        self.assertIn("ignored non-executable lines: 4, 5", text)
+
+    def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="scripts/check_diff_coverage.py",
+                    executable_changed_lines=2,
+                    covered_lines=1,
+                    missing_lines=(20,),
+                    ignored_lines=(),
+                    missing_from_coverage=True,
+                )
+            ]
+        )
+
+        self.assertIn("missing-from-coverage", text)
+        self.assertIn("uncovered executable lines: 20", text)
+
+    def test_summarize_changed_coverage_reports_multi_file_diffs_sorted(self) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={
+                "scripts/z_file.py": {10, 11},
+                "app/a_module.py": {5, 6, 7},
+            },
+            coverage_index={
+                "scripts/z_file.py": {10: 1, 11: 0},
+                "app/a_module.py": {5: 1, 6: 1, 7: 0},
+            },
+            executable_lines={
+                "scripts/z_file.py": {10, 11},
+                "app/a_module.py": {5, 6, 7},
+            },
+        )
+
+        self.assertEqual(len(summary), 2)
+        self.assertEqual(summary[0].filename, "app/a_module.py")
+        self.assertEqual(summary[1].filename, "scripts/z_file.py")
+        self.assertEqual(summary[0].missing_lines, (7,))
+        self.assertEqual(summary[1].missing_lines, (11,))
+
+    def test_summarize_changed_coverage_reports_ignored_non_executable_lines(
+        self,
+    ) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={"app/trading/foo.py": {11, 12, 99}},
+            coverage_index={"app/trading/foo.py": {11: 1, 12: 0, 30: 1}},
+            executable_lines={"app/trading/foo.py": {11, 12}},
+        )
+
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0].filename, "app/trading/foo.py")
+        self.assertEqual(summary[0].covered_lines, 1)
+        self.assertEqual(summary[0].executable_changed_lines, 2)
+        self.assertEqual(summary[0].missing_lines, (12,))
+        self.assertEqual(summary[0].ignored_lines, (99,))
+
+    def test_summarize_changed_coverage_handles_empty_executable_lines(self) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={"app/__init__.py": {1}},
+            coverage_index={"app/__init__.py": {}},
+            executable_lines={"app/__init__.py": set()},
+        )
+
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0].filename, "app/__init__.py")
+        self.assertEqual(summary[0].executable_changed_lines, 0)
+        self.assertEqual(summary[0].covered_lines, 0)
+        self.assertEqual(summary[0].missing_lines, ())
+        self.assertEqual(summary[0].ignored_lines, (1,))
+
+    def test_summarize_changed_coverage_preserves_existing_behavior_for_covered_lines(
+        self,
+    ) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={"app/trading/foo.py": {11, 12}},
+            coverage_index={"app/trading/foo.py": {11: 1, 12: 1}},
+            executable_lines={"app/trading/foo.py": {11, 12}},
+        )
+
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0].filename, "app/trading/foo.py")
+        self.assertEqual(summary[0].executable_changed_lines, 2)
+        self.assertEqual(summary[0].covered_lines, 2)
+        self.assertEqual(summary[0].missing_lines, ())
+        self.assertEqual(summary[0].ignored_lines, ())
+
+    def test_format_summary_shows_stable_ordering_for_multiple_files(self) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={
+                "scripts/z_last.py": {5},
+                "app/a_first.py": {3},
+                "app/b_middle.py": {10},
+            },
+            coverage_index={
+                "scripts/z_last.py": {5: 0},
+                "app/a_first.py": {3: 0},
+                "app/b_middle.py": {10: 1},
+            },
+            executable_lines={
+                "scripts/z_last.py": {5},
+                "app/a_first.py": {3},
+                "app/b_middle.py": {10},
+            },
+        )
+        text = _format_summary(summary)
+
+        lines = text.split("\n")
+        self.assertIn("app/a_first.py", lines[0])
+        self.assertIn("app/b_middle.py", lines[2])
+        self.assertIn("scripts/z_last.py", lines[3])


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-eval-torghut-minimal-20260616b.
- Prompt variant: `minimal` (`d68005d5c5147ca6`).
- Session artifact: `/workspace/.anypi/sessions/ci-repair-1-7aa7aa2b/2026-06-16T20-55-13-816Z_019ed237-8298-7346-ab32-b596e2a5b476.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0
- CI: unavailable: gh pr checks failed (1): no checks reported on the 'codex/anypi-eval/minimal/torghut-diff-coverage-20260616b' branch

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
