### PR TITLE
feat(anypi): improve torghut diff coverage diagnostic grouping

### DIFF
--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -265,7 +265,15 @@ def summarize_changed_coverage(
     return summary
 
 
-def _format_summary(summary: list[FileDiffCoverage]) -> str:
+def _load_source_lines(path: Path) -> list[str]:
+    """Load source file lines, returning empty list if file doesn't exist."""
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except (FileNotFoundError, OSError):
+        return []
+
+
+def _format_summary(summary: list[FileDiffCoverage], service_root: Path) -> str:
     lines: list[str] = []
     for item in summary:
         coverage_pct = item.coverage_ratio * 100
@@ -275,10 +283,49 @@ def _format_summary(summary: list[FileDiffCoverage]) -> str:
             f"lines covered ({coverage_pct:.2f}%){suffix}"
         )
         if item.missing_lines:
-            lines.append(
-                f"  missing lines: {', '.join(str(line) for line in item.missing_lines)}"
-            )
+            source_lines = _load_source_lines(service_root / item.filename)
+            # Show range for consecutive lines for conciseness
+            missing_str = _format_missing_line_range(item.missing_lines)
+            lines.append(f"  missing lines: {missing_str}")
+            # Show context for first 3 missing lines to help decide next test
+            shown = 0
+            for line_no in sorted(item.missing_lines):
+                if shown >= 3:
+                    lines.append(
+                        f"  ... and {len(item.missing_lines) - shown} more missing lines"
+                    )
+                    break
+                if 1 <= line_no <= len(source_lines):
+                    code = source_lines[line_no - 1].rstrip()
+                    if code:
+                        lines.append(f"    +{line_no}: {code}")
+                        shown += 1
     return "\n".join(lines)
+
+
+def _format_missing_line_range(missing_lines: tuple[int, ...]) -> str:
+    """Format missing line numbers concisely, using ranges for consecutive lines."""
+    if not missing_lines:
+        return "none"
+    ranges: list[str] = []
+    start = missing_lines[0]
+    end = start
+    for line in missing_lines[1:]:
+        if line == end + 1:
+            end = line
+        else:
+            ranges.append(_format_range(start, end))
+            start = line
+            end = line
+    ranges.append(_format_range(start, end))
+    return ", ".join(ranges)
+
+
+def _format_range(start: int, end: int) -> str:
+    """Format a range of line numbers, showing single number if start == end."""
+    if start == end:
+        return str(start)
+    return f"{start}-{end}"
 
 
 def main() -> int:
@@ -329,7 +376,7 @@ def main() -> int:
     coverage_pct = (
         (total_covered / total_executable) * 100 if total_executable else 100.0
     )
-    print(_format_summary(summary))
+    print(_format_summary(summary, service_root))
     print(
         f"total changed-line coverage: {total_covered}/{total_executable} ({coverage_pct:.2f}%)"
     )

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -13,6 +13,8 @@ from scripts.check_diff_coverage import (
     FileDiffCoverage,
     _drop_missing_non_executable_files,
     _executable_source_lines,
+    _format_missing_line_range,
+    _format_range,
     _format_summary,
     _git,
     _git_optional,
@@ -455,20 +457,143 @@ diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
         self.assertEqual(summary, [])
 
     def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
-        text = _format_summary(
-            [
-                FileDiffCoverage(
-                    filename="scripts/check_diff_coverage.py",
-                    executable_changed_lines=2,
-                    covered_lines=1,
-                    missing_lines=(20,),
-                    missing_from_coverage=True,
-                )
-            ]
-        )
+        with TemporaryDirectory() as tmpdir:
+            # Create a dummy source file to test line context
+            scripts_dir = Path(tmpdir) / "scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            (scripts_dir / "check_diff_coverage.py").write_text(
+                'def main():\n    return 0\n    print("hello")\n', encoding="utf-8"
+            )
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="scripts/check_diff_coverage.py",
+                        executable_changed_lines=2,
+                        covered_lines=0,
+                        missing_lines=(1, 2),  # Use valid line numbers
+                        missing_from_coverage=True,
+                    )
+                ],
+                service_root=Path(tmpdir),
+            )
 
         self.assertIn("missing-from-coverage", text)
-        self.assertIn("missing lines: 20", text)
+        self.assertIn("missing lines: 1-2", text)
+        # The context should show the code on the missing lines
+        self.assertIn("+1: def main():", text)
+        self.assertIn("+2:     return 0", text)
+
+    def test_format_summary_shows_consecutive_line_ranges(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            source_path = Path(tmpdir) / "app" / "trading" / "foo.py"
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_text(
+                "def func():\n    a = 1\n    b = 2\n    c = 3\n    d = 4\n",
+                encoding="utf-8",
+            )
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="app/trading/foo.py",
+                        executable_changed_lines=4,
+                        covered_lines=1,
+                        missing_lines=(2, 3, 4),
+                    )
+                ],
+                service_root=Path(tmpdir),
+            )
+
+        # Consecutive lines should be shown as a range
+        self.assertIn("missing lines: 2-4", text)
+        # Context should show code for first 3 lines
+        self.assertIn("+2:     a = 1", text)
+        self.assertIn("+3:     b = 2", text)
+        self.assertIn("+4:     c = 3", text)
+
+    def test_format_summary_shows_individual_lines_when_not_consecutive(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            source_path = Path(tmpdir) / "app" / "trading" / "foo.py"
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_text(
+                "def func():\n    a = 1\n    b = 2\n    c = 3\n", encoding="utf-8"
+            )
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="app/trading/foo.py",
+                        executable_changed_lines=3,
+                        covered_lines=0,
+                        missing_lines=(1, 4),  # Not consecutive
+                    )
+                ],
+                service_root=Path(tmpdir),
+            )
+
+        # Non-consecutive lines should be shown individually
+        self.assertIn("missing lines: 1, 4", text)
+        # Context should show code
+        self.assertIn("+1: def func():", text)
+        self.assertIn("+4:     c = 3", text)
+
+    def test_format_summary_truncates_context_after_three_lines(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            source_path = Path(tmpdir) / "app" / "trading" / "foo.py"
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_text(
+                "def func():\n    a = 1\n    b = 2\n    c = 3\n    d = 4\n    e = 5\n",
+                encoding="utf-8",
+            )
+            text = _format_summary(
+                [
+                    FileDiffCoverage(
+                        filename="app/trading/foo.py",
+                        executable_changed_lines=5,
+                        covered_lines=0,
+                        missing_lines=(1, 2, 3, 4, 5),
+                    )
+                ],
+                service_root=Path(tmpdir),
+            )
+
+        # Should show ranges
+        self.assertIn("missing lines: 1-5", text)
+        # Should only show first 3 lines of context
+        self.assertIn("+1: def func():", text)
+        self.assertIn("+2:     a = 1", text)
+        self.assertIn("+3:     b = 2", text)
+        # Should indicate there are more
+        self.assertIn("... and 2 more missing lines", text)
+        # Should not show lines 4 and 5 in context
+        self.assertNotIn("+4:", text)
+        self.assertNotIn("+5:", text)
+
+    def test_format_missing_line_range_single_line(self) -> None:
+        result = _format_missing_line_range((5,))
+        self.assertEqual(result, "5")
+
+    def test_format_missing_line_range_consecutive(self) -> None:
+        result = _format_missing_line_range((1, 2, 3))
+        self.assertEqual(result, "1-3")
+
+    def test_format_missing_line_range_non_consecutive(self) -> None:
+        result = _format_missing_line_range((1, 3, 5))
+        self.assertEqual(result, "1, 3, 5")
+
+    def test_format_missing_line_range_mixed(self) -> None:
+        result = _format_missing_line_range((1, 2, 5, 7, 8, 9))
+        self.assertEqual(result, "1-2, 5, 7-9")
+
+    def test_format_missing_line_range_empty(self) -> None:
+        result = _format_missing_line_range(())
+        self.assertEqual(result, "none")
+
+    def test_format_range_single_number(self) -> None:
+        result = _format_range(5, 5)
+        self.assertEqual(result, "5")
+
+    def test_format_range_multiple_numbers(self) -> None:
+        result = _format_range(1, 3)
+        self.assertEqual(result, "1-3")
 
     @patch("scripts.check_diff_coverage._parse_args")
     @patch("scripts.check_diff_coverage._repo_root")


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-eval-torghut-repair-20260616g.
- Prompt variant: `repair-loop` (`b77c133ef91aab25`).
- Session artifact: `/workspace/.anypi/sessions/initial-95047423/2026-06-17T00-25-09-571Z_019ed2f7-b4c3-7542-ab16-2aeaa53ad77c.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc cd services/torghut && uv sync --frozen --extra dev` exit 0
- `bash -lc cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` exit 0
- `bash -lc cd services/torghut && uv run --frozen pytest tests/test_check_diff_coverage.py -q` exit 0
- CI: passed: 24 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
