### PR TITLE
fix(torghut): bound stale TCA refresh work

### DIFF
--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -63,6 +63,8 @@ spec:
                       key: password
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: TORGHUT_EXECUTION_TCA_ACTIVITY_LOOKBACK_SECONDS
+                  value: "86400"
               command:
                 - /bin/bash
                 - -lc

--- a/services/dorvud/websockets/src/main/resources/logback.xml
+++ b/services/dorvud/websockets/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{ISO8601} %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.apache.kafka" level="${KAFKA_CLIENT_LOG_LEVEL:-WARN}" />
+  <logger name="org.apache.kafka.clients.NetworkClient" level="WARN" />
+  <logger name="org.apache.kafka.common.network" level="WARN" />
+  <logger name="org.apache.kafka.common.security" level="WARN" />
+
+  <root level="${LOG_LEVEL:-INFO}">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/LoggingConfigTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/LoggingConfigTest.kt
@@ -1,0 +1,18 @@
+package ai.proompteng.dorvud.ws
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
+
+class LoggingConfigTest {
+  @Test
+  fun `keeps kafka client internals out of default debug logs`() {
+    val resource = Thread.currentThread().contextClassLoader.getResource("logback.xml")
+    assertNotNull(resource)
+
+    val config = resource.readText()
+    assertContains(config, """<root level="${'$'}{LOG_LEVEL:-INFO}">""")
+    assertContains(config, """<logger name="org.apache.kafka" level="${'$'}{KAFKA_CLIENT_LOG_LEVEL:-WARN}" />""")
+    assertContains(config, """<logger name="org.apache.kafka.clients.NetworkClient" level="WARN" />""")
+  }
+}

--- a/services/torghut/app/trading/tca_modules/lineage_read_model.py
+++ b/services/torghut/app/trading/tca_modules/lineage_read_model.py
@@ -284,6 +284,7 @@ def refresh_execution_tca_metrics(
     *,
     account_label: str | None = None,
     stale_before: datetime | None = None,
+    execution_activity_after: datetime | None = None,
     limit: int = 500,
     dry_run: bool = False,
 ) -> dict[str, object]:
@@ -318,6 +319,14 @@ def refresh_execution_tca_metrics(
                 ExecutionTCAMetric.computed_at < stale_before,
             )
         )
+    if execution_activity_after is not None:
+        stmt = stmt.where(
+            or_(
+                Execution.last_update_at >= execution_activity_after,
+                Execution.order_feed_last_event_ts >= execution_activity_after,
+                Execution.created_at >= execution_activity_after,
+            )
+        )
 
     executions = session.execute(stmt).scalars().all()
     if dry_run:
@@ -328,6 +337,9 @@ def refresh_execution_tca_metrics(
             "limit": bounded_limit,
             "account_label": normalized_account_label or None,
             "stale_before": stale_before.isoformat() if stale_before else None,
+            "execution_activity_after": execution_activity_after.isoformat()
+            if execution_activity_after
+            else None,
             "runtime_ledger_lineage": _execution_lineage_summary(executions),
         }
 
@@ -346,6 +358,9 @@ def refresh_execution_tca_metrics(
         "limit": bounded_limit,
         "account_label": normalized_account_label or None,
         "stale_before": stale_before.isoformat() if stale_before else None,
+        "execution_activity_after": execution_activity_after.isoformat()
+        if execution_activity_after
+        else None,
         "runtime_ledger_lineage": lineage_summary,
     }
 

--- a/services/torghut/scripts/refresh_execution_tca_metrics.py
+++ b/services/torghut/scripts/refresh_execution_tca_metrics.py
@@ -17,6 +17,13 @@ from app.db import SessionLocal
 from app.trading.tca import refresh_execution_tca_metrics
 
 
+def _env_int_or_none(name: str) -> int | None:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    return int(raw)
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Refresh stale execution_tca_metrics rows from persisted executions.",
@@ -32,6 +39,16 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=86400,
         help="Only refresh rows with computed_at older than this age. Use 0 to refresh all current rows once.",
+    )
+    parser.add_argument(
+        "--execution-activity-lookback-seconds",
+        type=int,
+        default=_env_int_or_none("TORGHUT_EXECUTION_TCA_ACTIVITY_LOOKBACK_SECONDS"),
+        help=(
+            "Only refresh executions with created, broker-update, or order-feed activity inside this lookback. "
+            "Defaults to TORGHUT_EXECUTION_TCA_ACTIVITY_LOOKBACK_SECONDS when set. "
+            "Omit for unrestricted manual backfills."
+        ),
     )
     parser.add_argument("--batch-size", type=int, default=1000)
     parser.add_argument("--max-batches", type=int, default=20)
@@ -88,6 +105,9 @@ def _payload(
         "dsn_env": args.dsn_env,
         "account_label": args.account_label,
         "older_than_seconds": max(0, int(args.older_than_seconds)),
+        "execution_activity_lookback_seconds": None
+        if args.execution_activity_lookback_seconds is None
+        else max(0, int(args.execution_activity_lookback_seconds)),
         "batch_size": max(1, min(int(args.batch_size), 5000)),
         "max_batches": max(1, int(args.max_batches)),
         "selected": selected,
@@ -102,6 +122,12 @@ def main() -> int:
     args = _parse_args()
     started_at = datetime.now(timezone.utc)
     stale_before = started_at - timedelta(seconds=max(0, int(args.older_than_seconds)))
+    execution_activity_after = (
+        None
+        if args.execution_activity_lookback_seconds is None
+        else started_at
+        - timedelta(seconds=max(0, int(args.execution_activity_lookback_seconds)))
+    )
     batch_size = max(1, min(int(args.batch_size), 5000))
     max_batches = max(1, int(args.max_batches))
     batches: list[dict[str, Any]] = []
@@ -114,6 +140,7 @@ def main() -> int:
                     session,
                     account_label=args.account_label,
                     stale_before=stale_before,
+                    execution_activity_after=execution_activity_after,
                     limit=batch_size,
                     dry_run=not bool(args.apply),
                 )

--- a/services/torghut/tests/tca_adaptive_policy/test_adaptive_policy_derivation.py
+++ b/services/torghut/tests/tca_adaptive_policy/test_adaptive_policy_derivation.py
@@ -618,6 +618,87 @@ class TestAdaptivePolicyDerivation(_TestAdaptiveExecutionPolicyDerivationBase):
         self.assertEqual(result["dry_run"], True)
         self.assertEqual(result["account_label"], "paper")
 
+    def test_refresh_execution_tca_metrics_skips_inactive_stale_rows(self) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "strategy_id": str(strategy.id),
+                    "symbol": "AAPL",
+                    "action": "buy",
+                    "qty": "1",
+                    "params": {"price": "100"},
+                },
+                rationale="test",
+                status="submitted",
+                decision_hash="hash-inactive-tca",
+            )
+            session.add(decision)
+            session.flush()
+            old_activity_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+            recent_refresh_side_effect_at = datetime(2026, 1, 20, tzinfo=timezone.utc)
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_order_id="order-inactive-tca",
+                client_order_id="client-inactive-tca",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                alpaca_account_label="paper",
+                execution_expected_adapter="alpaca",
+                execution_actual_adapter="alpaca",
+                created_at=old_activity_at,
+                updated_at=recent_refresh_side_effect_at,
+                last_update_at=old_activity_at,
+                order_feed_last_event_ts=old_activity_at,
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    side="buy",
+                    arrival_price=Decimal("101"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    slippage_bps=Decimal("-99.00990099"),
+                    shortfall_notional=Decimal("-1"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=old_activity_at,
+                )
+            )
+            session.commit()
+
+            result = refresh_execution_tca_metrics(
+                session,
+                account_label="paper",
+                stale_before=datetime(2026, 2, 1, tzinfo=timezone.utc),
+                execution_activity_after=datetime(2026, 1, 15, tzinfo=timezone.utc),
+                limit=10,
+            )
+
+        self.assertEqual(result["selected"], 0)
+        self.assertEqual(result["refreshed"], 0)
+        self.assertEqual(
+            result["execution_activity_after"],
+            "2026-01-15T00:00:00+00:00",
+        )
+
     def test_upsert_tca_preserves_execution_account_without_decision_link(self) -> None:
         with self.session_local() as session:
             execution = Execution(

--- a/services/torghut/tests/test_refresh_execution_tca_metrics_script.py
+++ b/services/torghut/tests/test_refresh_execution_tca_metrics_script.py
@@ -51,6 +51,17 @@ class TestRefreshExecutionTcaMetricsScript(TestCase):
             "sqlite:///tmp/torghut.db",
         )
 
+    def test_env_int_or_none_uses_blank_as_unset(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"TORGHUT_EXECUTION_TCA_ACTIVITY_LOOKBACK_SECONDS": " "},
+        ):
+            self.assertIsNone(
+                script._env_int_or_none(
+                    "TORGHUT_EXECUTION_TCA_ACTIVITY_LOOKBACK_SECONDS"
+                )
+            )
+
     def test_main_defaults_to_dry_run_and_rolls_back(self) -> None:
         fake_session = _FakeSession()
         stdout = io.StringIO()
@@ -106,6 +117,10 @@ class TestRefreshExecutionTcaMetricsScript(TestCase):
                     "3",
                 ],
             ),
+            patch.dict(
+                os.environ,
+                {"TORGHUT_EXECUTION_TCA_ACTIVITY_LOOKBACK_SECONDS": "86400"},
+            ),
             patch.object(script, "SessionLocal", return_value=fake_session),
             patch.object(
                 script,
@@ -138,6 +153,7 @@ class TestRefreshExecutionTcaMetricsScript(TestCase):
         self.assertEqual(payload["apply"], True)
         self.assertEqual(payload["account_label"], "paper")
         self.assertEqual(payload["older_than_seconds"], 0)
+        self.assertEqual(payload["execution_activity_lookback_seconds"], 86400)
         self.assertEqual(payload["selected"], 3)
         self.assertEqual(payload["refreshed"], 3)
         self.assertEqual(fake_session.commits, 2)
@@ -146,6 +162,7 @@ class TestRefreshExecutionTcaMetricsScript(TestCase):
         self.assertEqual(refresh.call_args.kwargs["account_label"], "paper")
         self.assertEqual(refresh.call_args.kwargs["limit"], 2)
         self.assertEqual(refresh.call_args.kwargs["dry_run"], False)
+        self.assertIsNotNone(refresh.call_args.kwargs["execution_activity_after"])
 
     def test_main_can_refresh_non_default_dsn_env(self) -> None:
         fake_engine = _FakeEngine()


### PR DESCRIPTION
## Summary

- Added an execution activity cutoff to `refresh_execution_tca_metrics` so stale TCA rows are only refreshed when the source execution was recently created or updated by broker/order-feed activity.
- Applied a rollout-safe env-based 24-hour source-activity lookback to the live `torghut-execution-tca-refresh` CronJob to stop repeated five-minute recomputation of old historical executions once the rebuilt image is promoted.
- Added explicit websocket Logback defaults that keep Kafka client internals at WARN while preserving application INFO logs.
- Added regressions for inactive stale TCA rows, CLI argument forwarding, and websocket logging config.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_refresh_execution_tca_metrics_script.py tests/tca_adaptive_policy/test_adaptive_policy_derivation.py -q`
- `uv run --frozen pytest tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py -q`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `./gradlew :websockets:test`
- `./gradlew :websockets:ktlintCheck :websockets:build`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
