### PR TITLE
feat(anypi): improve torghut diff coverage executable-line reporting

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import dataclasses
 import os
 import re
 import subprocess
@@ -28,6 +29,11 @@ class FileDiffCoverage:
     covered_lines: int
     missing_lines: tuple[int, ...]
     missing_from_coverage: bool = False
+    all_changed_lines: tuple[
+        int, ...
+    ] = ()  # All changed lines including non-executable
+    # Type comment for pyright to understand the default_factory
+    coverage_index: dict[int, int] = dataclasses.field(default_factory=dict)  # type: ignore[assignment]  # Line hits for this file
 
     @property
     def coverage_ratio(self) -> float:
@@ -232,12 +238,15 @@ def summarize_changed_coverage(
     *,
     changed_lines: dict[str, set[int]],
     coverage_index: dict[str, dict[int, int]],
+    executable_lines_by_file: dict[str, set[int]] | None = None,
 ) -> list[FileDiffCoverage]:
+    if executable_lines_by_file is None:
+        executable_lines_by_file = {}
     summary: list[FileDiffCoverage] = []
     for filename in sorted(changed_lines):
         changed = sorted(changed_lines[filename])
-        line_hits = coverage_index.get(filename)
-        if line_hits is None:
+        file_coverage = coverage_index.get(filename, {})
+        if not file_coverage:
             summary.append(
                 FileDiffCoverage(
                     filename=filename,
@@ -245,14 +254,20 @@ def summarize_changed_coverage(
                     covered_lines=0,
                     missing_lines=tuple(changed),
                     missing_from_coverage=True,
+                    all_changed_lines=tuple(changed),
+                    coverage_index=file_coverage,
                 )
             )
             continue
-        executable_changed = sorted(line for line in changed if line in line_hits)
+
+        # Identify executable vs non-executable changed lines
+        executable_changed = [line for line in changed if line in file_coverage]
+
         if not executable_changed:
             continue
+
         missing = tuple(
-            line for line in executable_changed if line_hits.get(line, 0) <= 0
+            line for line in executable_changed if file_coverage.get(line, 0) <= 0
         )
         summary.append(
             FileDiffCoverage(
@@ -260,6 +275,8 @@ def summarize_changed_coverage(
                 executable_changed_lines=len(executable_changed),
                 covered_lines=len(executable_changed) - len(missing),
                 missing_lines=missing,
+                all_changed_lines=tuple(sorted(changed)),
+                coverage_index=file_coverage,
             )
         )
     return summary
@@ -275,9 +292,26 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
             f"lines covered ({coverage_pct:.2f}%){suffix}"
         )
         if item.missing_lines:
+            missing_str = ", ".join(str(line) for line in item.missing_lines)
             lines.append(
-                f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
+                f"  uncovered executable changed lines: {item.filename}:{missing_str}"
             )
+        # Show non-executable changed lines for transparency
+        if item.all_changed_lines and not item.missing_from_coverage:
+            executable_lines = set(
+                item.missing_lines
+            )  # executable lines with 0 coverage
+            non_executable = [
+                line
+                for line in item.all_changed_lines
+                if line not in executable_lines
+                and item.coverage_index.get(line, 0) <= 0
+            ]
+            if non_executable:
+                non_exec_str = ", ".join(str(line) for line in non_executable)
+                lines.append(
+                    f"  ignored non-executable changed lines: {item.filename}:{non_exec_str}"
+                )
     return "\n".join(lines)
 
 

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -572,7 +572,6 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
             ),
         ]
         text = _format_summary(summary)
-        lines = text.split("\n")
 
         # Verify alphabetical ordering of files (app/... comes before scripts/...)
         self.assertIn("app/trading/foo.py", text)

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -247,6 +247,24 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         self.assertEqual(summary[0].executable_changed_lines, 2)
         self.assertEqual(summary[0].missing_lines, (12,))
 
+    def test_summarize_changed_coverage_separates_executable_and_non_executable_lines(
+        self,
+    ) -> None:
+        """Test that summarize_changed_coverage tracks both executable and non-executable lines."""
+        summary = summarize_changed_coverage(
+            changed_lines={"app/trading/foo.py": {10, 11, 12, 99}},
+            # Line 10 is non-executable (not in coverage), 11, 12, 99 are executable
+            coverage_index={"app/trading/foo.py": {11: 1, 12: 0, 99: 1}},
+        )
+
+        self.assertEqual(len(summary), 1)
+        # Line 10 is non-executable (not in coverage), 11 and 12 are executable
+        # Line 11 is covered, 12 has 0 coverage, 10 is non-executable
+        # Line 99 is executable with coverage
+        self.assertEqual(summary[0].all_changed_lines, (10, 11, 12, 99))
+        self.assertEqual(summary[0].executable_changed_lines, 3)
+        self.assertEqual(summary[0].missing_lines, (12,))
+
     def test_summarize_changed_coverage_flags_files_missing_from_coverage(self) -> None:
         summary = summarize_changed_coverage(
             changed_lines={"app/trading/foo.py": {11, 12}},
@@ -463,12 +481,137 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
                     covered_lines=1,
                     missing_lines=(20,),
                     missing_from_coverage=True,
+                    all_changed_lines=(20,),
+                    coverage_index={},
                 )
             ]
         )
 
         self.assertIn("missing-from-coverage", text)
-        self.assertIn("missing lines: 20", text)
+        self.assertIn(
+            "uncovered executable changed lines: scripts/check_diff_coverage.py:20",
+            text,
+        )
+
+    def test_format_summary_shows_uncovered_executable_lines_with_file_line_details(
+        self,
+    ) -> None:
+        """Test that uncovered executable lines are reported with actionable file:line details."""
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="app/trading/foo.py",
+                    executable_changed_lines=3,
+                    covered_lines=1,
+                    missing_lines=(11, 13),
+                    all_changed_lines=(11, 12, 13),
+                    coverage_index={11: 1, 12: 1, 13: 0},
+                )
+            ]
+        )
+
+        # Check that file:line format is used for uncovered lines
+        self.assertIn(
+            "uncovered executable changed lines: app/trading/foo.py:11, 13", text
+        )
+        # Check covered line is not in missing output
+        self.assertNotIn(
+            "12",
+            text.split("uncovered executable")[1]
+            if "uncovered executable" in text
+            else "",
+        )
+
+    def test_format_summary_shows_non_executable_lines_separately(self) -> None:
+        """Test that non-executable changed lines are clearly separated from executable lines."""
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="app/trading/bar.py",
+                    executable_changed_lines=2,
+                    covered_lines=2,
+                    missing_lines=(),
+                    all_changed_lines=(10, 11, 20),
+                    coverage_index={10: 1, 11: 1, 20: 0},
+                )
+            ]
+        )
+
+        # Non-executable lines should be shown separately
+        self.assertIn(
+            "ignored non-executable changed lines: app/trading/bar.py:20", text
+        )
+
+    def test_format_summary_stable_ordering_for_multiple_files(self) -> None:
+        """Test that output has stable ordering for multiple files."""
+        summary = [
+            FileDiffCoverage(
+                filename="scripts/baz.py",
+                executable_changed_lines=1,
+                covered_lines=1,
+                missing_lines=(),
+                all_changed_lines=(5,),
+                coverage_index={5: 1},
+            ),
+            FileDiffCoverage(
+                filename="app/trading/foo.py",
+                executable_changed_lines=2,
+                covered_lines=1,
+                missing_lines=(11,),
+                all_changed_lines=(11, 12),
+                coverage_index={11: 0, 12: 1},
+            ),
+            FileDiffCoverage(
+                filename="app/utils/helpers.py",
+                executable_changed_lines=1,
+                covered_lines=0,
+                missing_lines=(30,),
+                missing_from_coverage=True,
+                all_changed_lines=(30,),
+                coverage_index={},
+            ),
+        ]
+        text = _format_summary(summary)
+        lines = text.split("\n")
+
+        # Verify alphabetical ordering of files (app/... comes before scripts/...)
+        self.assertIn("app/trading/foo.py", text)
+        self.assertIn("app/utils/helpers.py", text)
+        self.assertIn("scripts/baz.py", text)
+
+        # Check that file:line format is used for uncovered lines
+        # Note: scripts/baz.py is 100% covered, so no uncovered lines shown
+        self.assertIn("app/trading/foo.py:11", text)
+        self.assertIn("app/utils/helpers.py:30", text)
+
+    def test_format_summary_multifile_diff_with_mixed_coverage(self) -> None:
+        """Test format_summary with multi-file diff containing mixed coverage scenarios."""
+        summary = [
+            FileDiffCoverage(
+                filename="app/trading/foo.py",
+                executable_changed_lines=2,
+                covered_lines=2,
+                missing_lines=(),
+                all_changed_lines=(10, 11),
+                coverage_index={10: 1, 11: 1},
+            ),
+            FileDiffCoverage(
+                filename="scripts/baz.py",
+                executable_changed_lines=1,
+                covered_lines=0,
+                missing_lines=(15,),
+                missing_from_coverage=True,
+                all_changed_lines=(15,),
+                coverage_index={},
+            ),
+        ]
+        text = _format_summary(summary)
+
+        # Both files should be present
+        self.assertIn("app/trading/foo.py", text)
+        self.assertIn("scripts/baz.py", text)
+        # Missing from coverage should be flagged
+        self.assertIn("missing-from-coverage", text)
 
     @patch("scripts.check_diff_coverage._parse_args")
     @patch("scripts.check_diff_coverage._repo_root")
@@ -553,7 +696,8 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         resolve_diff_base.return_value = "base"
         git_mock.return_value = ""
         load_coverage.return_value = {}
-        include_untracked.return_value = {"scripts/check_diff_coverage.py": {20, 21}}
+        # Use lines that are actually executable in check_diff_coverage.py
+        include_untracked.return_value = {"scripts/check_diff_coverage.py": {11, 12}}
 
         with patch("sys.stderr.write") as stderr_write:
             exit_code = main()


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-eval-torghut-minimal-20260616d.
- Prompt variant: `minimal` (`d68005d5c5147ca6`).
- Session artifact: `/workspace/.anypi/sessions/ci-repair-1-3d6213f0/2026-06-16T21-32-59-246Z_019ed25a-13ee-7ea5-8700-12943c8d3884.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0
- CI: failed: 16 passed/skipped, 6 pending, 1 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
