### PR TITLE
fix(torghut): keep scheduled job history from blocking rollout

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -14,6 +14,56 @@ data:
     hs.status = "Healthy"
     hs.message = "SealedSecret health is ignored; decryption is handled by the sealed-secrets controller."
     return hs
+  resource.customizations.health.batch_CronJob: |
+    hs = {}
+    local metadata = obj.metadata or {}
+    local labels = metadata.labels or {}
+    local spec = obj.spec or {}
+    local status = obj.status or {}
+    local active = status.active or {}
+
+    if spec.suspend == true then
+      hs.status = "Suspended"
+      hs.message = "CronJob is suspended."
+      return hs
+    end
+
+    if metadata.namespace == "torghut" and labels["app.kubernetes.io/name"] == "torghut" then
+      if #active > 0 then
+        hs.status = "Progressing"
+        hs.message = "Torghut CronJob has active run(s); runtime rollout checks remain authoritative."
+        return hs
+      end
+
+      hs.status = "Healthy"
+      hs.message = "Torghut CronJob schedule is reconciled; scheduled job results are monitored outside Argo app health."
+      return hs
+    end
+
+    if #active > 0 then
+      hs.status = "Progressing"
+      hs.message = "CronJob has active run(s)."
+      return hs
+    end
+
+    if status.lastScheduleTime ~= nil and status.lastSuccessfulTime == nil then
+      hs.status = "Degraded"
+      hs.message = "CronJob has not completed its last execution successfully."
+      return hs
+    end
+
+    local lastRunFailed = status.lastScheduleTime ~= nil and
+      status.lastSuccessfulTime ~= nil and
+      status.lastScheduleTime > status.lastSuccessfulTime
+    if lastRunFailed then
+      hs.status = "Degraded"
+      hs.message = "CronJob has not completed its last execution successfully."
+      return hs
+    end
+
+    hs.status = "Healthy"
+    hs.message = "CronJob is healthy."
+    return hs
   resource.customizations.health.flink.apache.org_FlinkDeployment: |
     hs = {}
     local spec = obj.spec or {}

--- a/packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts
+++ b/packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'bun:test'
+import YAML from 'yaml'
+
+import { repoRoot } from '../../shared/cli'
+
+type ArgoConfigMap = {
+  data?: Record<string, string>
+}
+
+const argoConfigMap = YAML.parse(
+  readFileSync(join(repoRoot, 'argocd/applications/argocd/overlays/argocd-cm.yaml'), 'utf8'),
+) as ArgoConfigMap
+
+const cronJobHealth = argoConfigMap.data?.['resource.customizations.health.batch_CronJob'] ?? ''
+
+describe('Argo CD CronJob health customization', () => {
+  it('keeps stale Torghut scheduled-job history from blocking app promotion sync', () => {
+    expect(cronJobHealth).toContain('metadata.namespace == "torghut"')
+    expect(cronJobHealth).toContain('labels["app.kubernetes.io/name"] == "torghut"')
+    expect(cronJobHealth).toContain('scheduled job results are monitored outside Argo app health')
+    expect(cronJobHealth).not.toContain('torghut-paper-account-flatten')
+  })
+
+  it('retains failed-run health for non-Torghut CronJobs', () => {
+    expect(cronJobHealth).toContain('status.lastScheduleTime ~= nil and status.lastSuccessfulTime == nil')
+    expect(cronJobHealth).toContain('status.lastScheduleTime > status.lastSuccessfulTime')
+    expect(cronJobHealth).toContain('CronJob has not completed its last execution successfully.')
+  })
+})


### PR DESCRIPTION
## Summary

- Add an Argo CD `batch/CronJob` health customization that stops stale Torghut scheduled-job history from blocking app promotion sync.
- Keep active Torghut CronJobs as `Progressing`, and keep non-Torghut CronJob failed-run history as `Degraded`.
- Add a Bun regression test for the Torghut-specific CronJob health behavior and the generic failed-run fallback.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argocd >/tmp/argocd-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
