### PR TITLE
ci(torghut): fix push diff base for file length gate

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,7 +43,7 @@ jobs:
           page=1
           while true; do
             response="$(
-              curl -fsSL \
+              curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
                 -H 'Accept: application/vnd.github+json' \
                 -H 'X-GitHub-Api-Version: 2022-11-28' \
                 "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}"

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -387,6 +387,31 @@ jobs:
         working-directory: services/torghut
         run: uv sync --frozen --extra dev
 
+      - name: Resolve Torghut diff base
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          repo_root="$(git rev-parse --show-toplevel)"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            if [ -z "${BASE_REF}" ]; then
+              echo "BASE_REF is required for pull_request Torghut diff base resolution" >&2
+              exit 1
+            fi
+            base="$(git -C "${repo_root}" merge-base "origin/${BASE_REF}" HEAD)"
+          elif [ -n "${BEFORE_SHA}" ] && ! [[ "${BEFORE_SHA}" =~ ^0+$ ]] && git -C "${repo_root}" cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            base="${BEFORE_SHA}"
+          else
+            base="$(git -C "${repo_root}" rev-parse HEAD^)"
+          fi
+
+          echo "Resolved Torghut diff base: ${base}"
+          echo "TORGHUT_DIFF_BASE=${base}" >> "${GITHUB_ENV}"
+
       - name: Bytecode check
         working-directory: services/torghut
         run: uv run --frozen python -m compileall app scripts
@@ -406,8 +431,7 @@ jobs:
           set -euo pipefail
 
           repo_root="$(git rev-parse --show-toplevel)"
-          base_spec="origin/${GITHUB_BASE_REF:-main}"
-          base="$(git -C "${repo_root}" merge-base "${base_spec}" HEAD 2>/dev/null || git -C "${repo_root}" rev-parse HEAD^)"
+          base="${TORGHUT_DIFF_BASE:?TORGHUT_DIFF_BASE is required}"
           changed_python=()
           while IFS= read -r python_file; do
             changed_python+=("${python_file}")
@@ -434,8 +458,7 @@ jobs:
           set -euo pipefail
 
           repo_root="$(git rev-parse --show-toplevel)"
-          base_spec="origin/${GITHUB_BASE_REF:-main}"
-          base="$(git -C "${repo_root}" merge-base "${base_spec}" HEAD 2>/dev/null || git -C "${repo_root}" rev-parse HEAD^)"
+          base="${TORGHUT_DIFF_BASE:?TORGHUT_DIFF_BASE is required}"
           changed_python=()
           while IFS= read -r python_file; do
             changed_python+=("${python_file}")
@@ -463,8 +486,7 @@ jobs:
           set -euo pipefail
 
           repo_root="$(git rev-parse --show-toplevel)"
-          base_spec="origin/${GITHUB_BASE_REF:-main}"
-          base="$(git -C "${repo_root}" merge-base "${base_spec}" HEAD 2>/dev/null || git -C "${repo_root}" rev-parse HEAD^)"
+          base="${TORGHUT_DIFF_BASE:?TORGHUT_DIFF_BASE is required}"
           changed_python=()
           while IFS= read -r python_file; do
             changed_python+=("${python_file}")

--- a/services/torghut/scripts/run_pylint_torghut_file_length_gate.py
+++ b/services/torghut/scripts/run_pylint_torghut_file_length_gate.py
@@ -16,6 +16,17 @@ _PYLINT_MESSAGE_RE = re.compile(
     r"(?P<code>[A-Z]\d+): "
 )
 _SOURCE_PAYLOAD_FILE_PREFIX = "source_" + "segment_"
+# PR 10945 turned these generated payloads into real modules. Later cleanup PRs
+# should split them; until then, keep the gate blocking every other long file.
+_TRANSITIONAL_EXTRACTED_SOURCE_MODULES = {
+    "app/trading/autonomy/lane.py",
+    "app/trading/discovery/candidate_specs.py",
+    "app/trading/research_sleeves.py",
+    "scripts/assemble_runtime_ledger_proof_packet.py",
+    "scripts/import_hypothesis_runtime_windows.py",
+    "scripts/run_whitepaper_autoresearch_profit_target.py",
+    "scripts/search_consistent_profitability_frontier.py",
+}
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -28,7 +39,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("files", nargs="+", help="Paths to pass to Pylint")
     args = parser.parse_args(argv)
 
-    extracted_paths = _base_extracted_source_paths(args.base)
+    extracted_paths = (
+        _TRANSITIONAL_EXTRACTED_SOURCE_MODULES | _base_extracted_source_paths(args.base)
+    )
     pylint_output = _run(
         [
             sys.executable,

--- a/services/torghut/tests/test_pylint_torghut_gate_helpers.py
+++ b/services/torghut/tests/test_pylint_torghut_gate_helpers.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import subprocess
+
+from scripts import run_pylint_torghut_file_length_gate as file_length_gate
 from scripts.run_pylint_torghut_file_length_gate import (
+    _TRANSITIONAL_EXTRACTED_SOURCE_MODULES,
     _filter_legacy_extracted_messages,
 )
 from scripts.run_pylint_torghut_quality_diff_gate import _source_literal_lines
@@ -30,3 +34,60 @@ def test_file_length_filter_ignores_only_extracted_source_paths() -> None:
     assert messages == [
         "app/trading/new_long_module.py:1:0: C0302: Too many lines in module (1200/1000) (too-many-lines)"
     ]
+
+
+def test_file_length_filter_carries_transitional_extracted_source_baseline() -> None:
+    output = "\n".join(
+        (
+            "scripts/run_whitepaper_autoresearch_profit_target.py:1:0: C0302: Too many lines in module (13541/1000) (too-many-lines)",
+            "scripts/new_long_tool.py:1:0: C0302: Too many lines in module (1200/1000) (too-many-lines)",
+        )
+    )
+
+    messages = _filter_legacy_extracted_messages(
+        output,
+        extracted_paths=_TRANSITIONAL_EXTRACTED_SOURCE_MODULES,
+    )
+
+    assert messages == [
+        "scripts/new_long_tool.py:1:0: C0302: Too many lines in module (1200/1000) (too-many-lines)"
+    ]
+
+
+def test_file_length_main_combines_transitional_extracted_source_baseline(
+    monkeypatch,
+    capsys,
+) -> None:
+    def fake_base_extracted_source_paths(base: str) -> set[str]:
+        assert base == "HEAD^"
+        return set()
+
+    def fake_run(command, *, check: bool, cwd=None):
+        assert check is False
+        assert cwd is None
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(
+                "scripts/run_whitepaper_autoresearch_profit_target.py:1:0: "
+                "C0302: Too many lines in module (13541/1000) (too-many-lines)\n"
+            ),
+        )
+
+    monkeypatch.setattr(
+        file_length_gate,
+        "_base_extracted_source_paths",
+        fake_base_extracted_source_paths,
+    )
+    monkeypatch.setattr(file_length_gate, "_run", fake_run)
+
+    result = file_length_gate.main(
+        [
+            "--base",
+            "HEAD^",
+            "scripts/run_whitepaper_autoresearch_profit_target.py",
+        ]
+    )
+
+    assert result == 0
+    assert "No blocking Pylint file-length violations." in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Fix Torghut static-guards diff-base resolution for push events after the source-segment cleanup merge.
- Resolve `TORGHUT_DIFF_BASE` once per static-guards job and reuse it across the Pylint refactor, design, and file-length gates.
- Keep pull-request runs on the existing merge-base behavior while push runs prefer `github.event.before` and fall back to `HEAD^`.
- Carry an explicit transitional file-length baseline for the seven modules extracted from generated source payloads in PR 10945.
- Add retries to the repo-level PR changed-file API call after repeated GitHub 504 responses.

## Related Issues

None

## Testing

- Ran the workflow diff-base resolver command with `EVENT_NAME=push`, empty `BASE_REF`, and `BEFORE_SHA=17a315d04d457ae9d64ef52af67b3acaabefef06`; it returned `17a315d04d457ae9d64ef52af67b3acaabefef06`.
- Ran the workflow diff-base resolver command with `EVENT_NAME=pull_request`, `BASE_REF=main`, and empty `BEFORE_SHA`; it returned `deb28117dde1763ec151900366c9cb4547ce97c3`.
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base 17a315d04d457ae9d64ef52af67b3acaabefef06 app scripts tests migrations`
- `cd services/torghut && uv run --frozen ruff format --check scripts/run_pylint_torghut_file_length_gate.py tests/test_pylint_torghut_gate_helpers.py`
- `cd services/torghut && uv run --frozen ruff check scripts/run_pylint_torghut_file_length_gate.py tests/test_pylint_torghut_gate_helpers.py`
- `cd services/torghut && uv run --frozen pytest tests/test_pylint_torghut_gate_helpers.py`
- `base=$(git merge-base origin/main HEAD); cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base "${base}" scripts/run_pylint_torghut_file_length_gate.py tests/test_pylint_torghut_gate_helpers.py`
- `git diff --check`
- CI rerun after adding retries for the `check_changed_files` GitHub API 504 path.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
