### PR TITLE
feat(anypi): improve torghut diff coverage diagnostic grouping

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -21,6 +21,33 @@ TRACKED_PREFIXES = (
 _HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
 
+def _format_line_ranges(lines: tuple[int, ...]) -> str:
+    """Format a sorted tuple of line numbers as compact ranges.
+
+    Example: (20, 21, 22, 25, 28, 29, 30) -> "20-22, 25, 28-30"
+    """
+    if not lines:
+        return ""
+    ranges: list[str] = []
+    start = lines[0]
+    end = lines[0]
+    for line in lines[1:]:
+        if line == end + 1:
+            end = line
+        else:
+            if start == end:
+                ranges.append(str(start))
+            else:
+                ranges.append(f"{start}-{end}")
+            start = line
+            end = line
+    if start == end:
+        ranges.append(str(start))
+    else:
+        ranges.append(f"{start}-{end}")
+    return ", ".join(ranges)
+
+
 @dataclass(frozen=True)
 class FileDiffCoverage:
     filename: str
@@ -275,9 +302,7 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
             f"lines covered ({coverage_pct:.2f}%){suffix}"
         )
         if item.missing_lines:
-            lines.append(
-                f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
-            )
+            lines.append(f"  missing lines: {_format_line_ranges(item.missing_lines)}")
     return "\n".join(lines)
 
 

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -13,6 +13,7 @@ from scripts.check_diff_coverage import (
     FileDiffCoverage,
     _drop_missing_non_executable_files,
     _executable_source_lines,
+    _format_line_ranges,
     _format_summary,
     _git,
     _git_optional,
@@ -453,6 +454,31 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         )
 
         self.assertEqual(summary, [])
+
+    def test_format_line_ranges_converts_single_line(self) -> None:
+        result = _format_line_ranges((20,))
+
+        self.assertEqual(result, "20")
+
+    def test_format_line_ranges_converts_consecutive_lines_to_range(self) -> None:
+        result = _format_line_ranges((20, 21, 22))
+
+        self.assertEqual(result, "20-22")
+
+    def test_format_line_ranges_converts_mixed_lines(self) -> None:
+        result = _format_line_ranges((20, 21, 22, 25, 28, 29, 30))
+
+        self.assertEqual(result, "20-22, 25, 28-30")
+
+    def test_format_line_ranges_handles_empty_tuple(self) -> None:
+        result = _format_line_ranges(())
+
+        self.assertEqual(result, "")
+
+    def test_format_line_ranges_handles_already_sorted_lines(self) -> None:
+        result = _format_line_ranges((5, 10, 15, 20))
+
+        self.assertEqual(result, "5, 10, 15, 20")
 
     def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
         text = _format_summary(


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-eval-torghut-repair-20260616e.
- Prompt variant: `repair-loop` (`b77c133ef91aab25`).
- Session artifact: `/workspace/.anypi/sessions/validation-repair-1-199e5856/2026-06-16T22-17-35-552Z_019ed282-ea40-787c-88ae-a279c0023d51.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0
- CI: Pending: pull request checks have not completed yet.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
