### PR TITLE
feat(anypi): improve torghut diff coverage diagnostic grouping

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -265,6 +265,30 @@ def summarize_changed_coverage(
     return summary
 
 
+def _format_missing_lines(missing_lines: tuple[int, ...]) -> str:
+    if not missing_lines:
+        return ""
+    ranges: list[str] = []
+    sorted_lines = sorted(missing_lines)
+    start = sorted_lines[0]
+    end = start
+    for line in sorted_lines[1:]:
+        if line == end + 1:
+            end = line
+        else:
+            if start == end:
+                ranges.append(str(start))
+            else:
+                ranges.append(f"{start}-{end}")
+            start = line
+            end = line
+    if start == end:
+        ranges.append(str(start))
+    else:
+        ranges.append(f"{start}-{end}")
+    return ", ".join(ranges)
+
+
 def _format_summary(summary: list[FileDiffCoverage]) -> str:
     lines: list[str] = []
     for item in summary:
@@ -272,12 +296,11 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
         suffix = " missing-from-coverage" if item.missing_from_coverage else ""
         lines.append(
             f"{item.filename}: {item.covered_lines}/{item.executable_changed_lines} "
-            f"lines covered ({coverage_pct:.2f}%){suffix}"
+            f"lines covered ({coverage_pct:.2f}%) - {len(item.missing_lines)} missing{suffix}"
         )
         if item.missing_lines:
-            lines.append(
-                f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
-            )
+            formatted = _format_missing_lines(item.missing_lines)
+            lines.append(f"  missing lines: {formatted}")
     return "\n".join(lines)
 
 

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -13,6 +13,7 @@ from scripts.check_diff_coverage import (
     FileDiffCoverage,
     _drop_missing_non_executable_files,
     _executable_source_lines,
+    _format_missing_lines,
     _format_summary,
     _git,
     _git_optional,
@@ -453,6 +454,34 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         )
 
         self.assertEqual(summary, [])
+
+    def test_format_missing_lines_formats_consecutive_ranges(self) -> None:
+        self.assertEqual(_format_missing_lines((1, 2, 3)), "1-3")
+        self.assertEqual(_format_missing_lines((1, 2, 3, 5, 6)), "1-3, 5-6")
+        self.assertEqual(_format_missing_lines((1, 3, 5)), "1, 3, 5")
+        self.assertEqual(_format_missing_lines((1,)), "1")
+        self.assertEqual(_format_missing_lines(()), "")
+
+    def test_format_missing_lines_handles_sorted_input(self) -> None:
+        # Input is already sorted in the tuple, but we verify it handles reversed order
+        self.assertEqual(_format_missing_lines((5, 3, 1)), "1, 3, 5")
+
+    def test_format_summary_includes_consecutive_line_ranges(self) -> None:
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename="app/trading/foo.py",
+                    executable_changed_lines=5,
+                    covered_lines=2,
+                    missing_lines=(2, 3, 5, 8, 9, 10),
+                )
+            ]
+        )
+
+        self.assertIn("2-3", text)  # consecutive lines 2,3
+        self.assertIn("8-10", text)  # consecutive lines 8,9,10
+        self.assertIn("5", text)  # single line 5
+        self.assertIn("- 6 missing", text)  # concise count
 
     def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
         text = _format_summary(


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-eval-torghut-repair-20260616f.
- Prompt variant: `repair-loop` (`b77c133ef91aab25`).
- Session artifact: `/workspace/.anypi/sessions/initial-9af2b08c/2026-06-17T00-15-02-602Z_019ed2ee-71ca-7324-ac2c-f4bad88f139a.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0
- CI: passed: 24 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
