### PR TITLE
fix(torghut): bootstrap bounded paper collection

### DIFF
--- a/services/torghut/app/trading/submission_council_modules/import_plan.py
+++ b/services/torghut/app/trading/submission_council_modules/import_plan.py
@@ -16,7 +16,6 @@ from .common import (
 )
 from .paper_probation import (
     BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS as _BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS,
-    BOUNDED_PAPER_ROUTE_COLLECTION_SCOPE as _BOUNDED_PAPER_ROUTE_COLLECTION_SCOPE,
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_KIND as _BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_KIND,
     HPAIRS_BOUNDED_COLLECTION_CANDIDATE_ID as _HPAIRS_BOUNDED_COLLECTION_CANDIDATE_ID,
     HPAIRS_BOUNDED_COLLECTION_HYPOTHESIS_ID as _HPAIRS_BOUNDED_COLLECTION_HYPOTHESIS_ID,
@@ -639,11 +638,8 @@ def _bounded_paper_route_manifest_collection_targets(
                 "proof_mode": "probation",
                 "evidence_collection_ok": True,
                 "canary_collection_authorized": False,
-                "bounded_live_paper_collection_authorized": False,
-                "bounded_evidence_collection_authorized": False,
-                "bounded_evidence_collection_scope": (
-                    _BOUNDED_PAPER_ROUTE_COLLECTION_SCOPE
-                ),
+                "bounded_live_paper_collection_authorized": True,
+                **_bounded_paper_route_probe_collection_payload(authorized=True),
                 "capital_promotion_allowed": False,
                 "final_authority_ok": False,
                 "evidence_collection_stage": "paper",
@@ -667,7 +663,6 @@ def _bounded_paper_route_manifest_collection_targets(
                 "promotion_gate": "runtime_ledger_live_or_live_paper_required",
                 "selected_by": "hypothesis_manifest_bounded_paper_route_collection",
                 "selection_reason": "source_decisions_missing_for_bounded_paper_route",
-                "max_notional": "0",
             }
         )
     return targets

--- a/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
+++ b/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
@@ -100,7 +100,7 @@ class TestSubmissionCouncilRuntimeCertificateMerge(SubmissionCouncilTestCase):
         import_plan = gate["runtime_ledger_paper_probation_import_plan"]
         self.assertEqual(import_plan["target_count"], 1)
         self.assertEqual(import_plan["manifest_bounded_collection_target_count"], 1)
-        self.assertFalse(import_plan["bounded_live_paper_collection_authorized"])
+        self.assertTrue(import_plan["bounded_live_paper_collection_authorized"])
         self.assertFalse(
             import_plan["paper_probation_satisfied_for_bounded_live_paper_collection"]
         )
@@ -114,8 +114,15 @@ class TestSubmissionCouncilRuntimeCertificateMerge(SubmissionCouncilTestCase):
         self.assertEqual(
             target["runtime_strategy_name"], "microbar-cross-sectional-pairs-v1"
         )
-        self.assertFalse(target["bounded_evidence_collection_authorized"])
-        self.assertFalse(target["bounded_live_paper_collection_authorized"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertTrue(target["bounded_live_paper_collection_authorized"])
+        self.assertEqual(
+            target["bounded_evidence_collection_scope"],
+            "paper_route_probe_next_session_only",
+        )
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["paper_route_probe_next_session_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
         self.assertFalse(
             target["paper_probation_satisfied_for_bounded_live_paper_collection"]
         )


### PR DESCRIPTION
## Summary

- Authorizes the H-PAIRS manifest-seeded bootstrap target for bounded paper evidence collection when no source rows exist yet.
- Keeps promotion and live-capital authority blocked: paper probation remains unsatisfied, canary collection stays false, and all promotion/final authority flags stay false.
- Uses the existing `TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL` cap so the bootstrap target cannot exceed the configured bounded collection notional.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/submission_council/test_runtime_certificate_merge.py tests/simple_pipeline/test_local_target_plan_enriches_probe_contract_before_bounded_gate.py`
- `cd services/torghut && uv run --frozen pytest tests/submission_council/test_paper_probation_import_plan.py tests/submission_council/test_runtime_ledger_repair_candidates.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council_modules/import_plan.py tests/submission_council/test_runtime_certificate_merge.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council_modules/import_plan.py tests/submission_council/test_runtime_certificate_merge.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
