### PR TITLE
fix(torghut): disable hot path paper route retry scan

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -136,6 +136,10 @@ spec:
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "100"
+            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_BATCH_LIMIT
+              value: "0"
+            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_SCAN_LIMIT
+              value: "0"
             - name: TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER
               value: "100"
             - name: TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL

--- a/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
@@ -744,6 +744,12 @@ class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
             env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
             _SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL,
         )
+        self.assertEqual(
+            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_BATCH_LIMIT"), "0"
+        )
+        self.assertEqual(
+            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_SCAN_LIMIT"), "0"
+        )
         self.assertEqual(env.get("TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER"), "100")
         self.assertEqual(env.get("TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL"), "250")
         self.assertEqual(env.get("TRADING_SIMPLE_MAX_ORDER_PCT_EQUITY"), "0.25")


### PR DESCRIPTION
## Summary

- Disable the live Torghut paper-route probe retry batch/scan by setting both retry limits to `0` in the Knative env contract.
- Keep bounded paper-route probe acquisition enabled and capped at `$100`; this only removes the expensive old blocked/rejected decision retry scan from the live hot path.
- Add manifest contract coverage so the retry scan stays disabled during the June 17 bounded-submit activation.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py -k simple_lane_profile`
- `cd services/torghut && uv run --frozen ruff check tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py && uv run --frozen ruff format --check tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
