### PR TITLE
fix(torghut): enable bounded live proof probe

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -144,6 +144,10 @@ spec:
               value: "0.25"
             - name: TRADING_SIMPLE_MAX_GROSS_EXPOSURE_PCT_EQUITY
               value: "0.05"
+            - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
+              value: http://torghut.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=next&limit=20
+            - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
+              value: "10"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS

--- a/services/torghut/app/trading/scheduler/source_collection_modules/source_decisions.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/source_decisions.py
@@ -16,6 +16,7 @@ from ....models import (
     Strategy,
     TradeDecision,
 )
+from ...live_submit_activation import live_submit_activation_status
 from ...models import StrategyDecision
 from ...runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
@@ -23,6 +24,7 @@ from ...runtime_decision_authority import (
 )
 from ..target_plan_helpers_modules import (
     PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK as _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK,
+    target_bounded_collection_authorized as _target_bounded_collection_authorized,
     bounded_sim_collection_blockers as _bounded_sim_collection_blockers,
     bounded_sim_collection_reserves_account as _bounded_sim_collection_reserves_account,
     bounded_sim_collection_target_with_runtime_account_audit as _bounded_sim_collection_target_with_runtime_account_audit,
@@ -41,6 +43,8 @@ from ..target_plan_helpers_modules import (
     target_probe_window as _target_probe_window,
     target_requires_bounded_sim_collection_gate as _target_requires_bounded_sim_collection_gate,
     target_runtime_account_matches as _target_runtime_account_matches,
+    target_symbols as _target_symbols,
+    target_truthy as _target_truthy,
 )
 from .collection_types import (
     SourceCollectionAction,
@@ -144,11 +148,17 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
         allowed_symbols: set[str],
         session: Session | None,
     ) -> SourceCollectionState | None:
-        if settings.trading_mode != "paper":
+        trading_mode = settings.trading_mode
+        if trading_mode not in {"paper", "live"}:
             return None
         if not settings.trading_simple_paper_route_probe_enabled:
             return None
         now = self._trading_now().astimezone(timezone.utc)
+        if trading_mode == "live" and (
+            blocker := self._live_bounded_paper_route_source_collection_blocker(now)
+        ):
+            self._record_bounded_target_plan_blocker(reason=blocker)
+            return None
         if not self._is_market_session_open(now):
             self._record_bounded_target_plan_blocker(
                 reason="paper_route_session_window_not_open"
@@ -200,15 +210,20 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
         positions: Sequence[Mapping[str, Any]] | None,
         state: SourceCollectionState,
     ) -> SourceCollectionTargetContext | None:
-        target = _bounded_sim_collection_target_with_runtime_account_audit(
-            raw_target,
-            positions=(
-                positions
-                if _target_requires_bounded_sim_collection_gate(raw_target)
-                else None
-            ),
-            account_label=self.account_label,
-        )
+        if settings.trading_mode == "live":
+            target = self._live_bounded_paper_route_target(raw_target)
+            if target is None:
+                return None
+        else:
+            target = _bounded_sim_collection_target_with_runtime_account_audit(
+                raw_target,
+                positions=(
+                    positions
+                    if _target_requires_bounded_sim_collection_gate(raw_target)
+                    else None
+                ),
+                account_label=self.account_label,
+            )
         window = _target_probe_window(target)
         target_cap = _target_probe_cap(target)
         strategy = self._paper_route_target_strategy(target, strategies)
@@ -248,6 +263,84 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
             return None
         return context
 
+    def _live_bounded_paper_route_source_collection_blocker(
+        self,
+        now: datetime,
+    ) -> str | None:
+        if not settings.trading_simple_submit_enabled:
+            return "simple_submit_disabled"
+        activation = live_submit_activation_status(now=now)
+        if activation.get("configured") is not True:
+            return "live_submit_activation_missing"
+        if activation.get("valid") is not True:
+            return str(activation.get("reason") or "live_submit_activation_invalid")
+        if activation.get("expired") is True:
+            return str(activation.get("reason") or "live_submit_activation_expired")
+        max_notional = _optional_decimal(
+            settings.trading_simple_paper_route_probe_max_notional
+        )
+        if max_notional is None or max_notional <= 0:
+            return "paper_route_probe_notional_not_configured"
+        return None
+
+    def _live_bounded_paper_route_target(
+        self,
+        raw_target: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        target = dict(raw_target)
+        target_cap = _target_probe_cap(target)
+        configured_cap = _optional_decimal(
+            settings.trading_simple_paper_route_probe_max_notional
+        )
+        if target_cap is None or configured_cap is None:
+            capped_notional: Decimal | None = None
+        else:
+            capped_notional = min(target_cap, configured_cap)
+        promotion_requested = any(
+            _target_truthy(target.get(key))
+            for key in (
+                "promotion_allowed",
+                "capital_promotion_allowed",
+                "final_promotion_authorized",
+                "final_promotion_allowed",
+            )
+        )
+        if (
+            capped_notional is None
+            or capped_notional <= 0
+            or not _target_bounded_collection_authorized(target)
+            or _safe_text(target.get("source_kind")) is None
+            or promotion_requested
+        ):
+            return None
+
+        symbols = sorted(_target_symbols(target))
+        if not symbols:
+            return None
+        target["paper_route_probe_total_max_notional"] = str(capped_notional)
+        target["paper_route_probe_next_session_max_notional"] = str(capped_notional)
+        target["paper_route_probe_effective_max_notional"] = str(capped_notional)
+        target["bounded_evidence_collection_max_notional"] = str(capped_notional)
+        target["max_notional"] = str(capped_notional)
+        target.setdefault("paper_route_probe_symbols", symbols)
+        target.setdefault("observed_stage", "paper")
+        target["bounded_evidence_collection_authorized"] = True
+        target["bounded_live_paper_collection_authorized"] = True
+        target["source_collection_authorized"] = True
+        target.setdefault(
+            "source_collection_authorization_scope",
+            "source_window_evidence_collection_only",
+        )
+        target.setdefault("evidence_collection_ok", True)
+        target.setdefault(
+            "source_manifest_ref",
+            f"trading_proofs:{_safe_text(target.get('candidate_id')) or _safe_text(target.get('hypothesis_id')) or 'unknown'}",
+        )
+        target["execution_account_label"] = self.account_label
+        target["paper_route_runtime_account_label"] = self.account_label
+        target["paper_account_label"] = self.account_label
+        return target
+
     def _paper_route_target_owner_skip(
         self,
         target: Mapping[str, Any],
@@ -278,6 +371,10 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
         self,
         target: Mapping[str, Any],
     ) -> bool:
+        if settings.trading_mode == "live" and _target_truthy(
+            target.get("bounded_live_paper_collection_authorized")
+        ):
+            return False
         if not _target_requires_bounded_sim_collection_gate(target):
             return False
         collection_blockers = _bounded_sim_collection_blockers(

--- a/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
@@ -72,7 +72,7 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
     def _paper_route_target_plan_url_points_to_current_service(url: str) -> bool:
         parsed = urlsplit(url)
         path = (parsed.path or "").rstrip("/")
-        if path not in {"/trading/paper-route-target-plan", "/trading/proofs"}:
+        if path != "/trading/paper-route-target-plan":
             return False
         hostname = (parsed.hostname or "").strip().lower()
         service_name = os.getenv("K_SERVICE", "").strip().lower()
@@ -574,6 +574,10 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
             "paper_route_probe_symbols": sorted(_target_symbols(target)),
             "paper_route_probe_window_start": context.window_start.isoformat(),
             "paper_route_probe_window_end": context.window_end.isoformat(),
+            "paper_route_probe_total_max_notional": (
+                _safe_text(target.get("paper_route_probe_total_max_notional"))
+                or str(context.target_cap)
+            ),
             "paper_route_probe_next_session_max_notional": str(context.target_cap),
             "paper_route_probe_effective_max_notional": str(context.target_cap),
             "paper_route_probe_symbol_quantities": {

--- a/services/torghut/app/trading/scheduler/submission_preparation_modules/direct_submission.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation_modules/direct_submission.py
@@ -286,6 +286,11 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
             decision.symbol,
         )
         if proof_floor_symbol_block_reason is not None:
+            if self._bounded_live_paper_route_probe_profit_floor_allowed(
+                decision,
+                proof_floor_symbol_block_reason,
+            ):
+                return True
             self._block_decision_submission(
                 session=request.session,
                 decision=decision,

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+from app.trading.scheduler.submission_preparation_modules.shared import (
+    TradingSubmissionRequest,
+)
+
+from tests.simple_pipeline.support import (
+    Decimal,
+    MarketSnapshot,
+    SimpleNamespace,
+    SimpleTradingPipeline,
+    Strategy,
+    _bounded_hpairs_target,
+    _routeability_decision,
+    datetime,
+    settings,
+    timezone,
+)
+
+
+def test_live_bounded_paper_route_target_generates_capped_source_decisions(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    submit_enabled_before = settings.trading_simple_submit_enabled
+    activation_expires_at_before = settings.trading_live_submit_activation_expires_at
+    probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
+    allow_shorts_before = settings.trading_allow_shorts
+    try:
+        settings.trading_mode = "live"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_submit_enabled = True
+        settings.trading_live_submit_activation_expires_at = "2026-06-17T20:05:00Z"
+        settings.trading_simple_paper_route_probe_max_notional = 100
+        settings.trading_allow_shorts = True
+        now = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            account_label="TORGHUT_REPLAY",
+            source_account_label="TORGHUT_REPLAY",
+            paper_account_label="TORGHUT_REPLAY",
+            execution_account_label="TORGHUT_REPLAY",
+            target_notional="500",
+            paper_route_probe_next_session_max_notional="500",
+            paper_route_probe_window_start="2026-06-17T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-17T20:00:00+00:00",
+            paper_route_probe_symbol_quantities={},
+            source_kind="runtime_ledger_source_collection_candidate",
+        )
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "PA3SX7FYNUTF"
+        pipeline.price_fetcher = SimpleNamespace(
+            fetch_market_snapshot=lambda signal: MarketSnapshot(
+                symbol=signal.symbol,
+                as_of=signal.event_ts,
+                price=Decimal("25"),
+                spread=Decimal("0"),
+                source="fixture",
+                bid=Decimal("25"),
+                ask=Decimal("25"),
+            )
+        )
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL", "AMZN"},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[strategy],
+            allowed_symbols={"AAPL", "AMZN"},
+            positions=[],
+            session=None,
+        )
+
+        assert {decision.symbol for decision in decisions} == {"AAPL", "AMZN"}
+        assert {decision.symbol: decision.qty for decision in decisions} == {
+            "AAPL": Decimal("2.0000"),
+            "AMZN": Decimal("2.0000"),
+        }
+        for decision in decisions:
+            params = decision.params
+            metadata = params["paper_route_target_plan_source_decision"]
+            assert params["source_decision_mode"] == "bounded_paper_route_collection"
+            assert params["profit_proof_eligible"] is True
+            assert params["final_authority_ok"] is False
+            assert params["bounded_paper_route_submit_path"] == (
+                "bounded_paper_route_collection"
+            )
+            assert metadata["account_label"] == "TORGHUT_REPLAY"
+            assert metadata["source_account_label"] == "TORGHUT_REPLAY"
+            assert metadata["paper_route_probe_total_max_notional"] == "100"
+            assert metadata["paper_route_probe_next_session_max_notional"] == "100"
+            assert metadata["bounded_live_paper_collection_authorized"] is True
+            assert metadata["source_collection_authorized"] is True
+            assert metadata["promotion_allowed"] is False
+            policy = params["bounded_paper_route_execution_policy"]
+            assert policy["live_capital_routing_enabled"] is False
+            assert policy["runtime_account_label"] == "PA3SX7FYNUTF"
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_submit_enabled = submit_enabled_before
+        settings.trading_live_submit_activation_expires_at = (
+            activation_expires_at_before
+        )
+        settings.trading_simple_paper_route_probe_max_notional = (
+            probe_max_notional_before
+        )
+        settings.trading_allow_shorts = allow_shorts_before
+
+
+def test_live_bounded_paper_route_target_blocks_without_activation(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    submit_enabled_before = settings.trading_simple_submit_enabled
+    activation_expires_at_before = settings.trading_live_submit_activation_expires_at
+    probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
+    try:
+        settings.trading_mode = "live"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_submit_enabled = True
+        settings.trading_live_submit_activation_expires_at = "2026-06-17T13:40:00Z"
+        settings.trading_simple_paper_route_probe_max_notional = 100
+        now = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "PA3SX7FYNUTF"
+        pipeline.state = SimpleNamespace()
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL"},
+            None,
+            [_bounded_hpairs_target()],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[],
+            allowed_symbols={"AAPL"},
+            positions=[],
+            session=None,
+        )
+
+        assert decisions == []
+        assert pipeline.state.last_bounded_evidence_collection_blocker["reason"] == (
+            "live_submit_activation_expired"
+        )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_submit_enabled = submit_enabled_before
+        settings.trading_live_submit_activation_expires_at = (
+            activation_expires_at_before
+        )
+        settings.trading_simple_paper_route_probe_max_notional = (
+            probe_max_notional_before
+        )
+
+
+def test_live_bounded_paper_route_source_collection_contract_blockers() -> None:
+    submit_enabled_before = settings.trading_simple_submit_enabled
+    activation_expires_at_before = settings.trading_live_submit_activation_expires_at
+    probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
+    try:
+        now = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
+        pipeline = object.__new__(SimpleTradingPipeline)
+
+        settings.trading_simple_submit_enabled = False
+        assert (
+            pipeline._live_bounded_paper_route_source_collection_blocker(now)
+            == "simple_submit_disabled"
+        )
+
+        settings.trading_simple_submit_enabled = True
+        settings.trading_live_submit_activation_expires_at = "invalid"
+        assert (
+            pipeline._live_bounded_paper_route_source_collection_blocker(now)
+            == "live_submit_activation_expiry_invalid"
+        )
+
+        settings.trading_live_submit_activation_expires_at = "2026-06-17T20:05:00Z"
+        settings.trading_simple_paper_route_probe_max_notional = 0
+        assert (
+            pipeline._live_bounded_paper_route_source_collection_blocker(now)
+            == "paper_route_probe_notional_not_configured"
+        )
+    finally:
+        settings.trading_simple_submit_enabled = submit_enabled_before
+        settings.trading_live_submit_activation_expires_at = (
+            activation_expires_at_before
+        )
+        settings.trading_simple_paper_route_probe_max_notional = (
+            probe_max_notional_before
+        )
+
+
+def test_live_bounded_paper_route_target_rejects_missing_cap_and_symbols(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    submit_enabled_before = settings.trading_simple_submit_enabled
+    activation_expires_at_before = settings.trading_live_submit_activation_expires_at
+    probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
+    try:
+        settings.trading_mode = "live"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_submit_enabled = True
+        settings.trading_live_submit_activation_expires_at = "2026-06-17T20:05:00Z"
+        settings.trading_simple_paper_route_probe_max_notional = 100
+        now = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
+        missing_cap_target = _bounded_hpairs_target(
+            paper_route_probe_window_start="2026-06-17T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-17T20:00:00+00:00",
+            target_notional=None,
+            paper_route_probe_next_session_max_notional=None,
+            paper_route_probe_effective_max_notional=None,
+            bounded_evidence_collection_max_notional=None,
+            max_notional=None,
+        )
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "PA3SX7FYNUTF"
+        pipeline.price_fetcher = SimpleNamespace(
+            fetch_market_snapshot=lambda signal: MarketSnapshot(
+                symbol=signal.symbol,
+                as_of=signal.event_ts,
+                price=Decimal("25"),
+                spread=Decimal("0"),
+                source="fixture",
+                bid=Decimal("25"),
+                ask=Decimal("25"),
+            )
+        )
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL", "AMZN"},
+            None,
+            [missing_cap_target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[strategy],
+            allowed_symbols={"AAPL", "AMZN"},
+            positions=[],
+            session=None,
+        )
+
+        assert decisions == []
+        assert (
+            pipeline._live_bounded_paper_route_target(
+                {
+                    "paper_route_probe_next_session_max_notional": "100",
+                    "bounded_evidence_collection_authorized": True,
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                }
+            )
+            is None
+        )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_submit_enabled = submit_enabled_before
+        settings.trading_live_submit_activation_expires_at = (
+            activation_expires_at_before
+        )
+        settings.trading_simple_paper_route_probe_max_notional = (
+            probe_max_notional_before
+        )
+
+
+def test_live_bounded_paper_route_symbol_floor_allows_bounded_probe() -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    submit_enabled_before = settings.trading_simple_submit_enabled
+    try:
+        settings.trading_mode = "live"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_submit_enabled = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "PA3SX7FYNUTF"
+        pipeline._profitability_proof_floor = lambda session: {
+            "capital_state": "shadow",
+        }
+        pipeline._proof_floor_symbol_block_reason = lambda proof_floor, symbol: (
+            "runtime_ledger_source_collection_pending"
+        )
+        pipeline._block_decision_submission = lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("bounded live probe must not be blocked")
+        )
+        decision = _routeability_decision(
+            params={
+                "source_decision_mode": "bounded_paper_route_collection",
+                "profit_proof_eligible": True,
+                "paper_route_target_plan_source_decision": _bounded_hpairs_target(
+                    source_decision_mode="bounded_paper_route_collection",
+                    profit_proof_eligible=True,
+                ),
+            }
+        )
+
+        assert pipeline._profitability_floor_symbol_submission_allowed(
+            TradingSubmissionRequest(
+                session=SimpleNamespace(),
+                decision=decision,
+                decision_row=SimpleNamespace(status="planned"),
+            )
+        )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_submit_enabled = submit_enabled_before

--- a/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
+++ b/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
@@ -81,6 +81,20 @@ def test_target_runtime_account_and_window_helpers_cover_identity_edges() -> Non
     )
 
 
+def test_scheduler_fetches_canonical_proofs_url_even_on_current_service(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("K_SERVICE", "torghut")
+    monkeypatch.setenv("POD_NAMESPACE", "torghut")
+
+    assert SimpleTradingPipeline._paper_route_target_plan_url_points_to_current_service(
+        "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
+    )
+    assert not SimpleTradingPipeline._paper_route_target_plan_url_points_to_current_service(
+        "http://torghut.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=next&limit=20"
+    )
+
+
 def test_target_plan_fetch_error_reserves_configured_paper_account(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Enables live-mode bounded proof-target source decisions for Torghut when the June 17 activation contract is valid, simple submit is enabled, market session is open, and the configured probe cap is positive.
- Wires the live Knative service to fetch canonical `/trading/proofs?kind=runtime_window&window=next&limit=20` targets, while keeping deprecated `/trading/paper-route-target-plan` self-reference protection.
- Preserves capped proof-target notional evidence in decision metadata and lets bounded live proof probes pass the existing proof-floor symbol gate without enabling capital promotion.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/simple_pipeline/test_target_source_decisions_fail_closed_without_target_notional_price.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_paper_route_external.py tests/test_trading_proofs_api.py tests/pipeline/test_trading_pipeline_external_targets_a.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/source_collection_modules/source_decisions.py app/trading/scheduler/source_collection_modules/target_plan_fetch.py app/trading/scheduler/submission_preparation_modules/direct_submission.py tests/simple_pipeline/test_target_source_decisions_fail_closed_without_target_notional_price.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/source_collection_modules/source_decisions.py app/trading/scheduler/source_collection_modules/target_plan_fetch.py app/trading/scheduler/submission_preparation_modules/direct_submission.py tests/simple_pipeline/test_target_source_decisions_fail_closed_without_target_notional_price.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base 639f0fcd2ede2728d7250733ed9cc0a606a41703 --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks app/trading/scheduler/source_collection_modules/source_decisions.py app/trading/scheduler/source_collection_modules/target_plan_fetch.py app/trading/scheduler/submission_preparation_modules/direct_submission.py`
- `cd services/torghut && uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/simple_pipeline/test_target_source_decisions_fail_closed_without_target_notional_price.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
