### PR TITLE
fix(torghut): match live submit activation evidence shape

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -38,11 +38,11 @@ const baseTradingStatus = {
     allowed: true,
     reason: null,
     blocked_reasons: [],
+    live_submit_activation: baseLiveSubmitActivation,
     simple_lane: {
       submit_enabled: true,
       shared_gate_enforced: true,
       blocked_reasons: [],
-      live_submit_activation: baseLiveSubmitActivation,
     },
   },
   simple_lane_status: {
@@ -183,13 +183,10 @@ describe('validatePostDeployEvidence', () => {
           ...baseTradingStatus,
           live_submission_gate: {
             ...baseTradingStatus.live_submission_gate,
-            simple_lane: {
-              ...baseTradingStatus.live_submission_gate.simple_lane,
-              live_submit_activation: {
-                ...baseLiveSubmitActivation,
-                expired: true,
-                reason: 'live_submit_activation_expired',
-              },
+            live_submit_activation: {
+              ...baseLiveSubmitActivation,
+              expired: true,
+              reason: 'live_submit_activation_expired',
             },
           },
         },

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -189,7 +189,10 @@ const assertBoundedLiveSubmitContract = (status: JsonObject) => {
   const liveSubmissionGate = requireObject(status.live_submission_gate, 'torghut status live_submission_gate')
   const simpleLane = requireObject(liveSubmissionGate.simple_lane, 'torghut status live_submission_gate.simple_lane')
   const simpleLaneStatus = requireObject(status.simple_lane_status, 'torghut status simple_lane_status')
-  const activation = requireObject(simpleLane.live_submit_activation, 'torghut status live_submit_activation')
+  const activation = requireObject(
+    liveSubmissionGate.live_submit_activation,
+    'torghut status live_submission_gate.live_submit_activation',
+  )
   const empiricalJobs = requireObject(status.empirical_jobs, 'torghut status empirical_jobs')
 
   if (requireBoolean(status.autonomy_enabled, 'torghut status autonomy_enabled') !== false) {


### PR DESCRIPTION
## Summary

- Match post-deploy live-submit activation validation to the deployed `/trading/status` API shape.
- Keep the June 17 activation expiry and capped-submit assertions unchanged.
- Update the regression fixture so future validator changes follow the live gate contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --filter @proompteng/scripts lint`
- Live validation: fetched current Torghut `/readyz`, `/trading/status`, `/trading/revenue-repair`, and live/sim proof payloads from namespace `torghut`; patched `post-deploy-evidence.ts` accepted promoted image `sha256:6ac45dd1eb4ba3e61ac029e3c27f8da3a2c4e43b6fc28724343d4c514d44b9a9` as `healthy_2xx` with activation expiry `2026-06-17T20:05:00+00:00`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
