### PR TITLE
fix(agents): publish multi-arch control plane images

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -465,10 +465,24 @@ jobs:
           repo_root="$(git rev-parse --show-toplevel)"
           base_spec="origin/${GITHUB_BASE_REF:-main}"
           base="$(git -C "${repo_root}" merge-base "${base_spec}" HEAD 2>/dev/null || git -C "${repo_root}" rev-parse HEAD^)"
+          changed_python=()
+          while IFS= read -r python_file; do
+            changed_python+=("${python_file}")
+          done < <(
+            git -C "${repo_root}" diff --name-only --diff-filter=ACMR "${base}...HEAD" \
+              -- services/torghut/app services/torghut/scripts services/torghut/tests services/torghut/migrations |
+              sed 's#^services/torghut/##' |
+              grep -E '^(app|scripts|tests|migrations)/.*\.pyi?$' || true
+          )
+
+          if [ "${#changed_python[@]}" -eq 0 ]; then
+            echo "No changed Torghut Python files for Pylint file length gate."
+            exit 0
+          fi
 
           uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py \
             --base "${base}" \
-            app scripts tests migrations
+            "${changed_python[@]}"
 
       - name: Pylint design complexity inventory (non-blocking)
         continue-on-error: true

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 4a010a93
-  digest: sha256:149ad97c4ae40ea651123d3f190a68003dba4ff0a6a073398b0d3adcca98bd4a
+  tag: 17a315d04
+  digest: sha256:96c6b68d191cdb50b4429b6009ca63f5c941d44b093fa49f01a7b99f5db0870b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,21 +14,21 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 4a010a93
-    digest: sha256:2ac77605ac90c2a8301fe50facb242adc13d9563487d084694b4f61e7e4687a5
+    tag: 17a315d04
+    digest: sha256:447b37336cd42ad23526fe7c0f462cbb838f8ec08f5eb2a0e48de65be633fbdb
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 4a010a937bc9fbe6405d310eee1bc5a8204e4cd8
-      AGENTS_GITOPS_REVISION: 4a010a937bc9fbe6405d310eee1bc5a8204e4cd8
+      AGENTS_SOURCE_HEAD_SHA: 17a315d04d457ae9d64ef52af67b3acaabefef06
+      AGENTS_GITOPS_REVISION: 17a315d04d457ae9d64ef52af67b3acaabefef06
       AGENTS_SOURCE_CI_RUN_ID: "26999079708"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:2ac77605ac90c2a8301fe50facb242adc13d9563487d084694b4f61e7e4687a5
-      AGENTS_SERVING_BUILD_COMMIT: 4a010a937bc9fbe6405d310eee1bc5a8204e4cd8
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:2ac77605ac90c2a8301fe50facb242adc13d9563487d084694b4f61e7e4687a5
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:447b37336cd42ad23526fe7c0f462cbb838f8ec08f5eb2a0e48de65be633fbdb
+      AGENTS_SERVING_BUILD_COMMIT: 17a315d04d457ae9d64ef52af67b3acaabefef06
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:447b37336cd42ad23526fe7c0f462cbb838f8ec08f5eb2a0e48de65be633fbdb
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
@@ -88,8 +88,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 4a010a93
-    digest: sha256:149ad97c4ae40ea651123d3f190a68003dba4ff0a6a073398b0d3adcca98bd4a
+    tag: 17a315d04
+    digest: sha256:96c6b68d191cdb50b4429b6009ca63f5c941d44b093fa49f01a7b99f5db0870b
   autoscaling:
     enabled: false
 swarm:

--- a/packages/scripts/src/shared/__tests__/docker.test.ts
+++ b/packages/scripts/src/shared/__tests__/docker.test.ts
@@ -18,11 +18,19 @@ afterEach(() => {
 const streamFromText = (text: string) => new Response(text).body!
 
 describe('inspectImageDigest', () => {
-  it('prefers the locally cached repo digest when available', () => {
+  it('prefers the remote repo digest when both remote and local digests are available', () => {
+    const calls: string[] = []
     const spawnMock = ((command: Parameters<typeof Bun.spawnSync>[0], args, _opts) => {
       const commandString = typeof command === 'string' ? command : Array.prototype.join.call(command, ' ')
       const argString = Array.isArray(args) ? args.join(' ') : args ? String(args) : ''
       const joined = `${commandString} ${argString}`.trim()
+      calls.push(joined)
+      if (joined.startsWith('docker buildx imagetools inspect')) {
+        const payload = JSON.stringify({ digest: 'sha256:222' })
+        return { exitCode: 0, stdout: Buffer.from(payload), stderr: new Uint8Array() } as ReturnType<
+          typeof Bun.spawnSync
+        >
+      }
       if (joined.startsWith('docker image inspect')) {
         return {
           exitCode: 0,
@@ -36,24 +44,24 @@ describe('inspectImageDigest', () => {
     __private.setSpawnSync(spawnMock)
 
     const digest = inspectImageDigest('registry/repo:tag')
-    expect(digest).toBe('registry/repo@sha256:111')
+    expect(digest).toBe('registry/repo@sha256:222')
+    expect(calls.some((call) => call.startsWith('docker image inspect'))).toBe(false)
   })
 
-  it('falls back to docker imagetools when the local image is missing', () => {
-    let imagetoolsCalled = false
+  it('falls back to the locally cached repo digest when the remote image is missing', () => {
     const spawnMock = ((command: Parameters<typeof Bun.spawnSync>[0], args, _opts) => {
       const commandString = typeof command === 'string' ? command : Array.prototype.join.call(command, ' ')
       const argString = Array.isArray(args) ? args.join(' ') : args ? String(args) : ''
       const joined = `${commandString} ${argString}`.trim()
-      if (joined.startsWith('docker image inspect')) {
+      if (joined.startsWith('docker buildx imagetools inspect')) {
         return { exitCode: 1, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
       }
-      if (joined.startsWith('docker buildx imagetools inspect')) {
-        imagetoolsCalled = true
-        const payload = JSON.stringify({ digest: 'sha256:222' })
-        return { exitCode: 0, stdout: Buffer.from(payload), stderr: new Uint8Array() } as ReturnType<
-          typeof Bun.spawnSync
-        >
+      if (joined.startsWith('docker image inspect')) {
+        return {
+          exitCode: 0,
+          stdout: Buffer.from('["registry.example/froussard@sha256:111"]'),
+          stderr: new Uint8Array(),
+        } as ReturnType<typeof Bun.spawnSync>
       }
       return { exitCode: 1, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
     }) as typeof Bun.spawnSync
@@ -61,8 +69,7 @@ describe('inspectImageDigest', () => {
     __private.setSpawnSync(spawnMock)
 
     const digest = inspectImageDigest('registry.example/froussard:latest')
-    expect(imagetoolsCalled).toBe(true)
-    expect(digest).toBe('registry.example/froussard@sha256:222')
+    expect(digest).toBe('registry.example/froussard@sha256:111')
   })
 })
 

--- a/packages/scripts/src/shared/docker.ts
+++ b/packages/scripts/src/shared/docker.ts
@@ -454,14 +454,14 @@ const getDockerBuildxDriver = (): string | undefined => {
 
 export const inspectImageDigest = (image: string): string => {
   ensureCli('docker')
-  const repoDigest = inspectLocalImageDigest(image)
-  if (repoDigest) {
-    return repoDigest
-  }
-
   const remoteDigest = inspectRemoteImageDigest(image)
   if (remoteDigest) {
     return remoteDigest
+  }
+
+  const repoDigest = inspectLocalImageDigest(image)
+  if (repoDigest) {
+    return repoDigest
   }
 
   throw new Error(`Unable to determine digest for image ${image}`)


### PR DESCRIPTION
## Summary

- Publishes multi-arch Agents controller and control-plane image indexes for `17a315d04` with both `linux/amd64` and `linux/arm64` manifests.
- Pins the Agents GitOps values to the verified remote OCI index digests and leaves workload scheduling unpinned with `nodeSelector: {}`.
- Fixes Docker digest resolution to prefer the pushed remote manifest digest over a stale local Docker image digest.
- Makes Torghut's file-length CI gate diff-aware so shared Docker script changes do not fail on unrelated pre-existing Torghut modules.

## Related Issues

None

## Testing

- `BUILDX_BUILDER=codex-jangar AGENTS_APPLY=false AGENTS_BUILD_RUNNER=false AGENTS_IMAGE_TAG=17a315d04 AGENTS_IMAGE_PLATFORMS=linux/amd64,linux/arm64 AGENTS_BUILD_CACHE_REF='' AGENTS_BUILD_NODE_OPTIONS='--max-old-space-size=4096' AGENTS_BUILD_SOURCEMAP=0 AGENTS_BUILD_CI=true AGENTS_BUILD_LOG_LEVEL=warn DOCKER_BUILD_PROVENANCE=max DOCKER_BUILD_SBOM=true bun run agents:deploy -- --skip-runner --no-apply`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/agents-controller:17a315d04@sha256:96c6b68d191cdb50b4429b6009ca63f5c941d44b093fa49f01a7b99f5db0870b`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/agents-control-plane:17a315d04@sha256:447b37336cd42ad23526fe7c0f462cbb838f8ec08f5eb2a0e48de65be633fbdb`
- `bun test packages/scripts/src/shared/__tests__/docker.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/docker.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents-multiarch.yaml`
- `kubectl apply --dry-run=server -f /tmp/agents-multiarch.yaml`
- `rg -n "kubernetes.io/arch|nodeSelector:" /tmp/agents-multiarch.yaml || true`
- Local shell smoke for the Torghut file-length gate changed-file detection printed `No changed Torghut Python files for Pylint file length gate.`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/torghut-ci.yml"); puts "torghut-ci yaml parsed"'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
