### PR TITLE
fix(external-secrets): include canary remote defaults

### DIFF
--- a/argocd/applications/external-secrets/external-secrets-canary.yaml
+++ b/argocd/applications/external-secrets/external-secrets-canary.yaml
@@ -15,4 +15,8 @@ spec:
   data:
     - secretKey: password
       remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
         key: external-secrets-canary/password
+        metadataPolicy: None
+        nullBytePolicy: Ignore


### PR DESCRIPTION
## Summary

- Adds the ESO-defaulted `remoteRef` fields to the canary `ExternalSecret` manifest.
- Matches the live API-normalized canary object so Argo can stop repeatedly marking only that resource OutOfSync.
- Leaves the operator, store, bootstrap token, and existing SealedSecret-backed workloads unchanged.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/external-secrets`
- `bun run lint:argocd`
- `git diff --check`
- Live readback before this patch showed `ClusterSecretStore/onepassword-infra` Ready and `ExternalSecret/external-secrets-canary` Ready, with only Argo resource-level drift on the canary.

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
