### PR TITLE
fix(torghut): bound hyperliquid rollout coverage

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -11,7 +11,8 @@ data:
   HYPERLIQUID_WS_URL: "wss://api.hyperliquid.xyz/ws"
   HYPERLIQUID_INCLUDE_PERPS: "true"
   HYPERLIQUID_INCLUDE_SPOT: "true"
-  HYPERLIQUID_MARKET_COVERAGE: "all"
+  HYPERLIQUID_MARKET_COVERAGE: "top-liquidity-canary"
+  HYPERLIQUID_CANARY_COINS: "BTC,ETH,SOL,HYPE"
   HYPERLIQUID_WS_CHANNELS: "allMids,trades,l2Book,bbo,candle,activeAssetCtx,allDexsAssetCtxs"
   # Keep websocket subscription pressure below the documented 1000-subscription limit.
   # Additional candle intervals are backfill/query scope, not always-on websocket scope.


### PR DESCRIPTION
## Summary

- Bound the live Hyperliquid feed rollout to `top-liquidity-canary` coverage for BTC, ETH, SOL, and HYPE.
- Keep all public websocket channels enabled for the canary subset while staying below Hyperliquid's 1000-subscription limit.

## Related Issues

Follow-up to #11045, #11048, and #11050

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed >/tmp/torghut-hyperliquid-feed-render-canary.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This scopes the new Hyperliquid deployment to the planned canary rollout phase.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
