### PR TITLE
ci(torghut): avoid qemu setup on image builds

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -39,11 +39,6 @@ jobs:
         id: meta
         run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: amd64,arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/torghut-ta-build-push.yaml
+++ b/.github/workflows/torghut-ta-build-push.yaml
@@ -41,11 +41,6 @@ jobs:
         id: meta
         run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: amd64,arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -41,11 +41,6 @@ jobs:
         id: meta
         run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: amd64,arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -56,7 +56,7 @@ describe('torghut build-push workflow', () => {
 
   it('publishes and contracts the core Torghut image as amd64 and arm64', () => {
     expect(workflow).toContain('TORGHUT_IMAGE_PLATFORMS: linux/amd64,linux/arm64')
-    expect(workflow).toContain('name: Set up Docker QEMU')
+    expect(workflow).not.toContain('docker/setup-qemu-action')
     expect(workflow).toContain('name: Verify multi-arch image manifest')
     expect(workflow).toContain('for platform in linux/amd64 linux/arm64; do')
     expect(workflow).toContain("--platforms 'linux/amd64,linux/arm64'")
@@ -69,7 +69,7 @@ describe('torghut build-push workflow', () => {
       expect(serviceWorkflow).toContain('push:')
       expect(serviceWorkflow).toContain("- 'services/dorvud/**'")
       expect(serviceWorkflow).toContain("github.event_name == 'push'")
-      expect(serviceWorkflow).toContain('name: Set up Docker QEMU')
+      expect(serviceWorkflow).not.toContain('docker/setup-qemu-action')
       expect(serviceWorkflow).toContain('platforms: linux/amd64,linux/arm64')
       expect(serviceWorkflow).toContain('name: Verify multi-arch image manifest')
       expect(serviceWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')


### PR DESCRIPTION
## Summary

- Removed docker/setup-qemu-action from Torghut core, TA, and WS build-push workflows so ARC runners do not try to mount binfmt_misc.
- Kept buildx multi-arch publishing, manifest verification, and enriched release-contract writes intact.
- Updated workflow regression coverage to prevent QEMU/binfmt setup from returning to the Torghut image builds.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-build-push.yaml .github/workflows/torghut-ta-build-push.yaml .github/workflows/torghut-ws-build-push.yaml`
- `bun run --filter @proompteng/scripts lint`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
