### PR TITLE
chore(symphony): promote image d5bbb059

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:08:33Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:35:26Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d8168428"
-    digest: sha256:c92076682e168756da0963e4423776e28558c5a54ba0cdffbe91c786e795a237
+    newTag: "d5bbb059"
+    digest: sha256:a158075106ff584a2964f2ad61e90aadb3b9c782fb98749aaf4f8ba8837546da

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:08:33Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:35:26Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d8168428"
-    digest: sha256:c92076682e168756da0963e4423776e28558c5a54ba0cdffbe91c786e795a237
+    newTag: "d5bbb059"
+    digest: sha256:a158075106ff584a2964f2ad61e90aadb3b9c782fb98749aaf4f8ba8837546da

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:08:33Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:35:26Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d8168428"
-    digest: sha256:c92076682e168756da0963e4423776e28558c5a54ba0cdffbe91c786e795a237
+    newTag: "d5bbb059"
+    digest: sha256:a158075106ff584a2964f2ad61e90aadb3b9c782fb98749aaf4f8ba8837546da


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `d5bbb059e0f67c9d857f3c8b876d1db8682430a8`
- Image tag: `d5bbb059`
- Image digest: `sha256:a158075106ff584a2964f2ad61e90aadb3b9c782fb98749aaf4f8ba8837546da`