### PR TITLE
revert(torghut): rollback failed promotion e1f5374656b6075a5beb1b9bad610e0e8eea6f05

### DIFF
--- a/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
@@ -7,10 +7,10 @@ spec:
   schedule: "17 4 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       template:
         spec:
           restartPolicy: OnFailure

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -7,17 +7,19 @@ spec:
   schedule: "23 8,21 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 900
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 2
       activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: OnFailure
           serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
           containers:
             - name: renew
               image: registry.ide-newton.ts.net/lab/torghut@sha256:f7e5a2039dd203c18226ee348e55eb599a6d9fecade2260d96f0ccac9b81d964
@@ -42,10 +44,8 @@ spec:
                   PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json
                   HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT=/tmp/torghut-empirical-renewal/hpairs-source-proof-census.json
                   mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")" "$(dirname "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}")"
-                  echo "stage=empirical_promotion_renewal started_at=$(date -Iseconds)"
                   WINDOW_END="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
                   WINDOW_START="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
-                  echo "stage=reconcile_cross_dsn_order_feed_links started_at=$(date -Iseconds) window_start=${WINDOW_START} window_end=${WINDOW_END}"
                   /opt/venv/bin/python scripts/reconcile_cross_dsn_order_feed_links.py \
                     --event-dsn-env DB_DSN \
                     --canonical-dsn-env SIM_DB_DSN \
@@ -131,10 +131,7 @@ spec:
                     --artifact-prefix 'runtime-ledger-proof-packets/{run_id}' \
                     --require-artifact-upload \
                     --allow-blocked-exit-zero
-                  echo "stage=empirical_promotion_renewal completed_at=$(date -Iseconds)"
               env:
-                - name: PYTHONUNBUFFERED
-                  value: "1"
                 - name: DB_DSN
                   valueFrom:
                     secretKeyRef:

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -10,16 +10,18 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 1
       activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: OnFailure
           serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
               image: registry.ide-newton.ts.net/lab/torghut@sha256:f7e5a2039dd203c18226ee348e55eb599a6d9fecade2260d96f0ccac9b81d964
@@ -34,8 +36,6 @@ spec:
                   memory: 1Gi
                   ephemeral-storage: 512Mi
               env:
-                - name: PYTHONUNBUFFERED
-                  value: "1"
                 - name: DB_DSN
                   valueFrom:
                     secretKeyRef:

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -130,15 +130,11 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "100"
-            - name: TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER
-              value: "100"
-            - name: TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL
-              value: "250"
+              value: "25000"
             - name: TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY
               value: "0.25"
             - name: TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY
-              value: "0.05"
+              value: "1.0"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
               value: http://torghut.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=next&limit=20
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
@@ -434,7 +430,7 @@ spec:
             - name: WHITEPAPER_INNGEST_FINALIZE_FUNCTION_ID
               value: torghut-whitepaper-synthesis-index-v1
             - name: WHITEPAPER_SEMANTIC_INDEXING_ENABLED
-              value: "false"
+              value: "true"
             - name: WHITEPAPER_SEMANTIC_REQUIRED
               value: "false"
             - name: WHITEPAPER_EMBEDDING_API_BASE_URL

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -127,23 +127,17 @@ spec:
             - name: TRADING_PIPELINE_MODE
               value: simple
             - name: TRADING_SIMPLE_SUBMIT_ENABLED
-              value: "true"
-            - name: TRADING_LIVE_SUBMIT_ACTIVATION_EXPIRES_AT
-              value: "2026-06-17T20:05:00Z"
+              value: "false"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "100"
-            - name: TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER
-              value: "100"
-            - name: TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL
-              value: "250"
+              value: "25000"
             - name: TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY
               value: "0.25"
             - name: TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY
-              value: "0.05"
+              value: "1.0"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS
@@ -274,9 +268,9 @@ spec:
             - name: POSTHOG_ENABLED
               value: "false"
             - name: WHITEPAPER_WORKFLOW_ENABLED
-              value: "false"
+              value: "true"
             - name: WHITEPAPER_KAFKA_ENABLED
-              value: "false"
+              value: "true"
             - name: WHITEPAPER_KAFKA_BOOTSTRAP_SERVERS
               value: kafka-kafka-bootstrap.kafka:9092
             - name: WHITEPAPER_KAFKA_TOPIC
@@ -326,7 +320,7 @@ spec:
             - name: WHITEPAPER_CEPH_SECRET_DIR
               value: /etc/torghut/whitepapers-secret
             - name: WHITEPAPER_AGENTRUN_AUTO_DISPATCH
-              value: "false"
+              value: "true"
             - name: WHITEPAPER_AGENTRUN_NAMESPACE
               value: agents
             - name: WHITEPAPER_AGENT_NAME
@@ -370,7 +364,7 @@ spec:
             - name: WHITEPAPER_INNGEST_FINALIZE_FUNCTION_ID
               value: torghut-whitepaper-synthesis-index-v1
             - name: WHITEPAPER_SEMANTIC_INDEXING_ENABLED
-              value: "false"
+              value: "true"
             - name: WHITEPAPER_SEMANTIC_REQUIRED
               value: "false"
             - name: WHITEPAPER_EMBEDDING_API_BASE_URL

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -10,17 +10,19 @@ spec:
   schedule: "13,43 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 1
       activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: Never
           serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
               image: registry.ide-newton.ts.net/lab/torghut@sha256:f7e5a2039dd203c18226ee348e55eb599a6d9fecade2260d96f0ccac9b81d964

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -11,17 +11,19 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 1
       activeDeadlineSeconds: 300
       template:
         spec:
           restartPolicy: OnFailure
           serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
               image: registry.ide-newton.ts.net/lab/torghut@sha256:f7e5a2039dd203c18226ee348e55eb599a6d9fecade2260d96f0ccac9b81d964
@@ -52,7 +54,6 @@ spec:
                       --allow-pending-clean-window-baseline-readback
                     )
                   fi
-                  echo "stage=flatten_paper_account started_at=$(date -Iseconds)"
                   /opt/venv/bin/python scripts/flatten_paper_account_positions.py \
                     --account-label TORGHUT_SIM \
                     --expected-account-label TORGHUT_SIM \
@@ -70,10 +71,7 @@ spec:
                     --persist-lineage \
                     --apply \
                     --json
-                  echo "stage=flatten_paper_account completed_at=$(date -Iseconds)"
               env:
-                - name: PYTHONUNBUFFERED
-                  value: "1"
                 - name: DB_DSN
                   valueFrom:
                     secretKeyRef:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -10,17 +10,19 @@ spec:
   schedule: "*/6 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 0
       activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: Never
           serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -102,17 +104,19 @@ spec:
   schedule: "21,51 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 0
       activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: Never
           serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
           securityContext:
             runAsNonRoot: true
             runAsUser: 999

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -11,17 +11,19 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 0
       activeDeadlineSeconds: 300
       template:
         spec:
           restartPolicy: Never
           serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
           containers:
             - name: run-zero-notional-drift-repair
               image: registry.ide-newton.ts.net/lab/torghut@sha256:f7e5a2039dd203c18226ee348e55eb599a6d9fecade2260d96f0ccac9b81d964


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `e1f5374656b6075a5beb1b9bad610e0e8eea6f05`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/27684035343`
- Rollback source: `HEAD^` manifests from the failed run checkout