### PR TITLE
revert(torghut): rollback failed promotion f66d46117785d44c272805eff28fc4024478866a

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -134,8 +134,6 @@ spec:
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
-            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE
-              value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "100"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_BATCH_LIMIT


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `f66d46117785d44c272805eff28fc4024478866a`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/27714930100`
- Rollback source: `HEAD^` manifests from the failed run checkout