### PR TITLE
chore(symphony): promote image d8168428

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-16T07:05:11Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:08:33Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e874f7df"
-    digest: sha256:1bd8cfa6d44e34a40dcf96b52d191ca9ec0725b0d3ef4be98866df5645837d44
+    newTag: "d8168428"
+    digest: sha256:c92076682e168756da0963e4423776e28558c5a54ba0cdffbe91c786e795a237

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-16T07:05:11Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:08:33Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e874f7df"
-    digest: sha256:1bd8cfa6d44e34a40dcf96b52d191ca9ec0725b0d3ef4be98866df5645837d44
+    newTag: "d8168428"
+    digest: sha256:c92076682e168756da0963e4423776e28558c5a54ba0cdffbe91c786e795a237

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-16T07:05:11Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:08:33Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e874f7df"
-    digest: sha256:1bd8cfa6d44e34a40dcf96b52d191ca9ec0725b0d3ef4be98866df5645837d44
+    newTag: "d8168428"
+    digest: sha256:c92076682e168756da0963e4423776e28558c5a54ba0cdffbe91c786e795a237


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `d816842843a0ecc8d81506727a53ac5729858b3e`
- Image tag: `d8168428`
- Image digest: `sha256:c92076682e168756da0963e4423776e28558c5a54ba0cdffbe91c786e795a237`