### PR TITLE
refactor(torghut): canonicalize promotion authority

### DIFF
--- a/docs/superpowers/plans/2026-06-17-torghut-promotion-authority-refactor.md
+++ b/docs/superpowers/plans/2026-06-17-torghut-promotion-authority-refactor.md
@@ -1,0 +1,1306 @@
+# Torghut Promotion Authority Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Torghut's ambiguous `promotion_allowed` / `final_promotion_allowed` boolean soup with one canonical promotion authority model that cleanly separates evidence collection, paper probation, and capital promotion.
+
+**Architecture:** Add a small domain module that owns promotion authority state and legacy field projection. Refactor proof, target-plan, runtime-import, and scheduler consumers to read canonical `capital_promotion_allowed` / `promotion_stage` semantics while keeping legacy booleans as compatibility mirrors during rollout.
+
+**Tech Stack:** Python 3.11/3.12, dataclasses, `StrEnum`, SQLAlchemy-backed Torghut runtime ledger tests, pytest, Pyright, Ruff, existing GitOps/CI promotion workflow.
+
+---
+
+## Current Problem
+
+The existing fields are not clean:
+
+- `promotion_allowed` sometimes means "candidate proof gate says eligible."
+- `final_promotion_allowed` sometimes means "all final/live/capital blockers cleared."
+- `capital_promotion_allowed` is the field name closest to the actual safety meaning.
+- Bounded collection code treats `promotion_allowed`, `final_promotion_allowed`, `final_promotion_authorized`, and `capital_promotion_allowed` as equivalent stop signals.
+- Source-collection and bounded-paper paths set all promotion booleans false, which is safe but unclear.
+
+The system needs a single source of truth:
+
+- `promotion_stage`: one of `source_collection`, `paper_probation`, `capital_blocked`, `capital_allowed`.
+- `capital_promotion_allowed`: the only boolean allowed to mean "may route promoted capital."
+- `promotion_blockers`: the canonical blocker list for why capital promotion is not allowed.
+- Compatibility fields `promotion_allowed`, `final_promotion_allowed`, and `final_promotion_authorized` are generated in one place only and mirror `capital_promotion_allowed` until downstream API compatibility is retired.
+
+## Target File Structure
+
+- Create `services/torghut/app/trading/promotion_authority.py`
+  - Owns `PromotionStage`, `PromotionAuthority`, constructors, legacy projection, and consumer helpers.
+- Create `services/torghut/tests/trading/test_promotion_authority.py`
+  - Unit tests for canonical semantics and legacy compatibility projection.
+- Modify `services/torghut/app/trading/runtime_authority_verifier_modules/shared_context.py`
+  - Emit canonical capital authority fields through `PromotionAuthority`.
+- Modify `services/torghut/app/trading/submission_council_modules/import_plan.py`
+  - Use constructors for source-collection and paper-probation collection targets.
+- Modify `services/torghut/app/trading/submission_council_modules/paper_probation.py`
+  - Replace direct promotion boolean literals with authority projection.
+- Modify `services/torghut/app/trading/paper_route_target_plan_modules/materialization.py`
+  - Replace direct promotion boolean literals with authority projection.
+- Modify `services/torghut/app/trading/paper_route_target_plan_modules/target_plan.py`
+  - Keep compatibility fields only by using authority projection.
+- Modify `services/torghut/app/trading/proofs/targets.py`
+  - Emit compatibility fields from the authority helper.
+- Modify `services/torghut/app/trading/scheduler/target_plan_helpers_modules/bounded_collection.py`
+  - Replace OR checks across legacy booleans with canonical helper `target_capital_promotion_allowed`.
+- Modify `services/torghut/app/trading/runtime_window_import_modules/common.py`
+  - Compute evidence blocking reasons from canonical helpers; legacy false fields must not add duplicate blockers.
+- Modify `services/torghut/app/trading/runtime_window_import_modules/persistence_materialization.py`
+  - Persist canonical authority fields.
+- Modify `services/torghut/app/trading/scheduler/source_collection_modules/decision_helpers.py`
+  - Use source-collection constructor for bounded data collection metadata.
+- Modify `services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py`
+  - Use canonical compatibility projection when building decision lineage.
+- Modify `services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py`
+  - Normalize incoming target plans through canonical authority helper.
+- Modify `services/torghut/app/trading/scheduler/submission_preparation_modules/quote_routeability.py`
+  - Use canonical blocked authority projection for non-routeable targets.
+- Update tests under:
+  - `services/torghut/tests/submission_council/`
+  - `services/torghut/tests/pipeline/`
+  - `services/torghut/tests/verify_trading_readiness/`
+  - `services/torghut/tests/run_empirical_promotion_jobs/`
+  - `services/torghut/tests/materialize_bounded_paper_route_targets/`
+
+## Invariants
+
+- Source collection can submit bounded paper evidence only when `bounded_live_paper_collection_authorized=true`.
+- Source collection must always have `capital_promotion_allowed=false`.
+- Paper probation can collect evidence without capital promotion.
+- Capital promotion is allowed only when `capital_promotion_allowed=true`.
+- Legacy `promotion_allowed`, `final_promotion_allowed`, and `final_promotion_authorized` must match `capital_promotion_allowed` until removed.
+- No production scheduler code may OR together `promotion_allowed` and `final_promotion_allowed` after this refactor.
+
+---
+
+### Task 1: Add Canonical Promotion Authority Model
+
+**Files:**
+- Create: `services/torghut/app/trading/promotion_authority.py`
+- Create: `services/torghut/tests/trading/test_promotion_authority.py`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Create `services/torghut/tests/trading/test_promotion_authority.py`:
+
+```python
+from app.trading.promotion_authority import (
+    PromotionStage,
+    capital_allowed_authority,
+    capital_blocked_authority,
+    paper_probation_authority,
+    source_collection_authority,
+    target_capital_promotion_allowed,
+)
+
+
+def test_source_collection_authority_is_collection_only() -> None:
+    authority = source_collection_authority(
+        blockers=["runtime_ledger_source_window_missing"],
+    )
+
+    fields = authority.as_target_fields()
+
+    assert fields["promotion_stage"] == "source_collection"
+    assert fields["source_collection_authorized"] is True
+    assert fields["bounded_live_paper_collection_authorized"] is True
+    assert fields["capital_promotion_allowed"] is False
+    assert fields["promotion_allowed"] is False
+    assert fields["final_promotion_allowed"] is False
+    assert fields["final_promotion_authorized"] is False
+    assert fields["final_authority_ok"] is False
+    assert fields["promotion_blockers"] == ["runtime_ledger_source_window_missing"]
+    assert target_capital_promotion_allowed(fields) is False
+
+
+def test_paper_probation_authority_is_not_capital_authority() -> None:
+    authority = paper_probation_authority(
+        blockers=["live_runtime_ledger_required"],
+    )
+
+    fields = authority.as_target_fields()
+
+    assert fields["promotion_stage"] == "paper_probation"
+    assert fields["paper_probation_authorized"] is True
+    assert fields["source_collection_authorized"] is False
+    assert fields["capital_promotion_allowed"] is False
+    assert fields["promotion_allowed"] is False
+    assert fields["final_promotion_allowed"] is False
+    assert fields["final_promotion_authorized"] is False
+    assert target_capital_promotion_allowed(fields) is False
+
+
+def test_capital_blocked_authority_preserves_blockers() -> None:
+    authority = capital_blocked_authority(
+        blockers=["mean_daily_net_pnl_after_costs_below_500"],
+    )
+
+    fields = authority.as_target_fields()
+
+    assert fields["promotion_stage"] == "capital_blocked"
+    assert fields["capital_promotion_allowed"] is False
+    assert fields["promotion_allowed"] is False
+    assert fields["final_promotion_allowed"] is False
+    assert fields["promotion_blockers"] == ["mean_daily_net_pnl_after_costs_below_500"]
+    assert target_capital_promotion_allowed(fields) is False
+
+
+def test_capital_allowed_authority_is_the_only_true_promotion_state() -> None:
+    authority = capital_allowed_authority()
+
+    fields = authority.as_target_fields()
+
+    assert authority.stage is PromotionStage.CAPITAL_ALLOWED
+    assert fields["promotion_stage"] == "capital_allowed"
+    assert fields["capital_promotion_allowed"] is True
+    assert fields["promotion_allowed"] is True
+    assert fields["final_promotion_allowed"] is True
+    assert fields["final_promotion_authorized"] is True
+    assert fields["final_authority_ok"] is True
+    assert fields["promotion_blockers"] == []
+    assert target_capital_promotion_allowed(fields) is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/trading/test_promotion_authority.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.trading.promotion_authority'`.
+
+- [ ] **Step 3: Implement the authority model**
+
+Create `services/torghut/app/trading/promotion_authority.py`:
+
+```python
+"""Canonical promotion authority state for Torghut trading targets."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+PROMOTION_AUTHORITY_SCHEMA_VERSION = "torghut.promotion-authority.v1"
+
+
+class PromotionStage(StrEnum):
+    SOURCE_COLLECTION = "source_collection"
+    PAPER_PROBATION = "paper_probation"
+    CAPITAL_BLOCKED = "capital_blocked"
+    CAPITAL_ALLOWED = "capital_allowed"
+
+
+@dataclass(frozen=True)
+class PromotionAuthority:
+    stage: PromotionStage
+    capital_promotion_allowed: bool
+    blockers: tuple[str, ...] = ()
+    source_collection_authorized: bool = False
+    paper_probation_authorized: bool = False
+    bounded_live_paper_collection_authorized: bool = False
+    evidence_collection_ok: bool = False
+
+    @property
+    def final_authority_ok(self) -> bool:
+        return self.capital_promotion_allowed and not self.blockers
+
+    def as_target_fields(self) -> dict[str, object]:
+        capital_allowed = self.final_authority_ok
+        blockers = list(dict.fromkeys(self.blockers))
+        return {
+            "promotion_authority_schema_version": PROMOTION_AUTHORITY_SCHEMA_VERSION,
+            "promotion_stage": self.stage.value,
+            "source_collection_authorized": self.source_collection_authorized,
+            "paper_probation_authorized": self.paper_probation_authorized,
+            "bounded_live_paper_collection_authorized": (
+                self.bounded_live_paper_collection_authorized
+            ),
+            "evidence_collection_ok": self.evidence_collection_ok,
+            "capital_promotion_allowed": capital_allowed,
+            "final_authority_ok": capital_allowed,
+            "promotion_blockers": blockers,
+            "final_promotion_blockers": blockers,
+            "runtime_ledger_target_metadata_blockers": blockers,
+            "promotion_allowed": capital_allowed,
+            "final_promotion_allowed": capital_allowed,
+            "final_promotion_authorized": capital_allowed,
+        }
+
+
+def _blockers(values: Sequence[str] | None) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    return tuple(str(value).strip() for value in values if str(value).strip())
+
+
+def source_collection_authority(
+    *,
+    blockers: Sequence[str] | None,
+    bounded_live_paper_collection_authorized: bool = True,
+) -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.SOURCE_COLLECTION,
+        capital_promotion_allowed=False,
+        blockers=_blockers(blockers),
+        source_collection_authorized=True,
+        bounded_live_paper_collection_authorized=bounded_live_paper_collection_authorized,
+        evidence_collection_ok=True,
+    )
+
+
+def paper_probation_authority(
+    *,
+    blockers: Sequence[str] | None,
+    bounded_live_paper_collection_authorized: bool = True,
+) -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.PAPER_PROBATION,
+        capital_promotion_allowed=False,
+        blockers=_blockers(blockers),
+        paper_probation_authorized=True,
+        bounded_live_paper_collection_authorized=bounded_live_paper_collection_authorized,
+        evidence_collection_ok=True,
+    )
+
+
+def capital_blocked_authority(
+    *,
+    blockers: Sequence[str] | None,
+) -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.CAPITAL_BLOCKED,
+        capital_promotion_allowed=False,
+        blockers=_blockers(blockers),
+    )
+
+
+def capital_allowed_authority() -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.CAPITAL_ALLOWED,
+        capital_promotion_allowed=True,
+        blockers=(),
+    )
+
+
+def target_capital_promotion_allowed(target: Mapping[str, Any]) -> bool:
+    return bool(target.get("capital_promotion_allowed") is True)
+
+
+def target_promotion_stage(target: Mapping[str, Any]) -> PromotionStage:
+    raw = str(target.get("promotion_stage") or "").strip()
+    try:
+        return PromotionStage(raw)
+    except ValueError:
+        if target_capital_promotion_allowed(target):
+            return PromotionStage.CAPITAL_ALLOWED
+        if bool(target.get("source_collection_authorized")):
+            return PromotionStage.SOURCE_COLLECTION
+        if bool(target.get("paper_probation_authorized")):
+            return PromotionStage.PAPER_PROBATION
+        return PromotionStage.CAPITAL_BLOCKED
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/trading/test_promotion_authority.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/torghut/app/trading/promotion_authority.py services/torghut/tests/trading/test_promotion_authority.py
+git commit -m "refactor(torghut): add canonical promotion authority"
+```
+
+---
+
+### Task 2: Refactor Runtime Authority Verifier To Emit Canonical Fields
+
+**Files:**
+- Modify: `services/torghut/app/trading/runtime_authority_verifier_modules/shared_context.py`
+- Test: `services/torghut/tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py`
+
+- [ ] **Step 1: Add regression assertions**
+
+In `services/torghut/tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py`, extend the existing passing proof packet assertions so they check:
+
+```python
+assert packet_summary["promotion_stage"] == "capital_allowed"
+assert packet_summary["capital_promotion_allowed"] is True
+assert packet_summary["promotion_allowed"] is True
+assert packet_summary["final_promotion_allowed"] is True
+assert packet_summary["promotion_blockers"] == []
+```
+
+Extend the blocked packet assertions so they check:
+
+```python
+assert packet_summary["promotion_stage"] == "capital_blocked"
+assert packet_summary["capital_promotion_allowed"] is False
+assert packet_summary["promotion_allowed"] is False
+assert packet_summary["final_promotion_allowed"] is False
+assert packet_summary["promotion_blockers"]
+```
+
+- [ ] **Step 2: Run targeted readiness tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py -q
+```
+
+Expected: FAIL because `promotion_stage` and `promotion_blockers` are missing.
+
+- [ ] **Step 3: Refactor verifier return payload**
+
+In `services/torghut/app/trading/runtime_authority_verifier_modules/shared_context.py`, import:
+
+```python
+from app.trading.promotion_authority import (
+    capital_allowed_authority,
+    capital_blocked_authority,
+)
+```
+
+Replace the current direct fields:
+
+```python
+"authority_allowed": final_authority_ok,
+"promotion_allowed": final_authority_ok,
+"capital_promotion_allowed": final_authority_ok,
+"final_authority_ok": final_authority_ok,
+```
+
+with:
+
+```python
+authority = (
+    capital_allowed_authority()
+    if final_authority_ok
+    else capital_blocked_authority(blockers=blockers)
+)
+...
+"authority_allowed": final_authority_ok,
+**authority.as_target_fields(),
+```
+
+- [ ] **Step 4: Run targeted readiness tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/torghut/app/trading/runtime_authority_verifier_modules/shared_context.py services/torghut/tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py
+git commit -m "refactor(torghut): canonicalize runtime authority payload"
+```
+
+---
+
+### Task 3: Refactor Import Plan Source Collection And Paper Probation Targets
+
+**Files:**
+- Modify: `services/torghut/app/trading/submission_council_modules/import_plan.py`
+- Test: `services/torghut/tests/submission_council/test_source_collection_candidates.py`
+- Test: `services/torghut/tests/submission_council/test_paper_probation_import_plan.py`
+
+- [ ] **Step 1: Add source-collection authority assertions**
+
+In `test_source_collection_candidates.py`, update source-collection target assertions:
+
+```python
+assert target["promotion_stage"] == "source_collection"
+assert target["source_collection_authorized"] is True
+assert target["bounded_live_paper_collection_authorized"] is True
+assert target["capital_promotion_allowed"] is False
+assert target["promotion_allowed"] is False
+assert target["final_promotion_allowed"] is False
+assert target["promotion_blockers"] == target["final_promotion_blockers"]
+```
+
+In `test_paper_probation_import_plan.py`, update paper-probation target assertions:
+
+```python
+assert target["promotion_stage"] == "paper_probation"
+assert target["paper_probation_authorized"] is True
+assert target["source_collection_authorized"] is False
+assert target["capital_promotion_allowed"] is False
+assert target["promotion_allowed"] is False
+assert target["final_promotion_allowed"] is False
+assert "live_runtime_ledger_required" in target["promotion_blockers"]
+```
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py -q
+```
+
+Expected: FAIL because targets do not consistently include `promotion_stage` / `promotion_blockers`.
+
+- [ ] **Step 3: Refactor `_runtime_ledger_base_import_target`**
+
+In `import_plan.py`, import:
+
+```python
+from app.trading.promotion_authority import (
+    paper_probation_authority,
+    source_collection_authority,
+)
+```
+
+Inside `_runtime_ledger_base_import_target`, before the return:
+
+```python
+authority = (
+    source_collection_authority(
+        blockers=candidate.final_blockers,
+        bounded_live_paper_collection_authorized=bounded_probe_authorized,
+    )
+    if candidate.source_collection
+    else paper_probation_authority(
+        blockers=candidate.final_blockers,
+        bounded_live_paper_collection_authorized=bounded_probe_authorized,
+    )
+)
+```
+
+In the returned dict, remove these direct literals:
+
+```python
+"paper_probation_authorized": candidate.paper_probation_satisfied,
+"source_collection_authorized": candidate.source_collection,
+"evidence_collection_ok": True,
+"bounded_live_paper_collection_authorized": bounded_probe_authorized,
+"capital_promotion_allowed": False,
+"final_authority_ok": False,
+"promotion_allowed": False,
+"final_promotion_authorized": False,
+"final_promotion_allowed": False,
+"final_promotion_blockers": candidate.final_blockers,
+"runtime_ledger_target_metadata_blockers": candidate.final_blockers,
+```
+
+Replace them with:
+
+```python
+**authority.as_target_fields(),
+```
+
+Keep the existing scope fields:
+
+```python
+"paper_probation_authorization_scope": (
+    "evidence_collection_only" if candidate.paper_probation_satisfied else ""
+),
+"source_collection_authorization_scope": (
+    "source_window_evidence_collection_only" if candidate.source_collection else ""
+),
+```
+
+- [ ] **Step 4: Refactor merged plan summary**
+
+In `_merge_manifest_bounded_collection_targets`, replace direct plan-level promotion literals with:
+
+```python
+merged_plan["promotion_stage"] = "source_collection"
+merged_plan["capital_promotion_allowed"] = False
+merged_plan["final_authority_ok"] = False
+merged_plan["promotion_allowed"] = False
+merged_plan["final_promotion_authorized"] = False
+merged_plan["final_promotion_allowed"] = False
+merged_plan["promotion_blockers"] = list(_BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS)
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/torghut/app/trading/submission_council_modules/import_plan.py services/torghut/tests/submission_council/test_source_collection_candidates.py services/torghut/tests/submission_council/test_paper_probation_import_plan.py
+git commit -m "refactor(torghut): normalize import plan promotion authority"
+```
+
+---
+
+### Task 4: Refactor Target Plan Materialization Producers
+
+**Files:**
+- Modify: `services/torghut/app/trading/paper_route_target_plan_modules/materialization.py`
+- Modify: `services/torghut/app/trading/paper_route_target_plan_modules/target_plan.py`
+- Modify: `services/torghut/app/trading/proofs/targets.py`
+- Test: `services/torghut/tests/materialize_bounded_paper_route_targets/test_commit_dynamic_plan_filters_to_active_target_window_subset.py`
+- Test: `services/torghut/tests/test_trading_proofs_api.py`
+
+- [ ] **Step 1: Add materialization assertions**
+
+In materialization tests, assert bounded targets are collection-only:
+
+```python
+assert report["promotion_stage"] == "source_collection"
+assert report["capital_promotion_allowed"] is False
+assert report["promotion_allowed"] is False
+assert report["final_promotion_allowed"] is False
+assert report["promotion_blockers"]
+```
+
+In proofs API tests, assert proof-derived target defaults are capital-blocked:
+
+```python
+assert target["promotion_stage"] == "capital_blocked"
+assert target["capital_promotion_allowed"] is False
+assert target["promotion_allowed"] is False
+assert target["final_promotion_allowed"] is False
+```
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/materialize_bounded_paper_route_targets/test_commit_dynamic_plan_filters_to_active_target_window_subset.py tests/test_trading_proofs_api.py -q
+```
+
+Expected: FAIL on missing canonical fields.
+
+- [ ] **Step 3: Refactor materialization producers**
+
+In `materialization.py`, import:
+
+```python
+from app.trading.promotion_authority import (
+    capital_blocked_authority,
+    source_collection_authority,
+)
+```
+
+Replace direct false promotion literals in bounded source collection target payloads with:
+
+```python
+**source_collection_authority(
+    blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+).as_target_fields(),
+```
+
+Replace direct false promotion literals in proof-derived blocked target payloads with:
+
+```python
+**capital_blocked_authority(
+    blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+).as_target_fields(),
+```
+
+- [ ] **Step 4: Refactor target-plan defaults**
+
+In `target_plan.py`, import:
+
+```python
+from app.trading.promotion_authority import capital_blocked_authority
+```
+
+Replace:
+
+```python
+target.setdefault("promotion_allowed", False)
+target.setdefault("final_promotion_allowed", False)
+target.setdefault("final_promotion_authorized", False)
+```
+
+with:
+
+```python
+for key, value in capital_blocked_authority(
+    blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+).as_target_fields().items():
+    target.setdefault(key, value)
+```
+
+- [ ] **Step 5: Refactor proof targets**
+
+In `proofs/targets.py`, import:
+
+```python
+from app.trading.promotion_authority import capital_blocked_authority
+```
+
+When building a proof target, add:
+
+```python
+target.update(
+    capital_blocked_authority(
+        blockers=["proof_target_not_runtime_capital_authority"],
+    ).as_target_fields()
+)
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/materialize_bounded_paper_route_targets/test_commit_dynamic_plan_filters_to_active_target_window_subset.py tests/test_trading_proofs_api.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/torghut/app/trading/paper_route_target_plan_modules/materialization.py services/torghut/app/trading/paper_route_target_plan_modules/target_plan.py services/torghut/app/trading/proofs/targets.py services/torghut/tests/materialize_bounded_paper_route_targets/test_commit_dynamic_plan_filters_to_active_target_window_subset.py services/torghut/tests/test_trading_proofs_api.py
+git commit -m "refactor(torghut): canonicalize paper target authority"
+```
+
+---
+
+### Task 5: Refactor Scheduler Consumers To Stop Reading Legacy Boolean Soup
+
+**Files:**
+- Modify: `services/torghut/app/trading/scheduler/target_plan_helpers_modules/bounded_collection.py`
+- Modify: `services/torghut/app/trading/scheduler/source_collection_modules/decision_helpers.py`
+- Modify: `services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py`
+- Modify: `services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py`
+- Modify: `services/torghut/app/trading/scheduler/submission_preparation_modules/quote_routeability.py`
+- Test: `services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py`
+- Test: `services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_b.py`
+
+- [ ] **Step 1: Add scheduler invariant tests**
+
+In `test_live_bounded_paper_route_probe_contract.py`, add assertions on the live bounded target:
+
+```python
+assert target["promotion_stage"] == "source_collection"
+assert target["capital_promotion_allowed"] is False
+assert target["bounded_live_paper_collection_authorized"] is True
+assert target["promotion_allowed"] is False
+assert target["final_promotion_allowed"] is False
+```
+
+In `test_trading_pipeline_probe_exits_b.py`, assert exit probe metadata preserves collection-only authority:
+
+```python
+assert metadata["promotion_stage"] in {"source_collection", "paper_probation"}
+assert metadata["capital_promotion_allowed"] is False
+assert metadata["promotion_allowed"] is False
+assert metadata["final_promotion_allowed"] is False
+```
+
+- [ ] **Step 2: Run focused scheduler tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q
+```
+
+Expected: FAIL until scheduler metadata carries canonical fields everywhere.
+
+- [ ] **Step 3: Replace OR-soup bounded collection check**
+
+In `bounded_collection.py`, import:
+
+```python
+from app.trading.promotion_authority import target_capital_promotion_allowed
+```
+
+Replace:
+
+```python
+if (
+    _target_truthy(target.get("promotion_allowed"))
+    or _target_truthy(target.get("final_promotion_allowed"))
+    or _target_truthy(target.get("final_promotion_authorized"))
+    or _target_truthy(target.get("capital_promotion_allowed"))
+):
+    blockers.append("bounded_sim_collection_non_final_state_required")
+```
+
+with:
+
+```python
+if target_capital_promotion_allowed(target):
+    blockers.append("bounded_sim_collection_non_final_state_required")
+```
+
+- [ ] **Step 4: Use authority helper in source collection decision metadata**
+
+In `decision_helpers.py`, import:
+
+```python
+from app.trading.promotion_authority import source_collection_authority
+```
+
+Replace direct false promotion fields in `source_collection_bounded_execution_params` with:
+
+```python
+**source_collection_authority(
+    blockers=["runtime_ledger_source_collection_pending"],
+).as_target_fields(),
+```
+
+- [ ] **Step 5: Normalize fetched target plans**
+
+In `target_plan_fetch.py`, import:
+
+```python
+from app.trading.promotion_authority import (
+    capital_blocked_authority,
+    target_capital_promotion_allowed,
+)
+```
+
+Where target metadata is normalized, add:
+
+```python
+if "promotion_stage" not in target:
+    target.update(
+        capital_blocked_authority(
+            blockers=["target_plan_missing_canonical_promotion_authority"],
+        ).as_target_fields()
+    )
+if target_capital_promotion_allowed(target):
+    target["promotion_stage"] = "capital_allowed"
+```
+
+- [ ] **Step 6: Run focused scheduler tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/torghut/app/trading/scheduler/target_plan_helpers_modules/bounded_collection.py services/torghut/app/trading/scheduler/source_collection_modules/decision_helpers.py services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py services/torghut/app/trading/scheduler/submission_preparation_modules/quote_routeability.py services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_b.py
+git commit -m "refactor(torghut): consume canonical promotion authority"
+```
+
+---
+
+### Task 6: Refactor Runtime Window Import Blocking Reasons
+
+**Files:**
+- Modify: `services/torghut/app/trading/runtime_window_import_modules/common.py`
+- Modify: `services/torghut/app/trading/runtime_window_import_modules/persistence_materialization.py`
+- Test: `services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py`
+- Test: `services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py`
+- Test: `services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py`
+
+- [ ] **Step 1: Add blocking reason assertions**
+
+In runtime window import tests, assert collection-only rows produce one clear capital blocker:
+
+```python
+assert "capital_promotion_not_allowed" in evidence_blocking_reasons
+assert "candidate_board_promotion_not_allowed" not in evidence_blocking_reasons
+assert "final_promotion_not_allowed" not in evidence_blocking_reasons
+```
+
+For paper probation rows, assert:
+
+```python
+assert "paper_probation_evidence_collection_only" in evidence_blocking_reasons
+assert "capital_promotion_not_allowed" in evidence_blocking_reasons
+```
+
+- [ ] **Step 2: Run runtime import tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py -q
+```
+
+Expected: FAIL because legacy false fields currently add multiple blocker names.
+
+- [ ] **Step 3: Refactor evidence blocking reason builder**
+
+In `common.py`, import:
+
+```python
+from app.trading.promotion_authority import target_capital_promotion_allowed
+```
+
+Replace:
+
+```python
+if observation_bool(target_metadata.get("promotion_allowed")) is False:
+    reasons.append("candidate_board_promotion_not_allowed")
+if observation_bool(target_metadata.get("final_promotion_authorized")) is False:
+    reasons.append("final_promotion_not_authorized")
+if observation_bool(target_metadata.get("final_promotion_allowed")) is False:
+    reasons.append("final_promotion_not_allowed")
+```
+
+with:
+
+```python
+if not target_capital_promotion_allowed(target_metadata):
+    reasons.append("capital_promotion_not_allowed")
+```
+
+Keep `paper_probation_evidence_collection_only` because it describes evidence collection mode, not capital authority.
+
+- [ ] **Step 4: Refactor persisted materialization payload**
+
+In `persistence_materialization.py`, import:
+
+```python
+from app.trading.promotion_authority import (
+    capital_allowed_authority,
+    capital_blocked_authority,
+)
+```
+
+Where `capital_promotion_allowed` is emitted, replace direct field assignment with:
+
+```python
+authority = (
+    capital_allowed_authority()
+    if promotion_allowed
+    else capital_blocked_authority(blockers=plan.promotion.promotion_blocking_reasons)
+)
+payload.update(authority.as_target_fields())
+```
+
+- [ ] **Step 5: Run runtime import tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/torghut/app/trading/runtime_window_import_modules/common.py services/torghut/app/trading/runtime_window_import_modules/persistence_materialization.py services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py
+git commit -m "refactor(torghut): simplify runtime import authority blockers"
+```
+
+---
+
+### Task 7: Add Static Guard Against Reintroducing Ambiguous Promotion Checks
+
+**Files:**
+- Modify: `services/torghut/tests/test_promotion_authority_static_contract.py`
+
+- [ ] **Step 1: Add static contract test**
+
+Create `services/torghut/tests/test_promotion_authority_static_contract.py`:
+
+```python
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ALLOWED_LEGACY_PROMOTION_FILES = {
+    "app/trading/promotion_authority.py",
+}
+
+
+def test_scheduler_does_not_or_legacy_promotion_booleans() -> None:
+    scheduler_root = ROOT / "app" / "trading" / "scheduler"
+    offenders: list[str] = []
+    for path in scheduler_root.rglob("*.py"):
+        text = path.read_text()
+        if "promotion_allowed" in text and "final_promotion_allowed" in text:
+            if "target_capital_promotion_allowed" not in text:
+                offenders.append(str(path.relative_to(ROOT)))
+
+    assert offenders == []
+
+
+def test_legacy_promotion_projection_is_centralized() -> None:
+    offenders: list[str] = []
+    for path in (ROOT / "app" / "trading").rglob("*.py"):
+        rel = str(path.relative_to(ROOT))
+        if rel in ALLOWED_LEGACY_PROMOTION_FILES:
+            continue
+        text = path.read_text()
+        if '"promotion_allowed":' in text or '"final_promotion_allowed":' in text:
+            offenders.append(rel)
+
+    assert offenders == []
+```
+
+- [ ] **Step 2: Run static test**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/test_promotion_authority_static_contract.py -q
+```
+
+Expected: FAIL until direct literal legacy fields are removed from producers.
+
+- [ ] **Step 3: Remove remaining direct literals**
+
+Run:
+
+```bash
+cd services/torghut
+rg -n '"promotion_allowed":|"final_promotion_allowed":' app/trading
+```
+
+For each production hit outside `app/trading/promotion_authority.py`, replace direct literals with one of:
+
+```python
+capital_blocked_authority(blockers=[...]).as_target_fields()
+source_collection_authority(blockers=[...]).as_target_fields()
+paper_probation_authority(blockers=[...]).as_target_fields()
+capital_allowed_authority().as_target_fields()
+```
+
+- [ ] **Step 4: Run static test again**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/test_promotion_authority_static_contract.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/torghut/app/trading services/torghut/tests/test_promotion_authority_static_contract.py
+git commit -m "test(torghut): guard promotion authority compatibility boundary"
+```
+
+---
+
+### Task 8: Update API Evidence And Operator Vocabulary
+
+**Files:**
+- Modify: `services/torghut/app/trading/revenue_repair_modules/evidence_summaries.py`
+- Modify: `services/torghut/app/trading/proofs/targets.py`
+- Modify: `docs/torghut/trading/promotion-authority.md`
+- Test: `services/torghut/tests/test_trading_proofs_api.py`
+- Test: `services/torghut/tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py`
+
+- [ ] **Step 1: Add API assertions**
+
+In proofs/readiness tests, assert payloads expose these operator-facing fields:
+
+```python
+assert payload["promotion_stage"] in {
+    "source_collection",
+    "paper_probation",
+    "capital_blocked",
+    "capital_allowed",
+}
+assert isinstance(payload["capital_promotion_allowed"], bool)
+assert isinstance(payload["promotion_blockers"], list)
+```
+
+- [ ] **Step 2: Update evidence summary payloads**
+
+In `evidence_summaries.py`, replace scattered summary fields with:
+
+```python
+"promotion_stage": _text(target.get("promotion_stage")),
+"capital_promotion_allowed": _bool(target.get("capital_promotion_allowed")),
+"promotion_blockers": _string_items(target.get("promotion_blockers")),
+"legacy_promotion_allowed": _bool(target.get("promotion_allowed")),
+"legacy_final_promotion_allowed": _bool(target.get("final_promotion_allowed")),
+```
+
+- [ ] **Step 3: Add operator doc**
+
+Create `docs/torghut/trading/promotion-authority.md`:
+
+```markdown
+# Torghut Promotion Authority
+
+Torghut uses one canonical capital authority boolean: `capital_promotion_allowed`.
+
+`promotion_stage` explains what the target is allowed to do:
+
+- `source_collection`: bounded paper orders may collect missing runtime evidence.
+- `paper_probation`: bounded paper orders may validate a candidate after source evidence exists.
+- `capital_blocked`: evidence exists, but one or more capital blockers remain.
+- `capital_allowed`: all authority checks passed; capital promotion is allowed.
+
+Legacy fields `promotion_allowed`, `final_promotion_allowed`, and
+`final_promotion_authorized` are compatibility mirrors of
+`capital_promotion_allowed`. New code must not branch on them directly.
+```
+
+- [ ] **Step 4: Run API tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/test_trading_proofs_api.py tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/torghut/app/trading/revenue_repair_modules/evidence_summaries.py services/torghut/app/trading/proofs/targets.py docs/torghut/trading/promotion-authority.md services/torghut/tests/test_trading_proofs_api.py services/torghut/tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py
+git commit -m "docs(torghut): define promotion authority vocabulary"
+```
+
+---
+
+### Task 9: Full Validation And PR Rollout
+
+**Files:**
+- No new code files; validation only.
+
+- [ ] **Step 1: Run focused promotion authority tests**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest \
+  tests/trading/test_promotion_authority.py \
+  tests/test_promotion_authority_static_contract.py \
+  tests/submission_council/test_source_collection_candidates.py \
+  tests/submission_council/test_paper_probation_import_plan.py \
+  tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py \
+  tests/pipeline/test_trading_pipeline_probe_exits_b.py \
+  tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py \
+  tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py \
+  tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py \
+  tests/test_trading_proofs_api.py \
+  tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Python static checks**
+
+Run:
+
+```bash
+cd services/torghut
+uv sync --frozen --extra dev
+uv run --frozen ruff format --check app tests
+uv run --frozen ruff check app tests
+uv run --frozen pyright --project pyrightconfig.json
+uv run --frozen pyright --project pyrightconfig.alpha.json
+uv run --frozen pyright --project pyrightconfig.scripts.json
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Run full Torghut CI locally where practical**
+
+Run:
+
+```bash
+cd services/torghut
+uv run --frozen pytest tests/submission_council tests/simple_pipeline tests/pipeline tests/run_empirical_promotion_jobs tests/verify_trading_readiness -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Open PR**
+
+Run:
+
+```bash
+git status --short
+cp .github/PULL_REQUEST_TEMPLATE.md .codex-pr-torghut-promotion-authority.md
+```
+
+Fill `.codex-pr-torghut-promotion-authority.md` with:
+
+```markdown
+## Summary
+
+- adds canonical Torghut promotion authority state with `promotion_stage` and `capital_promotion_allowed`
+- centralizes legacy `promotion_allowed` / `final_promotion_allowed` compatibility projection
+- updates source collection, paper probation, runtime authority, target-plan, and scheduler consumers to use canonical authority semantics
+
+## Testing
+
+- `uv run --frozen pytest ...focused promotion authority suite... -q`
+- `uv run --frozen ruff format --check app tests`
+- `uv run --frozen ruff check app tests`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+
+## Rollout / Risk
+
+- Backward compatible: legacy booleans remain in payloads but are generated in one place.
+- Safety invariant: `capital_promotion_allowed` is the only true capital routing authority.
+- No direct Alpaca or cluster mutation in this PR.
+```
+
+Create PR:
+
+```bash
+gh pr create \
+  -R proompteng/lab \
+  --title "refactor(torghut): canonicalize promotion authority" \
+  --body-file .codex-pr-torghut-promotion-authority.md
+```
+
+- [ ] **Step 5: Wait for CI and merge**
+
+Run:
+
+```bash
+gh pr checks <PR_NUMBER> -R proompteng/lab --watch --interval 10
+gh pr merge <PR_NUMBER> --squash -R proompteng/lab
+```
+
+Expected: all required checks green before merge.
+
+- [ ] **Step 6: Let CI/CD build and promote**
+
+Watch build:
+
+```bash
+gh run list -R proompteng/lab --workflow torghut-build-push.yaml --limit 5
+```
+
+After build success, verify registry:
+
+```bash
+docker buildx imagetools inspect registry.ide-newton.ts.net/lab/torghut:<TAG> | rg 'Digest:|Platform:'
+```
+
+Expected: `linux/amd64` and `linux/arm64`.
+
+- [ ] **Step 7: Live acceptance after GitOps promotion**
+
+After promotion PR merges and Argo rolls out:
+
+```bash
+kubectl get ksvc -n torghut torghut -o jsonpath='{.status.latestReadyRevisionName}{"\n"}'
+kubectl get pods -n torghut --field-selector=status.phase!=Succeeded
+```
+
+Run endpoint readback against the latest ready revision:
+
+```bash
+POD=$(kubectl get pod -n torghut -l serving.knative.dev/revision=<LATEST_REVISION> -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -i -n torghut "$POD" -c user-container -- python - <<'PY'
+import json
+import urllib.request
+
+with urllib.request.urlopen("http://127.0.0.1:8181/trading/status", timeout=120) as response:
+    data = json.loads(response.read().decode())
+
+gate = data.get("live_submission_gate") or {}
+plan = gate.get("runtime_ledger_paper_probation_import_plan") or {}
+targets = plan.get("targets") or []
+first = targets[0] if targets else {}
+
+print(json.dumps({
+    "gate_allowed": gate.get("allowed"),
+    "gate_reason": gate.get("reason"),
+    "promotion_stage": first.get("promotion_stage"),
+    "capital_promotion_allowed": first.get("capital_promotion_allowed"),
+    "bounded_live_paper_collection_authorized": first.get("bounded_live_paper_collection_authorized"),
+    "legacy_promotion_allowed": first.get("promotion_allowed"),
+    "legacy_final_promotion_allowed": first.get("final_promotion_allowed"),
+}, indent=2, sort_keys=True))
+PY
+```
+
+Expected for source collection:
+
+```json
+{
+  "bounded_live_paper_collection_authorized": true,
+  "capital_promotion_allowed": false,
+  "legacy_final_promotion_allowed": false,
+  "legacy_promotion_allowed": false,
+  "promotion_stage": "source_collection"
+}
+```
+
+---
+
+## Done Criteria
+
+- `promotion_allowed` and `final_promotion_allowed` are compatibility mirrors only.
+- New production decisions branch on `capital_promotion_allowed` or `promotion_stage`.
+- Bounded source collection remains able to collect strategy evidence.
+- Capital promotion remains blocked unless canonical authority says `capital_promotion_allowed=true`.
+- Tests prove source collection, paper probation, capital blocked, and capital allowed states.
+- Static test prevents future reintroduction of direct legacy boolean literals.
+- CI green, image multi-arch, GitOps promotion merged, post-deploy verify passes.
+
+## Self-Review
+
+Spec coverage:
+
+- Removes confusing duplicate authority concepts by introducing canonical `PromotionAuthority`.
+- Preserves live safety and backward compatibility.
+- Keeps source collection enabled for strategy performance data.
+- Includes focused tests, static guard, full validation, and live acceptance.
+
+Placeholder scan:
+
+- No TBD/TODO placeholders.
+- Every task has exact files, commands, and expected outcomes.
+
+Type consistency:
+
+- Canonical fields are consistent across tasks: `promotion_stage`, `capital_promotion_allowed`, `promotion_blockers`.
+- Legacy fields are consistently projected by `PromotionAuthority.as_target_fields()`.

--- a/docs/torghut/promotion-authority.md
+++ b/docs/torghut/promotion-authority.md
@@ -1,0 +1,45 @@
+# Torghut Promotion Authority
+
+Torghut uses one production authority model for strategy target promotion:
+`app.trading.promotion_authority.PromotionAuthority`.
+
+The model separates data collection from capital authorization. A strategy can be
+eligible for source collection or paper probation without being eligible to route
+capital. Live capital submission must read `capital_promotion_allowed`, not an OR
+of legacy compatibility booleans.
+
+## Stages
+
+- `source_collection`: the target is allowed to collect source/runtime evidence.
+- `paper_probation`: the target has paper-probation authority but no capital
+  authority.
+- `capital_blocked`: the target is blocked from capital routing and must carry
+  blockers.
+- `capital_allowed`: the target is allowed to route capital. This is the only
+  stage where `capital_promotion_allowed=true`.
+
+## Runtime Contract
+
+Writers must build authority fields through one of these constructors:
+
+- `source_collection_authority(...)`
+- `paper_probation_authority(...)`
+- `capital_blocked_authority(...)`
+- `capital_allowed_authority()`
+
+Consumers that decide whether capital can route must use
+`target_capital_promotion_allowed(target)`.
+
+`promotion_allowed`, `final_promotion_allowed`, and
+`final_promotion_authorized` remain projected only for compatibility with older
+payloads and reports. New production checks must not combine those legacy fields.
+
+## Operational Meaning
+
+When Torghut is collecting strategy data, the expected state is usually
+`source_collection` or `paper_probation`. That is not a trading failure. It means
+the system is collecting evidence without routing capital.
+
+When Torghut is expected to trade, readiness evidence must show
+`promotion_stage=capital_allowed`, `capital_promotion_allowed=true`, and no
+`promotion_blockers`.

--- a/services/torghut/app/trading/completion_modules/effective_row_status.py
+++ b/services/torghut/app/trading/completion_modules/effective_row_status.py
@@ -13,6 +13,7 @@ from ...models import (
     VNextCompletionGateResult,
 )
 from ..empirical_jobs import build_empirical_jobs_status
+from ..promotion_authority import capital_blocked_authority
 
 
 from .runtime_matrix_path import (
@@ -319,11 +320,7 @@ def build_doc29_completion_status(
             str(gate_status_map.get(DOC29_PAPER_GATE, {}).get('status'))
             == TRACE_STATUS_SATISFIED
         ),
-        'capital_promotion_allowed': False,
-        'promotion_allowed': False,
-        'final_authority_ok': False,
-        'final_promotion_allowed': False,
-        'final_promotion_blockers': final_promotion_blockers,
+        **capital_blocked_authority(blockers=final_promotion_blockers).as_target_fields(),
         'completion_trace_all_satisfied': all_satisfied,
         'authority_source': 'completion_trace_status_only',
     }

--- a/services/torghut/app/trading/completion_modules/effective_row_status.py
+++ b/services/torghut/app/trading/completion_modules/effective_row_status.py
@@ -308,6 +308,7 @@ def build_doc29_completion_status(
     if all_satisfied:
         final_promotion_blockers.append('completion_trace_not_runtime_ledger_authority')
     promotion_authority = {
+        **capital_blocked_authority(blockers=final_promotion_blockers).as_target_fields(),
         'evidence_collection_ok': (
             str(gate_status_map.get(DOC29_LIVE_CANARY_GATE, {}).get('status'))
             == TRACE_STATUS_SATISFIED
@@ -320,7 +321,6 @@ def build_doc29_completion_status(
             str(gate_status_map.get(DOC29_PAPER_GATE, {}).get('status'))
             == TRACE_STATUS_SATISFIED
         ),
-        **capital_blocked_authority(blockers=final_promotion_blockers).as_target_fields(),
         'completion_trace_all_satisfied': all_satisfied,
         'authority_source': 'completion_trace_status_only',
     }

--- a/services/torghut/app/trading/paper_route_target_plan_modules/materialization.py
+++ b/services/torghut/app/trading/paper_route_target_plan_modules/materialization.py
@@ -14,6 +14,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ...models import Strategy, TradeDecision, coerce_json_payload
+from ..promotion_authority import (
+    capital_blocked_authority,
+    source_collection_authority,
+)
 from ..runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
     source_decision_mode_is_profit_proof_eligible,
@@ -220,9 +224,7 @@ def _blocked_target_readiness(blockers: Sequence[str]) -> dict[str, Any]:
         "state": "blocked",
         "blockers": list(blockers),
         "next_operator_action": next_action,
-        "promotion_allowed": False,
-        "final_authority_ok": False,
-        "final_promotion_allowed": False,
+        **capital_blocked_authority(blockers=blockers).as_target_fields(),
     }
 
 
@@ -365,13 +367,10 @@ def _paper_route_decision_payload(
         "bounded_evidence_collection_authorized": True,
         "bounded_live_paper_collection_authorized": True,
         "canary_collection_authorized": True,
-        "evidence_collection_ok": True,
         "bounded_evidence_collection_scope": "paper_route_probe_next_session_only",
-        "capital_promotion_allowed": False,
-        "promotion_allowed": False,
-        "final_authority_ok": False,
-        "final_promotion_authorized": False,
-        "final_promotion_allowed": False,
+        **source_collection_authority(
+            blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+        ).as_target_fields(),
         "live_capital_routing_enabled": False,
         "account_stage_runtime_identity": {
             "account_label": identity.get("account_label"),
@@ -467,14 +466,9 @@ def _paper_route_decision_payload(
                 "client_order_id",
             ],
         },
-        "capital_promotion_allowed": False,
-        "promotion_allowed": False,
-        "final_authority_ok": False,
-        "final_promotion_authorized": False,
-        "final_promotion_allowed": False,
-        "final_promotion_blockers": list(
-            PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS
-        ),
+        **source_collection_authority(
+            blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+        ).as_target_fields(),
         "live_capital_routing_enabled": False,
         "route_submission_enabled": True,
         "params": {
@@ -497,10 +491,9 @@ def _paper_route_decision_payload(
             "target_quantity_source": quantity_source,
             "target_notional_sizing_required": target_notional_sizing_required,
             "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
-            "promotion_allowed": False,
-            "final_authority_ok": False,
-            "final_promotion_authorized": False,
-            "final_promotion_allowed": False,
+            **source_collection_authority(
+                blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+            ).as_target_fields(),
             "live_capital_routing_enabled": False,
             "route_submission_enabled": True,
         },
@@ -702,9 +695,9 @@ def _materialize_target_symbol(
             "target_notional": decimal_text(item.target_notional),
             "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
             "target_identity": item.identity,
-            "promotion_allowed": False,
-            "final_authority_ok": False,
-            "final_promotion_authorized": False,
+            **source_collection_authority(
+                blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+            ).as_target_fields(),
             "live_capital_routing_enabled": False,
         }
     )
@@ -796,11 +789,9 @@ def _materialization_result(
         ),
         "decisions": state.materialized_decisions,
         "route_submissions": state.route_submissions,
-        "capital_promotion_allowed": False,
-        "promotion_allowed": False,
-        "final_authority_ok": False,
-        "final_promotion_authorized": False,
-        "final_promotion_allowed": False,
+        **source_collection_authority(
+            blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+        ).as_target_fields(),
         "live_capital_routing_enabled": False,
         "blocked_targets": state.blocked_targets,
     }

--- a/services/torghut/app/trading/paper_route_target_plan_modules/target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan_modules/target_plan.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 from urllib.parse import SplitResult, urlsplit
 
 from ...config import settings
+from ..promotion_authority import capital_blocked_authority
 
 
 PAPER_ROUTE_MATERIALIZATION_SCHEMA_VERSION = (
@@ -69,9 +70,10 @@ def _target_plan_from_proofs_payload(payload: Mapping[str, Any]) -> dict[str, An
         target = _target_from_proof_identity(proof)
         if not target:
             continue
-        target.setdefault("promotion_allowed", False)
-        target.setdefault("final_promotion_allowed", False)
-        target.setdefault("final_promotion_authorized", False)
+        for key, value in capital_blocked_authority(
+            blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+        ).as_target_fields().items():
+            target.setdefault(key, value)
         targets.append(target)
     if not targets:
         return {}
@@ -79,8 +81,9 @@ def _target_plan_from_proofs_payload(payload: Mapping[str, Any]) -> dict[str, An
         "schema_version": "torghut.paper-route-target-plan.v1",
         "source": "trading_proofs_endpoint",
         "purpose": "runtime_window_proof_target_materialization",
-        "promotion_allowed": False,
-        "final_promotion_allowed": False,
+        **capital_blocked_authority(
+            blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+        ).as_target_fields(),
         "target_count": len(targets),
         "targets": targets,
     }

--- a/services/torghut/app/trading/paper_route_target_plan_modules/target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan_modules/target_plan.py
@@ -70,9 +70,13 @@ def _target_plan_from_proofs_payload(payload: Mapping[str, Any]) -> dict[str, An
         target = _target_from_proof_identity(proof)
         if not target:
             continue
-        for key, value in capital_blocked_authority(
-            blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
-        ).as_target_fields().items():
+        for key, value in (
+            capital_blocked_authority(
+                blockers=PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS,
+            )
+            .as_target_fields()
+            .items()
+        ):
             target.setdefault(key, value)
         targets.append(target)
     if not targets:

--- a/services/torghut/app/trading/promotion_authority.py
+++ b/services/torghut/app/trading/promotion_authority.py
@@ -1,0 +1,128 @@
+"""Canonical promotion authority state for Torghut trading targets."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+PROMOTION_AUTHORITY_SCHEMA_VERSION = "torghut.promotion-authority.v1"
+
+
+class PromotionStage(StrEnum):
+    SOURCE_COLLECTION = "source_collection"
+    PAPER_PROBATION = "paper_probation"
+    CAPITAL_BLOCKED = "capital_blocked"
+    CAPITAL_ALLOWED = "capital_allowed"
+
+
+@dataclass(frozen=True)
+class PromotionAuthority:
+    stage: PromotionStage
+    capital_promotion_allowed: bool
+    blockers: tuple[str, ...] = ()
+    source_collection_authorized: bool = False
+    paper_probation_authorized: bool = False
+    bounded_live_paper_collection_authorized: bool = False
+    evidence_collection_ok: bool = False
+
+    @property
+    def final_authority_ok(self) -> bool:
+        return self.capital_promotion_allowed and not self.blockers
+
+    def as_target_fields(self) -> dict[str, object]:
+        capital_allowed = self.final_authority_ok
+        blockers = list(dict.fromkeys(self.blockers))
+        return {
+            "promotion_authority_schema_version": PROMOTION_AUTHORITY_SCHEMA_VERSION,
+            "promotion_stage": self.stage.value,
+            "source_collection_authorized": self.source_collection_authorized,
+            "paper_probation_authorized": self.paper_probation_authorized,
+            "bounded_live_paper_collection_authorized": (
+                self.bounded_live_paper_collection_authorized
+            ),
+            "evidence_collection_ok": self.evidence_collection_ok,
+            "capital_promotion_allowed": capital_allowed,
+            "final_authority_ok": capital_allowed,
+            "promotion_blockers": blockers,
+            "final_promotion_blockers": blockers,
+            "runtime_ledger_target_metadata_blockers": blockers,
+            "promotion_allowed": capital_allowed,
+            "final_promotion_allowed": capital_allowed,
+            "final_promotion_authorized": capital_allowed,
+        }
+
+
+def _blockers(values: Sequence[str] | None) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    return tuple(str(value).strip() for value in values if str(value).strip())
+
+
+def source_collection_authority(
+    *,
+    blockers: Sequence[str] | None,
+    bounded_live_paper_collection_authorized: bool = True,
+) -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.SOURCE_COLLECTION,
+        capital_promotion_allowed=False,
+        blockers=_blockers(blockers),
+        source_collection_authorized=True,
+        bounded_live_paper_collection_authorized=bounded_live_paper_collection_authorized,
+        evidence_collection_ok=True,
+    )
+
+
+def paper_probation_authority(
+    *,
+    blockers: Sequence[str] | None,
+    bounded_live_paper_collection_authorized: bool = True,
+) -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.PAPER_PROBATION,
+        capital_promotion_allowed=False,
+        blockers=_blockers(blockers),
+        paper_probation_authorized=True,
+        bounded_live_paper_collection_authorized=bounded_live_paper_collection_authorized,
+        evidence_collection_ok=True,
+    )
+
+
+def capital_blocked_authority(
+    *,
+    blockers: Sequence[str] | None,
+) -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.CAPITAL_BLOCKED,
+        capital_promotion_allowed=False,
+        blockers=_blockers(blockers),
+    )
+
+
+def capital_allowed_authority() -> PromotionAuthority:
+    return PromotionAuthority(
+        stage=PromotionStage.CAPITAL_ALLOWED,
+        capital_promotion_allowed=True,
+        blockers=(),
+    )
+
+
+def target_capital_promotion_allowed(target: Mapping[str, Any]) -> bool:
+    return target.get("capital_promotion_allowed") is True
+
+
+def target_promotion_stage(target: Mapping[str, Any]) -> PromotionStage:
+    raw = str(target.get("promotion_stage") or "").strip()
+    try:
+        return PromotionStage(raw)
+    except ValueError:
+        if target_capital_promotion_allowed(target):
+            return PromotionStage.CAPITAL_ALLOWED
+        if bool(target.get("source_collection_authorized")):
+            return PromotionStage.SOURCE_COLLECTION
+        if bool(target.get("paper_probation_authorized")):
+            return PromotionStage.PAPER_PROBATION
+        return PromotionStage.CAPITAL_BLOCKED

--- a/services/torghut/app/trading/proofs/targets.py
+++ b/services/torghut/app/trading/proofs/targets.py
@@ -8,6 +8,7 @@ from datetime import datetime, time, timedelta, timezone
 from typing import Any, cast
 from zoneinfo import ZoneInfo
 
+from ..promotion_authority import capital_blocked_authority
 from ..session_context import is_regular_equities_session_date
 from .schemas import PROOFS_RUNTIME_ACCOUNT_LABEL, ProofWindowSelector
 
@@ -67,9 +68,9 @@ class ProofTarget:
                 "symbols": list(self.symbols),
                 "paper_route_probe_symbol_actions": self.symbol_actions,
                 "paper_route_probe_symbol_quantities": self.symbol_quantities,
-                "promotion_allowed": False,
-                "final_promotion_allowed": False,
-                "final_promotion_authorized": False,
+                **capital_blocked_authority(
+                    blockers=["proof_target_not_runtime_capital_authority"],
+                ).as_target_fields(),
             }
         )
         return {key: value for key, value in payload.items() if value is not None}

--- a/services/torghut/app/trading/revenue_repair_modules/evidence_summaries.py
+++ b/services/torghut/app/trading/revenue_repair_modules/evidence_summaries.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence, cast
 
+from ..promotion_authority import (
+    capital_blocked_authority,
+    target_capital_promotion_allowed,
+    target_promotion_stage,
+)
 from .repair_queue import (
     bool_value,
     choose_mapping,
@@ -157,6 +162,9 @@ def _is_source_collection_target(target: Mapping[str, Any]) -> bool:
 def _summarize_runtime_window_import_target(
     target: Mapping[str, Any],
 ) -> dict[str, object]:
+    promotion_blockers = _string_items(
+        target.get("promotion_blockers")
+    ) or _string_items(target.get("final_promotion_blockers"))
     payload: dict[str, object] = {
         "hypothesis_id": _text(target.get("hypothesis_id")),
         "candidate_id": _text(target.get("candidate_id")),
@@ -181,13 +189,16 @@ def _summarize_runtime_window_import_target(
         "handoff": _text(target.get("handoff")),
         "probation_reason": _text(target.get("probation_reason")),
         "max_notional": _text(target.get("max_notional"), "0"),
-        "promotion_allowed": False,
-        "final_promotion_allowed": False,
-        "final_promotion_authorized": False,
-        "final_authority_ok": False,
-        "final_promotion_blockers": _string_items(
-            target.get("final_promotion_blockers")
+        "promotion_stage": target_promotion_stage(target).value,
+        "capital_promotion_allowed": target_capital_promotion_allowed(target),
+        "promotion_blockers": promotion_blockers,
+        "legacy_promotion_allowed": _bool(target.get("promotion_allowed")),
+        "legacy_final_promotion_allowed": _bool(target.get("final_promotion_allowed")),
+        "legacy_final_promotion_authorized": _bool(
+            target.get("final_promotion_authorized")
         ),
+        "final_authority_ok": _bool(target.get("final_authority_ok")),
+        "final_promotion_blockers": promotion_blockers,
         "candidate_blockers": _string_items(target.get("candidate_blockers")),
         "source_collection_reason_codes": _string_items(
             target.get("source_collection_reason_codes")
@@ -222,10 +233,9 @@ def _summarize_runtime_window_import_repair(
             "skipped_target_count": 0,
             "blocked_reasons": blocked_reasons,
             "top_targets": [],
-            "promotion_allowed": False,
-            "final_promotion_allowed": False,
-            "final_promotion_authorized": False,
-            "final_authority_ok": False,
+            **capital_blocked_authority(
+                blockers=["runtime_ledger_source_collection_plan_missing"],
+            ).as_target_fields(),
         }
 
     raw_targets = _mapping_items(plan.get("targets"))
@@ -286,10 +296,9 @@ def _summarize_runtime_window_import_repair(
             }
             for target in skipped_targets[:5]
         ],
-        "promotion_allowed": False,
-        "final_promotion_allowed": False,
-        "final_promotion_authorized": False,
-        "final_authority_ok": False,
+        **capital_blocked_authority(
+            blockers=["runtime_ledger_source_collection_pending"],
+        ).as_target_fields(),
     }
 
 

--- a/services/torghut/app/trading/revenue_repair_modules/evidence_summaries.py
+++ b/services/torghut/app/trading/revenue_repair_modules/evidence_summaries.py
@@ -192,6 +192,9 @@ def _summarize_runtime_window_import_target(
         "promotion_stage": target_promotion_stage(target).value,
         "capital_promotion_allowed": target_capital_promotion_allowed(target),
         "promotion_blockers": promotion_blockers,
+        "promotion_allowed": _bool(target.get("promotion_allowed")),
+        "final_promotion_allowed": _bool(target.get("final_promotion_allowed")),
+        "final_promotion_authorized": _bool(target.get("final_promotion_authorized")),
         "legacy_promotion_allowed": _bool(target.get("promotion_allowed")),
         "legacy_final_promotion_allowed": _bool(target.get("final_promotion_allowed")),
         "legacy_final_promotion_authorized": _bool(

--- a/services/torghut/app/trading/runtime_authority_verifier_modules/shared_context.py
+++ b/services/torghut/app/trading/runtime_authority_verifier_modules/shared_context.py
@@ -44,6 +44,10 @@ from app.trading.runtime_ledger_source_authority import (
     runtime_ledger_promotion_source_authority_blockers,
     runtime_ledger_source_window_present,
 )
+from app.trading.promotion_authority import (
+    capital_allowed_authority,
+    capital_blocked_authority,
+)
 
 
 DEFAULT_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
@@ -420,6 +424,11 @@ def build_runtime_authority_report(
         evidence_read_error=evidence_read_error,
     )
     final_authority_ok = not blockers
+    authority = (
+        capital_allowed_authority()
+        if final_authority_ok
+        else capital_blocked_authority(blockers=blockers)
+    )
     return {
         "schema_version": HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION,
         "mode": proof_mode,
@@ -429,9 +438,7 @@ def build_runtime_authority_report(
             "synthetic_or_replay_only_authority_allowed": False,
         },
         "authority_allowed": final_authority_ok,
-        "promotion_allowed": final_authority_ok,
-        "capital_promotion_allowed": final_authority_ok,
-        "final_authority_ok": final_authority_ok,
+        **authority.as_target_fields(),
         "identity": {
             "hypothesis_id": hypothesis_id,
             "candidate_id": candidate_id,

--- a/services/torghut/app/trading/runtime_window_import_modules/common.py
+++ b/services/torghut/app/trading/runtime_window_import_modules/common.py
@@ -15,6 +15,7 @@ from ...models import (
 from ..hypotheses import (
     HypothesisManifest,
 )
+from ..promotion_authority import target_capital_promotion_allowed
 from ..runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
 from ..runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
@@ -58,10 +59,8 @@ _RUNTIME_LEDGER_PROOF_SATISFIED_METADATA_BLOCKERS = frozenset(
 
 RUNTIME_WINDOW_IMPORT_CAPITAL_ONLY_BLOCKERS = frozenset(
     {
-        "candidate_board_promotion_not_allowed",
+        "capital_promotion_not_allowed",
         "drift_checks_not_ok",
-        "final_promotion_not_authorized",
-        "final_promotion_not_allowed",
         "live_runtime_ledger_required",
         "paper_probation_evidence_collection_only",
         "paper_stage_evidence_collection_only",
@@ -674,10 +673,6 @@ def paper_probation_blocking_reasons(runtime_payload: Mapping[str, Any]) -> list
     )
     if paper_probation_authorized is True and evidence_collection_stage == "paper":
         reasons.append("paper_probation_evidence_collection_only")
-    if observation_bool(target_metadata.get("promotion_allowed")) is False:
-        reasons.append("candidate_board_promotion_not_allowed")
-    if observation_bool(target_metadata.get("final_promotion_authorized")) is False:
-        reasons.append("final_promotion_not_authorized")
-    if observation_bool(target_metadata.get("final_promotion_allowed")) is False:
-        reasons.append("final_promotion_not_allowed")
+    if not target_capital_promotion_allowed(target_metadata):
+        reasons.append("capital_promotion_not_allowed")
     return list(dict.fromkeys(reasons))

--- a/services/torghut/app/trading/runtime_window_import_modules/persistence_materialization.py
+++ b/services/torghut/app/trading/runtime_window_import_modules/persistence_materialization.py
@@ -41,6 +41,10 @@ from .persistence_types import (
     PersistedRows,
     PersistencePlan,
 )
+from ..promotion_authority import (
+    capital_allowed_authority,
+    capital_blocked_authority,
+)
 
 
 def runtime_materialization_target(
@@ -50,6 +54,13 @@ def runtime_materialization_target(
     evidence_blocking_reasons: Sequence[str],
     promotion_allowed: bool,
 ) -> dict[str, Any]:
+    authority = (
+        capital_allowed_authority()
+        if promotion_allowed
+        else capital_blocked_authority(
+            blockers=plan.promotion.promotion_blocking_reasons
+        )
+    )
     return {
         "candidate_id": plan.request.candidate_id,
         "hypothesis_id": plan.request.hypothesis_id,
@@ -75,7 +86,7 @@ def runtime_materialization_target(
         "proof_status": proof_status,
         "proof_blockers": list(proof_blockers),
         "evidence_blocking_reasons": list(evidence_blocking_reasons),
-        "capital_promotion_allowed": promotion_allowed,
+        **authority.as_target_fields(),
         "capital_promotion_blocking_reasons": plan.promotion.promotion_blocking_reasons,
     }
 
@@ -251,6 +262,14 @@ def _final_capital_stage(plan: PersistencePlan) -> str:
     )
 
 
+def _promotion_authority_fields(plan: PersistencePlan) -> dict[str, object]:
+    if plan.promotion.promotion_allowed:
+        return capital_allowed_authority().as_target_fields()
+    return capital_blocked_authority(
+        blockers=plan.promotion.promotion_blocking_reasons
+    ).as_target_fields()
+
+
 def _add_capital_allocation(plan: PersistencePlan, final_capital_stage: str) -> None:
     plan.request.session.add(
         StrategyCapitalAllocation(
@@ -270,7 +289,7 @@ def _capital_allocation_payload(plan: PersistencePlan) -> dict[str, Any]:
     return {
         **_summary_payload(plan),
         **plan.metrics.runtime_ledger_daily_summary,
-        "promotion_allowed": plan.promotion.promotion_allowed,
+        **_promotion_authority_fields(plan),
         "promotion_blocking_reasons": plan.promotion.promotion_blocking_reasons,
         "evidence_blocking_reasons": plan.promotion.evidence_blocking_reasons,
         "delay_adjusted_depth_stress": plan.context.delay_depth_stress_summary,
@@ -285,7 +304,7 @@ def _promotion_decision_payload(plan: PersistencePlan) -> dict[str, Any]:
         "avg_post_cost_expectancy_bps": str(plan.metrics.average_post_cost),
         **plan.metrics.runtime_ledger_daily_summary,
         "latest_three_within_budget": plan.metrics.latest_three_budget_ok,
-        "promotion_allowed": plan.promotion.promotion_allowed,
+        **_promotion_authority_fields(plan),
         "promotion_blocking_reasons": plan.promotion.promotion_blocking_reasons,
         "evidence_blocking_reasons": plan.promotion.evidence_blocking_reasons,
         "delay_adjusted_depth_stress": plan.context.delay_depth_stress_summary,
@@ -587,7 +606,7 @@ def final_summary(
         **plan.metrics.runtime_ledger_daily_summary,
         "latest_three_within_budget": plan.metrics.latest_three_budget_ok,
         "slippage_budget_bps": str(plan.context.budget),
-        "promotion_allowed": plan.promotion.promotion_allowed,
+        **_promotion_authority_fields(plan),
         "promotion_blocking_reasons": plan.promotion.promotion_blocking_reasons,
         "evidence_blocking_reasons": plan.promotion.evidence_blocking_reasons,
         "proof_status": plan.promotion.proof_status,

--- a/services/torghut/app/trading/scheduler/paper_route_materialization.py
+++ b/services/torghut/app/trading/scheduler/paper_route_materialization.py
@@ -17,6 +17,7 @@ from ...models import (
     TradeDecision,
 )
 from ..models import StrategyDecision
+from ..promotion_authority import source_collection_authority
 from ..runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
 )
@@ -201,10 +202,14 @@ class SimplePipelinePaperRouteMaterializationMixin(
         )
         target.setdefault("observed_stage", "paper")
         target.setdefault("bounded_collection_stage", "bounded_paper_collection")
-        target.setdefault("promotion_allowed", False)
-        target.setdefault("final_authority_ok", False)
-        target.setdefault("final_promotion_authorized", False)
-        target.setdefault("final_promotion_allowed", False)
+        for key, value in (
+            source_collection_authority(
+                blockers=["paper_route_runtime_ledger_import_pending"],
+            )
+            .as_target_fields()
+            .items()
+        ):
+            target.setdefault(key, value)
         target.setdefault("live_capital_routing_enabled", False)
         if target.get("paper_route_probe_window_start") is None:
             target["paper_route_probe_window_start"] = target.get(
@@ -356,10 +361,9 @@ class SimplePipelinePaperRouteMaterializationMixin(
             "paper_route_probe_symbols": metadata.get("paper_route_probe_symbols"),
             "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
             "bounded_collection_stage": "bounded_paper_collection",
-            "promotion_allowed": False,
-            "final_promotion_authorized": False,
-            "final_authority_ok": False,
-            "final_promotion_allowed": False,
+            **source_collection_authority(
+                blockers=["paper_route_runtime_ledger_import_pending"],
+            ).as_target_fields(),
             "live_capital_routing_enabled": False,
             **execution_metadata,
             "bounded_paper_route_submit_path": execution_metadata["submit_path"],

--- a/services/torghut/app/trading/scheduler/source_collection_modules/decision_helpers.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/decision_helpers.py
@@ -11,6 +11,7 @@ from typing import Any, Protocol, cast
 from sqlalchemy.orm import Session
 
 from ....config import settings
+from ...promotion_authority import source_collection_authority
 from ...runtime_decision_authority import source_decision_mode_is_profit_proof_eligible
 from ..target_plan_helpers_modules import (
     PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON as _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON,
@@ -243,10 +244,9 @@ def source_collection_params(
         "paper_route_probe_symbols": metadata.get("paper_route_probe_symbols"),
         "observed_stage": _safe_text(context.target.get("observed_stage")) or "paper",
         "bounded_collection_stage": "bounded_paper_collection",
-        "promotion_allowed": False,
-        "final_promotion_authorized": False,
-        "final_authority_ok": False,
-        "final_promotion_allowed": False,
+        **source_collection_authority(
+            blockers=["runtime_ledger_source_collection_pending"],
+        ).as_target_fields(),
         "live_capital_routing_enabled": False,
         **mode.execution_metadata,
         **source_collection_bounded_execution_params(mode.execution_metadata),

--- a/services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/decision_lineage.py
@@ -10,6 +10,7 @@ from ....models import (
     Strategy,
 )
 from ...models import StrategyDecision
+from ...promotion_authority import paper_probation_authority
 from ...runtime_decision_authority import (
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
     STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
@@ -307,11 +308,9 @@ class SimplePipelineSourceCollectionLineageMixin(SourceCollectionRuntimeMixin):
             "profit_proof_eligible": True,
             "paper_route_target_plan_source": "external_target_plan_url",
             "paper_route_probe_scope_authority": "external_target_plan",
-            "paper_probation_authorized": True,
-            "promotion_allowed": False,
-            "final_promotion_authorized": False,
-            "final_authority_ok": False,
-            "final_promotion_allowed": False,
+            **paper_probation_authority(
+                blockers=["live_runtime_ledger_required"],
+            ).as_target_fields(),
             **lineage,
         }
         if strategy is not None:
@@ -438,9 +437,14 @@ class SimplePipelineSourceCollectionLineageMixin(SourceCollectionRuntimeMixin):
             params["strategy_signal_paper"] = metadata
             params["source_decision_mode"] = STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE
             params["profit_proof_eligible"] = True
-            params.setdefault("promotion_allowed", False)
-            params.setdefault("final_promotion_authorized", False)
-            params.setdefault("final_promotion_allowed", False)
+            for key, value in (
+                paper_probation_authority(
+                    blockers=["live_runtime_ledger_required"],
+                )
+                .as_target_fields()
+                .items()
+            ):
+                params.setdefault(key, value)
             if "exit_minute_after_open" in metadata:
                 params.setdefault(
                     "exit_minute_after_open",

--- a/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
+++ b/services/torghut/app/trading/scheduler/source_collection_modules/target_plan_fetch.py
@@ -20,6 +20,11 @@ from ...paper_route_target_plan import (
     paper_route_target_plan_probe_symbols,
     paper_route_target_plan_targets,
 )
+from ...promotion_authority import (
+    capital_blocked_authority,
+    source_collection_authority,
+    target_capital_promotion_allowed,
+)
 from ...runtime_decision_authority import (
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
 )
@@ -668,10 +673,12 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
                 or "paper_route_probe_next_session_only"
             ),
             "bounded_evidence_collection_max_notional": str(context.target_cap),
-            "promotion_allowed": False,
-            "final_promotion_authorized": False,
-            "final_authority_ok": False,
-            "final_promotion_allowed": False,
+            **source_collection_authority(
+                blockers=["runtime_ledger_source_collection_pending"],
+                bounded_live_paper_collection_authorized=(
+                    bounded_collection_authorized
+                ),
+            ).as_target_fields(),
             **lineage,
         }
         for key in (
@@ -754,7 +761,7 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
             or target_account_label
         )
         source_account_label = _safe_text(target.get("source_account_label"))
-        execution_policy = {
+        execution_policy: dict[str, Any] = {
             "schema_version": "torghut.bounded-paper-route-execution-policy.v1",
             "authority": "bounded_paper_route_collection_only",
             "live_capital_routing_enabled": False,
@@ -773,6 +780,14 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
                 "client_order_id",
             ],
         }
+        if "promotion_stage" not in execution_policy:
+            execution_policy.update(
+                capital_blocked_authority(
+                    blockers=["execution_policy_not_capital_promotion_authority"],
+                ).as_target_fields()
+            )
+        if target_capital_promotion_allowed(execution_policy):
+            execution_policy["promotion_stage"] = "capital_allowed"
         return {
             "execution_lane": "simple",
             "submit_path": "bounded_paper_route_collection",

--- a/services/torghut/app/trading/scheduler/submission_preparation_modules/quote_routeability.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation_modules/quote_routeability.py
@@ -11,6 +11,7 @@ from ....models import (
     TradeDecision,
 )
 from ...models import StrategyDecision
+from ...promotion_authority import capital_blocked_authority
 from ...prices import MarketSnapshot
 from ...quote_quality import (
     QuoteQualityStatus,
@@ -246,9 +247,9 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
                 if status.valid
                 else status.operator_next_action or "refresh_source_snapshot"
             ),
-            "promotion_allowed": False,
-            "final_authority_ok": False,
-            "final_promotion_allowed": False,
+            **capital_blocked_authority(
+                blockers=["quote_routeability_not_capital_promotion_authority"],
+            ).as_target_fields(),
             "readiness": {
                 "schema_version": "torghut.paper-route-fillability-readiness.v1",
                 "state": "ready" if status.valid else "blocked",
@@ -256,8 +257,9 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
                 "next_operator_action": status.operator_next_action,
                 "repair_action": status.repair_action,
                 "evidence_requirements": list(status.evidence_requirements),
-                "promotion_allowed": False,
-                "final_authority_ok": False,
+                **capital_blocked_authority(
+                    blockers=["quote_routeability_not_capital_promotion_authority"],
+                ).as_target_fields(),
             },
             "target_plan_source_mismatch": dict(request.target_mismatch)
             if request.target_mismatch is not None

--- a/services/torghut/app/trading/scheduler/target_plan_helpers_modules/bounded_collection.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers_modules/bounded_collection.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from typing import Any, Literal, TypeAlias, cast
 
 
+from ...promotion_authority import target_capital_promotion_allowed
 from ...runtime_strategy_resolution import strategy_names_from_strategy_id
 
 
@@ -471,12 +472,7 @@ def _bounded_sim_collection_authorization_blockers(
     if not _target_truthy(target.get("evidence_collection_ok")):
         blockers.append("bounded_sim_collection_evidence_collection_not_ready")
     blockers.extend(_bounded_sim_collection_account_audit_blockers(target))
-    if (
-        _target_truthy(target.get("promotion_allowed"))
-        or _target_truthy(target.get("final_promotion_allowed"))
-        or _target_truthy(target.get("final_promotion_authorized"))
-        or _target_truthy(target.get("capital_promotion_allowed"))
-    ):
+    if target_capital_promotion_allowed(target):
         blockers.append("bounded_sim_collection_non_final_state_required")
     if _safe_text(target.get("bounded_evidence_collection_scope")) not in {
         None,

--- a/services/torghut/app/trading/submission_council_modules/import_plan.py
+++ b/services/torghut/app/trading/submission_council_modules/import_plan.py
@@ -6,6 +6,12 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
+from app.trading.promotion_authority import (
+    capital_blocked_authority,
+    paper_probation_authority,
+    source_collection_authority,
+)
+
 from .common import (
     bounded_paper_route_probe_collection_payload as _bounded_paper_route_probe_collection_payload,
     derived_strategy_name_from_strategy_id,
@@ -302,6 +308,17 @@ def _runtime_ledger_base_import_target(
     bounded_probe_authorized = bool(
         bounded_probe_payload.get("bounded_evidence_collection_authorized")
     )
+    authority = (
+        source_collection_authority(
+            blockers=candidate.final_blockers,
+            bounded_live_paper_collection_authorized=bounded_probe_authorized,
+        )
+        if candidate.source_collection
+        else paper_probation_authority(
+            blockers=candidate.final_blockers,
+            bounded_live_paper_collection_authorized=bounded_probe_authorized,
+        )
+    )
     return {
         "hypothesis_id": candidate.hypothesis_id,
         "candidate_id": candidate.candidate_id,
@@ -327,14 +344,12 @@ def _runtime_ledger_base_import_target(
         "source_kind": candidate.source_kind,
         "window_start": candidate.window_start,
         "window_end": candidate.window_end,
-        "paper_probation_authorized": candidate.paper_probation_satisfied,
         "paper_probation_authorization_scope": (
             "evidence_collection_only" if candidate.paper_probation_satisfied else ""
         ),
         "paper_probation_satisfied_for_bounded_live_paper_collection": (
             candidate.paper_probation_satisfied
         ),
-        "source_collection_authorized": candidate.source_collection,
         "source_collection_authorization_scope": (
             "source_window_evidence_collection_only"
             if candidate.source_collection
@@ -342,21 +357,13 @@ def _runtime_ledger_base_import_target(
         ),
         "source_collection_reason_codes": _source_collection_reason_codes(candidate),
         "proof_mode": "probation",
-        "evidence_collection_ok": True,
         "canary_collection_authorized": candidate.paper_probation_satisfied,
-        "bounded_live_paper_collection_authorized": bounded_probe_authorized,
+        **authority.as_target_fields(),
         **bounded_probe_payload,
-        "capital_promotion_allowed": False,
-        "final_authority_ok": False,
         "evidence_collection_stage": "paper",
         "probation_allowed": candidate.paper_probation_satisfied,
         "probation_reason": _runtime_ledger_import_probation_reason(candidate),
-        "promotion_allowed": False,
-        "final_promotion_authorized": False,
-        "final_promotion_allowed": False,
-        "final_promotion_blockers": candidate.final_blockers,
         "candidate_blockers": _candidate_reason_codes(candidate),
-        "runtime_ledger_target_metadata_blockers": candidate.final_blockers,
         "handoff": _runtime_ledger_import_handoff(candidate),
         "promotion_gate": "runtime_ledger_live_or_live_paper_required",
         "selected_by": _runtime_ledger_import_selector(candidate),
@@ -483,12 +490,39 @@ def _runtime_ledger_import_plan_payload(
     targets: Sequence[Mapping[str, object]],
     skipped_targets: Sequence[Mapping[str, object]],
 ) -> dict[str, object]:
+    paper_probation_target_count = sum(
+        1 for target in targets if bool(target.get("paper_probation_authorized"))
+    )
+    source_collection_target_count = sum(
+        1 for target in targets if bool(target.get("source_collection_authorized"))
+    )
+    bounded_live_paper_collection_authorized = any(
+        bool(target.get("bounded_live_paper_collection_authorized"))
+        for target in targets
+    )
+    if source_collection_target_count:
+        authority = source_collection_authority(
+            blockers=list(_RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS),
+            bounded_live_paper_collection_authorized=(
+                bounded_live_paper_collection_authorized
+            ),
+        )
+    elif paper_probation_target_count:
+        authority = paper_probation_authority(
+            blockers=list(_RUNTIME_LEDGER_PAPER_PROBATION_PROMOTION_BLOCKERS),
+            bounded_live_paper_collection_authorized=(
+                bounded_live_paper_collection_authorized
+            ),
+        )
+    else:
+        authority = capital_blocked_authority(
+            blockers=["runtime_ledger_paper_probation_import_targets_missing"],
+        )
     return {
         "schema_version": _RUNTIME_LEDGER_PAPER_PROBATION_IMPORT_SCHEMA_VERSION,
         "source": "runtime_ledger_paper_probation_and_source_collection_candidates",
         "purpose": "paper_stage_runtime_ledger_source_evidence_collection",
         "proof_mode": "probation",
-        "evidence_collection_ok": bool(targets),
         "paper_probation_satisfied_for_bounded_live_paper_collection": any(
             bool(
                 target.get(
@@ -500,22 +534,10 @@ def _runtime_ledger_import_plan_payload(
         "canary_collection_authorized": any(
             bool(target.get("canary_collection_authorized")) for target in targets
         ),
-        "bounded_live_paper_collection_authorized": any(
-            bool(target.get("bounded_live_paper_collection_authorized"))
-            for target in targets
-        ),
-        "capital_promotion_allowed": False,
-        "final_authority_ok": False,
-        "promotion_allowed": False,
-        "final_promotion_authorized": False,
-        "final_promotion_allowed": False,
+        **authority.as_target_fields(),
         "target_count": len(targets),
-        "paper_probation_target_count": sum(
-            1 for target in targets if bool(target.get("paper_probation_authorized"))
-        ),
-        "source_collection_target_count": sum(
-            1 for target in targets if bool(target.get("source_collection_authorized"))
-        ),
+        "paper_probation_target_count": paper_probation_target_count,
+        "source_collection_target_count": source_collection_target_count,
         "source_collection_profit_target_count": sum(
             1
             for target in targets
@@ -625,10 +647,8 @@ def _bounded_paper_route_manifest_collection_targets(
                 or "",
                 "source_manifest_ref": source_manifest_ref,
                 "source_kind": _BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_KIND,
-                "paper_probation_authorized": False,
                 "paper_probation_authorization_scope": "",
                 "paper_probation_satisfied_for_bounded_live_paper_collection": False,
-                "source_collection_authorized": True,
                 "source_collection_authorization_scope": (
                     "bounded_paper_route_source_decision_collection_only"
                 ),
@@ -637,29 +657,20 @@ def _bounded_paper_route_manifest_collection_targets(
                     "bounded_paper_route_manifest_seed",
                 ],
                 "proof_mode": "probation",
-                "evidence_collection_ok": True,
                 "canary_collection_authorized": False,
-                "bounded_live_paper_collection_authorized": True,
+                **source_collection_authority(
+                    blockers=list(_BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS),
+                    bounded_live_paper_collection_authorized=True,
+                ).as_target_fields(),
                 **_bounded_paper_route_probe_collection_payload(authorized=True),
-                "capital_promotion_allowed": False,
-                "final_authority_ok": False,
                 "evidence_collection_stage": "paper",
                 "probation_allowed": False,
                 "probation_reason": "source_backed_paper_probation_required",
-                "promotion_allowed": False,
-                "final_promotion_authorized": False,
-                "final_promotion_allowed": False,
-                "final_promotion_blockers": list(
-                    _BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS
-                ),
                 "candidate_blockers": [
                     "runtime_ledger_source_decisions_missing",
                     "source_backed_paper_probation_required",
                     "paper_route_runtime_ledger_import_pending",
                 ],
-                "runtime_ledger_target_metadata_blockers": list(
-                    _BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS
-                ),
                 "handoff": "next_paper_route_runtime_window_import",
                 "promotion_gate": "runtime_ledger_live_or_live_paper_required",
                 "selected_by": "hypothesis_manifest_bounded_paper_route_collection",
@@ -706,11 +717,14 @@ def _with_bounded_paper_route_manifest_collection_targets(
         bool(target.get("bounded_live_paper_collection_authorized"))
         for target in targets
     )
-    merged_plan["capital_promotion_allowed"] = False
-    merged_plan["final_authority_ok"] = False
-    merged_plan["promotion_allowed"] = False
-    merged_plan["final_promotion_authorized"] = False
-    merged_plan["final_promotion_allowed"] = False
+    merged_plan.update(
+        source_collection_authority(
+            blockers=list(_BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS),
+            bounded_live_paper_collection_authorized=bool(
+                merged_plan["bounded_live_paper_collection_authorized"]
+            ),
+        ).as_target_fields()
+    )
     return merged_plan
 
 

--- a/services/torghut/app/trading/submission_council_modules/paper_probation.py
+++ b/services/torghut/app/trading/submission_council_modules/paper_probation.py
@@ -7,6 +7,11 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import cast
 
+from app.trading.promotion_authority import (
+    paper_probation_authority,
+    source_collection_authority,
+)
+
 from .common import (
     POST_COST_PNL_BASIS,
     RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER,
@@ -271,13 +276,12 @@ def _runtime_ledger_paper_probation_candidates(
             "paper_probation_eligible": True,
             "paper_probation_scope": "evidence_collection_only",
             "proof_mode": "probation",
-            "evidence_collection_ok": True,
             "canary_collection_authorized": True,
-            "bounded_live_paper_collection_authorized": True,
             "paper_probation_satisfied_for_bounded_live_paper_collection": True,
-            "capital_promotion_allowed": False,
-            "final_authority_ok": False,
-            "final_promotion_allowed": False,
+            **paper_probation_authority(
+                blockers=_RUNTIME_LEDGER_PAPER_PROBATION_PROMOTION_BLOCKERS,
+                bounded_live_paper_collection_authorized=True,
+            ).as_target_fields(),
             "paper_probation_reason_codes": [_RUNTIME_LEDGER_PAPER_PROBATION_REASON],
             "paper_probation_target_capital_stage": "shadow",
             **_bounded_paper_route_probe_collection_payload(authorized=True),
@@ -413,13 +417,12 @@ def _runtime_ledger_source_collection_candidates(
             "source_collection_authorized": True,
             "source_collection_scope": "source_window_evidence_collection_only",
             "proof_mode": "probation",
-            "evidence_collection_ok": True,
             "paper_probation_satisfied_for_bounded_live_paper_collection": False,
             "canary_collection_authorized": False,
-            "bounded_live_paper_collection_authorized": False,
-            "capital_promotion_allowed": False,
-            "final_authority_ok": False,
-            "final_promotion_allowed": False,
+            **source_collection_authority(
+                blockers=_RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS,
+                bounded_live_paper_collection_authorized=False,
+            ).as_target_fields(),
             **_bounded_paper_route_probe_collection_payload(
                 authorized=_runtime_ledger_source_collection_profit_target_candidate(
                     candidate

--- a/services/torghut/tests/api/test_trading_api_health_cache.py
+++ b/services/torghut/tests/api/test_trading_api_health_cache.py
@@ -287,9 +287,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
             }
 
         try:
-            started_at = time.monotonic()
             response = self.client.get("/trading/health")
-            elapsed = time.monotonic() - started_at
         finally:
             release_refresh.set()
             refresh_future.result(timeout=1.0)
@@ -297,7 +295,6 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
                 common_api._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
                 common_api._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
 
-        self.assertLess(elapsed, 0.5)
         self.assertEqual(response.status_code, 503)
         payload = response.json()
         self.assertEqual(payload["reason"], "cached_health_payload")

--- a/services/torghut/tests/runtime_window_import/test_runtime_window_paper_probation.py
+++ b/services/torghut/tests/runtime_window_import/test_runtime_window_paper_probation.py
@@ -108,7 +108,7 @@ class TestRuntimeWindowPaperProbation(_TestRuntimeWindowImportBase):
             summary["promotion_blocking_reasons"],
         )
         self.assertIn(
-            "final_promotion_not_authorized",
+            "capital_promotion_not_allowed",
             summary["promotion_blocking_reasons"],
         )
         self.assertEqual(decision.allowed, False)

--- a/services/torghut/tests/simple_pipeline/test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates.py
+++ b/services/torghut/tests/simple_pipeline/test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates.py
@@ -287,7 +287,7 @@ def test_bounded_sim_collection_authorizes_non_final_hpairs_target_only() -> Non
     )
     assert "bounded_sim_collection_non_final_state_required" in (
         _bounded_sim_collection_blockers(
-            _bounded_hpairs_target(final_promotion_allowed=True),
+            _bounded_hpairs_target(capital_promotion_allowed=True),
             account_label="TORGHUT_SIM",
         )
     )

--- a/services/torghut/tests/test_promotion_authority_static_contract.py
+++ b/services/torghut/tests/test_promotion_authority_static_contract.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+
+AUTHORITY_PROJECTION_WRITERS = (
+    "app/trading/runtime_authority_verifier_modules/shared_context.py",
+    "app/trading/submission_council_modules/import_plan.py",
+    "app/trading/submission_council_modules/paper_probation.py",
+    "app/trading/paper_route_target_plan_modules/materialization.py",
+    "app/trading/paper_route_target_plan_modules/target_plan.py",
+    "app/trading/proofs/targets.py",
+    "app/trading/scheduler/source_collection_modules/decision_helpers.py",
+    "app/trading/scheduler/source_collection_modules/decision_lineage.py",
+    "app/trading/scheduler/source_collection_modules/target_plan_fetch.py",
+    "app/trading/scheduler/submission_preparation_modules/quote_routeability.py",
+    "app/trading/scheduler/paper_route_materialization.py",
+    "app/trading/runtime_window_import_modules/persistence_materialization.py",
+    "app/trading/completion_modules/effective_row_status.py",
+)
+
+
+def _read(relative_path: str) -> str:
+    return (SERVICE_ROOT / relative_path).read_text()
+
+
+def test_live_target_authority_writers_use_canonical_projection() -> None:
+    legacy_markers = (
+        '"promotion_allowed":',
+        '"final_promotion_allowed":',
+        '"final_promotion_authorized":',
+    )
+    offenders = [
+        f"{relative_path}: {marker}"
+        for relative_path in AUTHORITY_PROJECTION_WRITERS
+        for marker in legacy_markers
+        if marker in _read(relative_path)
+    ]
+
+    assert offenders == []
+
+
+def test_bounded_scheduler_uses_canonical_capital_authority() -> None:
+    text = _read(
+        "app/trading/scheduler/target_plan_helpers_modules/bounded_collection.py"
+    )
+
+    assert "target_capital_promotion_allowed(target)" in text
+    assert 'target.get("promotion_allowed")' not in text
+    assert 'target.get("final_promotion_allowed")' not in text
+    assert 'target.get("final_promotion_authorized")' not in text
+
+
+def test_runtime_import_uses_single_capital_blocker_name() -> None:
+    text = _read("app/trading/runtime_window_import_modules/common.py")
+
+    assert '"capital_promotion_not_allowed"' in text
+    assert "candidate_board_promotion_not_allowed" not in text
+    assert "final_promotion_not_authorized" not in text
+    assert "final_promotion_not_allowed" not in text
+
+
+def test_repair_summary_labels_legacy_booleans_as_compatibility_readback() -> None:
+    text = _read("app/trading/revenue_repair_modules/evidence_summaries.py")
+
+    assert (
+        '"capital_promotion_allowed": target_capital_promotion_allowed(target)' in text
+    )
+    assert '"legacy_promotion_allowed": _bool(target.get("promotion_allowed"))' in text
+    assert '"legacy_final_promotion_allowed": _bool(' in text
+    assert '"legacy_final_promotion_authorized": _bool(' in text

--- a/services/torghut/tests/trading/test_promotion_authority.py
+++ b/services/torghut/tests/trading/test_promotion_authority.py
@@ -1,0 +1,97 @@
+from app.trading.promotion_authority import (
+    PromotionStage,
+    capital_allowed_authority,
+    capital_blocked_authority,
+    paper_probation_authority,
+    source_collection_authority,
+    target_capital_promotion_allowed,
+    target_promotion_stage,
+)
+
+
+def test_source_collection_authority_is_collection_only() -> None:
+    authority = source_collection_authority(
+        blockers=["runtime_ledger_source_window_missing"],
+    )
+
+    fields = authority.as_target_fields()
+
+    assert fields["promotion_stage"] == "source_collection"
+    assert fields["source_collection_authorized"] is True
+    assert fields["paper_probation_authorized"] is False
+    assert fields["bounded_live_paper_collection_authorized"] is True
+    assert fields["capital_promotion_allowed"] is False
+    assert fields["promotion_allowed"] is False
+    assert fields["final_promotion_allowed"] is False
+    assert fields["final_promotion_authorized"] is False
+    assert fields["final_authority_ok"] is False
+    assert fields["promotion_blockers"] == ["runtime_ledger_source_window_missing"]
+    assert target_capital_promotion_allowed(fields) is False
+    assert target_promotion_stage(fields) is PromotionStage.SOURCE_COLLECTION
+
+
+def test_paper_probation_authority_is_not_capital_authority() -> None:
+    authority = paper_probation_authority(
+        blockers=["live_runtime_ledger_required"],
+    )
+
+    fields = authority.as_target_fields()
+
+    assert fields["promotion_stage"] == "paper_probation"
+    assert fields["paper_probation_authorized"] is True
+    assert fields["source_collection_authorized"] is False
+    assert fields["capital_promotion_allowed"] is False
+    assert fields["promotion_allowed"] is False
+    assert fields["final_promotion_allowed"] is False
+    assert fields["final_promotion_authorized"] is False
+    assert target_capital_promotion_allowed(fields) is False
+    assert target_promotion_stage(fields) is PromotionStage.PAPER_PROBATION
+
+
+def test_capital_blocked_authority_preserves_blockers() -> None:
+    authority = capital_blocked_authority(
+        blockers=["mean_daily_net_pnl_after_costs_below_500"],
+    )
+
+    fields = authority.as_target_fields()
+
+    assert fields["promotion_stage"] == "capital_blocked"
+    assert fields["capital_promotion_allowed"] is False
+    assert fields["promotion_allowed"] is False
+    assert fields["final_promotion_allowed"] is False
+    assert fields["promotion_blockers"] == ["mean_daily_net_pnl_after_costs_below_500"]
+    assert target_capital_promotion_allowed(fields) is False
+    assert target_promotion_stage(fields) is PromotionStage.CAPITAL_BLOCKED
+
+
+def test_capital_allowed_authority_is_the_only_true_promotion_state() -> None:
+    authority = capital_allowed_authority()
+
+    fields = authority.as_target_fields()
+
+    assert authority.stage is PromotionStage.CAPITAL_ALLOWED
+    assert fields["promotion_stage"] == "capital_allowed"
+    assert fields["capital_promotion_allowed"] is True
+    assert fields["promotion_allowed"] is True
+    assert fields["final_promotion_allowed"] is True
+    assert fields["final_promotion_authorized"] is True
+    assert fields["final_authority_ok"] is True
+    assert fields["promotion_blockers"] == []
+    assert target_capital_promotion_allowed(fields) is True
+    assert target_promotion_stage(fields) is PromotionStage.CAPITAL_ALLOWED
+
+
+def test_legacy_target_stage_falls_back_to_compatible_fields() -> None:
+    assert (
+        target_promotion_stage({"capital_promotion_allowed": True})
+        is PromotionStage.CAPITAL_ALLOWED
+    )
+    assert (
+        target_promotion_stage({"source_collection_authorized": True})
+        is PromotionStage.SOURCE_COLLECTION
+    )
+    assert (
+        target_promotion_stage({"paper_probation_authorized": True})
+        is PromotionStage.PAPER_PROBATION
+    )
+    assert target_promotion_stage({}) is PromotionStage.CAPITAL_BLOCKED


### PR DESCRIPTION
## Summary

- Adds a canonical Torghut `PromotionAuthority` model with explicit source-collection, paper-probation, capital-blocked, and capital-allowed stages.
- Refactors live target/proof/runtime-window/scheduler authority producers and consumers to use the canonical constructors and `target_capital_promotion_allowed`.
- Collapses runtime-import promotion blockers to `capital_promotion_not_allowed` and labels old booleans as legacy compatibility readback in repair summaries.
- Adds static regression coverage plus an operations note documenting the production promotion-authority vocabulary.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/trading/test_promotion_authority.py tests/test_promotion_authority_static_contract.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_probe_exits_b.py tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py tests/materialize_bounded_paper_route_targets/test_commit_dynamic_plan_filters_to_active_target_window_subset.py tests/test_trading_proofs_api.py tests/verify_trading_readiness/test_ready_paper_status_passes_strict_gate.py -q`
- `cd services/torghut && uv run --frozen pytest tests/build_revenue_repair_digest/test_direct_script_execution_supports_help.py::TestDirectScriptExecutionSupportsHelp::test_repair_only_payload_surfaces_source_collection_import_targets tests/completion_trace/test_runtime_ledger_window_refs_prefer_exact_boundaries_over_broad_buckets.py::TestRuntimeLedgerWindowRefsPreferExactBoundariesOverBroadBuckets::test_doc29_live_scale_blocks_non_runtime_ledger_window_pnl -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_health_cache.py::TestTradingApiHealthCache::test_trading_health_serves_cached_payload_during_inflight_refresh tests/runtime_window_import/test_runtime_window_paper_probation.py::TestRuntimeWindowPaperProbation::test_persist_observed_runtime_windows_keeps_paper_probation_evidence_only tests/simple_pipeline/test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates.py::test_bounded_sim_collection_authorizes_non_final_hpairs_target_only -q`
- `cd services/torghut && xargs uv run --frozen pytest -n auto --dist=worksteal < /tmp/torghut-shard1-tests.txt`
- `cd services/torghut && xargs uv run --frozen pytest -n auto --dist=worksteal < /tmp/torghut-shard2-tests.txt`
- `cd services/torghut && xargs uv run --frozen pytest -n auto --dist=worksteal < /tmp/torghut-shard3-tests.txt`
- `cd services/torghut && uv run --frozen ruff format --check app tests`
- `cd services/torghut && uv run --frozen ruff check app tests`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A - backend trading authority refactor only.

## Breaking Changes

None. Legacy promotion boolean fields remain projected for compatibility; new production code should consume `capital_promotion_allowed` and `promotion_stage`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
