### PR TITLE
chore(torghut): promote image a2bfc517

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-624-g3a8ed2acd
+              value: v0.596.0-627-ga2bfc517f
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 3a8ed2acdf07e1e3335f792aaf67e8d1607ce671
+              value: a2bfc517f7bd5491098371ecd785c4861017812b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-624-g3a8ed2acd
+              value: v0.596.0-627-ga2bfc517f
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 3a8ed2acdf07e1e3335f792aaf67e8d1607ce671
+              value: a2bfc517f7bd5491098371ecd785c4861017812b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -164,9 +164,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+                  value: sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
                 - name: TORGHUT_COMMIT
-                  value: 3a8ed2acdf07e1e3335f792aaf67e8d1607ce671
+                  value: a2bfc517f7bd5491098371ecd785c4861017812b
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-17T15:11:27Z"
+        client.knative.dev/updateTimestamp: "2026-06-17T15:38:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           ports:
             - name: http1
               containerPort: 8181
@@ -541,11 +541,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-624-g3a8ed2acd
+              value: v0.596.0-627-ga2bfc517f
             - name: TORGHUT_COMMIT
-              value: 3a8ed2acdf07e1e3335f792aaf67e8d1607ce671
+              value: a2bfc517f7bd5491098371ecd785c4861017812b
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              value: sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-17T15:11:27Z"
+        client.knative.dev/updateTimestamp: "2026-06-17T15:38:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           ports:
             - name: http1
               containerPort: 8181
@@ -413,11 +413,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-624-g3a8ed2acd
+              value: v0.596.0-627-ga2bfc517f
             - name: TORGHUT_COMMIT
-              value: 3a8ed2acdf07e1e3335f792aaf67e8d1607ce671
+              value: a2bfc517f7bd5491098371ecd785c4861017812b
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              value: sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -29,7 +29,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -86,7 +86,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+                  value: sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -121,7 +121,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -193,6 +193,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+                  value: sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 3a8ed2acdf07e1e3335f792aaf67e8d1607ce671
+            value: a2bfc517f7bd5491098371ecd785c4861017812b
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+            value: sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5732aec1d3973934af808b36ee49c3b20a85b9c4738a0421299d6804be323f7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a2bfc517f7bd5491098371ecd785c4861017812b`
- Image tag: `a2bfc517`
- Image digest: `sha256:590d2bc59cfa09e514dfbcb8727572999d7f7b07fd7643032778488980143534`
- Manifests: core Torghut, simulation, jobs/workflows, options catalog, options enricher