### PR TITLE
fix(torghut): import live status proof targets

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -95,6 +95,7 @@ spec:
                     --hpairs-source-proof-census-file "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}" \
                     --runtime-window-import \
                     --runtime-window-target-plan-url 'http://torghut-sim.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=latest_closed&full_audit=true&limit=5' \
+                    --runtime-window-target-plan-url 'http://torghut.torghut.svc.cluster.local/trading/status' \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \

--- a/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
@@ -409,9 +409,9 @@ class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
             "'http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
             args,
         )
-        self.assertNotIn(
+        self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/status",
+            "'http://torghut.torghut.svc.cluster.local/trading/status'",
             args,
         )
         self.assertIn("--runtime-window-target-plan-url-timeout-seconds 45", args)


### PR DESCRIPTION
## Summary

- Add the live Torghut `/trading/status` payload as a runtime-window target-plan source for the empirical renewal conductor.
- Keep the existing sim latest-closed proof payload in place so source collection and sim proof renewal run together.
- Update the live config manifest contract test to require the live status target-plan URL.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `cd services/torghut && uv run --frozen ruff check tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py && uv run --frozen ruff format --check tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
