### PR TITLE
fix(agents): avoid emulated bun builds

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -408,8 +408,18 @@ jobs:
           }
 
           run_kind_load_with_fallback() {
+            if run_with_progress "kind load docker-image" "${KIND_LOAD_TIMEOUT_MINUTES}" kind load docker-image "${IMAGE}" --name "${KIND_CLUSTER_NAME}"; then
+              echo "Loaded local image ${IMAGE} into kind cluster ${KIND_CLUSTER_NAME}."
+              docker image rm "${IMAGE}" >/dev/null 2>&1 || true
+              return 0
+            fi
+
+            echo "kind load docker-image failed; retrying with image archive path."
+            rm -f "${KIND_IMAGE_TAR}"
+
             if ! run_with_progress "docker save image archive" "${KIND_LOAD_TIMEOUT_MINUTES}" docker save --output "${KIND_IMAGE_TAR}" "${IMAGE}"; then
               echo "Failed to save local image archive ${KIND_IMAGE_TAR}."
+              rm -f "${KIND_IMAGE_TAR}"
               return 1
             fi
 
@@ -417,14 +427,12 @@ jobs:
 
             if run_with_progress "kind load image-archive" "${KIND_LOAD_TIMEOUT_MINUTES}" kind load image-archive "${KIND_IMAGE_TAR}" --name "${KIND_CLUSTER_NAME}"; then
               echo "Loaded local image archive ${KIND_IMAGE_TAR} into kind cluster ${KIND_CLUSTER_NAME}."
+              rm -f "${KIND_IMAGE_TAR}"
+              docker image rm "${IMAGE}" >/dev/null 2>&1 || true
               return 0
             fi
 
-            echo "kind load image-archive failed; retrying with docker-image path."
-            if run_with_progress "kind load docker-image" "${KIND_LOAD_TIMEOUT_MINUTES}" kind load docker-image "${IMAGE}" --name "${KIND_CLUSTER_NAME}"; then
-              echo "Loaded local image ${IMAGE} into kind cluster ${KIND_CLUSTER_NAME}."
-              return 0
-            fi
+            rm -f "${KIND_IMAGE_TAR}"
             return 1
           }
 

--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -10,6 +10,50 @@ ARG NODE24_VERSION=24.11.1
 ARG KUBECTL_VERSION=1.34.3
 ARG NATSCLI_VERSION=v0.4.0
 
+FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE}:${BUN_VERSION} AS agents-build-tools
+ARG BUILDARCH
+ARG NODE24_VERSION
+WORKDIR /app
+
+ENV BUN_INSTALL_CACHE_DIR=/root/.bun/install/cache
+
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
+  --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+  set -eux; \
+  export DEBIAN_FRONTEND=noninteractive; \
+  apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
+  apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  python3 \
+  xz-utils; \
+  rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+  ARCH="${BUILDARCH:-$(uname -m)}"; \
+  case "$ARCH" in \
+  amd64|x86_64) NODE_ARCH=x64 ;; \
+  arm64|aarch64) NODE_ARCH=arm64 ;; \
+  ppc64le) NODE_ARCH=ppc64le ;; \
+  s390x) NODE_ARCH=s390x ;; \
+  *) NODE_ARCH="$ARCH" ;; \
+  esac; \
+  curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+    "https://nodejs.org/dist/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+    -o /tmp/node.tar.xz; \
+  tar -xJf /tmp/node.tar.xz -C /tmp; \
+  rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack; \
+  cp -r /tmp/node-v${NODE24_VERSION}-linux-${NODE_ARCH}/bin /usr/local/; \
+  cp -r /tmp/node-v${NODE24_VERSION}-linux-${NODE_ARCH}/include /usr/local/; \
+  cp -r /tmp/node-v${NODE24_VERSION}-linux-${NODE_ARCH}/lib /usr/local/; \
+  cp -r /tmp/node-v${NODE24_VERSION}-linux-${NODE_ARCH}/share /usr/local/; \
+  rm -rf /tmp/node-v${NODE24_VERSION}-linux-${NODE_ARCH} /tmp/node.tar.xz; \
+  node --version
+
+COPY tsconfig.base.json ./
+
 FROM ${BUN_BASE_IMAGE}:${BUN_VERSION} AS agents-tools
 ARG NODE24_VERSION
 ARG KUBECTL_VERSION
@@ -91,9 +135,7 @@ RUN set -eux; \
   rm -rf "${NATS_ARCHIVE}" "/tmp/nats-${NATS_VERSION}-linux-${NATS_ARCH}"; \
   nats --version
 
-COPY tsconfig.base.json ./
-
-FROM agents-tools AS agents-workspace-deps
+FROM agents-build-tools AS agents-workspace-deps
 WORKDIR /app
 ENV NODE_ENV=development
 COPY json/ .

--- a/services/agents/Dockerfile.codex-runner
+++ b/services/agents/Dockerfile.codex-runner
@@ -22,7 +22,7 @@ RUN npm install -g "@openai/codex@${CODEX_VERSION}" \
     && npm cache clean --force \
     && test -x /usr/local/bin/codex
 
-FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS codex-package-build
+FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS codex-package-build
 
 RUN set -eux; \
     apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 \
@@ -41,7 +41,7 @@ COPY tsconfig.base.json /opt/proompteng/tsconfig.base.json
 
 RUN bash -lc 'cd /opt/proompteng/packages/codex && bun install --no-save && bun run build && rm -rf node_modules'
 
-FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS agents-runner-build
+FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS agents-runner-build
 
 WORKDIR /opt/proompteng
 

--- a/services/agents/src/runner/codex-runner-image-layout.test.ts
+++ b/services/agents/src/runner/codex-runner-image-layout.test.ts
@@ -36,6 +36,18 @@ describe('Agents Codex runner image layout', () => {
     expect(content).not.toContain('node-gyp')
   })
 
+  it('runs runner bundle builds on the build platform', () => {
+    const content = dockerfile()
+
+    expect(content).toContain(
+      'FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS codex-package-build',
+    )
+    expect(content).toContain(
+      'FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim AS agents-runner-build',
+    )
+    expect(finalStage()).toContain('FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim')
+  })
+
   it('copies only built runner and Codex package payloads into the final image', () => {
     const content = finalStage()
 

--- a/services/agents/src/server/__tests__/control-plane-image-layout.test.ts
+++ b/services/agents/src/server/__tests__/control-plane-image-layout.test.ts
@@ -60,6 +60,16 @@ describe('Agents control-plane image layout', () => {
     expect(dockerfileTarget('controller')).toContain('AGENTS_SERVER_PROFILE=agents-controllers')
   })
 
+  it('runs package builds on the build platform while keeping runtime dependencies target-native', () => {
+    const content = dockerfile()
+
+    expect(content).toContain('FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE}:${BUN_VERSION} AS agents-build-tools')
+    expect(content).toContain('FROM agents-build-tools AS agents-workspace-deps')
+    expect(content).toContain('FROM agents-tools AS agents-deps-prod')
+    expect(dockerfileTarget('agents-build-tools')).toContain('ARCH="${BUILDARCH:-$(uname -m)}"')
+    expect(dockerfileTarget('agents-tools')).toContain('ARCH="${TARGETARCH:-$(uname -m)}"')
+  })
+
   it('installs runtime helper CLIs from cx-tools rather than service-local scripts', () => {
     const content = dockerfile()
 


### PR DESCRIPTION
## Summary

- Moves Agents controller/control-plane package compilation stages onto Docker BuildKit's build platform so multi-arch image publishing does not run Bun/Vite builds through QEMU.
- Keeps target-platform runtime stages for kubectl, nats, production node_modules, and final controller/control-plane images.
- Applies the same build-platform split to the Codex runner bundle stages and adds layout regression tests for both Dockerfiles.
- Loads local Agents images into kind directly before falling back to image archives, and cleans tar/image artifacts to avoid CI disk exhaustion.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/agents test -- src/server/__tests__/control-plane-image-layout.test.ts src/runner/codex-runner-image-layout.test.ts`
- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/build-image.test.ts`
- `bunx oxfmt --check services/agents/src/server/__tests__/control-plane-image-layout.test.ts services/agents/src/runner/codex-runner-image-layout.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agents-ci.yml"); puts "agents-ci.yml parsed"'`
- `bun run --filter @proompteng/agents tsc`
- `bun run --filter @proompteng/agents test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
