### PR TITLE
fix(torghut): publish multi-arch live images

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -43,8 +44,9 @@ jobs:
           page=1
           while true; do
             response="$(
-              curl -fsSL \
+              curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
                 -H 'Accept: application/vnd.github+json' \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
                 -H 'X-GitHub-Api-Version: 2022-11-28' \
                 "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}"
             )"

--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -39,6 +39,11 @@ jobs:
         id: meta
         run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -83,26 +88,41 @@ jobs:
       - name: Build and push torghut image
         env:
           TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
-          TORGHUT_IMAGE_PLATFORMS: linux/arm64
+          TORGHUT_IMAGE_PLATFORMS: linux/amd64,linux/arm64
           # Remote cache export has intermittently canceled after the image push,
           # before the release contract can be written. Keep the image contract
           # path authoritative and skip the cache until the exporter is stable.
           TORGHUT_IMAGE_CACHE_REF: none
         run: bun run packages/scripts/src/torghut/build-image.ts
 
-      - name: Resolve pushed image digest
+      - name: Verify multi-arch image manifest
         id: digest
         shell: bash
         run: |
           set -euo pipefail
           IMAGE='registry.ide-newton.ts.net/lab/torghut'
           TAG='${{ steps.meta.outputs.tag }}'
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
-          if [ -z "${DIGEST}" ]; then
+          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
+          DIGEST="$(jq -r '.manifest.digest // empty' <<< "${MANIFEST_JSON}")"
+          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
             echo "Failed to resolve digest for ${IMAGE}:${TAG}"
             exit 1
           fi
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${MANIFEST_JSON}" | head -n 1
+            )"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}"
+              docker buildx imagetools inspect "${IMAGE}:${TAG}"
+              exit 1
+            fi
+            echo "platform_digest_${platform#linux/}=${platform_digest}" >> "$GITHUB_OUTPUT"
+          done
 
       - name: Write release contract artifact
         shell: bash
@@ -113,7 +133,10 @@ jobs:
             --source-sha "${GITHUB_SHA}" \
             --tag "${{ steps.meta.outputs.tag }}" \
             --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/torghut'
+            --image 'registry.ide-newton.ts.net/lab/torghut' \
+            --platforms 'linux/amd64,linux/arm64' \
+            --platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}' \
+            --platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'
 
       - name: Upload release contract artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -14,7 +14,12 @@ on:
       - '.github/workflows/torghut-deploy-automerge.yml'
       - '.github/workflows/torghut-post-deploy-verify.yml'
       - '.github/workflows/torghut-release.yml'
+      - '.github/workflows/torghut-ta-build-push.yaml'
+      - '.github/workflows/torghut-ta-release.yml'
+      - '.github/workflows/torghut-ws-build-push.yaml'
+      - '.github/workflows/torghut-ws-release.yml'
       - 'argocd/applications/torghut/**'
+      - 'argocd/applications/torghut-options/**'
   pull_request:
     paths:
       - 'services/torghut/**'
@@ -27,7 +32,12 @@ on:
       - '.github/workflows/torghut-deploy-automerge.yml'
       - '.github/workflows/torghut-post-deploy-verify.yml'
       - '.github/workflows/torghut-release.yml'
+      - '.github/workflows/torghut-ta-build-push.yaml'
+      - '.github/workflows/torghut-ta-release.yml'
+      - '.github/workflows/torghut-ws-build-push.yaml'
+      - '.github/workflows/torghut-ws-release.yml'
       - 'argocd/applications/torghut/**'
+      - 'argocd/applications/torghut-options/**'
   workflow_dispatch:
 
 permissions:
@@ -113,10 +123,10 @@ jobs:
 
           service=false
           manifests=false
-          if matches_any '^(services/torghut/|packages/scripts/src/torghut/|packages/scripts/src/shared/(cli|docker|git)\.ts$|\.github/workflows/torghut-(ci|deploy-automerge|post-deploy-verify|release)\.yml$|\.github/workflows/torghut-build-push\.yaml$)'; then
+          if matches_any '^(services/torghut/|packages/scripts/src/torghut/|packages/scripts/src/shared/(cli|docker|git)\.ts$|\.github/workflows/torghut-(ci|deploy-automerge|post-deploy-verify|release|ta-release|ws-release)\.yml$|\.github/workflows/torghut-(build-push|ta-build-push|ws-build-push)\.yaml$)'; then
             service=true
           fi
-          if matches_any '^argocd/applications/torghut/'; then
+          if matches_any '^argocd/applications/(torghut|torghut-options)/'; then
             manifests=true
           fi
 

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -30,6 +30,8 @@ on:
       - 'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
       - 'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
       - 'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'
+      - 'argocd/applications/torghut-options/catalog/deployment.yaml'
+      - 'argocd/applications/torghut-options/enricher/deployment.yaml'
       - '.github/workflows/torghut-deploy-automerge.yml'
 
 permissions:
@@ -88,6 +90,8 @@ jobs:
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
             'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'
+            'argocd/applications/torghut-options/catalog/deployment.yaml'
+            'argocd/applications/torghut-options/enricher/deployment.yaml'
           )
 
           contains() {

--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'argocd/applications/torghut/**'
+      - 'argocd/applications/torghut-options/**'
   workflow_dispatch:
     inputs:
       expected_revision:
@@ -108,7 +109,7 @@ jobs:
             git fetch --no-tags --depth=200 origin main
           fi
 
-          for app in torghut; do
+          for app in torghut torghut-options; do
             kubectl annotate application "${app}" -n argocd argocd.argoproj.io/refresh=hard --overwrite
           done
 
@@ -124,7 +125,7 @@ jobs:
             git cat-file -e "${revision}^{commit}" >/dev/null 2>&1
           }
 
-          for app in torghut; do
+          for app in torghut torghut-options; do
             for attempt in $(seq 1 90); do
               STATUS="$(kubectl get application "${app}" -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision} {.status.operationState.phase} {.status.operationState.syncResult.revision} {.status.history[-1].revision}')"
               SYNC_STATUS="$(echo "${STATUS}" | awk '{print $1}')"
@@ -220,6 +221,33 @@ jobs:
             fi
           elif [ "${SIM_KNSVC_READY}" != 'True' ]; then
             echo "Knative Service torghut-sim is not Ready"
+            exit 1
+          fi
+
+          for deployment in \
+            torghut-options-catalog \
+            torghut-options-enricher \
+            torghut-options-ta \
+            torghut-ta \
+            torghut-ta-sim \
+            torghut-ws \
+            torghut-ws-options; do
+            kubectl rollout status "deployment/${deployment}" -n torghut --timeout=10m
+          done
+
+          pull_failures="$(
+            kubectl get pods -n torghut -o json |
+              jq -r '
+                .items[] as $pod
+                | (($pod.status.initContainerStatuses // []) + ($pod.status.containerStatuses // []))[]?
+                | select(((.state.waiting.reason // "") == "ImagePullBackOff") or ((.state.waiting.reason // "") == "ErrImagePull"))
+                | select(.image | startswith("registry.ide-newton.ts.net/lab/torghut"))
+                | [$pod.metadata.name, .name, .image, .state.waiting.reason] | @tsv
+              '
+          )"
+          if [ -n "${pull_failures}" ]; then
+            echo "Torghut-managed image pull failures remain after deploy:"
+            printf '%s\n' "${pull_failures}"
             exit 1
           fi
 

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -117,7 +117,11 @@ jobs:
                     .github/workflows/torghut-ci.yml \
                     .github/workflows/torghut-deploy-automerge.yml \
                     .github/workflows/torghut-post-deploy-verify.yml \
-                    .github/workflows/torghut-release.yml
+                    .github/workflows/torghut-release.yml \
+                    .github/workflows/torghut-ta-build-push.yaml \
+                    .github/workflows/torghut-ta-release.yml \
+                    .github/workflows/torghut-ws-build-push.yaml \
+                    .github/workflows/torghut-ws-release.yml
                 )"
                 if [ -n "${TORGHUT_CHANGES}" ]; then
                   echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; newer Torghut build inputs changed:"
@@ -199,6 +203,29 @@ jobs:
 
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify promoted image platform contract
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image }}
+          IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${IMAGE_NAME}@${IMAGE_DIGEST}"
+          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE_REF}")"
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${MANIFEST_JSON}" | head -n 1
+            )"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Promoted image ${IMAGE_REF} is missing required platform ${platform}"
+              docker buildx imagetools inspect "${IMAGE_REF}"
+              exit 1
+            fi
+          done
+
       - name: Evaluate migration safety gate
         if: steps.meta.outputs.promote == 'true'
         id: migration
@@ -262,7 +289,9 @@ jobs:
             argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml \
-            argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml; then
+            argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml \
+            argocd/applications/torghut-options/catalog/deployment.yaml \
+            argocd/applications/torghut-options/enricher/deployment.yaml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -306,6 +335,8 @@ jobs:
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
             argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+            argocd/applications/torghut-options/catalog/deployment.yaml
+            argocd/applications/torghut-options/enricher/deployment.yaml
           body: |
             ## Summary
             Promote Torghut image into GitOps manifests.
@@ -314,6 +345,7 @@ jobs:
             - Image tag: `${{ steps.meta.outputs.tag }}`
             - Image digest: `${{ steps.digest.outputs.digest }}`
             - Migration change detected under `services/torghut/migrations/**`
+            - Manifests: core Torghut, simulation, jobs/workflows, options catalog, options enricher
             - Added `do-not-automerge`; manual DB migration approval required before merge
 
       - name: Create deploy pull request (auto-merge eligible)
@@ -352,6 +384,8 @@ jobs:
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
             argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+            argocd/applications/torghut-options/catalog/deployment.yaml
+            argocd/applications/torghut-options/enricher/deployment.yaml
           body: |
             ## Summary
             Promote Torghut image into GitOps manifests.
@@ -359,6 +393,7 @@ jobs:
             - Source commit: `${{ steps.meta.outputs.source_sha }}`
             - Image tag: `${{ steps.meta.outputs.tag }}`
             - Image digest: `${{ steps.digest.outputs.digest }}`
+            - Manifests: core Torghut, simulation, jobs/workflows, options catalog, options enricher
 
       - name: No manifest changes detected
         if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'

--- a/.github/workflows/torghut-ta-build-push.yaml
+++ b/.github/workflows/torghut-ta-build-push.yaml
@@ -5,6 +5,14 @@ permissions:
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/dorvud/**'
+      - 'packages/scripts/src/torghut/release-contract.ts'
+      - 'packages/scripts/src/shared/docker.ts'
+      - '.github/workflows/torghut-ta-build-push.yaml'
   workflow_run:
     workflows:
       - dorvud-ci
@@ -13,7 +21,12 @@ on:
 
 jobs:
   build-and-push:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      }}
     runs-on: arc-arm64
     steps:
       - name: Checkout
@@ -28,6 +41,11 @@ jobs:
         id: meta
         run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -36,7 +54,7 @@ jobs:
         with:
           context: services/dorvud
           file: services/dorvud/technical-analysis-flink/Dockerfile
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             registry.ide-newton.ts.net/lab/torghut-ta:${{ steps.meta.outputs.tag }}
@@ -44,19 +62,34 @@ jobs:
           cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ta:latest
           cache-to: type=inline
 
-      - name: Resolve pushed image digest
+      - name: Verify multi-arch image manifest
         id: digest
         shell: bash
         run: |
           set -euo pipefail
           IMAGE='registry.ide-newton.ts.net/lab/torghut-ta'
           TAG='${{ steps.meta.outputs.tag }}'
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
-          if [ -z "${DIGEST}" ]; then
+          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
+          DIGEST="$(jq -r '.manifest.digest // empty' <<< "${MANIFEST_JSON}")"
+          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
             echo "Failed to resolve digest for ${IMAGE}:${TAG}"
             exit 1
           fi
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${MANIFEST_JSON}" | head -n 1
+            )"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}"
+              docker buildx imagetools inspect "${IMAGE}:${TAG}"
+              exit 1
+            fi
+            echo "platform_digest_${platform#linux/}=${platform_digest}" >> "$GITHUB_OUTPUT"
+          done
 
       - name: Write release contract artifact
         shell: bash
@@ -67,7 +100,10 @@ jobs:
             --source-sha "${GITHUB_SHA}" \
             --tag "${{ steps.meta.outputs.tag }}" \
             --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/torghut-ta'
+            --image 'registry.ide-newton.ts.net/lab/torghut-ta' \
+            --platforms 'linux/amd64,linux/arm64' \
+            --platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}' \
+            --platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'
 
       - name: Upload release contract artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/torghut-ta-release.yml
+++ b/.github/workflows/torghut-ta-release.yml
@@ -175,6 +175,29 @@ jobs:
 
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify promoted image platform contract
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image }}
+          IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${IMAGE_NAME}@${IMAGE_DIGEST}"
+          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE_REF}")"
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${MANIFEST_JSON}" | head -n 1
+            )"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Promoted image ${IMAGE_REF} is missing required platform ${platform}"
+              docker buildx imagetools inspect "${IMAGE_REF}"
+              exit 1
+            fi
+          done
+
       - name: Update torghut ta manifests
         if: steps.meta.outputs.promote == 'true'
         shell: bash

--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -5,6 +5,14 @@ permissions:
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/dorvud/**'
+      - 'packages/scripts/src/torghut/release-contract.ts'
+      - 'packages/scripts/src/shared/docker.ts'
+      - '.github/workflows/torghut-ws-build-push.yaml'
   workflow_run:
     workflows:
       - dorvud-ci
@@ -13,7 +21,12 @@ on:
 
 jobs:
   build-and-push:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      }}
     runs-on: arc-arm64
     steps:
       - name: Checkout
@@ -28,6 +41,11 @@ jobs:
         id: meta
         run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -36,7 +54,7 @@ jobs:
         with:
           context: services/dorvud
           file: services/dorvud/websockets/Dockerfile
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             registry.ide-newton.ts.net/lab/torghut-ws:${{ steps.meta.outputs.tag }}
@@ -44,19 +62,34 @@ jobs:
           cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ws:latest
           cache-to: type=inline
 
-      - name: Resolve pushed image digest
+      - name: Verify multi-arch image manifest
         id: digest
         shell: bash
         run: |
           set -euo pipefail
           IMAGE='registry.ide-newton.ts.net/lab/torghut-ws'
           TAG='${{ steps.meta.outputs.tag }}'
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
-          if [ -z "${DIGEST}" ]; then
+          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
+          DIGEST="$(jq -r '.manifest.digest // empty' <<< "${MANIFEST_JSON}")"
+          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
             echo "Failed to resolve digest for ${IMAGE}:${TAG}"
             exit 1
           fi
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${MANIFEST_JSON}" | head -n 1
+            )"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}"
+              docker buildx imagetools inspect "${IMAGE}:${TAG}"
+              exit 1
+            fi
+            echo "platform_digest_${platform#linux/}=${platform_digest}" >> "$GITHUB_OUTPUT"
+          done
 
       - name: Write release contract artifact
         shell: bash
@@ -67,7 +100,10 @@ jobs:
             --source-sha "${GITHUB_SHA}" \
             --tag "${{ steps.meta.outputs.tag }}" \
             --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/torghut-ws'
+            --image 'registry.ide-newton.ts.net/lab/torghut-ws' \
+            --platforms 'linux/amd64,linux/arm64' \
+            --platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}' \
+            --platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'
 
       - name: Upload release contract artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/torghut-ws-release.yml
+++ b/.github/workflows/torghut-ws-release.yml
@@ -175,6 +175,29 @@ jobs:
 
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify promoted image platform contract
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image }}
+          IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${IMAGE_NAME}@${IMAGE_DIGEST}"
+          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE_REF}")"
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${MANIFEST_JSON}" | head -n 1
+            )"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Promoted image ${IMAGE_REF} is missing required platform ${platform}"
+              docker buildx imagetools inspect "${IMAGE_REF}"
+              exit 1
+            fi
+          done
+
       - name: Update torghut-ws options manifest
         if: steps.meta.outputs.promote == 'true'
         shell: bash

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -542,6 +542,10 @@ spec:
               value: d816842843a0ecc8d81506727a53ac5729858b3e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:8e7174da484164e1e4d1f2c3e9d59f454162a9f63875e0bda625611d421620ad
+            - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
+              value: linux/amd64,linux/arm64
+            - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS
+              value: linux/amd64,linux/arm64
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -404,6 +404,10 @@ spec:
               value: d816842843a0ecc8d81506727a53ac5729858b3e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:8e7174da484164e1e4d1f2c3e9d59f454162a9f63875e0bda625611d421620ad
+            - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
+              value: linux/amd64,linux/arm64
+            - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS
+              value: linux/amd64,linux/arm64
           livenessProbe:
             httpGet:
               path: /healthz

--- a/packages/scripts/src/shared/__tests__/docker.test.ts
+++ b/packages/scripts/src/shared/__tests__/docker.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 
-import { __private, buildAndPushDockerImage, inspectImageDigest, resolveBuildAttestations } from '../docker'
+import {
+  __private,
+  assertImageSupportsPlatforms,
+  buildAndPushDockerImage,
+  inspectImageDigest,
+  inspectImagePlatforms,
+  resolveBuildAttestations,
+} from '../docker'
 
 const originalSpawn = Bun.spawn
 const originalWhich = Bun.which
@@ -70,6 +77,83 @@ describe('inspectImageDigest', () => {
 
     const digest = inspectImageDigest('registry.example/froussard:latest')
     expect(digest).toBe('registry.example/froussard@sha256:111')
+  })
+})
+
+describe('inspectImagePlatforms', () => {
+  it('returns schedulable platforms and ignores attestation manifests', () => {
+    Bun.which = ((binary: string) => (binary === 'docker' ? '/usr/bin/docker' : null)) as typeof Bun.which
+    __private.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+      const joined = typeof command === 'string' ? command : command.join(' ')
+      if (joined.startsWith('docker buildx imagetools inspect')) {
+        return {
+          exitCode: 0,
+          stdout: Buffer.from(
+            JSON.stringify({
+              manifest: {
+                manifests: [
+                  {
+                    digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    platform: { os: 'linux', architecture: 'amd64' },
+                  },
+                  {
+                    digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                    platform: { os: 'unknown', architecture: 'unknown' },
+                  },
+                  {
+                    digest: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+                    platform: { os: 'linux', architecture: 'arm64' },
+                  },
+                ],
+              },
+            }),
+          ),
+          stderr: new Uint8Array(),
+        } as ReturnType<typeof Bun.spawnSync>
+      }
+      return { exitCode: 1, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
+    }) as typeof Bun.spawnSync)
+
+    expect(inspectImagePlatforms('registry.example/lab/torghut:tag')).toEqual([
+      {
+        platform: 'linux/amd64',
+        digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      {
+        platform: 'linux/arm64',
+        digest: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      },
+    ])
+  })
+
+  it('fails when a required platform is missing', () => {
+    Bun.which = ((binary: string) => (binary === 'docker' ? '/usr/bin/docker' : null)) as typeof Bun.which
+    __private.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+      const joined = typeof command === 'string' ? command : command.join(' ')
+      if (joined.startsWith('docker buildx imagetools inspect')) {
+        return {
+          exitCode: 0,
+          stdout: Buffer.from(
+            JSON.stringify({
+              manifest: {
+                manifests: [
+                  {
+                    digest: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+                    platform: { os: 'linux', architecture: 'arm64' },
+                  },
+                ],
+              },
+            }),
+          ),
+          stderr: new Uint8Array(),
+        } as ReturnType<typeof Bun.spawnSync>
+      }
+      return { exitCode: 1, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
+    }) as typeof Bun.spawnSync)
+
+    expect(() =>
+      assertImageSupportsPlatforms('registry.example/lab/torghut:tag', ['linux/amd64', 'linux/arm64']),
+    ).toThrow('missing required platform(s): linux/amd64')
   })
 })
 

--- a/packages/scripts/src/shared/docker.ts
+++ b/packages/scripts/src/shared/docker.ts
@@ -41,6 +41,11 @@ export type DockerBakeResult = {
   targets: Array<DockerBuildResult & { name: string }>
 }
 
+export type DockerImagePlatform = {
+  platform: string
+  digest: string
+}
+
 type SpawnSync = typeof Bun.spawnSync
 
 let spawnSyncImpl: SpawnSync = Bun.spawnSync
@@ -513,6 +518,64 @@ export const inspectImageDigestForPlatform = (image: string, platform: string): 
   }
 }
 
+export const inspectImagePlatforms = (image: string): DockerImagePlatform[] => {
+  ensureCli('docker')
+  const inspect = spawnSyncImpl(['docker', 'buildx', 'imagetools', 'inspect', '--format', '{{json .}}', image], {
+    cwd: repoRoot,
+  })
+
+  if (inspect.exitCode !== 0) {
+    const output = `${inspect.stdout.toString()}\n${inspect.stderr.toString()}`.trim()
+    throw new Error(`Unable to inspect image platforms for ${image}${output ? `: ${output}` : ''}`)
+  }
+
+  try {
+    const parsed = JSON.parse(inspect.stdout.toString()) as {
+      manifest?: {
+        manifests?: Array<{
+          digest?: string
+          platform?: { os?: string; architecture?: string; variant?: string }
+        }>
+      }
+    }
+    return (
+      parsed.manifest?.manifests
+        ?.map((entry) => {
+          const platform = formatPlatform(entry.platform)
+          const digest = entry.digest?.trim()
+          if (!platform || !digest) return undefined
+          return { platform, digest }
+        })
+        .filter((entry): entry is DockerImagePlatform => Boolean(entry)) ?? []
+    )
+  } catch (error) {
+    throw new Error(
+      `Failed to parse docker imagetools inspect output for ${image}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+}
+
+export const assertImageSupportsPlatforms = (image: string, requiredPlatforms: string[]): DockerImagePlatform[] => {
+  const observedPlatforms = inspectImagePlatforms(image)
+  const observed = new Set(observedPlatforms.map((entry) => entry.platform))
+  const missing = requiredPlatforms
+    .map((platform) => platform.trim())
+    .filter(Boolean)
+    .filter((platform) => !observed.has(platform))
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Image ${image} is missing required platform(s): ${missing.join(', ')}; observed: ${
+        [...observed].sort().join(', ') || 'none'
+      }`,
+    )
+  }
+
+  return observedPlatforms
+}
+
 const inspectLocalImageDigest = (image: string): string | undefined => {
   const inspect = spawnSyncImpl(['docker', 'image', 'inspect', '--format', '{{json .RepoDigests}}', image], {
     cwd: repoRoot,
@@ -593,6 +656,18 @@ const parsePlatform = (platform: string): { os: string; architecture: string; va
   return { os, architecture, variant }
 }
 
+const formatPlatform = (
+  platform: { os?: string; architecture?: string; variant?: string } | undefined,
+): string | undefined => {
+  const os = platform?.os?.trim()
+  const architecture = platform?.architecture?.trim()
+  const variant = platform?.variant?.trim()
+  if (!os || !architecture || os === 'unknown' || architecture === 'unknown') {
+    return undefined
+  }
+  return variant ? `${os}/${architecture}/${variant}` : `${os}/${architecture}`
+}
+
 const setSpawnSync = (fn?: SpawnSync) => {
   spawnSyncImpl = fn ?? Bun.spawnSync
 }
@@ -600,6 +675,7 @@ const setSpawnSync = (fn?: SpawnSync) => {
 export const __private = {
   inspectLocalImageDigest,
   inspectRemoteImageDigest,
+  formatPlatform,
   getRepositoryFromReference,
   isRetryableDockerCommandError,
   setSpawnSync,

--- a/packages/scripts/src/torghut/__tests__/build-image.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-image.test.ts
@@ -64,4 +64,25 @@ describe('buildImage', () => {
 
     expect(captured?.cacheRef).toBeUndefined()
   })
+
+  it('defaults to amd64 and arm64 image platforms', async () => {
+    let captured: DockerBuildOptions | undefined
+
+    __private.setExecGit((args) => {
+      if (args[0] === 'describe') return 'v0.1.0'
+      if (args[0] === 'rev-parse') return '0123456789abcdef0123456789abcdef01234567'
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+    __private.setBuildAndPushDockerImage(async (options) => {
+      captured = options
+      return {
+        ...options,
+        image: `${options.registry}/${options.repository}:${options.tag}`,
+      }
+    })
+
+    await buildImage({ tag: '01234567' })
+
+    expect(captured?.platforms).toEqual(['linux/amd64', 'linux/arm64'])
+  })
 })

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -15,6 +15,10 @@ const wsWorkflow = readFileSync(
   'utf8',
 )
 const ciWorkflow = readFileSync(new URL('../../../../../.github/workflows/torghut-ci.yml', import.meta.url), 'utf8')
+const pullRequestWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/pull-request.yml', import.meta.url),
+  'utf8',
+)
 
 const pathPatternIndex = (pattern: string): number =>
   workflow.split('\n').findIndex((line) => line.trim() === `- '${pattern}'`)
@@ -103,6 +107,20 @@ describe('torghut build-push workflow', () => {
     expect(authHeader).toBeGreaterThan(tokenEnv)
     expect(prFilesCall).toBeGreaterThan(authHeader)
     expect(compareCall).toBeGreaterThan(authHeader)
+  })
+
+  it('retries generic pull-request changed-file planner GitHub API calls', () => {
+    const changesJob = pullRequestWorkflow.indexOf('check_changed_files:')
+    const tokenEnv = pullRequestWorkflow.indexOf('GH_TOKEN: ${{ github.token }}', changesJob)
+    const retryCurl = pullRequestWorkflow.indexOf('curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors', tokenEnv)
+    const authHeader = pullRequestWorkflow.indexOf('-H "Authorization: Bearer ${GH_TOKEN}"', retryCurl)
+    const prFilesCall = pullRequestWorkflow.indexOf('/pulls/${PR_NUMBER}/files?per_page=100&page=${page}', authHeader)
+
+    expect(changesJob).toBeGreaterThan(-1)
+    expect(tokenEnv).toBeGreaterThan(changesJob)
+    expect(retryCurl).toBeGreaterThan(tokenEnv)
+    expect(authHeader).toBeGreaterThan(retryCurl)
+    expect(prFilesCall).toBeGreaterThan(authHeader)
   })
 
   it('does not cancel main source CI that release promotion must verify', () => {

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -6,6 +6,14 @@ const workflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-build-push.yaml', import.meta.url),
   'utf8',
 )
+const taWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-ta-build-push.yaml', import.meta.url),
+  'utf8',
+)
+const wsWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-ws-build-push.yaml', import.meta.url),
+  'utf8',
+)
 const ciWorkflow = readFileSync(new URL('../../../../../.github/workflows/torghut-ci.yml', import.meta.url), 'utf8')
 
 const pathPatternIndex = (pattern: string): number =>
@@ -40,6 +48,35 @@ describe('torghut build-push workflow', () => {
     expect(buildStep).toBeGreaterThan(registryWaitStep)
     expect(workflow).toContain('REGISTRY_URL: https://registry.ide-newton.ts.net/v2/')
     expect(workflow).toContain('REGISTRY_WAIT_TIMEOUT_SECONDS: 7200')
+  })
+
+  it('publishes and contracts the core Torghut image as amd64 and arm64', () => {
+    expect(workflow).toContain('TORGHUT_IMAGE_PLATFORMS: linux/amd64,linux/arm64')
+    expect(workflow).toContain('name: Set up Docker QEMU')
+    expect(workflow).toContain('name: Verify multi-arch image manifest')
+    expect(workflow).toContain('for platform in linux/amd64 linux/arm64; do')
+    expect(workflow).toContain("--platforms 'linux/amd64,linux/arm64'")
+    expect(workflow).toContain("--platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}'")
+    expect(workflow).toContain("--platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'")
+  })
+
+  it('publishes and contracts TA and WS images as amd64 and arm64 from direct pushes', () => {
+    for (const serviceWorkflow of [taWorkflow, wsWorkflow]) {
+      expect(serviceWorkflow).toContain('push:')
+      expect(serviceWorkflow).toContain("- 'services/dorvud/**'")
+      expect(serviceWorkflow).toContain("github.event_name == 'push'")
+      expect(serviceWorkflow).toContain('name: Set up Docker QEMU')
+      expect(serviceWorkflow).toContain('platforms: linux/amd64,linux/arm64')
+      expect(serviceWorkflow).toContain('name: Verify multi-arch image manifest')
+      expect(serviceWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')
+      expect(serviceWorkflow).toContain("--platforms 'linux/amd64,linux/arm64'")
+      expect(serviceWorkflow).toContain(
+        "--platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}'",
+      )
+      expect(serviceWorkflow).toContain(
+        "--platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'",
+      )
+    }
   })
 
   it('caches Bun downloads before manifest-only CI installs script dependencies', () => {

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -28,10 +28,17 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('[ "${OPERATION_PHASE}" = \'Succeeded\' ]')
   })
 
-  it('keeps options and websocket deployments out of core Torghut post-deploy verification', () => {
-    expect(workflow).not.toContain('torghut-options')
-    expect(workflow).not.toContain('kubectl rollout status deployment/torghut-ws')
-    expect(workflow).not.toContain('http://torghut-ws.torghut.svc.cluster.local/readyz')
+  it('verifies options, TA, and websocket deployments after Torghut GitOps changes', () => {
+    expect(workflow).toContain("- 'argocd/applications/torghut-options/**'")
+    expect(workflow).toContain('for app in torghut torghut-options; do')
+    expect(workflow).toContain('kubectl rollout status "deployment/${deployment}"')
+    expect(workflow).toContain('torghut-options-catalog')
+    expect(workflow).toContain('torghut-options-enricher')
+    expect(workflow).toContain('torghut-options-ta')
+    expect(workflow).toContain('torghut-ta')
+    expect(workflow).toContain('torghut-ta-sim')
+    expect(workflow).toContain('torghut-ws')
+    expect(workflow).toContain('torghut-ws-options')
   })
 
   it('delegates readyz acceptance to the revenue repair evidence validator', () => {
@@ -86,8 +93,14 @@ describe('torghut post-deploy verifier workflow', () => {
 
   it('requests Argo refresh before polling deployed revisions', () => {
     expect(workflow).toContain('argocd.argoproj.io/refresh=hard --overwrite')
-    expect(workflow).toContain('for app in torghut; do')
-    expect(workflow).not.toContain('for app in torghut torghut-options; do')
+    expect(workflow).toContain('for app in torghut torghut-options; do')
+  })
+
+  it('fails when Torghut-managed images still have pull errors', () => {
+    expect(workflow).toContain('ImagePullBackOff')
+    expect(workflow).toContain('ErrImagePull')
+    expect(workflow).toContain('startswith("registry.ide-newton.ts.net/lab/torghut")')
+    expect(workflow).toContain('Torghut-managed image pull failures remain after deploy')
   })
 
   it('grants the ARC runner read access to Torghut Knative Service readiness', () => {

--- a/packages/scripts/src/torghut/__tests__/release-contract.test.ts
+++ b/packages/scripts/src/torghut/__tests__/release-contract.test.ts
@@ -6,6 +6,11 @@ import { join, relative } from 'node:path'
 import { repoRoot } from '../../shared/cli'
 import { readReleaseContract, writeReleaseContract } from '../release-contract'
 
+const platformDigests = {
+  'linux/amd64': 'sha256:1111111111111111111111111111111111111111111111111111111111111111',
+  'linux/arm64': 'sha256:2222222222222222222222222222222222222222222222222222222222222222',
+}
+
 describe('torghut release-contract', () => {
   it('writes and reads a valid contract', () => {
     const dir = mkdtempSync(join(tmpdir(), 'torghut-release-contract-'))
@@ -16,6 +21,8 @@ describe('torghut release-contract', () => {
       tag: '12345678',
       digest: 'sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe',
       image: 'registry.ide-newton.ts.net/lab/torghut',
+      platforms: ['linux/amd64', 'linux/arm64'],
+      platformDigests,
       createdAt: '2026-02-21T00:00:00.000Z',
     })
 
@@ -25,6 +32,8 @@ describe('torghut release-contract', () => {
       tag: '12345678',
       digest: 'sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe',
       image: 'registry.ide-newton.ts.net/lab/torghut',
+      platforms: ['linux/amd64', 'linux/arm64'],
+      platformDigests,
       createdAt: '2026-02-21T00:00:00.000Z',
     })
 
@@ -41,11 +50,54 @@ describe('torghut release-contract', () => {
       digest:
         'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
       image: 'registry.ide-newton.ts.net/lab/torghut',
+      platforms: ['linux/amd64', 'linux/arm64'],
+      platformDigests: {
+        'linux/amd64':
+          'registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111',
+        'linux/arm64':
+          'registry.ide-newton.ts.net/lab/torghut@sha256:2222222222222222222222222222222222222222222222222222222222222222',
+      },
       createdAt: '2026-02-21T00:01:00.000Z',
     })
 
     const parsed = readReleaseContract(relative(repoRoot, contractPath))
     expect(parsed.digest).toBe('sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
+    expect(parsed.platformDigests).toEqual(platformDigests)
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('rejects contracts without required platform metadata', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'torghut-release-contract-'))
+    const contractPath = join(dir, 'contract.json')
+
+    expect(() =>
+      writeReleaseContract(relative(repoRoot, contractPath), {
+        sourceSha: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        tag: 'abcdefab',
+        digest: 'sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+        image: 'registry.ide-newton.ts.net/lab/torghut',
+        platforms: ['linux/arm64'],
+        platformDigests: {
+          'linux/arm64': 'sha256:2222222222222222222222222222222222222222222222222222222222222222',
+        },
+        createdAt: '2026-02-21T00:01:00.000Z',
+      }),
+    ).toThrow('platforms missing required values: linux/amd64')
+
+    expect(() =>
+      writeReleaseContract(relative(repoRoot, contractPath), {
+        sourceSha: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        tag: 'abcdefab',
+        digest: 'sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+        image: 'registry.ide-newton.ts.net/lab/torghut',
+        platforms: ['linux/amd64', 'linux/arm64'],
+        platformDigests: {
+          'linux/arm64': 'sha256:2222222222222222222222222222222222222222222222222222222222222222',
+        },
+        createdAt: '2026-02-21T00:01:00.000Z',
+      }),
+    ).toThrow("Invalid digest for platform 'linux/amd64'")
 
     rmSync(dir, { recursive: true, force: true })
   })

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -354,12 +354,14 @@ describe('update-manifests', () => {
     expect(serviceManifest).toContain('value: v0.600.0')
     expect(serviceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(serviceManifest).toContain('value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
+    expect(serviceManifest).toContain('value: linux/amd64,linux/arm64')
     expect(simulationServiceManifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
     expect(simulationServiceManifest).toContain('value: v0.600.0')
     expect(simulationServiceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(simulationServiceManifest).toContain(
       'value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
+    expect(simulationServiceManifest).toContain('value: linux/amd64,linux/arm64')
     expect(migrationManifest).toContain(
       'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
@@ -401,25 +403,25 @@ describe('update-manifests', () => {
     ).toBe(2)
     for (const manifest of [optionsCatalogManifest, optionsEnricherManifest]) {
       expect(manifest).toContain(
-        'image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111',
+        'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
       )
-      expect(manifest).toContain('value: old-version')
-      expect(manifest).toContain('value: old-commit')
+      expect(manifest).toContain('value: v0.600.0')
+      expect(manifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     }
     expect(result.changed).toBe(true)
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(20)
+    expect(result.changedPaths.length).toBe(22)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
 
-  it('updates options manifests only when explicitly included', () => {
+  it('can skip options manifests when explicitly disabled', () => {
     const fixture = createFixture()
     const result = __private.updateTorghutManifests(
       updateOptionsForFixture(fixture, {
-        includeOptionsManifests: true,
+        includeOptionsManifests: false,
       }),
     )
     const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
@@ -427,12 +429,12 @@ describe('update-manifests', () => {
 
     for (const manifest of [optionsCatalogManifest, optionsEnricherManifest]) {
       expect(manifest).toContain(
-        'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+        'image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111',
       )
-      expect(manifest).toContain('value: v0.600.0')
-      expect(manifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+      expect(manifest).toContain('value: old-version')
+      expect(manifest).toContain('value: old-commit')
     }
-    expect(result.changedPaths.length).toBe(22)
+    expect(result.changedPaths.length).toBe(20)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })

--- a/packages/scripts/src/torghut/build-image.ts
+++ b/packages/scripts/src/torghut/build-image.ts
@@ -48,7 +48,7 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
           .split(',')
           .map((p) => p.trim())
           .filter((p) => p.length > 0 && p.toLowerCase() !== 'none')
-      : ['linux/arm64'])
+      : ['linux/amd64', 'linux/arm64'])
 
   const version = execGitImpl(['describe', '--tags', '--always'])
   const commit = execGitImpl(['rev-parse', 'HEAD'])

--- a/packages/scripts/src/torghut/deploy-service.ts
+++ b/packages/scripts/src/torghut/deploy-service.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import YAML from 'yaml'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { buildAndPushDockerImage, inspectImageDigest, inspectImageDigestForPlatform } from '../shared/docker'
+import { buildAndPushDockerImage, inspectImageDigest } from '../shared/docker'
 import { buildImage } from './build-image'
 
 const manifestPath = resolve(repoRoot, 'argocd/applications/torghut/knative-service.yaml')
@@ -344,7 +344,7 @@ const buildWebsocketImage = async () => {
   )
   const platforms = process.env.TORGHUT_WS_IMAGE_PLATFORMS?.split(',')
     .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/arm64']
+    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/amd64', 'linux/arm64']
   const codexAuthPath = process.env.TORGHUT_WS_CODEX_AUTH_PATH
 
   return buildAndPushDockerImage({
@@ -369,7 +369,7 @@ const buildTechnicalAnalysisImage = async () => {
   )
   const platforms = process.env.TORGHUT_TA_IMAGE_PLATFORMS?.split(',')
     .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/arm64']
+    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/amd64', 'linux/arm64']
   const codexAuthPath = process.env.TORGHUT_TA_CODEX_AUTH_PATH
 
   return buildAndPushDockerImage({
@@ -594,18 +594,14 @@ const applyTechnicalAnalysisResources = async () => {
 const main = async () => {
   ensureTools()
 
-  const defaultPlatform = process.env.TORGHUT_IMAGE_PLATFORM ?? 'linux/arm64'
   const { image, version, commit } = await buildImage()
-  const digestRef = inspectImageDigestForPlatform(image, defaultPlatform) ?? inspectImageDigest(image)
+  const digestRef = inspectImageDigest(image)
 
   const websocketImage = await buildWebsocketImage()
-  const websocketPlatform = process.env.TORGHUT_WS_IMAGE_PLATFORM ?? defaultPlatform
-  const websocketDigestRef =
-    inspectImageDigestForPlatform(websocketImage.image, websocketPlatform) ?? inspectImageDigest(websocketImage.image)
+  const websocketDigestRef = inspectImageDigest(websocketImage.image)
 
   const taImage = await buildTechnicalAnalysisImage()
-  const taPlatform = process.env.TORGHUT_TA_IMAGE_PLATFORM ?? defaultPlatform
-  const taDigestRef = inspectImageDigestForPlatform(taImage.image, taPlatform) ?? inspectImageDigest(taImage.image)
+  const taDigestRef = inspectImageDigest(taImage.image)
 
   updateManifest(digestRef, version, commit)
   updateWebsocketDeployment(websocketDigestRef, version, commit)

--- a/packages/scripts/src/torghut/deploy-ta.ts
+++ b/packages/scripts/src/torghut/deploy-ta.ts
@@ -30,7 +30,7 @@ const buildTechnicalAnalysisImage = async () => {
   )
   const platforms = process.env.TORGHUT_TA_IMAGE_PLATFORMS?.split(',')
     .map((entry) => entry.trim())
-    .filter(Boolean) ?? ['linux/arm64']
+    .filter(Boolean) ?? ['linux/amd64', 'linux/arm64']
   const codexAuthPath = process.env.TORGHUT_TA_CODEX_AUTH_PATH
   const version = execGit(['describe', '--tags', '--always'])
   const commit = execGit(['rev-parse', 'HEAD'])

--- a/packages/scripts/src/torghut/release-contract.ts
+++ b/packages/scripts/src/torghut/release-contract.ts
@@ -11,12 +11,15 @@ const defaultContractPath = 'torghut-release-contract.json'
 const sourceShaPattern = /^[0-9a-f]{40}$/i
 const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
 const digestPattern = /^sha256:[0-9a-f]{64}$/i
+const requiredPlatforms = ['linux/amd64', 'linux/arm64'] as const
 
 export type TorghutReleaseContract = {
   sourceSha: string
   tag: string
   digest: string
   image: string
+  platforms: string[]
+  platformDigests: Record<string, string>
   createdAt: string
 }
 
@@ -29,6 +32,8 @@ type CliOptions = {
   tag?: string
   digest?: string
   image?: string
+  platforms?: string[]
+  platformDigests?: Record<string, string>
   field?: ContractField
 }
 
@@ -38,6 +43,34 @@ const normalizeDigest = (value: string): string => {
     return trimmed
   }
   return trimmed.includes('@') ? trimmed.slice(trimmed.lastIndexOf('@') + 1) : trimmed
+}
+
+const parsePlatformList = (value: string): string[] =>
+  value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+const normalizePlatformDigests = (value: Record<string, unknown>): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(value)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      .map(([platform, digest]) => [platform.trim(), normalizeDigest(digest)])
+      .filter(([platform]) => platform),
+  )
+
+const parsePlatformDigest = (value: string): [string, string] => {
+  const separatorIndex = value.indexOf('=')
+  if (separatorIndex < 0) {
+    throw new Error(`Invalid platform digest '${value}'; expected <platform>=<sha256:...>`)
+  }
+
+  const platform = value.slice(0, separatorIndex).trim()
+  const digest = normalizeDigest(value.slice(separatorIndex + 1))
+  if (!platform || !digest) {
+    throw new Error(`Invalid platform digest '${value}'; expected <platform>=<sha256:...>`)
+  }
+  return [platform, digest]
 }
 
 const resolveContractPath = (path: string) => resolve(repoRoot, path)
@@ -58,9 +91,11 @@ Commands:
     --tag <tag>
     --digest <sha256:...>
     --image <registry/repo>
+    --platforms <linux/amd64,linux/arm64>
+    --platform-digest <platform>=<sha256:...>  May be repeated
   get
     --path <path>
-    --field <sourceSha|tag|digest|image|createdAt>
+    --field <sourceSha|tag|digest|image|platforms|platformDigests|createdAt>
   emit-github-output
     --path <path>`)
       process.exit(0)
@@ -100,8 +135,18 @@ Commands:
       case '--image':
         options.image = value
         break
+      case '--platforms':
+        options.platforms = parsePlatformList(value)
+        break
+      case '--platform-digest':
+        options.platformDigests ??= {}
+        {
+          const [platform, digest] = parsePlatformDigest(value)
+          options.platformDigests[platform] = digest
+        }
+        break
       case '--field':
-        if (!['sourceSha', 'tag', 'digest', 'image', 'createdAt'].includes(value)) {
+        if (!['sourceSha', 'tag', 'digest', 'image', 'platforms', 'platformDigests', 'createdAt'].includes(value)) {
           throw new Error(`Unknown field: ${value}`)
         }
         options.field = value as ContractField
@@ -127,6 +172,26 @@ const assertValidContract = (contract: TorghutReleaseContract) => {
   if (!contract.image.trim()) {
     throw new Error('image cannot be empty')
   }
+  if (!Array.isArray(contract.platforms) || contract.platforms.length === 0) {
+    throw new Error('platforms cannot be empty')
+  }
+  const uniquePlatforms = new Set(contract.platforms)
+  if (uniquePlatforms.size !== contract.platforms.length) {
+    throw new Error(`platforms contains duplicates: ${contract.platforms.join(', ')}`)
+  }
+  const missingRequiredPlatforms = requiredPlatforms.filter((platform) => !uniquePlatforms.has(platform))
+  if (missingRequiredPlatforms.length > 0) {
+    throw new Error(`platforms missing required values: ${missingRequiredPlatforms.join(', ')}`)
+  }
+  for (const platform of contract.platforms) {
+    if (!platform.trim() || !/^[a-z0-9]+\/[a-z0-9]+(?:\/[A-Za-z0-9._-]+)?$/.test(platform)) {
+      throw new Error(`Invalid platform '${platform}'`)
+    }
+    const platformDigest = contract.platformDigests[platform]
+    if (!digestPattern.test(platformDigest ?? '')) {
+      throw new Error(`Invalid digest for platform '${platform}': '${platformDigest ?? ''}'`)
+    }
+  }
   if (!contract.createdAt.trim()) {
     throw new Error('createdAt cannot be empty')
   }
@@ -139,6 +204,8 @@ export const writeReleaseContract = (path: string, contract: TorghutReleaseContr
   const normalized: TorghutReleaseContract = {
     ...contract,
     digest: normalizeDigest(contract.digest),
+    platforms: [...contract.platforms],
+    platformDigests: normalizePlatformDigests(contract.platformDigests),
   }
   assertValidContract(normalized)
   writeFileSync(resolveContractPath(path), `${JSON.stringify(normalized, null, 2)}\n`, 'utf8')
@@ -152,6 +219,13 @@ export const readReleaseContract = (path: string): TorghutReleaseContract => {
     tag: parsed.tag ?? '',
     digest: normalizeDigest(parsed.digest ?? ''),
     image: parsed.image ?? '',
+    platforms: Array.isArray(parsed.platforms)
+      ? parsed.platforms.filter((value): value is string => typeof value === 'string')
+      : [],
+    platformDigests:
+      parsed.platformDigests && typeof parsed.platformDigests === 'object' && !Array.isArray(parsed.platformDigests)
+        ? normalizePlatformDigests(parsed.platformDigests as Record<string, string>)
+        : {},
     createdAt: parsed.createdAt ?? '',
   }
   assertValidContract(contract)
@@ -172,6 +246,8 @@ const main = (cliOptions?: CliOptions) => {
     const tag = parsed.tag?.trim() ?? ''
     const digest = normalizeDigest(parsed.digest ?? '')
     const image = parsed.image?.trim() ?? ''
+    const platforms = parsed.platforms ?? []
+    const platformDigests = parsed.platformDigests ?? {}
     const createdAt = new Date().toISOString()
 
     writeReleaseContract(path, {
@@ -179,6 +255,8 @@ const main = (cliOptions?: CliOptions) => {
       tag,
       digest,
       image,
+      platforms,
+      platformDigests,
       createdAt,
     })
     return
@@ -190,7 +268,8 @@ const main = (cliOptions?: CliOptions) => {
     if (!parsed.field) {
       throw new Error('get requires --field')
     }
-    console.log(contract[parsed.field])
+    const value = contract[parsed.field]
+    console.log(typeof value === 'string' ? value : JSON.stringify(value))
     return
   }
 
@@ -198,6 +277,8 @@ const main = (cliOptions?: CliOptions) => {
   console.log(`tag=${contract.tag}`)
   console.log(`digest=${contract.digest}`)
   console.log(`image=${contract.image}`)
+  console.log(`platforms=${contract.platforms.join(',')}`)
+  console.log(`platform_digests=${JSON.stringify(contract.platformDigests)}`)
   console.log(`created_at=${contract.createdAt}`)
 }
 

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -40,6 +40,7 @@ const defaultTigerBeetleJournalOrderEventsManifestPath =
   'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'
 const defaultOptionsCatalogManifestPath = 'argocd/applications/torghut-options/catalog/deployment.yaml'
 const defaultOptionsEnricherManifestPath = 'argocd/applications/torghut-options/enricher/deployment.yaml'
+const defaultRequiredImagePlatforms = 'linux/amd64,linux/arm64'
 
 const digestPattern = /^sha256:[0-9a-f]{64}$/i
 
@@ -188,6 +189,8 @@ const updateTorghutManifest = (options: UpdateManifestsOptions) => {
   updated = replaceIfPresent(updated, /(- name:\s*TORGHUT_VERSION\s*\n\s*value:\s*)([^\n]+)/, `$1${options.version}`)
   updated = replaceIfPresent(updated, /(- name:\s*TORGHUT_COMMIT\s*\n\s*value:\s*)([^\n]+)/, `$1${options.commit}`)
   updated = upsertKnativeEnvValue(updated, 'TORGHUT_IMAGE_DIGEST', options.digest)
+  updated = upsertKnativeEnvValue(updated, 'TORGHUT_REQUIRED_IMAGE_PLATFORMS', defaultRequiredImagePlatforms)
+  updated = upsertKnativeEnvValue(updated, 'TORGHUT_OBSERVED_IMAGE_PLATFORMS', defaultRequiredImagePlatforms)
   updated = updated.replace(/^\s*serving\.knative\.dev\/lastModifier:\s*[^\n]+\n/gm, '')
 
   if (updated !== source) {
@@ -387,7 +390,8 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.tigerBeetleJournalOrderEventsManifestPath ?? defaultTigerBeetleJournalOrderEventsManifestPath,
     'torghut-tigerbeetle-journal-order-events image reference',
   )
-  const optionalResults = options.includeOptionsManifests
+  const includeOptionsManifests = options.includeOptionsManifests ?? true
+  const optionalResults = includeOptionsManifests
     ? [
         updateVersionedDeploymentManifest(
           options,
@@ -598,7 +602,10 @@ Options:
   return options
 }
 
-const parseBooleanEnv = (value: string | undefined): boolean => value === '1' || value?.toLowerCase() === 'true'
+const parseOptionalBooleanEnv = (value: string | undefined): boolean | undefined => {
+  if (value === undefined) return undefined
+  return value === '1' || value.toLowerCase() === 'true'
+}
 
 const main = (cliOptions?: CliOptions) => {
   const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
@@ -662,7 +669,7 @@ const main = (cliOptions?: CliOptions) => {
       parsed.tigerBeetleJournalOrderEventsManifestPath ??
       process.env.TORGHUT_TIGERBEETLE_JOURNAL_ORDER_EVENTS_MANIFEST_PATH,
     includeOptionsManifests:
-      parsed.includeOptionsManifests ?? parseBooleanEnv(process.env.TORGHUT_INCLUDE_OPTIONS_MANIFESTS),
+      parsed.includeOptionsManifests ?? parseOptionalBooleanEnv(process.env.TORGHUT_INCLUDE_OPTIONS_MANIFESTS),
     optionsCatalogManifestPath: parsed.optionsCatalogManifestPath ?? process.env.TORGHUT_OPTIONS_CATALOG_MANIFEST_PATH,
     optionsEnricherManifestPath:
       parsed.optionsEnricherManifestPath ?? process.env.TORGHUT_OPTIONS_ENRICHER_MANIFEST_PATH,


### PR DESCRIPTION
## Summary

- Builds `lab/torghut`, `lab/torghut-ta`, and `lab/torghut-ws` for `linux/amd64,linux/arm64` and verifies the pushed OCI index before writing release contracts.
- Extends Torghut release contracts with required platform metadata and child platform digests so stale single-arch artifacts fail promotion.
- Promotes options catalog/enricher manifests with core Torghut releases and records required/observed image platforms in service/sim manifests.
- Expands post-deploy verification to refresh `torghut` and `torghut-options`, check TA/WS/options rollouts, and fail on Torghut-owned image pull errors.
- Retries and authenticates the generic PR changed-file planner so transient GitHub API 504s do not fail unrelated CI gates.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/docker.test.ts packages/scripts/src/torghut/__tests__/build-image.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/release-contract.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/update-ta-manifest.test.ts packages/scripts/src/torghut/__tests__/update-ws-manifest.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run --filter @proompteng/scripts lint:oxlint:type`
- `bun run lint:argocd`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-build-push.yaml .github/workflows/torghut-ta-build-push.yaml .github/workflows/torghut-ws-build-push.yaml .github/workflows/torghut-release.yml .github/workflows/torghut-ta-release.yml .github/workflows/torghut-ws-release.yml .github/workflows/torghut-post-deploy-verify.yml .github/workflows/torghut-ci.yml .github/workflows/torghut-deploy-automerge.yml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
