### PR TITLE
fix(torghut): use local live proof probe targets

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -149,7 +149,7 @@ class SimpleTradingPipeline(
     ) = None
 
     def _trading_now(self) -> datetime:
-        return trading_now(account_label=self.account_label)
+        return trading_now(account_label=getattr(self, "account_label", None))
 
     def _fetch_paper_route_target_plan_url(
         self,

--- a/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
@@ -72,7 +72,7 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
     def _paper_route_target_plan_url_points_to_current_service(url: str) -> bool:
         parsed = urlsplit(url)
         path = (parsed.path or "").rstrip("/")
-        if path != "/trading/paper-route-target-plan":
+        if path not in {"/trading/paper-route-target-plan", "/trading/proofs"}:
             return False
         hostname = (parsed.hostname or "").strip().lower()
         service_name = os.getenv("K_SERVICE", "").strip().lower()
@@ -457,14 +457,30 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
         elif raw_symbols and "paper_route_probe_symbols" not in normalized:
             normalized["paper_route_probe_symbols"] = sorted(raw_symbols)
 
-        if (
-            _target_has_bounded_source_collection_authorization(normalized)
-            and _target_probe_window(normalized) is None
-            and _target_missing_explicit_probe_window(normalized)
-        ):
+        if _target_has_bounded_source_collection_authorization(normalized):
             now = self._trading_now().astimezone(timezone.utc)
+        else:
+            now = None
+        if now is not None and self._paper_route_target_uses_current_session_window(
+            normalized,
+            now=now,
+        ):
+            source_window = _target_probe_window(normalized)
             window_start = regular_session_open_utc_for(now)
             window_end = window_start + timedelta(minutes=_REGULAR_SESSION_MINUTES)
+            if source_window is not None:
+                normalized.setdefault(
+                    "paper_route_probe_source_window_start",
+                    source_window[0].isoformat(),
+                )
+                normalized.setdefault(
+                    "paper_route_probe_source_window_end",
+                    source_window[1].isoformat(),
+                )
+                normalized.setdefault(
+                    "paper_route_probe_window_overrode_source_window",
+                    True,
+                )
             normalized["paper_route_probe_window_start"] = window_start.isoformat()
             normalized["paper_route_probe_window_end"] = window_end.isoformat()
             normalized.setdefault("paper_route_probe_window_defaulted", True)
@@ -483,6 +499,27 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
                 )
             )
         return normalized
+
+    @staticmethod
+    def _paper_route_target_uses_current_session_window(
+        target: Mapping[str, Any],
+        *,
+        now: datetime,
+    ) -> bool:
+        if _target_missing_explicit_probe_window(target):
+            return True
+        scope = _safe_text(target.get("bounded_evidence_collection_scope"))
+        next_session_cap = _optional_decimal(
+            target.get("paper_route_probe_next_session_max_notional")
+        )
+        if scope != "paper_route_probe_next_session_only" and next_session_cap is None:
+            return False
+        source_window = _target_probe_window(target)
+        if source_window is None:
+            return True
+        window_start = regular_session_open_utc_for(now)
+        window_end = window_start + timedelta(minutes=_REGULAR_SESSION_MINUTES)
+        return source_window != (window_start, window_end)
 
     @staticmethod
     def _paper_route_target_source_decision_metadata(

--- a/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
+++ b/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
@@ -9,6 +9,7 @@ from tests.simple_pipeline.support import (
     _bounded_hpairs_target,
     _bounded_sim_collection_blockers,
     _target_active_in_window,
+    _target_probe_window,
     _target_runtime_account_matches,
     datetime,
     settings,
@@ -81,7 +82,7 @@ def test_target_runtime_account_and_window_helpers_cover_identity_edges() -> Non
     )
 
 
-def test_scheduler_fetches_canonical_proofs_url_even_on_current_service(
+def test_scheduler_uses_local_gate_for_canonical_proofs_url_on_current_service(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("K_SERVICE", "torghut")
@@ -90,8 +91,55 @@ def test_scheduler_fetches_canonical_proofs_url_even_on_current_service(
     assert SimpleTradingPipeline._paper_route_target_plan_url_points_to_current_service(
         "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
     )
-    assert not SimpleTradingPipeline._paper_route_target_plan_url_points_to_current_service(
+    assert SimpleTradingPipeline._paper_route_target_plan_url_points_to_current_service(
         "http://torghut.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=next&limit=20"
+    )
+
+
+def test_next_session_source_collection_target_overrides_historical_source_window(
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
+    target = _bounded_hpairs_target(
+        source_kind="runtime_ledger_source_collection_candidate",
+        source_collection_authorized=True,
+        source_collection_authorization_scope="source_window_evidence_collection_only",
+        paper_route_probe_next_session_max_notional="100",
+        bounded_evidence_collection_max_notional="100",
+        paper_route_probe_window_start="2026-05-13T17:00:00+00:00",
+        paper_route_probe_window_end="2026-05-13T17:30:00+00:00",
+    )
+    strategy = Strategy(
+        name="microbar-cross-sectional-pairs-v1",
+        description="metadata fixture",
+        enabled=True,
+        base_timeframe="1Sec",
+        universe_type="static",
+        universe_symbols=["AAPL", "AMZN"],
+    )
+    pipeline = object.__new__(SimpleTradingPipeline)
+    pipeline.account_label = "PA3SX7FYNUTF"
+    monkeypatch.setattr(
+        "app.trading.scheduler.simple_pipeline.trading_now",
+        lambda account_label=None: now,
+    )
+
+    normalized = pipeline._paper_route_target_with_local_probe_contract(
+        target,
+        strategies=[strategy],
+    )
+
+    assert normalized["paper_route_probe_source_window_start"] == (
+        "2026-05-13T17:00:00+00:00"
+    )
+    assert normalized["paper_route_probe_source_window_end"] == (
+        "2026-05-13T17:30:00+00:00"
+    )
+    assert normalized["paper_route_probe_window_overrode_source_window"] is True
+    assert normalized["paper_route_probe_window_defaulted"] is True
+    assert _target_probe_window(normalized) == (
+        datetime(2026, 6, 17, 13, 30, tzinfo=timezone.utc),
+        datetime(2026, 6, 17, 20, 0, tzinfo=timezone.utc),
     )
 
 


### PR DESCRIPTION
## Summary

- Route self-referential Torghut `/trading/proofs` target-plan URLs through the scheduler's local live gate instead of HTTP self-fetch.
- Normalize bounded next-session source-collection targets onto the current regular trading session while retaining the original evidence window audit fields.
- Keep target-plan clock access lazy and tolerate partially constructed scheduler test objects without an account label.
- Add regression coverage for the canonical proofs self URL and June 17 current-session window override.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/trading/scheduler/source_collection_modules/target_plan_fetch.py app/trading/scheduler/simple_pipeline.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `uv run --frozen ruff format --check app/trading/scheduler/source_collection_modules/target_plan_fetch.py app/trading/scheduler/simple_pipeline.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `uv run --frozen pytest tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_target_plan_source_c.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
