### PR TITLE
chore(agents): bump chart version to 0.9.25

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.24
+version: 0.9.25
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.24
+version: 0.9.25
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Bumps the Agents Helm chart package metadata from 0.9.24 to 0.9.25.
- Unblocks chart publishing after PR #11027 changed chart contents.
- Keeps the Artifact Hub package metadata version aligned with Chart.yaml.

## Related Issues

None

## Testing

- `git diff --check`
- `mise exec go@1.24 helm@3 -- scripts/agents/validate-agents.sh`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
