### PR TITLE
chore(torghut): promote ta image a0739d7b

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:02328fa9e111cdfbe54a0122cc7eeac31d9325850ef0cab42335f8b1b3ba92b5
   imagePullPolicy: IfNotPresent
-  restartNonce: 14
+  restartNonce: 15
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -88,9 +88,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: a0739d7b
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: a0739d7bf5391a8e52a0e21440989f9a8323983e
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:02328fa9e111cdfbe54a0122cc7eeac31d9325850ef0cab42335f8b1b3ba92b5
   imagePullPolicy: IfNotPresent
-  restartNonce: 18
+  restartNonce: 19
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: a0739d7b
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: a0739d7bf5391a8e52a0e21440989f9a8323983e
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:02328fa9e111cdfbe54a0122cc7eeac31d9325850ef0cab42335f8b1b3ba92b5
   imagePullPolicy: IfNotPresent
-  restartNonce: 12
+  restartNonce: 13
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: a0739d7b
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: a0739d7bf5391a8e52a0e21440989f9a8323983e
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `a0739d7bf5391a8e52a0e21440989f9a8323983e`
- Image tag: `a0739d7b`
- Image digest: `sha256:02328fa9e111cdfbe54a0122cc7eeac31d9325850ef0cab42335f8b1b3ba92b5`
- Manifests: live TA, sim TA, options TA