### PR TITLE
feat(anypi): improve torghut diff coverage diagnostic grouping

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -265,7 +265,11 @@ def summarize_changed_coverage(
     return summary
 
 
-def _format_summary(summary: list[FileDiffCoverage]) -> str:
+def _format_summary(
+    summary: list[FileDiffCoverage],
+    coverage_index: dict[str, dict[int, int]],
+    service_root: Path,
+) -> str:
     lines: list[str] = []
     for item in summary:
         coverage_pct = item.coverage_ratio * 100
@@ -276,9 +280,72 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
         )
         if item.missing_lines:
             lines.append(
-                f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
+                _format_missing_lines(
+                    item.filename,
+                    item.missing_lines,
+                    coverage_index.get(item.filename),
+                    service_root,
+                )
             )
     return "\n".join(lines)
+
+
+def _format_missing_lines(
+    filename: str,
+    missing_lines: tuple[int, ...],
+    line_hits: dict[int, int] | None,
+    service_root: Path,
+) -> str:
+    """Format missing lines with context for better test guidance."""
+    lines: list[str] = []
+    # Sort missing lines for consistent output
+    sorted_missing = tuple(sorted(missing_lines))
+    lines.append(f"  missing lines: {', '.join(str(line) for line in sorted_missing)}")
+
+    # Try to provide function context
+    path = service_root / filename
+    if path.exists() and line_hits is not None:
+        context = _get_function_context(path, sorted_missing)
+        if context:
+            for func_name, line_range in context:
+                lines.append(f"    -> {func_name} (lines {line_range})")
+
+    return "\n".join(lines)
+
+
+def _get_function_context(
+    path: Path, missing_lines: tuple[int, ...]
+) -> list[tuple[str, str]]:
+    """Get function names containing missing lines."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, OSError):
+        return []
+
+    # Build a mapping of line ranges to function names
+    func_ranges: list[tuple[str, int, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            if hasattr(node, "lineno"):
+                func_end = getattr(node, "end_lineno", node.lineno)
+                func_ranges.append((node.name, node.lineno, func_end))
+
+    if not func_ranges:
+        return []
+
+    # Find which functions contain each missing line
+    context: list[tuple[str, str]] = []
+    seen_funcs: set[str] = set()
+
+    for line in missing_lines:
+        for func_name, start_line, end_line in func_ranges:
+            if start_line <= line <= end_line:
+                if func_name not in seen_funcs:
+                    seen_funcs.add(func_name)
+                    context.append((func_name, f"{start_line}-{end_line}"))
+                break
+
+    return context
 
 
 def main() -> int:
@@ -329,7 +396,7 @@ def main() -> int:
     coverage_pct = (
         (total_covered / total_executable) * 100 if total_executable else 100.0
     )
-    print(_format_summary(summary))
+    print(_format_summary(summary, coverage_index, service_root))
     print(
         f"total changed-line coverage: {total_covered}/{total_executable} ({coverage_pct:.2f}%)"
     )

--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -210,11 +210,14 @@ def _load_coverage_index(xml_path: Path) -> dict[str, dict[int, int]]:
                 continue
             normalized = filename.replace("\\", "/").lstrip("./")
             if not normalized.startswith(("app/", "scripts/")):
-                app_path = service_root / "app" / normalized
-                script_path = service_root / "scripts" / normalized
-                if app_path.exists() and not script_path.exists():
+                # Check existence of app/script paths inline to avoid extra local var
+                if (service_root / "app" / normalized).exists() and not (
+                    service_root / "scripts" / normalized
+                ).exists():
                     normalized = f"app/{normalized}"
-                elif script_path.exists() and not app_path.exists():
+                elif (service_root / "scripts" / normalized).exists() and not (
+                    service_root / "app" / normalized
+                ).exists():
                     normalized = f"scripts/{normalized}"
                 elif "/" not in normalized and package_name in {"app", "scripts"}:
                     normalized = f"{package_name}/{normalized}"

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -455,20 +455,122 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         self.assertEqual(summary, [])
 
     def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
-        text = _format_summary(
-            [
-                FileDiffCoverage(
-                    filename="scripts/check_diff_coverage.py",
-                    executable_changed_lines=2,
-                    covered_lines=1,
-                    missing_lines=(20,),
-                    missing_from_coverage=True,
-                )
-            ]
-        )
+        with TemporaryDirectory() as tmpdir:
+            service_root = Path(tmpdir)
+            # Create the file to enable function context
+            scripts_dir = service_root / "scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            (scripts_dir / "check_diff_coverage.py").write_text(
+                "def main() -> int:\n    return 0\n", encoding="utf-8"
+            )
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="scripts/check_diff_coverage.py",
+                        executable_changed_lines=2,
+                        covered_lines=1,
+                        missing_lines=(20,),
+                        missing_from_coverage=True,
+                    )
+                ],
+                {},
+                service_root,
+            )
 
         self.assertIn("missing-from-coverage", text)
         self.assertIn("missing lines: 20", text)
+
+    def test_format_summary_includes_function_context(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            service_root = Path(tmpdir)
+            # Create a file with multiple functions
+            scripts_dir = service_root / "scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            (scripts_dir / "new_tool.py").write_text(
+                """
+def build() -> int:
+    value = 1
+    return value
+
+
+def run() -> str:
+    return "ok"
+""",
+                encoding="utf-8",
+            )
+            # Coverage index has line 4 (inside build) and line 8 (inside run) as missing
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="scripts/new_tool.py",
+                        executable_changed_lines=2,
+                        covered_lines=0,
+                        missing_lines=(4, 8),
+                    )
+                ],
+                {"scripts/new_tool.py": {4: 0, 8: 0}},
+                service_root,
+            )
+
+        self.assertIn("missing lines: 4, 8", text)
+        self.assertIn("build", text)
+        self.assertIn("run", text)
+
+    def test_format_summary_includes_function_context_only_once_per_function(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            service_root = Path(tmpdir)
+            scripts_dir = service_root / "scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            (scripts_dir / "new_tool.py").write_text(
+                """
+def build() -> int:
+    value = 1
+    value += 1
+    return value
+""",
+                encoding="utf-8",
+            )
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="scripts/new_tool.py",
+                        executable_changed_lines=3,
+                        covered_lines=0,
+                        missing_lines=(3, 4),
+                    )
+                ],
+                {"scripts/new_tool.py": {3: 0, 4: 0}},
+                service_root,
+            )
+
+        # build should only appear once even though multiple lines are missing
+        self.assertIn("build", text)
+        self.assertEqual(text.count("build"), 1)
+
+    def test_format_summary_shows_sorted_line_numbers(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            service_root = Path(tmpdir)
+            scripts_dir = service_root / "scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            (scripts_dir / "new_tool.py").write_text(
+                "def main() -> int:\n    return 1\n", encoding="utf-8"
+            )
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="scripts/new_tool.py",
+                        executable_changed_lines=2,
+                        covered_lines=0,
+                        missing_lines=(2, 1),
+                    )
+                ],
+                {"scripts/new_tool.py": {1: 0, 2: 0}},
+                service_root,
+            )
+
+        self.assertIn("missing lines: 1, 2", text)
 
     @patch("scripts.check_diff_coverage._parse_args")
     @patch("scripts.check_diff_coverage._repo_root")


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-eval-torghut-repair-20260616d.
- Prompt variant: `repair-loop` (`cc10bb81ae0f003f`).
- Session artifact: `/workspace/.anypi/sessions/ci-repair-1-7ac35a6a/2026-06-16T21-29-37-972Z_019ed257-01b4-7aa3-a98f-42f58e62cd10.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0
- CI: passed: 24 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
