### PR TITLE
chore(torghut): promote ta image 72a1961c

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:14db888567acf0df87a1e6f2521c28ae89cc9141fb6d4ac8201666727bc27ca5
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
   imagePullPolicy: IfNotPresent
-  restartNonce: 13
+  restartNonce: 14
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -88,9 +88,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: df204d51
+              value: 72a1961c
             - name: TORGHUT_TA_COMMIT
-              value: df204d51cc7d49a6ff22bcb975a70bc3b3e7450c
+              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:14db888567acf0df87a1e6f2521c28ae89cc9141fb6d4ac8201666727bc27ca5
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
   imagePullPolicy: IfNotPresent
-  restartNonce: 17
+  restartNonce: 18
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: df204d51
+              value: 72a1961c
             - name: TORGHUT_TA_COMMIT
-              value: df204d51cc7d49a6ff22bcb975a70bc3b3e7450c
+              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:14db888567acf0df87a1e6f2521c28ae89cc9141fb6d4ac8201666727bc27ca5
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
   imagePullPolicy: IfNotPresent
-  restartNonce: 11
+  restartNonce: 12
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: df204d51
+              value: 72a1961c
             - name: TORGHUT_TA_COMMIT
-              value: df204d51cc7d49a6ff22bcb975a70bc3b3e7450c
+              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `72a1961c5773c805b99997b3b6e726d5e1df6cd5`
- Image tag: `72a1961c`
- Image digest: `sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149`
- Manifests: live TA, sim TA, options TA