### PR TITLE
fix(torghut): validate live submit activation shape

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -38,11 +38,11 @@ const baseTradingStatus = {
     allowed: true,
     reason: null,
     blocked_reasons: [],
+    live_submit_activation: baseLiveSubmitActivation,
     simple_lane: {
       submit_enabled: true,
       shared_gate_enforced: true,
       blocked_reasons: [],
-      live_submit_activation: baseLiveSubmitActivation,
     },
   },
   simple_lane_status: {
@@ -183,13 +183,10 @@ describe('validatePostDeployEvidence', () => {
           ...baseTradingStatus,
           live_submission_gate: {
             ...baseTradingStatus.live_submission_gate,
-            simple_lane: {
-              ...baseTradingStatus.live_submission_gate.simple_lane,
-              live_submit_activation: {
-                ...baseLiveSubmitActivation,
-                expired: true,
-                reason: 'live_submit_activation_expired',
-              },
+            live_submit_activation: {
+              ...baseLiveSubmitActivation,
+              expired: true,
+              reason: 'live_submit_activation_expired',
             },
           },
         },

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -189,7 +189,10 @@ const assertBoundedLiveSubmitContract = (status: JsonObject) => {
   const liveSubmissionGate = requireObject(status.live_submission_gate, 'torghut status live_submission_gate')
   const simpleLane = requireObject(liveSubmissionGate.simple_lane, 'torghut status live_submission_gate.simple_lane')
   const simpleLaneStatus = requireObject(status.simple_lane_status, 'torghut status simple_lane_status')
-  const activation = requireObject(simpleLane.live_submit_activation, 'torghut status live_submit_activation')
+  const activation = requireObject(
+    liveSubmissionGate.live_submit_activation,
+    'torghut status live_submission_gate.live_submit_activation',
+  )
   const empiricalJobs = requireObject(status.empirical_jobs, 'torghut status empirical_jobs')
 
   if (requireBoolean(status.autonomy_enabled, 'torghut status autonomy_enabled') !== false) {


### PR DESCRIPTION
## Summary

- Fixes the Torghut post-deploy evidence validator to read `live_submit_activation` from `live_submission_gate`, matching the deployed `/trading/status` contract.
- Updates the post-deploy evidence fixture so the bounded June 17 live-submit contract uses the live payload shape that failed in rollout.
- Replayed the failing post-deploy artifact successfully against the patched validator.

## Related Issues

None

## Testing

- `env TORGHUT_READYZ_HTTP_STATUS=200 TORGHUT_READYZ_PAYLOAD=/tmp/torghut-post-deploy-27684498960/torghut-readyz.json TORGHUT_REVENUE_REPAIR_DIGEST=/tmp/torghut-post-deploy-27684498960/torghut-revenue-repair-digest.json TORGHUT_STATUS_PAYLOAD=/tmp/torghut-post-deploy-27684498960/torghut-status.json TORGHUT_PAPER_ROUTE_EVIDENCE=/tmp/torghut-post-deploy-27684498960/torghut-proofs.json TORGHUT_SIM_PAPER_ROUTE_EVIDENCE=/tmp/torghut-post-deploy-27684498960/torghut-sim-proofs.json bun run packages/scripts/src/torghut/post-deploy-evidence.ts`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --filter @proompteng/scripts lint`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
