### PR TITLE
fix(torghut): roll hyperliquid canary config

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       app: torghut-hyperliquid-feed
   template:
     metadata:
+      annotations:
+        proompteng.ai/config-revision: hyperliquid-canary-20260617a
       labels:
         app: torghut-hyperliquid-feed
     spec:


### PR DESCRIPTION
## Summary

- Add a pod-template config revision annotation for the Hyperliquid feed deployment.
- Force the new ReplicaSet to pick up the canary coverage ConfigMap from #11053 without a manual rollout restart.

## Related Issues

Follow-up to #11053

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed >/tmp/torghut-hyperliquid-feed-render-config-rollout.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This only rolls the new Hyperliquid feed pod onto the already-synced canary ConfigMap.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
