### PR TITLE
ci(torghut): build multi-arch images natively

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -23,8 +23,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: arc-arm64
+  build-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     steps:
       - name: Checkout
@@ -82,13 +92,48 @@ jobs:
 
       - name: Build and push torghut image
         env:
-          TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
-          TORGHUT_IMAGE_PLATFORMS: linux/amd64,linux/arm64
+          TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
+          TORGHUT_IMAGE_PLATFORMS: ${{ matrix.platform }}
           # Remote cache export has intermittently canceled after the image push,
           # before the release contract can be written. Keep the image contract
           # path authoritative and skip the cache until the exporter is stable.
           TORGHUT_IMAGE_CACHE_REF: none
         run: bun run packages/scripts/src/torghut/build-image.ts
+
+  publish-index:
+    needs: build-platform
+    runs-on: arc-arm64
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
+
+      - name: Create multi-arch image index
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE='registry.ide-newton.ts.net/lab/torghut'
+          TAG='${{ steps.meta.outputs.tag }}'
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            -t "${IMAGE}:latest" \
+            "${IMAGE}:${TAG}-amd64" \
+            "${IMAGE}:${TAG}-arm64"
 
       - name: Verify multi-arch image manifest
         id: digest
@@ -140,30 +185,3 @@ jobs:
           path: torghut-release-contract.json
           if-no-files-found: error
           retention-days: 3
-
-      - name: Update latest tag (best effort)
-        id: latest_tag
-        continue-on-error: true
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut'
-          TAG='${{ steps.meta.outputs.tag }}'
-          docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${TAG}"
-          docker buildx imagetools inspect "${IMAGE}:${TAG}"
-          docker buildx imagetools inspect "${IMAGE}:latest"
-
-      - name: Warn on latest tag update failure
-        if: steps.latest_tag.outcome == 'failure'
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut'
-          echo "::warning::Non-blocking failure updating ${IMAGE}:latest; digest-tagged image and release artifact are still valid."
-          {
-            echo "### Latest tag update failed (non-blocking)"
-            echo ""
-            echo "- Registry alias update failed for \`registry.ide-newton.ts.net/lab/torghut:latest\`."
-            echo "- Immutable release contract artifact was already produced and uploaded."
-            echo "- \`torghut-release\` can proceed using the digest from the contract."
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/torghut-ta-build-push.yaml
+++ b/.github/workflows/torghut-ta-build-push.yaml
@@ -20,14 +20,24 @@ on:
       - completed
 
 jobs:
-  build-and-push:
+  build-platform:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'push' ||
         (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
       }}
-    runs-on: arc-arm64
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -49,13 +59,47 @@ jobs:
         with:
           context: services/dorvud
           file: services/dorvud/technical-analysis-flink/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            registry.ide-newton.ts.net/lab/torghut-ta:${{ steps.meta.outputs.tag }}
-            registry.ide-newton.ts.net/lab/torghut-ta:latest
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ta:latest
+            registry.ide-newton.ts.net/lab/torghut-ta:${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
+            registry.ide-newton.ts.net/lab/torghut-ta:latest-${{ matrix.arch }}
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ta:latest-${{ matrix.arch }}
           cache-to: type=inline
+
+  publish-index:
+    needs: build-platform
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
+
+      - name: Create multi-arch image index
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE='registry.ide-newton.ts.net/lab/torghut-ta'
+          TAG='${{ steps.meta.outputs.tag }}'
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            -t "${IMAGE}:latest" \
+            "${IMAGE}:${TAG}-amd64" \
+            "${IMAGE}:${TAG}-arm64"
 
       - name: Verify multi-arch image manifest
         id: digest

--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -20,14 +20,24 @@ on:
       - completed
 
 jobs:
-  build-and-push:
+  build-platform:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'push' ||
         (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
       }}
-    runs-on: arc-arm64
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -49,13 +59,47 @@ jobs:
         with:
           context: services/dorvud
           file: services/dorvud/websockets/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            registry.ide-newton.ts.net/lab/torghut-ws:${{ steps.meta.outputs.tag }}
-            registry.ide-newton.ts.net/lab/torghut-ws:latest
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ws:latest
+            registry.ide-newton.ts.net/lab/torghut-ws:${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
+            registry.ide-newton.ts.net/lab/torghut-ws:latest-${{ matrix.arch }}
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ws:latest-${{ matrix.arch }}
           cache-to: type=inline
+
+  publish-index:
+    needs: build-platform
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
+
+      - name: Create multi-arch image index
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE='registry.ide-newton.ts.net/lab/torghut-ws'
+          TAG='${{ steps.meta.outputs.tag }}'
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            -t "${IMAGE}:latest" \
+            "${IMAGE}:${TAG}-amd64" \
+            "${IMAGE}:${TAG}-arm64"
 
       - name: Verify multi-arch image manifest
         id: digest

--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -154,6 +154,141 @@ spec:
       chart: actions/actions-runner-controller-charts/gha-runner-scale-set
       targetRevision: 0.14.1
       helm:
+        releaseName: arc-runner-set-amd64
+        skipCrds: false
+        valuesObject:
+          controllerServiceAccount:
+            name: arc-controller-gha-rs-controller
+            namespace: arc
+          githubConfigUrl: https://github.com/proompteng/lab
+          githubConfigSecret: github-token
+          runnerScaleSetName: arc-amd64
+          scaleSetLabels:
+            - arc-amd64
+          minRunners: 0
+          maxRunners: 2
+          containerMode:
+            type: "kubernetes"
+            kubernetesModeWorkVolumeClaim:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "rook-ceph-block"
+              resources:
+                requests:
+                  storage: 20Gi
+          listenerTemplate:
+            spec:
+              dnsConfig:
+                searches:
+                  - ide-newton.ts.net
+              containers:
+                - name: listener
+          template:
+            spec:
+              nodeSelector:
+                kubernetes.io/arch: amd64
+              dnsConfig:
+                searches:
+                  - ide-newton.ts.net
+              securityContext:
+                runAsNonRoot: false
+                fsGroup: 1001
+                fsGroupChangePolicy: OnRootMismatch
+              initContainers:
+                - name: init-dind-externals
+                  image: ghcr.io/actions/actions-runner:latest
+                  command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+                  resources:
+                    requests:
+                      cpu: "100m"
+                      memory: "128Mi"
+                    limits:
+                      cpu: "200m"
+                      memory: "256Mi"
+              containers:
+                - name: runner
+                  image: ghcr.io/actions/actions-runner:latest
+                  command: ["/bin/bash", "-lc"]
+                  args:
+                    - |
+                      set -euo pipefail
+                      for attempt in $(seq 1 60); do
+                        if docker version >/dev/null 2>&1; then
+                          exec /home/runner/run.sh
+                        fi
+                        sleep 2
+                      done
+                      docker version
+                  resources:
+                    requests:
+                      cpu: "4"
+                      memory: "8Gi"
+                      ephemeral-storage: "40Gi"
+                    limits:
+                      cpu: "8"
+                      memory: "16Gi"
+                      ephemeral-storage: "80Gi"
+                  env:
+                    - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+                      value: /home/runner/k8s/index.js
+                    - name: ACTIONS_RUNNER_POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: DOCKER_HOST
+                      value: unix:///var/run/docker.sock
+                    - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                      value: "false"
+                  volumeMounts:
+                    - name: work
+                      mountPath: /home/runner/_work
+                    - name: dind-sock
+                      mountPath: /var/run
+                - name: dind
+                  image: docker:dind
+                  args:
+                    - dockerd
+                    - --host=unix:///var/run/docker.sock
+                    - --group=$(DOCKER_GROUP_GID)
+                    - --max-concurrent-uploads=8
+                  resources:
+                    requests:
+                      cpu: "4"
+                      memory: "8Gi"
+                      ephemeral-storage: "30Gi"
+                    limits:
+                      cpu: "12"
+                      memory: "16Gi"
+                      ephemeral-storage: "50Gi"
+                  env:
+                    - name: DOCKER_GROUP_GID
+                      value: "123"
+                  securityContext:
+                    privileged: true
+                  volumeMounts:
+                    - name: work
+                      mountPath: /home/runner/_work
+                    - name: dind-sock
+                      mountPath: /var/run
+                    - name: dind-externals
+                      mountPath: /home/runner/externals
+              volumes:
+                - name: work
+                  ephemeral:
+                    volumeClaimTemplate:
+                      spec:
+                        accessModes: ["ReadWriteOnce"]
+                        storageClassName: "rook-ceph-block"
+                        resources:
+                          requests:
+                            storage: 20Gi
+                - name: dind-sock
+                  emptyDir: {}
+                - name: dind-externals
+                  emptyDir: {}
+    - repoURL: ghcr.io
+      chart: actions/actions-runner-controller-charts/gha-runner-scale-set
+      targetRevision: 0.14.1
+      helm:
         releaseName: arc-runner-set-analysis
         skipCrds: false
         valuesObject:

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -19,6 +19,10 @@ const pullRequestWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/pull-request.yml', import.meta.url),
   'utf8',
 )
+const arcApplication = readFileSync(
+  new URL('../../../../../argocd/applications/arc/application.yaml', import.meta.url),
+  'utf8',
+)
 
 const pathPatternIndex = (pattern: string): number =>
   workflow.split('\n').findIndex((line) => line.trim() === `- '${pattern}'`)
@@ -35,7 +39,7 @@ describe('torghut build-push workflow', () => {
   })
 
   it('does not use actions/cache on the ARC-backed build runner', () => {
-    const buildJob = workflow.indexOf('build-and-push:')
+    const buildJob = workflow.indexOf('build-platform:')
     const cacheStep = workflow.indexOf('uses: actions/cache@v4', buildJob)
 
     expect(buildJob).toBeGreaterThan(-1)
@@ -43,10 +47,11 @@ describe('torghut build-push workflow', () => {
   })
 
   it('waits for the private registry before building the release image', () => {
-    const buildJob = workflow.indexOf('build-and-push:')
+    const buildJob = workflow.indexOf('build-platform:')
     const registryWaitStep = workflow.indexOf('name: Wait for private registry', buildJob)
     const buildStep = workflow.indexOf('name: Build and push torghut image', buildJob)
 
+    expect(buildJob).toBeGreaterThan(-1)
     expect(workflow).toContain('timeout-minutes: 180')
     expect(registryWaitStep).toBeGreaterThan(buildJob)
     expect(buildStep).toBeGreaterThan(registryWaitStep)
@@ -55,8 +60,15 @@ describe('torghut build-push workflow', () => {
   })
 
   it('publishes and contracts the core Torghut image as amd64 and arm64', () => {
-    expect(workflow).toContain('TORGHUT_IMAGE_PLATFORMS: linux/amd64,linux/arm64')
+    expect(workflow).toContain('runner: arc-amd64')
+    expect(workflow).toContain('runner: arc-arm64')
+    expect(workflow).toContain('runs-on: ${{ matrix.runner }}')
+    expect(workflow).toContain('TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}')
+    expect(workflow).toContain('TORGHUT_IMAGE_PLATFORMS: ${{ matrix.platform }}')
     expect(workflow).not.toContain('docker/setup-qemu-action')
+    expect(workflow).toContain('name: Create multi-arch image index')
+    expect(workflow).toContain('"${IMAGE}:${TAG}-amd64"')
+    expect(workflow).toContain('"${IMAGE}:${TAG}-arm64"')
     expect(workflow).toContain('name: Verify multi-arch image manifest')
     expect(workflow).toContain('for platform in linux/amd64 linux/arm64; do')
     expect(workflow).toContain("--platforms 'linux/amd64,linux/arm64'")
@@ -69,8 +81,16 @@ describe('torghut build-push workflow', () => {
       expect(serviceWorkflow).toContain('push:')
       expect(serviceWorkflow).toContain("- 'services/dorvud/**'")
       expect(serviceWorkflow).toContain("github.event_name == 'push'")
+      expect(serviceWorkflow).toContain('runner: arc-amd64')
+      expect(serviceWorkflow).toContain('runner: arc-arm64')
+      expect(serviceWorkflow).toContain('runs-on: ${{ matrix.runner }}')
       expect(serviceWorkflow).not.toContain('docker/setup-qemu-action')
-      expect(serviceWorkflow).toContain('platforms: linux/amd64,linux/arm64')
+      expect(serviceWorkflow).toContain('platforms: ${{ matrix.platform }}')
+      expect(serviceWorkflow).toContain(':${{ steps.meta.outputs.tag }}-${{ matrix.arch }}')
+      expect(serviceWorkflow).toContain(':latest-${{ matrix.arch }}')
+      expect(serviceWorkflow).toContain('name: Create multi-arch image index')
+      expect(serviceWorkflow).toContain('"${IMAGE}:${TAG}-amd64"')
+      expect(serviceWorkflow).toContain('"${IMAGE}:${TAG}-arm64"')
       expect(serviceWorkflow).toContain('name: Verify multi-arch image manifest')
       expect(serviceWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')
       expect(serviceWorkflow).toContain("--platforms 'linux/amd64,linux/arm64'")
@@ -81,6 +101,15 @@ describe('torghut build-push workflow', () => {
         "--platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'",
       )
     }
+  })
+
+  it('defines native amd64 and arm64 GitHub runner scale sets for Torghut image builds', () => {
+    expect(arcApplication).toContain('runnerScaleSetName: arc-amd64')
+    expect(arcApplication).toContain('- arc-amd64')
+    expect(arcApplication).toContain('kubernetes.io/arch: amd64')
+    expect(arcApplication).toContain('runnerScaleSetName: arc-arm64')
+    expect(arcApplication).toContain('- arc-arm64')
+    expect(arcApplication).toContain('kubernetes.io/arch: arm64')
   })
 
   it('caches Bun downloads before manifest-only CI installs script dependencies', () => {


### PR DESCRIPTION
## Summary

- Added an `arc-amd64` GitHub Actions runner scale set in the ARC GitOps application so amd64 image builds run natively on amd64 Kubernetes nodes.
- Changed Torghut core, TA, and WS image workflows to build `linux/amd64` and `linux/arm64` as native per-platform jobs, then publish a top-level OCI index and `latest` alias.
- Kept multi-arch manifest verification and enriched release-contract artifacts after index creation, with regression coverage for native runner labels and index assembly.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/torghut-build-push.yaml .github/workflows/torghut-ta-build-push.yaml .github/workflows/torghut-ws-build-push.yaml`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This adds amd64 GitHub runner capacity and changes Torghut image publishing to native per-platform builds before manifest assembly.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
