### PR TITLE
refactor(torghut): prune typed suppression surfaces

### DIFF
--- a/services/torghut/app/api/health_checks_modules/load_options_catalog_freshness_summary.py
+++ b/services/torghut/app/api/health_checks_modules/load_options_catalog_freshness_summary.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations

--- a/services/torghut/app/api/health_checks_modules/remember_alpaca_success.py
+++ b/services/torghut/app/api/health_checks_modules/remember_alpaca_success.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations

--- a/services/torghut/app/api/proof_floor_payloads_modules/__init__.py
+++ b/services/torghut/app/api/proof_floor_payloads_modules/__init__.py
@@ -14,73 +14,73 @@ _IMPLEMENTATION_MODULES: tuple[object, ...] = (
 )
 
 _build_profitability_proof_floor_payload: Any = getattr(
-    _proof_refs, "_build_profitability_proof_floor_payload"
+    _proof_floor, "_build_profitability_proof_floor_payload"
 )
 _build_renewal_bond_profit_escrow_payload: Any = getattr(
-    _proof_refs, "_build_renewal_bond_profit_escrow_payload"
+    _proof_floor, "_build_renewal_bond_profit_escrow_payload"
 )
 _build_route_reacquisition_board_payload: Any = getattr(
-    _proof_refs, "_build_route_reacquisition_board_payload"
+    _proof_floor, "_build_route_reacquisition_board_payload"
 )
 _build_jangar_contract_graduation_ref: Any = getattr(
-    _proof_refs, "_build_jangar_contract_graduation_ref"
+    _proof_floor, "_build_jangar_contract_graduation_ref"
 )
 _build_jangar_material_verdict_ref: Any = getattr(
-    _proof_refs, "_build_jangar_material_verdict_ref"
+    _proof_floor, "_build_jangar_material_verdict_ref"
 )
 _build_jangar_execution_trust_admission_ref: Any = getattr(
-    _proof_refs, "_build_jangar_execution_trust_admission_ref"
+    _proof_floor, "_build_jangar_execution_trust_admission_ref"
 )
 _consumer_evidence_jangar_continuity_packet: Any = getattr(
-    _proof_refs, "_consumer_evidence_jangar_continuity_packet"
+    _proof_floor, "_consumer_evidence_jangar_continuity_packet"
 )
 _build_capital_replay_projection_payload: Any = getattr(
     _proof_refs, "_build_capital_replay_projection_payload"
 )
 _build_profit_carry_passport_ledger_payload: Any = getattr(
-    _proof_refs, "_build_profit_carry_passport_ledger_payload"
+    _proof_floor, "_build_profit_carry_passport_ledger_payload"
 )
 _build_capital_reentry_cohort_ledger_payload: Any = getattr(
-    _proof_refs, "_build_capital_reentry_cohort_ledger_payload"
+    _proof_floor, "_build_capital_reentry_cohort_ledger_payload"
 )
 _build_profit_repair_settlement_ledger_payload: Any = getattr(
-    _proof_refs, "_build_profit_repair_settlement_ledger_payload"
+    _proof_floor, "_build_profit_repair_settlement_ledger_payload"
 )
 _build_profit_freshness_frontier_payload: Any = getattr(
-    _proof_refs, "_build_profit_freshness_frontier_payload"
+    _proof_floor, "_build_profit_freshness_frontier_payload"
 )
 _build_routeability_repair_acceptance_ledger_payload: Any = getattr(
-    _proof_refs, "_build_routeability_repair_acceptance_ledger_payload"
+    _proof_floor, "_build_routeability_repair_acceptance_ledger_payload"
 )
 _build_evidence_clock_payloads: Any = getattr(
-    _proof_refs, "_build_evidence_clock_payloads"
+    _proof_floor, "_build_evidence_clock_payloads"
 )
 _build_clock_settlement_payload: Any = getattr(
-    _proof_refs, "_build_clock_settlement_payload"
+    _proof_floor, "_build_clock_settlement_payload"
 )
 _build_route_image_proof_summary: Any = getattr(
-    _proof_refs, "_build_route_image_proof_summary"
+    _proof_floor, "_build_route_image_proof_summary"
 )
 _build_route_evidence_clearinghouse_payload: Any = getattr(
-    _proof_refs, "_build_route_evidence_clearinghouse_payload"
+    _proof_floor, "_build_route_evidence_clearinghouse_payload"
 )
 _build_repair_bid_settlement_payload: Any = getattr(
-    _proof_refs, "_build_repair_bid_settlement_payload"
+    _proof_floor, "_build_repair_bid_settlement_payload"
 )
 _build_route_warrant_exchange_payload: Any = getattr(
-    _proof_refs, "_build_route_warrant_exchange_payload"
+    _proof_floor, "_build_route_warrant_exchange_payload"
 )
 _build_source_serving_repair_receipt_payload: Any = getattr(
-    _proof_refs, "_build_source_serving_repair_receipt_payload"
+    _proof_floor, "_build_source_serving_repair_receipt_payload"
 )
 _build_freshness_carry_ledger_payload: Any = getattr(
-    _proof_refs, "_build_freshness_carry_ledger_payload"
+    _proof_floor, "_build_freshness_carry_ledger_payload"
 )
 _build_repair_receipt_frontier_payload: Any = getattr(
-    _proof_refs, "_build_repair_receipt_frontier_payload"
+    _proof_floor, "_build_repair_receipt_frontier_payload"
 )
 _build_repair_outcome_dividend_ledger_payload: Any = getattr(
-    _proof_refs, "_build_repair_outcome_dividend_ledger_payload"
+    _proof_floor, "_build_repair_outcome_dividend_ledger_payload"
 )
 _build_jangar_reliability_settlement_ref: Any = getattr(
     _proof_refs, "_build_jangar_reliability_settlement_ref"

--- a/services/torghut/app/api/proof_floor_payloads_modules/build_jangar_reliability_settlement_ref.py
+++ b/services/torghut/app/api/proof_floor_payloads_modules/build_jangar_reliability_settlement_ref.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations
@@ -16,29 +15,10 @@ from .shared_context import (
     SessionLocal,
     TradingScheduler,
     SIMPLE_LANE_ALLOWED_REJECT_REASONS as _SIMPLE_LANE_ALLOWED_REJECT_REASONS,
-    build_capital_reentry_cohort_ledger_payload as _build_capital_reentry_cohort_ledger_payload,
     build_capital_replay_projection_payload as _build_capital_replay_projection_payload,
-    build_clock_settlement_payload as _build_clock_settlement_payload,
-    build_evidence_clock_payloads as _build_evidence_clock_payloads,
-    build_freshness_carry_ledger_payload as _build_freshness_carry_ledger_payload,
     build_jangar_contract_graduation_ref as _build_jangar_contract_graduation_ref,
-    build_jangar_execution_trust_admission_ref as _build_jangar_execution_trust_admission_ref,
-    build_jangar_material_verdict_ref as _build_jangar_material_verdict_ref,
-    build_profit_carry_passport_ledger_payload as _build_profit_carry_passport_ledger_payload,
-    build_profit_freshness_frontier_payload as _build_profit_freshness_frontier_payload,
-    build_profit_repair_settlement_ledger_payload as _build_profit_repair_settlement_ledger_payload,
     build_profitability_proof_floor_payload as _build_profitability_proof_floor_payload,
-    build_renewal_bond_profit_escrow_payload as _build_renewal_bond_profit_escrow_payload,
-    build_repair_bid_settlement_payload as _build_repair_bid_settlement_payload,
-    build_repair_outcome_dividend_ledger_payload as _build_repair_outcome_dividend_ledger_payload,
-    build_repair_receipt_frontier_payload as _build_repair_receipt_frontier_payload,
-    build_route_evidence_clearinghouse_payload as _build_route_evidence_clearinghouse_payload,
-    build_route_image_proof_summary as _build_route_image_proof_summary,
     build_route_reacquisition_board_payload as _build_route_reacquisition_board_payload,
-    build_route_warrant_exchange_payload as _build_route_warrant_exchange_payload,
-    build_routeability_repair_acceptance_ledger_payload as _build_routeability_repair_acceptance_ledger_payload,
-    build_source_serving_repair_receipt_payload as _build_source_serving_repair_receipt_payload,
-    consumer_evidence_jangar_continuity_packet as _consumer_evidence_jangar_continuity_packet,
     build_capital_replay_projection,
     build_profit_signal_quorum,
     build_quality_adjusted_profit_frontier,
@@ -659,33 +639,26 @@ def _load_route_provenance_summary(session: Session) -> dict[str, object]:
 
 
 build_jangar_reliability_settlement_ref = _build_jangar_reliability_settlement_ref
+build_torghut_routeability_admission_ref = _build_torghut_routeability_admission_ref
 build_torghut_stage_clearance_packet_ref = _build_torghut_stage_clearance_packet_ref
+build_profit_signal_quorum_payload = _build_profit_signal_quorum_payload
+build_quality_adjusted_profit_frontier_payload = (
+    _build_quality_adjusted_profit_frontier_payload
+)
+build_autonomy_capital_replay_projection = _build_autonomy_capital_replay_projection
+simple_lane_reject_reason_totals = _simple_lane_reject_reason_totals
+build_rejected_signal_outcome_learning_payload = (
+    _build_rejected_signal_outcome_learning_payload
+)
+load_rejected_signal_outcome_learning_summary = (
+    _load_rejected_signal_outcome_learning_summary
+)
+load_route_provenance_summary = _load_route_provenance_summary
 
 
 __all__ = [
-    "_build_profitability_proof_floor_payload",
-    "_build_renewal_bond_profit_escrow_payload",
-    "_build_route_reacquisition_board_payload",
     "_build_jangar_contract_graduation_ref",
-    "_build_jangar_material_verdict_ref",
-    "_build_jangar_execution_trust_admission_ref",
-    "_consumer_evidence_jangar_continuity_packet",
     "_build_capital_replay_projection_payload",
-    "_build_profit_carry_passport_ledger_payload",
-    "_build_capital_reentry_cohort_ledger_payload",
-    "_build_profit_repair_settlement_ledger_payload",
-    "_build_profit_freshness_frontier_payload",
-    "_build_routeability_repair_acceptance_ledger_payload",
-    "_build_evidence_clock_payloads",
-    "_build_clock_settlement_payload",
-    "_build_route_image_proof_summary",
-    "_build_route_evidence_clearinghouse_payload",
-    "_build_repair_bid_settlement_payload",
-    "_build_route_warrant_exchange_payload",
-    "_build_source_serving_repair_receipt_payload",
-    "_build_freshness_carry_ledger_payload",
-    "_build_repair_receipt_frontier_payload",
-    "_build_repair_outcome_dividend_ledger_payload",
     "_build_jangar_reliability_settlement_ref",
     "_build_torghut_routeability_admission_ref",
     "_build_torghut_stage_clearance_packet_ref",
@@ -699,7 +672,15 @@ __all__ = [
     "_load_rejected_signal_outcome_learning_summary",
     "_load_route_provenance_summary",
     "build_jangar_reliability_settlement_ref",
+    "build_torghut_routeability_admission_ref",
     "build_torghut_stage_clearance_packet_ref",
+    "build_profit_signal_quorum_payload",
+    "build_quality_adjusted_profit_frontier_payload",
+    "build_autonomy_capital_replay_projection",
+    "simple_lane_reject_reason_totals",
+    "build_rejected_signal_outcome_learning_payload",
+    "load_rejected_signal_outcome_learning_summary",
+    "load_route_provenance_summary",
 ]
 
 capture_module_exports(globals(), __all__)
@@ -707,5 +688,13 @@ capture_module_exports(globals(), __all__)
 
 __all__ = (
     "build_jangar_reliability_settlement_ref",
+    "build_torghut_routeability_admission_ref",
     "build_torghut_stage_clearance_packet_ref",
+    "build_profit_signal_quorum_payload",
+    "build_quality_adjusted_profit_frontier_payload",
+    "build_autonomy_capital_replay_projection",
+    "simple_lane_reject_reason_totals",
+    "build_rejected_signal_outcome_learning_payload",
+    "load_rejected_signal_outcome_learning_summary",
+    "load_route_provenance_summary",
 )

--- a/services/torghut/app/api/readiness_helpers_modules/__init__.py
+++ b/services/torghut/app/api/readiness_helpers_modules/__init__.py
@@ -8,6 +8,7 @@ from . import shared_context as _dependency_surface
 from . import evaluate_trading_health_payload_bounded as _bounded_health
 from . import evaluate_trading_health_payload as _trading_health
 from . import refresh_universe_state_for_readiness as _database_contract
+from . import universe_dependency as _universe_dependency
 from ..proxy import capture_module_exports
 
 _IMPLEMENTATION_MODULES: tuple[object, ...] = (
@@ -15,77 +16,78 @@ _IMPLEMENTATION_MODULES: tuple[object, ...] = (
     _bounded_health,
     _trading_health,
     _database_contract,
+    _universe_dependency,
 )
 
 _readiness_dependency_cache_key: Any = getattr(
-    _database_contract, "_readiness_dependency_cache_key"
+    _dependency_surface, "readiness_dependency_cache_key"
 )
 _readiness_dependency_checks: Any = getattr(
-    _database_contract, "_readiness_dependency_checks"
+    _dependency_surface, "readiness_dependency_checks"
 )
 _readiness_dependency_snapshot: Any = getattr(
-    _database_contract, "_readiness_dependency_snapshot"
+    _dependency_surface, "readiness_dependency_snapshot"
 )
 _readiness_authority_truthy: Any = getattr(
-    _database_contract, "_readiness_authority_truthy"
+    _dependency_surface, "readiness_authority_truthy"
 )
-_append_unique_reason: Any = getattr(_database_contract, "_append_unique_reason")
+_append_unique_reason: Any = getattr(_dependency_surface, "append_unique_reason")
 _readiness_dependency_degradation_reason_codes: Any = getattr(
-    _database_contract, "_readiness_dependency_degradation_reason_codes"
+    _dependency_surface, "readiness_dependency_degradation_reason_codes"
 )
 _guard_live_submission_gate_for_readiness: Any = getattr(
-    _database_contract, "_guard_live_submission_gate_for_readiness"
+    _dependency_surface, "guard_live_submission_gate_for_readiness"
 )
 _strip_promotion_authority_claims_for_readiness: Any = getattr(
-    _database_contract, "_strip_promotion_authority_claims_for_readiness"
+    _dependency_surface, "strip_promotion_authority_claims_for_readiness"
 )
 _core_readiness_live_submission_gate: Any = getattr(
-    _database_contract, "_core_readiness_live_submission_gate"
+    _dependency_surface, "core_readiness_live_submission_gate"
 )
 _evaluate_core_readiness_payload: Any = getattr(
-    _database_contract, "_evaluate_core_readiness_payload"
+    _dependency_surface, "evaluate_core_readiness_payload"
 )
 _trading_health_surface_cache_key: Any = getattr(
-    _database_contract, "_trading_health_surface_cache_key"
+    _dependency_surface, "trading_health_surface_cache_key"
 )
 _cache_completed_trading_health_surface_payload: Any = getattr(
-    _database_contract, "_cache_completed_trading_health_surface_payload"
+    _dependency_surface, "cache_completed_trading_health_surface_payload"
 )
 _record_trading_health_surface_completion: Any = getattr(
-    _database_contract, "_record_trading_health_surface_completion"
+    _dependency_surface, "record_trading_health_surface_completion"
 )
 _cached_trading_health_surface_payload: Any = getattr(
-    _database_contract, "_cached_trading_health_surface_payload"
+    _dependency_surface, "cached_trading_health_surface_payload"
 )
 _cached_readiness_dependencies_for_health_surface: Any = getattr(
-    _database_contract, "_cached_readiness_dependencies_for_health_surface"
+    _dependency_surface, "cached_readiness_dependencies_for_health_surface"
 )
 _fail_closed_health_evaluation_gate: Any = getattr(
-    _database_contract, "_fail_closed_health_evaluation_gate"
+    _dependency_surface, "fail_closed_health_evaluation_gate"
 )
 _health_surface_timeout_dependency_placeholder: Any = getattr(
-    _database_contract, "_health_surface_timeout_dependency_placeholder"
+    _dependency_surface, "health_surface_timeout_dependency_placeholder"
 )
 _minimal_health_surface_timeout_live_submission_gate: Any = getattr(
-    _database_contract, "_minimal_health_surface_timeout_live_submission_gate"
+    _dependency_surface, "minimal_health_surface_timeout_live_submission_gate"
 )
 _minimal_health_surface_timeout_proof_floor: Any = getattr(
-    _database_contract, "_minimal_health_surface_timeout_proof_floor"
+    _dependency_surface, "minimal_health_surface_timeout_proof_floor"
 )
 _minimal_health_surface_timeout_payload: Any = getattr(
-    _database_contract, "_minimal_health_surface_timeout_payload"
+    _dependency_surface, "minimal_health_surface_timeout_payload"
 )
 _health_surface_timeout_fallback_payload: Any = getattr(
-    _database_contract, "_health_surface_timeout_fallback_payload"
+    _dependency_surface, "health_surface_timeout_fallback_payload"
 )
 _evaluate_trading_health_payload_bounded: Any = getattr(
-    _database_contract, "_evaluate_trading_health_payload_bounded"
+    _bounded_health, "_evaluate_trading_health_payload_bounded"
 )
 _evaluate_trading_health_payload: Any = getattr(
-    _database_contract, "_evaluate_trading_health_payload"
+    _trading_health, "_evaluate_trading_health_payload"
 )
 _evaluate_universe_dependency: Any = getattr(
-    _database_contract, "_evaluate_universe_dependency"
+    _universe_dependency, "evaluate_universe_dependency"
 )
 _refresh_universe_state_for_readiness: Any = getattr(
     _database_contract, "_refresh_universe_state_for_readiness"

--- a/services/torghut/app/api/readiness_helpers_modules/evaluate_trading_health_payload.py
+++ b/services/torghut/app/api/readiness_helpers_modules/evaluate_trading_health_payload.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations

--- a/services/torghut/app/api/readiness_helpers_modules/evaluate_trading_health_payload_bounded.py
+++ b/services/torghut/app/api/readiness_helpers_modules/evaluate_trading_health_payload_bounded.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations

--- a/services/torghut/app/api/readiness_helpers_modules/refresh_universe_state_for_readiness.py
+++ b/services/torghut/app/api/readiness_helpers_modules/refresh_universe_state_for_readiness.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations
@@ -15,44 +14,13 @@ from .shared_context import (
     SessionLocal,
     TradingScheduler,
     ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS as _ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS,
-    append_unique_reason as _append_unique_reason,
-    cache_completed_trading_health_surface_payload as _cache_completed_trading_health_surface_payload,
-    cached_readiness_dependencies_for_health_surface as _cached_readiness_dependencies_for_health_surface,
-    cached_trading_health_surface_payload as _cached_trading_health_surface_payload,
-    core_readiness_live_submission_gate as _core_readiness_live_submission_gate,
-    evaluate_core_readiness_payload as _evaluate_core_readiness_payload,
-    fail_closed_health_evaluation_gate as _fail_closed_health_evaluation_gate,
-    guard_live_submission_gate_for_readiness as _guard_live_submission_gate_for_readiness,
-    health_surface_timeout_dependency_placeholder as _health_surface_timeout_dependency_placeholder,
-    health_surface_timeout_fallback_payload as _health_surface_timeout_fallback_payload,
-    minimal_health_surface_timeout_live_submission_gate as _minimal_health_surface_timeout_live_submission_gate,
-    minimal_health_surface_timeout_payload as _minimal_health_surface_timeout_payload,
-    minimal_health_surface_timeout_proof_floor as _minimal_health_surface_timeout_proof_floor,
-    readiness_authority_truthy as _readiness_authority_truthy,
-    readiness_dependency_cache_key as _readiness_dependency_cache_key,
-    readiness_dependency_checks as _readiness_dependency_checks,
-    readiness_dependency_degradation_reason_codes as _readiness_dependency_degradation_reason_codes,
-    readiness_dependency_snapshot as _readiness_dependency_snapshot,
-    record_trading_health_surface_completion as _record_trading_health_surface_completion,
-    strip_promotion_authority_claims_for_readiness as _strip_promotion_authority_claims_for_readiness,
-    trading_health_surface_cache_key as _trading_health_surface_cache_key,
     bindparam,
-    capture_module_exports,
     cast,
     check_schema_current,
     datetime,
     settings,
     text,
     timezone,
-)
-from .evaluate_trading_health_payload_bounded import (
-    evaluate_trading_health_payload_bounded as _evaluate_trading_health_payload_bounded,
-)
-from .evaluate_trading_health_payload import (
-    evaluate_trading_health_payload as _evaluate_trading_health_payload,
-)
-from .universe_dependency import (
-    evaluate_universe_dependency as _evaluate_universe_dependency,
 )
 
 
@@ -585,7 +553,7 @@ def _database_contract_account_scope(
             "account_scope_check_mode": "bounded_catalog",
             "account_scope_check_failed": True,
         }
-    return _apply_account_scope_bypass(account_scope_checks)
+    return _apply_account_scope_bypass(cast(dict[str, object], account_scope_checks))
 
 
 def _apply_account_scope_bypass(
@@ -740,30 +708,6 @@ def _append_schema_graph_branch_count_message(
 
 
 __all__ = [
-    "_readiness_dependency_cache_key",
-    "_readiness_dependency_checks",
-    "_readiness_dependency_snapshot",
-    "_readiness_authority_truthy",
-    "_append_unique_reason",
-    "_readiness_dependency_degradation_reason_codes",
-    "_guard_live_submission_gate_for_readiness",
-    "_strip_promotion_authority_claims_for_readiness",
-    "_core_readiness_live_submission_gate",
-    "_evaluate_core_readiness_payload",
-    "_trading_health_surface_cache_key",
-    "_cache_completed_trading_health_surface_payload",
-    "_record_trading_health_surface_completion",
-    "_cached_trading_health_surface_payload",
-    "_cached_readiness_dependencies_for_health_surface",
-    "_fail_closed_health_evaluation_gate",
-    "_health_surface_timeout_dependency_placeholder",
-    "_minimal_health_surface_timeout_live_submission_gate",
-    "_minimal_health_surface_timeout_proof_floor",
-    "_minimal_health_surface_timeout_payload",
-    "_health_surface_timeout_fallback_payload",
-    "_evaluate_trading_health_payload_bounded",
-    "_evaluate_trading_health_payload",
-    "_evaluate_universe_dependency",
     "_refresh_universe_state_for_readiness",
     "_resolve_universe_resolver_for_readiness",
     "_execute_readiness_account_scope_query",
@@ -771,8 +715,14 @@ __all__ = [
     "_evaluate_database_contract",
 ]
 
-capture_module_exports(globals(), __all__)
-
 refresh_universe_state_for_readiness = _refresh_universe_state_for_readiness
 
-__all__ = ("SessionLocal", "refresh_universe_state_for_readiness")
+__all__ = (
+    "SessionLocal",
+    "_refresh_universe_state_for_readiness",
+    "_resolve_universe_resolver_for_readiness",
+    "_execute_readiness_account_scope_query",
+    "_check_account_scope_invariants_bounded",
+    "_evaluate_database_contract",
+    "refresh_universe_state_for_readiness",
+)

--- a/services/torghut/app/api/trading_misc_modules/__init__.py
+++ b/services/torghut/app/api/trading_misc_modules/__init__.py
@@ -17,53 +17,49 @@ _IMPLEMENTATION_MODULES: tuple[object, ...] = (
 
 router: Any = getattr(_executions, "router")
 _consumer_evidence_dependency_quorum: Any = getattr(
-    _executions, "_consumer_evidence_dependency_quorum"
+    _consumer_evidence, "_consumer_evidence_dependency_quorum"
 )
 _build_consumer_evidence_receipt_projection: Any = getattr(
-    _executions, "_build_consumer_evidence_receipt_projection"
+    _consumer_evidence, "_build_consumer_evidence_receipt_projection"
 )
 _consumer_evidence_summary_view: Any = getattr(
-    _executions, "_consumer_evidence_summary_view"
+    _consumer_evidence, "_consumer_evidence_summary_view"
 )
 _revenue_repair_topline_fields: Any = getattr(
-    _executions, "_revenue_repair_topline_fields"
+    _consumer_evidence, "_revenue_repair_topline_fields"
 )
 _build_trading_consumer_evidence_payload: Any = getattr(
-    _executions, "_build_trading_consumer_evidence_payload"
+    _consumer_evidence, "_build_trading_consumer_evidence_payload"
 )
-trading_consumer_evidence: Any = getattr(_executions, "trading_consumer_evidence")
-trading_metrics: Any = getattr(_executions, "trading_metrics")
-trading_simulation_progress: Any = getattr(_executions, "trading_simulation_progress")
-submit_lean_backtest: Any = getattr(_executions, "submit_lean_backtest")
-get_lean_backtest: Any = getattr(_executions, "get_lean_backtest")
-get_lean_shadow_parity: Any = getattr(_executions, "get_lean_shadow_parity")
-trading_autonomy: Any = getattr(_executions, "trading_autonomy")
+trading_consumer_evidence: Any = getattr(
+    _consumer_evidence, "trading_consumer_evidence"
+)
+trading_metrics: Any = getattr(_consumer_evidence, "trading_metrics")
+trading_simulation_progress: Any = getattr(
+    _consumer_evidence, "trading_simulation_progress"
+)
+submit_lean_backtest: Any = getattr(_consumer_evidence, "submit_lean_backtest")
+get_lean_backtest: Any = getattr(_consumer_evidence, "get_lean_backtest")
+get_lean_shadow_parity: Any = getattr(_consumer_evidence, "get_lean_shadow_parity")
+trading_autonomy: Any = getattr(_autonomy, "trading_autonomy")
 _runtime_ledger_bucket_evidence_grade: Any = getattr(
-    _executions, "_runtime_ledger_bucket_evidence_grade"
+    _autonomy, "_runtime_ledger_bucket_evidence_grade"
 )
 _daily_runtime_ledger_portfolio_summary: Any = getattr(
-    _executions, "_daily_runtime_ledger_portfolio_summary"
+    _autonomy, "_daily_runtime_ledger_portfolio_summary"
 )
-_build_current_evidence_epoch: Any = getattr(
-    _executions, "_build_current_evidence_epoch"
-)
-trading_evidence_epoch_latest: Any = getattr(
-    _executions, "trading_evidence_epoch_latest"
-)
-trading_evidence_epoch_detail: Any = getattr(
-    _executions, "trading_evidence_epoch_detail"
-)
-trading_empirical_jobs: Any = getattr(_executions, "trading_empirical_jobs")
-trading_completion_doc29: Any = getattr(_executions, "trading_completion_doc29")
-trading_completion_doc29_gate: Any = getattr(
-    _executions, "trading_completion_doc29_gate"
-)
+_build_current_evidence_epoch: Any = getattr(_autonomy, "_build_current_evidence_epoch")
+trading_evidence_epoch_latest: Any = getattr(_autonomy, "trading_evidence_epoch_latest")
+trading_evidence_epoch_detail: Any = getattr(_autonomy, "trading_evidence_epoch_detail")
+trading_empirical_jobs: Any = getattr(_autonomy, "trading_empirical_jobs")
+trading_completion_doc29: Any = getattr(_autonomy, "trading_completion_doc29")
+trading_completion_doc29_gate: Any = getattr(_autonomy, "trading_completion_doc29_gate")
 trading_autonomy_evidence_continuity: Any = getattr(
-    _executions, "trading_autonomy_evidence_continuity"
+    _autonomy, "trading_autonomy_evidence_continuity"
 )
-trading_llm_evaluation: Any = getattr(_executions, "trading_llm_evaluation")
-prometheus_metrics: Any = getattr(_executions, "prometheus_metrics")
-trading_decisions: Any = getattr(_executions, "trading_decisions")
+trading_llm_evaluation: Any = getattr(_autonomy, "trading_llm_evaluation")
+prometheus_metrics: Any = getattr(_autonomy, "prometheus_metrics")
+trading_decisions: Any = getattr(_autonomy, "trading_decisions")
 trading_executions: Any = getattr(_executions, "trading_executions")
 
 __all__ = (

--- a/services/torghut/app/api/trading_misc_modules/trading_autonomy.py
+++ b/services/torghut/app/api/trading_misc_modules/trading_autonomy.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations

--- a/services/torghut/app/api/trading_misc_modules/trading_executions.py
+++ b/services/torghut/app/api/trading_misc_modules/trading_executions.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Extracted Torghut API route and support functions."""
 
 from __future__ import annotations
@@ -11,38 +10,11 @@ from .shared_context import (
     ExecutionTCAMetric,
     Query,
     Session,
-    build_consumer_evidence_receipt_projection as _build_consumer_evidence_receipt_projection,
-    build_trading_consumer_evidence_payload as _build_trading_consumer_evidence_payload,
-    consumer_evidence_dependency_quorum as _consumer_evidence_dependency_quorum,
-    consumer_evidence_summary_view as _consumer_evidence_summary_view,
-    revenue_repair_topline_fields as _revenue_repair_topline_fields,
-    capture_module_exports,
     datetime,
-    get_lean_backtest,
-    get_lean_shadow_parity,
     get_session,
     jsonable_encoder,
     router,
     select,
-    submit_lean_backtest,
-    trading_consumer_evidence,
-    trading_metrics,
-    trading_simulation_progress,
-)
-from .trading_autonomy import (
-    build_current_evidence_epoch as _build_current_evidence_epoch,
-    daily_runtime_ledger_portfolio_summary as _daily_runtime_ledger_portfolio_summary,
-    runtime_ledger_bucket_evidence_grade as _runtime_ledger_bucket_evidence_grade,
-    prometheus_metrics,
-    trading_autonomy,
-    trading_autonomy_evidence_continuity,
-    trading_completion_doc29,
-    trading_completion_doc29_gate,
-    trading_decisions,
-    trading_empirical_jobs,
-    trading_evidence_epoch_detail,
-    trading_evidence_epoch_latest,
-    trading_llm_evaluation,
 )
 
 
@@ -98,37 +70,6 @@ def trading_executions(
         for execution in executions
     ]
     return jsonable_encoder(payload)
-
-
-__all__ = [
-    "_consumer_evidence_dependency_quorum",
-    "_build_consumer_evidence_receipt_projection",
-    "_consumer_evidence_summary_view",
-    "_revenue_repair_topline_fields",
-    "_build_trading_consumer_evidence_payload",
-    "trading_consumer_evidence",
-    "trading_metrics",
-    "trading_simulation_progress",
-    "submit_lean_backtest",
-    "get_lean_backtest",
-    "get_lean_shadow_parity",
-    "trading_autonomy",
-    "_runtime_ledger_bucket_evidence_grade",
-    "_daily_runtime_ledger_portfolio_summary",
-    "_build_current_evidence_epoch",
-    "trading_evidence_epoch_latest",
-    "trading_evidence_epoch_detail",
-    "trading_empirical_jobs",
-    "trading_completion_doc29",
-    "trading_completion_doc29_gate",
-    "trading_autonomy_evidence_continuity",
-    "trading_llm_evaluation",
-    "prometheus_metrics",
-    "trading_decisions",
-    "trading_executions",
-]
-
-capture_module_exports(globals(), __all__)
 
 
 __all__ = ("trading_executions",)

--- a/services/torghut/app/trading/autonomy/policy_check_modules/advisor_fallback.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/advisor_fallback.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Advisor fallback SLO evidence validation."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/benchmark_parity.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/benchmark_parity.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Benchmark parity evidence validation."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/deeplob_bdlob.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/deeplob_bdlob.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """DeepLOB and BDLOB contract evidence validation."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/evidence_artifacts.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/evidence_artifacts.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Simulation, shadow-live, fold, stress, and rationale evidence validation."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/evidence_core.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/evidence_core.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Core Janus, contamination, HMM, and expert-router evidence validation."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/foundation_router.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/foundation_router.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Foundation-router parity evidence validation."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/profitability_manifest.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/profitability_manifest.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Profitability manifest and prerequisite evidence checks."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/promotion_evidence.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/promotion_evidence.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Promotion evidence evaluation and policy toggles."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/autonomy/policy_check_modules/requirements.py
+++ b/services/torghut/app/trading/autonomy/policy_check_modules/requirements.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Target requirements, artifact references, coercion, and parsing helpers."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/completion_modules/effective_row_status.py
+++ b/services/torghut/app/trading/completion_modules/effective_row_status.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 # fmt: off
 """Traceability helpers for doc 29 completion gates."""
 
@@ -17,108 +16,33 @@ from ..empirical_jobs import build_empirical_jobs_status
 
 
 from .runtime_matrix_path import (
-    DOC29_COMPLETION_ENDPOINT,
-    DOC29_COMPLETION_MATRIX_DOC_PATH,
-    DOC29_COMPLETION_MATRIX_RUNTIME_PATH,
     DOC29_EMPIRICAL_JOBS_GATE,
-    DOC29_EMPIRICAL_MANIFEST_GATE,
     DOC29_LIVE_CANARY_GATE,
     DOC29_LIVE_SCALE_GATE,
     DOC29_PAPER_GATE,
     DOC29_SIMULATION_FULL_DAY_GATE,
-    DOC29_SIMULATION_SMOKE_GATE,
     TRACE_STATUSES,
     TRACE_STATUS_BLOCKED,
     TRACE_STATUS_REGRESSED,
     TRACE_STATUS_SATISFIED,
     TRACE_STATUS_STALE,
-    build_completion_trace,
+    as_dict as _as_dict,
+    as_list as _as_list,
+    as_text as _as_text,
+    latest_completion_rows as _latest_completion_rows,
+    latest_completion_rows_filtered as _latest_completion_rows_filtered,
+    latest_empirical_rows as _latest_empirical_rows,
+    latest_hypothesis_windows as _latest_hypothesis_windows,
     load_doc29_completion_matrix,
-    persist_completion_trace,
-    runtime_and_doc_completion_matrices_match,
-    upsert_completion_gate_result,
-    validate_doc29_completion_matrix,
+    promotion_decision_keys_for_windows as _promotion_decision_keys_for_windows,
+    safe_int as _safe_int,
 )
-from . import runtime_matrix_path as _runtime_matrix_path_private_41
-from . import runtime_ledger_bucket_existing_blockers as _runtime_ledger_bucket_existing_blockers_private_97
-
-_PromotionDecisionKey = getattr(_runtime_matrix_path_private_41, '_PromotionDecisionKey')
-_RUNTIME_LEDGER_BUCKET_SCHEMAS = getattr(_runtime_matrix_path_private_41, '_RUNTIME_LEDGER_BUCKET_SCHEMAS')
-_as_dict = getattr(_runtime_matrix_path_private_41, '_as_dict')
-_as_list = getattr(_runtime_matrix_path_private_41, '_as_list')
-_as_text = getattr(_runtime_matrix_path_private_41, '_as_text')
-_candidate_hypothesis_manifests = getattr(_runtime_matrix_path_private_41, '_candidate_hypothesis_manifests')
-_doc_matrix_path = getattr(_runtime_matrix_path_private_41, '_doc_matrix_path')
-_gate_policy_parameters = getattr(_runtime_matrix_path_private_41, '_gate_policy_parameters')
-_latest_completion_rows = getattr(_runtime_matrix_path_private_41, '_latest_completion_rows')
-_latest_completion_rows_filtered = getattr(_runtime_matrix_path_private_41, '_latest_completion_rows_filtered')
-_latest_empirical_rows = getattr(_runtime_matrix_path_private_41, '_latest_empirical_rows')
-_latest_hypothesis_windows = getattr(_runtime_matrix_path_private_41, '_latest_hypothesis_windows')
-_load_hypothesis_manifests_by_id = getattr(_runtime_matrix_path_private_41, '_load_hypothesis_manifests_by_id')
-_load_yaml_mapping = getattr(_runtime_matrix_path_private_41, '_load_yaml_mapping')
-_manifest_runtime_session_threshold = getattr(_runtime_matrix_path_private_41, '_manifest_runtime_session_threshold')
-_median_decimal = getattr(_runtime_matrix_path_private_41, '_median_decimal')
-_normalize_gate_definition = getattr(_runtime_matrix_path_private_41, '_normalize_gate_definition')
-_p10_decimal = getattr(_runtime_matrix_path_private_41, '_p10_decimal')
-_policy_int = getattr(_runtime_matrix_path_private_41, '_policy_int')
-_positive_hash_count = getattr(_runtime_matrix_path_private_41, '_positive_hash_count')
-_promotion_decision_blocked_reason = getattr(_runtime_matrix_path_private_41, '_promotion_decision_blocked_reason')
-_promotion_decision_key = getattr(_runtime_matrix_path_private_41, '_promotion_decision_key')
-_promotion_decision_key_for_decision = getattr(_runtime_matrix_path_private_41, '_promotion_decision_key_for_decision')
-_promotion_decision_key_for_window = getattr(_runtime_matrix_path_private_41, '_promotion_decision_key_for_window')
-_promotion_decision_keys_for_windows = getattr(_runtime_matrix_path_private_41, '_promotion_decision_keys_for_windows')
-_runtime_ledger_bucket_promotion_payload = getattr(_runtime_matrix_path_private_41, '_runtime_ledger_bucket_promotion_payload')
-_runtime_ledger_trading_day_key = getattr(_runtime_matrix_path_private_41, '_runtime_ledger_trading_day_key')
-_runtime_matrix_path = getattr(_runtime_matrix_path_private_41, '_runtime_matrix_path')
-_safe_float = getattr(_runtime_matrix_path_private_41, '_safe_float')
-_safe_int = getattr(_runtime_matrix_path_private_41, '_safe_int')
-_utc = getattr(_runtime_matrix_path_private_41, '_utc')
-_windows_with_allowed_promotion_decisions = getattr(_runtime_matrix_path_private_41, '_windows_with_allowed_promotion_decisions')
-_EmpiricalJobsGateEvidence = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_EmpiricalJobsGateEvidence')
-_LiveScaleRuntimeSummary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_LiveScaleRuntimeSummary')
-_RuntimeLedgerBucketTotals = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_RuntimeLedgerBucketTotals')
-_RuntimeLedgerDailySeries = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_RuntimeLedgerDailySeries')
-_RuntimeLedgerSourceAuthoritySummary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_RuntimeLedgerSourceAuthoritySummary')
-_TraceGateRefs = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_TraceGateRefs')
-_WindowWeightedMetrics = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_WindowWeightedMetrics')
-_benchmark_missing_families = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_benchmark_missing_families')
-_blocked_trace_gate_result = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_blocked_trace_gate_result')
-_empirical_jobs_consistency_status = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_empirical_jobs_consistency_status')
-_empirical_jobs_gate_evidence = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_empirical_jobs_gate_evidence')
-_evaluate_empirical_jobs_gate = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_evaluate_empirical_jobs_gate')
-_evaluate_live_canary_gate = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_evaluate_live_canary_gate')
-_evaluate_live_scale_gate = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_evaluate_live_scale_gate')
-_evaluate_paper_gate = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_evaluate_paper_gate')
-_latest_three_within_budget = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_latest_three_within_budget')
-_live_scale_blocked_reason = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_live_scale_blocked_reason')
-_live_scale_gate_result = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_live_scale_gate_result')
-_live_scale_runtime_summary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_live_scale_runtime_summary')
-_missing_or_ineligible_empirical_jobs = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_missing_or_ineligible_empirical_jobs')
-_paper_gate_acceptance = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_paper_gate_acceptance')
-_paper_gate_benchmark_blocked_reason = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_paper_gate_benchmark_blocked_reason')
-_paper_gate_has_insufficient_decisions = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_paper_gate_has_insufficient_decisions')
-_paper_gate_identity_result = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_paper_gate_identity_result')
-_paper_gate_precondition_result = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_paper_gate_precondition_result')
-_paper_gate_refs_with_fill_price_artifact = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_paper_gate_refs_with_fill_price_artifact')
-_promotion_decision_blocked_gate_result = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_promotion_decision_blocked_gate_result')
-_runtime_ledger_bucket_existing_blockers = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_bucket_existing_blockers')
-_runtime_ledger_bucket_is_promotion_grade = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_bucket_is_promotion_grade')
-_runtime_ledger_bucket_matches_window = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_bucket_matches_window')
-_runtime_ledger_bucket_refs_for_windows = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_bucket_refs_for_windows')
-_runtime_ledger_bucket_summary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_bucket_summary')
-_runtime_ledger_bucket_totals = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_bucket_totals')
-_runtime_ledger_bucket_window_match_key = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_bucket_window_match_key')
-_runtime_ledger_daily_series = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_daily_series')
-_runtime_ledger_daily_summary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_daily_summary')
-_runtime_ledger_persisted_daily_summary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_persisted_daily_summary')
-_runtime_ledger_schema_versions = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_schema_versions')
-_runtime_ledger_source_authority_summary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_ledger_source_authority_summary')
-_runtime_observed_rows_for_candidate = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_runtime_observed_rows_for_candidate')
-_satisfied_trace_gate_result = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_satisfied_trace_gate_result')
-_trace_gate_refs_from_gate = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_trace_gate_refs_from_gate')
-_trace_gate_result = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_trace_gate_result')
-_window_gate_summary = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_window_gate_summary')
-_window_weighted_metrics = getattr(_runtime_ledger_bucket_existing_blockers_private_97, '_window_weighted_metrics')
+from .runtime_ledger_bucket_existing_blockers import (
+    evaluate_empirical_jobs_gate as _evaluate_empirical_jobs_gate,
+    evaluate_live_canary_gate as _evaluate_live_canary_gate,
+    evaluate_live_scale_gate as _evaluate_live_scale_gate,
+    evaluate_paper_gate as _evaluate_paper_gate,
+)
 
 
 def _effective_row_status(
@@ -418,31 +342,6 @@ def build_doc29_completion_status(
         'promotion_authority': promotion_authority,
         'gates': gates,
     }
-
-__all__ = [
-    'DOC29_COMPLETION_ENDPOINT',
-    'DOC29_COMPLETION_MATRIX_DOC_PATH',
-    'DOC29_COMPLETION_MATRIX_RUNTIME_PATH',
-    'DOC29_EMPIRICAL_JOBS_GATE',
-    'DOC29_EMPIRICAL_MANIFEST_GATE',
-    'DOC29_LIVE_CANARY_GATE',
-    'DOC29_LIVE_SCALE_GATE',
-    'DOC29_PAPER_GATE',
-    'DOC29_SIMULATION_FULL_DAY_GATE',
-    'DOC29_SIMULATION_SMOKE_GATE',
-    'TRACE_STATUS_BLOCKED',
-    'TRACE_STATUS_REGRESSED',
-    'TRACE_STATUS_SATISFIED',
-    'TRACE_STATUS_STALE',
-    'build_completion_trace',
-    'build_doc29_completion_status',
-    'load_doc29_completion_matrix',
-    'persist_completion_trace',
-    'runtime_and_doc_completion_matrices_match',
-    'upsert_completion_gate_result',
-    'validate_doc29_completion_matrix',
-]
-
 
 __all__ = (
     "build_doc29_completion_status",

--- a/services/torghut/app/trading/completion_modules/runtime_ledger_bucket_existing_blockers.py
+++ b/services/torghut/app/trading/completion_modules/runtime_ledger_bucket_existing_blockers.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 # fmt: off
 """Traceability helpers for doc 29 completion gates."""
 
@@ -596,6 +595,7 @@ def _evaluate_paper_gate(
     precondition_result = _paper_gate_precondition_result(empirical_gate, full_day_row)
     if precondition_result is not None:
         return precondition_result
+    assert full_day_row is not None
     full_day_ref = {'simulation_full_day_coverage': str(full_day_row.id)}
     refs = _trace_gate_refs_from_gate(empirical_gate, db_row_refs=full_day_ref)
     identity_result = _paper_gate_identity_result(empirical_gate, full_day_row)
@@ -912,8 +912,16 @@ runtime_ledger_bucket_matches_window = _runtime_ledger_bucket_matches_window
 runtime_ledger_bucket_refs_for_windows = _runtime_ledger_bucket_refs_for_windows
 runtime_ledger_bucket_summary = _runtime_ledger_bucket_summary
 runtime_ledger_daily_summary = _runtime_ledger_daily_summary
+evaluate_empirical_jobs_gate = _evaluate_empirical_jobs_gate
+evaluate_paper_gate = _evaluate_paper_gate
+evaluate_live_canary_gate = _evaluate_live_canary_gate
+evaluate_live_scale_gate = _evaluate_live_scale_gate
 
 __all__ = (
+    "evaluate_empirical_jobs_gate",
+    "evaluate_live_canary_gate",
+    "evaluate_live_scale_gate",
+    "evaluate_paper_gate",
     "runtime_ledger_bucket_matches_window",
     "runtime_ledger_bucket_refs_for_windows",
     "runtime_ledger_bucket_summary",

--- a/services/torghut/app/trading/decisions_modules/decision_engine_core_methods.py
+++ b/services/torghut/app/trading/decisions_modules/decision_engine_core_methods.py
@@ -1,11 +1,10 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Trading decision engine based on TA signals."""
 
 from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Iterable, Literal, Optional, cast
+from typing import Any, Iterable, Literal, Optional, Protocol, cast
 
 from ...config import settings
 from ...models import Strategy
@@ -63,6 +62,17 @@ from .decision_engine_core_support import (
 )
 
 
+class _LegacyStrategyEvaluator(Protocol):
+    def evaluate_legacy_strategy(
+        self,
+        signal: SignalEnvelope,
+        strategy: Strategy,
+        *,
+        equity: Optional[Decimal],
+        positions: Optional[list[dict[str, Any]]],
+    ) -> Optional[StrategyDecision]: ...
+
+
 class _DecisionEngineCoreMethods:
     def __init__(
         self,
@@ -104,6 +114,9 @@ class _DecisionEngineCoreMethods:
             else None
         )
         self._last_forecast_telemetry: list[ForecastRoutingTelemetry] = []
+
+    def append_forecast_telemetry(self, telemetry: ForecastRoutingTelemetry) -> None:
+        self._last_forecast_telemetry.append(telemetry)
 
     def evaluate(
         self,
@@ -791,7 +804,7 @@ class _DecisionEngineCoreMethods:
                     strategy.base_timeframe,
                 )
                 continue
-            decision = self._evaluate_legacy_strategy(
+            decision = cast(_LegacyStrategyEvaluator, self).evaluate_legacy_strategy(
                 signal,
                 strategy,
                 equity=equity,

--- a/services/torghut/app/trading/decisions_modules/decision_engine_core_support.py
+++ b/services/torghut/app/trading/decisions_modules/decision_engine_core_support.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from ...models import Strategy
 from ..models import SignalEnvelope, StrategyDecision
@@ -174,7 +174,9 @@ def _record_runtime_trade_policy_decision(*args: Any, **kwargs: Any) -> None:
     record_decision(*args, **kwargs)
 
 
-def _runtime_intent_exit_side(*args: Any, **kwargs: Any) -> str | None:
+def _runtime_intent_exit_side(
+    *args: Any, **kwargs: Any
+) -> Literal["long", "short"] | None:
     from .resolve_runtime_trade_policy import (
         runtime_intent_exit_side,
     )

--- a/services/torghut/app/trading/decisions_modules/decision_engine_runtime_methods.py
+++ b/services/torghut/app/trading/decisions_modules/decision_engine_runtime_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Trading decision engine based on TA signals."""
 
 from __future__ import annotations
@@ -6,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 from ...models import Strategy
 from ..features import (
@@ -15,6 +14,7 @@ from ..features import (
     extract_signal_features,
     normalize_feature_vector_v3,
 )
+from ..forecasting import ForecastRouterV5
 from ..microstructure import parse_microstructure_state
 from ..models import SignalEnvelope, StrategyDecision
 from ..regime_hmm import (
@@ -78,7 +78,7 @@ def _resolve_legacy_action(features: SignalFeatures) -> Any:
 class _LegacyDecisionInputs:
     timeframe: str
     features: SignalFeatures
-    action: str
+    action: Literal["buy", "sell"]
     rationale_parts: list[str]
 
 
@@ -111,6 +111,21 @@ class _BuildParamsRequest:
 
 
 class _DecisionEngineRuntimeMethods:
+    def evaluate_legacy_strategy(
+        self,
+        signal: SignalEnvelope,
+        strategy: Strategy,
+        *,
+        equity: Optional[Decimal],
+        positions: Optional[list[dict[str, Any]]],
+    ) -> Optional[StrategyDecision]:
+        return self._evaluate_legacy_strategy(
+            signal,
+            strategy,
+            equity=equity,
+            positions=positions,
+        )
+
     def _evaluate_legacy_strategy(
         self,
         signal: SignalEnvelope,
@@ -176,8 +191,10 @@ class _DecisionEngineRuntimeMethods:
     ) -> tuple[Optional[Decimal], Optional[MarketSnapshot]]:
         price = features.price
         snapshot: Optional[MarketSnapshot] = None
-        if price is None and self.price_fetcher is not None:
-            snapshot = self.price_fetcher.fetch_market_snapshot(signal)
+        core_methods = cast(_DecisionEngineCoreMethods, self)
+        price_fetcher = core_methods.price_fetcher
+        if price is None and price_fetcher is not None:
+            snapshot = price_fetcher.fetch_market_snapshot(signal)
             if snapshot is not None:
                 price = snapshot.price
         return price, snapshot
@@ -189,7 +206,9 @@ class _DecisionEngineRuntimeMethods:
         timeframe: str,
         price: Optional[Decimal],
     ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-        if self.forecast_router is None:
+        core_methods = cast(_DecisionEngineCoreMethods, self)
+        forecast_router: ForecastRouterV5 | None = core_methods.forecast_router
+        if forecast_router is None:
             return None, None
         normalized_payload = dict(signal.payload)
         if price is not None and "price" not in normalized_payload:
@@ -199,12 +218,12 @@ class _DecisionEngineRuntimeMethods:
             feature_vector = normalize_feature_vector_v3(normalized_signal)
         except FeatureNormalizationError:
             return None, None
-        forecast_result = self.forecast_router.route_and_forecast(
+        forecast_result = forecast_router.route_and_forecast(
             feature_vector=feature_vector,
             horizon=timeframe,
             event_ts=signal.event_ts,
         )
-        self._last_forecast_telemetry.append(forecast_result.telemetry)
+        core_methods.append_forecast_telemetry(forecast_result.telemetry)
         return forecast_result.contract.to_payload(), forecast_result.audit.to_payload()
 
 
@@ -224,10 +243,12 @@ def _legacy_decision_inputs(
     if action_bundle is None:
         return None
     action, rationale_parts = action_bundle
+    if action not in {"buy", "sell"}:
+        return None
     return _LegacyDecisionInputs(
         timeframe=timeframe,
         features=features,
-        action=action,
+        action=cast(Literal["buy", "sell"], action),
         rationale_parts=list(rationale_parts),
     )
 

--- a/services/torghut/app/trading/discovery/queue_survival_fill_stress_modules/extract_queue_survival_fill_stress.py
+++ b/services/torghut/app/trading/discovery/queue_survival_fill_stress_modules/extract_queue_survival_fill_stress.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Preview-only queue-survival fill stress for replay candidate ranking.
 
 This module actualizes recent queue-position, fill-probability, and execution-delay
@@ -65,7 +64,7 @@ def _group_normalized_downside_reward_penalty_bps(*args: Any, **kwargs: Any) -> 
 def _label_has_token(label: str, tokens: set[str] | frozenset[str]) -> bool:
     from .group_normalized_downside_reward_penalty_b import label_has_token as impl
 
-    return impl(label, tokens)
+    return impl(label, frozenset(tokens))
 
 
 def _log1p(value: float) -> float:

--- a/services/torghut/app/trading/execution_modules/sell_inventory_payloads.py
+++ b/services/torghut/app/trading/execution_modules/sell_inventory_payloads.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnusedImport=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false
 """Sell-inventory conflict payload helpers for order execution."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/hypotheses_modules/runtime_ledger_row_rank.py
+++ b/services/torghut/app/trading/hypotheses_modules/runtime_ledger_row_rank.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Hypothesis registry loading and runtime alpha-readiness compilation."""
 
 from __future__ import annotations
@@ -28,6 +27,9 @@ from .shared_context import (
 from . import shared_context as _shared_context_private_26
 
 from . import extract_stage_renewal_bonds as _extract_stage_renewal_bonds_private_68
+from .extract_stage_renewal_bonds import (
+    RuntimeLedgerReadinessInputs as _RuntimeLedgerReadinessInputs,
+)
 
 _CAPITAL_STAGE_RANK = getattr(_shared_context_private_26, "_CAPITAL_STAGE_RANK")
 _DEPENDENCY_REASONS = getattr(_shared_context_private_26, "_DEPENDENCY_REASONS")
@@ -90,9 +92,6 @@ _NON_AUTHORITY_TCA_DECISION_MODES = getattr(
 )
 _NON_AUTHORITY_TCA_SOURCE_KINDS = getattr(
     _extract_stage_renewal_bonds_private_68, "_NON_AUTHORITY_TCA_SOURCE_KINDS"
-)
-_RuntimeLedgerReadinessInputs = getattr(
-    _extract_stage_renewal_bonds_private_68, "_RuntimeLedgerReadinessInputs"
 )
 _TcaReadinessInputs = getattr(
     _extract_stage_renewal_bonds_private_68, "_TcaReadinessInputs"

--- a/services/torghut/app/trading/submission_council_modules/certificate_loading.py
+++ b/services/torghut/app/trading/submission_council_modules/certificate_loading.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Promotion certificate loading and runtime evidence merging."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/submission_council_modules/common.py
+++ b/services/torghut/app/trading/submission_council_modules/common.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from threading import Lock
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, TypeVar, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
@@ -75,6 +75,8 @@ from ..tca import build_tca_gate_inputs
 
 
 logger = logging.getLogger("app.trading.submission_council")
+
+_CompatSymbol = TypeVar("_CompatSymbol")
 
 _CAPITAL_STAGE_ORDER = (
     "shadow",
@@ -146,11 +148,11 @@ _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES = frozenset(
 )
 
 
-def _compat_symbol(name: str, fallback: object) -> object:
+def _compat_symbol(name: str, fallback: _CompatSymbol) -> _CompatSymbol:
     facade = sys.modules.get("app.trading.submission_council")
     if facade is None:
         return fallback
-    return getattr(facade, name, fallback)
+    return cast(_CompatSymbol, getattr(facade, name, fallback))
 
 
 def _safe_int(value: object) -> int:

--- a/services/torghut/app/trading/submission_council_modules/profit_readiness.py
+++ b/services/torghut/app/trading/submission_council_modules/profit_readiness.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Profit readiness summaries and live controls."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/submission_council_modules/quant_health.py
+++ b/services/torghut/app/trading/submission_council_modules/quant_health.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Quant health and runtime-window health helpers."""
 
 from __future__ import annotations
@@ -27,7 +26,6 @@ from .common import (
     TYPED_QUANT_HEALTH_PATH as _TYPED_QUANT_HEALTH_PATH,
     coerce_aware_datetime as _coerce_aware_datetime,
     compat_symbol as _compat_symbol,
-    normalize_reason_codes as _normalize_reason_codes,
     safe_attr_text as _safe_attr_text,
     safe_bool as _safe_bool,
     safe_int as _safe_int,
@@ -91,43 +89,6 @@ def _rollback_runtime_ledger_status_session(session: Session) -> None:
         rollback()
     except SQLAlchemyError:
         logger.warning("Failed to roll back runtime-ledger status session")
-
-
-def _sqlalchemy_error_indicates_statement_timeout(exc: SQLAlchemyError) -> bool:
-    message = str(exc).lower()
-    return (
-        "statement timeout" in message
-        or "querycanceled" in message
-        or "query canceled" in message
-    )
-
-
-def _unavailable_certificate_evidence_rows(
-    *,
-    hypothesis_ids: Sequence[str],
-    reason_code: str,
-) -> list[dict[str, object]]:
-    return [
-        {
-            "hypothesis_id": hypothesis_id,
-            "metric_window": None,
-            "promotion_decision": None,
-            "runtime_ledger_bucket": None,
-            "reason_codes": [reason_code],
-            "read_model_unavailable": True,
-        }
-        for hypothesis_id in hypothesis_ids
-    ]
-
-
-def _certificate_evidence_reason_codes(row: Mapping[str, object]) -> list[str]:
-    return _normalize_reason_codes(
-        [
-            str(reason).strip()
-            for reason in cast(Sequence[object], row.get("reason_codes") or [])
-            if str(reason).strip()
-        ]
-    )
 
 
 def _empty_profit_promotion_table_counts(

--- a/services/torghut/app/trading/submission_council_modules/runtime_summary.py
+++ b/services/torghut/app/trading/submission_council_modules/runtime_summary.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Runtime ledger summary payload helpers."""
 
 from __future__ import annotations

--- a/services/torghut/app/trading/tigerbeetle_reconcile_modules/latest_tigerbeetle_reconciliation_status_p.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile_modules/latest_tigerbeetle_reconciliation_status_p.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """TigerBeetle reconciliation for Torghut ledger references."""
 
 from __future__ import annotations
@@ -258,6 +257,8 @@ def reconcile_tigerbeetle_transfers(
                 create_tigerbeetle_client,
             )
             tb_client = client or client_factory(settings_obj)
+            if tb_client is None:
+                raise RuntimeError("tigerbeetle_client_unavailable")
             looked_up = tb_client.lookup_transfers(
                 [int(ref.transfer_id) for ref in refs]
             )

--- a/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_service.py
+++ b/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_service.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Whitepaper workflow ingestion, orchestration, and persistence helpers."""
 
 from __future__ import annotations
@@ -13,19 +12,11 @@ from sqlalchemy.orm import Session
 from .shared_context import (
     int_env as _int_env,
     str_env as _str_env,
-    build_whitepaper_run_id,
-    comment_requests_requeue,
-    extract_pdf_urls,
     logger,
-    normalize_github_issue_event,
-    parse_marker_block,
-    whitepaper_inngest_enabled,
     whitepaper_kafka_enabled,
-    whitepaper_semantic_indexing_enabled,
     whitepaper_workflow_enabled,
 )
 from .ceph_s3_client import (
-    IssueKickoffResult,
     WhitepaperWorkflowServiceFields as _WhitepaperWorkflowServiceFields,
 )
 from .whitepaper_workflow_ingestion_methods import (
@@ -217,7 +208,7 @@ class WhitepaperKafkaIssueIngestor:
             records: list[Any] = []
             for bucket in cast(Mapping[Any, Any], polled).values():
                 if isinstance(bucket, list):
-                    records.extend(bucket)
+                    records.extend(cast(list[Any], bucket))
             return records
         if isinstance(polled, list):
             return cast(list[Any], polled)
@@ -312,23 +303,6 @@ class WhitepaperKafkaWorker:
     def _ingest_once(self) -> None:
         with self._session_factory() as session:
             self._ingestor.ingest_once(session)
-
-
-__all__ = [
-    "IssueKickoffResult",
-    "WhitepaperKafkaIssueIngestor",
-    "WhitepaperKafkaWorker",
-    "WhitepaperWorkflowService",
-    "build_whitepaper_run_id",
-    "comment_requests_requeue",
-    "extract_pdf_urls",
-    "normalize_github_issue_event",
-    "parse_marker_block",
-    "whitepaper_inngest_enabled",
-    "whitepaper_kafka_enabled",
-    "whitepaper_semantic_indexing_enabled",
-    "whitepaper_workflow_enabled",
-]
 
 
 __all__ = (


### PR DESCRIPTION
## Summary

- Removed 30 Torghut file-level Pyright suppressions without restoring private-usage suppression.
- Replaced broad split-module export shims with explicit ownership in trading misc, proof-floor payloads, readiness helpers, completion status, submission council, and whitepaper workflow modules.
- Tightened typed decision/submission/TigerBeetle/readiness call surfaces and removed dead duplicate quant-health helpers.

## Related Issues

None

## Testing

- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff format --check app scripts tests migrations`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main ...`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks ...`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main ...`
- `uv run --frozen pytest tests/submission_council tests/whitepaper_workflow tests/test_queue_survival_fill_stress.py tests/tigerbeetle_reconcile/test_reconciliation_passes_when_postgres_refs_match_tigerbeetle.py tests/decisions tests/completion_trace tests/api/test_trading_api_status_consumer_evidence.py tests/api/test_trading_api_readyz_contract.py tests/api/test_trading_api_health_dependency.py tests/api/test_trading_api_db_contract.py -q`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
