### PR TITLE
chore(agents): promote images 2d1507c1

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 17a315d04
-  digest: sha256:96c6b68d191cdb50b4429b6009ca63f5c941d44b093fa49f01a7b99f5db0870b
+  tag: 2d1507c1
+  digest: sha256:72aba63d6354af8ae7bd04e3d70742ef1c12e22fcdcc888a01a0eb0778ffd07a
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,26 +14,26 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 17a315d04
-    digest: sha256:447b37336cd42ad23526fe7c0f462cbb838f8ec08f5eb2a0e48de65be633fbdb
+    tag: 2d1507c1
+    digest: sha256:00bfa7df812ed0c2d0320a0f888ec529faf0b8132e859714dff656519d8d2d1d
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 17a315d04d457ae9d64ef52af67b3acaabefef06
-      AGENTS_GITOPS_REVISION: 17a315d04d457ae9d64ef52af67b3acaabefef06
-      AGENTS_SOURCE_CI_RUN_ID: "26999079708"
+      AGENTS_SOURCE_HEAD_SHA: 2d1507c141e1c56fd12a8df96dd6b8f7f7ae336a
+      AGENTS_GITOPS_REVISION: 2d1507c141e1c56fd12a8df96dd6b8f7f7ae336a
+      AGENTS_SOURCE_CI_RUN_ID: "27671421879"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:447b37336cd42ad23526fe7c0f462cbb838f8ec08f5eb2a0e48de65be633fbdb
-      AGENTS_SERVING_BUILD_COMMIT: 17a315d04d457ae9d64ef52af67b3acaabefef06
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:447b37336cd42ad23526fe7c0f462cbb838f8ec08f5eb2a0e48de65be633fbdb
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:00bfa7df812ed0c2d0320a0f888ec529faf0b8132e859714dff656519d8d2d1d
+      AGENTS_SERVING_BUILD_COMMIT: 2d1507c141e1c56fd12a8df96dd6b8f7f7ae336a
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:00bfa7df812ed0c2d0320a0f888ec529faf0b8132e859714dff656519d8d2d1d
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: b18caf3d8
-    digest: sha256:4e1cb399c4ec0d458622e2689b02f5166bd9205b64a33fe904e5756b3d89f004
+    tag: 2d1507c1
+    digest: sha256:d4e3f50dcae017dc27703fb661e4006129514b87dd7a2d03e73ea47c7c009628
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -88,8 +88,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 17a315d04
-    digest: sha256:96c6b68d191cdb50b4429b6009ca63f5c941d44b093fa49f01a7b99f5db0870b
+    tag: 2d1507c1
+    digest: sha256:72aba63d6354af8ae7bd04e3d70742ef1c12e22fcdcc888a01a0eb0778ffd07a
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `2d1507c141e1c56fd12a8df96dd6b8f7f7ae336a`
- Image tag: `2d1507c1`
- Agents build run: `27671421879`
- Promotion source: `manual_dispatch`