### PR TITLE
fix(torghut): scope live paper signal polling

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -157,7 +157,11 @@ class SimpleTradingPipeline(
                 strategies,
                 session=session,
             )
-            batch = self._fetch_signal_batch(session, signal_scope=signal_scope)
+            batch = self._fetch_signal_batch(
+                session,
+                signal_scope=signal_scope,
+                strategies=strategies,
+            )
             self._record_ingest_window(batch)
             if self._signal_ingest_unavailable(batch):
                 self._prepare_batch_for_decisions(
@@ -303,7 +307,12 @@ class SimpleTradingPipeline(
         session: Session,
         *,
         signal_scope: tuple[set[str], set[str]] | None,
+        strategies: Sequence[Strategy] | None = None,
     ) -> SignalBatch:
+        if signal_scope is None:
+            signal_scope = self._live_bounded_collection_fallback_signal_scope(
+                strategies or ()
+            )
         if signal_scope is None:
             return self.ingestor.fetch_signals(session)
         symbols, timeframes = signal_scope
@@ -323,6 +332,38 @@ class SimpleTradingPipeline(
                 ",".join(sorted(timeframes)) or "*",
             )
             return self.ingestor.fetch_signals(session)
+
+    def _live_bounded_collection_fallback_signal_scope(
+        self,
+        strategies: Sequence[Strategy],
+    ) -> tuple[set[str], set[str]] | None:
+        if settings.trading_mode != "live":
+            return None
+        if not settings.trading_simple_paper_route_probe_allow_live_mode:
+            return None
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return None
+        symbols = {
+            str(symbol).strip().upper()
+            for symbol in settings.trading_static_symbols
+            if str(symbol).strip()
+        }
+        timeframes = {
+            str(strategy.base_timeframe).strip()
+            for strategy in strategies
+            if str(strategy.base_timeframe).strip()
+        }
+        for strategy in strategies:
+            if strategy.universe_type != "static":
+                continue
+            symbols.update(
+                str(symbol).strip().upper()
+                for symbol in strategy.universe_symbols or ()
+                if str(symbol).strip()
+            )
+        if not symbols:
+            return None
+        return symbols, timeframes
 
     @staticmethod
     def _signal_ingest_unavailable(batch: SignalBatch) -> bool:

--- a/services/torghut/tests/pipeline/test_trading_pipeline_external_targets_d.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_external_targets_d.py
@@ -352,6 +352,136 @@ class TestTradingPipelineExternalTargetsD(TradingPipelineTestCaseBase):
         self.assertEqual(batch.signals, [])
         self.assertEqual(ingestor.calls, 1)
 
+    def test_live_bounded_collection_fallback_scopes_signal_fetch_to_static_universe(
+        self,
+    ) -> None:
+        from app import config
+
+        class ScopedIngestor:
+            def __init__(self) -> None:
+                self.calls: list[tuple[set[str] | None, set[str] | None]] = []
+
+            def fetch_signals(
+                self,
+                session: Session,
+                *,
+                symbols: set[str] | None = None,
+                timeframes: set[str] | None = None,
+            ) -> SignalBatch:
+                self.calls.append((symbols, timeframes))
+                return SignalBatch(
+                    signals=[],
+                    cursor_at=None,
+                    cursor_seq=None,
+                    cursor_symbol=None,
+                )
+
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+        }
+        try:
+            config.settings.trading_mode = "live"
+            config.settings.trading_simple_paper_route_probe_enabled = True
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = True
+            config.settings.trading_static_symbols_raw = "AAPL,AMZN,INTC,NVDA"
+            ingestor = ScopedIngestor()
+            pipeline = object.__new__(SimpleTradingPipeline)
+            setattr(pipeline, "account_label", "PA3SX7FYNUTF")
+            setattr(pipeline, "ingestor", ingestor)
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+            )
+
+            with self.session_local() as session:
+                batch = pipeline._fetch_signal_batch(
+                    session,
+                    signal_scope=None,
+                    strategies=[strategy],
+                )
+
+            self.assertEqual(batch.signals, [])
+            self.assertEqual(
+                ingestor.calls,
+                [({"AAPL", "AMZN", "INTC", "NVDA"}, {"1Sec"})],
+            )
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_simple_paper_route_probe_enabled = original[
+                "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+
+    def test_live_bounded_collection_fallback_respects_disabled_and_empty_scopes(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+        }
+        pipeline = object.__new__(SimpleTradingPipeline)
+        dynamic_strategy = Strategy(
+            name="dynamic-universe",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="dynamic",
+            universe_symbols=[],
+        )
+        try:
+            config.settings.trading_mode = "live"
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = True
+            config.settings.trading_simple_paper_route_probe_enabled = False
+            config.settings.trading_static_symbols_raw = "AAPL"
+
+            self.assertIsNone(
+                pipeline._live_bounded_collection_fallback_signal_scope(
+                    [dynamic_strategy]
+                )
+            )
+
+            config.settings.trading_simple_paper_route_probe_enabled = True
+            config.settings.trading_static_symbols_raw = ""
+
+            self.assertIsNone(
+                pipeline._live_bounded_collection_fallback_signal_scope(
+                    [dynamic_strategy]
+                )
+            )
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_simple_paper_route_probe_enabled = original[
+                "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+
     def test_bounded_signal_scope_skips_unusable_targets_before_valid_target(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Scope live bounded paper-route signal polling to the static Torghut universe when no active target-plan scope is available.
- Preserve live capital/promotion gates while avoiding unbounded ClickHouse signal scans in the evidence-collection lane.
- Add regression coverage proving the live bounded collection fallback passes static symbols and strategy timeframes into the ingestor.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_external_targets_d.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/pipeline/test_trading_pipeline_external_targets_d.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/pipeline/test_trading_pipeline_external_targets_d.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
