### PR TITLE
fix(torghut): accept expired live submit verifier state

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -21,7 +21,7 @@ const baseLiveSubmitActivation = {
   configured: true,
   valid: true,
   expired: false,
-  expires_at: '2026-06-17T20:05:00+00:00',
+  expires_at: '2030-06-17T20:05:00+00:00',
   observed_at: '2026-06-17T14:00:00+00:00',
   reason: null,
 }
@@ -171,10 +171,36 @@ describe('validatePostDeployEvidence', () => {
     })
 
     expect(result.readyzAcceptedReason).toBe('healthy_2xx')
-    expect(result.summaryLines.join('\n')).toContain('Live submit contract: `bounded_june17_activation`')
+    expect(result.liveSubmitContract).toBe('bounded_live_submit_active')
+    expect(result.summaryLines.join('\n')).toContain('Live submit contract: `bounded_live_submit_active`')
   })
 
-  it('rejects healthy readyz when live submit is not bounded by the June 17 activation contract', () => {
+  it('accepts healthy readyz after live submit activation expiry when live submit is blocked', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '200',
+      readyz: { status: 'ok' },
+      revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+      tradingStatus: {
+        ...baseTradingStatus,
+        live_submission_gate: {
+          ...baseTradingStatus.live_submission_gate,
+          allowed: false,
+          reason: 'live_submit_activation_expired',
+          blocked_reasons: ['live_submit_activation_expired'],
+          live_submit_activation: {
+            ...baseLiveSubmitActivation,
+            expired: true,
+            reason: 'live_submit_activation_expired',
+          },
+        },
+      },
+    })
+
+    expect(result.liveSubmitContract).toBe('expired_activation_blocked')
+    expect(result.summaryLines.join('\n')).toContain('Live submit contract: `expired_activation_blocked`')
+  })
+
+  it('rejects healthy readyz after live submit activation expiry when live submit is still allowed', () => {
     expect(() =>
       validatePostDeployEvidence({
         readyzHttpStatus: '200',
@@ -184,6 +210,7 @@ describe('validatePostDeployEvidence', () => {
           ...baseTradingStatus,
           live_submission_gate: {
             ...baseTradingStatus.live_submission_gate,
+            allowed: true,
             live_submit_activation: {
               ...baseLiveSubmitActivation,
               expired: true,
@@ -192,7 +219,31 @@ describe('validatePostDeployEvidence', () => {
           },
         },
       }),
-    ).toThrow('live_submit_activation.expired must be false')
+    ).toThrow('live_submission_gate.allowed must be false')
+  })
+
+  it('rejects healthy readyz when live submit activation expiry reason is missing', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: {
+          ...baseTradingStatus,
+          live_submission_gate: {
+            ...baseTradingStatus.live_submission_gate,
+            allowed: false,
+            reason: 'live_submit_activation_expired',
+            blocked_reasons: ['live_submit_activation_expired'],
+            live_submit_activation: {
+              ...baseLiveSubmitActivation,
+              expired: true,
+              reason: null,
+            },
+          },
+        },
+      }),
+    ).toThrow('live_submit_activation.reason must be live_submit_activation_expired')
   })
 
   it('rejects healthy readyz when live submit caps drift above the GitOps contract', () => {

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -27,10 +27,13 @@ type PostDeployEvidenceInput = {
   simPaperRouteEvidence?: unknown
 }
 
+type LiveSubmitContract = 'bounded_live_submit_active' | 'expired_activation_blocked'
+
 export type PostDeployEvidenceResult = {
   readyzAcceptedReason: 'healthy_2xx' | 'repair_only_zero_notional'
   readyzStatusCode: number
   summaryLines: string[]
+  liveSubmitContract?: LiveSubmitContract
 }
 
 const requireObject = (value: unknown, label: string): JsonObject => {
@@ -65,6 +68,21 @@ const requireBoolean = (value: unknown, label: string): boolean => {
 const requireScalarValue = (value: unknown, expected: string, label: string) => {
   if (normalizedScalar(value) !== expected) {
     throw new Error(`${label} must be ${expected}`)
+  }
+}
+
+const requireTimestamp = (value: unknown, label: string): string => {
+  const timestamp = formatScalar(value, '').trim()
+  if (!timestamp || Number.isNaN(Date.parse(timestamp))) {
+    throw new Error(`${label} must be a parseable timestamp`)
+  }
+  return timestamp
+}
+
+const requireArrayIncludes = (value: unknown, expected: string, label: string) => {
+  const values = requireArray(value, label).map((item) => formatScalar(item, ''))
+  if (!values.includes(expected)) {
+    throw new Error(`${label} must include ${expected}`)
   }
 }
 
@@ -166,26 +184,29 @@ const assertRepairOnlyZeroNotionalReadyz = (readyz: JsonObject, digest: JsonObje
   }
 }
 
-const assertLiveSubmitActivationContract = (activation: JsonObject) => {
+const assertLiveSubmitActivationContract = (activation: JsonObject): LiveSubmitContract => {
   if (requireBoolean(activation.configured, 'torghut live_submit_activation.configured') !== true) {
     throw new Error('torghut live_submit_activation.configured must be true')
   }
   if (requireBoolean(activation.valid, 'torghut live_submit_activation.valid') !== true) {
     throw new Error('torghut live_submit_activation.valid must be true')
   }
-  if (requireBoolean(activation.expired, 'torghut live_submit_activation.expired') !== false) {
-    throw new Error('torghut live_submit_activation.expired must be false')
+  requireTimestamp(activation.expires_at, 'torghut live_submit_activation.expires_at')
+  const expired = requireBoolean(activation.expired, 'torghut live_submit_activation.expired')
+  const reason = formatScalar(activation.reason, '')
+  if (expired) {
+    if (reason !== 'live_submit_activation_expired') {
+      throw new Error('torghut live_submit_activation.reason must be live_submit_activation_expired after expiry')
+    }
+    return 'expired_activation_blocked'
   }
-  const expiresAt = formatScalar(activation.expires_at, '')
-  if (!expiresAt.startsWith('2026-06-17T20:05:00')) {
-    throw new Error('torghut live_submit_activation.expires_at must be 2026-06-17T20:05:00Z')
-  }
-  if (activation.reason !== null && activation.reason !== undefined && formatScalar(activation.reason, '') !== '') {
+  if (activation.reason !== null && activation.reason !== undefined && reason !== '') {
     throw new Error('torghut live_submit_activation.reason must be empty before expiry')
   }
+  return 'bounded_live_submit_active'
 }
 
-const assertBoundedLiveSubmitContract = (status: JsonObject) => {
+const assertBoundedLiveSubmitContract = (status: JsonObject): LiveSubmitContract => {
   const liveSubmissionGate = requireObject(status.live_submission_gate, 'torghut status live_submission_gate')
   const simpleLane = requireObject(liveSubmissionGate.simple_lane, 'torghut status live_submission_gate.simple_lane')
   const simpleLaneStatus = requireObject(status.simple_lane_status, 'torghut status simple_lane_status')
@@ -204,7 +225,22 @@ const assertBoundedLiveSubmitContract = (status: JsonObject) => {
   if (requireBoolean(simpleLaneStatus.submit_enabled, 'torghut simple_lane_status.submit_enabled') !== true) {
     throw new Error('torghut simple_lane_status.submit_enabled must be true')
   }
-  assertLiveSubmitActivationContract(activation)
+  const liveSubmitContract = assertLiveSubmitActivationContract(activation)
+  if (liveSubmitContract === 'expired_activation_blocked') {
+    if (requireBoolean(liveSubmissionGate.allowed, 'torghut status live_submission_gate.allowed') !== false) {
+      throw new Error('torghut live_submission_gate.allowed must be false after live submit activation expiry')
+    }
+    requireScalarValue(
+      liveSubmissionGate.reason,
+      'live_submit_activation_expired',
+      'torghut live_submission_gate.reason',
+    )
+    requireArrayIncludes(
+      liveSubmissionGate.blocked_reasons,
+      'live_submit_activation_expired',
+      'torghut live_submission_gate.blocked_reasons',
+    )
+  }
   if (
     requireBoolean(
       simpleLaneStatus.paper_route_probe_allow_live_mode,
@@ -221,6 +257,7 @@ const assertBoundedLiveSubmitContract = (status: JsonObject) => {
     throw new Error('torghut empirical jobs must be fresh before bounded live-submit rollout acceptance')
   }
   requireScalarValue(empiricalJobs.status, 'healthy', 'torghut empirical_jobs.status')
+  return liveSubmitContract
 }
 
 type PaperRouteTargetEnvelope = {
@@ -546,6 +583,7 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
   }
 
   let readyzAcceptedReason: PostDeployEvidenceResult['readyzAcceptedReason'] = 'healthy_2xx'
+  let liveSubmitContract: LiveSubmitContract | undefined
   if (readyzStatusCode < 200 || readyzStatusCode >= 300) {
     if (readyzStatusCode !== 503) {
       throw new Error(`Torghut /readyz returned HTTP ${readyzStatusCode}; expected 2xx or repair-only 503`)
@@ -553,7 +591,7 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     assertRepairOnlyZeroNotionalReadyz(readyz, digest)
     readyzAcceptedReason = 'repair_only_zero_notional'
   } else {
-    assertBoundedLiveSubmitContract(status)
+    liveSubmitContract = assertBoundedLiveSubmitContract(status)
   }
 
   const routeBoard = requireObject(status.route_reacquisition_board, 'torghut status route_reacquisition_board')
@@ -625,8 +663,8 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     `- Capital state: \`${formatScalar(capital.capital_state)}\``,
     `- Max notional: \`${formatScalar(capital.max_notional)}\``,
   ]
-  if (readyzAcceptedReason === 'healthy_2xx') {
-    lines.push('- Live submit contract: `bounded_june17_activation`')
+  if (liveSubmitContract) {
+    lines.push(`- Live submit contract: \`${liveSubmitContract}\``)
   }
   if (blockerReasons.length > 0) {
     lines.push(`- Blockers: ${blockerReasons.map((reason) => `\`${reason}\``).join(', ')}`)
@@ -669,7 +707,7 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     }
   }
 
-  return { readyzAcceptedReason, readyzStatusCode, summaryLines: lines }
+  return { readyzAcceptedReason, readyzStatusCode, summaryLines: lines, liveSubmitContract }
 }
 
 const loadJsonFile = (path: string, label: string): unknown => {


### PR DESCRIPTION
## Summary

- Treat expired-but-valid live submit activation as an accepted post-deploy verifier state only when live submission is blocked.
- Remove the hard-coded verifier timestamp and require a parseable activation expiry from live status evidence.
- Report the accepted live-submit contract in post-deploy summaries and cover active and expired states in tests.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun test packages/scripts/src/torghut/__tests__`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type` passes with existing warnings outside this change
- `bun run --cwd packages/scripts lint` passes with existing warnings outside this change

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
