### PR TITLE
chore(torghut): promote ws image 72a1961c

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:044b86edb4dbc1838c0369f5a2e5af65aae225a2809d171991d3feef60f05d04
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:64f6e4432cf94ee25a7d30f89bf22140c72aee9e8f378e65708c453aa3610bb8
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -53,9 +53,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-4ced8b14
+              value: main-72a1961c
             - name: TORGHUT_WS_COMMIT
-              value: 4ced8b146553fea9b104d2c1718c892f11f6664f
+              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:044b86edb4dbc1838c0369f5a2e5af65aae225a2809d171991d3feef60f05d04
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:64f6e4432cf94ee25a7d30f89bf22140c72aee9e8f378e65708c453aa3610bb8
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-4ced8b14
+              value: main-72a1961c
             - name: TORGHUT_WS_COMMIT
-              value: 4ced8b146553fea9b104d2c1718c892f11f6664f
+              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `72a1961c5773c805b99997b3b6e726d5e1df6cd5`
- Image tag: `72a1961c`
- Image digest: `sha256:64f6e4432cf94ee25a7d30f89bf22140c72aee9e8f378e65708c453aa3610bb8`