### PR TITLE
fix(torghut): use numeric hyperliquid schema version

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
@@ -29,63 +29,63 @@ data:
       version UInt32,
       payload String
     )
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_raw', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_raw', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (channel, symbol, event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 7 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_market_catalog ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_market_catalog', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_market_catalog', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_trades ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_trades', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_trades', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_l2_books ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_l2_books', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_l2_books', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 7 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_bbo ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_bbo', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_bbo', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_candles ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_candles', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_candles', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_asset_contexts ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_asset_contexts', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_asset_contexts', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_funding ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_funding', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_funding', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (coalesce(market_id, symbol), event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 35 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_status ON CLUSTER default AS torghut.hyperliquid_raw
-    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_status', '{replica}', ingest_ts)
+    ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_status', '{replica}', version)
     PARTITION BY toDate(parseDateTimeBestEffort(event_ts))
     ORDER BY (channel, symbol, event_ts, seq)
     TTL parseDateTimeBestEffort(event_ts) + INTERVAL 7 DAY

--- a/packages/scripts/src/torghut/__tests__/hyperliquid-schema.test.ts
+++ b/packages/scripts/src/torghut/__tests__/hyperliquid-schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import YAML from 'yaml'
+
+import { repoRoot } from '../../shared/cli'
+
+type ConfigMapManifest = {
+  data?: Record<string, string>
+}
+
+const schemaManifestPath = 'argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml'
+
+const readSchemaSql = (): string => {
+  const manifest = YAML.parse(readFileSync(join(repoRoot, schemaManifestPath), 'utf8')) as ConfigMapManifest
+  const schemaSql = manifest.data?.['schema.sql']
+  if (typeof schemaSql !== 'string') {
+    throw new Error(`Missing schema.sql in ${schemaManifestPath}`)
+  }
+  return schemaSql
+}
+
+describe('Torghut Hyperliquid ClickHouse schema', () => {
+  it('uses a ClickHouse-compatible ReplacingMergeTree version column', () => {
+    const schemaSql = readSchemaSql()
+    const engines = schemaSql.match(/ReplicatedReplacingMergeTree\([^)]+\)/g) ?? []
+
+    expect(engines.length).toBe(9)
+    expect(schemaSql).toContain('version UInt32')
+
+    for (const engine of engines) {
+      expect(engine).toContain(', version)')
+      expect(engine).not.toContain(', ingest_ts)')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Fix the Torghut Hyperliquid ClickHouse schema hook by using the existing numeric `version UInt32` column as the `ReplicatedReplacingMergeTree` version column.
- Apply the same version-column contract to all Hyperliquid derived tables created from `hyperliquid_raw`.
- Add a Torghut manifest regression test so schema changes cannot reintroduce `ingest_ts` as a String version column.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/hyperliquid-schema.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint` (0 errors; existing warnings only)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
