### PR TITLE
fix(torghut): tolerate empty runtime plan refs

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs_modules/raise_if_runtime_window_target_plan_import.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs_modules/raise_if_runtime_window_target_plan_import.py
@@ -429,8 +429,11 @@ def _runtime_window_plan_targets(
         if str(item).strip()
     ]
     targets: list[RuntimeWindowImportTarget] = []
+    allow_empty_multi_ref = len(file_refs) + len(url_refs) > 1
     for ref in file_refs:
         plan = _read_runtime_window_target_plan(ref)
+        if allow_empty_multi_ref and _runtime_window_target_plan_has_no_targets(plan):
+            continue
         targets.extend(_runtime_window_targets_from_plan(plan=plan, ref=ref, args=args))
     timeout_seconds = float(
         getattr(args, "runtime_window_target_plan_url_timeout_seconds", 5.0) or 5.0
@@ -451,6 +454,8 @@ def _runtime_window_plan_targets(
             attempts=url_attempts,
             retry_backoff_seconds=retry_backoff_seconds,
         )
+        if allow_empty_multi_ref and _runtime_window_target_plan_has_no_targets(plan):
+            continue
         targets.extend(_runtime_window_targets_from_plan(plan=plan, ref=ref, args=args))
     return targets
 
@@ -467,6 +472,17 @@ def _runtime_window_target_plan_ref_count(args: argparse.Namespace) -> int:
         if str(item).strip()
     ]
     return len(file_refs) + len(url_refs)
+
+
+def _runtime_window_target_plan_has_no_targets(plan: Mapping[str, Any]) -> bool:
+    raw_targets = plan.get("targets")
+    if raw_targets is None:
+        return True
+    return (
+        isinstance(raw_targets, Sequence)
+        and not isinstance(raw_targets, (str, bytes, bytearray))
+        and len(raw_targets) == 0
+    )
 
 
 def _runtime_window_targets_from_plan(

--- a/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_multi_ref.py
+++ b/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_multi_ref.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+# ruff: noqa: F401,F403,F405
+from tests.run_empirical_promotion_jobs.support import (
+    MagicMock,
+    RunEmpiricalPromotionJobsTestCase,
+    SimpleNamespace,
+    json,
+    patch,
+    renewal,
+)
+
+
+def _empty_proofs_response() -> MagicMock:
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = json.dumps(
+        {
+            "schema_version": "torghut.proofs.v1",
+            "summary": {"proof_count": 0},
+        }
+    ).encode("utf-8")
+    return response
+
+
+def _runtime_window_plan_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        runtime_window_target=[],
+        runtime_window_target_plan_ref=[],
+        runtime_window_target_plan_url=[
+            "http://torghut-sim.torghut.svc.cluster.local/trading/proofs",
+            "http://torghut.torghut.svc.cluster.local/trading/status",
+        ],
+        runtime_window_target_plan_url_timeout_seconds=1.0,
+        runtime_window_target_plan_url_attempts=1,
+        runtime_window_target_plan_url_retry_backoff_seconds=0.0,
+        runtime_window_target_plan_required=True,
+        runtime_window_target_plan_exclusive=True,
+        runtime_window_targets_from_latest_autoresearch=True,
+        runtime_window_targets_from_registry=True,
+        runtime_window_hypothesis_id="",
+        runtime_window_candidate_id="",
+        runtime_window_observed_stage="paper",
+        runtime_window_strategy_family="",
+        runtime_window_source_dsn_env="SIM_DB_DSN",
+        runtime_window_strategy_name="",
+        runtime_window_account_label="TORGHUT_SIM",
+        runtime_window_dataset_snapshot_ref="",
+        runtime_window_source_manifest_ref="",
+        runtime_window_source_kind="paper_runtime_observed",
+    )
+
+
+class TestRunEmpiricalPromotionJobsRuntimeWindowTargetPlanMultiRef(
+    RunEmpiricalPromotionJobsTestCase
+):
+    def test_runtime_window_target_plan_url_uses_later_ref_when_first_plan_empty(
+        self,
+    ) -> None:
+        live_status_plan = MagicMock()
+        live_status_plan.__enter__.return_value.read.return_value = json.dumps(
+            {
+                "schema_version": "torghut.trading-status.v1",
+                "live_submission_gate": {
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "source": "runtime_ledger_paper_probation_and_source_collection_candidates",
+                        "target_count": 1,
+                        "source_collection_target_count": 1,
+                        "paper_route_target_count": 0,
+                        "targets": [
+                            {
+                                "candidate_id": "cand-source-collection",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "source_kind": "runtime_ledger_source_collection_candidate",
+                                "source_collection_authorized": True,
+                            }
+                        ],
+                    },
+                },
+            }
+        ).encode("utf-8")
+
+        with (
+            patch.object(
+                renewal.urllib.request,
+                "urlopen",
+                side_effect=[_empty_proofs_response(), live_status_plan],
+            ) as urlopen,
+            patch.object(
+                renewal,
+                "_latest_autoresearch_runtime_window_targets",
+            ) as latest,
+            patch.object(renewal, "_registry_runtime_window_targets") as registry,
+        ):
+            targets = renewal._runtime_window_targets(_runtime_window_plan_args())
+
+        self.assertEqual(urlopen.call_count, 2)
+        latest.assert_not_called()
+        registry.assert_not_called()
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].candidate_id, "cand-source-collection")
+        self.assertEqual(
+            targets[0].source_kind, "runtime_ledger_source_collection_candidate"
+        )
+
+    def test_runtime_window_target_plan_url_required_fails_when_all_refs_empty(
+        self,
+    ) -> None:
+        with (
+            patch.object(
+                renewal.urllib.request,
+                "urlopen",
+                side_effect=[_empty_proofs_response(), _empty_proofs_response()],
+            ) as urlopen,
+            patch.object(
+                renewal,
+                "_latest_autoresearch_runtime_window_targets",
+            ) as latest,
+            patch.object(renewal, "_registry_runtime_window_targets") as registry,
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_target_plan_required_but_empty",
+            ),
+        ):
+            renewal._runtime_window_targets(_runtime_window_plan_args())
+
+        self.assertEqual(urlopen.call_count, 2)
+        latest.assert_not_called()
+        registry.assert_not_called()


### PR DESCRIPTION
## Summary

- Allows multi-ref runtime-window target-plan imports to skip empty/no-target plans and continue to later refs.
- Preserves fail-closed behavior for single-ref missing targets, invalid URLs, malformed JSON, and invalid target payloads.
- Adds focused regression coverage for the deployed two-URL renewal shape and the all-empty required-plan failure case.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_b.py tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_multi_ref.py tests/run_empirical_promotion_jobs/test_empirical_job_core.py -k 'runtime_window_target_plan or multi_ref'`
- `cd services/torghut && base=$(git merge-base origin/main HEAD) && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base "$base" scripts/renew_latest_empirical_promotion_jobs_modules/raise_if_runtime_window_target_plan_import.py tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_b.py tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_multi_ref.py`
- `cd services/torghut && uv run --frozen python -m compileall app scripts && uv run --frozen ruff format --check app tests scripts migrations && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
