### PR TITLE
fix(torghut): allow bounded live paper evidence collection

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -134,6 +134,8 @@ spec:
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
+            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE
+              value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "100"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_BATCH_LIMIT

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -47,6 +47,7 @@ const baseTradingStatus = {
   },
   simple_lane_status: {
     submit_enabled: true,
+    paper_route_probe_allow_live_mode: true,
     paper_route_probe_max_notional: 100,
     max_notional_per_order: 100,
     max_notional_per_symbol: 250,

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -205,6 +205,14 @@ const assertBoundedLiveSubmitContract = (status: JsonObject) => {
     throw new Error('torghut simple_lane_status.submit_enabled must be true')
   }
   assertLiveSubmitActivationContract(activation)
+  if (
+    requireBoolean(
+      simpleLaneStatus.paper_route_probe_allow_live_mode,
+      'torghut simple_lane_status.paper_route_probe_allow_live_mode',
+    ) !== true
+  ) {
+    throw new Error('torghut simple_lane_status.paper_route_probe_allow_live_mode must be true')
+  }
   requireScalarValue(simpleLaneStatus.paper_route_probe_max_notional, '100', 'torghut paper_route_probe_max_notional')
   requireScalarValue(simpleLaneStatus.max_notional_per_order, '100', 'torghut max_notional_per_order')
   requireScalarValue(simpleLaneStatus.max_notional_per_symbol, '250', 'torghut max_notional_per_symbol')

--- a/services/torghut/app/api/health_checks_modules/load_options_catalog_freshness_summary.py
+++ b/services/torghut/app/api/health_checks_modules/load_options_catalog_freshness_summary.py
@@ -758,6 +758,9 @@ def _build_simple_lane_status_payload() -> dict[str, object]:
         "paper_route_probe_enabled": (
             settings.trading_simple_paper_route_probe_enabled
         ),
+        "paper_route_probe_allow_live_mode": (
+            settings.trading_simple_paper_route_probe_allow_live_mode
+        ),
         "paper_route_probe_max_notional": (
             settings.trading_simple_paper_route_probe_max_notional
         ),

--- a/services/torghut/app/config_modules/runtime_risk_fields.py
+++ b/services/torghut/app/config_modules/runtime_risk_fields.py
@@ -237,6 +237,15 @@ class RuntimeRiskSettingsFields(BaseSettings):
         ),
     )
 
+    trading_simple_paper_route_probe_allow_live_mode: bool = Field(
+        default=False,
+        alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE",
+        description=(
+            "Permit bounded paper-route evidence collection while TRADING_MODE=live. "
+            "This does not grant live capital or promotion authority."
+        ),
+    )
+
     trading_simple_paper_route_probe_max_notional: float = Field(
         default=25.0,
         alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL",

--- a/services/torghut/app/trading/proof_floor_modules/receipt_builder.py
+++ b/services/torghut/app/trading/proof_floor_modules/receipt_builder.py
@@ -720,10 +720,14 @@ def build_profitability_proof_floor_receipt(
         },
     }
     paper_route_probe_enabled = False
+    paper_route_probe_allow_live_mode = False
     paper_route_probe_max_notional: object | None = None
     if isinstance(simple_lane_status, Mapping):
         paper_route_probe_enabled = truthy(
             simple_lane_status.get("paper_route_probe_enabled")
+        )
+        paper_route_probe_allow_live_mode = truthy(
+            simple_lane_status.get("paper_route_probe_allow_live_mode")
         )
         paper_route_probe_max_notional = simple_lane_status.get(
             "paper_route_probe_max_notional"
@@ -733,6 +737,7 @@ def build_profitability_proof_floor_receipt(
         trading_mode=trading_mode,
         market_session_open=market_session_open,
         paper_route_probe_enabled=paper_route_probe_enabled,
+        paper_route_probe_allow_live_mode=paper_route_probe_allow_live_mode,
         paper_route_probe_max_notional=paper_route_probe_max_notional,
     )
     receipt["route_reacquisition_book"] = route_reacquisition_book

--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -484,11 +484,15 @@ def _paper_route_probe_blockers(
     trading_mode: str,
     market_session_open: bool | None,
     enabled: bool,
+    allow_live_mode: bool,
     configured_limit: str | None,
     eligible_symbol_count: int,
 ) -> list[str]:
     blockers: list[str] = []
-    if trading_mode != "paper":
+    if trading_mode == "live":
+        if not allow_live_mode:
+            blockers.append("live_paper_route_probe_collection_disabled")
+    elif trading_mode != "paper":
         blockers.append("not_paper_mode")
     if not enabled:
         blockers.append("paper_route_probe_disabled")
@@ -511,6 +515,7 @@ def build_route_reacquisition_book(
     trading_mode: str,
     market_session_open: bool | None,
     paper_route_probe_enabled: bool = False,
+    paper_route_probe_allow_live_mode: bool = False,
     paper_route_probe_max_notional: object | None = None,
 ) -> dict[str, object]:
     """Build a symbol-level route repair book from proof-floor source refs.
@@ -612,6 +617,7 @@ def build_route_reacquisition_book(
         trading_mode=trading_mode,
         market_session_open=market_session_open,
         enabled=paper_route_probe_enabled,
+        allow_live_mode=paper_route_probe_allow_live_mode,
         configured_limit=configured_probe_limit,
         eligible_symbol_count=len(eligible_probe_symbols),
     )
@@ -632,6 +638,7 @@ def build_route_reacquisition_book(
             "next_session_notional_limit": next_session_probe_limit
             if eligible
             else "0",
+            "live_mode_collection_allowed": paper_route_probe_allow_live_mode,
             "blocking_reasons": probe_blockers if eligible else [],
             "capital_authority": "none",
             "promotion_authority": False,
@@ -704,6 +711,7 @@ def build_route_reacquisition_book(
         },
         "paper_route_probe": {
             "configured_enabled": paper_route_probe_enabled,
+            "live_mode_collection_allowed": paper_route_probe_allow_live_mode,
             "configured_max_notional": configured_probe_limit or "0",
             "active": probe_active,
             "effective_max_notional": effective_probe_limit,

--- a/services/torghut/app/trading/scheduler/proof_floor.py
+++ b/services/torghut/app/trading/scheduler/proof_floor.py
@@ -83,6 +83,9 @@ class SimplePipelineProofFloorMixin:
                     "paper_route_probe_enabled": (
                         settings.trading_simple_paper_route_probe_enabled
                     ),
+                    "paper_route_probe_allow_live_mode": (
+                        settings.trading_simple_paper_route_probe_allow_live_mode
+                    ),
                     "paper_route_probe_max_notional": (
                         settings.trading_simple_paper_route_probe_max_notional
                     ),

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -404,7 +404,12 @@ class SimpleTradingPipeline(
         *,
         session: Session | None = None,
     ) -> tuple[set[str], set[str]] | None:
-        if settings.trading_mode != "paper":
+        if settings.trading_mode not in {"paper", "live"}:
+            return None
+        if (
+            settings.trading_mode == "live"
+            and not settings.trading_simple_paper_route_probe_allow_live_mode
+        ):
             return None
         if not settings.trading_simple_paper_route_probe_enabled:
             return None
@@ -526,6 +531,9 @@ class SimpleTradingPipeline(
             "shared_gate_enforced": True,
             "blocked_reasons": simple_blocked_reasons,
             "live_submit_activation": live_submit_activation_status(),
+            "paper_route_probe_allow_live_mode": (
+                settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
             "paper_route_probe_max_notional": (
                 settings.trading_simple_paper_route_probe_max_notional
             ),

--- a/services/torghut/app/trading/scheduler/source_collection_modules/source_decisions.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/source_decisions.py
@@ -267,6 +267,8 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
         self,
         now: datetime,
     ) -> str | None:
+        if not settings.trading_simple_paper_route_probe_allow_live_mode:
+            return "live_paper_route_probe_collection_disabled"
         if not settings.trading_simple_submit_enabled:
             return "simple_submit_disabled"
         activation = live_submit_activation_status(now=now)
@@ -667,7 +669,13 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
 
     def _paper_route_target_plan_reservation_enabled(self, now: datetime) -> bool:
         return (
-            settings.trading_mode == "paper"
+            (
+                settings.trading_mode == "paper"
+                or (
+                    settings.trading_mode == "live"
+                    and settings.trading_simple_paper_route_probe_allow_live_mode
+                )
+            )
             and settings.trading_simple_paper_route_probe_enabled
             and self._is_market_session_open(now)
         )

--- a/services/torghut/app/trading/scheduler/submission_preparation_modules/direct_submission.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation_modules/direct_submission.py
@@ -400,6 +400,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
             settings.trading_mode == "live"
             and settings.trading_simple_submit_enabled
             and settings.trading_simple_paper_route_probe_enabled
+            and settings.trading_simple_paper_route_probe_allow_live_mode
             and (
                 self._paper_route_probe_exit_metadata(decision) is not None
                 or paper_route_probe_entry_metadata(decision.params) is not None

--- a/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
+++ b/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
@@ -274,6 +274,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             "trading_simple_submit_enabled",
             "trading_simple_order_feed_telemetry_enabled",
             "trading_simple_paper_route_probe_enabled",
+            "trading_simple_paper_route_probe_allow_live_mode",
             "trading_options_catalog_freshness_exact_route_scope_enabled",
             "trading_empirical_jobs_health_required",
             "trading_jangar_quant_health_required",

--- a/services/torghut/tests/config/test_tigerbeetle_settings_are_normalized.py
+++ b/services/torghut/tests/config/test_tigerbeetle_settings_are_normalized.py
@@ -791,6 +791,7 @@ class TestTigerbeetleSettingsAreNormalized(_TestConfigBase):
             TRADING_LIVE_SUBMIT_ACTIVATION_EXPIRES_AT="2026-06-17T20:05:00Z",
             TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED=True,
             TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED=True,
+            TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE=True,
             TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL=15.0,
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
@@ -808,6 +809,7 @@ class TestTigerbeetleSettingsAreNormalized(_TestConfigBase):
         )
         self.assertTrue(settings.trading_simple_order_feed_telemetry_enabled)
         self.assertTrue(settings.trading_simple_paper_route_probe_enabled)
+        self.assertTrue(settings.trading_simple_paper_route_probe_allow_live_mode)
         self.assertEqual(settings.trading_simple_paper_route_probe_max_notional, 15.0)
 
         defaults = Settings(
@@ -817,3 +819,4 @@ class TestTigerbeetleSettingsAreNormalized(_TestConfigBase):
         )
         self.assertEqual(defaults.trading_simple_max_order_pct_equity, 0.25)
         self.assertEqual(defaults.trading_simple_max_gross_exposure_pct_equity, 1.0)
+        self.assertFalse(defaults.trading_simple_paper_route_probe_allow_live_mode)

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -406,6 +406,9 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
         self.assertTrue(
             _manifest_bool(sim_env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED")
         )
+        self.assertFalse(
+            _manifest_bool(sim_env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE")
+        )
         self.assertEqual(
             sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
             _SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL,

--- a/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
@@ -739,6 +739,9 @@ class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
             "2026-06-17T20:05:00Z",
         )
         self.assertTrue(_manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED"))
+        self.assertTrue(
+            _manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE")
+        )
         self.assertEqual(
             env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
             _SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL,

--- a/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
@@ -42,10 +42,14 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
             "trading_simple_paper_route_probe_enabled": (
                 config.settings.trading_simple_paper_route_probe_enabled
             ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
         }
         config.settings.trading_mode = "live"
         config.settings.trading_simple_submit_enabled = True
         config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_allow_live_mode = True
         try:
             pipeline = SimpleTradingPipeline(
                 alpaca_client=FakeAlpacaClient(),
@@ -88,6 +92,15 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
                 ],
             }
 
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = False
+            self.assertFalse(
+                pipeline._bounded_live_paper_route_probe_submission_allowed(
+                    decision,
+                    gate,
+                )
+            )
+
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = True
             self.assertTrue(
                 pipeline._bounded_live_paper_route_probe_submission_allowed(
                     decision,
@@ -119,6 +132,9 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
             ]
             config.settings.trading_simple_paper_route_probe_enabled = original[
                 "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
             ]
 
     def test_live_gate_records_expired_activation_on_simple_lane(self) -> None:
@@ -203,11 +219,15 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
             "trading_simple_paper_route_probe_enabled": (
                 config.settings.trading_simple_paper_route_probe_enabled
             ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
         }
         config.settings.trading_enabled = True
         config.settings.trading_mode = "live"
         config.settings.trading_simple_submit_enabled = True
         config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_allow_live_mode = True
         try:
             pipeline = SimpleTradingPipeline(
                 alpaca_client=FakeAlpacaClient(),
@@ -334,6 +354,9 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
             ]
             config.settings.trading_simple_paper_route_probe_enabled = original[
                 "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
             ]
 
     def test_process_paper_route_target_source_decisions_records_submit_failure(

--- a/services/torghut/tests/profitability_proof_floor/test_execution_tca_route_universe_uses_widest_hypothesis_guardrail.py
+++ b/services/torghut/tests/profitability_proof_floor/test_execution_tca_route_universe_uses_widest_hypothesis_guardrail.py
@@ -662,6 +662,7 @@ def test_paper_route_probe_config_flows_into_proof_floor_route_book() -> None:
         simple_lane_status={
             **_simple_lane_status(),
             "paper_route_probe_enabled": True,
+            "paper_route_probe_allow_live_mode": True,
             "paper_route_probe_max_notional": "25",
         },
         now=NOW,
@@ -676,6 +677,7 @@ def test_paper_route_probe_config_flows_into_proof_floor_route_book() -> None:
     assert receipt["capital_state"] == "zero_notional"
     assert probe == route_probe
     assert probe["configured_enabled"] is True
+    assert probe["live_mode_collection_allowed"] is True
     assert probe["active"] is False
     assert probe["next_session_max_notional"] == "25"
     assert probe["eligible_symbols"] == ["AMZN", "AAPL"]

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -23,6 +23,7 @@ def test_live_bounded_paper_route_target_generates_capped_source_decisions(
 ) -> None:
     trading_mode_before = settings.trading_mode
     probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    probe_allow_live_before = settings.trading_simple_paper_route_probe_allow_live_mode
     submit_enabled_before = settings.trading_simple_submit_enabled
     activation_expires_at_before = settings.trading_live_submit_activation_expires_at
     probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
@@ -30,6 +31,7 @@ def test_live_bounded_paper_route_target_generates_capped_source_decisions(
     try:
         settings.trading_mode = "live"
         settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
         settings.trading_simple_submit_enabled = True
         settings.trading_live_submit_activation_expires_at = "2026-06-17T20:05:00Z"
         settings.trading_simple_paper_route_probe_max_notional = 100
@@ -113,6 +115,9 @@ def test_live_bounded_paper_route_target_generates_capped_source_decisions(
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_paper_route_probe_allow_live_mode = (
+            probe_allow_live_before
+        )
         settings.trading_simple_submit_enabled = submit_enabled_before
         settings.trading_live_submit_activation_expires_at = (
             activation_expires_at_before
@@ -128,12 +133,14 @@ def test_live_bounded_paper_route_target_blocks_without_activation(
 ) -> None:
     trading_mode_before = settings.trading_mode
     probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    probe_allow_live_before = settings.trading_simple_paper_route_probe_allow_live_mode
     submit_enabled_before = settings.trading_simple_submit_enabled
     activation_expires_at_before = settings.trading_live_submit_activation_expires_at
     probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
     try:
         settings.trading_mode = "live"
         settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
         settings.trading_simple_submit_enabled = True
         settings.trading_live_submit_activation_expires_at = "2026-06-17T13:40:00Z"
         settings.trading_simple_paper_route_probe_max_notional = 100
@@ -166,6 +173,9 @@ def test_live_bounded_paper_route_target_blocks_without_activation(
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_paper_route_probe_allow_live_mode = (
+            probe_allow_live_before
+        )
         settings.trading_simple_submit_enabled = submit_enabled_before
         settings.trading_live_submit_activation_expires_at = (
             activation_expires_at_before
@@ -176,6 +186,7 @@ def test_live_bounded_paper_route_target_blocks_without_activation(
 
 
 def test_live_bounded_paper_route_source_collection_contract_blockers() -> None:
+    probe_allow_live_before = settings.trading_simple_paper_route_probe_allow_live_mode
     submit_enabled_before = settings.trading_simple_submit_enabled
     activation_expires_at_before = settings.trading_live_submit_activation_expires_at
     probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
@@ -183,6 +194,13 @@ def test_live_bounded_paper_route_source_collection_contract_blockers() -> None:
         now = datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc)
         pipeline = object.__new__(SimpleTradingPipeline)
 
+        settings.trading_simple_paper_route_probe_allow_live_mode = False
+        assert (
+            pipeline._live_bounded_paper_route_source_collection_blocker(now)
+            == "live_paper_route_probe_collection_disabled"
+        )
+
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
         settings.trading_simple_submit_enabled = False
         assert (
             pipeline._live_bounded_paper_route_source_collection_blocker(now)
@@ -203,6 +221,9 @@ def test_live_bounded_paper_route_source_collection_contract_blockers() -> None:
             == "paper_route_probe_notional_not_configured"
         )
     finally:
+        settings.trading_simple_paper_route_probe_allow_live_mode = (
+            probe_allow_live_before
+        )
         settings.trading_simple_submit_enabled = submit_enabled_before
         settings.trading_live_submit_activation_expires_at = (
             activation_expires_at_before
@@ -217,12 +238,14 @@ def test_live_bounded_paper_route_target_rejects_missing_cap_and_symbols(
 ) -> None:
     trading_mode_before = settings.trading_mode
     probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    probe_allow_live_before = settings.trading_simple_paper_route_probe_allow_live_mode
     submit_enabled_before = settings.trading_simple_submit_enabled
     activation_expires_at_before = settings.trading_live_submit_activation_expires_at
     probe_max_notional_before = settings.trading_simple_paper_route_probe_max_notional
     try:
         settings.trading_mode = "live"
         settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
         settings.trading_simple_submit_enabled = True
         settings.trading_live_submit_activation_expires_at = "2026-06-17T20:05:00Z"
         settings.trading_simple_paper_route_probe_max_notional = 100
@@ -289,6 +312,9 @@ def test_live_bounded_paper_route_target_rejects_missing_cap_and_symbols(
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_paper_route_probe_allow_live_mode = (
+            probe_allow_live_before
+        )
         settings.trading_simple_submit_enabled = submit_enabled_before
         settings.trading_live_submit_activation_expires_at = (
             activation_expires_at_before
@@ -301,10 +327,12 @@ def test_live_bounded_paper_route_target_rejects_missing_cap_and_symbols(
 def test_live_bounded_paper_route_symbol_floor_allows_bounded_probe() -> None:
     trading_mode_before = settings.trading_mode
     probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    probe_allow_live_before = settings.trading_simple_paper_route_probe_allow_live_mode
     submit_enabled_before = settings.trading_simple_submit_enabled
     try:
         settings.trading_mode = "live"
         settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
         settings.trading_simple_submit_enabled = True
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "PA3SX7FYNUTF"
@@ -338,4 +366,7 @@ def test_live_bounded_paper_route_symbol_floor_allows_bounded_probe() -> None:
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_paper_route_probe_allow_live_mode = (
+            probe_allow_live_before
+        )
         settings.trading_simple_submit_enabled = submit_enabled_before

--- a/services/torghut/tests/test_route_reacquisition.py
+++ b/services/torghut/tests/test_route_reacquisition.py
@@ -432,7 +432,10 @@ def test_live_route_book_can_advertise_next_session_paper_probe_without_capital_
     assert probe["next_session_max_notional"] == "25"
     assert probe["eligible_symbols"] == ["AAPL"]
     assert probe["active_symbols"] == []
-    assert probe["blocking_reasons"] == ["not_paper_mode", "session_closed"]
+    assert probe["blocking_reasons"] == [
+        "live_paper_route_probe_collection_disabled",
+        "session_closed",
+    ]
     assert probe["capital_authority"] == "none"
     assert book["capital_rule"] == "live_zero_notional_unchanged"
 
@@ -444,6 +447,71 @@ def test_live_route_book_can_advertise_next_session_paper_probe_without_capital_
     assert aapl_probe["notional_limit"] == "0"
     assert aapl_probe["next_session_notional_limit"] == "25"
     assert aapl_probe["capital_authority"] == "none"
+
+
+def test_live_route_book_allows_bounded_paper_probe_collection_with_explicit_opt_in() -> (
+    None
+):
+    book = build_route_reacquisition_book(
+        proof_floor_receipt={
+            "generated_at": "2026-06-17T13:45:00+00:00",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "source_ref": {
+                        "symbol_routes": {
+                            "scope_symbols": ["AAPL"],
+                            "scope_symbol_count": 1,
+                            "routeable_symbols": [],
+                            "blocked_symbols": [],
+                            "missing_symbols": ["AAPL"],
+                        }
+                    },
+                },
+                {"dimension": "market_context", "state": "pass"},
+                {"dimension": "quant_ingestion", "state": "pass"},
+                {"dimension": "alpha_readiness", "state": "fail"},
+            ],
+        },
+        trading_mode="live",
+        market_session_open=True,
+        paper_route_probe_enabled=True,
+        paper_route_probe_allow_live_mode=True,
+        paper_route_probe_max_notional="100",
+    )
+
+    assert book["capital_rule"] == "live_zero_notional_unchanged"
+    assert book["promotion_authority"] is False
+    assert book["rollback_target"] == {
+        "paper_probe_notional_limit": "0",
+        "live_submit_enabled": False,
+        "promotion_authority": False,
+    }
+    probe = cast(Mapping[str, Any], book["paper_route_probe"])
+    assert probe["configured_enabled"] is True
+    assert probe["live_mode_collection_allowed"] is True
+    assert probe["active"] is True
+    assert probe["effective_max_notional"] == "100"
+    assert probe["next_session_max_notional"] == "100"
+    assert probe["eligible_symbols"] == ["AAPL"]
+    assert probe["active_symbols"] == ["AAPL"]
+    assert probe["blocking_reasons"] == []
+    assert probe["capital_authority"] == "none"
+    assert probe["promotion_authority"] is False
+
+    records = cast(list[Mapping[str, Any]], book["records"])
+    aapl = next(item for item in records if item["symbol"] == "AAPL")
+    aapl_probe = cast(Mapping[str, Any], aapl["paper_route_probe"])
+    assert aapl["paper_probe_notional_limit"] == "0"
+    assert aapl_probe["active"] is True
+    assert aapl_probe["notional_limit"] == "100"
+    assert aapl_probe["next_session_notional_limit"] == "100"
+    assert aapl_probe["capital_authority"] == "none"
+    assert aapl_probe["promotion_authority"] is False
 
 
 def test_route_book_marks_paper_route_probe_active_only_when_market_open() -> None:


### PR DESCRIPTION
## Summary

- Adds an explicit `TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE` safety switch for bounded paper-route evidence collection while Torghut is in live mode.
- Wires the switch through `/trading/status` simple-lane payloads, proof-floor receipt route books, source-collection decisions, and collection-only submission bypass checks.
- Enables the switch in the live Torghut Knative service and tightens post-deploy evidence validation to require it alongside the $100 cap contract.
- Adds regression coverage proving live evidence collection remains opt-in and does not grant capital or promotion authority.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_route_reacquisition.py -k 'paper_route_probe or live_route_book'`
- `uv run --frozen pytest tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_target_plan_source_b.py -k 'live_bounded_paper_route_probe'`
- `uv run --frozen pytest tests/profitability_proof_floor/test_execution_tca_route_universe_uses_widest_hypothesis_guardrail.py::test_paper_route_probe_config_flows_into_proof_floor_route_book`
- `uv run --frozen pytest tests/config/test_tigerbeetle_settings_are_normalized.py::TestTigerbeetleSettingsAreNormalized::test_simple_pipeline_settings_are_supported`
- `uv run --frozen pytest tests/config/test_parses_signal_staleness_critical_reasons.py::TestParsesSignalStalenessCriticalReasons::test_feature_flag_map_covers_all_boolean_runtime_gates`
- `uv run --frozen pytest tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py::TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim::test_manifest_simple_lane_profile_is_enforced`
- `uv run --frozen pytest tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py`
- `uv run --frozen ruff format --check app tests`
- `uv run --frozen ruff check app tests`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
