### PR TITLE
fix(torghut): authorize source collection probes

### DIFF
--- a/services/torghut/app/trading/submission_council_modules/import_plan.py
+++ b/services/torghut/app/trading/submission_council_modules/import_plan.py
@@ -296,6 +296,12 @@ def _runtime_ledger_import_target(
 def _runtime_ledger_base_import_target(
     candidate: _RuntimeLedgerImportCandidate,
 ) -> dict[str, object]:
+    bounded_probe_payload = _bounded_paper_route_probe_collection_payload(
+        authorized=candidate.paper_probation_satisfied or candidate.source_collection
+    )
+    bounded_probe_authorized = bool(
+        bounded_probe_payload.get("bounded_evidence_collection_authorized")
+    )
     return {
         "hypothesis_id": candidate.hypothesis_id,
         "candidate_id": candidate.candidate_id,
@@ -338,13 +344,8 @@ def _runtime_ledger_base_import_target(
         "proof_mode": "probation",
         "evidence_collection_ok": True,
         "canary_collection_authorized": candidate.paper_probation_satisfied,
-        "bounded_live_paper_collection_authorized": candidate.paper_probation_satisfied,
-        **_bounded_paper_route_probe_collection_payload(
-            authorized=(
-                candidate.paper_probation_satisfied
-                or candidate.profit_target_source_collection
-            )
-        ),
+        "bounded_live_paper_collection_authorized": bounded_probe_authorized,
+        **bounded_probe_payload,
         "capital_promotion_allowed": False,
         "final_authority_ok": False,
         "evidence_collection_stage": "paper",

--- a/services/torghut/tests/submission_council/test_paper_probation_import_plan.py
+++ b/services/torghut/tests/submission_council/test_paper_probation_import_plan.py
@@ -205,7 +205,10 @@ class TestSubmissionCouncilPaperProbationImportPlan(SubmissionCouncilTestCase):
         self.assertFalse(
             target["paper_probation_satisfied_for_bounded_live_paper_collection"]
         )
-        self.assertFalse(target["bounded_live_paper_collection_authorized"])
+        self.assertTrue(target["bounded_live_paper_collection_authorized"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_authorized"])
         self.assertFalse(target["final_promotion_allowed"])

--- a/services/torghut/tests/submission_council/test_source_collection_candidates.py
+++ b/services/torghut/tests/submission_council/test_source_collection_candidates.py
@@ -232,7 +232,13 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
         )
         plan = _runtime_ledger_paper_probation_import_plan(source_candidates)
         self.assertEqual(plan["source_collection_profit_target_count"], 0)
-        self.assertEqual(plan["targets"][0]["max_notional"], "0")
+        target = plan["targets"][0]
+        self.assertTrue(target["bounded_live_paper_collection_authorized"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
 
     def test_htsmom_runtime_candidate_alias_unlocks_paper_probation_only(
         self,
@@ -537,7 +543,15 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
         self.assertEqual(plan["target_count"], 1)
         target = plan["targets"][0]
         self.assertTrue(target["source_collection_authorized"])
-        self.assertFalse(target["bounded_evidence_collection_authorized"])
+        self.assertTrue(target["bounded_live_paper_collection_authorized"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(
+            target["bounded_evidence_collection_scope"],
+            "paper_route_probe_next_session_only",
+        )
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
+        self.assertFalse(target["promotion_allowed"])
         self.assertTrue(target["runtime_ledger_source_collection_window_defaulted"])
         self.assertEqual(
             target["runtime_ledger_source_collection_window_source"],


### PR DESCRIPTION
## Summary

- Authorizes bounded paper-route evidence probes for runtime source-collection targets, including non-profit-target source-window candidates.
- Keeps live capital, promotion, final authority, and canary promotion flags blocked while allowing capped data collection.
- Updates regression tests that previously froze source-collection targets at zero notional.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py tests/submission_council/test_runtime_ledger_repair_candidates.py tests/submission_council/test_runtime_certificate_merge.py`
- `cd services/torghut && uv run --frozen pytest tests/simple_pipeline/test_local_target_plan_enriches_probe_contract_before_bounded_gate.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py tests/pipeline/test_trading_pipeline_target_plan_source_c.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council_modules/import_plan.py tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council_modules/import_plan.py tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
