### PR TITLE
chore(torghut): promote ws image a0739d7b

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:64f6e4432cf94ee25a7d30f89bf22140c72aee9e8f378e65708c453aa3610bb8
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:2d7d9ccb30fa78e31bdb884bb75c3218197b177adaecff6a4d9f51577da5f10a
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -53,9 +53,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-72a1961c
+              value: main-a0739d7b
             - name: TORGHUT_WS_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: a0739d7bf5391a8e52a0e21440989f9a8323983e
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:64f6e4432cf94ee25a7d30f89bf22140c72aee9e8f378e65708c453aa3610bb8
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:2d7d9ccb30fa78e31bdb884bb75c3218197b177adaecff6a4d9f51577da5f10a
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-72a1961c
+              value: main-a0739d7b
             - name: TORGHUT_WS_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: a0739d7bf5391a8e52a0e21440989f9a8323983e
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `a0739d7bf5391a8e52a0e21440989f9a8323983e`
- Image tag: `a0739d7b`
- Image digest: `sha256:2d7d9ccb30fa78e31bdb884bb75c3218197b177adaecff6a4d9f51577da5f10a`