### PR TITLE
refactor(torghut): prune pyright file suppressions

### DIFF
--- a/services/torghut/app/trading/autonomy/gates_modules/gate7_uncertainty_calibration.py
+++ b/services/torghut/app/trading/autonomy/gates_modules/gate7_uncertainty_calibration.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Gate policy matrix evaluator for Torghut v3 autonomous lanes."""
 
 from __future__ import annotations
@@ -450,11 +449,31 @@ def _fragility_state_rank(state: str) -> int:
     return ranks.get(normalized, 1)
 
 
+# Public aliases used by split-module consumers.
+decimal_or_default = _decimal_or_default
+gate2_base_reasons = _gate2_base_reasons
+gate2_tca_reasons = _gate2_tca_reasons
+gate6_early_result = _gate6_early_result
+gate6_janus_q_reasons = _gate6_janus_q_reasons
+gate6_reproducibility_reasons = _gate6_reproducibility_reasons
+gate6_schema_reasons = _gate6_schema_reasons
+gate6_threshold_reasons = _gate6_threshold_reasons
+gate7_uncertainty_calibration = _gate7_uncertainty_calibration
+
 __all__ = [
     "GateEvaluationReport",
     "GateInputs",
     "GatePolicyMatrix",
     "GateResult",
     "PromotionTarget",
+    "decimal_or_default",
     "evaluate_gate_matrix",
+    "gate2_base_reasons",
+    "gate2_tca_reasons",
+    "gate6_early_result",
+    "gate6_janus_q_reasons",
+    "gate6_reproducibility_reasons",
+    "gate6_schema_reasons",
+    "gate6_threshold_reasons",
+    "gate7_uncertainty_calibration",
 ]

--- a/services/torghut/app/trading/decisions_modules/count_open_short_positions.py
+++ b/services/torghut/app/trading/decisions_modules/count_open_short_positions.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Trading decision engine based on TA signals."""
 
 from __future__ import annotations
@@ -9,17 +8,17 @@ from typing import Any, Optional, cast
 
 from ...config import settings
 from ..features import (
-    SignalFeatures,
-    extract_signal_features,
+    SignalFeatures as SignalFeatures,
+    extract_signal_features as extract_signal_features,
 )
 from ..models import SignalEnvelope
 
 
 from .shared_context import (
-    DecisionRuntimeTelemetry,
+    DecisionRuntimeTelemetry as DecisionRuntimeTelemetry,
 )
 from .decision_engine_runtime_methods import (
-    DecisionEngine,
+    DecisionEngine as DecisionEngine,
 )
 from .positions_for_strategy_action import (
     position_qty_from_payload as _position_qty_from_payload,
@@ -54,26 +53,6 @@ def _count_open_short_positions(positions: Optional[list[dict[str, Any]]]) -> in
         if side == "short" and market_value != 0:
             open_symbols.add(symbol)
     return len(open_symbols)
-
-
-def _int_param(value: Any) -> int:
-    if value is None:
-        return 0
-    try:
-        return int(str(value))
-    except (TypeError, ValueError):
-        return 0
-
-
-def _bool_param(value: Any) -> bool | None:
-    if value is None:
-        return None
-    normalized = str(value).strip().lower()
-    if normalized in {"1", "true", "t", "yes", "y", "on"}:
-        return True
-    if normalized in {"0", "false", "f", "no", "n", "off"}:
-        return False
-    return None
 
 
 def _resolve_signal_timeframe(signal: SignalEnvelope) -> Optional[str]:

--- a/services/torghut/app/trading/discovery/fast_replay_modules/extract_price.py
+++ b/services/torghut/app/trading/discovery/fast_replay_modules/extract_price.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Preview-only vectorized scoring over manifest-verified replay tapes."""
 
 from __future__ import annotations
@@ -16,19 +15,19 @@ from app.trading.models import SignalEnvelope
 
 
 from .shared_context import (
-    FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
-    FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
-    FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP,
-    FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION,
-    FAST_REPLAY_PREVIEW_SCHEMA_VERSION,
-    FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+    FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT as FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
+    FAST_REPLAY_DEFAULT_EXPLORATION_COUNT as FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
+    FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP as FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP,
+    FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION as FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION,
+    FAST_REPLAY_PREVIEW_SCHEMA_VERSION as FAST_REPLAY_PREVIEW_SCHEMA_VERSION,
+    FAST_REPLAY_PROOF_SEMANTICS_LABEL as FAST_REPLAY_PROOF_SEMANTICS_LABEL,
     FAST_REPLAY_TARGET_NET_PNL_PER_DAY,
-    FAST_REPLAY_WHITEPAPER_MECHANISMS,
+    FAST_REPLAY_WHITEPAPER_MECHANISMS as FAST_REPLAY_WHITEPAPER_MECHANISMS,
     FastReplayPreviewRow,
 )
 from .fast_replay_preview_result import (
-    FastReplayPreviewResult,
-    build_fast_replay_preview,
+    FastReplayPreviewResult as FastReplayPreviewResult,
+    build_fast_replay_preview as build_fast_replay_preview,
 )
 from .preview_rank_key import (
     adaptive_market_limit_allocation_rank_penalty_bps_split_export as _adaptive_market_limit_allocation_rank_penalty_bps,

--- a/services/torghut/app/trading/discovery/microstructure_prefilter_modules/weighted_average.py
+++ b/services/torghut/app/trading/discovery/microstructure_prefilter_modules/weighted_average.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Bounded H-PAIRS ClusterLOB/OFI candidate prefiltering.
 
 The scores in this module are discovery metadata only. They intentionally rank
@@ -19,16 +18,16 @@ from numpy.typing import NDArray
 
 
 from .shared_context import (
-    HPAIRS_AUTHORITY_BLOCKERS,
-    HPAIRS_FAMILY_TEMPLATE_ID,
-    HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
-    HPAIRS_PREFILTER_PROOF_SOURCE,
-    HPAIRS_PREFILTER_ROW_SCHEMA_VERSION,
-    HPAIRS_PREFILTER_SCHEMA_VERSION,
-    HPAIRS_RUNTIME_STRATEGY_NAME,
-    MicrostructureCandidatePrefilterRow,
-    MicrostructurePrefilterResult,
-    build_hpairs_microstructure_prefilter,
+    HPAIRS_AUTHORITY_BLOCKERS as HPAIRS_AUTHORITY_BLOCKERS,
+    HPAIRS_FAMILY_TEMPLATE_ID as HPAIRS_FAMILY_TEMPLATE_ID,
+    HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL as HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
+    HPAIRS_PREFILTER_PROOF_SOURCE as HPAIRS_PREFILTER_PROOF_SOURCE,
+    HPAIRS_PREFILTER_ROW_SCHEMA_VERSION as HPAIRS_PREFILTER_ROW_SCHEMA_VERSION,
+    HPAIRS_PREFILTER_SCHEMA_VERSION as HPAIRS_PREFILTER_SCHEMA_VERSION,
+    HPAIRS_RUNTIME_STRATEGY_NAME as HPAIRS_RUNTIME_STRATEGY_NAME,
+    MicrostructureCandidatePrefilterRow as MicrostructureCandidatePrefilterRow,
+    MicrostructurePrefilterResult as MicrostructurePrefilterResult,
+    build_hpairs_microstructure_prefilter as build_hpairs_microstructure_prefilter,
 )
 
 

--- a/services/torghut/app/trading/discovery/microstructure_regime_tokenization_stress_modules/microstructure_observation.py
+++ b/services/torghut/app/trading/discovery/microstructure_regime_tokenization_stress_modules/microstructure_observation.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Preview-only microstructure regime/tokenization replay stress.
 
 This module converts current 2025-2026 market-microstructure papers into
@@ -24,19 +23,19 @@ from typing import Any, cast
 
 
 from .shared_context import (
-    MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_PRIMARY_SOURCES,
-    MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_PROOF_SEMANTICS_LABEL,
-    MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_SCHEMA_VERSION,
-    MicrostructureRegimeTokenizationStressSummary,
+    MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_PRIMARY_SOURCES as MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_PRIMARY_SOURCES,
+    MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_PROOF_SEMANTICS_LABEL as MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_PROOF_SEMANTICS_LABEL,
+    MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_SCHEMA_VERSION as MICROSTRUCTURE_REGIME_TOKENIZATION_STRESS_SCHEMA_VERSION,
+    MicrostructureRegimeTokenizationStressSummary as MicrostructureRegimeTokenizationStressSummary,
     DEPTH_FIELDS as _DEPTH_FIELDS,
     EARLY_WARNING_LOOKAHEAD as _EARLY_WARNING_LOOKAHEAD,
     EVENT_TYPE_FIELDS as _EVENT_TYPE_FIELDS,
     LOBERT_LIFECYCLE_ACTIONS as _LOBERT_LIFECYCLE_ACTIONS,
     MIN_EARLY_WARNING_ROWS as _MIN_EARLY_WARNING_ROWS,
     POST_MESSAGE_SNAPSHOT_PRICE_FIELDS as _POST_MESSAGE_SNAPSHOT_PRICE_FIELDS,
-    build_microstructure_regime_tokenization_stress_schema_hash,
-    extract_microstructure_regime_tokenization_stress,
-    microstructure_regime_tokenization_stress_contract,
+    build_microstructure_regime_tokenization_stress_schema_hash as build_microstructure_regime_tokenization_stress_schema_hash,
+    extract_microstructure_regime_tokenization_stress as extract_microstructure_regime_tokenization_stress,
+    microstructure_regime_tokenization_stress_contract as microstructure_regime_tokenization_stress_contract,
 )
 
 

--- a/services/torghut/app/trading/discovery/queue_survival_fill_stress_modules/group_normalized_downside_reward_penalty_b.py
+++ b/services/torghut/app/trading/discovery/queue_survival_fill_stress_modules/group_normalized_downside_reward_penalty_b.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Preview-only queue-survival fill stress for replay candidate ranking.
 
 This module actualizes recent queue-position, fill-probability, and execution-delay
@@ -11,7 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping, Sequence
-from math import isfinite, log1p
+from math import isfinite, log1p as _math_log1p
 from typing import Any, cast
 
 from app.trading.models import SignalEnvelope
@@ -167,7 +166,7 @@ def _quantile(values: Sequence[float], quantile: float) -> float:
 
 
 def _log1p(value: float) -> float:
-    return 0.0 if value <= -1.0 else log1p(value)
+    return 0.0 if value <= -1.0 else _math_log1p(value)
 
 
 def _stable_float(value: float) -> str:
@@ -192,6 +191,7 @@ group_normalized_downside_reward_penalty_bps = (
     _group_normalized_downside_reward_penalty_bps
 )
 label_has_token = _label_has_token
+log1p = _log1p
 median = _median
 nonnegative_float = _nonnegative_float
 positive_float = _positive_float
@@ -205,6 +205,7 @@ __all__ = (
     "float_or_none",
     "group_normalized_downside_reward_penalty_bps",
     "label_has_token",
+    "log1p",
     "median",
     "nonnegative_float",
     "positive_float",

--- a/services/torghut/app/trading/discovery/replay_ledger_ranker_modules/row_has_fill_status.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker_modules/row_has_fill_status.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Rank exact replay ledger artifacts with runtime-ledger PnL semantics."""
 
 from __future__ import annotations
@@ -176,9 +175,11 @@ parse_window_datetime = _parse_window_datetime
 positive_decimal = _positive_decimal
 profit_factor = _profit_factor
 ranking_sort_key = _ranking_sort_key
+row_has_fill_status = _row_has_fill_status
 safe_divide = _safe_divide
 symbols = _symbols
 text = _text
+utc = _utc
 
 __all__ = (
     "best_day_share",
@@ -191,7 +192,9 @@ __all__ = (
     "positive_decimal",
     "profit_factor",
     "ranking_sort_key",
+    "row_has_fill_status",
     "safe_divide",
     "symbols",
     "text",
+    "utc",
 )

--- a/services/torghut/app/trading/evaluation_modules/bootstrap_mean_samples.py
+++ b/services/torghut/app/trading/evaluation_modules/bootstrap_mean_samples.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Walk-forward evaluation harness for offline backtests."""
 
 from __future__ import annotations
@@ -149,6 +148,16 @@ def _as_int(value: Any) -> int | None:
         return None
 
 
+# Public aliases used by split-module consumers.
+as_int = _as_int
+bootstrap_mean_samples = _bootstrap_mean_samples
+decimal_mean = _decimal_mean
+decimal_std = _decimal_std
+quantile_decimal = _quantile_decimal
+reproducibility_payload = _reproducibility_payload
+report_fold_net_pnls = _report_fold_net_pnls
+safe_ratio = _safe_ratio
+
 __all__ = [
     "FixtureSignalSource",
     "FillPriceErrorBudgetReportV1",
@@ -162,11 +171,19 @@ __all__ = [
     "WalkForwardDecision",
     "WalkForwardFold",
     "WalkForwardResults",
+    "as_int",
+    "bootstrap_mean_samples",
     "build_fill_price_error_budget_report_v1",
+    "decimal_mean",
+    "decimal_std",
     "build_profitability_evidence_v4",
     "execute_profitability_benchmark_v4",
     "generate_walk_forward_folds",
+    "quantile_decimal",
+    "reproducibility_payload",
+    "report_fold_net_pnls",
     "run_walk_forward",
+    "safe_ratio",
     "validate_profitability_evidence_v4",
     "write_walk_forward_results",
 ]

--- a/services/torghut/app/trading/executable_alpha_receipts_modules/candidate_replays.py
+++ b/services/torghut/app/trading/executable_alpha_receipts_modules/candidate_replays.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Executable alpha receipt projection for zero-notional repair planning."""
 
 from __future__ import annotations
@@ -12,11 +11,11 @@ from typing import Any
 from .shared_context import (
     CAPITAL_REPLAY_BOARD_SCHEMA_VERSION,
     EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION,
-    EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION,
-    EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION,
-    EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION,
-    EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION,
-    EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION,
+    EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION as EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION,
+    EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION as EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION,
+    EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION as EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION,
+    EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION as EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION,
+    EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION as EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION,
     GraduationState,
     ALPHA_RUNTIME_REPLAY_CLASS as _ALPHA_RUNTIME_REPLAY_CLASS,
     BREADTH_HYPOTHESIS as _BREADTH_HYPOTHESIS,
@@ -33,9 +32,9 @@ from .shared_context import (
     text as _text,
 )
 from .build_executable_alpha_repair_receipts import (
-    build_executable_alpha_repair_receipts,
-    build_executable_alpha_settlement_slots,
-    compact_executable_alpha_settlement_slots,
+    build_executable_alpha_repair_receipts as build_executable_alpha_repair_receipts,
+    build_executable_alpha_settlement_slots as build_executable_alpha_settlement_slots,
+    compact_executable_alpha_settlement_slots as compact_executable_alpha_settlement_slots,
 )
 from .required_after_refs import (
     alpha_runtime_replay_item as _alpha_runtime_replay_item,

--- a/services/torghut/app/trading/execution_modules/validate_pre_submit_request.py
+++ b/services/torghut/app/trading/execution_modules/validate_pre_submit_request.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Order execution and idempotency helpers."""
 
 from __future__ import annotations
@@ -41,7 +40,7 @@ from .shared_context import (
     RUNTIME_COST_PAYLOAD_KEYS as _RUNTIME_COST_PAYLOAD_KEYS,
 )
 from .order_executor_submission_methods import (
-    OrderExecutor,
+    OrderExecutor as OrderExecutor,
     coerce_json as _coerce_json,
     copy_mapping as _copy_mapping,
     first_mapping_text as _first_mapping_text,

--- a/services/torghut/app/trading/ingest_modules/attach_simulation_context.py
+++ b/services/torghut/app/trading/ingest_modules/attach_simulation_context.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Signal ingestion from ClickHouse."""
 
 from __future__ import annotations
@@ -14,10 +13,10 @@ from ..simulation import (
 
 
 from .shared_context import (
-    SignalBatch,
+    SignalBatch as SignalBatch,
 )
 from .clickhouse_signal_ingestor_persistence_methods import (
-    ClickHouseSignalIngestor,
+    ClickHouseSignalIngestor as ClickHouseSignalIngestor,
     coerce_seq as _coerce_seq,
 )
 

--- a/services/torghut/app/trading/intraday_tsmom_contract_modules/decimal.py
+++ b/services/torghut/app/trading/intraday_tsmom_contract_modules/decimal.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Shared parameter contract for intraday_tsmom_v1 across runtimes."""
 
 from __future__ import annotations
@@ -9,12 +8,12 @@ from typing import Any, Mapping
 
 
 from .intraday_tsmom_threshold_profile import (
-    IntradayTsmomEvaluation,
-    IntradayTsmomThresholdProfile,
+    IntradayTsmomEvaluation as IntradayTsmomEvaluation,
+    IntradayTsmomThresholdProfile as IntradayTsmomThresholdProfile,
     optional_decimal_param as _optional_decimal_param,
-    evaluate_intraday_tsmom_signal,
-    resolve_intraday_tsmom_thresholds,
-    validate_intraday_tsmom_params,
+    evaluate_intraday_tsmom_signal as evaluate_intraday_tsmom_signal,
+    resolve_intraday_tsmom_thresholds as resolve_intraday_tsmom_thresholds,
+    validate_intraday_tsmom_params as validate_intraday_tsmom_params,
 )
 
 

--- a/services/torghut/app/trading/llm/dspy_compile/workflow_modules/load_eval_report_from_ref.py
+++ b/services/torghut/app/trading/llm/dspy_compile/workflow_modules/load_eval_report_from_ref.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """DSPy compile/eval/promotion workflow helpers with Jangar-compatible contracts."""
 
 from __future__ import annotations
@@ -366,6 +365,9 @@ def _http_json_request(
         connection.close()
 
 
+execute_local_dspy_lane = _execute_local_dspy_lane
+http_json_request = _http_json_request
+
 __all__ = [
     "DSPyWorkflowLane",
     "build_compile_result",
@@ -374,7 +376,9 @@ __all__ = [
     "orchestrate_dspy_agentrun_workflow",
     "build_promotion_record",
     "bundle_artifacts",
+    "execute_local_dspy_lane",
     "get_agents_agentrun",
+    "http_json_request",
     "wait_for_agents_agentrun_terminal_status",
     "submit_agents_agentrun",
     "upsert_workflow_artifact_record",

--- a/services/torghut/app/trading/order_feed_modules/flatten_poll_records.py
+++ b/services/torghut/app/trading/order_feed_modules/flatten_poll_records.py
@@ -1,10 +1,8 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Kafka-backed order-feed ingestion and persistence helpers."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from decimal import Decimal
 from typing import Any, Callable, Mapping, cast
 
 from sqlalchemy import func, select
@@ -21,28 +19,28 @@ from ...models import (
 
 
 from .shared_context import (
-    EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION,
-    HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
-    NormalizationResult,
+    EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION as EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION,
+    HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION as HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
+    NormalizationResult as NormalizationResult,
     NormalizedOrderEvent,
     ORDER_FEED_SOURCE_REVISION,
     logger,
 )
 
-from .order_feed_ingestor import OrderFeedIngestor
+from .order_feed_ingestor import OrderFeedIngestor as OrderFeedIngestor
 from .normalize_order_feed_record import (
-    apply_order_event_to_execution,
-    latest_order_event_for_execution,
-    link_order_events_to_execution,
-    normalize_order_feed_record,
-    persist_order_event,
+    apply_order_event_to_execution as apply_order_event_to_execution,
+    latest_order_event_for_execution as latest_order_event_for_execution,
+    link_order_events_to_execution as link_order_events_to_execution,
+    normalize_order_feed_record as normalize_order_feed_record,
+    persist_order_event as persist_order_event,
 )
 from .repair_order_feed_execution_links import (
-    backfill_order_feed_events_from_executions,
-    backfill_order_feed_source_windows,
-    repair_order_feed_execution_links,
-    repair_order_feed_execution_states,
-    repair_order_feed_fill_deltas,
+    backfill_order_feed_events_from_executions as backfill_order_feed_events_from_executions,
+    backfill_order_feed_source_windows as backfill_order_feed_source_windows,
+    repair_order_feed_execution_links as repair_order_feed_execution_links,
+    repair_order_feed_execution_states as repair_order_feed_execution_states,
+    repair_order_feed_fill_deltas as repair_order_feed_fill_deltas,
 )
 
 
@@ -212,53 +210,6 @@ def _upsert_order_feed_consumer_cursor_from_source(
         cursor.duplicate_event_count = int(cursor.duplicate_event_count or 0) + 1
     session.add(cursor)
     return True
-
-
-def _coerce_text(value: Any) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        normalized = value.strip()
-        return normalized or None
-    return None
-
-
-def _coerce_datetime(value: Any) -> datetime | None:
-    text = _coerce_text(value)
-    if text is None:
-        return None
-    normalized = text.replace("Z", "+00:00")
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
-def _coerce_decimal(value: Any) -> Decimal | None:
-    if value is None:
-        return None
-    try:
-        return Decimal(str(value))
-    except (ArithmeticError, ValueError):
-        return None
-
-
-def _coerce_int(value: Any) -> int | None:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _as_mapping(value: Any) -> Mapping[str, Any] | None:
-    if isinstance(value, Mapping):
-        return cast(Mapping[str, Any], value)
-    return None
 
 
 def _is_stale_by_seq(execution: Execution, event: ExecutionOrderEvent) -> bool:

--- a/services/torghut/app/trading/order_feed_modules/repair_order_feed_execution_links.py
+++ b/services/torghut/app/trading/order_feed_modules/repair_order_feed_execution_links.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Kafka-backed order-feed ingestion and persistence helpers."""
 
 from __future__ import annotations
@@ -77,14 +76,6 @@ def _refresh_source_window_linkage_counts(*args: Any, **kwargs: Any) -> None:
     )
 
     refresh_linkage_counts(*args, **kwargs)
-
-
-def _stable_execution_source_offset(value: object) -> int:
-    from .resolve_execution_linkage_for_identity import (
-        stable_execution_source_offset,
-    )
-
-    return stable_execution_source_offset(value)
 
 
 def _source_offset_in_use(*args: Any, **kwargs: Any) -> bool:

--- a/services/torghut/app/trading/reporting_modules/cover_short.py
+++ b/services/torghut/app/trading/reporting_modules/cover_short.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Evaluation report generation and governance gates for walk-forward runs."""
 
 from __future__ import annotations
@@ -16,23 +15,23 @@ from ..evaluation_trace import SweepCandidateResult
 
 
 from .evaluationreportconfig import (
-    EvaluationGateOutcome,
-    EvaluationGatePolicy,
+    EvaluationGateOutcome as EvaluationGateOutcome,
+    EvaluationGatePolicy as EvaluationGatePolicy,
     EvaluationImpactAssumptions,
-    EvaluationMetrics,
-    EvaluationReport,
-    EvaluationReportConfig,
-    MultipleTestingSummary,
-    PromotionEvidenceSummary,
-    PromotionRecommendation,
-    RobustnessFoldMetrics,
-    RobustnessReport,
+    EvaluationMetrics as EvaluationMetrics,
+    EvaluationReport as EvaluationReport,
+    EvaluationReportConfig as EvaluationReportConfig,
+    MultipleTestingSummary as MultipleTestingSummary,
+    PromotionEvidenceSummary as PromotionEvidenceSummary,
+    PromotionRecommendation as PromotionRecommendation,
+    RobustnessFoldMetrics as RobustnessFoldMetrics,
+    RobustnessReport as RobustnessReport,
     PositionState as _PositionState,
     ResolvedImpactInputs as _ResolvedImpactInputs,
     open_long as _open_long,
-    build_promotion_recommendation,
-    generate_evaluation_report,
-    write_evaluation_report,
+    build_promotion_recommendation as build_promotion_recommendation,
+    generate_evaluation_report as generate_evaluation_report,
+    write_evaluation_report as write_evaluation_report,
 )
 
 

--- a/services/torghut/app/trading/runtime_authority_verifier_modules/row_authority_blockers.py
+++ b/services/torghut/app/trading/runtime_authority_verifier_modules/row_authority_blockers.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Read-only H-PAIRS runtime authority proof verifier.
 
 This module deliberately only reads durable runtime-ledger buckets and turns them
@@ -26,7 +25,7 @@ from app.trading.runtime_ledger_proof_policy import (
 )
 from app.trading.runtime_ledger_source_authority import (
     EXECUTION_ECONOMICS_MISSING_BLOCKER,
-    ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+    ORDER_FEED_LIFECYCLE_MISSING_BLOCKER as ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
     RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
     RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
     RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
@@ -62,17 +61,17 @@ from .shared_context import (
     AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
     AUTHORITY_TRADING_DAYS_BLOCKER,
     AUTHORITY_WORST_DAY_BLOCKER,
-    DEFAULT_HPAIRS_ACCOUNT_LABEL,
-    DEFAULT_HPAIRS_CANDIDATE_ID,
-    DEFAULT_HPAIRS_HYPOTHESIS_ID,
-    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-    HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION,
+    DEFAULT_HPAIRS_ACCOUNT_LABEL as DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID as DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID as DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY as DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION as HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION,
     RuntimeAuthorityEvidenceRow,
     DailyAccumulator as _DailyAccumulator,
     PROMOTION_GRADE_LEDGER_SCHEMAS as _PROMOTION_GRADE_LEDGER_SCHEMAS,
-    build_runtime_authority_report,
-    load_runtime_authority_rows,
-    runtime_authority_report_json,
+    build_runtime_authority_report as build_runtime_authority_report,
+    load_runtime_authority_rows as load_runtime_authority_rows,
+    runtime_authority_report_json as runtime_authority_report_json,
 )
 
 

--- a/services/torghut/app/trading/runtime_ledger_modules/is_order_feed_lifecycle_only_row.py
+++ b/services/torghut/app/trading/runtime_ledger_modules/is_order_feed_lifecycle_only_row.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Runtime execution ledger primitives for honest post-cost PnL proof."""
 
 from __future__ import annotations
@@ -245,10 +244,33 @@ def _dedupe(items: Sequence[str]) -> list[str]:
     return list(dict.fromkeys(items))
 
 
+allocate = _allocate
+bucket_field = _bucket_field
+coerce_datetime = _coerce_datetime
+coerce_side = _coerce_side
+group_key = _group_key
+has_tca_pnl_shortcut = _has_tca_pnl_shortcut
+is_order_feed_lifecycle_only_row = _is_order_feed_lifecycle_only_row
+non_negative_decimal = _non_negative_decimal
+positive_decimal = _positive_decimal
+same_direction = _same_direction
+tigerbeetle_journal_blockers = _tigerbeetle_journal_blockers
+
 __all__ = [
     "EXACT_REPLAY_LEDGER_SCHEMA_VERSION",
     "POST_COST_PNL_BASIS",
     "RuntimeLedgerBucket",
     "RuntimeLedgerFill",
+    "allocate",
     "build_runtime_ledger_buckets",
+    "bucket_field",
+    "coerce_datetime",
+    "coerce_side",
+    "group_key",
+    "has_tca_pnl_shortcut",
+    "is_order_feed_lifecycle_only_row",
+    "non_negative_decimal",
+    "positive_decimal",
+    "same_direction",
+    "tigerbeetle_journal_blockers",
 ]

--- a/services/torghut/app/trading/strategy_runtime_modules/late_day_continuation_long_plugin.py
+++ b/services/torghut/app/trading/strategy_runtime_modules/late_day_continuation_long_plugin.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Strategy runtime scaffolding for deterministic plugin execution."""
 
 from __future__ import annotations
@@ -693,27 +692,6 @@ def _decimal(value: Any) -> Decimal | None:
         return Decimal(str(value))
     except (ArithmeticError, TypeError, ValueError):
         return None
-
-
-def _target_notional(params: dict[str, Any]) -> Decimal:
-    notional = _decimal(params.get("max_notional_per_trade"))
-    if notional is None or notional <= 0:
-        return Decimal("100")
-    return notional
-
-
-def _resolved_target_notional(
-    params: dict[str, Any],
-    *,
-    multiplier: Decimal | None = None,
-) -> Decimal:
-    base_notional = _target_notional(params)
-    if multiplier is None or multiplier <= 0:
-        return base_notional
-    resolved = base_notional * multiplier
-    if resolved <= 0:
-        return base_notional
-    return resolved.quantize(Decimal("0.0001"))
 
 
 __all__ = (

--- a/services/torghut/app/trading/tigerbeetle_reconcile_modules/runtime_ledger_ref_coverage.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile_modules/runtime_ledger_ref_coverage.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """TigerBeetle reconciliation for Torghut ledger references."""
 
 from __future__ import annotations
@@ -721,4 +720,15 @@ def _latest_run_compact_status_payload(
     }
 
 
-__all__ = ("tigerbeetle_ref_counts",)
+latest_run_compact_status_payload = _latest_run_compact_status_payload
+latest_run_payload = _latest_run_payload
+reconciliation_transfer_refs = _reconciliation_transfer_refs
+runtime_ledger_ref_matches_expected_bucket = _runtime_ledger_ref_matches_expected_bucket
+
+__all__ = (
+    "latest_run_compact_status_payload",
+    "latest_run_payload",
+    "reconciliation_transfer_refs",
+    "runtime_ledger_ref_matches_expected_bucket",
+    "tigerbeetle_ref_counts",
+)


### PR DESCRIPTION
## Summary

- Removed 20 Torghut file-level Pyright suppression headers from strict-profile app modules.
- Converted stale compatibility imports into explicit same-name re-exports and added public aliases for split-module helpers that are routed across module boundaries.
- Deleted duplicate/dead helpers in decision, order-feed, queue-survival, and strategy-runtime modules while preserving import compatibility for live surfaces.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app scripts tests migrations`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall -q app scripts tests migrations`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main $(git -C ../.. diff --name-only -- services/torghut/app | sed 's#^services/torghut/##')`
- `uv run --frozen pytest tests/test_explicit_module_facade_exports.py tests/autonomy_gates/test_gate_matrix_passes_paper_with_safe_metrics.py tests/test_intraday_tsmom_contract.py tests/test_executable_alpha_repair_receipts.py tests/order_feed/test_order_feed_backfill_and_cursor_a.py tests/test_tigerbeetle_status.py tests/tigerbeetle_reconcile/test_reconciliation_scopes_required_runtime_refs_by_account_label.py tests/test_verify_hpairs_runtime_authority.py tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py tests/test_run_dspy_workflow.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
