### PR TITLE
feat(torghut): select hyperliquid top volume markets

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -11,8 +11,8 @@ data:
   HYPERLIQUID_WS_URL: "wss://api.hyperliquid.xyz/ws"
   HYPERLIQUID_INCLUDE_PERPS: "true"
   HYPERLIQUID_INCLUDE_SPOT: "true"
-  HYPERLIQUID_MARKET_COVERAGE: "top-liquidity-canary"
-  HYPERLIQUID_CANARY_COINS: "BTC,ETH,SOL,HYPE"
+  HYPERLIQUID_MARKET_COVERAGE: "top-volume"
+  HYPERLIQUID_TOP_MARKET_COUNT: "100"
   HYPERLIQUID_WS_CHANNELS: "allMids,trades,l2Book,bbo,candle,activeAssetCtx,allDexsAssetCtxs"
   # Keep websocket subscription pressure below the documented 1000-subscription limit.
   # Additional candle intervals are backfill/query scope, not always-on websocket scope.

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-canary-20260617a
+        proompteng.ai/config-revision: hyperliquid-top-volume-100-20260617a
       labels:
         app: torghut-hyperliquid-feed
     spec:

--- a/docs/torghut/topics-and-schemas.md
+++ b/docs/torghut/topics-and-schemas.md
@@ -38,6 +38,12 @@ Hyperliquid market IDs:
 - Spot: `hl:spot:<index>:<name>`.
 - Spot websocket subscriptions use `PURR/USDC` for PURR and `@<index>` for other spot pairs.
 
+Live Hyperliquid feed coverage:
+
+- Production selects the top `100` perp/spot markets by Hyperliquid public 24h notional volume (`dayNtlVlm`).
+- Ranking uses public `metaAndAssetCtxs` across default and builder perp DEXes plus `spotMetaAndAssetCtxs`.
+- User-address streams, private keys, signed requests, and order placement remain out of scope for this lane.
+
 Notes:
 
 - Ordering is preserved per symbol by using Kafka message key = `symbol`.

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
@@ -35,6 +35,7 @@ data class HyperliquidConfig(
   val includePerps: Boolean,
   val includeSpot: Boolean,
   val marketCoverage: String,
+  val topMarketCount: Int,
   val canaryCoins: Set<String>,
   val candleIntervals: List<String>,
   val wsChannels: Set<String>,
@@ -81,6 +82,14 @@ data class HyperliquidConfig(
       val includePerps = mergedEnv["HYPERLIQUID_INCLUDE_PERPS"]?.toBooleanStrictOrNull() ?: true
       val includeSpot = mergedEnv["HYPERLIQUID_INCLUDE_SPOT"]?.toBooleanStrictOrNull() ?: true
       if (!includePerps && !includeSpot) error("At least one of HYPERLIQUID_INCLUDE_PERPS or HYPERLIQUID_INCLUDE_SPOT must be true")
+
+      val marketCoverage = mergedEnv["HYPERLIQUID_MARKET_COVERAGE"]?.trim()?.lowercase() ?: "all"
+      val supportedCoverage = setOf("all", "canary", "top-liquidity-canary", "top-volume", "top-volume-100")
+      if (marketCoverage !in supportedCoverage) {
+        error("HYPERLIQUID_MARKET_COVERAGE must be one of ${supportedCoverage.joinToString(",")}")
+      }
+      val topMarketCount = intEnv(mergedEnv, "HYPERLIQUID_TOP_MARKET_COUNT", 100)
+      if (topMarketCount !in 1..1000) error("HYPERLIQUID_TOP_MARKET_COUNT must be within 1..1000")
 
       val candleIntervals =
         csv(mergedEnv["HYPERLIQUID_CANDLE_INTERVALS"] ?: "1m")
@@ -133,7 +142,8 @@ data class HyperliquidConfig(
         wsUrl = mergedEnv["HYPERLIQUID_WS_URL"] ?: defaultWsUrl,
         includePerps = includePerps,
         includeSpot = includeSpot,
-        marketCoverage = mergedEnv["HYPERLIQUID_MARKET_COVERAGE"]?.trim()?.lowercase() ?: "all",
+        marketCoverage = marketCoverage,
+        topMarketCount = topMarketCount,
         canaryCoins = csv(mergedEnv["HYPERLIQUID_CANARY_COINS"] ?: "BTC,ETH,SOL,HYPE").map { it.uppercase() }.toSet(),
         candleIntervals = candleIntervals,
         wsChannels = wsChannels,

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidInfoClient.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidInfoClient.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
 import java.time.Instant
@@ -23,6 +24,11 @@ private val infoLogger = KotlinLogging.logger {}
 private data class InfoRequest(
   val type: String,
   val dex: String? = null,
+)
+
+private data class MarketVolumeScore(
+  val marketId: String,
+  val dayNotionalVolume: Double,
 )
 
 class HyperliquidInfoClient(
@@ -39,7 +45,12 @@ class HyperliquidInfoClient(
     if (config.includeSpot) {
       markets += loadSpotMarkets()
     }
-    return applyCoverage(markets).sortedWith(compareBy({ it.marketType.name }, { it.marketId }))
+    val selected = applyCoverage(markets)
+    return if (config.marketCoverage in setOf("top-volume", "top-volume-100")) {
+      selected
+    } else {
+      selected.sortedWith(compareBy({ it.marketType.name }, { it.marketId }))
+    }
   }
 
   suspend fun loadFundingAndContextRecords(markets: List<HyperliquidMarket>): List<RoutedEnvelope> {
@@ -156,7 +167,7 @@ class HyperliquidInfoClient(
     }
   }
 
-  private fun applyCoverage(markets: List<HyperliquidMarket>): List<HyperliquidMarket> =
+  private suspend fun applyCoverage(markets: List<HyperliquidMarket>): List<HyperliquidMarket> =
     when (config.marketCoverage) {
       "all" -> markets
       "canary", "top-liquidity-canary" ->
@@ -164,8 +175,78 @@ class HyperliquidInfoClient(
           market.coin.uppercase() in config.canaryCoins ||
             market.coin.substringBefore('/').uppercase() in config.canaryCoins
         }
-      else -> error("HYPERLIQUID_MARKET_COVERAGE must be all, canary, or top-liquidity-canary")
+      "top-volume", "top-volume-100" -> selectTopVolumeMarkets(markets)
+      else -> error("HYPERLIQUID_MARKET_COVERAGE must be all, canary, top-liquidity-canary, top-volume, or top-volume-100")
     }
+
+  private suspend fun selectTopVolumeMarkets(markets: List<HyperliquidMarket>): List<HyperliquidMarket> {
+    val scores =
+      buildList {
+        if (config.includePerps) addAll(loadPerpMarketVolumeScores())
+        if (config.includeSpot) addAll(loadSpotMarketVolumeScores())
+      }.associateBy({ it.marketId }, { it.dayNotionalVolume })
+
+    val selected =
+      markets
+        .sortedWith(
+          compareByDescending<HyperliquidMarket> { scores[it.marketId] ?: 0.0 }
+            .thenBy { it.marketType.name }
+            .thenBy { it.marketId },
+        ).take(config.topMarketCount)
+
+    val minSelectedVolume = selected.minOfOrNull { scores[it.marketId] ?: 0.0 } ?: 0.0
+    infoLogger.info {
+      "selected Hyperliquid top-volume markets count=${selected.size} configured=${config.topMarketCount} " +
+        "catalog=${markets.size} scored=${scores.size} min_day_notional_volume=$minSelectedVolume"
+    }
+    return selected
+  }
+
+  private suspend fun loadPerpMarketVolumeScores(): List<MarketVolumeScore> =
+    loadPerpDexNames().flatMap { dex ->
+      val context = postInfo("metaAndAssetCtxs", weight = 20, dex = dex)
+      val (universe, contexts) = contextPair(context) ?: return@flatMap emptyList()
+      universe.mapIndexedNotNull { index, marketElement ->
+        val market = marketElement as? JsonObject ?: return@mapIndexedNotNull null
+        val name = market["name"]?.jsonPrimitive?.contentOrNull ?: return@mapIndexedNotNull null
+        val volume = dayNotionalVolume(contexts.getOrNull(index) as? JsonObject)
+        MarketVolumeScore(
+          marketId = HyperliquidMarketIds.perp(name, dex),
+          dayNotionalVolume = volume,
+        )
+      }
+    }
+
+  private suspend fun loadSpotMarketVolumeScores(): List<MarketVolumeScore> {
+    val context = postInfo("spotMetaAndAssetCtxs", weight = 20)
+    val (universe, contexts) = contextPair(context) ?: return emptyList()
+    return universe.mapIndexedNotNull { index, marketElement ->
+      val market = marketElement as? JsonObject ?: return@mapIndexedNotNull null
+      val name = market["name"]?.jsonPrimitive?.contentOrNull ?: return@mapIndexedNotNull null
+      val spotIndex = market["index"]?.jsonPrimitive?.intOrNull ?: return@mapIndexedNotNull null
+      val volume = dayNotionalVolume(contexts.getOrNull(index) as? JsonObject)
+      MarketVolumeScore(
+        marketId = HyperliquidMarketIds.spot(spotIndex, name),
+        dayNotionalVolume = volume,
+      )
+    }
+  }
+
+  private fun contextPair(context: JsonElement): Pair<JsonArray, JsonArray>? {
+    val response = context as? JsonArray ?: return null
+    val meta = response.getOrNull(0) as? JsonObject ?: return null
+    val contexts = response.getOrNull(1) as? JsonArray ?: return null
+    val universe = meta["universe"] as? JsonArray ?: return null
+    return universe to contexts
+  }
+
+  private fun dayNotionalVolume(context: JsonObject?): Double =
+    context
+      ?.get("dayNtlVlm")
+      ?.jsonPrimitive
+      ?.contentOrNull
+      ?.toDoubleOrNull()
+      ?: 0.0
 
   private suspend fun postInfo(
     type: String,

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
@@ -22,7 +22,39 @@ class HyperliquidConfigTest {
     assertEquals("wss://api.hyperliquid.xyz/ws", config.wsUrl)
     assertTrue(config.includePerps)
     assertTrue(config.includeSpot)
+    assertEquals(100, config.topMarketCount)
     assertFalse(config.wsChannels.any { it.startsWith("user", ignoreCase = true) })
+  }
+
+  @Test
+  fun `accepts top volume market coverage with explicit count`() {
+    val config =
+      HyperliquidConfig.fromEnv(
+        mapOf(
+          "KAFKA_SASL_PASSWORD" to "secret",
+          "HYPERLIQUID_MARKET_COVERAGE" to "top-volume",
+          "HYPERLIQUID_TOP_MARKET_COUNT" to "250",
+        ),
+      )
+
+    assertEquals("top-volume", config.marketCoverage)
+    assertEquals(250, config.topMarketCount)
+  }
+
+  @Test
+  fun `rejects invalid top market count`() {
+    val error =
+      assertFailsWith<IllegalStateException> {
+        HyperliquidConfig.fromEnv(
+          mapOf(
+            "KAFKA_SASL_PASSWORD" to "secret",
+            "HYPERLIQUID_MARKET_COVERAGE" to "top-volume",
+            "HYPERLIQUID_TOP_MARKET_COUNT" to "0",
+          ),
+        )
+      }
+
+    assertTrue(error.message.orEmpty().contains("HYPERLIQUID_TOP_MARKET_COUNT"))
   }
 
   @Test

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidInfoClientTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidInfoClientTest.kt
@@ -56,10 +56,89 @@ class HyperliquidInfoClientTest {
       assertEquals(3, requests.size)
     }
 
+  @Test
+  fun `selects top markets by public twenty four hour notional volume`() =
+    runTest {
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            val body = (request.body as TextContent).text
+            when {
+              body.hasType("perpDexs") -> jsonResponse("""[null,{"name":"test"}]""")
+              body.hasType("metaAndAssetCtxs") && body.contains(""""dex":"test"""") ->
+                jsonResponse(
+                  """
+                  [
+                    {"universe":[{"name":"COIN1","szDecimals":1},{"name":"COIN2","szDecimals":1}]},
+                    [{"dayNtlVlm":"3000.25"},{"dayNtlVlm":"5"}]
+                  ]
+                  """.trimIndent(),
+                )
+              body.hasType("metaAndAssetCtxs") ->
+                jsonResponse(
+                  """
+                  [
+                    {"universe":[{"name":"BTC","szDecimals":5},{"name":"ETH","szDecimals":4}]},
+                    [{"dayNtlVlm":"1000"},{"dayNtlVlm":"25"}]
+                  ]
+                  """.trimIndent(),
+                )
+              body.hasType("meta") && body.contains(""""dex":"test"""") ->
+                jsonResponse("""{"universe":[{"name":"COIN1","szDecimals":1},{"name":"COIN2","szDecimals":1}]}""")
+              body.hasType("meta") ->
+                jsonResponse("""{"universe":[{"name":"BTC","szDecimals":5},{"name":"ETH","szDecimals":4}]}""")
+              body.hasType("spotMetaAndAssetCtxs") ->
+                jsonResponse(
+                  """
+                  [
+                    {"tokens":[],"universe":[{"name":"PURR/USDC","tokens":[0,1],"index":0},{"name":"@1","tokens":[2,1],"index":1}]},
+                    [{"dayNtlVlm":"2000"},{"dayNtlVlm":"10"}]
+                  ]
+                  """.trimIndent(),
+                )
+              body.hasType("spotMeta") ->
+                jsonResponse(
+                  """
+                  {
+                    "tokens": [],
+                    "universe": [
+                      {"name":"PURR/USDC","tokens":[0,1],"index":0},
+                      {"name":"@1","tokens":[2,1],"index":1}
+                    ]
+                  }
+                  """.trimIndent(),
+                )
+              else -> jsonResponse("""{}""")
+            }
+          },
+        ) {
+          install(ContentNegotiation) { json(json) }
+        }
+      val config =
+        HyperliquidConfig.fromEnv(
+          mapOf(
+            "KAFKA_SASL_PASSWORD" to "secret",
+            "CLICKHOUSE_ENABLED" to "false",
+            "HYPERLIQUID_MARKET_COVERAGE" to "top-volume",
+            "HYPERLIQUID_TOP_MARKET_COUNT" to "3",
+          ),
+        )
+      val infoClient = HyperliquidInfoClient(config, client, MinuteWeightBudget(1000), json)
+
+      val markets = infoClient.loadMarkets()
+
+      assertEquals(
+        listOf("hl:perp:test:COIN1", "hl:spot:0:PURR/USDC", "hl:perp:default:BTC"),
+        markets.map { it.marketId },
+      )
+    }
+
   private fun MockRequestHandleScope.jsonResponse(body: String): HttpResponseData =
     respond(
       content = body,
       status = HttpStatusCode.OK,
       headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
     )
+
+  private fun String.hasType(type: String): Boolean = contains(""""type":"$type"""")
 }


### PR DESCRIPTION
## Summary

- Adds `top-volume` Hyperliquid market coverage with `HYPERLIQUID_TOP_MARKET_COUNT` validation.
- Ranks default perp, builder DEX perp, and spot markets by public `dayNtlVlm` before websocket subscription planning.
- Updates the Torghut Hyperliquid GitOps config to ingest the top 100 markets and removes the fixed four-market subset from production config.
- Documents the live public-market coverage policy and keeps user-address/private exchange scope excluded.

## Related Issues

None

## Testing

- `./gradlew :hyperliquid-feed:test :hyperliquid-feed:ktlintCheck --no-daemon`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed >/tmp/torghut-hyperliquid-feed-render-top100.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
