### PR TITLE
fix(agents): build release images natively

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -29,8 +29,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: arc-arm64
+  build-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -53,14 +63,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts --filter @proompteng/agents
 
-      - name: Build and push Agents images
+      - name: Build and push native Agents images
         env:
           AGENTS_APPLY: 'false'
           AGENTS_BUILD_RUNNER: 'true'
           AGENTS_DOCKERFILE: services/agents/Dockerfile
-          AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
-          AGENTS_IMAGE_PLATFORMS: linux/amd64,linux/arm64
-          AGENTS_RUNNER_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-codex-runner:buildcache
+          AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
+          AGENTS_IMAGE_PLATFORMS: ${{ matrix.platform }}
+          AGENTS_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-buildcache:${{ matrix.arch }}
+          AGENTS_RUNNER_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-codex-runner:buildcache-${{ matrix.arch }}
           AGENTS_BUILD_CACHE_MODE: max
           AGENTS_BUILD_NODE_OPTIONS: --max-old-space-size=4096
           AGENTS_BUILD_SOURCEMAP: '0'
@@ -69,6 +80,109 @@ jobs:
           DOCKER_BUILD_PROVENANCE: max
           DOCKER_BUILD_SBOM: 'true'
         run: bun run agents:deploy -- --no-apply
+
+  publish-index:
+    needs: build-platform
+    runs-on: arc-arm64
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          cache-binary: false
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
+
+      - name: Create multi-arch Agents image indexes
+        id: digests
+        shell: bash
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          CONTROLLER_IMAGE: registry.ide-newton.ts.net/lab/agents-controller
+          CONTROL_PLANE_IMAGE: registry.ide-newton.ts.net/lab/agents-control-plane
+          RUNNER_IMAGE: registry.ide-newton.ts.net/lab/agents-codex-runner
+        run: |
+          set -euo pipefail
+
+          create_index() {
+            local image="$1"
+            docker buildx imagetools create \
+              -t "${image}:${TAG}" \
+              "${image}:${TAG}-amd64" \
+              "${image}:${TAG}-arm64"
+          }
+
+          resolve_digest() {
+            local image="$1"
+            local manifest_json
+            manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image}:${TAG}")"
+            local digest
+            digest="$(jq -r '.manifest.digest // empty' <<< "${manifest_json}")"
+            if ! printf '%s' "${digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Failed to resolve digest for ${image}:${TAG}" >&2
+              docker buildx imagetools inspect "${image}:${TAG}" >&2
+              exit 1
+            fi
+
+            for platform in linux/amd64 linux/arm64; do
+              local platform_digest
+              platform_digest="$(
+                jq -r --arg platform "${platform}" \
+                  '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                  <<< "${manifest_json}" | head -n 1
+              )"
+              if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+                echo "Image ${image}:${TAG} is missing required platform ${platform}" >&2
+                docker buildx imagetools inspect "${image}:${TAG}" >&2
+                exit 1
+              fi
+            done
+
+            printf '%s' "${digest}"
+          }
+
+          create_index "${CONTROLLER_IMAGE}"
+          create_index "${CONTROL_PLANE_IMAGE}"
+          create_index "${RUNNER_IMAGE}"
+
+          {
+            echo "controller_digest=$(resolve_digest "${CONTROLLER_IMAGE}")"
+            echo "control_plane_digest=$(resolve_digest "${CONTROL_PLANE_IMAGE}")"
+            echo "runner_digest=$(resolve_digest "${RUNNER_IMAGE}")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write rendered Agents values
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          CONTROLLER_DIGEST: ${{ steps.digests.outputs.controller_digest }}
+          CONTROL_PLANE_DIGEST: ${{ steps.digests.outputs.control_plane_digest }}
+          RUNNER_DIGEST: ${{ steps.digests.outputs.runner_digest }}
+        run: |
+          bun run packages/scripts/src/agents/update-values.ts \
+            --values argocd/applications/agents/values.yaml \
+            --tag "${TAG}" \
+            --controller-repository registry.ide-newton.ts.net/lab/agents-controller \
+            --controller-digest "${CONTROLLER_DIGEST}" \
+            --control-plane-repository registry.ide-newton.ts.net/lab/agents-control-plane \
+            --control-plane-digest "${CONTROL_PLANE_DIGEST}" \
+            --runner-repository registry.ide-newton.ts.net/lab/agents-codex-runner \
+            --runner-digest "${RUNNER_DIGEST}" \
+            --source-sha "${GITHUB_SHA}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --ci-conclusion success
 
       - name: Upload rendered Agents values
         uses: actions/upload-artifact@v6

--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -3,7 +3,11 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync 
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { __private } from '../build-image'
+import { __private, buildImages } from '../build-image'
+import { __private as dockerPrivate } from '../../shared/docker'
+
+const originalSpawn = Bun.spawn
+const originalWhich = Bun.which
 
 const envKeys = [
   'AGENTS_BUILD_CACHE_MODE',
@@ -13,6 +17,7 @@ const envKeys = [
   'AGENTS_BUILD_MINIFY',
   'AGENTS_BUILD_NODE_OPTIONS',
   'AGENTS_BUILD_PRUNE_SCOPE',
+  'AGENTS_BUILD_CACHE_REF',
   'AGENTS_BUILD_SOURCEMAP',
   'AGENTS_COMMIT',
   'AGENTS_DOCKERFILE',
@@ -28,6 +33,9 @@ afterEach(() => {
   for (const key of envKeys) {
     delete process.env[key]
   }
+  Bun.spawn = originalSpawn
+  Bun.which = originalWhich
+  dockerPrivate.setSpawnSync()
 })
 
 describe('agents build-image helpers', () => {
@@ -59,6 +67,15 @@ describe('agents build-image helpers', () => {
       AGENTS_BUILD_CI: 'true',
       AGENTS_BUILD_LOG_LEVEL: 'warn',
     })
+  })
+
+  it('keeps batch cache exports target-specific when a shared cache ref is configured', () => {
+    expect(__private.cacheRefForBatchTarget('registry.example/cache:amd64', 'controller', true)).toBe(
+      'registry.example/cache:amd64-controller',
+    )
+    expect(__private.cacheRefForBatchTarget('registry.example/cache:amd64', 'controller', false)).toBe(
+      'registry.example/cache:amd64',
+    )
   })
 
   it('uses the Agents workspace as the default control-plane prune scope', () => {
@@ -109,6 +126,66 @@ describe('agents build-image helpers', () => {
       expect(existsSync(agentsNodeModules)).toBeFalse()
       expect(existsSync(nestedNodeModules)).toBeFalse()
       expect(existsSync(sourceDirectory)).toBeTrue()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('builds a batch of Agents images through one Buildx Bake invocation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-batch-context-'))
+    const commands: string[][] = []
+    try {
+      process.env.AGENTS_BUILD_CONTEXT = dir
+      Bun.which = ((binary: string) => (binary === 'docker' ? '/usr/bin/docker' : null)) as typeof Bun.which
+      Bun.spawn = ((command: Parameters<typeof Bun.spawn>[0]) => {
+        commands.push(typeof command === 'string' ? [command] : [...command])
+        return {
+          exited: Promise.resolve(0),
+          stdout: new Response('').body,
+          stderr: new Response('').body,
+        } as ReturnType<typeof Bun.spawn>
+      }) as typeof Bun.spawn
+      dockerPrivate.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+        const joined = typeof command === 'string' ? command : command.join(' ')
+        if (joined === 'docker buildx version') {
+          return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
+        }
+        if (joined === 'docker buildx inspect') {
+          return {
+            exitCode: 0,
+            stdout: Buffer.from('Driver: docker-container\n'),
+            stderr: new Uint8Array(),
+          } as ReturnType<typeof Bun.spawnSync>
+        }
+        return { exitCode: 1, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
+      }) as typeof Bun.spawnSync)
+
+      const results = await buildImages([
+        {
+          registry: 'registry.example',
+          repository: 'lab/agents-controller',
+          tag: 'abc123',
+          target: 'controller',
+          platforms: ['linux/arm64'],
+        },
+        {
+          registry: 'registry.example',
+          repository: 'lab/agents-control-plane',
+          tag: 'abc123',
+          target: 'control-plane',
+          platforms: ['linux/arm64'],
+        },
+      ])
+
+      expect(results.map((result) => result.image)).toEqual([
+        'registry.example/lab/agents-controller:abc123',
+        'registry.example/lab/agents-control-plane:abc123',
+      ])
+      expect(commands).toHaveLength(1)
+      expect(commands[0].slice(0, 3)).toEqual(['docker', 'buildx', 'bake'])
+      expect(commands[0]).toContain('--push')
+      expect(commands[0]).toContain('controller')
+      expect(commands[0]).toContain('control-plane')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -237,6 +237,24 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).not.toContain('group: agents-build-${{ github.ref }}-${{ github.sha }}')
   })
 
+  it('publishes Agents images with native per-architecture runners', () => {
+    const workflow = readFileSync(
+      new URL('../../../../../.github/workflows/agents-build-push.yml', import.meta.url),
+      'utf8',
+    )
+
+    expect(workflow).toContain('runner: arc-amd64')
+    expect(workflow).toContain('runner: arc-arm64')
+    expect(workflow).toContain('AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}')
+    expect(workflow).toContain('AGENTS_IMAGE_PLATFORMS: ${{ matrix.platform }}')
+    expect(workflow).not.toContain('AGENTS_IMAGE_PLATFORMS: linux/amd64,linux/arm64')
+    expect(workflow).toContain('docker buildx imagetools create')
+    expect(workflow).toContain('registry.ide-newton.ts.net/lab/agents-controller')
+    expect(workflow).toContain('registry.ide-newton.ts.net/lab/agents-control-plane')
+    expect(workflow).toContain('registry.ide-newton.ts.net/lab/agents-codex-runner')
+    expect(workflow).toContain('packages/scripts/src/agents/update-values.ts')
+  })
+
   it('builds local Agents smoke images from the Agents Dockerfile', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 

--- a/packages/scripts/src/agents/__tests__/update-values.test.ts
+++ b/packages/scripts/src/agents/__tests__/update-values.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { __private, updateAgentsValuesFromCliOptions } from '../update-values'
+
+const sha = 'a'.repeat(40)
+const controllerDigest = `sha256:${'1'.repeat(64)}`
+const controlPlaneDigest = `sha256:${'2'.repeat(64)}`
+const runnerDigest = `sha256:${'3'.repeat(64)}`
+
+describe('agents update-values helper', () => {
+  it('writes promoted controller, control-plane, and runner multi-arch digests', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-update-values-'))
+    const valuesPath = join(dir, 'values.yaml')
+    try {
+      writeFileSync(
+        valuesPath,
+        `image:
+  repository: old/controller
+  tag: old
+  digest: sha256:old-controller
+controlPlane:
+  image:
+    repository: old/control-plane
+    tag: old
+    digest: sha256:old-control-plane
+runner:
+  image:
+    repository: old/runner
+    tag: old
+    digest: sha256:old-runner
+controllers:
+  image:
+    repository: old/controller
+    tag: old
+    digest: sha256:old-controller
+`,
+      )
+
+      updateAgentsValuesFromCliOptions({
+        valuesPath,
+        tag: 'abc12345',
+        controllerRepository: 'registry.example/lab/agents-controller',
+        controllerDigest,
+        controlPlaneRepository: 'registry.example/lab/agents-control-plane',
+        controlPlaneDigest,
+        runnerRepository: 'registry.example/lab/agents-codex-runner',
+        runnerDigest,
+        sourceSha: sha,
+        runId: '123456',
+        ciConclusion: 'success',
+      })
+
+      const updated = readFileSync(valuesPath, 'utf8')
+      expect(updated).toContain('repository: registry.example/lab/agents-controller')
+      expect(updated).toContain('repository: registry.example/lab/agents-control-plane')
+      expect(updated).toContain('repository: registry.example/lab/agents-codex-runner')
+      expect(updated).toContain('tag: abc12345')
+      expect(updated).toContain(`digest: ${controllerDigest}`)
+      expect(updated).toContain(`digest: ${controlPlaneDigest}`)
+      expect(updated).toContain(`digest: ${runnerDigest}`)
+      expect(updated).toContain(`AGENTS_SOURCE_HEAD_SHA: ${sha}`)
+      expect(updated).toContain('AGENTS_SOURCE_CI_RUN_ID: "123456"')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('normalizes repository-qualified digests and rejects malformed digests', () => {
+    expect(__private.normalizeDigest(`registry.example/repo@${controllerDigest}`)).toBe(controllerDigest)
+    expect(() =>
+      updateAgentsValuesFromCliOptions({
+        valuesPath: 'argocd/applications/agents/values.yaml',
+        tag: 'abc12345',
+        controllerRepository: 'registry.example/lab/agents-controller',
+        controllerDigest: 'sha256:not-valid',
+        controlPlaneRepository: 'registry.example/lab/agents-control-plane',
+        controlPlaneDigest,
+        runnerRepository: 'registry.example/lab/agents-codex-runner',
+        runnerDigest,
+        sourceSha: sha,
+      }),
+    ).toThrow('Invalid digest for controllerDigest')
+  })
+})

--- a/packages/scripts/src/agents/build-image.ts
+++ b/packages/scripts/src/agents/build-image.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 
 import { ensureCli, repoRoot, run } from '../shared/cli'
-import { buildAndPushDockerImage, type DockerCacheMode } from '../shared/docker'
+import { buildAndPushDockerImage, buildAndPushDockerImages, type DockerCacheMode } from '../shared/docker'
 import { execGit } from '../shared/git'
 
 export type BuildImageOptions = {
@@ -49,7 +49,7 @@ const parsePlatforms = (value: string | undefined): string[] | undefined => {
   return platforms.length > 0 ? platforms : undefined
 }
 
-const defaultPruneScopesForTarget = (target: string | undefined): string[] => [
+const defaultPruneScopesForTarget = (_target: string | undefined): string[] => [
   '@proompteng/agents',
   '@proompteng/agent-contracts',
   '@proompteng/otel',
@@ -207,6 +207,12 @@ const resolveBuildConfiguration = (options: BuildImageOptions = {}): BuildConfig
   }
 }
 
+const cacheRefForBatchTarget = (cacheRef: string, targetName: string, isSharedCacheRef: boolean): string => {
+  if (!isSharedCacheRef) return cacheRef
+  const separator = cacheRef.includes(':') ? '-' : ':'
+  return `${cacheRef}${separator}${targetName}`
+}
+
 export const buildImage = async (options: BuildImageOptions = {}) => {
   const config = resolveBuildConfiguration(options)
 
@@ -247,6 +253,63 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
   }
 }
 
+export const buildImages = async (options: BuildImageOptions[]) => {
+  if (options.length === 0) return []
+
+  const configs = options.map((option) => resolveBuildConfiguration(option))
+  const usesPrunedContext = configs.every((config) => config.usePrune)
+  const usesExplicitContext = configs.every((config) => !config.usePrune)
+  if (!usesPrunedContext && !usesExplicitContext) {
+    throw new Error('Agents image batch builds must use either all pruned contexts or all explicit contexts')
+  }
+
+  let pruneCleanup: (() => void) | undefined
+
+  try {
+    const sharedPrunedContext = usesPrunedContext ? await createPrunedContext() : undefined
+    pruneCleanup = sharedPrunedContext?.cleanup
+    const hasSharedCacheRef = new Set(configs.map((config) => config.cacheRef)).size < configs.length
+
+    const targets = configs.map((config, index) => {
+      const context =
+        sharedPrunedContext?.dir ?? resolve(repoRoot, options[index].context ?? process.env.AGENTS_BUILD_CONTEXT ?? '.')
+      const targetName = config.target ?? `agents-image-${index}`
+      const codexAuthPathForDocker = existsSync(config.codexAuthPath) ? config.codexAuthPath : undefined
+      if (!codexAuthPathForDocker) {
+        console.warn(`Codex auth not found at ${config.codexAuthPath}; build will proceed without it.`)
+      }
+
+      return {
+        name: targetName,
+        registry: config.registry,
+        repository: config.repository,
+        tag: config.tag,
+        context,
+        dockerfile: config.dockerfile,
+        target: config.target,
+        buildArgs: config.buildArgs,
+        codexAuthPath: codexAuthPathForDocker,
+        cacheRef: cacheRefForBatchTarget(config.cacheRef, targetName, hasSharedCacheRef),
+        cacheMode: config.cacheMode,
+        platforms: config.platforms,
+      }
+    })
+
+    const result = await buildAndPushDockerImages({
+      cwd: repoRoot,
+      targets,
+    })
+
+    return result.targets.map((target, index) => ({
+      ...target,
+      version: configs[index].version,
+      commit: configs[index].commit,
+    }))
+  } finally {
+    pruneCleanup?.()
+  }
+}
+
 if (import.meta.main) {
   buildImage().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error))
@@ -256,6 +319,7 @@ if (import.meta.main) {
 
 export const __private = {
   buildArgsFromEnv,
+  cacheRefForBatchTarget,
   execGit,
   parsePlatforms,
   parsePruneScopes,

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
 import YAML from 'yaml'
-import { buildImage, type BuildImageOptions } from './build-image'
+import { buildImages, type BuildImageOptions } from './build-image'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
 import { buildAndPushDockerImage, inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
@@ -426,6 +426,8 @@ const updateValuesFile = (
   )
 }
 
+export const updateAgentsValuesFile = updateValuesFile
+
 const readRunnerImagePin = (valuesPath: string): ImagePin => {
   const values = YAML.parse(readFileSync(valuesPath, 'utf8')) ?? {}
   const runnerImage = values.runner?.image
@@ -536,9 +538,7 @@ const main = async () => {
   const runnerImageName = `${options.registry}/${options.runnerRepository}`
   const runnerImage = `${runnerImageName}:${options.tag}`
 
-  for (const imagePlan of buildAgentsServiceImagePlans(options)) {
-    await buildImage(imagePlan)
-  }
+  await buildImages(buildAgentsServiceImagePlans(options))
   const runnerPin = options.buildRunner ? undefined : readRunnerImagePin(options.valuesPath)
   if (options.buildRunner) {
     if (!options.codexAuthPath) {

--- a/packages/scripts/src/agents/update-values.ts
+++ b/packages/scripts/src/agents/update-values.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+import { updateAgentsValuesFile } from './deploy-service'
+import { fatal, repoRoot } from '../shared/cli'
+import { execGit } from '../shared/git'
+
+type Options = {
+  valuesPath?: string
+  tag?: string
+  controllerRepository?: string
+  controllerDigest?: string
+  controlPlaneRepository?: string
+  controlPlaneDigest?: string
+  runnerRepository?: string
+  runnerDigest?: string
+  sourceSha?: string
+  runId?: string
+  ciConclusion?: string
+}
+
+const digestPattern = /^sha256:[0-9a-f]{64}$/i
+
+const parseArgs = (argv: string[]): Options => {
+  const options: Options = {}
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) i += 1
+    if (!flag.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (flag) {
+      case '--values':
+        options.valuesPath = value
+        break
+      case '--tag':
+        options.tag = value
+        break
+      case '--controller-repository':
+        options.controllerRepository = value
+        break
+      case '--controller-digest':
+        options.controllerDigest = normalizeDigest(value)
+        break
+      case '--control-plane-repository':
+        options.controlPlaneRepository = value
+        break
+      case '--control-plane-digest':
+        options.controlPlaneDigest = normalizeDigest(value)
+        break
+      case '--runner-repository':
+        options.runnerRepository = value
+        break
+      case '--runner-digest':
+        options.runnerDigest = normalizeDigest(value)
+        break
+      case '--source-sha':
+        options.sourceSha = value
+        break
+      case '--run-id':
+        options.runId = value
+        break
+      case '--ci-conclusion':
+        options.ciConclusion = value
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  return options
+}
+
+const normalizeDigest = (value: string): string => {
+  const trimmed = value.trim()
+  return trimmed.includes('@') ? trimmed.slice(trimmed.lastIndexOf('@') + 1) : trimmed
+}
+
+const requireValue = (options: Options, key: keyof Options): string => {
+  const value = options[key]
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Missing required option --${key.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`)
+  }
+  return value
+}
+
+const requireDigest = (options: Options, key: keyof Options): string => {
+  const digest = requireValue(options, key)
+  if (!digestPattern.test(digest)) {
+    throw new Error(`Invalid digest for ${key}: ${digest}`)
+  }
+  return digest
+}
+
+export const updateAgentsValuesFromCliOptions = (options: Options) => {
+  const valuesPath = resolve(repoRoot, options.valuesPath ?? 'argocd/applications/agents/values.yaml')
+  const tag = requireValue(options, 'tag')
+  const sourceSha = options.sourceSha ?? execGit(['rev-parse', 'HEAD'])
+  const controlPlaneDigest = requireDigest(options, 'controlPlaneDigest')
+
+  updateAgentsValuesFile(
+    valuesPath,
+    requireValue(options, 'controllerRepository'),
+    tag,
+    requireDigest(options, 'controllerDigest'),
+    requireValue(options, 'controlPlaneRepository'),
+    tag,
+    controlPlaneDigest,
+    requireValue(options, 'runnerRepository'),
+    tag,
+    requireDigest(options, 'runnerDigest'),
+    {
+      sourceHeadSha: sourceSha,
+      gitopsRevision: sourceSha,
+      sourceCiRunId: options.runId ?? process.env.GITHUB_RUN_ID,
+      sourceCiConclusion: options.ciConclusion ?? process.env.AGENTS_SOURCE_CI_CONCLUSION ?? 'success',
+      manifestImageDigest: controlPlaneDigest,
+      servingBuildCommit: sourceSha,
+      servingImageDigest: controlPlaneDigest,
+    },
+  )
+}
+
+if (import.meta.main) {
+  try {
+    updateAgentsValuesFromCliOptions(parseArgs(process.argv.slice(2)))
+  } catch (error) {
+    fatal('Failed to update Agents values', error)
+  }
+}
+
+export const __private = {
+  normalizeDigest,
+  parseArgs,
+  requireDigest,
+}


### PR DESCRIPTION
## Summary

- Split `agents-build-push` into native amd64 and arm64 build jobs so the runner image no longer installs Python packages under QEMU.
- Publish normal multi-arch image tags in a follow-up index job after both native architecture tags are pushed.
- Batch controller and control-plane service image builds through one shared Buildx Bake context while keeping target-specific cache exports.
- Add a small values writer for the index job and regression coverage for the workflow, batched build path, and values update.

## Related Issues

None

## Testing

- `bunx oxfmt --check .github/workflows/agents-build-push.yml packages/scripts/src/agents/build-image.ts packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/update-values.ts packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/update-values.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agents-build-push.yml"); puts "agents-build-push.yml parsed"'`
- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/update-values.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `bun run --filter @proompteng/agents tsc`
- `bun run --filter @proompteng/agents test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
