### PR TITLE
fix(torghut): allow post-deploy pod pull checks

### DIFF
--- a/argocd/applications/agents-ci/runner-rbac-cluster.yaml
+++ b/argocd/applications/agents-ci/runner-rbac-cluster.yaml
@@ -130,6 +130,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -103,9 +103,10 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('Torghut-managed image pull failures remain after deploy')
   })
 
-  it('grants the ARC runner read access to Torghut Knative Service readiness', () => {
+  it('grants the ARC runner read access to Torghut post-deploy resources', () => {
     expect(agentsCiClusterRbac).toContain('agents-ci-runner-torghut-post-deploy-read')
     expect(agentsCiClusterRbac).toContain('serving.knative.dev')
+    expect(agentsCiClusterRbac).toContain('resources:\n      - pods')
     expect(agentsCiClusterRbac).toContain('arc-arm64-gha-rs-kube-mode')
   })
 


### PR DESCRIPTION
## Summary

- Grants the ARC GitHub runner service account pod read access through the existing Torghut post-deploy verifier ClusterRole.
- Covers the new pod ImagePullBackOff/ErrImagePull verification path with the existing post-deploy workflow test.
- Keeps the RBAC scope limited to read-only pod access needed for the verifier.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run lint:argocd`
- `git diff --check`
- `bun run --filter @proompteng/scripts lint`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
