### PR TITLE
fix(agents): stop controller reconcile storm

### DIFF
--- a/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
@@ -215,4 +215,67 @@ describe('agents controller agent-run reconciler', () => {
       }),
     )
   })
+
+  it('returns terminal preserved AgentRuns without normal reconcile logging or runtime reconciliation', async () => {
+    const setStatus = vi.fn(async () => undefined)
+    const reconcileWorkflowRun = vi.fn()
+    const kube = {
+      patch: vi.fn(async () => ({})),
+      delete: vi.fn(async () => ({})),
+    }
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const reconciler = createAgentRunReconciler(createBaseDependencies({ setStatus, reconcileWorkflowRun }))
+
+    try {
+      await reconciler.reconcileAgentRun(
+        kube as never,
+        {
+          metadata: {
+            name: 'old-workflow-run',
+            namespace: 'agents',
+            generation: 1,
+            finalizers: ['agents.proompteng.ai/runtime-cleanup'],
+          },
+          spec: {
+            agentRef: { name: 'codex-agent' },
+            runtime: { type: 'workflow' },
+            ttlSecondsAfterFinished: 0,
+            parameters: {},
+          },
+          status: {
+            observedGeneration: 1,
+            phase: 'Succeeded',
+            finishedAt: '2026-05-18T13:08:00.000Z',
+            runtimeRef: {
+              type: 'workflow',
+              name: 'old-workflow-run-workflow',
+              namespace: 'agents',
+            },
+          },
+        },
+        'agents',
+        [],
+        [],
+        {
+          perNamespace: 10,
+          perAgent: 10,
+          cluster: 10,
+          repoConcurrency: { enabled: false, defaultLimit: 0, overrides: new Map() },
+        },
+        { total: 0, perAgent: new Map(), perRepository: new Map() },
+        0,
+      )
+    } finally {
+      infoSpy.mockRestore()
+    }
+
+    expect(kube.patch).not.toHaveBeenCalled()
+    expect(kube.delete).not.toHaveBeenCalled()
+    expect(setStatus).not.toHaveBeenCalled()
+    expect(reconcileWorkflowRun).not.toHaveBeenCalled()
+    expect(infoSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('reconcile_started'),
+      expect.objectContaining({ runName: 'old-workflow-run' }),
+    )
+  })
 })

--- a/services/agents/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.ts
@@ -341,11 +341,6 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       })
     }
 
-    logAgentsControllerInfo('reconcile_started', {
-      ...logContext,
-      decision: 'start',
-      phase,
-    })
     const runtimeCleanupContext = {
       kube,
       namespace,
@@ -418,7 +413,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           }
         }
       }
+      return
     }
+
+    logAgentsControllerInfo('reconcile_started', {
+      ...logContext,
+      decision: 'start',
+      phase,
+    })
 
     const runtimeRef = parseRuntimeRef(status.runtimeRef)
     const shouldSubmit =

--- a/services/agents/src/server/agents-controller/index.ts
+++ b/services/agents/src/server/agents-controller/index.ts
@@ -17,7 +17,7 @@ import {
 import { parseNamespaceScopeEnv } from '../namespace-scope'
 import { asRecord, asString, readNested } from '../primitives'
 import { createKubernetesClient, RESOURCE_MAP } from '../kube-types'
-import { shouldApplyStatus } from '../status-utils'
+import { buildResourceFingerprint, shouldApplyStatus } from '../status-utils'
 import { resolveAgentCommsSubscriberConfig } from '../integrations-config'
 import { createAgentRunReconciler } from './agent-run-reconciler'
 import {
@@ -627,6 +627,19 @@ const resetControllerRateState = () => {
   resetControllerRateStateMaps(runtimeMutableState.controllerRateState)
 }
 
+const shouldDependencyEventTriggerFullReconcile = (
+  map: Map<string, Record<string, unknown>>,
+  eventType: string | undefined,
+  resource: Record<string, unknown>,
+) => {
+  const name = asString(readNested(resource, ['metadata', 'name']))
+  if (!name) return false
+  if (eventType === 'DELETED') return true
+  const existing = map.get(name)
+  if (!existing) return true
+  return buildResourceFingerprint(existing) !== buildResourceFingerprint(resource)
+}
+
 const enqueueNamespaceTask = (namespace: string, task: () => Promise<void>) => {
   logAgentsControllerDebug('namespace_task_enqueued', { namespace })
   const current = runtimeMutableState.namespaceQueues.get(namespace) ?? Promise.resolve()
@@ -1118,43 +1131,49 @@ const startNamespaceWatches = async (
   const handleAgentEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
     const resource = asRecord(event.object)
     if (!resource) return
+    const shouldReconcile = shouldDependencyEventTriggerFullReconcile(nsState.agents, event.type, resource)
     updateStateMap(nsState.agents, event.type, resource)
-    void enqueueFull()
+    if (shouldReconcile) void enqueueFull()
   }
 
   const handleProviderEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
     const resource = asRecord(event.object)
     if (!resource) return
+    const shouldReconcile = shouldDependencyEventTriggerFullReconcile(nsState.providers, event.type, resource)
     updateStateMap(nsState.providers, event.type, resource)
-    void enqueueFull()
+    if (shouldReconcile) void enqueueFull()
   }
 
   const handleSpecEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
     const resource = asRecord(event.object)
     if (!resource) return
+    const shouldReconcile = shouldDependencyEventTriggerFullReconcile(nsState.specs, event.type, resource)
     updateStateMap(nsState.specs, event.type, resource)
-    void enqueueFull()
+    if (shouldReconcile) void enqueueFull()
   }
 
   const handleSourceEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
     const resource = asRecord(event.object)
     if (!resource) return
+    const shouldReconcile = shouldDependencyEventTriggerFullReconcile(nsState.sources, event.type, resource)
     updateStateMap(nsState.sources, event.type, resource)
-    void enqueueFull()
+    if (shouldReconcile) void enqueueFull()
   }
 
   const handleVcsProviderEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
     const resource = asRecord(event.object)
     if (!resource) return
+    const shouldReconcile = shouldDependencyEventTriggerFullReconcile(nsState.vcsProviders, event.type, resource)
     updateStateMap(nsState.vcsProviders, event.type, resource)
-    void enqueueFull()
+    if (shouldReconcile) void enqueueFull()
   }
 
   const handleMemoryEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
     const resource = asRecord(event.object)
     if (!resource) return
+    const shouldReconcile = shouldDependencyEventTriggerFullReconcile(nsState.memories, event.type, resource)
     updateStateMap(nsState.memories, event.type, resource)
-    void enqueueFull()
+    if (shouldReconcile) void enqueueFull()
   }
 
   const handleJobEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
@@ -1457,6 +1476,7 @@ export const __test = {
   resolveVcsPrRateLimits,
   resolveJobImage,
   resolveVcsContext,
+  shouldDependencyEventTriggerFullReconcile,
   getAgentRunUntouchedReasons,
   resyncAgentRunsForNamespace,
   startNamespaceWatches,

--- a/services/agents/src/server/agents-controller/startup-resync.test.ts
+++ b/services/agents/src/server/agents-controller/startup-resync.test.ts
@@ -120,4 +120,116 @@ describe('agents controller startup resync', () => {
 
     __test.stopWatchHandles(handles)
   })
+
+  it('does not trigger full reconcile for dependency heartbeat-only events', () => {
+    const existing = {
+      apiVersion: 'agents.proompteng.ai/v1alpha1',
+      kind: 'Memory',
+      metadata: {
+        name: 'agents-primitives',
+        namespace: 'agents',
+        generation: 2,
+        resourceVersion: '100',
+      },
+      spec: {
+        type: 'postgres',
+        connection: { secretRef: { name: 'memory-secret' } },
+      },
+      status: {
+        observedGeneration: 2,
+        updatedAt: '2026-01-20T00:00:00Z',
+        lastCheckedAt: '2026-01-20T00:00:00Z',
+        conditions: [{ type: 'Ready', status: 'True', reason: 'SecretResolved', message: '' }],
+      },
+    }
+    const resources = new Map([[existing.metadata.name, existing]])
+
+    expect(
+      __test.shouldDependencyEventTriggerFullReconcile(resources, 'MODIFIED', {
+        ...existing,
+        metadata: { ...existing.metadata, resourceVersion: '101' },
+        status: {
+          ...existing.status,
+          updatedAt: '2026-01-20T00:01:00Z',
+          lastCheckedAt: '2026-01-20T00:01:00Z',
+        },
+      }),
+    ).toBe(false)
+
+    expect(
+      __test.shouldDependencyEventTriggerFullReconcile(resources, 'MODIFIED', {
+        ...existing,
+        metadata: { ...existing.metadata, resourceVersion: '102' },
+        spec: {
+          ...existing.spec,
+          default: true,
+        },
+      }),
+    ).toBe(true)
+
+    expect(
+      __test.shouldDependencyEventTriggerFullReconcile(resources, 'MODIFIED', {
+        ...existing,
+        metadata: { ...existing.metadata, resourceVersion: '103' },
+        status: {
+          ...existing.status,
+          conditions: [{ type: 'Ready', status: 'False', reason: 'SecretNotFound', message: 'secret missing' }],
+        },
+      }),
+    ).toBe(true)
+
+    expect(__test.shouldDependencyEventTriggerFullReconcile(resources, 'DELETED', existing)).toBe(true)
+  })
+
+  it('does not apply primitive status when only heartbeat timestamps change', async () => {
+    const kube = buildKube()
+    const readyCondition = { type: 'Ready', status: 'True', reason: 'Reconciled', message: '' }
+    const stablePrimitiveConditions = [
+      readyCondition,
+      { type: 'Progressing', status: 'False', reason: 'Progressing', message: '' },
+      { type: 'Degraded', status: 'False', reason: 'Degraded', message: '' },
+    ]
+
+    await __test.setStatus(
+      kube as never,
+      {
+        apiVersion: 'agents.proompteng.ai/v1alpha1',
+        kind: 'Memory',
+        metadata: { name: 'agents-primitives', namespace: 'agents', generation: 2 },
+        status: {
+          observedGeneration: 2,
+          updatedAt: '2026-01-20T00:00:00Z',
+          lastCheckedAt: '2026-01-20T00:00:00Z',
+          conditions: stablePrimitiveConditions,
+        },
+      },
+      {
+        observedGeneration: 2,
+        lastCheckedAt: '2026-01-20T00:01:00Z',
+        conditions: [readyCondition],
+      },
+    )
+
+    await __test.setStatus(
+      kube as never,
+      {
+        apiVersion: 'agents.proompteng.ai/v1alpha1',
+        kind: 'VersionControlProvider',
+        metadata: { name: 'github', namespace: 'agents', generation: 2 },
+        status: {
+          observedGeneration: 2,
+          updatedAt: '2026-01-20T00:00:00Z',
+          lastValidatedAt: '2026-01-20T00:00:00Z',
+          conditions: stablePrimitiveConditions,
+        },
+      },
+      {
+        observedGeneration: 2,
+        lastValidatedAt: '2026-01-20T00:01:00Z',
+        conditions: [readyCondition],
+      },
+    )
+
+    expect(kube.applyStatus).not.toHaveBeenCalled()
+  })
 })

--- a/services/agents/src/server/status-utils.test.ts
+++ b/services/agents/src/server/status-utils.test.ts
@@ -7,6 +7,8 @@ describe('status utils', () => {
     const current = {
       phase: 'Running',
       updatedAt: '2026-01-20T00:00:00Z',
+      lastCheckedAt: '2026-01-20T00:00:00Z',
+      lastValidatedAt: '2026-01-20T00:00:00Z',
       conditions: [
         {
           type: 'Ready',
@@ -21,6 +23,8 @@ describe('status utils', () => {
     const next = {
       phase: 'Running',
       updatedAt: '2026-01-20T00:01:00Z',
+      lastCheckedAt: '2026-01-20T00:01:00Z',
+      lastValidatedAt: '2026-01-20T00:01:00Z',
       conditions: [
         {
           type: 'Ready',
@@ -69,6 +73,8 @@ describe('status utils', () => {
       spec: { runtime: { type: 'job' } },
       status: {
         updatedAt: '2026-01-20T00:00:00Z',
+        lastCheckedAt: '2026-01-20T00:00:00Z',
+        lastValidatedAt: '2026-01-20T00:00:00Z',
         conditions: [
           {
             type: 'Ready',
@@ -87,6 +93,8 @@ describe('status utils', () => {
       status: {
         ...base.status,
         updatedAt: '2026-01-20T00:01:00Z',
+        lastCheckedAt: '2026-01-20T00:01:00Z',
+        lastValidatedAt: '2026-01-20T00:01:00Z',
         conditions: [
           {
             type: 'Ready',

--- a/services/agents/src/server/status-utils.ts
+++ b/services/agents/src/server/status-utils.ts
@@ -52,6 +52,8 @@ export const normalizeStatusForCompare = (status: Record<string, unknown> | null
   const record = asRecord(status) ?? {}
   const next: Record<string, unknown> = { ...record }
   delete next.updatedAt
+  delete next.lastCheckedAt
+  delete next.lastValidatedAt
   const normalizedConditions = normalizeConditionsForCompare(record.conditions)
   if (normalizedConditions) {
     next.conditions = normalizedConditions


### PR DESCRIPTION
## Summary

- Stops timestamp-only Memory and VersionControlProvider status writes from changing primitive fingerprints or applying status patches.
- Filters dependency watch events so resourceVersion and heartbeat-only updates do not enqueue full namespace AgentRun reconciles.
- Returns preserved terminal AgentRuns before normal reconcile logging and runtime handling to avoid log storms over historical workflow runs.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/agents test -- src/server/agents-controller/resource-reconcilers-extra.test.ts src/server/agents-controller/resource-reconcilers.test.ts src/server/agents-controller/startup-resync.test.ts src/server/status-utils.test.ts src/server/agents-controller/agent-run-reconciler.test.ts`
- `bun run --filter @proompteng/agents test`
- `bun run --filter @proompteng/agents tsc`
- `bunx oxfmt --check services/agents/src/server/agents-controller services/agents/src/server/status-utils.ts services/agents/src/server/status-utils.test.ts`
- `git diff --check`
- `bun run --filter @proompteng/agents lint:oxlint -- services/agents/src/server/agents-controller/agent-run-reconciler.ts services/agents/src/server/agents-controller/index.ts services/agents/src/server/status-utils.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
