### PR TITLE
fix(torghut): correct hyperliquid clickhouse engines

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
@@ -29,63 +29,63 @@ data:
       version UInt32,
       payload String
     )
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_raw', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_raw', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (channel, symbol, event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 7 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_market_catalog ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_market_catalog', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_market_catalog', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_trades ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_trades', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_trades', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_l2_books ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_l2_books', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_l2_books', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 7 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_bbo ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_bbo', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_bbo', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_candles ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_candles', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_candles', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_asset_contexts ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_asset_contexts', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_asset_contexts', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_funding ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_funding', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_funding', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_status ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_status', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_status', '{replica}')
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (channel, symbol, event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 7 DAY


### PR DESCRIPTION
## Summary

- Fix the Hyperliquid ClickHouse schema DDL by removing the invalid `ingest_ts` ReplacingMergeTree version argument from replicated tables.
- Preserve the existing string timestamp columns, partition expressions, TTLs, and order keys used by the feed writer.

## Related Issues

Follow-up to #11045 and #11048

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed >/tmp/torghut-hyperliquid-feed-render-engine-fix.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This only corrects DDL for the new Hyperliquid ClickHouse tables before the feed deployment starts.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
