### PR TITLE
fix(torghut): cap hyperliquid live coverage

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -11,7 +11,8 @@ data:
   HYPERLIQUID_WS_URL: "wss://api.hyperliquid.xyz/ws"
   HYPERLIQUID_INCLUDE_PERPS: "true"
   HYPERLIQUID_INCLUDE_SPOT: "true"
-  HYPERLIQUID_MARKET_COVERAGE: "all"
+  HYPERLIQUID_MARKET_COVERAGE: "canary"
+  HYPERLIQUID_CANARY_COINS: "BTC,ETH,SOL,HYPE"
   HYPERLIQUID_WS_CHANNELS: "allMids,trades,l2Book,bbo,candle,activeAssetCtx,allDexsAssetCtxs"
   # Keep websocket subscription pressure below the documented 1000-subscription limit.
   # Additional candle intervals are backfill/query scope, not always-on websocket scope.

--- a/packages/scripts/src/torghut/__tests__/hyperliquid-feed-config.test.ts
+++ b/packages/scripts/src/torghut/__tests__/hyperliquid-feed-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import YAML from 'yaml'
+
+import { repoRoot } from '../../shared/cli'
+
+type ConfigMapManifest = {
+  data?: Record<string, string>
+}
+
+const configManifestPath = 'argocd/applications/torghut-hyperliquid-feed/configmap.yaml'
+
+const readConfigData = (): Record<string, string> => {
+  const manifest = YAML.parse(readFileSync(join(repoRoot, configManifestPath), 'utf8')) as ConfigMapManifest
+  if (!manifest.data) {
+    throw new Error(`Missing data in ${configManifestPath}`)
+  }
+  return manifest.data
+}
+
+describe('Torghut Hyperliquid feed config', () => {
+  it('keeps live websocket coverage inside the production subscription budget', () => {
+    const config = readConfigData()
+
+    expect(config.HYPERLIQUID_MARKET_COVERAGE).toBe('canary')
+    expect(config.HYPERLIQUID_CANARY_COINS).toBe('BTC,ETH,SOL,HYPE')
+    expect(Number(config.HYPERLIQUID_MAX_TOTAL_SUBSCRIPTIONS)).toBeLessThanOrEqual(1000)
+    expect(config.HYPERLIQUID_WS_CHANNELS).toBe('allMids,trades,l2Book,bbo,candle,activeAssetCtx,allDexsAssetCtxs')
+  })
+})


### PR DESCRIPTION
## Summary

- Change the live Torghut Hyperliquid feed from all-market websocket coverage to explicit canary coins (`BTC,ETH,SOL,HYPE`).
- Keep the documented 1,000-subscription production guardrail intact instead of raising the cap beyond the exchange-facing limit.
- Add a manifest regression test that locks the live config to canary coverage with the capped websocket budget.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/hyperliquid-feed-config.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint` (0 errors; existing warnings only)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
