### PR TITLE
fix(torghut): order hyperliquid schema sync hook

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: torghut-hyperliquid-clickhouse-schema
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 data:
   schema.sql: |-
     CREATE DATABASE IF NOT EXISTS torghut ON CLUSTER default;

--- a/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-job.yaml
@@ -4,8 +4,9 @@ metadata:
   name: torghut-hyperliquid-clickhouse-schema
   namespace: torghut
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   backoffLimit: 6
   activeDeadlineSeconds: 900

--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: torghut-hyperliquid-feed-config
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 data:
   HYPERLIQUID_NETWORK: "mainnet"
   HYPERLIQUID_INFO_URL: "https://api.hyperliquid.xyz/info"

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: torghut-hyperliquid-feed
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     app: torghut-hyperliquid-feed
 spec:

--- a/argocd/applications/torghut-hyperliquid-feed/pdb.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/pdb.yaml
@@ -3,6 +3,8 @@ kind: PodDisruptionBudget
 metadata:
   name: torghut-hyperliquid-feed
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   maxUnavailable: 1
   selector:

--- a/argocd/applications/torghut-hyperliquid-feed/service.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: torghut-hyperliquid-feed
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     app: torghut-hyperliquid-feed
 spec:


### PR DESCRIPTION
## Summary

- Fix the Hyperliquid ClickHouse schema rollout ordering by making the schema Job a Sync hook instead of a PreSync hook.
- Add Argo sync waves so the schema ConfigMap exists before the hook runs, and the workload resources apply after schema bootstrap.

## Related Issues

Follow-up to #11045

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed >/tmp/torghut-hyperliquid-feed-render-hotfix.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This only changes Argo ordering for the new Hyperliquid feed app.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
