### PR TITLE
refactor(torghut): remove pyright suppression headers

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -227,7 +227,7 @@ class TorghutAlpacaClient:
         return [self._model_to_dict(resp) for resp in responses]
 
     # ------------------- Market data -------------------
-    def get_bars(  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
+    def get_bars(
         self, symbols: Iterable[str] | str, timeframe: str, lookback_bars: int
     ) -> Dict[str, List[Dict[str, Any]]]:
         timeframe_obj = self._parse_timeframe(timeframe)
@@ -243,7 +243,7 @@ class TorghutAlpacaClient:
             start=start,
             limit=lookback_bars,
         )
-        bars = self.data.get_stock_bars(request)
+        bars = cast(Any, self.data).get_stock_bars(request)
 
         raw_data = getattr(bars, "data", bars)  # allow raw dicts in tests
         if not isinstance(raw_data, dict):

--- a/services/torghut/app/options_lane/kafka.py
+++ b/services/torghut/app/options_lane/kafka.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from importlib import import_module
 import threading
 from datetime import datetime
 from typing import Any, Protocol, cast
 
-from kafka import KafkaProducer  # pyright: ignore[reportMissingTypeStubs]
-
 from .json import dump_json
+
+KafkaProducer = getattr(import_module("kafka"), "KafkaProducer")
 
 
 class _KafkaProducerProtocol(Protocol):

--- a/services/torghut/app/options_lane/settings.py
+++ b/services/torghut/app/options_lane/settings.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, Callable, cast
 
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -228,4 +228,5 @@ class OptionsLaneSettings(BaseSettings):
 def get_options_lane_settings() -> OptionsLaneSettings:
     """Return the cached options-lane settings singleton."""
 
-    return OptionsLaneSettings()  # pyright: ignore[reportCallIssue]
+    settings_factory = cast(Callable[[], OptionsLaneSettings], OptionsLaneSettings)
+    return settings_factory()

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -2277,8 +2277,12 @@ def run_autonomous_lane(
     profitability_run_context: dict[str, Any] = {}
     walk_results_path = backtest_dir / "walkforward-results.json"
 
-    def _write_profitability_manifest() -> None:
+    def _missing_profitability_manifest_writer() -> None:
         raise RuntimeError("profitability_manifest_writer_not_initialized")
+
+    _write_profitability_manifest: Callable[[], None] = (
+        _missing_profitability_manifest_writer
+    )
 
     actuation_intent_path = output_dir / _ACTUATION_INTENT_PATH
 
@@ -2618,402 +2622,391 @@ def run_autonomous_lane(
         _write_janus_and_benchmark_artifacts(baseline_report)
         _write_router_contract_artifacts()
 
-    def _run_profitability_validation_phase() -> None:
-        def _artifact_ref(path: Path) -> str:
-            if output_dir.is_absolute():
-                return str(path)
-            return str(path.relative_to(output_dir))
+    def _artifact_ref(path: Path) -> str:
+        if output_dir.is_absolute():
+            return str(path)
+        return str(path.relative_to(output_dir))
 
-        def _write_profitability_evidence_artifacts() -> tuple[
-            Any,
-            dict[str, Any],
-            dict[str, object],
-        ]:
-            nonlocal profitability_validation
+    def _write_profitability_evidence_artifacts() -> tuple[
+        Any,
+        dict[str, Any],
+        dict[str, object],
+    ]:
+        nonlocal profitability_validation
 
-            profitability_evidence = build_profitability_evidence_v4(
-                run_id=run_id,
-                candidate_id=candidate_id,
-                baseline_id=baseline_candidate_id,
-                candidate_report_payload=report.to_payload(),
-                benchmark=benchmark,
-                confidence_values=_collect_confidence_values(walk_decisions),
-                reproducibility_hashes={
-                    "signals": _sha256_path(signals_path),
-                    "strategy_config": _sha256_path(strategy_config_path),
-                    "gate_policy": _sha256_path(gate_policy_path),
-                    "walkforward_results": _sha256_path(walk_results_path),
-                    "foundation_router_parity": _sha256_path(
-                        foundation_router_parity_path
-                    ),
-                    "deeplob_bdlob_contract": _sha256_path(deeplob_bdlob_report_path),
-                    "advisor_fallback_slo": _sha256_path(
-                        advisor_fallback_slo_report_path
-                    ),
-                    "hmm_state_posterior": _sha256_path(hmm_state_posterior_path),
-                    "expert_router_registry": _sha256_path(expert_router_registry_path),
-                    "candidate_report": _sha256_path(evaluation_report_path),
-                    "baseline_report": _sha256_path(baseline_report_path),
-                    "janus_event_car": _sha256_path(janus_event_car_path),
-                    "janus_hgrm_reward": _sha256_path(janus_hgrm_reward_path),
-                },
-                artifact_refs=[
-                    str(evaluation_report_path),
-                    str(baseline_report_path),
-                    str(walk_results_path),
-                    str(hmm_state_posterior_path),
-                    str(expert_router_registry_path),
-                    str(deeplob_bdlob_report_path),
-                    str(advisor_fallback_slo_report_path),
-                    str(signals_path),
-                    str(strategy_config_path),
-                    str(gate_policy_path),
-                ],
-                generated_at=now,
-            )
-            evidence_payload = profitability_evidence.to_payload()
-            evidence_payload["janus_q"] = janus_q_summary
-            profitability_evidence_path.write_text(
-                json.dumps(evidence_payload, indent=2), encoding="utf-8"
-            )
-            profitability_validation = validate_profitability_evidence_v4(
-                profitability_evidence,
-                thresholds=ProfitabilityEvidenceThresholdsV4.from_payload(
-                    _profitability_threshold_payload(gate_policy_payload)
-                ),
-                checked_at=now,
-            )
-            profitability_validation_path.write_text(
-                json.dumps(profitability_validation.to_payload(), indent=2),
-                encoding="utf-8",
-            )
-            return (
-                profitability_evidence,
-                evidence_payload,
-                _load_tca_gate_inputs(factory),
-            )
+        profitability_evidence = build_profitability_evidence_v4(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            baseline_id=baseline_candidate_id,
+            candidate_report_payload=report.to_payload(),
+            benchmark=benchmark,
+            confidence_values=_collect_confidence_values(walk_decisions),
+            reproducibility_hashes={
+                "signals": _sha256_path(signals_path),
+                "strategy_config": _sha256_path(strategy_config_path),
+                "gate_policy": _sha256_path(gate_policy_path),
+                "walkforward_results": _sha256_path(walk_results_path),
+                "foundation_router_parity": _sha256_path(foundation_router_parity_path),
+                "deeplob_bdlob_contract": _sha256_path(deeplob_bdlob_report_path),
+                "advisor_fallback_slo": _sha256_path(advisor_fallback_slo_report_path),
+                "hmm_state_posterior": _sha256_path(hmm_state_posterior_path),
+                "expert_router_registry": _sha256_path(expert_router_registry_path),
+                "candidate_report": _sha256_path(evaluation_report_path),
+                "baseline_report": _sha256_path(baseline_report_path),
+                "janus_event_car": _sha256_path(janus_event_car_path),
+                "janus_hgrm_reward": _sha256_path(janus_hgrm_reward_path),
+            },
+            artifact_refs=[
+                str(evaluation_report_path),
+                str(baseline_report_path),
+                str(walk_results_path),
+                str(hmm_state_posterior_path),
+                str(expert_router_registry_path),
+                str(deeplob_bdlob_report_path),
+                str(advisor_fallback_slo_report_path),
+                str(signals_path),
+                str(strategy_config_path),
+                str(gate_policy_path),
+            ],
+            generated_at=now,
+        )
+        evidence_payload = profitability_evidence.to_payload()
+        evidence_payload["janus_q"] = janus_q_summary
+        profitability_evidence_path.write_text(
+            json.dumps(evidence_payload, indent=2), encoding="utf-8"
+        )
+        profitability_validation = validate_profitability_evidence_v4(
+            profitability_evidence,
+            thresholds=ProfitabilityEvidenceThresholdsV4.from_payload(
+                _profitability_threshold_payload(gate_policy_payload)
+            ),
+            checked_at=now,
+        )
+        profitability_validation_path.write_text(
+            json.dumps(profitability_validation.to_payload(), indent=2),
+            encoding="utf-8",
+        )
+        return (
+            profitability_evidence,
+            evidence_payload,
+            _load_tca_gate_inputs(factory),
+        )
 
-        def _write_simulation_and_contamination_artifacts(
-            profitability_evidence: Any,
-            tca_gate_inputs: dict[str, object],
-        ) -> None:
-            nonlocal contamination_registry_payload
-            nonlocal shadow_live_deviation_report_payload
-            nonlocal simulation_calibration_report_payload
+    def _write_simulation_and_contamination_artifacts(
+        profitability_evidence: Any,
+        tca_gate_inputs: dict[str, object],
+    ) -> None:
+        nonlocal contamination_registry_payload
+        nonlocal shadow_live_deviation_report_payload
+        nonlocal simulation_calibration_report_payload
 
-            simulation_calibration_report = build_simulation_calibration_report_v1(
-                run_id=run_id,
-                candidate_id=candidate_id,
-                profitability_evidence=profitability_evidence,
-                tca_metrics=tca_gate_inputs,
-                min_order_count=_coerce_int(
-                    gate_policy_payload.get(
-                        "promotion_simulation_calibration_min_order_count",
-                        1,
-                    ),
-                    default=1,
+        simulation_calibration_report = build_simulation_calibration_report_v1(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            profitability_evidence=profitability_evidence,
+            tca_metrics=tca_gate_inputs,
+            min_order_count=_coerce_int(
+                gate_policy_payload.get(
+                    "promotion_simulation_calibration_min_order_count",
+                    1,
                 ),
-                min_expected_shortfall_coverage=_decimal_or_zero(
-                    gate_policy_payload.get(
-                        "promotion_simulation_calibration_min_expected_shortfall_coverage",
-                        "0.50",
-                    )
-                ),
-                max_avg_calibration_error_bps=_decimal_or_zero(
-                    gate_policy_payload.get(
-                        "promotion_simulation_calibration_max_avg_calibration_error_bps",
-                        "25",
-                    )
-                ),
-                generated_at=now,
-            )
-            simulation_calibration_report_payload = (
-                simulation_calibration_report.to_payload()
-            )
-            simulation_calibration_report_path.write_text(
-                json.dumps(simulation_calibration_report_payload, indent=2),
-                encoding="utf-8",
-            )
-            shadow_live_deviation_report = build_shadow_live_deviation_report_v1(
-                run_id=run_id,
-                candidate_id=candidate_id,
-                profitability_evidence=profitability_evidence,
-                tca_metrics=tca_gate_inputs,
-                min_order_count=_coerce_int(
-                    gate_policy_payload.get(
-                        "promotion_shadow_live_deviation_min_order_count",
-                        1,
-                    ),
-                    default=1,
-                ),
-                max_avg_abs_slippage_bps=_decimal_or_zero(
-                    gate_policy_payload.get(
-                        "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
-                        "20",
-                    )
-                ),
-                max_avg_abs_divergence_bps=_decimal_or_zero(
-                    gate_policy_payload.get(
-                        "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
-                        "15",
-                    )
-                ),
-                generated_at=now,
-            )
-            shadow_live_deviation_report_payload = (
-                shadow_live_deviation_report.to_payload()
-            )
-            shadow_live_deviation_report_path.write_text(
-                json.dumps(shadow_live_deviation_report_payload, indent=2),
-                encoding="utf-8",
-            )
-            contamination_registry_payload = _build_contamination_registry_payload(
-                output_dir=output_dir,
-                run_id=run_id,
-                candidate_id=candidate_id,
-                now=now,
-                artifact_refs=[
-                    signals_path,
-                    strategy_config_path,
-                    gate_policy_path,
-                    walk_results_path,
-                    evaluation_report_path,
-                    baseline_report_path,
-                    profitability_evidence_path,
-                    profitability_validation_path,
-                    simulation_calibration_report_path,
-                    shadow_live_deviation_report_path,
-                    profitability_benchmark_path,
-                    benchmark_parity_path,
-                    foundation_router_parity_path,
-                    deeplob_bdlob_report_path,
-                    hmm_state_posterior_path,
-                    expert_router_registry_path,
-                ],
-            )
-            contamination_registry_path.write_text(
-                json.dumps(contamination_registry_payload, indent=2),
-                encoding="utf-8",
-            )
-
-        def _write_recalibration_request(
-            profitability_evidence_payload: dict[str, Any],
-        ) -> dict[str, Any]:
-            confidence_calibration, uncertainty_action, recalibration_run_id = (
-                _resolve_confidence_calibration(
-                    profitability_evidence_payload=profitability_evidence_payload,
-                    run_id=run_id,
-                    recalibration_report_path=recalibration_report_path,
+                default=1,
+            ),
+            min_expected_shortfall_coverage=_decimal_or_zero(
+                gate_policy_payload.get(
+                    "promotion_simulation_calibration_min_expected_shortfall_coverage",
+                    "0.50",
                 )
-            )
-            recalibration_report_path.write_text(
-                json.dumps(
-                    {
-                        "schema_version": "recalibration_report_v1",
-                        "run_id": run_id,
-                        "candidate_id": candidate_id,
-                        "requested_at": now.isoformat(),
-                        "status": "queued" if recalibration_run_id else "not_required",
-                        "recalibration_run_id": recalibration_run_id,
-                        "uncertainty_gate_action": uncertainty_action,
-                        "coverage_error": confidence_calibration.get("coverage_error"),
-                        "shift_score": confidence_calibration.get("shift_score"),
-                        "artifact_refs": sorted(
-                            {
-                                str(profitability_evidence_path),
-                                str(profitability_validation_path),
-                            }
-                        ),
-                    },
-                    indent=2,
+            ),
+            max_avg_calibration_error_bps=_decimal_or_zero(
+                gate_policy_payload.get(
+                    "promotion_simulation_calibration_max_avg_calibration_error_bps",
+                    "25",
+                )
+            ),
+            generated_at=now,
+        )
+        simulation_calibration_report_payload = (
+            simulation_calibration_report.to_payload()
+        )
+        simulation_calibration_report_path.write_text(
+            json.dumps(simulation_calibration_report_payload, indent=2),
+            encoding="utf-8",
+        )
+        shadow_live_deviation_report = build_shadow_live_deviation_report_v1(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            profitability_evidence=profitability_evidence,
+            tca_metrics=tca_gate_inputs,
+            min_order_count=_coerce_int(
+                gate_policy_payload.get(
+                    "promotion_shadow_live_deviation_min_order_count",
+                    1,
                 ),
-                encoding="utf-8",
-            )
-            return confidence_calibration
+                default=1,
+            ),
+            max_avg_abs_slippage_bps=_decimal_or_zero(
+                gate_policy_payload.get(
+                    "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
+                    "20",
+                )
+            ),
+            max_avg_abs_divergence_bps=_decimal_or_zero(
+                gate_policy_payload.get(
+                    "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
+                    "15",
+                )
+            ),
+            generated_at=now,
+        )
+        shadow_live_deviation_report_payload = shadow_live_deviation_report.to_payload()
+        shadow_live_deviation_report_path.write_text(
+            json.dumps(shadow_live_deviation_report_payload, indent=2),
+            encoding="utf-8",
+        )
+        contamination_registry_payload = _build_contamination_registry_payload(
+            output_dir=output_dir,
+            run_id=run_id,
+            candidate_id=candidate_id,
+            now=now,
+            artifact_refs=[
+                signals_path,
+                strategy_config_path,
+                gate_policy_path,
+                walk_results_path,
+                evaluation_report_path,
+                baseline_report_path,
+                profitability_evidence_path,
+                profitability_validation_path,
+                simulation_calibration_report_path,
+                shadow_live_deviation_report_path,
+                profitability_benchmark_path,
+                benchmark_parity_path,
+                foundation_router_parity_path,
+                deeplob_bdlob_report_path,
+                hmm_state_posterior_path,
+                expert_router_registry_path,
+            ],
+        )
+        contamination_registry_path.write_text(
+            json.dumps(contamination_registry_payload, indent=2),
+            encoding="utf-8",
+        )
 
-        def _evaluate_gate_report(
-            profitability_evidence_payload: dict[str, Any],
-            tca_gate_inputs: dict[str, object],
-        ) -> None:
-            nonlocal candidate_alpha_readiness_payload
-            nonlocal candidate_dependency_quorum_payload, candidate_state_payload
-            nonlocal fold_evidence, gate_report, stress_evidence, stress_metrics_count
-
-            metrics_payload = report.metrics.to_payload()
-            gate_policy = GatePolicyMatrix.from_path(gate_policy_path)
-            profitability_evidence_payload["validation"] = (
-                profitability_validation.to_payload()
-            )
-            (
-                fragility_state,
-                fragility_score,
-                stability_mode_active,
-                fragility_inputs_valid,
-            ) = _resolve_gate_fragility_inputs(
-                metrics_payload=metrics_payload, decisions=walk_decisions
-            )
-            _write_recalibration_request(profitability_evidence_payload)
-            (
-                candidate_alpha_readiness_payload,
-                candidate_dependency_quorum_payload,
-            ) = _build_candidate_alpha_readiness_payload(
-                runtime_strategies=runtime_strategies,
-            )
-            candidate_state_payload = _build_candidate_state_payload(
-                candidate_id=candidate_id,
+    def _write_recalibration_request(
+        profitability_evidence_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        confidence_calibration, uncertainty_action, recalibration_run_id = (
+            _resolve_confidence_calibration(
+                profitability_evidence_payload=profitability_evidence_payload,
                 run_id=run_id,
-                promotion_target=promotion_target,
-                approval_token=approval_token,
-                runtime_strategies=runtime_strategies,
-                now=now,
-                code_version=code_version,
-                runbook_validated=_is_runbook_valid(strategy_configmap_path),
-                dependency_quorum_payload=candidate_dependency_quorum_payload,
-                alpha_readiness_payload=candidate_alpha_readiness_payload,
+                recalibration_report_path=recalibration_report_path,
             )
-            candidate_state_readiness = _candidate_state_readiness_payload(
-                candidate_state_payload
-            )
-            gate_report = evaluate_gate_matrix(
-                GateInputs(
-                    feature_schema_version=gate_policy.required_feature_schema_version,
-                    required_feature_null_rate=_required_feature_null_rate(signals),
-                    staleness_ms_p95=_resolve_gate_staleness_ms_p95(
-                        signals=ordered_signals,
-                    ),
-                    symbol_coverage=len({signal.symbol for signal in signals}),
-                    metrics=metrics_payload,
-                    robustness=report.robustness.to_payload(),
-                    tca_metrics=tca_gate_inputs,
-                    llm_metrics=_resolve_gate_llm_metrics(
-                        session_factory=factory,
-                        now=now,
-                    ),
-                    forecast_metrics=_resolve_gate_forecast_metrics(
-                        signals=ordered_signals
-                    ),
-                    profitability_evidence=profitability_evidence_payload,
-                    fragility_state=fragility_state,
-                    fragility_score=fragility_score,
-                    stability_mode_active=stability_mode_active,
-                    fragility_inputs_valid=fragility_inputs_valid,
-                    operational_ready=not bool(
-                        candidate_state_payload.get("paused", False)
-                    ),
-                    runbook_validated=bool(
-                        _coerce_evidence_bool(
-                            candidate_state_payload.get("runbookValidated")
-                        )
-                    ),
-                    kill_switch_dry_run_passed=bool(
-                        _coerce_evidence_bool(
-                            candidate_state_readiness.get("killSwitchDryRunPassed")
-                        )
-                    ),
-                    rollback_dry_run_passed=bool(
-                        _coerce_evidence_bool(
-                            candidate_state_readiness.get("gitopsRevertDryRunPassed")
-                        )
-                        and _coerce_evidence_bool(
-                            candidate_state_readiness.get("strategyDisableDryRunPassed")
-                        )
-                    ),
-                    approval_token=approval_token,
-                ),
-                policy=gate_policy,
-                promotion_target=promotion_target,
-                code_version=code_version,
-                evaluated_at=now,
-            )
-            fold_evidence = [
+        )
+        recalibration_report_path.write_text(
+            json.dumps(
                 {
-                    "fold_name": fold.fold_name,
-                    "decision_count": fold.decision_count,
-                    "trade_count": fold.trade_count,
-                    "net_pnl": str(fold.net_pnl),
-                    "max_drawdown": str(fold.max_drawdown),
-                    "cost_bps": str(fold.cost_bps),
-                    "regime_label": fold.regime.label(),
-                }
-                for fold in report.robustness.folds
-            ]
-            stress_evidence = [
-                _build_stress_bundle(report, stress_case)
-                for stress_case in _STRESS_METRICS_CASES
-            ]
-            stress_metrics_count = len(stress_evidence)
+                    "schema_version": "recalibration_report_v1",
+                    "run_id": run_id,
+                    "candidate_id": candidate_id,
+                    "requested_at": now.isoformat(),
+                    "status": "queued" if recalibration_run_id else "not_required",
+                    "recalibration_run_id": recalibration_run_id,
+                    "uncertainty_gate_action": uncertainty_action,
+                    "coverage_error": confidence_calibration.get("coverage_error"),
+                    "shift_score": confidence_calibration.get("shift_score"),
+                    "artifact_refs": sorted(
+                        {
+                            str(profitability_evidence_path),
+                            str(profitability_validation_path),
+                        }
+                    ),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        return confidence_calibration
 
-        def _write_metric_artifact_refs() -> None:
-            nonlocal advisor_fallback_slo_artifact_ref, benchmark_parity_artifact_ref
-            nonlocal contamination_registry_artifact_ref, deeplob_bdlob_artifact_ref
-            nonlocal expert_router_registry_artifact_ref, fold_metrics_artifact_ref
-            nonlocal foundation_router_parity_artifact_ref, gate_report_payload
-            nonlocal hmm_state_posterior_artifact_ref
-            nonlocal shadow_live_deviation_artifact_ref
-            nonlocal simulation_calibration_artifact_ref, stress_metrics_artifact_ref
+    def _evaluate_gate_report(
+        profitability_evidence_payload: dict[str, Any],
+        tca_gate_inputs: dict[str, object],
+    ) -> None:
+        nonlocal candidate_alpha_readiness_payload
+        nonlocal candidate_dependency_quorum_payload, candidate_state_payload
+        nonlocal fold_evidence, gate_report, stress_evidence, stress_metrics_count
 
-            stress_metrics_path.write_text(
-                json.dumps(
-                    {
-                        "schema_version": "stress-metrics-v1",
-                        "run_id": run_id,
-                        "generated_at": now.isoformat(),
-                        "count": stress_metrics_count,
-                        "items": stress_evidence,
-                        "artifact_authority": evidence_contract_payload(
-                            provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
-                            maturity=EvidenceMaturity.UNCALIBRATED,
-                            calibration_summary={"status": "pending_calibration"},
-                        ),
-                    },
-                    indent=2,
+        gate_policy = GatePolicyMatrix.from_path(gate_policy_path)
+        profitability_evidence_payload["validation"] = (
+            profitability_validation.to_payload()
+        )
+        (
+            fragility_state,
+            fragility_score,
+            stability_mode_active,
+            fragility_inputs_valid,
+        ) = _resolve_gate_fragility_inputs(
+            metrics_payload=report.metrics.to_payload(), decisions=walk_decisions
+        )
+        _write_recalibration_request(profitability_evidence_payload)
+        (
+            candidate_alpha_readiness_payload,
+            candidate_dependency_quorum_payload,
+        ) = _build_candidate_alpha_readiness_payload(
+            runtime_strategies=runtime_strategies,
+        )
+        candidate_state_payload = _build_candidate_state_payload(
+            candidate_id=candidate_id,
+            run_id=run_id,
+            promotion_target=promotion_target,
+            approval_token=approval_token,
+            runtime_strategies=runtime_strategies,
+            now=now,
+            code_version=code_version,
+            runbook_validated=_is_runbook_valid(strategy_configmap_path),
+            dependency_quorum_payload=candidate_dependency_quorum_payload,
+            alpha_readiness_payload=candidate_alpha_readiness_payload,
+        )
+        candidate_state_readiness = _candidate_state_readiness_payload(
+            candidate_state_payload
+        )
+        gate_report = evaluate_gate_matrix(
+            GateInputs(
+                feature_schema_version=gate_policy.required_feature_schema_version,
+                required_feature_null_rate=_required_feature_null_rate(signals),
+                staleness_ms_p95=_resolve_gate_staleness_ms_p95(
+                    signals=ordered_signals,
                 ),
-                encoding="utf-8",
-            )
-            fold_metrics_path.write_text(
-                json.dumps(
-                    {
-                        "schema_version": "fold-metrics-v1",
-                        "run_id": run_id,
-                        "generated_at": now.isoformat(),
-                        "count": len(fold_evidence),
-                        "items": fold_evidence,
-                        "artifact_authority": evidence_contract_payload(
-                            provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
-                            maturity=EvidenceMaturity.UNCALIBRATED,
-                            calibration_summary={"status": "pending_calibration"},
-                        ),
-                    },
-                    indent=2,
+                symbol_coverage=len({signal.symbol for signal in signals}),
+                metrics=report.metrics.to_payload(),
+                robustness=report.robustness.to_payload(),
+                tca_metrics=tca_gate_inputs,
+                llm_metrics=_resolve_gate_llm_metrics(
+                    session_factory=factory,
+                    now=now,
                 ),
-                encoding="utf-8",
-            )
-            stress_metrics_artifact_ref = _artifact_ref(stress_metrics_path)
-            fold_metrics_artifact_ref = _artifact_ref(fold_metrics_path)
-            simulation_calibration_artifact_ref = _artifact_ref(
-                simulation_calibration_report_path
-            )
-            shadow_live_deviation_artifact_ref = _artifact_ref(
-                shadow_live_deviation_report_path
-            )
-            benchmark_parity_artifact_ref = _artifact_ref(benchmark_parity_path)
-            foundation_router_parity_artifact_ref = _artifact_ref(
-                foundation_router_parity_path
-            )
-            deeplob_bdlob_artifact_ref = _artifact_ref(deeplob_bdlob_report_path)
-            advisor_fallback_slo_artifact_ref = _artifact_ref(
-                advisor_fallback_slo_report_path
-            )
-            contamination_registry_artifact_ref = _artifact_ref(
-                contamination_registry_path
-            )
-            hmm_state_posterior_artifact_ref = _artifact_ref(hmm_state_posterior_path)
-            expert_router_registry_artifact_ref = _artifact_ref(
-                expert_router_registry_path
-            )
-            gate_report_payload = gate_report.to_payload()
-            gate_report_payload["run_id"] = run_id
+                forecast_metrics=_resolve_gate_forecast_metrics(
+                    signals=ordered_signals
+                ),
+                profitability_evidence=profitability_evidence_payload,
+                fragility_state=fragility_state,
+                fragility_score=fragility_score,
+                stability_mode_active=stability_mode_active,
+                fragility_inputs_valid=fragility_inputs_valid,
+                operational_ready=not bool(
+                    candidate_state_payload.get("paused", False)
+                ),
+                runbook_validated=bool(
+                    _coerce_evidence_bool(
+                        candidate_state_payload.get("runbookValidated")
+                    )
+                ),
+                kill_switch_dry_run_passed=bool(
+                    _coerce_evidence_bool(
+                        candidate_state_readiness.get("killSwitchDryRunPassed")
+                    )
+                ),
+                rollback_dry_run_passed=bool(
+                    _coerce_evidence_bool(
+                        candidate_state_readiness.get("gitopsRevertDryRunPassed")
+                    )
+                    and _coerce_evidence_bool(
+                        candidate_state_readiness.get("strategyDisableDryRunPassed")
+                    )
+                ),
+                approval_token=approval_token,
+            ),
+            policy=gate_policy,
+            promotion_target=promotion_target,
+            code_version=code_version,
+            evaluated_at=now,
+        )
+        fold_evidence = [
+            {
+                "fold_name": fold.fold_name,
+                "decision_count": fold.decision_count,
+                "trade_count": fold.trade_count,
+                "net_pnl": str(fold.net_pnl),
+                "max_drawdown": str(fold.max_drawdown),
+                "cost_bps": str(fold.cost_bps),
+                "regime_label": fold.regime.label(),
+            }
+            for fold in report.robustness.folds
+        ]
+        stress_evidence = [
+            _build_stress_bundle(report, stress_case)
+            for stress_case in _STRESS_METRICS_CASES
+        ]
+        stress_metrics_count = len(stress_evidence)
 
+    def _write_metric_artifact_refs() -> None:
+        nonlocal advisor_fallback_slo_artifact_ref, benchmark_parity_artifact_ref
+        nonlocal contamination_registry_artifact_ref, deeplob_bdlob_artifact_ref
+        nonlocal expert_router_registry_artifact_ref, fold_metrics_artifact_ref
+        nonlocal foundation_router_parity_artifact_ref, gate_report_payload
+        nonlocal hmm_state_posterior_artifact_ref
+        nonlocal shadow_live_deviation_artifact_ref
+        nonlocal simulation_calibration_artifact_ref, stress_metrics_artifact_ref
+
+        stress_metrics_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "stress-metrics-v1",
+                    "run_id": run_id,
+                    "generated_at": now.isoformat(),
+                    "count": stress_metrics_count,
+                    "items": stress_evidence,
+                    "artifact_authority": evidence_contract_payload(
+                        provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
+                        maturity=EvidenceMaturity.UNCALIBRATED,
+                        calibration_summary={"status": "pending_calibration"},
+                    ),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        fold_metrics_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "fold-metrics-v1",
+                    "run_id": run_id,
+                    "generated_at": now.isoformat(),
+                    "count": len(fold_evidence),
+                    "items": fold_evidence,
+                    "artifact_authority": evidence_contract_payload(
+                        provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
+                        maturity=EvidenceMaturity.UNCALIBRATED,
+                        calibration_summary={"status": "pending_calibration"},
+                    ),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        stress_metrics_artifact_ref = _artifact_ref(stress_metrics_path)
+        fold_metrics_artifact_ref = _artifact_ref(fold_metrics_path)
+        simulation_calibration_artifact_ref = _artifact_ref(
+            simulation_calibration_report_path
+        )
+        shadow_live_deviation_artifact_ref = _artifact_ref(
+            shadow_live_deviation_report_path
+        )
+        benchmark_parity_artifact_ref = _artifact_ref(benchmark_parity_path)
+        foundation_router_parity_artifact_ref = _artifact_ref(
+            foundation_router_parity_path
+        )
+        deeplob_bdlob_artifact_ref = _artifact_ref(deeplob_bdlob_report_path)
+        advisor_fallback_slo_artifact_ref = _artifact_ref(
+            advisor_fallback_slo_report_path
+        )
+        contamination_registry_artifact_ref = _artifact_ref(contamination_registry_path)
+        hmm_state_posterior_artifact_ref = _artifact_ref(hmm_state_posterior_path)
+        expert_router_registry_artifact_ref = _artifact_ref(expert_router_registry_path)
+        gate_report_payload = gate_report.to_payload()
+        gate_report_payload["run_id"] = run_id
+
+    def _run_profitability_validation_phase() -> None:
         profitability_evidence, evidence_payload, tca_gate_inputs = (
             _write_profitability_evidence_artifacts()
         )
@@ -3483,312 +3476,305 @@ def run_autonomous_lane(
             "priority_id": str(resolved_governance_priority_id or ""),
         }
 
-    def _run_promotion_recommendation_phase() -> None:
-        nonlocal _write_profitability_manifest
+    def _write_current_profitability_manifest() -> None:
+        profitability_manifest_payload = _build_profitability_stage_manifest(
+            output_dir=output_dir,
+            run_id=run_id,
+            candidate_id=candidate_id,
+            strategy_family=strategy_family,
+            llm_artifact_ref=None,
+            router_artifact_ref=router_artifact_ref,
+            run_context=profitability_run_context,
+            research_manifest_path=manifest_paths.get(_STAGE_CANDIDATE_GENERATION),
+            candidate_spec_path=candidate_spec_path,
+            evaluation_report_path=evaluation_report_path,
+            walkforward_results_path=walk_results_path,
+            baseline_evaluation_report_path=baseline_report_path,
+            gate_report_payload=gate_report_payload,
+            gate_report_path=gate_report_path,
+            profitability_benchmark_path=profitability_benchmark_path,
+            contamination_registry_path=contamination_registry_path,
+            profitability_evidence_path=profitability_evidence_path,
+            profitability_validation_path=profitability_validation_path,
+            simulation_calibration_report_path=simulation_calibration_report_path,
+            shadow_live_deviation_report_path=shadow_live_deviation_report_path,
+            hmm_state_posterior_path=hmm_state_posterior_path,
+            expert_router_registry_path=expert_router_registry_path,
+            benchmark_parity_path=benchmark_parity_path,
+            foundation_router_parity_path=foundation_router_parity_path,
+            deeplob_bdlob_report_path=deeplob_bdlob_report_path,
+            advisor_fallback_slo_report_path=advisor_fallback_slo_report_path,
+            janus_event_car_path=janus_event_car_path,
+            janus_hgrm_reward_path=janus_hgrm_reward_path,
+            recalibration_report_path=recalibration_report_path,
+            rollback_check=rollback_check,
+            drift_gate_check=drift_gate_check,
+            patch_path=patch_path,
+            now=now,
+        )
+        profitability_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        profitability_manifest_path.write_text(
+            json.dumps(profitability_manifest_payload, indent=2),
+            encoding="utf-8",
+        )
 
-        def _write_profitability_manifest() -> None:
-            profitability_manifest_payload = _build_profitability_stage_manifest(
-                output_dir=output_dir,
-                run_id=run_id,
-                candidate_id=candidate_id,
-                strategy_family=strategy_family,
-                llm_artifact_ref=None,
-                router_artifact_ref=router_artifact_ref,
-                run_context=profitability_run_context,
-                research_manifest_path=manifest_paths.get(_STAGE_CANDIDATE_GENERATION),
-                candidate_spec_path=candidate_spec_path,
-                evaluation_report_path=evaluation_report_path,
-                walkforward_results_path=walk_results_path,
-                baseline_evaluation_report_path=baseline_report_path,
-                gate_report_payload=gate_report_payload,
-                gate_report_path=gate_report_path,
-                profitability_benchmark_path=profitability_benchmark_path,
-                contamination_registry_path=contamination_registry_path,
-                profitability_evidence_path=profitability_evidence_path,
-                profitability_validation_path=profitability_validation_path,
-                simulation_calibration_report_path=simulation_calibration_report_path,
-                shadow_live_deviation_report_path=shadow_live_deviation_report_path,
-                hmm_state_posterior_path=hmm_state_posterior_path,
-                expert_router_registry_path=expert_router_registry_path,
-                benchmark_parity_path=benchmark_parity_path,
-                foundation_router_parity_path=foundation_router_parity_path,
-                deeplob_bdlob_report_path=deeplob_bdlob_report_path,
-                advisor_fallback_slo_report_path=advisor_fallback_slo_report_path,
-                janus_event_car_path=janus_event_car_path,
-                janus_hgrm_reward_path=janus_hgrm_reward_path,
-                recalibration_report_path=recalibration_report_path,
-                rollback_check=rollback_check,
-                drift_gate_check=drift_gate_check,
-                patch_path=patch_path,
-                now=now,
-            )
-            profitability_manifest_path.parent.mkdir(parents=True, exist_ok=True)
-            profitability_manifest_path.write_text(
-                json.dumps(profitability_manifest_payload, indent=2),
-                encoding="utf-8",
-            )
+    _write_profitability_manifest = _write_current_profitability_manifest
 
-        def _build_promotion_policy_payload() -> dict[str, Any]:
-            promotion_policy_payload = dict(raw_gate_policy)
-            promotion_policy_payload[
-                "promotion_require_profitability_stage_manifest"
-            ] = True
-            promotion_policy_payload[
-                "promotion_require_truthful_evidence_contracts"
-            ] = True
-            require_jangar_dependency_quorum = (
-                hypothesis_registry_requires_dependency_capability(
-                    load_hypothesis_registry(),
-                    "jangar_dependency_quorum",
-                )
+    def _build_promotion_policy_payload() -> dict[str, Any]:
+        promotion_policy_payload = dict(raw_gate_policy)
+        promotion_policy_payload["promotion_require_profitability_stage_manifest"] = (
+            True
+        )
+        promotion_policy_payload["promotion_require_truthful_evidence_contracts"] = True
+        require_jangar_dependency_quorum = (
+            hypothesis_registry_requires_dependency_capability(
+                load_hypothesis_registry(),
+                "jangar_dependency_quorum",
             )
-            promotion_policy_payload["promotion_require_jangar_dependency_quorum"] = (
-                require_jangar_dependency_quorum
-            )
-            if require_jangar_dependency_quorum:
-                promotion_policy_payload.setdefault(
-                    "promotion_jangar_dependency_quorum_required_targets",
-                    ["paper", "live"],
-                )
-            else:
-                promotion_policy_payload.pop(
-                    "promotion_jangar_dependency_quorum_required_targets",
-                    None,
-                )
-            promotion_policy_payload["promotion_require_alpha_readiness_contract"] = (
-                True
-            )
+        )
+        promotion_policy_payload["promotion_require_jangar_dependency_quorum"] = (
+            require_jangar_dependency_quorum
+        )
+        if require_jangar_dependency_quorum:
             promotion_policy_payload.setdefault(
-                "promotion_alpha_readiness_required_targets",
+                "promotion_jangar_dependency_quorum_required_targets",
                 ["paper", "live"],
             )
-            promotion_policy_payload.setdefault(
-                "promotion_alpha_readiness_require_registry_match",
-                True,
+        else:
+            promotion_policy_payload.pop(
+                "promotion_jangar_dependency_quorum_required_targets",
+                None,
             )
-            promotion_policy_payload.setdefault(
-                "promotion_require_simulation_calibration",
-                True,
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_simulation_calibration_required_artifacts",
-                ["gates/simulation-calibration-report-v1.json"],
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_simulation_calibration_required_targets",
-                ["paper", "live"],
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_simulation_calibration_min_order_count",
-                1,
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_simulation_calibration_min_expected_shortfall_coverage",
-                "0.50",
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_simulation_calibration_max_avg_calibration_error_bps",
-                "25",
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_require_shadow_live_deviation",
-                True,
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_shadow_live_deviation_required_artifacts",
-                ["gates/shadow-live-deviation-report-v1.json"],
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_shadow_live_deviation_required_targets",
-                ["paper", "live"],
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_shadow_live_deviation_min_order_count",
-                1,
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
-                "20",
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
-                "15",
-            )
-            promotion_policy_payload.setdefault(
-                "promotion_profitability_stage_manifest_artifact",
-                _PROFITABILITY_STAGE_MANIFEST_PATH,
-            )
-            return promotion_policy_payload
+        promotion_policy_payload["promotion_require_alpha_readiness_contract"] = True
+        promotion_policy_payload.setdefault(
+            "promotion_alpha_readiness_required_targets",
+            ["paper", "live"],
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_alpha_readiness_require_registry_match",
+            True,
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_require_simulation_calibration",
+            True,
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_simulation_calibration_required_artifacts",
+            ["gates/simulation-calibration-report-v1.json"],
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_simulation_calibration_required_targets",
+            ["paper", "live"],
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_simulation_calibration_min_order_count",
+            1,
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_simulation_calibration_min_expected_shortfall_coverage",
+            "0.50",
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_simulation_calibration_max_avg_calibration_error_bps",
+            "25",
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_require_shadow_live_deviation",
+            True,
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_shadow_live_deviation_required_artifacts",
+            ["gates/shadow-live-deviation-report-v1.json"],
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_shadow_live_deviation_required_targets",
+            ["paper", "live"],
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_shadow_live_deviation_min_order_count",
+            1,
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
+            "20",
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
+            "15",
+        )
+        promotion_policy_payload.setdefault(
+            "promotion_profitability_stage_manifest_artifact",
+            _PROFITABILITY_STAGE_MANIFEST_PATH,
+        )
+        return promotion_policy_payload
 
-        def _evaluate_promotion_prerequisites(
-            promotion_policy_payload: dict[str, Any],
-        ) -> None:
-            nonlocal promotion_check
+    def _evaluate_promotion_prerequisites(
+        promotion_policy_payload: dict[str, Any],
+    ) -> None:
+        nonlocal promotion_check
 
-            promotion_check = evaluate_promotion_prerequisites(
-                policy_payload=promotion_policy_payload,
-                gate_report_payload=gate_report_payload,
-                candidate_state_payload=candidate_state_payload,
+        promotion_check = evaluate_promotion_prerequisites(
+            policy_payload=promotion_policy_payload,
+            gate_report_payload=gate_report_payload,
+            candidate_state_payload=candidate_state_payload,
+            promotion_target=promotion_target,
+            artifact_root=output_dir,
+            now=now,
+        )
+        promotion_check_path.write_text(
+            json.dumps(promotion_check.to_payload(), indent=2), encoding="utf-8"
+        )
+
+    def _record_promotion_recommendation() -> None:
+        nonlocal fold_metrics_count, patch_path, promotion_allowed
+        nonlocal promotion_reasons, promotion_recommendation
+        nonlocal recommendation_trace_id, recommended_mode
+
+        fold_metrics_count = len(walk_results.folds)
+        promotion_recommendation = build_promotion_recommendation(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            requested_mode=promotion_target,
+            recommended_mode=gate_report.recommended_mode,
+            gate_allowed=(
+                gate_report.promotion_allowed and bool(drift_gate_check["allowed"])
+            ),
+            prerequisite_allowed=promotion_check.allowed and strategy_factory_allowed,
+            rollback_ready=rollback_check.ready,
+            fold_metrics_count=fold_metrics_count,
+            stress_metrics_count=stress_metrics_count,
+            rationale=_build_promotion_rationale(
+                gate_report=gate_report,
+                promotion_check_reasons=promotion_check.reasons,
+                rollback_check_reasons=rollback_check.reasons,
                 promotion_target=promotion_target,
-                artifact_root=output_dir,
-                now=now,
-            )
-            promotion_check_path.write_text(
-                json.dumps(promotion_check.to_payload(), indent=2), encoding="utf-8"
-            )
-
-        def _record_promotion_recommendation() -> None:
-            nonlocal fold_metrics_count, patch_path, promotion_allowed
-            nonlocal promotion_reasons, promotion_recommendation
-            nonlocal recommendation_trace_id, recommended_mode
-
-            fold_metrics_count = len(walk_results.folds)
-            promotion_recommendation = build_promotion_recommendation(
-                run_id=run_id,
-                candidate_id=candidate_id,
-                requested_mode=promotion_target,
-                recommended_mode=gate_report.recommended_mode,
-                gate_allowed=(
-                    gate_report.promotion_allowed and bool(drift_gate_check["allowed"])
-                ),
-                prerequisite_allowed=promotion_check.allowed
-                and strategy_factory_allowed,
-                rollback_ready=rollback_check.ready,
-                fold_metrics_count=fold_metrics_count,
-                stress_metrics_count=stress_metrics_count,
-                rationale=_build_promotion_rationale(
-                    gate_report=gate_report,
-                    promotion_check_reasons=promotion_check.reasons,
-                    rollback_check_reasons=rollback_check.reasons,
-                    promotion_target=promotion_target,
-                    additional_reasons=strategy_factory_reasons,
-                ),
-                reasons=[
-                    *gate_report.reasons,
-                    *promotion_check.reasons,
-                    *strategy_factory_reasons,
-                    *rollback_check.reasons,
-                    *[
-                        str(item)
-                        for item in drift_gate_check.get("reasons", [])
-                        if str(item).strip()
-                    ],
+                additional_reasons=strategy_factory_reasons,
+            ),
+            reasons=[
+                *gate_report.reasons,
+                *promotion_check.reasons,
+                *strategy_factory_reasons,
+                *rollback_check.reasons,
+                *[
+                    str(item)
+                    for item in drift_gate_check.get("reasons", [])
+                    if str(item).strip()
                 ],
+            ],
+        )
+        promotion_allowed = promotion_recommendation.eligible
+        if patch_path is None and promotion_allowed:
+            patch_path = _resolve_paper_patch_path(
+                gate_report=gate_report,
+                strategy_configmap_path=strategy_configmap_path,
+                runtime_strategies=runtime_strategies,
+                candidate_id=candidate_id,
+                promotion_target=promotion_target,
+                paper_dir=paper_dir,
             )
-            promotion_allowed = promotion_recommendation.eligible
-            if patch_path is None and promotion_allowed:
-                patch_path = _resolve_paper_patch_path(
-                    gate_report=gate_report,
-                    strategy_configmap_path=strategy_configmap_path,
-                    runtime_strategies=runtime_strategies,
-                    candidate_id=candidate_id,
-                    promotion_target=promotion_target,
-                    paper_dir=paper_dir,
-                )
-            promotion_reasons = promotion_recommendation.reasons
-            recommended_mode = promotion_recommendation.recommended_mode
-            recommendation_trace_id = promotion_recommendation.trace_id
-            research_spec["promotion_recommendation"] = (
-                promotion_recommendation.to_payload()
-            )
-            research_spec["promotion_evidence_requirements"] = {
-                "fold_metrics_count": len(fold_evidence),
-                "stress_case_count": len(stress_evidence),
-                "deeplob_bdlob_contract_required": True,
-                "advisor_fallback_slo_required": True,
-                "strategy_factory_required": strategy_factory_bridge is not None,
-                "rationale_required": True,
-                "rationale_reason_codes": promotion_reasons,
-            }
-            candidate_spec_path.write_text(
-                json.dumps(research_spec, indent=2), encoding="utf-8"
-            )
+        promotion_reasons = promotion_recommendation.reasons
+        recommended_mode = promotion_recommendation.recommended_mode
+        recommendation_trace_id = promotion_recommendation.trace_id
+        research_spec["promotion_recommendation"] = (
+            promotion_recommendation.to_payload()
+        )
+        research_spec["promotion_evidence_requirements"] = {
+            "fold_metrics_count": len(fold_evidence),
+            "stress_case_count": len(stress_evidence),
+            "deeplob_bdlob_contract_required": True,
+            "advisor_fallback_slo_required": True,
+            "strategy_factory_required": strategy_factory_bridge is not None,
+            "rationale_required": True,
+            "rationale_reason_codes": promotion_reasons,
+        }
+        candidate_spec_path.write_text(
+            json.dumps(research_spec, indent=2), encoding="utf-8"
+        )
 
-        def _promotion_gate_artifact_refs() -> list[str]:
-            return sorted(
-                {
-                    str(promotion_check_path),
-                    str(rollback_check_path),
-                    str(gate_report_path),
-                    str(benchmark_parity_path),
-                    str(deeplob_bdlob_report_path),
-                    str(advisor_fallback_slo_report_path),
-                    str(contamination_registry_path),
-                    str(profitability_benchmark_path),
-                    str(profitability_evidence_path),
-                    str(profitability_validation_path),
-                    str(simulation_calibration_report_path),
-                    str(shadow_live_deviation_report_path),
-                    str(fold_metrics_path),
-                    str(stress_metrics_path),
-                    str(hmm_state_posterior_path),
-                    str(expert_router_registry_path),
-                    str(janus_event_car_path),
-                    str(janus_hgrm_reward_path),
-                    *[
-                        str(item)
-                        for item in drift_gate_check.get("artifact_refs", [])
-                        if str(item).strip()
+    def _promotion_gate_artifact_refs() -> list[str]:
+        return sorted(
+            {
+                str(promotion_check_path),
+                str(rollback_check_path),
+                str(gate_report_path),
+                str(benchmark_parity_path),
+                str(deeplob_bdlob_report_path),
+                str(advisor_fallback_slo_report_path),
+                str(contamination_registry_path),
+                str(profitability_benchmark_path),
+                str(profitability_evidence_path),
+                str(profitability_validation_path),
+                str(simulation_calibration_report_path),
+                str(shadow_live_deviation_report_path),
+                str(fold_metrics_path),
+                str(stress_metrics_path),
+                str(hmm_state_posterior_path),
+                str(expert_router_registry_path),
+                str(janus_event_car_path),
+                str(janus_hgrm_reward_path),
+                *[
+                    str(item)
+                    for item in drift_gate_check.get("artifact_refs", [])
+                    if str(item).strip()
+                ],
+                str(recalibration_report_path),
+                *strategy_factory_artifact_refs,
+            }
+        )
+
+    def _write_promotion_gate_payload() -> None:
+        promotion_gate_payload: dict[str, Any] = {
+            "allowed": promotion_allowed,
+            "recommended_mode": recommended_mode,
+            "reasons": promotion_reasons,
+            "checks": {
+                "gate_matrix": {
+                    "allowed": gate_report.promotion_allowed,
+                    "reasons": gate_report.reasons,
+                    "artifact_refs": [
+                        str(gate_report_path),
+                        str(benchmark_parity_path),
+                        str(deeplob_bdlob_report_path),
+                        str(advisor_fallback_slo_report_path),
+                        str(profitability_evidence_path),
+                        str(profitability_validation_path),
+                        str(simulation_calibration_report_path),
+                        str(shadow_live_deviation_report_path),
+                        str(stress_metrics_path),
+                        str(hmm_state_posterior_path),
+                        str(expert_router_registry_path),
+                        str(fold_metrics_path),
+                        str(janus_event_car_path),
+                        str(janus_hgrm_reward_path),
+                        str(recalibration_report_path),
+                        *strategy_factory_artifact_refs,
                     ],
-                    str(recalibration_report_path),
-                    *strategy_factory_artifact_refs,
-                }
-            )
-
-        def _write_promotion_gate_payload() -> None:
-            promotion_gate_payload: dict[str, Any] = {
-                "allowed": promotion_allowed,
-                "recommended_mode": recommended_mode,
-                "reasons": promotion_reasons,
-                "checks": {
-                    "gate_matrix": {
-                        "allowed": gate_report.promotion_allowed,
-                        "reasons": gate_report.reasons,
-                        "artifact_refs": [
-                            str(gate_report_path),
-                            str(benchmark_parity_path),
-                            str(deeplob_bdlob_report_path),
-                            str(advisor_fallback_slo_report_path),
-                            str(profitability_evidence_path),
-                            str(profitability_validation_path),
-                            str(simulation_calibration_report_path),
-                            str(shadow_live_deviation_report_path),
-                            str(stress_metrics_path),
-                            str(hmm_state_posterior_path),
-                            str(expert_router_registry_path),
-                            str(fold_metrics_path),
-                            str(janus_event_car_path),
-                            str(janus_hgrm_reward_path),
-                            str(recalibration_report_path),
-                            *strategy_factory_artifact_refs,
-                        ],
-                    },
-                    "promotion_prerequisites": promotion_check.to_payload(),
-                    "rollback_readiness": rollback_check.to_payload(),
-                    "profitability_validation": profitability_validation.to_payload(),
-                    "janus_q": janus_q_summary,
-                    "drift_governance": drift_gate_check,
-                    "evidence_requirements": (
-                        promotion_recommendation.evidence.to_payload()
-                    ),
                 },
-                "recommendation": promotion_recommendation.to_payload(),
-                "artifact_refs": _promotion_gate_artifact_refs(),
-            }
-            if strategy_factory_bridge is not None:
-                promotion_gate_checks = cast(
-                    dict[str, Any], promotion_gate_payload["checks"]
-                )
-                promotion_gate_checks["strategy_factory"] = dict(
-                    strategy_factory_summary
-                )
-            promotion_gate_path.write_text(
-                json.dumps(promotion_gate_payload, indent=2), encoding="utf-8"
+                "promotion_prerequisites": promotion_check.to_payload(),
+                "rollback_readiness": rollback_check.to_payload(),
+                "profitability_validation": profitability_validation.to_payload(),
+                "janus_q": janus_q_summary,
+                "drift_governance": drift_gate_check,
+                "evidence_requirements": (
+                    promotion_recommendation.evidence.to_payload()
+                ),
+            },
+            "recommendation": promotion_recommendation.to_payload(),
+            "artifact_refs": _promotion_gate_artifact_refs(),
+        }
+        if strategy_factory_bridge is not None:
+            promotion_gate_checks = cast(
+                dict[str, Any], promotion_gate_payload["checks"]
             )
-            gate_report_payload["promotion_recommendation"] = (
-                promotion_recommendation.to_payload()
-            )
+            promotion_gate_checks["strategy_factory"] = dict(strategy_factory_summary)
+        promotion_gate_path.write_text(
+            json.dumps(promotion_gate_payload, indent=2), encoding="utf-8"
+        )
+        gate_report_payload["promotion_recommendation"] = (
+            promotion_recommendation.to_payload()
+        )
 
+    def _run_promotion_recommendation_phase() -> None:
         _write_profitability_manifest()
         _evaluate_promotion_prerequisites(_build_promotion_policy_payload())
         _record_promotion_recommendation()

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -2296,33 +2296,11 @@ def run_autonomous_lane(
             now=now,
         )
 
-    def _run_candidate_generation_phase() -> None:
-        nonlocal \
-            advisor_fallback_slo_report, \
-            baseline_candidate_id, \
-            baseline_runtime_errors, \
-            benchmark
-        nonlocal \
-            candidate_generation_stage_record, \
-            evaluation_report_path, \
-            expert_router_registry_payload
-        nonlocal gate_policy_payload, hmm_state_posterior_payload, janus_event_count
-        nonlocal \
-            janus_evidence_complete, \
-            janus_q_summary, \
-            janus_reasons, \
-            janus_reward_count
-        nonlocal ordered_signals, report, runtime_errors, strategy_factory_allowed
-        nonlocal \
-            strategy_factory_artifact_refs, \
-            strategy_factory_bridge, \
-            strategy_factory_reasons
-        nonlocal \
-            strategy_factory_summary, \
-            strategy_family, \
-            router_artifact_ref, \
-            walk_decisions
-        nonlocal walk_results, walk_results_path
+    def _run_strategy_factory_gate() -> None:
+        nonlocal strategy_factory_allowed, strategy_factory_artifact_refs
+        nonlocal strategy_factory_bridge, strategy_factory_reasons
+        nonlocal strategy_factory_summary
+
         strategy_factory_bridge = _build_strategy_factory_bridge(
             output_dir=output_dir,
             notes_artifact_root=notes_artifact_root,
@@ -2346,18 +2324,28 @@ def run_autonomous_lane(
             promotion_target=promotion_target,
             now=now,
         )
-        if strategy_factory_bridge is not None:
-            (
-                strategy_factory_allowed,
-                strategy_factory_reasons,
-                strategy_factory_summary,
-            ) = _strategy_factory_gate_summary(
-                strategy_factory_bridge,
-                promotion_target=promotion_target,
-            )
-            strategy_factory_artifact_refs = _strategy_factory_artifact_refs(
-                strategy_factory_bridge
-            )
+        if strategy_factory_bridge is None:
+            return
+        (
+            strategy_factory_allowed,
+            strategy_factory_reasons,
+            strategy_factory_summary,
+        ) = _strategy_factory_gate_summary(
+            strategy_factory_bridge,
+            promotion_target=promotion_target,
+        )
+        strategy_factory_artifact_refs = _strategy_factory_artifact_refs(
+            strategy_factory_bridge
+        )
+
+    def _build_walkforward_artifacts() -> tuple[
+        list[StrategyRuntimeConfig],
+        WalkForwardResults,
+    ]:
+        nonlocal baseline_runtime_errors, ordered_signals, router_artifact_ref
+        nonlocal runtime_errors, strategy_family, walk_decisions, walk_results
+        nonlocal walk_results_path
+
         ordered_signals = sorted(
             signals, key=lambda item: (item.event_ts, item.symbol, item.seq or 0)
         )
@@ -2372,7 +2360,6 @@ def run_autonomous_lane(
             ordered_signals=ordered_signals,
             runtime_strategies=runtime_strategies,
         )
-
         baseline_runtime_strategies = _baseline_runtime_strategies()
         baseline_walk_decisions, baseline_runtime_errors = (
             _collect_walk_decisions_for_runtime(
@@ -2381,7 +2368,6 @@ def run_autonomous_lane(
                 runtime_strategies=baseline_runtime_strategies,
             )
         )
-
         walk_fold = WalkForwardFold(
             name="autonomous_lane",
             train_start=signals[0].event_ts,
@@ -2393,7 +2379,9 @@ def run_autonomous_lane(
             generated_at=now,
             folds=[
                 FoldResult(
-                    fold=walk_fold, decisions=walk_decisions, signals_count=len(signals)
+                    fold=walk_fold,
+                    decisions=walk_decisions,
+                    signals_count=len(signals),
                 )
             ],
             feature_spec="app.trading.features.normalize_feature_vector_v3",
@@ -2409,9 +2397,17 @@ def run_autonomous_lane(
             ],
             feature_spec="app.trading.features.normalize_feature_vector_v3",
         )
-
         walk_results_path = backtest_dir / "walkforward-results.json"
         write_walk_forward_results(walk_results, walk_results_path)
+        return baseline_runtime_strategies, baseline_walk_results
+
+    def _write_evaluation_artifacts(
+        baseline_runtime_strategies: list[StrategyRuntimeConfig],
+        baseline_walk_results: WalkForwardResults,
+    ) -> EvaluationReport:
+        nonlocal baseline_candidate_id, candidate_generation_stage_record
+        nonlocal evaluation_report_path, hmm_state_posterior_payload, report
+
         hmm_state_posterior_payload = _build_hmm_state_posterior_payload(
             output_dir=output_dir,
             run_id=run_id,
@@ -2426,34 +2422,33 @@ def run_autonomous_lane(
             json.dumps(hmm_state_posterior_payload, indent=2),
             encoding="utf-8",
         )
-
-        report_config = EvaluationReportConfig(
-            evaluation_start=signals[0].event_ts,
-            evaluation_end=signals[-1].event_ts,
-            signal_source=str(signals_path),
-            strategies=_to_orm_strategies(runtime_strategies),
-            run_id=run_id,
-            strategy_config_path=str(strategy_config_path),
-            git_sha=code_version,
-        )
         report = generate_evaluation_report(
-            walk_results, config=report_config, promotion_target=promotion_target
+            walk_results,
+            config=EvaluationReportConfig(
+                evaluation_start=signals[0].event_ts,
+                evaluation_end=signals[-1].event_ts,
+                signal_source=str(signals_path),
+                strategies=_to_orm_strategies(runtime_strategies),
+                run_id=run_id,
+                strategy_config_path=str(strategy_config_path),
+                git_sha=code_version,
+            ),
+            promotion_target=promotion_target,
         )
         evaluation_report_path = backtest_dir / "evaluation-report.json"
         write_evaluation_report(report, evaluation_report_path)
         baseline_candidate_id = "baseline-legacy-macd-rsi"
-        baseline_report_config = EvaluationReportConfig(
-            evaluation_start=signals[0].event_ts,
-            evaluation_end=signals[-1].event_ts,
-            signal_source=str(signals_path),
-            strategies=_to_orm_strategies(baseline_runtime_strategies),
-            run_id=f"{run_id}-baseline",
-            strategy_config_path=f"baseline:{baseline_candidate_id}@1.0.0",
-            git_sha=code_version,
-        )
         baseline_report = generate_evaluation_report(
             baseline_walk_results,
-            config=baseline_report_config,
+            config=EvaluationReportConfig(
+                evaluation_start=signals[0].event_ts,
+                evaluation_end=signals[-1].event_ts,
+                signal_source=str(signals_path),
+                strategies=_to_orm_strategies(baseline_runtime_strategies),
+                run_id=f"{run_id}-baseline",
+                strategy_config_path=f"baseline:{baseline_candidate_id}@1.0.0",
+                git_sha=code_version,
+            ),
             promotion_target="shadow",
         )
         write_evaluation_report(baseline_report, baseline_report_path)
@@ -2490,13 +2485,22 @@ def run_autonomous_lane(
         stage_trace_ids[_STAGE_CANDIDATE_GENERATION] = (
             candidate_generation_stage_record.stage_trace_id
         )
+        return baseline_report
+
+    def _write_janus_and_benchmark_artifacts(
+        baseline_report: EvaluationReport,
+    ) -> None:
+        nonlocal benchmark, janus_event_count, janus_evidence_complete
+        nonlocal janus_q_summary, janus_reasons, janus_reward_count
+
         janus_event_car = build_janus_event_car_artifact_v1(
             run_id=run_id,
             signals=ordered_signals,
             generated_at=now,
         )
         janus_event_car_path.write_text(
-            json.dumps(janus_event_car.to_payload(), indent=2), encoding="utf-8"
+            json.dumps(janus_event_car.to_payload(), indent=2),
+            encoding="utf-8",
         )
         janus_hgrm_reward = build_janus_hgrm_reward_artifact_v1(
             run_id=run_id,
@@ -2520,7 +2524,6 @@ def run_autonomous_lane(
             janus_evidence_complete,
             janus_reasons,
         ) = _extract_janus_q_metrics(janus_q_summary)
-
         benchmark = execute_profitability_benchmark_v4(
             candidate_id=candidate_id,
             baseline_id=baseline_candidate_id,
@@ -2541,6 +2544,11 @@ def run_autonomous_lane(
             now=now,
         )
         write_benchmark_parity_report(benchmark_parity_report, benchmark_parity_path)
+
+    def _write_router_contract_artifacts() -> None:
+        nonlocal advisor_fallback_slo_report, expert_router_registry_payload
+        nonlocal gate_policy_payload
+
         gate_policy_payload = json.loads(gate_policy_path.read_text(encoding="utf-8"))
         foundation_router_parity_report = build_foundation_router_parity_report(
             candidate_id=candidate_id,
@@ -2598,392 +2606,423 @@ def run_autonomous_lane(
             encoding="utf-8",
         )
 
+    def _run_candidate_generation_phase() -> None:
+        _run_strategy_factory_gate()
+        baseline_runtime_strategies, baseline_walk_results = (
+            _build_walkforward_artifacts()
+        )
+        baseline_report = _write_evaluation_artifacts(
+            baseline_runtime_strategies,
+            baseline_walk_results,
+        )
+        _write_janus_and_benchmark_artifacts(baseline_report)
+        _write_router_contract_artifacts()
+
     def _run_profitability_validation_phase() -> None:
-        nonlocal advisor_fallback_slo_artifact_ref, benchmark_parity_artifact_ref
-        nonlocal candidate_alpha_readiness_payload, candidate_dependency_quorum_payload
-        nonlocal candidate_state_payload, contamination_registry_artifact_ref
-        nonlocal contamination_registry_payload, deeplob_bdlob_artifact_ref
-        nonlocal \
-            expert_router_registry_artifact_ref, \
-            fold_evidence, \
-            fold_metrics_artifact_ref
-        nonlocal foundation_router_parity_artifact_ref, gate_report, gate_report_payload
-        nonlocal hmm_state_posterior_artifact_ref, profitability_validation
-        nonlocal \
-            shadow_live_deviation_artifact_ref, \
-            shadow_live_deviation_report_payload
-        nonlocal \
-            simulation_calibration_artifact_ref, \
-            simulation_calibration_report_payload, \
-            stress_evidence
-        nonlocal stress_metrics_artifact_ref, stress_metrics_count
-        confidence_values = _collect_confidence_values(walk_decisions)
-        reproducibility_hashes = {
-            "signals": _sha256_path(signals_path),
-            "strategy_config": _sha256_path(strategy_config_path),
-            "gate_policy": _sha256_path(gate_policy_path),
-            "walkforward_results": _sha256_path(walk_results_path),
-            "foundation_router_parity": _sha256_path(foundation_router_parity_path),
-            "deeplob_bdlob_contract": _sha256_path(deeplob_bdlob_report_path),
-            "advisor_fallback_slo": _sha256_path(advisor_fallback_slo_report_path),
-            "hmm_state_posterior": _sha256_path(hmm_state_posterior_path),
-            "expert_router_registry": _sha256_path(expert_router_registry_path),
-            "candidate_report": _sha256_path(evaluation_report_path),
-            "baseline_report": _sha256_path(baseline_report_path),
-            "janus_event_car": _sha256_path(janus_event_car_path),
-            "janus_hgrm_reward": _sha256_path(janus_hgrm_reward_path),
-        }
-        profitability_evidence = build_profitability_evidence_v4(
-            run_id=run_id,
-            candidate_id=candidate_id,
-            baseline_id=baseline_candidate_id,
-            candidate_report_payload=report.to_payload(),
-            benchmark=benchmark,
-            confidence_values=confidence_values,
-            reproducibility_hashes=reproducibility_hashes,
-            artifact_refs=[
-                str(evaluation_report_path),
-                str(baseline_report_path),
-                str(walk_results_path),
-                str(hmm_state_posterior_path),
-                str(expert_router_registry_path),
-                str(deeplob_bdlob_report_path),
-                str(advisor_fallback_slo_report_path),
-                str(signals_path),
-                str(strategy_config_path),
-                str(gate_policy_path),
-            ],
-            generated_at=now,
-        )
-        profitability_evidence_payload = profitability_evidence.to_payload()
-        profitability_evidence_payload["janus_q"] = janus_q_summary
-        profitability_evidence_path.write_text(
-            json.dumps(profitability_evidence_payload, indent=2), encoding="utf-8"
-        )
+        def _artifact_ref(path: Path) -> str:
+            if output_dir.is_absolute():
+                return str(path)
+            return str(path.relative_to(output_dir))
 
-        profitability_thresholds = ProfitabilityEvidenceThresholdsV4.from_payload(
-            _profitability_threshold_payload(gate_policy_payload)
-        )
-        profitability_validation = validate_profitability_evidence_v4(
-            profitability_evidence,
-            thresholds=profitability_thresholds,
-            checked_at=now,
-        )
-        profitability_validation_path.write_text(
-            json.dumps(profitability_validation.to_payload(), indent=2),
-            encoding="utf-8",
-        )
-        tca_gate_inputs = _load_tca_gate_inputs(factory)
-        simulation_calibration_report = build_simulation_calibration_report_v1(
-            run_id=run_id,
-            candidate_id=candidate_id,
-            profitability_evidence=profitability_evidence,
-            tca_metrics=tca_gate_inputs,
-            min_order_count=_coerce_int(
-                gate_policy_payload.get(
-                    "promotion_simulation_calibration_min_order_count",
-                    1,
-                ),
-                default=1,
-            ),
-            min_expected_shortfall_coverage=_decimal_or_zero(
-                gate_policy_payload.get(
-                    "promotion_simulation_calibration_min_expected_shortfall_coverage",
-                    "0.50",
-                )
-            ),
-            max_avg_calibration_error_bps=_decimal_or_zero(
-                gate_policy_payload.get(
-                    "promotion_simulation_calibration_max_avg_calibration_error_bps",
-                    "25",
-                )
-            ),
-            generated_at=now,
-        )
-        simulation_calibration_report_payload = (
-            simulation_calibration_report.to_payload()
-        )
-        simulation_calibration_report_path.write_text(
-            json.dumps(simulation_calibration_report_payload, indent=2),
-            encoding="utf-8",
-        )
-        shadow_live_deviation_report = build_shadow_live_deviation_report_v1(
-            run_id=run_id,
-            candidate_id=candidate_id,
-            profitability_evidence=profitability_evidence,
-            tca_metrics=tca_gate_inputs,
-            min_order_count=_coerce_int(
-                gate_policy_payload.get(
-                    "promotion_shadow_live_deviation_min_order_count",
-                    1,
-                ),
-                default=1,
-            ),
-            max_avg_abs_slippage_bps=_decimal_or_zero(
-                gate_policy_payload.get(
-                    "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
-                    "20",
-                )
-            ),
-            max_avg_abs_divergence_bps=_decimal_or_zero(
-                gate_policy_payload.get(
-                    "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
-                    "15",
-                )
-            ),
-            generated_at=now,
-        )
-        shadow_live_deviation_report_payload = shadow_live_deviation_report.to_payload()
-        shadow_live_deviation_report_path.write_text(
-            json.dumps(shadow_live_deviation_report_payload, indent=2),
-            encoding="utf-8",
-        )
-        contamination_registry_payload = _build_contamination_registry_payload(
-            output_dir=output_dir,
-            run_id=run_id,
-            candidate_id=candidate_id,
-            now=now,
-            artifact_refs=[
-                signals_path,
-                strategy_config_path,
-                gate_policy_path,
-                walk_results_path,
-                evaluation_report_path,
-                baseline_report_path,
-                profitability_evidence_path,
-                profitability_validation_path,
-                simulation_calibration_report_path,
-                shadow_live_deviation_report_path,
-                profitability_benchmark_path,
-                benchmark_parity_path,
-                foundation_router_parity_path,
-                deeplob_bdlob_report_path,
-                hmm_state_posterior_path,
-                expert_router_registry_path,
-            ],
-        )
-        contamination_registry_path.write_text(
-            json.dumps(contamination_registry_payload, indent=2),
-            encoding="utf-8",
-        )
-        metrics_payload = report.metrics.to_payload()
+        def _write_profitability_evidence_artifacts() -> tuple[
+            Any,
+            dict[str, Any],
+            dict[str, object],
+        ]:
+            nonlocal profitability_validation
 
-        gate_policy = GatePolicyMatrix.from_path(gate_policy_path)
-        profitability_evidence_payload["validation"] = (
-            profitability_validation.to_payload()
-        )
-        (
-            fragility_state,
-            fragility_score,
-            stability_mode_active,
-            fragility_inputs_valid,
-        ) = _resolve_gate_fragility_inputs(
-            metrics_payload=metrics_payload, decisions=walk_decisions
-        )
-        forecast_gate_metrics = _resolve_gate_forecast_metrics(signals=ordered_signals)
-        confidence_calibration, uncertainty_action, recalibration_run_id = (
-            _resolve_confidence_calibration(
-                profitability_evidence_payload=profitability_evidence_payload,
+            profitability_evidence = build_profitability_evidence_v4(
                 run_id=run_id,
-                recalibration_report_path=recalibration_report_path,
+                candidate_id=candidate_id,
+                baseline_id=baseline_candidate_id,
+                candidate_report_payload=report.to_payload(),
+                benchmark=benchmark,
+                confidence_values=_collect_confidence_values(walk_decisions),
+                reproducibility_hashes={
+                    "signals": _sha256_path(signals_path),
+                    "strategy_config": _sha256_path(strategy_config_path),
+                    "gate_policy": _sha256_path(gate_policy_path),
+                    "walkforward_results": _sha256_path(walk_results_path),
+                    "foundation_router_parity": _sha256_path(
+                        foundation_router_parity_path
+                    ),
+                    "deeplob_bdlob_contract": _sha256_path(deeplob_bdlob_report_path),
+                    "advisor_fallback_slo": _sha256_path(
+                        advisor_fallback_slo_report_path
+                    ),
+                    "hmm_state_posterior": _sha256_path(hmm_state_posterior_path),
+                    "expert_router_registry": _sha256_path(expert_router_registry_path),
+                    "candidate_report": _sha256_path(evaluation_report_path),
+                    "baseline_report": _sha256_path(baseline_report_path),
+                    "janus_event_car": _sha256_path(janus_event_car_path),
+                    "janus_hgrm_reward": _sha256_path(janus_hgrm_reward_path),
+                },
+                artifact_refs=[
+                    str(evaluation_report_path),
+                    str(baseline_report_path),
+                    str(walk_results_path),
+                    str(hmm_state_posterior_path),
+                    str(expert_router_registry_path),
+                    str(deeplob_bdlob_report_path),
+                    str(advisor_fallback_slo_report_path),
+                    str(signals_path),
+                    str(strategy_config_path),
+                    str(gate_policy_path),
+                ],
+                generated_at=now,
             )
-        )
-        recalibration_report_path.write_text(
-            json.dumps(
-                {
-                    "schema_version": "recalibration_report_v1",
-                    "run_id": run_id,
-                    "candidate_id": candidate_id,
-                    "requested_at": now.isoformat(),
-                    "status": "queued" if recalibration_run_id else "not_required",
-                    "recalibration_run_id": recalibration_run_id,
-                    "uncertainty_gate_action": uncertainty_action,
-                    "coverage_error": confidence_calibration.get("coverage_error"),
-                    "shift_score": confidence_calibration.get("shift_score"),
-                    "artifact_refs": sorted(
-                        set(
-                            [
+            evidence_payload = profitability_evidence.to_payload()
+            evidence_payload["janus_q"] = janus_q_summary
+            profitability_evidence_path.write_text(
+                json.dumps(evidence_payload, indent=2), encoding="utf-8"
+            )
+            profitability_validation = validate_profitability_evidence_v4(
+                profitability_evidence,
+                thresholds=ProfitabilityEvidenceThresholdsV4.from_payload(
+                    _profitability_threshold_payload(gate_policy_payload)
+                ),
+                checked_at=now,
+            )
+            profitability_validation_path.write_text(
+                json.dumps(profitability_validation.to_payload(), indent=2),
+                encoding="utf-8",
+            )
+            return (
+                profitability_evidence,
+                evidence_payload,
+                _load_tca_gate_inputs(factory),
+            )
+
+        def _write_simulation_and_contamination_artifacts(
+            profitability_evidence: Any,
+            tca_gate_inputs: dict[str, object],
+        ) -> None:
+            nonlocal contamination_registry_payload
+            nonlocal shadow_live_deviation_report_payload
+            nonlocal simulation_calibration_report_payload
+
+            simulation_calibration_report = build_simulation_calibration_report_v1(
+                run_id=run_id,
+                candidate_id=candidate_id,
+                profitability_evidence=profitability_evidence,
+                tca_metrics=tca_gate_inputs,
+                min_order_count=_coerce_int(
+                    gate_policy_payload.get(
+                        "promotion_simulation_calibration_min_order_count",
+                        1,
+                    ),
+                    default=1,
+                ),
+                min_expected_shortfall_coverage=_decimal_or_zero(
+                    gate_policy_payload.get(
+                        "promotion_simulation_calibration_min_expected_shortfall_coverage",
+                        "0.50",
+                    )
+                ),
+                max_avg_calibration_error_bps=_decimal_or_zero(
+                    gate_policy_payload.get(
+                        "promotion_simulation_calibration_max_avg_calibration_error_bps",
+                        "25",
+                    )
+                ),
+                generated_at=now,
+            )
+            simulation_calibration_report_payload = (
+                simulation_calibration_report.to_payload()
+            )
+            simulation_calibration_report_path.write_text(
+                json.dumps(simulation_calibration_report_payload, indent=2),
+                encoding="utf-8",
+            )
+            shadow_live_deviation_report = build_shadow_live_deviation_report_v1(
+                run_id=run_id,
+                candidate_id=candidate_id,
+                profitability_evidence=profitability_evidence,
+                tca_metrics=tca_gate_inputs,
+                min_order_count=_coerce_int(
+                    gate_policy_payload.get(
+                        "promotion_shadow_live_deviation_min_order_count",
+                        1,
+                    ),
+                    default=1,
+                ),
+                max_avg_abs_slippage_bps=_decimal_or_zero(
+                    gate_policy_payload.get(
+                        "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
+                        "20",
+                    )
+                ),
+                max_avg_abs_divergence_bps=_decimal_or_zero(
+                    gate_policy_payload.get(
+                        "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
+                        "15",
+                    )
+                ),
+                generated_at=now,
+            )
+            shadow_live_deviation_report_payload = (
+                shadow_live_deviation_report.to_payload()
+            )
+            shadow_live_deviation_report_path.write_text(
+                json.dumps(shadow_live_deviation_report_payload, indent=2),
+                encoding="utf-8",
+            )
+            contamination_registry_payload = _build_contamination_registry_payload(
+                output_dir=output_dir,
+                run_id=run_id,
+                candidate_id=candidate_id,
+                now=now,
+                artifact_refs=[
+                    signals_path,
+                    strategy_config_path,
+                    gate_policy_path,
+                    walk_results_path,
+                    evaluation_report_path,
+                    baseline_report_path,
+                    profitability_evidence_path,
+                    profitability_validation_path,
+                    simulation_calibration_report_path,
+                    shadow_live_deviation_report_path,
+                    profitability_benchmark_path,
+                    benchmark_parity_path,
+                    foundation_router_parity_path,
+                    deeplob_bdlob_report_path,
+                    hmm_state_posterior_path,
+                    expert_router_registry_path,
+                ],
+            )
+            contamination_registry_path.write_text(
+                json.dumps(contamination_registry_payload, indent=2),
+                encoding="utf-8",
+            )
+
+        def _write_recalibration_request(
+            profitability_evidence_payload: dict[str, Any],
+        ) -> dict[str, Any]:
+            confidence_calibration, uncertainty_action, recalibration_run_id = (
+                _resolve_confidence_calibration(
+                    profitability_evidence_payload=profitability_evidence_payload,
+                    run_id=run_id,
+                    recalibration_report_path=recalibration_report_path,
+                )
+            )
+            recalibration_report_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "recalibration_report_v1",
+                        "run_id": run_id,
+                        "candidate_id": candidate_id,
+                        "requested_at": now.isoformat(),
+                        "status": "queued" if recalibration_run_id else "not_required",
+                        "recalibration_run_id": recalibration_run_id,
+                        "uncertainty_gate_action": uncertainty_action,
+                        "coverage_error": confidence_calibration.get("coverage_error"),
+                        "shift_score": confidence_calibration.get("shift_score"),
+                        "artifact_refs": sorted(
+                            {
                                 str(profitability_evidence_path),
                                 str(profitability_validation_path),
-                            ]
+                            }
+                        ),
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            return confidence_calibration
+
+        def _evaluate_gate_report(
+            profitability_evidence_payload: dict[str, Any],
+            tca_gate_inputs: dict[str, object],
+        ) -> None:
+            nonlocal candidate_alpha_readiness_payload
+            nonlocal candidate_dependency_quorum_payload, candidate_state_payload
+            nonlocal fold_evidence, gate_report, stress_evidence, stress_metrics_count
+
+            metrics_payload = report.metrics.to_payload()
+            gate_policy = GatePolicyMatrix.from_path(gate_policy_path)
+            profitability_evidence_payload["validation"] = (
+                profitability_validation.to_payload()
+            )
+            (
+                fragility_state,
+                fragility_score,
+                stability_mode_active,
+                fragility_inputs_valid,
+            ) = _resolve_gate_fragility_inputs(
+                metrics_payload=metrics_payload, decisions=walk_decisions
+            )
+            _write_recalibration_request(profitability_evidence_payload)
+            (
+                candidate_alpha_readiness_payload,
+                candidate_dependency_quorum_payload,
+            ) = _build_candidate_alpha_readiness_payload(
+                runtime_strategies=runtime_strategies,
+            )
+            candidate_state_payload = _build_candidate_state_payload(
+                candidate_id=candidate_id,
+                run_id=run_id,
+                promotion_target=promotion_target,
+                approval_token=approval_token,
+                runtime_strategies=runtime_strategies,
+                now=now,
+                code_version=code_version,
+                runbook_validated=_is_runbook_valid(strategy_configmap_path),
+                dependency_quorum_payload=candidate_dependency_quorum_payload,
+                alpha_readiness_payload=candidate_alpha_readiness_payload,
+            )
+            candidate_state_readiness = _candidate_state_readiness_payload(
+                candidate_state_payload
+            )
+            gate_report = evaluate_gate_matrix(
+                GateInputs(
+                    feature_schema_version=gate_policy.required_feature_schema_version,
+                    required_feature_null_rate=_required_feature_null_rate(signals),
+                    staleness_ms_p95=_resolve_gate_staleness_ms_p95(
+                        signals=ordered_signals,
+                    ),
+                    symbol_coverage=len({signal.symbol for signal in signals}),
+                    metrics=metrics_payload,
+                    robustness=report.robustness.to_payload(),
+                    tca_metrics=tca_gate_inputs,
+                    llm_metrics=_resolve_gate_llm_metrics(
+                        session_factory=factory,
+                        now=now,
+                    ),
+                    forecast_metrics=_resolve_gate_forecast_metrics(
+                        signals=ordered_signals
+                    ),
+                    profitability_evidence=profitability_evidence_payload,
+                    fragility_state=fragility_state,
+                    fragility_score=fragility_score,
+                    stability_mode_active=stability_mode_active,
+                    fragility_inputs_valid=fragility_inputs_valid,
+                    operational_ready=not bool(
+                        candidate_state_payload.get("paused", False)
+                    ),
+                    runbook_validated=bool(
+                        _coerce_evidence_bool(
+                            candidate_state_payload.get("runbookValidated")
                         )
                     ),
-                },
-                indent=2,
-            ),
-            encoding="utf-8",
+                    kill_switch_dry_run_passed=bool(
+                        _coerce_evidence_bool(
+                            candidate_state_readiness.get("killSwitchDryRunPassed")
+                        )
+                    ),
+                    rollback_dry_run_passed=bool(
+                        _coerce_evidence_bool(
+                            candidate_state_readiness.get("gitopsRevertDryRunPassed")
+                        )
+                        and _coerce_evidence_bool(
+                            candidate_state_readiness.get("strategyDisableDryRunPassed")
+                        )
+                    ),
+                    approval_token=approval_token,
+                ),
+                policy=gate_policy,
+                promotion_target=promotion_target,
+                code_version=code_version,
+                evaluated_at=now,
+            )
+            fold_evidence = [
+                {
+                    "fold_name": fold.fold_name,
+                    "decision_count": fold.decision_count,
+                    "trade_count": fold.trade_count,
+                    "net_pnl": str(fold.net_pnl),
+                    "max_drawdown": str(fold.max_drawdown),
+                    "cost_bps": str(fold.cost_bps),
+                    "regime_label": fold.regime.label(),
+                }
+                for fold in report.robustness.folds
+            ]
+            stress_evidence = [
+                _build_stress_bundle(report, stress_case)
+                for stress_case in _STRESS_METRICS_CASES
+            ]
+            stress_metrics_count = len(stress_evidence)
+
+        def _write_metric_artifact_refs() -> None:
+            nonlocal advisor_fallback_slo_artifact_ref, benchmark_parity_artifact_ref
+            nonlocal contamination_registry_artifact_ref, deeplob_bdlob_artifact_ref
+            nonlocal expert_router_registry_artifact_ref, fold_metrics_artifact_ref
+            nonlocal foundation_router_parity_artifact_ref, gate_report_payload
+            nonlocal hmm_state_posterior_artifact_ref
+            nonlocal shadow_live_deviation_artifact_ref
+            nonlocal simulation_calibration_artifact_ref, stress_metrics_artifact_ref
+
+            stress_metrics_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "stress-metrics-v1",
+                        "run_id": run_id,
+                        "generated_at": now.isoformat(),
+                        "count": stress_metrics_count,
+                        "items": stress_evidence,
+                        "artifact_authority": evidence_contract_payload(
+                            provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
+                            maturity=EvidenceMaturity.UNCALIBRATED,
+                            calibration_summary={"status": "pending_calibration"},
+                        ),
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            fold_metrics_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "fold-metrics-v1",
+                        "run_id": run_id,
+                        "generated_at": now.isoformat(),
+                        "count": len(fold_evidence),
+                        "items": fold_evidence,
+                        "artifact_authority": evidence_contract_payload(
+                            provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
+                            maturity=EvidenceMaturity.UNCALIBRATED,
+                            calibration_summary={"status": "pending_calibration"},
+                        ),
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            stress_metrics_artifact_ref = _artifact_ref(stress_metrics_path)
+            fold_metrics_artifact_ref = _artifact_ref(fold_metrics_path)
+            simulation_calibration_artifact_ref = _artifact_ref(
+                simulation_calibration_report_path
+            )
+            shadow_live_deviation_artifact_ref = _artifact_ref(
+                shadow_live_deviation_report_path
+            )
+            benchmark_parity_artifact_ref = _artifact_ref(benchmark_parity_path)
+            foundation_router_parity_artifact_ref = _artifact_ref(
+                foundation_router_parity_path
+            )
+            deeplob_bdlob_artifact_ref = _artifact_ref(deeplob_bdlob_report_path)
+            advisor_fallback_slo_artifact_ref = _artifact_ref(
+                advisor_fallback_slo_report_path
+            )
+            contamination_registry_artifact_ref = _artifact_ref(
+                contamination_registry_path
+            )
+            hmm_state_posterior_artifact_ref = _artifact_ref(hmm_state_posterior_path)
+            expert_router_registry_artifact_ref = _artifact_ref(
+                expert_router_registry_path
+            )
+            gate_report_payload = gate_report.to_payload()
+            gate_report_payload["run_id"] = run_id
+
+        profitability_evidence, evidence_payload, tca_gate_inputs = (
+            _write_profitability_evidence_artifacts()
         )
-        (
-            candidate_alpha_readiness_payload,
-            candidate_dependency_quorum_payload,
-        ) = _build_candidate_alpha_readiness_payload(
-            runtime_strategies=runtime_strategies,
+        _write_simulation_and_contamination_artifacts(
+            profitability_evidence,
+            tca_gate_inputs,
         )
-        candidate_state_payload = _build_candidate_state_payload(
-            candidate_id=candidate_id,
-            run_id=run_id,
-            promotion_target=promotion_target,
-            approval_token=approval_token,
-            runtime_strategies=runtime_strategies,
-            now=now,
-            code_version=code_version,
-            runbook_validated=_is_runbook_valid(strategy_configmap_path),
-            dependency_quorum_payload=candidate_dependency_quorum_payload,
-            alpha_readiness_payload=candidate_alpha_readiness_payload,
-        )
-        candidate_state_readiness_raw = candidate_state_payload.get(
-            "rollbackReadiness", {}
-        )
-        candidate_state_readiness = (
-            cast(dict[str, Any], candidate_state_readiness_raw)
-            if isinstance(candidate_state_readiness_raw, dict)
-            else {}
-        )
-        gate_inputs = GateInputs(
-            feature_schema_version=gate_policy.required_feature_schema_version,
-            required_feature_null_rate=_required_feature_null_rate(signals),
-            staleness_ms_p95=_resolve_gate_staleness_ms_p95(
-                signals=ordered_signals,
-            ),
-            symbol_coverage=len({signal.symbol for signal in signals}),
-            metrics=metrics_payload,
-            robustness=report.robustness.to_payload(),
-            tca_metrics=tca_gate_inputs,
-            llm_metrics=_resolve_gate_llm_metrics(
-                session_factory=factory,
-                now=now,
-            ),
-            forecast_metrics=forecast_gate_metrics,
-            profitability_evidence=profitability_evidence_payload,
-            fragility_state=fragility_state,
-            fragility_score=fragility_score,
-            stability_mode_active=stability_mode_active,
-            fragility_inputs_valid=fragility_inputs_valid,
-            operational_ready=not bool(candidate_state_payload.get("paused", False)),
-            runbook_validated=bool(
-                _coerce_evidence_bool(candidate_state_payload.get("runbookValidated"))
-            ),
-            kill_switch_dry_run_passed=bool(
-                _coerce_evidence_bool(
-                    candidate_state_readiness.get("killSwitchDryRunPassed")
-                )
-            ),
-            rollback_dry_run_passed=bool(
-                _coerce_evidence_bool(
-                    candidate_state_readiness.get("gitopsRevertDryRunPassed")
-                )
-                and _coerce_evidence_bool(
-                    candidate_state_readiness.get("strategyDisableDryRunPassed")
-                )
-            ),
-            approval_token=approval_token,
-        )
-        gate_report = evaluate_gate_matrix(
-            gate_inputs,
-            policy=gate_policy,
-            promotion_target=promotion_target,
-            code_version=code_version,
-            evaluated_at=now,
-        )
-        fold_evidence = [
-            {
-                "fold_name": fold.fold_name,
-                "decision_count": fold.decision_count,
-                "trade_count": fold.trade_count,
-                "net_pnl": str(fold.net_pnl),
-                "max_drawdown": str(fold.max_drawdown),
-                "cost_bps": str(fold.cost_bps),
-                "regime_label": fold.regime.label(),
-            }
-            for fold in report.robustness.folds
-        ]
-        stress_evidence = [
-            _build_stress_bundle(report, stress_case)
-            for stress_case in _STRESS_METRICS_CASES
-        ]
-        stress_metrics_count = len(stress_evidence)
-        stress_metrics_payload = {
-            "schema_version": "stress-metrics-v1",
-            "run_id": run_id,
-            "generated_at": now.isoformat(),
-            "count": stress_metrics_count,
-            "items": stress_evidence,
-            "artifact_authority": evidence_contract_payload(
-                provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
-                maturity=EvidenceMaturity.UNCALIBRATED,
-                calibration_summary={"status": "pending_calibration"},
-            ),
-        }
-        stress_metrics_path.write_text(
-            json.dumps(stress_metrics_payload, indent=2), encoding="utf-8"
-        )
-        fold_metrics_payload = {
-            "schema_version": "fold-metrics-v1",
-            "run_id": run_id,
-            "generated_at": now.isoformat(),
-            "count": len(fold_evidence),
-            "items": fold_evidence,
-            "artifact_authority": evidence_contract_payload(
-                provenance=ArtifactProvenance.HISTORICAL_MARKET_REPLAY,
-                maturity=EvidenceMaturity.UNCALIBRATED,
-                calibration_summary={"status": "pending_calibration"},
-            ),
-        }
-        fold_metrics_path.write_text(
-            json.dumps(fold_metrics_payload, indent=2), encoding="utf-8"
-        )
-        stress_metrics_artifact_ref = str(stress_metrics_path)
-        fold_metrics_artifact_ref = str(fold_metrics_path)
-        simulation_calibration_artifact_ref = str(simulation_calibration_report_path)
-        shadow_live_deviation_artifact_ref = str(shadow_live_deviation_report_path)
-        if not output_dir.is_absolute():
-            stress_metrics_artifact_ref = str(
-                stress_metrics_path.relative_to(output_dir)
-            )
-            fold_metrics_artifact_ref = str(fold_metrics_path.relative_to(output_dir))
-            simulation_calibration_artifact_ref = str(
-                simulation_calibration_report_path.relative_to(output_dir)
-            )
-            shadow_live_deviation_artifact_ref = str(
-                shadow_live_deviation_report_path.relative_to(output_dir)
-            )
-        benchmark_parity_artifact_ref = str(benchmark_parity_path)
-        if not output_dir.is_absolute():
-            benchmark_parity_artifact_ref = str(
-                benchmark_parity_path.relative_to(output_dir)
-            )
-        foundation_router_parity_artifact_ref = str(foundation_router_parity_path)
-        if not output_dir.is_absolute():
-            foundation_router_parity_artifact_ref = str(
-                foundation_router_parity_path.relative_to(output_dir)
-            )
-        deeplob_bdlob_artifact_ref = str(deeplob_bdlob_report_path)
-        if not output_dir.is_absolute():
-            deeplob_bdlob_artifact_ref = str(
-                deeplob_bdlob_report_path.relative_to(output_dir)
-            )
-        advisor_fallback_slo_artifact_ref = str(advisor_fallback_slo_report_path)
-        if not output_dir.is_absolute():
-            advisor_fallback_slo_artifact_ref = str(
-                advisor_fallback_slo_report_path.relative_to(output_dir)
-            )
-        contamination_registry_artifact_ref = str(contamination_registry_path)
-        if not output_dir.is_absolute():
-            contamination_registry_artifact_ref = str(
-                contamination_registry_path.relative_to(output_dir)
-            )
-        hmm_state_posterior_artifact_ref = str(hmm_state_posterior_path)
-        if not output_dir.is_absolute():
-            hmm_state_posterior_artifact_ref = str(
-                hmm_state_posterior_path.relative_to(output_dir)
-            )
-        expert_router_registry_artifact_ref = str(expert_router_registry_path)
-        if not output_dir.is_absolute():
-            expert_router_registry_artifact_ref = str(
-                expert_router_registry_path.relative_to(output_dir)
-            )
-        gate_report_payload = gate_report.to_payload()
-        gate_report_payload["run_id"] = run_id
+        _evaluate_gate_report(evidence_payload, tca_gate_inputs)
+        _write_metric_artifact_refs()
 
     def _run_gate_report_spec_phase() -> None:
         nonlocal candidate_spec_path, drift_gate_check, gate_report_trace_id, patch_path
@@ -3445,17 +3484,7 @@ def run_autonomous_lane(
         }
 
     def _run_promotion_recommendation_phase() -> None:
-        nonlocal \
-            _write_profitability_manifest, \
-            fold_metrics_count, \
-            patch_path, \
-            promotion_allowed
-        nonlocal \
-            promotion_check, \
-            promotion_reasons, \
-            promotion_recommendation, \
-            recommendation_trace_id
-        nonlocal recommended_mode
+        nonlocal _write_profitability_manifest
 
         def _write_profitability_manifest() -> None:
             profitability_manifest_payload = _build_profitability_stage_manifest(
@@ -3499,242 +3528,271 @@ def run_autonomous_lane(
                 encoding="utf-8",
             )
 
-        _write_profitability_manifest()
-        promotion_policy_payload = dict(raw_gate_policy)
-        promotion_policy_payload["promotion_require_profitability_stage_manifest"] = (
-            True
-        )
-        promotion_policy_payload["promotion_require_truthful_evidence_contracts"] = True
-        require_jangar_dependency_quorum = (
-            hypothesis_registry_requires_dependency_capability(
-                load_hypothesis_registry(),
-                "jangar_dependency_quorum",
+        def _build_promotion_policy_payload() -> dict[str, Any]:
+            promotion_policy_payload = dict(raw_gate_policy)
+            promotion_policy_payload[
+                "promotion_require_profitability_stage_manifest"
+            ] = True
+            promotion_policy_payload[
+                "promotion_require_truthful_evidence_contracts"
+            ] = True
+            require_jangar_dependency_quorum = (
+                hypothesis_registry_requires_dependency_capability(
+                    load_hypothesis_registry(),
+                    "jangar_dependency_quorum",
+                )
             )
-        )
-        promotion_policy_payload["promotion_require_jangar_dependency_quorum"] = (
-            require_jangar_dependency_quorum
-        )
-        if require_jangar_dependency_quorum:
+            promotion_policy_payload["promotion_require_jangar_dependency_quorum"] = (
+                require_jangar_dependency_quorum
+            )
+            if require_jangar_dependency_quorum:
+                promotion_policy_payload.setdefault(
+                    "promotion_jangar_dependency_quorum_required_targets",
+                    ["paper", "live"],
+                )
+            else:
+                promotion_policy_payload.pop(
+                    "promotion_jangar_dependency_quorum_required_targets",
+                    None,
+                )
+            promotion_policy_payload["promotion_require_alpha_readiness_contract"] = (
+                True
+            )
             promotion_policy_payload.setdefault(
-                "promotion_jangar_dependency_quorum_required_targets",
+                "promotion_alpha_readiness_required_targets",
                 ["paper", "live"],
             )
-        else:
-            promotion_policy_payload.pop(
-                "promotion_jangar_dependency_quorum_required_targets",
-                None,
+            promotion_policy_payload.setdefault(
+                "promotion_alpha_readiness_require_registry_match",
+                True,
             )
-        promotion_policy_payload["promotion_require_alpha_readiness_contract"] = True
-        promotion_policy_payload.setdefault(
-            "promotion_alpha_readiness_required_targets",
-            ["paper", "live"],
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_alpha_readiness_require_registry_match",
-            True,
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_require_simulation_calibration",
-            True,
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_simulation_calibration_required_artifacts",
-            ["gates/simulation-calibration-report-v1.json"],
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_simulation_calibration_required_targets",
-            ["paper", "live"],
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_simulation_calibration_min_order_count",
-            1,
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_simulation_calibration_min_expected_shortfall_coverage",
-            "0.50",
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_simulation_calibration_max_avg_calibration_error_bps",
-            "25",
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_require_shadow_live_deviation",
-            True,
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_shadow_live_deviation_required_artifacts",
-            ["gates/shadow-live-deviation-report-v1.json"],
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_shadow_live_deviation_required_targets",
-            ["paper", "live"],
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_shadow_live_deviation_min_order_count",
-            1,
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
-            "20",
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
-            "15",
-        )
-        promotion_policy_payload.setdefault(
-            "promotion_profitability_stage_manifest_artifact",
-            _PROFITABILITY_STAGE_MANIFEST_PATH,
-        )
-        promotion_check = evaluate_promotion_prerequisites(
-            policy_payload=promotion_policy_payload,
-            gate_report_payload=gate_report_payload,
-            candidate_state_payload=candidate_state_payload,
-            promotion_target=promotion_target,
-            artifact_root=output_dir,
-            now=now,
-        )
-        promotion_check_path.write_text(
-            json.dumps(promotion_check.to_payload(), indent=2), encoding="utf-8"
-        )
-        fold_metrics_count = len(walk_results.folds)
-        promotion_rationale = _build_promotion_rationale(
-            gate_report=gate_report,
-            promotion_check_reasons=promotion_check.reasons,
-            rollback_check_reasons=rollback_check.reasons,
-            promotion_target=promotion_target,
-            additional_reasons=strategy_factory_reasons,
-        )
-        promotion_recommendation = build_promotion_recommendation(
-            run_id=run_id,
-            candidate_id=candidate_id,
-            requested_mode=promotion_target,
-            recommended_mode=gate_report.recommended_mode,
-            gate_allowed=(
-                gate_report.promotion_allowed and bool(drift_gate_check["allowed"])
-            ),
-            prerequisite_allowed=promotion_check.allowed and strategy_factory_allowed,
-            rollback_ready=rollback_check.ready,
-            fold_metrics_count=fold_metrics_count,
-            stress_metrics_count=stress_metrics_count,
-            rationale=promotion_rationale,
-            reasons=[
-                *gate_report.reasons,
-                *promotion_check.reasons,
-                *strategy_factory_reasons,
-                *rollback_check.reasons,
-                *[
-                    str(item)
-                    for item in drift_gate_check.get("reasons", [])
-                    if str(item).strip()
-                ],
-            ],
-        )
-        promotion_allowed = promotion_recommendation.eligible
-        if patch_path is None and promotion_allowed:
-            patch_path = _resolve_paper_patch_path(
-                gate_report=gate_report,
-                strategy_configmap_path=strategy_configmap_path,
-                runtime_strategies=runtime_strategies,
-                candidate_id=candidate_id,
+            promotion_policy_payload.setdefault(
+                "promotion_require_simulation_calibration",
+                True,
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_simulation_calibration_required_artifacts",
+                ["gates/simulation-calibration-report-v1.json"],
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_simulation_calibration_required_targets",
+                ["paper", "live"],
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_simulation_calibration_min_order_count",
+                1,
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_simulation_calibration_min_expected_shortfall_coverage",
+                "0.50",
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_simulation_calibration_max_avg_calibration_error_bps",
+                "25",
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_require_shadow_live_deviation",
+                True,
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_shadow_live_deviation_required_artifacts",
+                ["gates/shadow-live-deviation-report-v1.json"],
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_shadow_live_deviation_required_targets",
+                ["paper", "live"],
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_shadow_live_deviation_min_order_count",
+                1,
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_shadow_live_deviation_max_avg_abs_slippage_bps",
+                "20",
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_shadow_live_deviation_max_avg_abs_divergence_bps",
+                "15",
+            )
+            promotion_policy_payload.setdefault(
+                "promotion_profitability_stage_manifest_artifact",
+                _PROFITABILITY_STAGE_MANIFEST_PATH,
+            )
+            return promotion_policy_payload
+
+        def _evaluate_promotion_prerequisites(
+            promotion_policy_payload: dict[str, Any],
+        ) -> None:
+            nonlocal promotion_check
+
+            promotion_check = evaluate_promotion_prerequisites(
+                policy_payload=promotion_policy_payload,
+                gate_report_payload=gate_report_payload,
+                candidate_state_payload=candidate_state_payload,
                 promotion_target=promotion_target,
-                paper_dir=paper_dir,
+                artifact_root=output_dir,
+                now=now,
             )
-        promotion_reasons = promotion_recommendation.reasons
-        recommended_mode = promotion_recommendation.recommended_mode
-        recommendation_trace_id = promotion_recommendation.trace_id
-        research_spec["promotion_recommendation"] = (
-            promotion_recommendation.to_payload()
-        )
-        research_spec["promotion_evidence_requirements"] = {
-            "fold_metrics_count": len(fold_evidence),
-            "stress_case_count": len(stress_evidence),
-            "deeplob_bdlob_contract_required": True,
-            "advisor_fallback_slo_required": True,
-            "strategy_factory_required": strategy_factory_bridge is not None,
-            "rationale_required": True,
-            "rationale_reason_codes": promotion_reasons,
-        }
-        candidate_spec_path.write_text(
-            json.dumps(research_spec, indent=2), encoding="utf-8"
-        )
-        promotion_gate_payload: dict[str, Any] = {
-            "allowed": promotion_allowed,
-            "recommended_mode": recommended_mode,
-            "reasons": promotion_reasons,
-            "checks": {
-                "gate_matrix": {
-                    "allowed": gate_report.promotion_allowed,
-                    "reasons": gate_report.reasons,
-                    "artifact_refs": [
-                        str(gate_report_path),
-                        str(benchmark_parity_path),
-                        str(deeplob_bdlob_report_path),
-                        str(advisor_fallback_slo_report_path),
-                        str(profitability_evidence_path),
-                        str(profitability_validation_path),
-                        str(simulation_calibration_report_path),
-                        str(shadow_live_deviation_report_path),
-                        str(stress_metrics_path),
-                        str(hmm_state_posterior_path),
-                        str(expert_router_registry_path),
-                        str(fold_metrics_path),
-                        str(janus_event_car_path),
-                        str(janus_hgrm_reward_path),
-                        str(recalibration_report_path),
-                        *strategy_factory_artifact_refs,
+            promotion_check_path.write_text(
+                json.dumps(promotion_check.to_payload(), indent=2), encoding="utf-8"
+            )
+
+        def _record_promotion_recommendation() -> None:
+            nonlocal fold_metrics_count, patch_path, promotion_allowed
+            nonlocal promotion_reasons, promotion_recommendation
+            nonlocal recommendation_trace_id, recommended_mode
+
+            fold_metrics_count = len(walk_results.folds)
+            promotion_recommendation = build_promotion_recommendation(
+                run_id=run_id,
+                candidate_id=candidate_id,
+                requested_mode=promotion_target,
+                recommended_mode=gate_report.recommended_mode,
+                gate_allowed=(
+                    gate_report.promotion_allowed and bool(drift_gate_check["allowed"])
+                ),
+                prerequisite_allowed=promotion_check.allowed
+                and strategy_factory_allowed,
+                rollback_ready=rollback_check.ready,
+                fold_metrics_count=fold_metrics_count,
+                stress_metrics_count=stress_metrics_count,
+                rationale=_build_promotion_rationale(
+                    gate_report=gate_report,
+                    promotion_check_reasons=promotion_check.reasons,
+                    rollback_check_reasons=rollback_check.reasons,
+                    promotion_target=promotion_target,
+                    additional_reasons=strategy_factory_reasons,
+                ),
+                reasons=[
+                    *gate_report.reasons,
+                    *promotion_check.reasons,
+                    *strategy_factory_reasons,
+                    *rollback_check.reasons,
+                    *[
+                        str(item)
+                        for item in drift_gate_check.get("reasons", [])
+                        if str(item).strip()
                     ],
-                },
-                "promotion_prerequisites": promotion_check.to_payload(),
-                "rollback_readiness": rollback_check.to_payload(),
-                "profitability_validation": profitability_validation.to_payload(),
-                "janus_q": janus_q_summary,
-                "drift_governance": drift_gate_check,
-                "evidence_requirements": promotion_recommendation.evidence.to_payload(),
-            },
-            "recommendation": promotion_recommendation.to_payload(),
-            "artifact_refs": sorted(
-                set(
-                    [
-                        str(promotion_check_path),
-                        str(rollback_check_path),
-                        str(gate_report_path),
-                        str(benchmark_parity_path),
-                        str(deeplob_bdlob_report_path),
-                        str(advisor_fallback_slo_report_path),
-                        str(contamination_registry_path),
-                        str(profitability_benchmark_path),
-                        str(profitability_evidence_path),
-                        str(profitability_validation_path),
-                        str(simulation_calibration_report_path),
-                        str(shadow_live_deviation_report_path),
-                        str(fold_metrics_path),
-                        str(stress_metrics_path),
-                        str(hmm_state_posterior_path),
-                        str(expert_router_registry_path),
-                        str(janus_event_car_path),
-                        str(janus_hgrm_reward_path),
-                        *[
-                            str(item)
-                            for item in drift_gate_check.get("artifact_refs", [])
-                            if str(item).strip()
-                        ],
-                        str(recalibration_report_path),
-                        *strategy_factory_artifact_refs,
-                    ]
-                )
-            ),
-        }
-        if strategy_factory_bridge is not None:
-            promotion_gate_checks = cast(
-                dict[str, Any], promotion_gate_payload["checks"]
+                ],
             )
-            promotion_gate_checks["strategy_factory"] = dict(strategy_factory_summary)
-        promotion_gate_path.write_text(
-            json.dumps(promotion_gate_payload, indent=2), encoding="utf-8"
-        )
-        gate_report_payload["promotion_recommendation"] = (
-            promotion_recommendation.to_payload()
-        )
+            promotion_allowed = promotion_recommendation.eligible
+            if patch_path is None and promotion_allowed:
+                patch_path = _resolve_paper_patch_path(
+                    gate_report=gate_report,
+                    strategy_configmap_path=strategy_configmap_path,
+                    runtime_strategies=runtime_strategies,
+                    candidate_id=candidate_id,
+                    promotion_target=promotion_target,
+                    paper_dir=paper_dir,
+                )
+            promotion_reasons = promotion_recommendation.reasons
+            recommended_mode = promotion_recommendation.recommended_mode
+            recommendation_trace_id = promotion_recommendation.trace_id
+            research_spec["promotion_recommendation"] = (
+                promotion_recommendation.to_payload()
+            )
+            research_spec["promotion_evidence_requirements"] = {
+                "fold_metrics_count": len(fold_evidence),
+                "stress_case_count": len(stress_evidence),
+                "deeplob_bdlob_contract_required": True,
+                "advisor_fallback_slo_required": True,
+                "strategy_factory_required": strategy_factory_bridge is not None,
+                "rationale_required": True,
+                "rationale_reason_codes": promotion_reasons,
+            }
+            candidate_spec_path.write_text(
+                json.dumps(research_spec, indent=2), encoding="utf-8"
+            )
+
+        def _promotion_gate_artifact_refs() -> list[str]:
+            return sorted(
+                {
+                    str(promotion_check_path),
+                    str(rollback_check_path),
+                    str(gate_report_path),
+                    str(benchmark_parity_path),
+                    str(deeplob_bdlob_report_path),
+                    str(advisor_fallback_slo_report_path),
+                    str(contamination_registry_path),
+                    str(profitability_benchmark_path),
+                    str(profitability_evidence_path),
+                    str(profitability_validation_path),
+                    str(simulation_calibration_report_path),
+                    str(shadow_live_deviation_report_path),
+                    str(fold_metrics_path),
+                    str(stress_metrics_path),
+                    str(hmm_state_posterior_path),
+                    str(expert_router_registry_path),
+                    str(janus_event_car_path),
+                    str(janus_hgrm_reward_path),
+                    *[
+                        str(item)
+                        for item in drift_gate_check.get("artifact_refs", [])
+                        if str(item).strip()
+                    ],
+                    str(recalibration_report_path),
+                    *strategy_factory_artifact_refs,
+                }
+            )
+
+        def _write_promotion_gate_payload() -> None:
+            promotion_gate_payload: dict[str, Any] = {
+                "allowed": promotion_allowed,
+                "recommended_mode": recommended_mode,
+                "reasons": promotion_reasons,
+                "checks": {
+                    "gate_matrix": {
+                        "allowed": gate_report.promotion_allowed,
+                        "reasons": gate_report.reasons,
+                        "artifact_refs": [
+                            str(gate_report_path),
+                            str(benchmark_parity_path),
+                            str(deeplob_bdlob_report_path),
+                            str(advisor_fallback_slo_report_path),
+                            str(profitability_evidence_path),
+                            str(profitability_validation_path),
+                            str(simulation_calibration_report_path),
+                            str(shadow_live_deviation_report_path),
+                            str(stress_metrics_path),
+                            str(hmm_state_posterior_path),
+                            str(expert_router_registry_path),
+                            str(fold_metrics_path),
+                            str(janus_event_car_path),
+                            str(janus_hgrm_reward_path),
+                            str(recalibration_report_path),
+                            *strategy_factory_artifact_refs,
+                        ],
+                    },
+                    "promotion_prerequisites": promotion_check.to_payload(),
+                    "rollback_readiness": rollback_check.to_payload(),
+                    "profitability_validation": profitability_validation.to_payload(),
+                    "janus_q": janus_q_summary,
+                    "drift_governance": drift_gate_check,
+                    "evidence_requirements": (
+                        promotion_recommendation.evidence.to_payload()
+                    ),
+                },
+                "recommendation": promotion_recommendation.to_payload(),
+                "artifact_refs": _promotion_gate_artifact_refs(),
+            }
+            if strategy_factory_bridge is not None:
+                promotion_gate_checks = cast(
+                    dict[str, Any], promotion_gate_payload["checks"]
+                )
+                promotion_gate_checks["strategy_factory"] = dict(
+                    strategy_factory_summary
+                )
+            promotion_gate_path.write_text(
+                json.dumps(promotion_gate_payload, indent=2), encoding="utf-8"
+            )
+            gate_report_payload["promotion_recommendation"] = (
+                promotion_recommendation.to_payload()
+            )
+
+        _write_profitability_manifest()
+        _evaluate_promotion_prerequisites(_build_promotion_policy_payload())
+        _record_promotion_recommendation()
+        _write_promotion_gate_payload()
 
     def _run_lineage_replay_phase() -> None:
         nonlocal replay_artifacts, stage_lineage_payload
@@ -5099,11 +5157,8 @@ def _build_actuation_intent_payload(
     rollback_evidence_links.extend(
         [str(item) for item in promotion_check.get("artifact_refs", [])]
     )
-    candidate_state_readiness_raw = candidate_state_payload.get("rollbackReadiness", {})
-    candidate_state_readiness = (
-        cast(dict[str, Any], candidate_state_readiness_raw)
-        if isinstance(candidate_state_readiness_raw, dict)
-        else {}
+    candidate_state_readiness = _candidate_state_readiness_payload(
+        candidate_state_payload
     )
     return {
         "schema_version": _ACTUATION_INTENT_SCHEMA_VERSION,
@@ -5167,6 +5222,17 @@ def _build_actuation_intent_payload(
             "rollback_evidence_missing_checks": rollback_missing_checks,
         },
     }
+
+
+def _candidate_state_readiness_payload(
+    candidate_state_payload: dict[str, Any],
+) -> dict[str, Any]:
+    candidate_state_readiness_raw = candidate_state_payload.get("rollbackReadiness", {})
+    return (
+        cast(dict[str, Any], candidate_state_readiness_raw)
+        if isinstance(candidate_state_readiness_raw, dict)
+        else {}
+    )
 
 
 def _collect_walk_decisions_for_runtime(

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportMissingTypeStubs=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportUnnecessaryCast=false
 """Deterministic autonomous lane: research -> gate evaluation -> paper candidate patch."""
 
 from __future__ import annotations
@@ -11,7 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence, cast
+from typing import Any, Callable, Iterable, Mapping, Sequence, cast
 
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
@@ -167,14 +166,6 @@ _STAGE_PROFITABILITY = "profitability_stage_manifest"
 _V6_08_GOVERNING_DESIGN_DOC = "docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md"
 
 
-def _extract_report_slices(report_payload: dict[str, Any]) -> dict[str, dict[str, str]]:
-    from ..evaluation_modules.build_simulation_calibration_report_v1 import (
-        extract_report_slices,
-    )
-
-    return extract_report_slices(report_payload)
-
-
 @dataclass(frozen=True)
 class _StageManifestRecord:
     stage: str
@@ -187,7 +178,7 @@ class _StageManifestRecord:
     created_by: str = "run_autonomous_lane"
     parent_lineage_hash: str | None = None
     parent_stage: str | None = None
-    inputs: dict[str, str] = field(default_factory=dict)
+    inputs: dict[str, str] = field(default_factory=lambda: cast(dict[str, str], {}))
 
 
 def _coerce_evidence_bool(value: object) -> bool | None:
@@ -211,21 +202,23 @@ def _normalize_strategy_artifacts(value: object) -> object | None:
     if not isinstance(value, dict):
         return value
 
-    kind = str(value.get("kind", "")).strip().lower()
+    payload = cast(dict[str, object], value)
+    kind = str(payload.get("kind", "")).strip().lower()
     if kind == "configmap":
-        data = value.get("data")
+        data = payload.get("data")
         if not isinstance(data, dict):
             return None
-        strategies_yaml = data.get("strategies.yaml")
+        data_payload = cast(dict[str, object], data)
+        strategies_yaml = data_payload.get("strategies.yaml")
         if not isinstance(strategies_yaml, str):
             return None
         try:
-            nested_payload = yaml.safe_load(strategies_yaml)
+            nested_payload = cast(object, yaml.safe_load(strategies_yaml))
         except Exception:
             return None
         return _normalize_strategy_artifacts(nested_payload)
 
-    return value
+    return payload
 
 
 def _is_runbook_valid(strategy_configmap_path: Path | None) -> bool:
@@ -234,7 +227,9 @@ def _is_runbook_valid(strategy_configmap_path: Path | None) -> bool:
         return False
 
     try:
-        raw_payload = yaml.safe_load(resolved_path.read_text(encoding="utf-8"))
+        raw_payload = cast(
+            object, yaml.safe_load(resolved_path.read_text(encoding="utf-8"))
+        )
     except Exception:
         return False
 
@@ -244,16 +239,20 @@ def _is_runbook_valid(strategy_configmap_path: Path | None) -> bool:
         return False
 
     if isinstance(normalized_payload, dict):
-        strategies = normalized_payload.get("strategies")
+        payload = cast(dict[str, object], normalized_payload)
+        strategies = payload.get("strategies")
     elif isinstance(normalized_payload, list):
-        strategies = normalized_payload
+        strategies = cast(list[object], normalized_payload)
     else:
         return False
 
     if not isinstance(strategies, list):
         return False
 
-    return bool(strategies) and all(isinstance(item, dict) for item in strategies)
+    strategy_items = cast(list[object], strategies)
+    return bool(strategy_items) and all(
+        isinstance(item, dict) for item in strategy_items
+    )
 
 
 def _build_candidate_state_payload(
@@ -370,7 +369,9 @@ class AutonomousLaneResult:
     evaluation_manifest_path: Path
     recommendation_manifest_path: Path
     profitability_manifest_path: Path
-    stage_trace_ids: dict[str, str] = field(default_factory=dict)
+    stage_trace_ids: dict[str, str] = field(
+        default_factory=lambda: cast(dict[str, str], {})
+    )
     stage_lineage_root: str | None = None
 
 
@@ -654,9 +655,10 @@ def _safe_int(value: Any) -> int:
 
 
 def _as_object_dict(value: object) -> dict[str, object]:
-    if not isinstance(value, dict):
+    if not isinstance(value, Mapping):
         return {}
-    return {str(key): item for key, item in value.items()}
+    mapping = cast(Mapping[object, object], value)
+    return {str(key): item for key, item in mapping.items()}
 
 
 def _stable_hash(payload: object) -> str:
@@ -1923,7 +1925,7 @@ def _build_profitability_stage_manifest(
     )
     governance_pass = all(item["status"] == "pass" for item in governance_checks)
 
-    stage_payloads: dict[str, Any] = {
+    stage_payloads: dict[str, dict[str, Any]] = {
         "research": {
             "status": "pass" if research_pass else "fail",
             "checks": research_checks,
@@ -1970,16 +1972,16 @@ def _build_profitability_stage_manifest(
     ]
     replay_contract_artifact_hashes: dict[str, str] = {}
     for stage_payload in stage_payloads.values():
-        if not isinstance(stage_payload, dict):
-            continue
         artifacts_raw = stage_payload.get("artifacts")
         if not isinstance(artifacts_raw, dict):
             continue
-        for artifact_payload_raw in artifacts_raw.values():
+        artifacts = cast(dict[str, object], artifacts_raw)
+        for artifact_payload_raw in artifacts.values():
             if not isinstance(artifact_payload_raw, dict):
                 continue
-            artifact_ref = str(artifact_payload_raw.get("path", "")).strip()
-            artifact_sha = str(artifact_payload_raw.get("sha256", "")).strip()
+            artifact_payload = cast(dict[str, object], artifact_payload_raw)
+            artifact_ref = str(artifact_payload.get("path", "")).strip()
+            artifact_sha = str(artifact_payload.get("sha256", "")).strip()
             if not artifact_ref or not artifact_sha:
                 continue
             replay_contract_artifact_hashes[artifact_ref] = artifact_sha
@@ -2075,7 +2077,10 @@ def _extract_janus_q_metrics(
     reasons_raw = summary.get("reasons")
     reasons: list[str] = []
     if isinstance(reasons_raw, list):
-        reasons = [str(reason).strip() for reason in reasons_raw if str(reason).strip()]
+        reason_values = cast(list[object], reasons_raw)
+        reasons = [
+            str(reason).strip() for reason in reason_values if str(reason).strip()
+        ]
     return (
         _safe_int(event_car.get("event_count", 0)),
         _safe_int(hgrm_reward.get("reward_count", 0)),
@@ -2143,16 +2148,15 @@ def run_autonomous_lane(
     now = evaluated_at or datetime.now(timezone.utc)
     runtime = StrategyRuntime(default_runtime_registry())
     walk_decisions: list[WalkForwardDecision] = []
-    baseline_walk_decisions: list[WalkForwardDecision] = []
     runtime_errors: list[str] = []
     baseline_runtime_errors: list[str] = []
     patch_path: Path | None = None
-    walk_results: WalkForwardResults | None = None
-    report: EvaluationReport | None = None
-    gate_report: GateEvaluationReport | None = None
+    walk_results: Any = None
+    report: Any = None
+    gate_report: Any = None
     gate_report_trace_id: str | None = None
     recommendation_trace_id: str | None = None
-    promotion_recommendation: PromotionRecommendation | None = None
+    promotion_recommendation: Any = None
     gate_report_path = gates_dir / "gate-evaluation.json"
     promotion_check_path = gates_dir / "promotion-prerequisites.json"
     rollback_check_path = gates_dir / "rollback-readiness.json"
@@ -2222,6 +2226,61 @@ def run_autonomous_lane(
     strategy_factory_reasons: list[str] = []
     strategy_factory_summary: dict[str, Any] = {}
     strategy_factory_artifact_refs: list[str] = []
+    ordered_signals: list[SignalEnvelope] = []
+    advisor_fallback_slo_report: dict[str, Any] = {}
+    advisor_fallback_slo_artifact_ref = ""
+    baseline_candidate_id = ""
+    benchmark: Any = None
+    benchmark_parity_artifact_ref = ""
+    candidate_alpha_readiness_payload: dict[str, Any] = {}
+    candidate_dependency_quorum_payload: dict[str, Any] = {}
+    candidate_generation_stage_record: Any = None
+    candidate_spec_path = research_dir / "candidate-spec.json"
+    candidate_state_payload: dict[str, Any] = {}
+    contamination_registry_artifact_ref = ""
+    contamination_registry_payload: dict[str, Any] = {}
+    deeplob_bdlob_artifact_ref = ""
+    drift_gate_check: dict[str, Any] = {}
+    evaluation_report_path = backtest_dir / "evaluation-report.json"
+    expert_router_registry_artifact_ref = ""
+    fold_evidence: list[dict[str, Any]] = []
+    fold_metrics_artifact_ref = ""
+    fold_metrics_count = 0
+    foundation_router_parity_artifact_ref = ""
+    gate_report_payload: dict[str, Any] = {}
+    gate_policy_payload: dict[str, Any] = {}
+    hmm_state_posterior_artifact_ref = ""
+    janus_event_count = 0
+    janus_evidence_complete = False
+    janus_q_summary: dict[str, object] = {}
+    janus_reasons: list[str] = []
+    janus_reward_count = 0
+    profitability_validation: Any = None
+    promotion_allowed = False
+    promotion_check: Any = None
+    promotion_reasons: list[str] = []
+    raw_gate_policy: dict[str, Any] = {}
+    recommended_mode = promotion_target
+    replay_artifacts: dict[str, Path | None] = {}
+    research_spec: dict[str, Any] = {}
+    rollback_check: Any = None
+    shadow_live_deviation_artifact_ref = ""
+    shadow_live_deviation_report_payload: dict[str, Any] = {}
+    simulation_calibration_artifact_ref = ""
+    simulation_calibration_report_payload: dict[str, Any] = {}
+    stage_lineage_payload: dict[str, Any] = {}
+    strategy_family = ""
+    stress_evidence: list[dict[str, Any]] = []
+    stress_metrics_artifact_ref = ""
+    stress_metrics_count = 0
+    router_artifact_ref = ""
+    profitability_run_context: dict[str, Any] = {}
+    walk_results_path = backtest_dir / "walkforward-results.json"
+
+    def _write_profitability_manifest() -> None:
+        raise RuntimeError("profitability_manifest_writer_not_initialized")
+
+    actuation_intent_path = output_dir / _ACTUATION_INTENT_PATH
 
     factory = session_factory or SessionLocal
     if persist_results:
@@ -2236,7 +2295,34 @@ def run_autonomous_lane(
             code_version=code_version,
             now=now,
         )
-    try:
+
+    def _run_candidate_generation_phase() -> None:
+        nonlocal \
+            advisor_fallback_slo_report, \
+            baseline_candidate_id, \
+            baseline_runtime_errors, \
+            benchmark
+        nonlocal \
+            candidate_generation_stage_record, \
+            evaluation_report_path, \
+            expert_router_registry_payload
+        nonlocal gate_policy_payload, hmm_state_posterior_payload, janus_event_count
+        nonlocal \
+            janus_evidence_complete, \
+            janus_q_summary, \
+            janus_reasons, \
+            janus_reward_count
+        nonlocal ordered_signals, report, runtime_errors, strategy_factory_allowed
+        nonlocal \
+            strategy_factory_artifact_refs, \
+            strategy_factory_bridge, \
+            strategy_factory_reasons
+        nonlocal \
+            strategy_factory_summary, \
+            strategy_family, \
+            router_artifact_ref, \
+            walk_decisions
+        nonlocal walk_results, walk_results_path
         strategy_factory_bridge = _build_strategy_factory_bridge(
             output_dir=output_dir,
             notes_artifact_root=notes_artifact_root,
@@ -2512,6 +2598,25 @@ def run_autonomous_lane(
             encoding="utf-8",
         )
 
+    def _run_profitability_validation_phase() -> None:
+        nonlocal advisor_fallback_slo_artifact_ref, benchmark_parity_artifact_ref
+        nonlocal candidate_alpha_readiness_payload, candidate_dependency_quorum_payload
+        nonlocal candidate_state_payload, contamination_registry_artifact_ref
+        nonlocal contamination_registry_payload, deeplob_bdlob_artifact_ref
+        nonlocal \
+            expert_router_registry_artifact_ref, \
+            fold_evidence, \
+            fold_metrics_artifact_ref
+        nonlocal foundation_router_parity_artifact_ref, gate_report, gate_report_payload
+        nonlocal hmm_state_posterior_artifact_ref, profitability_validation
+        nonlocal \
+            shadow_live_deviation_artifact_ref, \
+            shadow_live_deviation_report_payload
+        nonlocal \
+            simulation_calibration_artifact_ref, \
+            simulation_calibration_report_payload, \
+            stress_evidence
+        nonlocal stress_metrics_artifact_ref, stress_metrics_count
         confidence_values = _collect_confidence_values(walk_decisions)
         reproducibility_hashes = {
             "signals": _sha256_path(signals_path),
@@ -2730,7 +2835,7 @@ def run_autonomous_lane(
             "rollbackReadiness", {}
         )
         candidate_state_readiness = (
-            candidate_state_readiness_raw
+            cast(dict[str, Any], candidate_state_readiness_raw)
             if isinstance(candidate_state_readiness_raw, dict)
             else {}
         )
@@ -2879,6 +2984,14 @@ def run_autonomous_lane(
             )
         gate_report_payload = gate_report.to_payload()
         gate_report_payload["run_id"] = run_id
+
+    def _run_gate_report_spec_phase() -> None:
+        nonlocal candidate_spec_path, drift_gate_check, gate_report_trace_id, patch_path
+        nonlocal \
+            profitability_run_context, \
+            raw_gate_policy, \
+            research_spec, \
+            rollback_check
         gate_report_payload["throughput"] = {
             "signal_count": len(signals),
             "decision_count": report.metrics.decision_count,
@@ -3084,7 +3197,7 @@ def run_autonomous_lane(
             json.dumps(gate_report_payload, indent=2), encoding="utf-8"
         )
 
-        research_spec: dict[str, Any] = {
+        research_spec = {
             "run_id": run_id,
             "candidate_id": candidate_id,
             "promotion_target": promotion_target,
@@ -3155,9 +3268,7 @@ def run_autonomous_lane(
                     {
                         "strategy_id": strategy.strategy_id,
                         "feature_view_spec_ref": str(
-                            cast(dict[str, Any], strategy.strategy_spec).get(
-                                "feature_view_spec_ref", ""
-                            )
+                            strategy.strategy_spec.get("feature_view_spec_ref", "")
                         ).strip()
                         if strategy.strategy_spec
                         else "",
@@ -3169,12 +3280,8 @@ def run_autonomous_lane(
                     {
                         "strategy_id": strategy.strategy_id,
                         "model_ref": str(
-                            cast(dict[str, Any], strategy.strategy_spec).get(
-                                "model_ref"
-                            )
-                            or cast(dict[str, Any], strategy.strategy_spec).get(
-                                "deterministic_rule_ref", ""
-                            )
+                            strategy.strategy_spec.get("model_ref")
+                            or strategy.strategy_spec.get("deterministic_rule_ref", "")
                         ).strip(),
                     }
                     for strategy in runtime_strategies
@@ -3301,7 +3408,7 @@ def run_autonomous_lane(
                 ).to_payload()
         candidate_spec_path = research_dir / "candidate-spec.json"
 
-        patch_path: Path | None = None
+        patch_path = None
 
         raw_gate_policy = gate_policy_payload
         patch_path = _resolve_paper_patch_path(
@@ -3336,6 +3443,19 @@ def run_autonomous_lane(
             "design_doc": str(resolved_design_doc or ""),
             "priority_id": str(resolved_governance_priority_id or ""),
         }
+
+    def _run_promotion_recommendation_phase() -> None:
+        nonlocal \
+            _write_profitability_manifest, \
+            fold_metrics_count, \
+            patch_path, \
+            promotion_allowed
+        nonlocal \
+            promotion_check, \
+            promotion_reasons, \
+            promotion_recommendation, \
+            recommendation_trace_id
+        nonlocal recommended_mode
 
         def _write_profitability_manifest() -> None:
             profitability_manifest_payload = _build_profitability_stage_manifest(
@@ -3537,7 +3657,7 @@ def run_autonomous_lane(
         candidate_spec_path.write_text(
             json.dumps(research_spec, indent=2), encoding="utf-8"
         )
-        promotion_gate_payload = {
+        promotion_gate_payload: dict[str, Any] = {
             "allowed": promotion_allowed,
             "recommended_mode": recommended_mode,
             "reasons": promotion_reasons,
@@ -3605,15 +3725,19 @@ def run_autonomous_lane(
             ),
         }
         if strategy_factory_bridge is not None:
-            promotion_gate_payload["checks"]["strategy_factory"] = dict(
-                strategy_factory_summary
+            promotion_gate_checks = cast(
+                dict[str, Any], promotion_gate_payload["checks"]
             )
+            promotion_gate_checks["strategy_factory"] = dict(strategy_factory_summary)
         promotion_gate_path.write_text(
             json.dumps(promotion_gate_payload, indent=2), encoding="utf-8"
         )
         gate_report_payload["promotion_recommendation"] = (
             promotion_recommendation.to_payload()
         )
+
+    def _run_lineage_replay_phase() -> None:
+        nonlocal replay_artifacts, stage_lineage_payload
         gate_report_payload["promotion_evidence"] = {
             "fold_metrics": {
                 "count": len(fold_evidence),
@@ -4086,6 +4210,11 @@ def run_autonomous_lane(
         candidate_spec_path.write_text(
             json.dumps(research_spec, indent=2), encoding="utf-8"
         )
+
+    def _run_actuation_persistence_phase() -> None:
+        nonlocal actuation_intent_path
+        if recommendation_trace_id is None or gate_report_trace_id is None:
+            raise RuntimeError("autonomous_lane_trace_ids_missing")
         candidate_spec_replay_artifacts: dict[str, Path | None] = {
             key: value
             for key, value in replay_artifacts.items()
@@ -4259,6 +4388,15 @@ def run_autonomous_lane(
             recommendation_trace_id=recommendation_trace_id,
         )
 
+    try:
+        _run_candidate_generation_phase()
+        _run_profitability_validation_phase()
+        _run_gate_report_spec_phase()
+        _run_promotion_recommendation_phase()
+        _run_lineage_replay_phase()
+        _run_actuation_persistence_phase()
+        if gate_report_trace_id is None or recommendation_trace_id is None:
+            raise RuntimeError("autonomous_lane_trace_ids_missing")
         return AutonomousLaneResult(
             run_id=run_id,
             candidate_id=candidate_id,
@@ -4310,16 +4448,25 @@ def _prepare_lane_output_dirs(output_dir: Path) -> tuple[Path, Path, Path, Path,
 def _normalize_governance_inputs(
     governance_inputs: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
-    raw = governance_inputs if isinstance(governance_inputs, Mapping) else {}
-    execution_context = raw.get("execution_context", {})
-    if not isinstance(execution_context, Mapping):
-        execution_context = {}
-    runtime = raw.get("runtime_governance", {})
-    if not isinstance(runtime, Mapping):
-        runtime = {}
-    rollback = raw.get("rollback_proof", {})
-    if not isinstance(rollback, Mapping):
-        rollback = {}
+    raw: Mapping[str, Any] = (
+        governance_inputs if isinstance(governance_inputs, Mapping) else {}
+    )
+    execution_context_raw = raw.get("execution_context", {})
+    execution_context: Mapping[str, Any] = (
+        cast(Mapping[str, Any], execution_context_raw)
+        if isinstance(execution_context_raw, Mapping)
+        else {}
+    )
+    runtime_raw = raw.get("runtime_governance", {})
+    runtime: Mapping[str, Any] = (
+        cast(Mapping[str, Any], runtime_raw) if isinstance(runtime_raw, Mapping) else {}
+    )
+    rollback_raw = raw.get("rollback_proof", {})
+    rollback: Mapping[str, Any] = (
+        cast(Mapping[str, Any], rollback_raw)
+        if isinstance(rollback_raw, Mapping)
+        else {}
+    )
     return {
         "execution_context": {
             "repository": _coerce_str(
@@ -4356,18 +4503,27 @@ def _coalesce_governance_context(
     priority_id: str | None,
     now: datetime,
 ) -> dict[str, Any]:
-    raw = governance_inputs if isinstance(governance_inputs, Mapping) else {}
-    execution_context = raw.get("execution_context", {})
-    if not isinstance(execution_context, Mapping):
-        execution_context = {}
-    runtime = raw.get("runtime_governance", {})
-    if not isinstance(runtime, Mapping):
-        runtime = {}
-    rollback = raw.get("rollback_proof", {})
-    if not isinstance(rollback, Mapping):
-        rollback = {}
+    raw: Mapping[str, Any] = (
+        governance_inputs if isinstance(governance_inputs, Mapping) else {}
+    )
+    execution_context_raw = raw.get("execution_context", {})
+    execution_context: Mapping[str, Any] = (
+        cast(Mapping[str, Any], execution_context_raw)
+        if isinstance(execution_context_raw, Mapping)
+        else {}
+    )
+    runtime_raw = raw.get("runtime_governance", {})
+    runtime: Mapping[str, Any] = (
+        cast(Mapping[str, Any], runtime_raw) if isinstance(runtime_raw, Mapping) else {}
+    )
+    rollback_raw = raw.get("rollback_proof", {})
+    rollback: Mapping[str, Any] = (
+        cast(Mapping[str, Any], rollback_raw)
+        if isinstance(rollback_raw, Mapping)
+        else {}
+    )
 
-    fallback_head = execution_context.get("head") or (
+    fallback_head = _coerce_str(execution_context.get("head")) or (
         f"agentruns/torghut-autonomy-{now.strftime('%Y%m%dT%H%M%S')}"
     )
     resolved_repository = _coerce_str(governance_repository)
@@ -4434,13 +4590,13 @@ def _build_phase_manifest(
 ) -> dict[str, Any]:
     phase_timestamp = evaluated_at.isoformat()
     governance = _normalize_governance_inputs(governance_inputs)
-    execution_context = governance["execution_context"]
+    execution_context = cast(Mapping[str, Any], governance["execution_context"])
     artifact_path = _coerce_str(
         execution_context.get("artifactPath"),
         default=str(output_dir),
     )
-    runtime_governance = governance["runtime_governance"]
-    rollback_proof = governance["rollback_proof"]
+    runtime_governance = cast(Mapping[str, Any], governance["runtime_governance"])
+    rollback_proof = cast(Mapping[str, Any], governance["rollback_proof"])
     gate_status = "pass" if gate_report.promotion_allowed else "fail"
     prerequisite_status = "pass" if promotion_check.allowed else "fail"
     rollback_ready_status = "pass" if rollback_check.ready else "fail"
@@ -4458,25 +4614,27 @@ def _build_phase_manifest(
         else ("fail" if requested_promotion_target == "paper" else "skipped")
     )
     gate_payload_gates = gate_report_payload.get("gates")
-    gate_entries = gate_payload_gates if isinstance(gate_payload_gates, list) else []
+    gate_entries = (
+        cast(list[object], gate_payload_gates)
+        if isinstance(gate_payload_gates, list)
+        else []
+    )
     slo_gates = _coerce_gate_phase_gates(gate_entries)
     throughput_payload = cast(
         Mapping[str, Any], gate_report_payload.get("throughput", {})
     )
     signal_count = _coerce_int(throughput_payload.get("signal_count"), default=0)
     decision_count = _coerce_int(throughput_payload.get("decision_count"), default=0)
+    drift_refs_raw = drift_gate_check.get("artifact_refs")
     drift_artifacts = _coerce_path_strings(
-        drift_gate_check.get("artifact_refs", [])
-        if isinstance(drift_gate_check.get("artifact_refs", []), list)
-        else []
+        drift_refs_raw if isinstance(drift_refs_raw, list) else []
     )
     runtime_gate_status = coerce_phase_status(
         runtime_governance.get("governance_status", "skipped")
     )
+    runtime_refs_raw = runtime_governance.get("artifact_refs")
     runtime_artifact_refs = _coerce_path_strings(
-        runtime_governance.get("artifact_refs", [])
-        if isinstance(runtime_governance.get("artifact_refs", []), list)
-        else []
+        runtime_refs_raw if isinstance(runtime_refs_raw, list) else []
     )
     rollback_triggered = bool(
         runtime_governance.get("rollback_triggered", False)
@@ -4494,19 +4652,15 @@ def _build_phase_manifest(
         if (not rollback_triggered)
         else ("pass" if rollback_proof_path else "fail")
     )
+    drift_evidence: Mapping[str, Any] = drift_promotion_evidence or {}
+    drift_evidence_refs_raw = drift_evidence.get("evidence_artifact_refs")
+    drift_evidence_refs = (
+        cast(list[object], drift_evidence_refs_raw)
+        if isinstance(drift_evidence_refs_raw, list)
+        else []
+    )
     drift_gate_artifacts = sorted(
-        {
-            str(item)
-            for item in (
-                (drift_promotion_evidence or {}).get("evidence_artifact_refs", [])
-                if isinstance(
-                    (drift_promotion_evidence or {}).get("evidence_artifact_refs", []),
-                    list,
-                )
-                else []
-            )
-            if str(item).strip()
-        }
+        {str(item) for item in drift_evidence_refs if str(item).strip()}
     )
 
     phase_summaries: list[dict[str, Any]] = [
@@ -4827,14 +4981,15 @@ def _coerce_int(raw: Any, default: int = 0) -> int:
 def _coerce_path_strings(values: Any) -> list[str]:
     if not isinstance(values, (list, tuple, set)):
         return []
-    return sorted({_coerce_str(value) for value in values if _coerce_str(value)})
+    value_items = cast(Iterable[object], values)
+    return sorted({_coerce_str(value) for value in value_items if _coerce_str(value)})
 
 
 def _coerce_gate_phase_gates(raw_gates: Any) -> list[dict[str, Any]]:
     gates: list[dict[str, Any]] = []
     if not isinstance(raw_gates, list):
         return gates
-    for item in raw_gates:
+    for item in cast(list[object], raw_gates):
         if not isinstance(item, dict):
             continue
         payload = cast(dict[str, Any], item)
@@ -4946,7 +5101,7 @@ def _build_actuation_intent_payload(
     )
     candidate_state_readiness_raw = candidate_state_payload.get("rollbackReadiness", {})
     candidate_state_readiness = (
-        candidate_state_readiness_raw
+        cast(dict[str, Any], candidate_state_readiness_raw)
         if isinstance(candidate_state_readiness_raw, dict)
         else {}
     )
@@ -5043,7 +5198,7 @@ def _resolve_confidence_calibration(
         "confidence_calibration"
     )
     confidence_calibration = (
-        dict(confidence_calibration_raw)
+        dict(cast(Mapping[str, Any], confidence_calibration_raw))
         if isinstance(confidence_calibration_raw, dict)
         else {}
     )
@@ -6936,30 +7091,37 @@ def _build_stress_bundle(report: EvaluationReport, stress_case: str) -> dict[str
 def load_runtime_strategy_config(path: Path) -> list[StrategyRuntimeConfig]:
     raw = path.read_text(encoding="utf-8")
     if path.suffix.lower() in {".yaml", ".yml"}:
-        payload = yaml.safe_load(raw)
+        payload_raw: object = yaml.safe_load(raw)
     else:
-        payload = json.loads(raw)
+        payload_raw = json.loads(raw)
 
-    if isinstance(payload, dict):
-        payload = payload.get("strategies", payload)
+    if isinstance(payload_raw, Mapping):
+        payload_mapping = cast(Mapping[str, Any], payload_raw)
+        payload: object = payload_mapping.get("strategies", payload_raw)
+    else:
+        payload = payload_raw
     if not isinstance(payload, list):
         raise ValueError("strategy config must be a list or include strategies key")
 
     strategies: list[StrategyRuntimeConfig] = []
-    for index, item in enumerate(payload):
-        if not isinstance(item, dict):
+    for index, item_raw in enumerate(cast(list[object], payload)):
+        if not isinstance(item_raw, Mapping):
             raise ValueError(f"invalid strategy entry at index {index}")
+        item = cast(Mapping[str, Any], item_raw)
         strategy_id = str(
             item.get("strategy_id") or item.get("name") or f"strategy-{index + 1}"
         )
-        if isinstance(item.get("strategy_spec_v2"), dict):
-            strategy_spec = load_strategy_spec_v2_payload(item["strategy_spec_v2"])
-            strategy_params = item.get("params", {})
-            if isinstance(strategy_params, dict) and strategy_params:
+        strategy_spec_raw = item.get("strategy_spec_v2")
+        if isinstance(strategy_spec_raw, Mapping):
+            strategy_spec = load_strategy_spec_v2_payload(
+                dict(cast(Mapping[str, Any], strategy_spec_raw))
+            )
+            strategy_params_raw = item.get("params", {})
+            if isinstance(strategy_params_raw, Mapping) and strategy_params_raw:
                 strategy_spec_payload = strategy_spec.to_payload()
                 strategy_spec_payload["runtime_parameters"] = {
                     **dict(strategy_spec.runtime_parameters),
-                    **cast(dict[str, Any], strategy_params),
+                    **dict(cast(Mapping[str, Any], strategy_params_raw)),
                 }
                 strategy_spec = load_strategy_spec_v2_payload(strategy_spec_payload)
             compiled = compile_strategy_spec_v2(strategy_spec)
@@ -6998,14 +7160,16 @@ def load_runtime_strategy_config(path: Path) -> list[StrategyRuntimeConfig]:
 
         strategy_type = str(item.get("strategy_type", "legacy_macd_rsi"))
         version = str(item.get("version", "1.0.0"))
-        params = item.get("params")
-        if params is None:
+        params_raw = item.get("params")
+        if params_raw is None:
             params = {
                 "buy_rsi_threshold": item.get("buy_rsi_threshold", 35),
                 "sell_rsi_threshold": item.get("sell_rsi_threshold", 65),
                 "qty": item.get("qty", 1),
             }
-        if not isinstance(params, dict):
+        elif isinstance(params_raw, Mapping):
+            params = dict(cast(Mapping[str, Any], params_raw))
+        else:
             raise ValueError(f"params for strategy {strategy_id} must be an object")
         config = StrategyRuntimeConfig(
             strategy_id=strategy_id,
@@ -7024,10 +7188,12 @@ def load_runtime_strategy_config(path: Path) -> list[StrategyRuntimeConfig]:
 
 
 def _load_signals(path: Path) -> list[SignalEnvelope]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload: object = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, list):
         raise ValueError("signals payload must be a list")
-    signals = [SignalEnvelope.model_validate(item) for item in payload]
+    signals = [
+        SignalEnvelope.model_validate(item) for item in cast(list[object], payload)
+    ]
     return sorted(signals, key=lambda item: (item.event_ts, item.symbol, item.seq or 0))
 
 
@@ -7062,15 +7228,20 @@ def _required_feature_null_rate(signals: list[SignalEnvelope]) -> Decimal:
     missing = 0
     total = 0
     for signal in signals:
-        payload = signal.payload or {}
+        payload = dict(signal.payload or {})
         for key in required_keys:
             total += 1
             if key == "macd":
                 macd_block = payload.get("macd")
+                macd_payload: dict[str, Any] = (
+                    dict(cast(Mapping[str, Any], macd_block))
+                    if isinstance(macd_block, Mapping)
+                    else {}
+                )
                 if (
-                    not isinstance(macd_block, dict)
-                    or macd_block.get("macd") is None
-                    or macd_block.get("signal") is None
+                    not macd_payload
+                    or macd_payload.get("macd") is None
+                    or macd_payload.get("signal") is None
                 ):
                     missing += 1
             elif key == "rsi":
@@ -7170,9 +7341,17 @@ def _resolve_gate_fragility_inputs(
     for item in decisions:
         params = item.decision.params
         allocator_payload = params.get("allocator")
-        allocator = allocator_payload if isinstance(allocator_payload, dict) else {}
+        allocator: dict[str, Any] = (
+            dict(cast(Mapping[str, Any], allocator_payload))
+            if isinstance(allocator_payload, Mapping)
+            else {}
+        )
         snapshot_payload = params.get("fragility_snapshot")
-        snapshot = snapshot_payload if isinstance(snapshot_payload, dict) else {}
+        snapshot: dict[str, Any] = (
+            dict(cast(Mapping[str, Any], snapshot_payload))
+            if isinstance(snapshot_payload, Mapping)
+            else {}
+        )
 
         raw_state = allocator.get("fragility_state")
         if raw_state is None:
@@ -7334,7 +7513,8 @@ def _resolve_gate_llm_metrics(
             metrics_payload = payload.get("metrics")
             if not isinstance(metrics_payload, dict):
                 return {}
-            error_rate = _to_finite_float(metrics_payload.get("error_rate"))
+            metrics = cast(Mapping[str, Any], metrics_payload)
+            error_rate = _to_finite_float(metrics.get("error_rate"))
             if error_rate is None or error_rate < 0 or error_rate > 1:
                 return {}
             return {"error_ratio": str(Decimal(str(error_rate)))}
@@ -7429,8 +7609,8 @@ def _collect_confidence_values(decisions: list[WalkForwardDecision]) -> list[Dec
         raw_value = item.decision.params.get("confidence")
         if raw_value is None:
             runtime_payload = item.decision.params.get("runtime")
-            if isinstance(runtime_payload, dict):
-                raw_value = runtime_payload.get("confidence")
+            if isinstance(runtime_payload, Mapping):
+                raw_value = cast(Mapping[str, Any], runtime_payload).get("confidence")
         if raw_value is None:
             continue
         try:
@@ -7496,7 +7676,11 @@ def _evaluate_drift_promotion_gate(
     evidence = drift_promotion_evidence or {}
     artifact_refs_raw = evidence.get("evidence_artifact_refs")
     artifact_refs = (
-        [str(item) for item in artifact_refs_raw if str(item).strip()]
+        [
+            str(item)
+            for item in cast(list[object], artifact_refs_raw)
+            if str(item).strip()
+        ]
         if isinstance(artifact_refs_raw, list)
         else []
     )
@@ -7520,7 +7704,7 @@ def _evaluate_drift_promotion_gate(
 
     reasons_raw = evidence.get("reasons")
     reasons = (
-        [str(item) for item in reasons_raw if str(item).strip()]
+        [str(item) for item in cast(list[object], reasons_raw) if str(item).strip()]
         if isinstance(reasons_raw, list)
         else []
     )
@@ -7549,9 +7733,12 @@ def _write_paper_candidate_patch(
     candidate_id: str,
     output_path: Path,
 ) -> Path:
-    configmap_payload = yaml.safe_load(configmap_path.read_text(encoding="utf-8"))
-    if not isinstance(configmap_payload, dict):
+    configmap_payload_raw: object = yaml.safe_load(
+        configmap_path.read_text(encoding="utf-8")
+    )
+    if not isinstance(configmap_payload_raw, Mapping):
         raise ValueError("invalid configmap payload")
+    configmap_payload = cast(Mapping[str, Any], configmap_payload_raw)
 
     candidate_strategies: list[dict[str, Any]] = []
     for strategy in runtime_strategies:
@@ -7571,16 +7758,18 @@ def _write_paper_candidate_patch(
 
     candidate_strategies.sort(key=lambda item: str(item["name"]))
 
-    patch_payload = {
+    metadata_raw = configmap_payload.get("metadata", {})
+    metadata: dict[str, Any] = (
+        dict(cast(Mapping[str, Any], metadata_raw))
+        if isinstance(metadata_raw, Mapping)
+        else {}
+    )
+    patch_payload: dict[str, Any] = {
         "apiVersion": "v1",
         "kind": "ConfigMap",
         "metadata": {
-            "name": configmap_payload.get("metadata", {}).get(
-                "name", "torghut-strategy-config"
-            ),
-            "namespace": configmap_payload.get("metadata", {}).get(
-                "namespace", "torghut"
-            ),
+            "name": metadata.get("name", "torghut-strategy-config"),
+            "namespace": metadata.get("namespace", "torghut"),
             "annotations": {
                 "torghut.proompteng.ai/candidate-id": candidate_id,
                 "torghut.proompteng.ai/recommended-mode": "paper",
@@ -7596,14 +7785,6 @@ def _write_paper_candidate_patch(
         yaml.safe_dump(patch_payload, sort_keys=False), encoding="utf-8"
     )
     return output_path
-
-
-__all__ = [
-    "AutonomousLaneResult",
-    "load_runtime_strategy_config",
-    "run_autonomous_lane",
-    "upsert_autonomy_no_signal_run",
-]
 
 
 __all__ = [

--- a/services/torghut/app/trading/execution_modules/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution_modules/order_executor_core_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Order execution and idempotency helpers."""
 
 from __future__ import annotations
@@ -8,7 +7,7 @@ import sys
 import time
 from collections.abc import Mapping
 from decimal import Decimal
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -36,6 +35,7 @@ from ..tca import upsert_execution_tca_metric
 
 
 from .shared_context import (
+    OrderExecutorContract as _OrderExecutorContract,
     SHORTING_METADATA_CACHE_TTL_SECONDS as _SHORTING_METADATA_CACHE_TTL_SECONDS,
     target_plan_source_decision_needs_refresh as _target_plan_source_decision_needs_refresh,
     logger,
@@ -77,7 +77,13 @@ def _execution_root_export(name: str, fallback: Any) -> Any:
     return getattr(root_module, name, fallback)
 
 
-class _OrderExecutorCoreMethods:
+if TYPE_CHECKING:
+    _OrderExecutorCoreBase = _OrderExecutorContract
+else:
+    _OrderExecutorCoreBase = object
+
+
+class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
     def __init__(self) -> None:
         self._account_metadata_cache: dict[str, Any] | None = None
         self._account_metadata_cached_at_monotonic: float | None = None

--- a/services/torghut/app/trading/execution_modules/order_executor_submission_methods.py
+++ b/services/torghut/app/trading/execution_modules/order_executor_submission_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Order execution and idempotency helpers."""
 
 from __future__ import annotations
@@ -9,7 +8,7 @@ import time
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, NamedTuple, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 
 from ...models import (
@@ -18,11 +17,13 @@ from ...models import (
 from ...config import settings
 from ..models import ExecutionRequest, StrategyDecision
 from ..quantity_rules import (
+    QuantityResolution,
     resolve_quantity_resolution,
 )
 
 
 from .shared_context import (
+    OrderExecutorContract as _OrderExecutorContract,
     OrderExecutorFields as _OrderExecutorFields,
     SHORTING_METADATA_CACHE_TTL_SECONDS as _SHORTING_METADATA_CACHE_TTL_SECONDS,
     logger,
@@ -40,7 +41,13 @@ def _optional_decimal(value: Any) -> Decimal | None:
     return optional_decimal(value)
 
 
-class _OrderExecutorSubmissionMethods:
+if TYPE_CHECKING:
+    _OrderExecutorSubmissionBase = _OrderExecutorContract
+else:
+    _OrderExecutorSubmissionBase = object
+
+
+class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
     def _retry_sell_inventory_conflict_after_cancel(
         self,
         *,
@@ -136,7 +143,7 @@ class _OrderExecutorSubmissionMethods:
         self,
         execution_client: Any,
         request: ExecutionRequest,
-    ) -> Any:
+    ) -> QuantityResolution:
         position_qty = self._position_qty_for_symbol(
             execution_client,
             request.symbol.strip().upper(),

--- a/services/torghut/app/trading/execution_modules/shared_context.py
+++ b/services/torghut/app/trading/execution_modules/shared_context.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, NamedTuple, Optional, cast
+from typing import Any, NamedTuple, Optional, Protocol, cast
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -28,6 +28,7 @@ from ..route_metadata import resolve_order_route_metadata
 from ..execution_policy import should_retry_order_error
 from ..models import ExecutionRequest, StrategyDecision, decision_hash
 from ..quantity_rules import (
+    QuantityResolution,
     min_qty_for_symbol,
     quantize_qty_for_symbol,
     qty_has_valid_increment,
@@ -203,6 +204,85 @@ def _target_plan_source_decision_needs_refresh(
 class _OrderExecutorFields:
     """Submit orders to a broker adapter with idempotency guards."""
 
+    _account_metadata_cache: dict[str, Any] | None
+    _account_metadata_cached_at_monotonic: float | None
+    _asset_metadata_cache: dict[str, tuple[dict[str, Any] | None, float]]
+    _shorting_metadata_status: dict[str, Any]
+
+
+class _OrderExecutorContract(Protocol):
+    _account_metadata_cache: dict[str, Any] | None
+    _account_metadata_cached_at_monotonic: float | None
+    _asset_metadata_cache: dict[str, tuple[dict[str, Any] | None, float]]
+    _shorting_metadata_status: dict[str, Any]
+
+    def _retry_sell_inventory_conflict_after_cancel(
+        self,
+        *,
+        execution_client: Any,
+        request: ExecutionRequest,
+        conflict: Mapping[str, Any],
+        fractional_equities_enabled: bool,
+    ) -> tuple[
+        ExecutionRequest,
+        dict[str, Any] | None,
+        dict[str, Any] | None,
+        dict[str, Any] | None,
+    ]: ...
+
+    @classmethod
+    def _remaining_order_qty(cls, order: Mapping[str, Any]) -> Decimal: ...
+
+    def _quantity_resolution_for_request(
+        self,
+        execution_client: Any,
+        request: ExecutionRequest,
+    ) -> QuantityResolution: ...
+
+    def _validate_short_sell_constraints(
+        self,
+        execution_client: Any,
+        request: ExecutionRequest,
+    ) -> dict[str, Any] | None: ...
+
+    @classmethod
+    def _position_qty_for_symbol(
+        cls,
+        execution_client: Any,
+        symbol: str,
+    ) -> Decimal | None: ...
+
+    @staticmethod
+    def _list_open_orders(execution_client: Any) -> list[dict[str, Any]]: ...
+
+    def _get_account(
+        self,
+        execution_client: Any,
+        *,
+        force_refresh: bool = False,
+    ) -> dict[str, Any] | None: ...
+
+    @classmethod
+    def _find_sell_inventory_conflict(
+        cls,
+        execution_client: Any,
+        request: ExecutionRequest,
+        open_orders: list[dict[str, Any]],
+    ) -> dict[str, Any] | None: ...
+
+    @classmethod
+    def _resolve_sell_inventory_conflict(
+        cls,
+        request: ExecutionRequest,
+        *,
+        conflict: Mapping[str, Any],
+        fractional_equities_enabled: bool,
+    ) -> tuple[
+        ExecutionRequest,
+        dict[str, Any] | None,
+        dict[str, Any] | None,
+    ]: ...
+
 
 # Public aliases used by split-module consumers.
 BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE = (
@@ -214,6 +294,7 @@ EXECUTION_POLICY_HASH_KEYS = _EXECUTION_POLICY_HASH_KEYS
 LINEAGE_HASH_KEYS = _LINEAGE_HASH_KEYS
 LINEAGE_PAYLOAD_KEYS = _LINEAGE_PAYLOAD_KEYS
 OrderExecutorFields = _OrderExecutorFields
+OrderExecutorContract = _OrderExecutorContract
 RUNTIME_COST_AMOUNT_KEYS = _RUNTIME_COST_AMOUNT_KEYS
 RUNTIME_COST_BASIS_KEYS = _RUNTIME_COST_BASIS_KEYS
 RUNTIME_COST_PAYLOAD_KEYS = _RUNTIME_COST_PAYLOAD_KEYS
@@ -236,6 +317,7 @@ __all__ = (
     "LINEAGE_HASH_KEYS",
     "LINEAGE_PAYLOAD_KEYS",
     "OrderExecutorFields",
+    "OrderExecutorContract",
     "RUNTIME_COST_AMOUNT_KEYS",
     "RUNTIME_COST_BASIS_KEYS",
     "RUNTIME_COST_PAYLOAD_KEYS",
@@ -258,6 +340,7 @@ __all__: tuple[str, ...] = (
     "COST_MODEL_HASH_KEYS",
     "COST_MODEL_PAYLOAD_KEYS",
     "Decimal",
+    "OrderExecutorContract",
     "EXECUTION_POLICY_HASH_KEYS",
     "Execution",
     "ExecutionRequest",

--- a/services/torghut/app/trading/hypotheses_modules/compile_hypothesis_runtime_statuses.py
+++ b/services/torghut/app/trading/hypotheses_modules/compile_hypothesis_runtime_statuses.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Hypothesis registry loading and runtime alpha-readiness compilation."""
 
 from __future__ import annotations
@@ -12,7 +11,6 @@ from typing import Any, cast
 
 from .shared_context import (
     CapitalStage,
-    HypothesisManifest,
     HypothesisRegistryLoadResult,
     HypothesisState,
     JangarDependencyQuorumStatus,
@@ -23,8 +21,6 @@ from .shared_context import (
     parse_iso8601 as _parse_iso8601,
     ranked_candidate_dossiers as _ranked_candidate_dossiers,
     resolve_required_dependency_capabilities as _resolve_required_dependency_capabilities,
-    hypothesis_registry_requires_dependency_capability,
-    resolve_hypothesis_dependency_quorum,
 )
 from .extract_stage_renewal_bonds import (
     manifest_pair_contract_blockers as _manifest_pair_contract_blockers,
@@ -33,10 +29,6 @@ from .extract_stage_renewal_bonds import (
 )
 from .runtime_ledger_row_rank import (
     resolve_runtime_ledger_readiness_inputs as _resolve_runtime_ledger_readiness_inputs,
-    load_hypothesis_registry,
-    load_jangar_dependency_quorum,
-    resolve_hypothesis_registry_path,
-    validate_hypothesis_registry_from_settings,
 )
 
 
@@ -677,21 +669,6 @@ def summarize_hypothesis_runtime_statuses(
         "rollback_required_total": rollback_required_total,
         "dependency_quorum": dependency_quorum.as_payload(),
     }
-
-
-__all__ = [
-    "HypothesisManifest",
-    "HypothesisRegistryLoadResult",
-    "JangarDependencyQuorumStatus",
-    "compile_hypothesis_runtime_statuses",
-    "hypothesis_registry_requires_dependency_capability",
-    "load_hypothesis_registry",
-    "load_jangar_dependency_quorum",
-    "resolve_hypothesis_dependency_quorum",
-    "resolve_hypothesis_registry_path",
-    "summarize_hypothesis_runtime_statuses",
-    "validate_hypothesis_registry_from_settings",
-]
 
 
 __all__ = (

--- a/services/torghut/app/trading/ingest_modules/clickhouse_signal_ingestor_core_methods.py
+++ b/services/torghut/app/trading/ingest_modules/clickhouse_signal_ingestor_core_methods.py
@@ -1,11 +1,10 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Signal ingestion from ClickHouse."""
 
 from __future__ import annotations
 
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy.orm import Session
 
@@ -22,6 +21,7 @@ from ..time_source import trading_now
 
 from .shared_context import (
     FLAT_CURSOR_OVERLAP,
+    ClickHouseSignalIngestorContract as _ClickHouseSignalIngestorContract,
     SignalBatch,
     simulation_fetch_window as _simulation_fetch_window,
     logger,
@@ -104,7 +104,13 @@ def _quote_literal(value: str) -> str:
     return quote_literal(value)
 
 
-class _ClickHouseSignalIngestorCoreMethods:
+if TYPE_CHECKING:
+    _ClickHouseSignalIngestorCoreBase = _ClickHouseSignalIngestorContract
+else:
+    _ClickHouseSignalIngestorCoreBase = object
+
+
+class _ClickHouseSignalIngestorCoreMethods(_ClickHouseSignalIngestorCoreBase):
     def __init__(
         self,
         url: Optional[str] = None,

--- a/services/torghut/app/trading/ingest_modules/clickhouse_signal_ingestor_market_methods.py
+++ b/services/torghut/app/trading/ingest_modules/clickhouse_signal_ingestor_market_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Signal ingestion from ClickHouse."""
 
 from __future__ import annotations
@@ -7,7 +6,7 @@ import json
 import logging
 from datetime import datetime, timedelta, timezone
 from http.client import HTTPConnection, HTTPSConnection
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import urlencode, urlsplit
 
 from sqlalchemy.orm import Session
@@ -22,6 +21,7 @@ from .shared_context import (
     ENVELOPE_SIGNAL_COLUMNS,
     FLAT_CURSOR_OVERLAP,
     FLAT_SIGNAL_COLUMNS,
+    ClickHouseSignalIngestorContract as _ClickHouseSignalIngestorContract,
     LATEST_SIGNAL_TS_CACHE_TTL,
     LATEST_SIGNAL_TS_ERROR_LOG_COOLDOWN,
     SignalBatch,
@@ -46,7 +46,13 @@ from .clickhouse_signal_ingestor_market_support import (
 logger = logging.getLogger("app.trading.ingest")
 
 
-class _ClickHouseSignalIngestorMarketMethods:
+if TYPE_CHECKING:
+    _ClickHouseSignalIngestorMarketBase = _ClickHouseSignalIngestorContract
+else:
+    _ClickHouseSignalIngestorMarketBase = object
+
+
+class _ClickHouseSignalIngestorMarketMethods(_ClickHouseSignalIngestorMarketBase):
     def _latest_signal_timestamp(
         self,
         time_column: str,

--- a/services/torghut/app/trading/ingest_modules/clickhouse_signal_ingestor_persistence_methods.py
+++ b/services/torghut/app/trading/ingest_modules/clickhouse_signal_ingestor_persistence_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Signal ingestion from ClickHouse."""
 
 from __future__ import annotations
@@ -7,7 +6,7 @@ import json
 import re
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Any, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Any, Mapping, Optional, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -23,6 +22,7 @@ from ..time_source import trading_now
 
 from .shared_context import (
     SIMULATION_CURSOR_BASELINE,
+    ClickHouseSignalIngestorContract as _ClickHouseSignalIngestorContract,
     ClickHouseSignalIngestorFields as _ClickHouseSignalIngestorFields,
     logger,
 )
@@ -41,7 +41,15 @@ def _ingest_root_export(name: str, fallback: Any) -> Any:
     return getattr(root_module, name, fallback)
 
 
-class _ClickHouseSignalIngestorPersistenceMethods:
+if TYPE_CHECKING:
+    _ClickHouseSignalIngestorPersistenceBase = _ClickHouseSignalIngestorContract
+else:
+    _ClickHouseSignalIngestorPersistenceBase = object
+
+
+class _ClickHouseSignalIngestorPersistenceMethods(
+    _ClickHouseSignalIngestorPersistenceBase
+):
     def _resolve_time_column(self) -> str:
         if self._time_column:
             return self._time_column

--- a/services/torghut/app/trading/ingest_modules/shared_context.py
+++ b/services/torghut/app/trading/ingest_modules/shared_context.py
@@ -8,7 +8,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass, field
 from http.client import HTTPConnection, HTTPSConnection
-from typing import Any, Mapping, Optional, cast
+from typing import Any, Mapping, Optional, Protocol, cast
 from urllib.parse import urlencode, urlsplit
 
 from sqlalchemy import select
@@ -120,8 +120,176 @@ class SignalBatch:
 class _ClickHouseSignalIngestorFields:
     """Poll ClickHouse for new TA signals using an event_ts cursor."""
 
+    url: str
+    username: Optional[str]
+    password: Optional[str]
+    table: str
+    batch_size: int
+    initial_lookback_minutes: int
+    schema: str
+    account_label: str
+    simulation_mode: bool
+    fast_forward_stale_cursor: bool
+    empty_batch_advance_seconds: int
+    _columns: Optional[set[str]]
+    _time_column: Optional[str]
+    _latest_signal_ts_cache: Optional[datetime]
+    _latest_signal_ts_checked_at: Optional[datetime]
+    _latest_signal_ts_last_error_at: Optional[datetime]
+    _latest_signal_ts_scoped_cache: dict[
+        tuple[tuple[str, ...], tuple[str, ...]], Optional[datetime]
+    ]
+    _latest_signal_ts_scoped_checked_at: dict[
+        tuple[tuple[str, ...], tuple[str, ...]], datetime
+    ]
+    _last_good_signal_batches: dict[
+        tuple[tuple[str, ...], tuple[str, ...]],
+        tuple[
+            datetime,
+            list[SignalEnvelope],
+            Optional[datetime],
+            Optional[datetime],
+        ],
+    ]
+
+
+class _ClickHouseSignalIngestorContract(Protocol):
+    url: str
+    username: Optional[str]
+    password: Optional[str]
+    table: str
+    batch_size: int
+    initial_lookback_minutes: int
+    schema: str
+    account_label: str
+    simulation_mode: bool
+    fast_forward_stale_cursor: bool
+    empty_batch_advance_seconds: int
+    _columns: Optional[set[str]]
+    _time_column: Optional[str]
+    _latest_signal_ts_cache: Optional[datetime]
+    _latest_signal_ts_checked_at: Optional[datetime]
+    _latest_signal_ts_last_error_at: Optional[datetime]
+    _latest_signal_ts_scoped_cache: dict[
+        tuple[tuple[str, ...], tuple[str, ...]], Optional[datetime]
+    ]
+    _latest_signal_ts_scoped_checked_at: dict[
+        tuple[tuple[str, ...], tuple[str, ...]], datetime
+    ]
+    _last_good_signal_batches: dict[
+        tuple[tuple[str, ...], tuple[str, ...]],
+        tuple[
+            datetime,
+            list[SignalEnvelope],
+            Optional[datetime],
+            Optional[datetime],
+        ],
+    ]
+
+    def _latest_signal_timestamp(
+        self,
+        time_column: str,
+        *,
+        symbols: tuple[str, ...] = (),
+        timeframes: tuple[str, ...] = (),
+    ) -> Optional[datetime]: ...
+
+    def parse_row(self, row: dict[str, Any]) -> Optional[SignalEnvelope]: ...
+
+    def _build_query(
+        self,
+        cursor_at: datetime,
+        cursor_seq: Optional[int],
+        cursor_symbol: Optional[str],
+        *,
+        symbols: tuple[str, ...] = (),
+        timeframes: tuple[str, ...] = (),
+    ) -> str: ...
+
+    def _dedupe_signals(
+        self, signals: list[SignalEnvelope]
+    ) -> list[SignalEnvelope]: ...
+
+    def _filter_signals(
+        self, signals: list[SignalEnvelope]
+    ) -> list[SignalEnvelope]: ...
+
+    def _sorted_signals(
+        self, signals: list[SignalEnvelope]
+    ) -> list[SignalEnvelope]: ...
+
+    def _query_clickhouse(self, query: str) -> list[dict[str, Any]]: ...
+
+    def _filter_cursor_boundary(
+        self,
+        signals: list[SignalEnvelope],
+        *,
+        cursor_at: datetime,
+        cursor_seq: Optional[int],
+        cursor_symbol: Optional[str],
+    ) -> list[SignalEnvelope]: ...
+
+    def _select_columns_and_expression(
+        self, time_column: str
+    ) -> tuple[list[str], str]: ...
+
+    def _maybe_join_microbar_volume(
+        self,
+        query: str,
+        *,
+        time_column: str,
+        selected_columns: list[str],
+    ) -> str: ...
+
+    def _source_where_clause(self) -> str | None: ...
+
+    def _scope_where_clauses(
+        self,
+        *,
+        symbols: tuple[str, ...] = (),
+        timeframes: tuple[str, ...] = (),
+    ) -> list[str]: ...
+
+    def _resolve_columns(self, force: bool = False) -> Optional[set[str]]: ...
+
+    def _remember_last_good_signals(
+        self,
+        *,
+        scope_key: tuple[tuple[str, ...], tuple[str, ...]],
+        signals: list[SignalEnvelope],
+        query_start: Optional[datetime],
+        query_end: Optional[datetime],
+        observed_at: datetime,
+    ) -> None: ...
+
+    def _timeout_degraded_batch(
+        self,
+        *,
+        reason: str,
+        query_start: Optional[datetime],
+        query_end: Optional[datetime],
+        scope_key: tuple[tuple[str, ...], tuple[str, ...]],
+    ) -> SignalBatch: ...
+
+    def _resolve_time_column(self) -> str: ...
+
+    def _get_cursor(
+        self, session: Session
+    ) -> tuple[datetime, Optional[int], Optional[str]]: ...
+
+    def _set_cursor(
+        self,
+        session: Session,
+        cursor_at: datetime,
+        cursor_seq: Optional[int],
+        cursor_symbol: Optional[str],
+    ) -> None: ...
+
+    def _supports_seq_for_time_column(self, time_column: str) -> bool: ...
+
 
 # Public aliases used by split-module consumers.
+ClickHouseSignalIngestorContract = _ClickHouseSignalIngestorContract
 ClickHouseSignalIngestorFields = _ClickHouseSignalIngestorFields
 coerce_count = _coerce_count
 simulation_fetch_window = _simulation_fetch_window
@@ -135,6 +303,7 @@ __all__ = (
     "FLAT_SIGNAL_COLUMNS",
     "ENVELOPE_SIGNAL_COLUMNS",
     "SignalBatch",
+    "ClickHouseSignalIngestorContract",
     "ClickHouseSignalIngestorFields",
     "coerce_count",
     "simulation_fetch_window",
@@ -144,6 +313,7 @@ __all__ = (
 # Explicit barrel exports; keeps re-export imports intentional without file-level Ruff ignores.
 __all__: tuple[str, ...] = (
     "Any",
+    "ClickHouseSignalIngestorContract",
     "ClickHouseSignalIngestorFields",
     "ENVELOPE_SIGNAL_COLUMNS",
     "FLAT_CURSOR_OVERLAP",

--- a/services/torghut/app/trading/scheduler/governance_modules/governance_mixin_decision_methods.py
+++ b/services/torghut/app/trading/scheduler/governance_modules/governance_mixin_decision_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Trading scheduler governance, autonomy, and safety workflows."""
 
 from __future__ import annotations
@@ -9,7 +8,7 @@ import sys
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from ....config import settings
 from ...autonomy import (
@@ -18,58 +17,14 @@ from ...autonomy import (
 )
 from ...ingest import SignalBatch
 from ...models import SignalEnvelope
-from .. import safety as _safety_private_37
-
-
+from ..safety import (
+    latch_signal_continuity_alert_state as _latch_signal_continuity_alert_state,
+    record_signal_continuity_recovery_cycle as _record_signal_continuity_recovery_cycle,
+)
 from .shared_context import (
+    TradingSchedulerGovernanceMixinContract as _TradingSchedulerGovernanceMixinContract,
+    resolve_autonomy_artifact_root as _resolve_autonomy_artifact_root,
     logger,
-)
-from . import shared_context as _shared_context_private_53
-
-from . import (
-    governance_mixin_lifecycle_methods as _governance_mixin_lifecycle_methods_private_61,
-)
-
-_FRESH_TAIL_NO_SIGNAL_REASONS = getattr(
-    _safety_private_37, "_FRESH_TAIL_NO_SIGNAL_REASONS"
-)
-_coerce_recovery_reason_sequence = getattr(
-    _safety_private_37, "_coerce_recovery_reason_sequence"
-)
-_is_market_session_open = getattr(_safety_private_37, "_is_market_session_open")
-_is_recoverable_emergency_stop_reason = getattr(
-    _safety_private_37, "_is_recoverable_emergency_stop_reason"
-)
-_latch_signal_continuity_alert_state = getattr(
-    _safety_private_37, "_latch_signal_continuity_alert_state"
-)
-_merge_emergency_stop_reasons = getattr(
-    _safety_private_37, "_merge_emergency_stop_reasons"
-)
-_record_signal_continuity_recovery_cycle = getattr(
-    _safety_private_37, "_record_signal_continuity_recovery_cycle"
-)
-_signal_bootstrap_grace_active = getattr(
-    _safety_private_37, "_signal_bootstrap_grace_active"
-)
-_signal_tail_is_fresh = getattr(_safety_private_37, "_signal_tail_is_fresh")
-_split_emergency_stop_reasons = getattr(
-    _safety_private_37, "_split_emergency_stop_reasons"
-)
-_TradingSchedulerGovernanceMixinFields = getattr(
-    _shared_context_private_53, "_TradingSchedulerGovernanceMixinFields"
-)
-_incident_payload_complete = getattr(
-    _shared_context_private_53, "_incident_payload_complete"
-)
-_int_from_mapping = getattr(_shared_context_private_53, "_int_from_mapping")
-_parse_iso_datetime = getattr(_shared_context_private_53, "_parse_iso_datetime")
-_resolve_autonomy_artifact_root = getattr(
-    _shared_context_private_53, "_resolve_autonomy_artifact_root"
-)
-_TradingSchedulerGovernanceLifecycleMethods = getattr(
-    _governance_mixin_lifecycle_methods_private_61,
-    "_TradingSchedulerGovernanceLifecycleMethods",
 )
 
 
@@ -80,7 +35,15 @@ def _governance_root_export(name: str, fallback: Any) -> Any:
     return getattr(root_module, name, fallback)
 
 
-class _TradingSchedulerGovernanceDecisionMethods:
+if TYPE_CHECKING:
+    _TradingSchedulerGovernanceDecisionBase = _TradingSchedulerGovernanceMixinContract
+else:
+    _TradingSchedulerGovernanceDecisionBase = object
+
+
+class _TradingSchedulerGovernanceDecisionMethods(
+    _TradingSchedulerGovernanceDecisionBase,
+):
     def _run_autonomous_cycle(
         self,
         *,

--- a/services/torghut/app/trading/scheduler/governance_modules/governance_mixin_lifecycle_methods.py
+++ b/services/torghut/app/trading/scheduler/governance_modules/governance_mixin_lifecycle_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Trading scheduler governance, autonomy, and safety workflows."""
 
 from __future__ import annotations
@@ -9,7 +8,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ....config import settings
 from ...autonomy import (
@@ -23,50 +22,22 @@ from ...autonomy import (
 from ...feature_quality import FeatureQualityThresholds, evaluate_feature_batch_quality
 from ...models import SignalEnvelope
 from ...time_source import trading_now
-from .. import safety as _safety_private_37
-
-
+from ..safety import (
+    FRESH_TAIL_NO_SIGNAL_REASONS as _FRESH_TAIL_NO_SIGNAL_REASONS,
+    coerce_recovery_reason_sequence as _coerce_recovery_reason_sequence,
+    is_market_session_open as _is_market_session_open,
+    is_recoverable_emergency_stop_reason as _is_recoverable_emergency_stop_reason,
+    merge_emergency_stop_reasons as _merge_emergency_stop_reasons,
+    signal_bootstrap_grace_active as _signal_bootstrap_grace_active,
+    signal_tail_is_fresh as _signal_tail_is_fresh,
+    split_emergency_stop_reasons as _split_emergency_stop_reasons,
+)
 from .shared_context import (
+    TradingSchedulerGovernanceMixinContract as _TradingSchedulerGovernanceMixinContract,
+    incident_payload_complete as _incident_payload_complete,
+    parse_iso_datetime as _parse_iso_datetime,
+    resolve_autonomy_artifact_root as _resolve_autonomy_artifact_root,
     logger,
-)
-from . import shared_context as _shared_context_private_53
-
-_FRESH_TAIL_NO_SIGNAL_REASONS = getattr(
-    _safety_private_37, "_FRESH_TAIL_NO_SIGNAL_REASONS"
-)
-_coerce_recovery_reason_sequence = getattr(
-    _safety_private_37, "_coerce_recovery_reason_sequence"
-)
-_is_market_session_open = getattr(_safety_private_37, "_is_market_session_open")
-_is_recoverable_emergency_stop_reason = getattr(
-    _safety_private_37, "_is_recoverable_emergency_stop_reason"
-)
-_latch_signal_continuity_alert_state = getattr(
-    _safety_private_37, "_latch_signal_continuity_alert_state"
-)
-_merge_emergency_stop_reasons = getattr(
-    _safety_private_37, "_merge_emergency_stop_reasons"
-)
-_record_signal_continuity_recovery_cycle = getattr(
-    _safety_private_37, "_record_signal_continuity_recovery_cycle"
-)
-_signal_bootstrap_grace_active = getattr(
-    _safety_private_37, "_signal_bootstrap_grace_active"
-)
-_signal_tail_is_fresh = getattr(_safety_private_37, "_signal_tail_is_fresh")
-_split_emergency_stop_reasons = getattr(
-    _safety_private_37, "_split_emergency_stop_reasons"
-)
-_TradingSchedulerGovernanceMixinFields = getattr(
-    _shared_context_private_53, "_TradingSchedulerGovernanceMixinFields"
-)
-_incident_payload_complete = getattr(
-    _shared_context_private_53, "_incident_payload_complete"
-)
-_int_from_mapping = getattr(_shared_context_private_53, "_int_from_mapping")
-_parse_iso_datetime = getattr(_shared_context_private_53, "_parse_iso_datetime")
-_resolve_autonomy_artifact_root = getattr(
-    _shared_context_private_53, "_resolve_autonomy_artifact_root"
 )
 
 
@@ -77,7 +48,15 @@ def _governance_root_export(name: str, fallback: Any) -> Any:
     return getattr(root_module, name, fallback)
 
 
-class _TradingSchedulerGovernanceLifecycleMethods:
+if TYPE_CHECKING:
+    _TradingSchedulerGovernanceLifecycleBase = _TradingSchedulerGovernanceMixinContract
+else:
+    _TradingSchedulerGovernanceLifecycleBase = object
+
+
+class _TradingSchedulerGovernanceLifecycleMethods(
+    _TradingSchedulerGovernanceLifecycleBase,
+):
     def _emit_autonomy_domain_telemetry(
         self, *, event_name: str, severity: str, properties: Mapping[str, Any]
     ) -> None:

--- a/services/torghut/app/trading/scheduler/governance_modules/governance_mixin_runtime_methods.py
+++ b/services/torghut/app/trading/scheduler/governance_modules/governance_mixin_runtime_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Trading scheduler governance, autonomy, and safety workflows."""
 
 from __future__ import annotations
@@ -7,7 +6,7 @@ import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ....config import settings
 from ...autonomy.phase_manifest_contract import (
@@ -18,9 +17,9 @@ from ...models import SignalEnvelope
 
 
 from .shared_context import (
+    TradingSchedulerGovernanceMixinContract as _TradingSchedulerGovernanceMixinContract,
     TradingSchedulerGovernanceMixinFields as _TradingSchedulerGovernanceMixinFields,
     int_from_mapping as _int_from_mapping,
-    resolve_autonomy_artifact_root as _resolve_autonomy_artifact_root,
     logger,
 )
 from .governance_mixin_lifecycle_methods import (
@@ -31,7 +30,15 @@ from .governance_mixin_decision_methods import (
 )
 
 
-class _TradingSchedulerGovernanceRuntimeMethods:
+if TYPE_CHECKING:
+    _TradingSchedulerGovernanceRuntimeBase = _TradingSchedulerGovernanceMixinContract
+else:
+    _TradingSchedulerGovernanceRuntimeBase = object
+
+
+class _TradingSchedulerGovernanceRuntimeMethods(
+    _TradingSchedulerGovernanceRuntimeBase,
+):
     def _apply_autonomy_lane_result(
         self,
         *,
@@ -489,9 +496,6 @@ class TradingSchedulerGovernanceMixin(
     object,
 ):
     pass
-
-
-__all__ = ["TradingSchedulerGovernanceMixin", "_resolve_autonomy_artifact_root"]
 
 
 __all__ = ("TradingSchedulerGovernanceMixin",)

--- a/services/torghut/app/trading/scheduler/governance_modules/shared_context.py
+++ b/services/torghut/app/trading/scheduler/governance_modules/shared_context.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, Optional, Protocol, cast
 
 from ....config import settings
 from ...autonomy import (
@@ -147,6 +147,36 @@ class _TradingSchedulerGovernanceMixinFields:
     _pipelines: list[TradingPipeline]
 
 
+class _TradingSchedulerGovernanceMixinContract(Protocol):
+    state: TradingState
+    _pipeline: Optional[TradingPipeline]
+    _pipelines: list[TradingPipeline]
+
+    def _append_runtime_governance_to_phase_manifest(
+        self, *args: Any, **kwargs: Any
+    ) -> Any: ...
+
+    def _apply_autonomy_lane_result(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def _current_drift_gate_evidence(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def _emit_autonomy_domain_telemetry(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def _evaluate_drift_governance(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def _evaluate_safety_controls(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def _governance_now(self, *args: Any, **kwargs: Any) -> datetime: ...
+
+    def _is_market_session_open(self, *args: Any, **kwargs: Any) -> bool: ...
+
+    def _update_autonomy_recommendation_state(
+        self, *args: Any, **kwargs: Any
+    ) -> Any: ...
+
+    def _update_autonomy_throughput_state(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
 resolve_autonomy_artifact_root = _resolve_autonomy_artifact_root
 
 __all__ = (
@@ -159,6 +189,7 @@ incident_payload_complete = _incident_payload_complete
 int_from_mapping = _int_from_mapping
 parse_iso_datetime = _parse_iso_datetime
 TradingSchedulerGovernanceMixinFields = _TradingSchedulerGovernanceMixinFields
+TradingSchedulerGovernanceMixinContract = _TradingSchedulerGovernanceMixinContract
 
 
 # Explicit barrel exports; keeps re-export imports intentional without file-level Ruff ignores.

--- a/services/torghut/app/trading/scheduler/paper_route_materialization.py
+++ b/services/torghut/app/trading/scheduler/paper_route_materialization.py
@@ -1,5 +1,3 @@
-# pyright: reportUnusedImport=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false
-
 from __future__ import annotations
 
 import logging

--- a/services/torghut/app/trading/scheduler/paper_route_materialization_processing.py
+++ b/services/torghut/app/trading/scheduler/paper_route_materialization_processing.py
@@ -1,4 +1,3 @@
-# pyright: reportUnusedImport=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false
 """Late-stage materialized paper-route processing mixin."""
 
 from __future__ import annotations
@@ -10,12 +9,13 @@ from datetime import datetime, timezone
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import select  # pyright: ignore[reportUnknownVariableType]
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ...config import settings
 from ...models import Strategy, TradeDecision, coerce_json_payload
 from ..models import StrategyDecision
+from .pipeline_modules.shared import TradingPipelineBase
 from .target_plan_helpers import (
     bounded_sim_collection_metadata_from_decision as _bounded_sim_collection_metadata_from_decision,
     safe_int as _safe_int,
@@ -33,7 +33,7 @@ class _MaterializedCandidateContext:
     now: datetime
 
 
-class SimplePipelinePaperRouteMaterializationProcessingMixin:
+class SimplePipelinePaperRouteMaterializationProcessingMixin(TradingPipelineBase):
     def _active_materialized_paper_route_client_order_ids(
         self,
         *,

--- a/services/torghut/app/trading/scheduler/pipeline_helpers.py
+++ b/services/torghut/app/trading/scheduler/pipeline_helpers.py
@@ -366,7 +366,7 @@ def _resolve_decision_regime_label_with_source(
     return regime_label, "legacy", None if regime_label is not None else "missing"
 
 
-def _resolve_decision_regime_label(decision: StrategyDecision) -> Optional[str]:  # pyright: ignore[reportUnusedFunction]
+def _resolve_decision_regime_label(decision: StrategyDecision) -> Optional[str]:
     # kept for backwards compatibility with existing tests and callers
     regime_label, _, _ = _resolve_decision_regime_label_with_source(decision)
     return regime_label
@@ -975,8 +975,10 @@ __all__ = [
     "_select_strictest_runtime_uncertainty_gate",
     "_uncertainty_gate_staleness_reason",
     "build_llm_policy_resolution",
+    "resolve_decision_regime_label",
 ]
 
 # Public aliases used by split modules.
 extract_json_error_payload = _extract_json_error_payload
 price_snapshot_payload = _price_snapshot_payload
+resolve_decision_regime_label = _resolve_decision_regime_label

--- a/services/torghut/app/trading/scheduler/pipeline_modules/shared.py
+++ b/services/torghut/app/trading/scheduler/pipeline_modules/shared.py
@@ -589,3 +589,104 @@ class TradingPipelineBase:
 
     def run_once(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
+
+    def _bounded_paper_route_execution_metadata(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _build_empirical_jobs_status(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _build_hypothesis_runtime_summary(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _build_profitability_proof_floor_receipt(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _build_submission_gate_market_context_status(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _build_tca_gate_inputs(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _load_quant_evidence_status(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _is_market_session_open(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_materialized_candidate(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_materialized_decision_with_execution_metadata(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_materialized_planned_candidate(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_materialized_planning_context(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_positions_without_materialized_open_order_projections(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_probe_reference_price(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_strategy(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_strategy_symbols(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_account_has_open_exposure(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_source_decision_metadata(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_source_cap(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_symbol_has_open_position(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_symbol_has_open_profit_proof_exposure(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _paper_route_target_symbol_has_open_strategy_exposure(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _reopen_rejected_paper_route_probe_exit_decision(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _reopen_rejected_paper_route_target_price_decision(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        raise NotImplementedError
+
+    def _with_paper_route_target_lineage(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError

--- a/services/torghut/app/trading/scheduler/proof_floor.py
+++ b/services/torghut/app/trading/scheduler/proof_floor.py
@@ -1,5 +1,3 @@
-# pyright: reportUnusedImport=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false
-
 from __future__ import annotations
 
 import logging
@@ -10,6 +8,7 @@ from typing import Any, cast
 from sqlalchemy.orm import Session
 
 from ...config import settings
+from .pipeline_modules.shared import TradingPipelineBase
 from .target_plan_helpers import (
     PAPER_ROUTE_PROBE_REASONS as _PAPER_ROUTE_PROBE_REASONS,
     PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS as _PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS,
@@ -21,7 +20,7 @@ from .target_plan_helpers import (
 logger = logging.getLogger(__name__)
 
 
-class SimplePipelineProofFloorMixin:
+class SimplePipelineProofFloorMixin(TradingPipelineBase):
     def _profitability_proof_floor(self, *, session: Session) -> Mapping[str, object]:
         try:
             self._refresh_market_context_for_proof_floor()

--- a/services/torghut/app/whitepapers/workflow_modules/ceph_s3_client.py
+++ b/services/torghut/app/whitepapers/workflow_modules/ceph_s3_client.py
@@ -6,11 +6,20 @@ import hashlib
 import hmac
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Mapping, Protocol
 from urllib.parse import quote, urlparse
 
+from sqlalchemy.orm import Session
+
+from ...models import (
+    WhitepaperAnalysisRun,
+    WhitepaperEngineeringTrigger,
+    WhitepaperRolloutTransition,
+)
 
 from .shared_context import (
+    GithubIssueEvent,
+    ManualApprovalPayload,
     WHITEPAPER_CEPH_DEFAULT_CONFIG_DIR as _WHITEPAPER_CEPH_DEFAULT_CONFIG_DIR,
     WHITEPAPER_CEPH_DEFAULT_SECRET_DIR as _WHITEPAPER_CEPH_DEFAULT_SECRET_DIR,
     bool_env as _bool_env,
@@ -291,13 +300,247 @@ class _PdfStorageOutcome:
 class _WhitepaperWorkflowServiceFields:
     """State transitions and persistence for whitepaper analysis workflow."""
 
+    ceph_client: Any | None
+    inngest_client: Any | None
+
+
+class _WhitepaperWorkflowServiceContract(Protocol):
+    ceph_client: Any | None
+    inngest_client: Any | None
+
+    def _structured_output_list(
+        self, payload: Mapping[str, Any], *, key: str
+    ) -> list[dict[str, Any]]: ...
+
+    def _build_chunks(
+        self, text_content: str, *, source_scope: str
+    ) -> list[dict[str, Any]]: ...
+
+    @staticmethod
+    def _build_whitepaper_prompt(
+        *,
+        run_id: str,
+        repository: str,
+        issue_url: str,
+        issue_title: str,
+        attachment_url: str,
+        ceph_uri: str,
+        subject: str | None,
+        tags: list[str],
+        analysis_mode: str,
+    ) -> str: ...
+
+    @staticmethod
+    def _coerce_string_list(value: Any) -> list[str]: ...
+
+    def _coerce_tag_list(self, value: Any) -> list[str]: ...
+
+    def _complete_run(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        payload: Mapping[str, Any],
+    ) -> None: ...
+
+    @staticmethod
+    def _download_pdf(url: str) -> bytes: ...
+
+    def _enqueue_finalized_inngest_event(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+    ) -> bool: ...
+
+    def _enqueue_requested_inngest_event(
+        self,
+        session: Session,
+        *,
+        run_row: WhitepaperAnalysisRun,
+    ) -> bool: ...
+
+    def _evaluate_and_process_engineering_trigger(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        *,
+        manual_approval: ManualApprovalPayload | None,
+    ) -> dict[str, Any]: ...
+
+    def _extract_pdf_text(self, pdf_bytes: bytes) -> dict[str, Any]: ...
+
+    def _ingest_artifacts(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        artifact_payload_raw: Any,
+    ) -> None: ...
+
+    @staticmethod
+    def _is_retryable_agentrun_status(status: str | None) -> bool: ...
+
+    def _next_step_attempt(
+        self,
+        session: Session,
+        *,
+        analysis_run_id: Any,
+        step_name: str,
+    ) -> int: ...
+
+    def _persist_semantic_chunks_and_embeddings(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+        source_scope: str,
+        chunks: list[dict[str, Any]],
+    ) -> dict[str, Any]: ...
+
+    def _submit_agents_agentrun(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]: ...
+
+    def _sync_structured_research_outputs(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        payload: Mapping[str, Any],
+    ) -> None: ...
+
+    def _upsert_design_pull_requests(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        pr_payload_raw: Any,
+    ) -> None: ...
+
+    def _upsert_steps(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        steps_raw: Any,
+    ) -> None: ...
+
+    def _upsert_synthesis(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        synthesis_payload_raw: Any,
+    ) -> None: ...
+
+    def _upsert_verdict(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        verdict_payload_raw: Any,
+    ) -> None: ...
+
+    def _upsert_whitepaper_content(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+        full_text: str,
+        extraction_meta: Mapping[str, Any] | None,
+    ) -> None: ...
+
+    @staticmethod
+    def _build_search_snippet(content: str, query: str) -> str: ...
+
+    def _embed_texts(self, texts: list[str]) -> tuple[str, int, list[list[float]]]: ...
+
+    @staticmethod
+    def _vector_to_text(values: list[float]) -> str: ...
+
+    @staticmethod
+    def _as_json_record(value: Any) -> dict[str, Any] | None: ...
+
+    def _build_engineering_trigger_payload(
+        self,
+        trigger: WhitepaperEngineeringTrigger,
+        rollout_transitions: list[WhitepaperRolloutTransition],
+    ) -> dict[str, Any]: ...
+
+    @staticmethod
+    def _compute_json_hash(payload: dict[str, Any] | None) -> str | None: ...
+
+    def _derive_hypothesis_id(self, run: WhitepaperAnalysisRun) -> str | None: ...
+
+    def _dispatch_engineering_agentrun(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+        trigger: WhitepaperEngineeringTrigger,
+        manual_approval: ManualApprovalPayload | None,
+    ) -> dict[str, Any]: ...
+
+    def _extract_gate_statuses(
+        self, gate_snapshot: dict[str, Any] | None
+    ) -> dict[str, str]: ...
+
+    @staticmethod
+    def _first_blocking_gate_id(reason_codes: list[str]) -> str | None: ...
+
+    def _gating_blocking_reason_codes(
+        self,
+        gate_snapshot: dict[str, Any] | None,
+        gate_statuses: dict[str, str],
+    ) -> list[str]: ...
+
+    def _manual_approval_allowed(self, rollout_profile: str) -> bool: ...
+
+    def _missing_gate_reason_codes(
+        self,
+        gate_statuses: dict[str, str],
+        *,
+        required: tuple[str, ...],
+    ) -> list[str]: ...
+
+    def _normalize_rollout_profile(self, value: str | None) -> str: ...
+
+    def _required_gate_failures(
+        self,
+        gate_statuses: dict[str, str],
+        *,
+        required: tuple[str, ...],
+    ) -> list[str]: ...
+
+    @staticmethod
+    def _rollback_target_stage(stage: str) -> str: ...
+
+    def _requeue_existing_run(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+        issue_event: GithubIssueEvent,
+        attachment_url: str,
+        marker: Mapping[str, Any],
+        source: str,
+    ) -> IssueKickoffResult: ...
+
+    def dispatch_codex_agentrun(
+        self,
+        session: Session,
+        run_id: str,
+        *,
+        force: bool = False,
+        allow_retry: bool = False,
+    ) -> dict[str, Any]: ...
+
 
 __all__ = (
     "CephS3Client",
     "IssueKickoffResult",
+    "WhitepaperWorkflowServiceContract",
 )
 
 # Public aliases used by split modules.
 IssueRunIdentity = _IssueRunIdentity
 PdfStorageOutcome = _PdfStorageOutcome
+WhitepaperWorkflowServiceContract = _WhitepaperWorkflowServiceContract
 WhitepaperWorkflowServiceFields = _WhitepaperWorkflowServiceFields

--- a/services/torghut/app/whitepapers/workflow_modules/shared_context.py
+++ b/services/torghut/app/whitepapers/workflow_modules/shared_context.py
@@ -309,6 +309,37 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    return text_value or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _optional_json(value: Any) -> Any:
+    if value is None:
+        return None
+    return coerce_json_payload(value)
+
+
 def _normalize_identifier(value: str) -> str:
     normalized = re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
     return normalized or "unknown"
@@ -668,6 +699,10 @@ int_env = _int_env
 MAX_SEMANTIC_RELEVANT_DISTANCE = _MAX_SEMANTIC_RELEVANT_DISTANCE
 mounted_or_env_value = _mounted_or_env_value
 normalize_identifier = _normalize_identifier
+optional_decimal = _optional_decimal
+optional_int = _optional_int
+optional_json = _optional_json
+optional_text = _optional_text
 PASS_GATE_STATUSES = _PASS_GATE_STATUSES
 read_text_file = _read_text_file
 REJECT_VERDICTS = _REJECT_VERDICTS
@@ -741,6 +776,10 @@ __all__: tuple[str, ...] = (
     "_int_env",
     "_mounted_or_env_value",
     "_normalize_identifier",
+    "_optional_decimal",
+    "_optional_int",
+    "_optional_json",
+    "_optional_text",
     "_read_text_file",
     "_sorted_unique",
     "_str_env",
@@ -783,6 +822,10 @@ __all__: tuple[str, ...] = (
     "normalize_attachment_url",
     "normalize_github_issue_event",
     "normalize_identifier",
+    "optional_decimal",
+    "optional_int",
+    "optional_json",
+    "optional_text",
     "os",
     "parse_marker_block",
     "parse_marker_tags",

--- a/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_agent_methods.py
+++ b/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_agent_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Whitepaper workflow ingestion, orchestration, and persistence helpers."""
 
 from __future__ import annotations
@@ -11,7 +10,7 @@ import tempfile
 import uuid
 from datetime import datetime, timezone
 from subprocess import CalledProcessError, run
-from typing import Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
@@ -29,12 +28,24 @@ from .shared_context import (
     SEMANTIC_RELATIVE_DISTANCE_WINDOW as _SEMANTIC_RELATIVE_DISTANCE_WINDOW,
     int_env as _int_env,
     normalize_identifier as _normalize_identifier,
+    optional_int as _optional_int,
+    optional_json as _optional_json,
+    optional_text as _optional_text,
     sorted_unique as _sorted_unique,
     parse_marker_tags,
 )
+from .ceph_s3_client import (
+    WhitepaperWorkflowServiceContract as _WhitepaperWorkflowServiceContract,
+)
 
 
-class _WhitepaperWorkflowAgentMethods:
+if TYPE_CHECKING:
+    _WhitepaperWorkflowAgentBase = _WhitepaperWorkflowServiceContract
+else:
+    _WhitepaperWorkflowAgentBase = object
+
+
+class _WhitepaperWorkflowAgentMethods(_WhitepaperWorkflowAgentBase):
     def search_semantic(
         self,
         session: Session,
@@ -269,7 +280,7 @@ class _WhitepaperWorkflowAgentMethods:
     def _coerce_string_list(value: Any) -> list[str]:
         if isinstance(value, list):
             result: list[str] = []
-            for item in value:
+            for item in cast(list[object], value):
                 text = str(item).strip() if item is not None else ""
                 if text:
                     result.append(text)
@@ -302,7 +313,7 @@ class _WhitepaperWorkflowAgentMethods:
             return _sorted_unique(
                 [
                     _normalize_identifier(str(item))
-                    for item in value
+                    for item in cast(list[object], value)
                     if item is not None and str(item).strip()
                 ]
             )
@@ -410,13 +421,11 @@ class _WhitepaperWorkflowAgentMethods:
         extraction_meta: Mapping[str, Any] | None,
     ) -> None:
         version = run.document_version
-        if version is None:
-            raise RuntimeError("whitepaper_version_missing")
 
         normalized_text = full_text.strip()
         full_text_sha256 = hashlib.sha256(normalized_text.encode("utf-8")).hexdigest()
         token_count = len(normalized_text.split()) if normalized_text else 0
-        page_count = self._optional_int((extraction_meta or {}).get("page_count"))
+        page_count = _optional_int((extraction_meta or {}).get("page_count"))
 
         content = session.execute(
             select(WhitepaperContent).where(
@@ -504,8 +513,6 @@ class _WhitepaperWorkflowAgentMethods:
         normalized_scope = source_scope.strip().lower()
         if normalized_scope not in {"full_text", "synthesis"}:
             raise ValueError("invalid_source_scope")
-        if run.document_version is None:
-            raise RuntimeError("whitepaper_version_missing")
 
         if not chunks:
             session.execute(
@@ -541,9 +548,9 @@ class _WhitepaperWorkflowAgentMethods:
             content = str(chunk.get("content") or "").strip()
             if not content:
                 continue
-            section_key = self._optional_text(chunk.get("section_key"))
-            token_count = self._optional_int(chunk.get("token_count"))
-            metadata_json = self._optional_json(chunk.get("metadata_json"))
+            section_key = _optional_text(chunk.get("section_key"))
+            token_count = _optional_int(chunk.get("token_count"))
+            metadata_json = _optional_json(chunk.get("metadata_json"))
             chunk_index = int(chunk.get("chunk_index") or 0)
             content_sha256 = hashlib.sha256(content.encode("utf-8")).hexdigest()
             vector_text = self._vector_to_text(embedding)

--- a/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_api_methods.py
+++ b/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_api_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Whitepaper workflow ingestion, orchestration, and persistence helpers."""
 
 from __future__ import annotations
@@ -9,7 +8,7 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
@@ -36,12 +35,25 @@ from .shared_context import (
     http_request_bytes as _http_request_bytes,
     int_env as _int_env,
     normalize_identifier as _normalize_identifier,
+    optional_decimal as _optional_decimal,
+    optional_int as _optional_int,
+    optional_json as _optional_json,
+    optional_text as _optional_text,
     str_env as _str_env,
     normalize_analysis_mode,
 )
+from .ceph_s3_client import (
+    WhitepaperWorkflowServiceContract as _WhitepaperWorkflowServiceContract,
+)
 
 
-class _WhitepaperWorkflowApiMethods:
+if TYPE_CHECKING:
+    _WhitepaperWorkflowApiBase = _WhitepaperWorkflowServiceContract
+else:
+    _WhitepaperWorkflowApiBase = object
+
+
+class _WhitepaperWorkflowApiMethods(_WhitepaperWorkflowApiBase):
     def _compiled_experiment_specs_from_templates(
         self,
         *,
@@ -82,15 +94,15 @@ class _WhitepaperWorkflowApiMethods:
         results: list[dict[str, Any]] = []
         for index, template in enumerate(templates, start=1):
             template_id = (
-                self._optional_text(template.get("template_id")) or f"template-{index}"
+                _optional_text(template.get("template_id")) or f"template-{index}"
             )
             family_template_id = (
-                self._optional_text(template.get("family_template_id"))
+                _optional_text(template.get("family_template_id"))
                 or "unspecified_family"
             )
             hypothesis = (
-                self._optional_text(template.get("hypothesis"))
-                or self._optional_text(template.get("economic_mechanism"))
+                _optional_text(template.get("hypothesis"))
+                or _optional_text(template.get("economic_mechanism"))
                 or f"Experiment for {family_template_id}"
             )
             results.append(
@@ -125,7 +137,7 @@ class _WhitepaperWorkflowApiMethods:
         events: list[dict[str, Any]] = []
         for relation in relations:
             relation_type = _normalize_identifier(
-                self._optional_text(relation.get("relation_type")) or ""
+                _optional_text(relation.get("relation_type")) or ""
             )
             if relation_type not in {
                 "contradicts",
@@ -134,23 +146,21 @@ class _WhitepaperWorkflowApiMethods:
                 "conflict",
             }:
                 continue
-            relation_id = self._optional_text(relation.get("relation_id")) or str(
+            relation_id = _optional_text(relation.get("relation_id")) or str(
                 uuid.uuid4()
             )
-            source_claim_id = self._optional_text(relation.get("source_claim_id"))
+            source_claim_id = _optional_text(relation.get("source_claim_id"))
             if not source_claim_id:
                 continue
             events.append(
                 {
                     "event_id": f"contradiction-{relation_id}",
                     "source_claim_id": source_claim_id,
-                    "target_claim_id": self._optional_text(
-                        relation.get("target_claim_id")
-                    ),
-                    "target_run_id": self._optional_text(relation.get("target_run_id")),
+                    "target_claim_id": _optional_text(relation.get("target_claim_id")),
+                    "target_run_id": _optional_text(relation.get("target_run_id")),
                     "status": "open",
                     "required_action": "revalidate_linked_family",
-                    "rationale": self._optional_text(relation.get("rationale")),
+                    "rationale": _optional_text(relation.get("rationale")),
                     "metadata": {"derived_from_relation_id": relation_id},
                 }
             )
@@ -212,64 +222,62 @@ class _WhitepaperWorkflowApiMethods:
         )
 
         for claim in claims:
-            claim_id = self._optional_text(claim.get("claim_id"))
-            claim_text = self._optional_text(
-                claim.get("claim_text")
-            ) or self._optional_text(claim.get("claim"))
+            claim_id = _optional_text(claim.get("claim_id"))
+            claim_text = _optional_text(claim.get("claim_text")) or _optional_text(
+                claim.get("claim")
+            )
             if not claim_id or not claim_text:
                 continue
             session.add(
                 WhitepaperClaim(
                     analysis_run_id=run.id,
                     claim_id=claim_id,
-                    claim_type=self._optional_text(claim.get("claim_type"))
+                    claim_type=_optional_text(claim.get("claim_type"))
                     or "signal_mechanism",
                     claim_text=claim_text,
-                    asset_scope=self._optional_text(claim.get("asset_scope")),
-                    horizon_scope=self._optional_text(claim.get("horizon_scope")),
-                    data_requirements_json=self._optional_json(
+                    asset_scope=_optional_text(claim.get("asset_scope")),
+                    horizon_scope=_optional_text(claim.get("horizon_scope")),
+                    data_requirements_json=_optional_json(
                         claim.get("data_requirements")
                     ),
-                    expected_direction=self._optional_text(
-                        claim.get("expected_direction")
-                    ),
-                    required_activity_conditions_json=self._optional_json(
+                    expected_direction=_optional_text(claim.get("expected_direction")),
+                    required_activity_conditions_json=_optional_json(
                         claim.get("required_activity_conditions")
                     ),
-                    liquidity_constraints_json=self._optional_json(
+                    liquidity_constraints_json=_optional_json(
                         claim.get("liquidity_constraints")
                     ),
-                    validation_notes=self._optional_text(claim.get("validation_notes")),
-                    confidence=self._optional_decimal(claim.get("confidence")),
-                    metadata_json=self._optional_json(claim.get("metadata")),
+                    validation_notes=_optional_text(claim.get("validation_notes")),
+                    confidence=_optional_decimal(claim.get("confidence")),
+                    metadata_json=_optional_json(claim.get("metadata")),
                 )
             )
 
         for relation in relations:
-            relation_id = self._optional_text(relation.get("relation_id"))
-            source_claim_id = self._optional_text(relation.get("source_claim_id"))
-            target_claim_id = self._optional_text(relation.get("target_claim_id"))
+            relation_id = _optional_text(relation.get("relation_id"))
+            source_claim_id = _optional_text(relation.get("source_claim_id"))
+            target_claim_id = _optional_text(relation.get("target_claim_id"))
             if not relation_id or not source_claim_id or not target_claim_id:
                 continue
             session.add(
                 WhitepaperClaimRelation(
                     analysis_run_id=run.id,
                     relation_id=relation_id,
-                    relation_type=self._optional_text(relation.get("relation_type"))
+                    relation_type=_optional_text(relation.get("relation_type"))
                     or "supports",
                     source_claim_id=source_claim_id,
                     target_claim_id=target_claim_id,
-                    target_run_id=self._optional_text(relation.get("target_run_id")),
-                    rationale=self._optional_text(relation.get("rationale")),
-                    confidence=self._optional_decimal(relation.get("confidence")),
-                    metadata_json=self._optional_json(relation.get("metadata")),
+                    target_run_id=_optional_text(relation.get("target_run_id")),
+                    rationale=_optional_text(relation.get("rationale")),
+                    confidence=_optional_decimal(relation.get("confidence")),
+                    metadata_json=_optional_json(relation.get("metadata")),
                 )
             )
 
         for template in templates:
-            template_id = self._optional_text(template.get("template_id"))
-            family_template_id = self._optional_text(template.get("family_template_id"))
-            economic_mechanism = self._optional_text(template.get("economic_mechanism"))
+            template_id = _optional_text(template.get("template_id"))
+            family_template_id = _optional_text(template.get("family_template_id"))
+            economic_mechanism = _optional_text(template.get("economic_mechanism"))
             if not template_id or not family_template_id or not economic_mechanism:
                 continue
             session.add(
@@ -278,42 +286,34 @@ class _WhitepaperWorkflowApiMethods:
                     template_id=template_id,
                     family_template_id=family_template_id,
                     economic_mechanism=economic_mechanism,
-                    hypothesis=self._optional_text(template.get("hypothesis")),
-                    supported_markets_json=self._optional_json(
+                    hypothesis=_optional_text(template.get("hypothesis")),
+                    supported_markets_json=_optional_json(
                         template.get("supported_markets")
                     ),
-                    required_features_json=self._optional_json(
+                    required_features_json=_optional_json(
                         template.get("required_features")
                     ),
-                    allowed_normalizations_json=self._optional_json(
+                    allowed_normalizations_json=_optional_json(
                         template.get("allowed_normalizations")
                     ),
-                    entry_motifs_json=self._optional_json(template.get("entry_motifs")),
-                    exit_motifs_json=self._optional_json(template.get("exit_motifs")),
-                    risk_controls_json=self._optional_json(
-                        template.get("risk_controls")
-                    ),
-                    activity_model_json=self._optional_json(
-                        template.get("activity_model")
-                    ),
-                    liquidity_assumptions_json=self._optional_json(
+                    entry_motifs_json=_optional_json(template.get("entry_motifs")),
+                    exit_motifs_json=_optional_json(template.get("exit_motifs")),
+                    risk_controls_json=_optional_json(template.get("risk_controls")),
+                    activity_model_json=_optional_json(template.get("activity_model")),
+                    liquidity_assumptions_json=_optional_json(
                         template.get("liquidity_assumptions")
                     ),
-                    regime_activation_rules_json=self._optional_json(
+                    regime_activation_rules_json=_optional_json(
                         template.get("regime_activation_rules")
                     ),
-                    day_veto_rules_json=self._optional_json(
-                        template.get("day_veto_rules")
-                    ),
-                    metadata_json=self._optional_json(template.get("metadata")),
+                    day_veto_rules_json=_optional_json(template.get("day_veto_rules")),
+                    metadata_json=_optional_json(template.get("metadata")),
                 )
             )
 
         for experiment in experiment_specs:
-            experiment_id = self._optional_text(experiment.get("experiment_id"))
-            family_template_id = self._optional_text(
-                experiment.get("family_template_id")
-            )
+            experiment_id = _optional_text(experiment.get("experiment_id"))
+            family_template_id = _optional_text(experiment.get("family_template_id"))
             if not experiment_id or not family_template_id:
                 continue
             payload_json = coerce_json_payload(dict(experiment))
@@ -322,31 +322,31 @@ class _WhitepaperWorkflowApiMethods:
                     analysis_run_id=run.id,
                     experiment_id=experiment_id,
                     family_template_id=family_template_id,
-                    template_id=self._optional_text(experiment.get("template_id")),
-                    hypothesis=self._optional_text(experiment.get("hypothesis")),
-                    paper_claim_links_json=self._optional_json(
+                    template_id=_optional_text(experiment.get("template_id")),
+                    hypothesis=_optional_text(experiment.get("hypothesis")),
+                    paper_claim_links_json=_optional_json(
                         experiment.get("paper_claim_links")
                     ),
-                    dataset_snapshot_policy_json=self._optional_json(
+                    dataset_snapshot_policy_json=_optional_json(
                         experiment.get("dataset_snapshot_policy")
                     ),
-                    template_overrides_json=self._optional_json(
+                    template_overrides_json=_optional_json(
                         experiment.get("template_overrides")
                     ),
-                    feature_variants_json=self._optional_json(
+                    feature_variants_json=_optional_json(
                         experiment.get("feature_variants")
                     ),
-                    veto_controller_variants_json=self._optional_json(
+                    veto_controller_variants_json=_optional_json(
                         experiment.get("veto_controller_variants")
                     ),
-                    selection_objectives_json=self._optional_json(
+                    selection_objectives_json=_optional_json(
                         experiment.get("selection_objectives")
                     ),
-                    hard_vetoes_json=self._optional_json(experiment.get("hard_vetoes")),
-                    expected_failure_modes_json=self._optional_json(
+                    hard_vetoes_json=_optional_json(experiment.get("hard_vetoes")),
+                    expected_failure_modes_json=_optional_json(
                         experiment.get("expected_failure_modes")
                     ),
-                    promotion_contract_json=self._optional_json(
+                    promotion_contract_json=_optional_json(
                         experiment.get("promotion_contract")
                     ),
                     payload_json=payload_json,
@@ -363,8 +363,8 @@ class _WhitepaperWorkflowApiMethods:
 
         seen_event_ids: set[str] = set()
         for event in contradiction_events:
-            event_id = self._optional_text(event.get("event_id"))
-            source_claim_id = self._optional_text(event.get("source_claim_id"))
+            event_id = _optional_text(event.get("event_id"))
+            source_claim_id = _optional_text(event.get("source_claim_id"))
             if not event_id or not source_claim_id or event_id in seen_event_ids:
                 continue
             seen_event_ids.add(event_id)
@@ -373,12 +373,12 @@ class _WhitepaperWorkflowApiMethods:
                     analysis_run_id=run.id,
                     event_id=event_id,
                     source_claim_id=source_claim_id,
-                    target_claim_id=self._optional_text(event.get("target_claim_id")),
-                    target_run_id=self._optional_text(event.get("target_run_id")),
-                    status=self._optional_text(event.get("status")) or "open",
-                    required_action=self._optional_text(event.get("required_action")),
-                    rationale=self._optional_text(event.get("rationale")),
-                    metadata_json=self._optional_json(event.get("metadata")),
+                    target_claim_id=_optional_text(event.get("target_claim_id")),
+                    target_run_id=_optional_text(event.get("target_run_id")),
+                    status=_optional_text(event.get("status")) or "open",
+                    required_action=_optional_text(event.get("required_action")),
+                    rationale=_optional_text(event.get("rationale")),
+                    metadata_json=_optional_json(event.get("metadata")),
                 )
             )
 
@@ -389,7 +389,7 @@ class _WhitepaperWorkflowApiMethods:
         if isinstance(pr_payload_raw, list):
             return [
                 cast(dict[str, Any], item)
-                for item in pr_payload_raw
+                for item in cast(list[object], pr_payload_raw)
                 if isinstance(item, Mapping)
             ]
         return []
@@ -422,8 +422,8 @@ class _WhitepaperWorkflowApiMethods:
 
         if pr_row is None:
             repository = (
-                self._optional_text(pr_payload.get("repository"))
-                or self._optional_text(
+                _optional_text(pr_payload.get("repository"))
+                or _optional_text(
                     cast(dict[str, Any], run.orchestration_context_json or {}).get(
                         "repository"
                     )
@@ -433,22 +433,19 @@ class _WhitepaperWorkflowApiMethods:
             pr_row = WhitepaperDesignPullRequest(
                 analysis_run_id=run.id,
                 attempt=attempt,
-                status=self._optional_text(pr_payload.get("status")) or "opened",
+                status=_optional_text(pr_payload.get("status")) or "opened",
                 repository=repository,
-                base_branch=self._optional_text(pr_payload.get("base_branch"))
-                or "main",
-                head_branch=self._optional_text(pr_payload.get("head_branch"))
+                base_branch=_optional_text(pr_payload.get("base_branch")) or "main",
+                head_branch=_optional_text(pr_payload.get("head_branch"))
                 or "codex/whitepaper",
-                pr_number=self._optional_int(pr_payload.get("pr_number")),
-                pr_url=self._optional_text(pr_payload.get("pr_url")),
-                title=self._optional_text(pr_payload.get("title")),
-                body=self._optional_text(pr_payload.get("body")),
-                commit_sha=self._optional_text(pr_payload.get("commit_sha")),
-                merge_commit_sha=self._optional_text(
-                    pr_payload.get("merge_commit_sha")
-                ),
-                checks_url=self._optional_text(pr_payload.get("checks_url")),
-                ci_status=self._optional_text(pr_payload.get("ci_status")),
+                pr_number=_optional_int(pr_payload.get("pr_number")),
+                pr_url=_optional_text(pr_payload.get("pr_url")),
+                title=_optional_text(pr_payload.get("title")),
+                body=_optional_text(pr_payload.get("body")),
+                commit_sha=_optional_text(pr_payload.get("commit_sha")),
+                merge_commit_sha=_optional_text(pr_payload.get("merge_commit_sha")),
+                checks_url=_optional_text(pr_payload.get("checks_url")),
+                ci_status=_optional_text(pr_payload.get("ci_status")),
                 is_merged=bool(pr_payload.get("is_merged")),
                 merged_at=datetime.now(timezone.utc)
                 if pr_payload.get("is_merged")
@@ -458,25 +455,25 @@ class _WhitepaperWorkflowApiMethods:
             session.add(pr_row)
             return
 
-        pr_row.status = self._optional_text(pr_payload.get("status")) or pr_row.status
+        pr_row.status = _optional_text(pr_payload.get("status")) or pr_row.status
         pr_row.pr_number = (
-            self._optional_int(pr_payload.get("pr_number")) or pr_row.pr_number
+            _optional_int(pr_payload.get("pr_number")) or pr_row.pr_number
         )
-        pr_row.pr_url = self._optional_text(pr_payload.get("pr_url")) or pr_row.pr_url
-        pr_row.title = self._optional_text(pr_payload.get("title")) or pr_row.title
-        pr_row.body = self._optional_text(pr_payload.get("body")) or pr_row.body
+        pr_row.pr_url = _optional_text(pr_payload.get("pr_url")) or pr_row.pr_url
+        pr_row.title = _optional_text(pr_payload.get("title")) or pr_row.title
+        pr_row.body = _optional_text(pr_payload.get("body")) or pr_row.body
         pr_row.commit_sha = (
-            self._optional_text(pr_payload.get("commit_sha")) or pr_row.commit_sha
+            _optional_text(pr_payload.get("commit_sha")) or pr_row.commit_sha
         )
         pr_row.merge_commit_sha = (
-            self._optional_text(pr_payload.get("merge_commit_sha"))
+            _optional_text(pr_payload.get("merge_commit_sha"))
             or pr_row.merge_commit_sha
         )
         pr_row.checks_url = (
-            self._optional_text(pr_payload.get("checks_url")) or pr_row.checks_url
+            _optional_text(pr_payload.get("checks_url")) or pr_row.checks_url
         )
         pr_row.ci_status = (
-            self._optional_text(pr_payload.get("ci_status")) or pr_row.ci_status
+            _optional_text(pr_payload.get("ci_status")) or pr_row.ci_status
         )
         pr_row.is_merged = bool(pr_payload.get("is_merged"))
         if pr_row.is_merged and pr_row.merged_at is None:
@@ -493,12 +490,12 @@ class _WhitepaperWorkflowApiMethods:
         if not isinstance(artifact_payload_raw, list):
             return
 
-        for item in artifact_payload_raw:
+        for item in cast(list[object], artifact_payload_raw):
             if not isinstance(item, Mapping):
                 continue
             artifact = cast(dict[str, Any], item)
-            bucket = self._optional_text(artifact.get("ceph_bucket"))
-            key = self._optional_text(artifact.get("ceph_object_key"))
+            bucket = _optional_text(artifact.get("ceph_bucket"))
+            key = _optional_text(artifact.get("ceph_object_key"))
             if bucket and key:
                 existing_artifact = session.execute(
                     select(WhitepaperArtifact).where(
@@ -513,19 +510,17 @@ class _WhitepaperWorkflowApiMethods:
                     document_id=run.document_id,
                     document_version_id=run.document_version_id,
                     analysis_run_id=run.id,
-                    artifact_scope=self._optional_text(artifact.get("artifact_scope"))
+                    artifact_scope=_optional_text(artifact.get("artifact_scope"))
                     or "run",
-                    artifact_type=self._optional_text(artifact.get("artifact_type"))
+                    artifact_type=_optional_text(artifact.get("artifact_type"))
                     or "generic",
-                    artifact_role=self._optional_text(artifact.get("artifact_role")),
+                    artifact_role=_optional_text(artifact.get("artifact_role")),
                     ceph_bucket=bucket,
                     ceph_object_key=key,
-                    artifact_uri=self._optional_text(artifact.get("artifact_uri")),
-                    checksum_sha256=self._optional_text(
-                        artifact.get("checksum_sha256")
-                    ),
-                    size_bytes=self._optional_int(artifact.get("size_bytes")),
-                    content_type=self._optional_text(artifact.get("content_type")),
+                    artifact_uri=_optional_text(artifact.get("artifact_uri")),
+                    checksum_sha256=_optional_text(artifact.get("checksum_sha256")),
+                    size_bytes=_optional_int(artifact.get("size_bytes")),
+                    content_type=_optional_text(artifact.get("content_type")),
                     metadata_json=coerce_json_payload(artifact),
                 )
             )
@@ -539,7 +534,7 @@ class _WhitepaperWorkflowApiMethods:
         if not isinstance(steps_raw, list):
             return
 
-        for index, step_raw in enumerate(steps_raw, start=1):
+        for index, step_raw in enumerate(cast(list[object], steps_raw), start=1):
             if not isinstance(step_raw, Mapping):
                 continue
             self._upsert_single_step(
@@ -553,9 +548,7 @@ class _WhitepaperWorkflowApiMethods:
         step_payload: dict[str, Any],
         index: int,
     ) -> None:
-        step_name = (
-            self._optional_text(step_payload.get("step_name")) or f"step_{index}"
-        )
+        step_name = _optional_text(step_payload.get("step_name")) or f"step_{index}"
         attempt = int(step_payload.get("attempt") or 1)
         step = session.execute(
             select(WhitepaperAnalysisStep).where(
@@ -570,34 +563,32 @@ class _WhitepaperWorkflowApiMethods:
                 step_name=step_name,
                 step_order=int(step_payload.get("step_order") or index),
                 attempt=attempt,
-                status=self._optional_text(step_payload.get("status")) or "completed",
-                executor=self._optional_text(step_payload.get("executor")),
-                idempotency_key=self._optional_text(
-                    step_payload.get("idempotency_key")
-                ),
-                trace_id=self._optional_text(step_payload.get("trace_id")),
+                status=_optional_text(step_payload.get("status")) or "completed",
+                executor=_optional_text(step_payload.get("executor")),
+                idempotency_key=_optional_text(step_payload.get("idempotency_key")),
+                trace_id=_optional_text(step_payload.get("trace_id")),
                 started_at=datetime.now(timezone.utc),
                 completed_at=datetime.now(timezone.utc),
-                duration_ms=self._optional_int(step_payload.get("duration_ms")),
-                input_json=self._optional_json(step_payload.get("input_json")),
-                output_json=self._optional_json(step_payload.get("output_json")),
-                error_json=self._optional_json(step_payload.get("error_json")),
+                duration_ms=_optional_int(step_payload.get("duration_ms")),
+                input_json=_optional_json(step_payload.get("input_json")),
+                output_json=_optional_json(step_payload.get("output_json")),
+                error_json=_optional_json(step_payload.get("error_json")),
             )
             session.add(step)
             return
 
-        step.status = self._optional_text(step_payload.get("status")) or step.status
+        step.status = _optional_text(step_payload.get("status")) or step.status
         step.duration_ms = (
-            self._optional_int(step_payload.get("duration_ms")) or step.duration_ms
+            _optional_int(step_payload.get("duration_ms")) or step.duration_ms
         )
         step.input_json = (
-            self._optional_json(step_payload.get("input_json")) or step.input_json
+            _optional_json(step_payload.get("input_json")) or step.input_json
         )
         step.output_json = (
-            self._optional_json(step_payload.get("output_json")) or step.output_json
+            _optional_json(step_payload.get("output_json")) or step.output_json
         )
         step.error_json = (
-            self._optional_json(step_payload.get("error_json")) or step.error_json
+            _optional_json(step_payload.get("error_json")) or step.error_json
         )
         step.completed_at = datetime.now(timezone.utc)
         session.add(step)
@@ -608,53 +599,20 @@ class _WhitepaperWorkflowApiMethods:
         run: WhitepaperAnalysisRun,
         payload: Mapping[str, Any],
     ) -> None:
-        target_status = self._optional_text(payload.get("status")) or "completed"
+        target_status = _optional_text(payload.get("status")) or "completed"
         run.status = target_status
         run.result_payload_json = coerce_json_payload(cast(dict[str, Any], payload))
         run.completed_at = datetime.now(timezone.utc)
         run.failure_reason = (
             None
             if target_status == "completed"
-            else self._optional_text(payload.get("failure_reason"))
+            else _optional_text(payload.get("failure_reason"))
         )
         session.add(run)
 
-        if run.document is None:
-            return
         run.document.status = "analyzed" if target_status == "completed" else "failed"
         run.document.last_processed_at = datetime.now(timezone.utc)
         session.add(run.document)
-
-    @staticmethod
-    def _optional_text(value: Any) -> str | None:
-        if value is None:
-            return None
-        text = str(value).strip()
-        return text or None
-
-    @staticmethod
-    def _optional_int(value: Any) -> int | None:
-        if value is None:
-            return None
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-
-    @staticmethod
-    def _optional_decimal(value: Any) -> Decimal | None:
-        if value is None:
-            return None
-        try:
-            return Decimal(str(value))
-        except Exception:
-            return None
-
-    @staticmethod
-    def _optional_json(value: Any) -> Any:
-        if value is None:
-            return None
-        return coerce_json_payload(value)
 
     @staticmethod
     def _download_pdf(url: str) -> bytes:

--- a/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_ingestion_methods.py
+++ b/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_ingestion_methods.py
@@ -1,11 +1,10 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Whitepaper workflow ingestion, orchestration, and persistence helpers."""
 
 from __future__ import annotations
 
 import hashlib
 from datetime import datetime, timezone
-from typing import Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 import inngest
 from sqlalchemy import case, func, select
@@ -24,6 +23,8 @@ from .shared_context import (
     RETRYABLE_AGENTRUN_STATUSES as _RETRYABLE_AGENTRUN_STATUSES,
     bool_env as _bool_env,
     normalize_identifier as _normalize_identifier,
+    optional_int as _optional_int,
+    optional_text as _optional_text,
     sorted_unique as _sorted_unique,
     str_env as _str_env,
     whitepaper_ceph_bucket_name as _whitepaper_ceph_bucket_name,
@@ -44,10 +45,17 @@ from .ceph_s3_client import (
     IssueKickoffResult,
     IssueRunIdentity as _IssueRunIdentity,
     PdfStorageOutcome as _PdfStorageOutcome,
+    WhitepaperWorkflowServiceContract as _WhitepaperWorkflowServiceContract,
 )
 
 
-class _WhitepaperWorkflowIngestionMethods:
+if TYPE_CHECKING:
+    _WhitepaperWorkflowIngestionBase = _WhitepaperWorkflowServiceContract
+else:
+    _WhitepaperWorkflowIngestionBase = object
+
+
+class _WhitepaperWorkflowIngestionMethods(_WhitepaperWorkflowIngestionBase):
     def __init__(self) -> None:
         self.ceph_client: Any | None = CephS3Client.from_env()
         self.inngest_client: inngest.Inngest | None = None
@@ -277,15 +285,15 @@ class _WhitepaperWorkflowIngestionMethods:
         issue_event: Any,
         marker: Mapping[str, Any],
     ) -> WhitepaperDocument:
-        subject = self._optional_text(marker.get("subject"))
-        marker_tags = parse_marker_tags(self._optional_text(marker.get("tags")))
+        subject = _optional_text(marker.get("subject"))
+        marker_tags = parse_marker_tags(_optional_text(marker.get("tags")))
         metadata = {
             "repository": issue_event.repository,
             "issue_number": issue_event.issue_number,
             "issue_url": issue_event.issue_url,
             "subject": subject,
             "analysis_mode": normalize_analysis_mode(
-                self._optional_text(marker.get("analysis_mode"))
+                _optional_text(marker.get("analysis_mode"))
             ),
         }
         document = session.execute(
@@ -310,11 +318,12 @@ class _WhitepaperWorkflowIngestionMethods:
 
         document.title = issue_event.issue_title or document.title
         merged_tags: list[str] = []
-        if isinstance(document.tags_json, list):
+        document_tags_raw: object = document.tags_json
+        if isinstance(document_tags_raw, list):
             merged_tags.extend(
                 [
-                    self._optional_text(item) or ""
-                    for item in cast(list[Any], document.tags_json)
+                    _optional_text(item) or ""
+                    for item in cast(list[object], document_tags_raw)
                 ]
             )
         merged_tags.extend(marker_tags)
@@ -442,10 +451,10 @@ class _WhitepaperWorkflowIngestionMethods:
         storage: _PdfStorageOutcome,
     ) -> WhitepaperAnalysisRun:
         run_status = "queued" if storage.parse_status == "stored" else "failed"
-        subject = self._optional_text(marker.get("subject"))
-        tags = parse_marker_tags(self._optional_text(marker.get("tags")))
+        subject = _optional_text(marker.get("subject"))
+        tags = parse_marker_tags(_optional_text(marker.get("tags")))
         analysis_mode = normalize_analysis_mode(
-            self._optional_text(marker.get("analysis_mode"))
+            _optional_text(marker.get("analysis_mode"))
         )
         run_row = WhitepaperAnalysisRun(
             run_id=run_identity.run_id,
@@ -556,7 +565,7 @@ class _WhitepaperWorkflowIngestionMethods:
             cast(Mapping[str, Any], run_row.orchestration_context_json or {})
         )
         enqueue_attempt = (
-            self._optional_int(context.get("inngest_enqueue_attempt")) or 0
+            _optional_int(context.get("inngest_enqueue_attempt")) or 0
         ) + 1
         enqueue_key = f"{run_row.run_id}:{enqueue_attempt}"
         try:

--- a/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_persistence_methods.py
+++ b/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_persistence_methods.py
@@ -1,11 +1,10 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Whitepaper workflow ingestion, orchestration, and persistence helpers."""
 
 from __future__ import annotations
 
 import hashlib
 from datetime import datetime, timezone
-from typing import Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -24,6 +23,7 @@ from .shared_context import (
     bool_env as _bool_env,
     int_env as _int_env,
     normalize_identifier as _normalize_identifier,
+    optional_text as _optional_text,
     sorted_unique as _sorted_unique,
     str_env as _str_env,
     github_issue_number_from_url,
@@ -35,10 +35,17 @@ from .shared_context import (
 )
 from .ceph_s3_client import (
     IssueKickoffResult,
+    WhitepaperWorkflowServiceContract as _WhitepaperWorkflowServiceContract,
 )
 
 
-class _WhitepaperWorkflowPersistenceMethods:
+if TYPE_CHECKING:
+    _WhitepaperWorkflowPersistenceBase = _WhitepaperWorkflowServiceContract
+else:
+    _WhitepaperWorkflowPersistenceBase = object
+
+
+class _WhitepaperWorkflowPersistenceMethods(_WhitepaperWorkflowPersistenceBase):
     def _requeue_existing_run(
         self,
         session: Session,
@@ -59,7 +66,7 @@ class _WhitepaperWorkflowPersistenceMethods:
             )
 
         version = run.document_version
-        if version is None or version.parse_status != "stored":
+        if getattr(version, "parse_status", None) != "stored":
             return IssueKickoffResult(
                 accepted=False,
                 reason="requeue_not_ready",
@@ -184,7 +191,12 @@ class _WhitepaperWorkflowPersistenceMethods:
             )
 
     def dispatch_codex_agentrun(
-        self, session: Session, run_id: str, *, allow_retry: bool = False
+        self,
+        session: Session,
+        run_id: str,
+        *,
+        force: bool = False,
+        allow_retry: bool = False,
     ) -> dict[str, Any]:
         run = session.execute(
             select(WhitepaperAnalysisRun).where(WhitepaperAnalysisRun.run_id == run_id)
@@ -202,8 +214,9 @@ class _WhitepaperWorkflowPersistenceMethods:
             .first()
         )
         if existing is not None:
-            if not allow_retry or not self._is_retryable_agentrun_status(
-                existing.status
+            if not force and (
+                not allow_retry
+                or not self._is_retryable_agentrun_status(existing.status)
             ):
                 return {
                     "idempotent": True,
@@ -234,14 +247,14 @@ class _WhitepaperWorkflowPersistenceMethods:
         attachment_url = str(context.get("attachment_url") or "")
         marker = cast(dict[str, Any], context.get("marker") or {})
         analysis_profile = cast(dict[str, Any], run.analysis_profile_json or {})
-        subject = self._optional_text(
-            analysis_profile.get("subject")
-        ) or self._optional_text(context.get("subject"))
+        subject = _optional_text(analysis_profile.get("subject")) or _optional_text(
+            context.get("subject")
+        )
         tags = self._coerce_tag_list(
             analysis_profile.get("tags") or context.get("tags")
         )
         analysis_mode = normalize_analysis_mode(
-            self._optional_text(
+            _optional_text(
                 analysis_profile.get("analysis_mode") or context.get("analysis_mode")
             )
         )
@@ -256,11 +269,10 @@ class _WhitepaperWorkflowPersistenceMethods:
         head_branch = str(marker.get("head_branch") or default_head_branch)
 
         version = run.document_version
-        if version is None:
+        bucket = _optional_text(version.ceph_bucket)
+        key = _optional_text(version.ceph_object_key)
+        if bucket is None or key is None:
             raise ValueError("whitepaper_version_missing")
-
-        bucket = version.ceph_bucket
-        key = version.ceph_object_key
         ceph_uri = f"s3://{bucket}/{key}"
 
         prompt = self._build_whitepaper_prompt(
@@ -461,8 +473,8 @@ class _WhitepaperWorkflowPersistenceMethods:
         rollout_profile: str | None = None,
     ) -> dict[str, Any]:
         run = self._get_run_or_raise(session, run_id)
-        approver = self._optional_text(approved_by)
-        reason = self._optional_text(approval_reason)
+        approver = _optional_text(approved_by)
+        reason = _optional_text(approval_reason)
         if run.status != "completed":
             raise ValueError("whitepaper_run_not_completed")
         if not approver:
@@ -480,7 +492,7 @@ class _WhitepaperWorkflowPersistenceMethods:
             manual_approval=ManualApprovalPayload(
                 approved_by=approver,
                 approval_reason=reason,
-                approval_source=self._optional_text(approval_source) or "jangar_ui",
+                approval_source=_optional_text(approval_source) or "jangar_ui",
                 target_scope=target_scope,
                 repository=repository,
                 base=base,
@@ -525,7 +537,7 @@ class _WhitepaperWorkflowPersistenceMethods:
         session.add(run)
 
         context = cast(dict[str, Any], run.orchestration_context_json or {})
-        attachment_url = self._optional_text(context.get("attachment_url"))
+        attachment_url = _optional_text(context.get("attachment_url"))
         if not attachment_url:
             run.status = "failed"
             run.failure_reason = "attachment_url_missing"

--- a/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_rollout_methods.py
+++ b/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_rollout_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Whitepaper workflow ingestion, orchestration, and persistence helpers."""
 
 from __future__ import annotations
@@ -6,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import datetime, timezone
-from typing import Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -29,13 +28,25 @@ from .shared_context import (
     bool_env as _bool_env,
     int_env as _int_env,
     normalize_identifier as _normalize_identifier,
+    optional_decimal as _optional_decimal,
+    optional_json as _optional_json,
+    optional_text as _optional_text,
     sorted_unique as _sorted_unique,
     str_env as _str_env,
     logger,
 )
+from .ceph_s3_client import (
+    WhitepaperWorkflowServiceContract as _WhitepaperWorkflowServiceContract,
+)
 
 
-class _WhitepaperWorkflowRolloutMethods:
+if TYPE_CHECKING:
+    _WhitepaperWorkflowRolloutBase = _WhitepaperWorkflowServiceContract
+else:
+    _WhitepaperWorkflowRolloutBase = object
+
+
+class _WhitepaperWorkflowRolloutMethods(_WhitepaperWorkflowRolloutBase):
     def _dispatch_engineering_agentrun(
         self,
         session: Session,
@@ -47,31 +58,31 @@ class _WhitepaperWorkflowRolloutMethods:
         context = cast(dict[str, Any], run.orchestration_context_json or {})
         marker = cast(dict[str, Any], context.get("marker") or {})
         repository = (
-            self._optional_text(
+            _optional_text(
                 manual_approval.repository if manual_approval is not None else None
             )
-            or self._optional_text(context.get("repository"))
+            or _optional_text(context.get("repository"))
             or _str_env("WHITEPAPER_DEFAULT_REPOSITORY", "proompteng/lab")
             or "proompteng/lab"
         )
         base_branch = (
-            self._optional_text(
+            _optional_text(
                 manual_approval.base if manual_approval is not None else None
             )
-            or self._optional_text(marker.get("base_branch"))
+            or _optional_text(marker.get("base_branch"))
             or _str_env("WHITEPAPER_DEFAULT_BASE_BRANCH", "main")
             or "main"
         )
-        head_branch = self._optional_text(
+        head_branch = _optional_text(
             manual_approval.head if manual_approval is not None else None
         ) or self._default_engineering_head_branch(
             run.run_id,
             suffix="manual" if manual_approval is not None else "auto",
         )
         artifact_path = f"docs/whitepapers/{run.run_id}"
-        issue_url = self._optional_text(context.get("issue_url")) or ""
+        issue_url = _optional_text(context.get("issue_url")) or ""
         issue_title = (
-            self._optional_text((run.document.title if run.document else None))
+            _optional_text((run.document.title if run.document else None))
             or "Whitepaper analysis"
         )
         prompt = self._build_engineering_trigger_prompt(
@@ -225,19 +236,22 @@ class _WhitepaperWorkflowRolloutMethods:
         trigger: WhitepaperEngineeringTrigger,
         rollout_transitions: list[WhitepaperRolloutTransition],
     ) -> dict[str, Any]:
-        transitions_payload = [
-            {
-                "transition_id": item.transition_id,
-                "from_stage": item.from_stage,
-                "to_stage": item.to_stage,
-                "transition_type": item.transition_type,
-                "status": item.status,
-                "reason_codes": item.reason_codes_json or [],
-                "blocking_gate": item.blocking_gate,
-                "created_at": item.created_at.isoformat() if item.created_at else None,
-            }
-            for item in rollout_transitions
-        ]
+        transitions_payload: list[dict[str, Any]] = []
+        for item in rollout_transitions:
+            transitions_payload.append(
+                {
+                    "transition_id": item.transition_id,
+                    "from_stage": item.from_stage,
+                    "to_stage": item.to_stage,
+                    "transition_type": item.transition_type,
+                    "status": item.status,
+                    "reason_codes": self._coerce_string_list(item.reason_codes_json),
+                    "blocking_gate": item.blocking_gate,
+                    "created_at": (
+                        item.created_at.isoformat() if item.created_at else None
+                    ),
+                }
+            )
         return {
             "trigger_id": trigger.trigger_id,
             "run_id": trigger.whitepaper_run_id,
@@ -326,23 +340,23 @@ class _WhitepaperWorkflowRolloutMethods:
                     gate_id = gate_id.replace("gate", "g", 1)
                 status_value = None
                 if isinstance(gate_payload, Mapping):
-                    status_value = self._optional_text(
+                    status_value = _optional_text(
                         cast(Mapping[str, Any], gate_payload).get("status")
                     )
                 else:
-                    status_value = self._optional_text(gate_payload)
+                    status_value = _optional_text(gate_payload)
                 if status_value:
                     statuses[gate_id] = _normalize_identifier(status_value)
         elif isinstance(gates_raw, list):
-            for entry in gates_raw:
+            for entry in cast(list[object], gates_raw):
                 if not isinstance(entry, Mapping):
                     continue
                 gate_id_raw = (
-                    self._optional_text(cast(Mapping[str, Any], entry).get("gate_id"))
-                    or self._optional_text(cast(Mapping[str, Any], entry).get("id"))
-                    or self._optional_text(cast(Mapping[str, Any], entry).get("name"))
+                    _optional_text(cast(Mapping[str, Any], entry).get("gate_id"))
+                    or _optional_text(cast(Mapping[str, Any], entry).get("id"))
+                    or _optional_text(cast(Mapping[str, Any], entry).get("name"))
                 )
-                status_value = self._optional_text(
+                status_value = _optional_text(
                     cast(Mapping[str, Any], entry).get("status")
                 )
                 if not gate_id_raw or not status_value:
@@ -355,7 +369,7 @@ class _WhitepaperWorkflowRolloutMethods:
         for key, value in gate_snapshot.items():
             normalized_key = _normalize_identifier(str(key))
             if normalized_key in {"g1", "g2", "g3", "g4", "g5", "g6", "g7"}:
-                normalized_status = self._optional_text(value)
+                normalized_status = _optional_text(value)
                 if normalized_status:
                     statuses[normalized_key] = _normalize_identifier(normalized_status)
         return statuses
@@ -387,7 +401,7 @@ class _WhitepaperWorkflowRolloutMethods:
         if blocked_flag:
             reasons.append("gating_blocked_flag_true")
 
-        blocking_lists = (
+        blocking_lists: tuple[object, ...] = (
             gate_snapshot.get("blocking_reasons"),
             gate_snapshot.get("blockingReasons"),
             gate_snapshot.get("blockers"),
@@ -395,8 +409,8 @@ class _WhitepaperWorkflowRolloutMethods:
         )
         for raw_list in blocking_lists:
             if isinstance(raw_list, list):
-                for item in raw_list:
-                    text = self._optional_text(item)
+                for item in cast(list[object], raw_list):
+                    text = _optional_text(item)
                     if text:
                         reasons.append(f"gating_blocker_{_normalize_identifier(text)}")
 
@@ -456,7 +470,7 @@ class _WhitepaperWorkflowRolloutMethods:
         return rollout_profile in allowed_profiles
 
     def _normalize_rollout_profile(self, value: str | None) -> str:
-        profile = self._optional_text(value) or "manual"
+        profile = _optional_text(value) or "manual"
         normalized = _normalize_identifier(profile)
         if normalized not in {"manual", "assisted", "automatic"}:
             return "manual"
@@ -467,7 +481,7 @@ class _WhitepaperWorkflowRolloutMethods:
             run.synthesis.synthesis_json if run.synthesis is not None else None
         )
         if isinstance(synthesis_payload, Mapping):
-            explicit = self._optional_text(
+            explicit = _optional_text(
                 cast(Mapping[str, Any], synthesis_payload).get("hypothesis_id")
             )
             if explicit:
@@ -502,68 +516,60 @@ class _WhitepaperWorkflowRolloutMethods:
                     synthesis_payload.get("synthesis_version") or "v1"
                 ),
                 generated_by=str(synthesis_payload.get("generated_by") or "codex"),
-                model_name=self._optional_text(synthesis_payload.get("model_name")),
-                prompt_version=self._optional_text(
-                    synthesis_payload.get("prompt_version")
-                ),
+                model_name=_optional_text(synthesis_payload.get("model_name")),
+                prompt_version=_optional_text(synthesis_payload.get("prompt_version")),
                 executive_summary=executive_summary,
-                problem_statement=self._optional_text(
+                problem_statement=_optional_text(
                     synthesis_payload.get("problem_statement")
                 ),
-                methodology_summary=self._optional_text(
+                methodology_summary=_optional_text(
                     synthesis_payload.get("methodology_summary")
                 ),
-                key_findings_json=self._optional_json(
-                    synthesis_payload.get("key_findings")
-                ),
-                novelty_claims_json=self._optional_json(
+                key_findings_json=_optional_json(synthesis_payload.get("key_findings")),
+                novelty_claims_json=_optional_json(
                     synthesis_payload.get("novelty_claims")
                 ),
-                risk_assessment_json=self._optional_json(
+                risk_assessment_json=_optional_json(
                     synthesis_payload.get("risk_assessment")
                 ),
-                citations_json=self._optional_json(synthesis_payload.get("citations")),
-                implementation_plan_md=self._optional_text(
+                citations_json=_optional_json(synthesis_payload.get("citations")),
+                implementation_plan_md=_optional_text(
                     synthesis_payload.get("implementation_plan_md")
                 ),
-                confidence=self._optional_decimal(synthesis_payload.get("confidence")),
+                confidence=_optional_decimal(synthesis_payload.get("confidence")),
                 synthesis_json=coerce_json_payload(synthesis_payload),
             )
             session.add(synthesis)
             return
 
         synthesis.executive_summary = executive_summary
-        synthesis.problem_statement = self._optional_text(
+        synthesis.problem_statement = _optional_text(
             synthesis_payload.get("problem_statement")
         )
-        synthesis.methodology_summary = self._optional_text(
+        synthesis.methodology_summary = _optional_text(
             synthesis_payload.get("methodology_summary")
         )
-        synthesis.key_findings_json = self._optional_json(
+        synthesis.key_findings_json = _optional_json(
             synthesis_payload.get("key_findings")
         )
-        synthesis.novelty_claims_json = self._optional_json(
+        synthesis.novelty_claims_json = _optional_json(
             synthesis_payload.get("novelty_claims")
         )
-        synthesis.risk_assessment_json = self._optional_json(
+        synthesis.risk_assessment_json = _optional_json(
             synthesis_payload.get("risk_assessment")
         )
-        synthesis.citations_json = self._optional_json(
-            synthesis_payload.get("citations")
-        )
-        synthesis.implementation_plan_md = self._optional_text(
+        synthesis.citations_json = _optional_json(synthesis_payload.get("citations"))
+        synthesis.implementation_plan_md = _optional_text(
             synthesis_payload.get("implementation_plan_md")
         )
-        synthesis.confidence = self._optional_decimal(
-            synthesis_payload.get("confidence")
-        )
+        synthesis.confidence = _optional_decimal(synthesis_payload.get("confidence"))
         synthesis.synthesis_json = coerce_json_payload(synthesis_payload)
         session.add(synthesis)
 
     def _populate_missing_implementation_plan_md(
         self, run_id: str, synthesis_payload: dict[str, Any]
     ) -> None:
-        if self._optional_text(synthesis_payload.get("implementation_plan_md")):
+        if _optional_text(synthesis_payload.get("implementation_plan_md")):
             return
         derived_value = self._derive_implementation_plan_md(
             synthesis_payload.get("implementation_implications")
@@ -584,7 +590,7 @@ class _WhitepaperWorkflowRolloutMethods:
             return text or None
         if isinstance(value, list):
             bullet_points: list[str] = []
-            for item in value:
+            for item in cast(list[object], value):
                 text = str(item).strip() if item is not None else ""
                 if text:
                     bullet_points.append(f"- {text}")
@@ -605,27 +611,23 @@ class _WhitepaperWorkflowRolloutMethods:
                 WhitepaperViabilityVerdict.analysis_run_id == run.id
             )
         ).scalar_one_or_none()
-        verdict_text = (
-            self._optional_text(verdict_payload.get("verdict")) or "needs_review"
-        )
-        approved_by = self._optional_text(verdict_payload.get("approved_by"))
+        verdict_text = _optional_text(verdict_payload.get("verdict")) or "needs_review"
+        approved_by = _optional_text(verdict_payload.get("approved_by"))
         gating_payload = self._build_verdict_gating_payload(verdict_payload)
 
         if verdict is None:
             verdict = WhitepaperViabilityVerdict(
                 analysis_run_id=run.id,
                 verdict=verdict_text,
-                score=self._optional_decimal(verdict_payload.get("score")),
-                confidence=self._optional_decimal(verdict_payload.get("confidence")),
-                decision_policy=self._optional_text(
-                    verdict_payload.get("decision_policy")
-                ),
-                gating_json=self._optional_json(gating_payload),
-                rationale=self._optional_text(verdict_payload.get("rationale")),
-                rejection_reasons_json=self._optional_json(
+                score=_optional_decimal(verdict_payload.get("score")),
+                confidence=_optional_decimal(verdict_payload.get("confidence")),
+                decision_policy=_optional_text(verdict_payload.get("decision_policy")),
+                gating_json=_optional_json(gating_payload),
+                rationale=_optional_text(verdict_payload.get("rationale")),
+                rejection_reasons_json=_optional_json(
                     verdict_payload.get("rejection_reasons")
                 ),
-                recommendations_json=self._optional_json(
+                recommendations_json=_optional_json(
                     verdict_payload.get("recommendations")
                 ),
                 requires_followup=bool(verdict_payload.get("requires_followup")),
@@ -636,17 +638,15 @@ class _WhitepaperWorkflowRolloutMethods:
             return
 
         verdict.verdict = verdict_text
-        verdict.score = self._optional_decimal(verdict_payload.get("score"))
-        verdict.confidence = self._optional_decimal(verdict_payload.get("confidence"))
-        verdict.decision_policy = self._optional_text(
-            verdict_payload.get("decision_policy")
-        )
-        verdict.gating_json = self._optional_json(gating_payload)
-        verdict.rationale = self._optional_text(verdict_payload.get("rationale"))
-        verdict.rejection_reasons_json = self._optional_json(
+        verdict.score = _optional_decimal(verdict_payload.get("score"))
+        verdict.confidence = _optional_decimal(verdict_payload.get("confidence"))
+        verdict.decision_policy = _optional_text(verdict_payload.get("decision_policy"))
+        verdict.gating_json = _optional_json(gating_payload)
+        verdict.rationale = _optional_text(verdict_payload.get("rationale"))
+        verdict.rejection_reasons_json = _optional_json(
             verdict_payload.get("rejection_reasons")
         )
-        verdict.recommendations_json = self._optional_json(
+        verdict.recommendations_json = _optional_json(
             verdict_payload.get("recommendations")
         )
         verdict.requires_followup = bool(verdict_payload.get("requires_followup"))
@@ -685,16 +685,17 @@ class _WhitepaperWorkflowRolloutMethods:
         if isinstance(direct, list):
             return [
                 cast(dict[str, Any], item)
-                for item in direct
+                for item in cast(list[object], direct)
                 if isinstance(item, Mapping)
             ]
         synthesis_payload = payload.get("synthesis")
         if isinstance(synthesis_payload, Mapping):
-            nested = synthesis_payload.get(key)
+            synthesis_map = cast(Mapping[str, Any], synthesis_payload)
+            nested = synthesis_map.get(key)
             if isinstance(nested, list):
                 return [
                     cast(dict[str, Any], item)
-                    for item in nested
+                    for item in cast(list[object], nested)
                     if isinstance(item, Mapping)
                 ]
         return []

--- a/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_verdict_methods.py
+++ b/services/torghut/app/whitepapers/workflow_modules/whitepaper_workflow_verdict_methods.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportUnusedImport=false, reportUnusedClass=false, reportUnusedFunction=false, reportUnusedVariable=false, reportUndefinedVariable=false, reportUnsupportedDunderAll=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportGeneralTypeIssues=false, reportInvalidTypeForm=false, reportReturnType=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportUnnecessaryComparison=false, reportMissingTypeStubs=false, reportUnnecessaryCast=false
 """Whitepaper workflow ingestion, orchestration, and persistence helpers."""
 
 from __future__ import annotations
@@ -8,7 +7,7 @@ import json
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -32,8 +31,12 @@ from .shared_context import (
     http_request_bytes as _http_request_bytes,
     int_env as _int_env,
     normalize_identifier as _normalize_identifier,
+    optional_text as _optional_text,
     sorted_unique as _sorted_unique,
     str_env as _str_env,
+)
+from .ceph_s3_client import (
+    WhitepaperWorkflowServiceContract as _WhitepaperWorkflowServiceContract,
 )
 
 
@@ -82,7 +85,13 @@ class EngineeringDecisionOutcome:
     dispatch_decision: str
 
 
-class WhitepaperWorkflowVerdictMethods:
+if TYPE_CHECKING:
+    _WhitepaperWorkflowVerdictBase = _WhitepaperWorkflowServiceContract
+else:
+    _WhitepaperWorkflowVerdictBase = object
+
+
+class WhitepaperWorkflowVerdictMethods(_WhitepaperWorkflowVerdictBase):
     def _embed_texts(self, texts: list[str]) -> tuple[str, int, list[list[float]]]:
         if not texts:
             raise ValueError("embedding_texts_required")
@@ -199,14 +208,15 @@ class WhitepaperWorkflowVerdictMethods:
         parsed = json.loads(body)
         if not isinstance(parsed, dict):
             raise RuntimeError("embedding_invalid_response")
+        parsed_payload = cast(Mapping[str, Any], parsed)
         if config.is_ollama_embed:
             return self._parse_ollama_embedding_response(
-                parsed,
+                parsed_payload,
                 batch_size=batch_size,
                 observed_dimension=observed_dimension,
             )
         return self._parse_openai_embedding_response(
-            parsed,
+            parsed_payload,
             batch_size=batch_size,
             observed_dimension=observed_dimension,
         )
@@ -223,10 +233,11 @@ class WhitepaperWorkflowVerdictMethods:
             raw_embeddings = parsed.get("embedding")
         if not isinstance(raw_embeddings, list):
             raise RuntimeError("embedding_invalid_data")
+        embedding_items = cast(list[Any], raw_embeddings)
         matrix = (
-            raw_embeddings
-            if raw_embeddings and isinstance(raw_embeddings[0], list)
-            else [raw_embeddings]
+            embedding_items
+            if embedding_items and isinstance(embedding_items[0], list)
+            else [embedding_items]
         )
         if len(matrix) != batch_size:
             raise RuntimeError("embedding_missing_row")
@@ -245,7 +256,7 @@ class WhitepaperWorkflowVerdictMethods:
         if not isinstance(data, list):
             raise RuntimeError("embedding_invalid_data")
         indexed_batch_embeddings = self._indexed_openai_embedding_rows(
-            data,
+            cast(list[Any], data),
             observed_dimension=observed_dimension,
         )
         embeddings: list[list[float]] = []
@@ -272,12 +283,13 @@ class WhitepaperWorkflowVerdictMethods:
         for row in data:
             if not isinstance(row, Mapping):
                 continue
-            index_raw = row.get("index")
-            embedding_raw = row.get("embedding")
+            row_payload = cast(Mapping[str, Any], row)
+            index_raw = row_payload.get("index")
+            embedding_raw = row_payload.get("embedding")
             if not isinstance(index_raw, int) or not isinstance(embedding_raw, list):
                 continue
             embedding_values, current_dimension = self._coerce_embedding_row(
-                embedding_raw,
+                cast(list[Any], embedding_raw),
                 observed_dimension=current_dimension,
             )
             indexed_batch_embeddings[index_raw] = embedding_values
@@ -295,7 +307,7 @@ class WhitepaperWorkflowVerdictMethods:
             if not isinstance(row, list):
                 raise RuntimeError("embedding_invalid_data")
             embedding_values, current_dimension = self._coerce_embedding_row(
-                row,
+                cast(list[Any], row),
                 observed_dimension=current_dimension,
             )
             embeddings.append(embedding_values)
@@ -367,7 +379,7 @@ class WhitepaperWorkflowVerdictMethods:
         ).scalar_one_or_none()
         already_dispatched = bool(
             existing_trigger is not None
-            and self._optional_text(existing_trigger.dispatched_agentrun_name)
+            and _optional_text(existing_trigger.dispatched_agentrun_name)
         )
         trigger = self._upsert_engineering_trigger(
             session,
@@ -391,7 +403,7 @@ class WhitepaperWorkflowVerdictMethods:
                     manual_approval=manual_approval,
                 )
                 trigger.decision = "dispatched"
-                trigger.dispatched_agentrun_name = self._optional_text(
+                trigger.dispatched_agentrun_name = _optional_text(
                     dispatch_result.get("agentrun_name")
                 )
             except Exception as exc:
@@ -510,6 +522,9 @@ class WhitepaperWorkflowVerdictMethods:
             verdict.gating_json if verdict is not None else None
         )
         gate_statuses = self._extract_gate_statuses(gate_snapshot)
+        verdict_text_raw = (
+            _optional_text(verdict.verdict) if verdict is not None else None
+        )
         return EngineeringDecisionSignals(
             gate_snapshot=gate_snapshot,
             gate_snapshot_hash=(
@@ -525,11 +540,9 @@ class WhitepaperWorkflowVerdictMethods:
                 gate_snapshot,
                 gate_statuses,
             ),
-            verdict_text=(
-                self._optional_text(verdict.verdict).lower()
-                if verdict is not None and verdict.verdict
-                else "missing"
-            ),
+            verdict_text=verdict_text_raw.lower()
+            if verdict_text_raw is not None
+            else "missing",
             score_value=(
                 float(verdict.score)
                 if verdict is not None and verdict.score is not None

--- a/services/torghut/pyproject.toml
+++ b/services/torghut/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "pytest-cov>=7.0.0,<8.0",
   "pytest-xdist>=3.8.0,<4.0",
   "ruff>=0.9.0,<1.0",
+  "pandas-stubs>=2.2.3,<3.0",
 ]
 cuda-research = [
   "torch==2.11.0+cu128 ; sys_platform == 'win32' or sys_platform == 'linux'",

--- a/services/torghut/uv.lock
+++ b/services/torghut/uv.lock
@@ -1557,6 +1557,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas-stubs"
+version = "2.3.3.260113"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "types-pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2386,6 +2399,7 @@ dev = [
     { name = "crosshair-tool" },
     { name = "hypothesis" },
     { name = "mutmut" },
+    { name = "pandas-stubs" },
     { name = "pylint" },
     { name = "pyright" },
     { name = "pytest" },
@@ -2411,6 +2425,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.1.2,<3.0" },
     { name = "openai", specifier = ">=1.55.3,<2.0" },
     { name = "pandas", specifier = ">=2.2.3,<3.0" },
+    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.3,<3.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.1,<4.0" },
     { name = "pydantic", specifier = ">=2.9.0,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0,<3.0" },
@@ -2465,6 +2480,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pytz"
+version = "2026.2.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/d9/9fa4019d2235bd374293e1fd4153879b28b6ae1d2bae98addd352c9713f2/types_pytz-2026.2.0.20260518.tar.gz", hash = "sha256:e5d254329e9c4e91f0781b22c43a4bb2d10bb044d97b24c4b05d45567b0eae16", size = 10871, upload-time = "2026-05-18T06:02:45.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/89/41e80670779a223d8bc8bc83019a619988cfa5c432cedac5cec23884fbc4/types_pytz-2026.2.0.20260518-py3-none-any.whl", hash = "sha256:3a12eaa38f476bd650902a9c9bb442f03f3c7dee2be5c5848bce61bd708d205a", size = 10125, upload-time = "2026-05-18T06:02:44.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removed Torghut app/script file-level Pyright suppression headers and the remaining app-code inline `pyright: ignore` comments.
- Added explicit split-module contracts for execution, ingest, governance, scheduler pipeline, and whitepaper workflow mixins so strict Pyright can analyze the modules directly.
- Refactored `run_autonomous_lane` into named execution phases and typed the JSON/YAML boundary helpers that were previously hidden by broad suppressions.
- Added `pandas-stubs` to the Torghut dev extra so the strict app profile no longer needs pandas-related blanket suppression.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format $(git -C ../.. diff --name-only -- services/torghut | sed 's#^services/torghut/##' | rg '\.py$')`
- `uv run --frozen ruff check $(git -C ../.. diff --name-only -- services/torghut | sed 's#^services/torghut/##' | rg '\.py$')`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_pylint_torghut_quality.py tests/test_pylint_torghut_quality_diff_gate.py tests/test_autonomous_lane.py tests/autonomous_lane tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py tests/pipeline/test_trading_pipeline_materialized_target_plan_b.py tests/pipeline/test_trading_pipeline_materialized_target_plan_c.py tests/whitepaper_workflow tests/test_whitepaper_api.py tests/test_alpaca_client.py tests/test_options_lane.py tests/test_scheduler_regime_resolution.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
