### PR TITLE
fix(agents): render empty node selector

### DIFF
--- a/charts/agents/templates/deployment-controllers.yaml
+++ b/charts/agents/templates/deployment-controllers.yaml
@@ -109,9 +109,13 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- if hasKey .Values "nodeSelector" }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.nodeSelector }}
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+        {{- else }}
+        {}
+        {{- end }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -86,9 +86,13 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- if hasKey .Values "nodeSelector" }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.nodeSelector }}
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+        {{- else }}
+        {}
+        {{- end }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:


### PR DESCRIPTION
## Summary

- Render an explicit empty `nodeSelector: {}` when the Agents chart values define an empty selector.
- Apply the same behavior to the control-plane and controller Deployments.
- Allows GitOps to remove the stale live `kubernetes.io/arch=arm64` selector after the multi-arch image rollout.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents-node-selector-empty.yaml`
- `rg -n "nodeSelector:|kubernetes.io/arch" /tmp/agents-node-selector-empty.yaml`
- `kubectl apply --dry-run=server -f /tmp/agents-node-selector-empty.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
