### PR TITLE
refactor(torghut): remove dynamic facade patch plumbing

### DIFF
--- a/services/torghut/app/api/common.py
+++ b/services/torghut/app/api/common.py
@@ -51,7 +51,6 @@ from ..models import (
     WhitepaperRolloutTransition,
 )
 from ..observability import capture_posthog_event, shutdown_posthog_telemetry
-from ..trading import TradingScheduler
 from ..trading.alpha_closure_dividend_slo import build_alpha_closure_dividend_slo
 from ..trading.alpha_evidence_foundry import compact_alpha_evidence_foundry
 from ..trading.alpha_readiness_settlement_conveyor import (
@@ -165,6 +164,7 @@ from ..trading.routeability_repair_acceptance import (
     build_routeability_repair_acceptance_ledger,
 )
 from ..trading.route_reacquisition_board import build_route_reacquisition_board
+from ..trading.scheduler import TradingScheduler
 from ..trading.source_serving_repair_receipt import (
     build_source_serving_repair_receipt_ledger,
 )

--- a/services/torghut/app/bootstrap.py
+++ b/services/torghut/app/bootstrap.py
@@ -32,7 +32,7 @@ from .api.common import (
     whitepaper_semantic_indexing_enabled,
     whitepaper_workflow_enabled,
 )
-from .trading import TradingScheduler
+from .trading.scheduler import TradingScheduler
 
 logger = logging.getLogger(__name__)
 

--- a/services/torghut/app/trading/__init__.py
+++ b/services/torghut/app/trading/__init__.py
@@ -1,17 +1,3 @@
 """Trading pipeline modules for torghut."""
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .scheduler import TradingScheduler
-
-
-def __getattr__(name: str):
-    if name == "TradingScheduler":
-        from .scheduler import TradingScheduler
-
-        return TradingScheduler
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-__all__ = ["TradingScheduler"]
+__all__: list[str] = []

--- a/services/torghut/app/trading/alpha/__init__.py
+++ b/services/torghut/app/trading/alpha/__init__.py
@@ -7,14 +7,10 @@ signal ingestion or broker execution.
 
 from __future__ import annotations
 
-from importlib import import_module
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from .lane import AlphaLaneResult, run_alpha_discovery_lane
-    from .metrics import PerformanceSummary, summarize_equity_curve
-    from .search import SearchResult, run_tsmom_grid_search
-    from .tsmom import TSMOMConfig, backtest_tsmom
+from .lane import AlphaLaneResult, run_alpha_discovery_lane
+from .metrics import PerformanceSummary, summarize_equity_curve
+from .search import SearchResult, run_tsmom_grid_search
+from .tsmom import TSMOMConfig, backtest_tsmom
 
 __all__ = [
     "PerformanceSummary",
@@ -26,24 +22,3 @@ __all__ = [
     "run_tsmom_grid_search",
     "summarize_equity_curve",
 ]
-
-_EXPORTS = {
-    "PerformanceSummary": (".metrics", "PerformanceSummary"),
-    "summarize_equity_curve": (".metrics", "summarize_equity_curve"),
-    "AlphaLaneResult": (".lane", "AlphaLaneResult"),
-    "run_alpha_discovery_lane": (".lane", "run_alpha_discovery_lane"),
-    "SearchResult": (".search", "SearchResult"),
-    "run_tsmom_grid_search": (".search", "run_tsmom_grid_search"),
-    "TSMOMConfig": (".tsmom", "TSMOMConfig"),
-    "backtest_tsmom": (".tsmom", "backtest_tsmom"),
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name not in _EXPORTS:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module_name, attribute = _EXPORTS[name]
-    module = import_module(module_name, __name__)
-    value = getattr(module, attribute)
-    globals()[name] = value
-    return value

--- a/services/torghut/app/trading/alpha/lane_modules/run_alpha_discovery_lane.py
+++ b/services/torghut/app/trading/alpha/lane_modules/run_alpha_discovery_lane.py
@@ -10,10 +10,6 @@ from typing import Any, Callable, Iterable, Mapping
 import pandas as pd
 from sqlalchemy.orm import Session
 
-from ...discovery import (
-    build_sequential_trial_summary,
-    build_strategy_factory_evaluation,
-)
 from ..metrics import summarize_equity_curve, to_jsonable
 from ..search import candidate_to_jsonable, run_tsmom_grid_search
 from ..tsmom import TSMOMConfig, backtest_tsmom
@@ -76,6 +72,9 @@ def run_alpha_discovery_lane(
     economic_rationale: str | None = None,
 ) -> AlphaLaneResult:
     """Run deterministic alpha candidate generation, evaluation, and recommendation."""
+
+    from ...discovery.sequential_trials import build_sequential_trial_summary
+    from ...discovery.validation import build_strategy_factory_evaluation
 
     train = _normalize_prices(train_prices, label="train")
     test = _normalize_prices(test_prices, label="test")

--- a/services/torghut/app/trading/discovery/__init__.py
+++ b/services/torghut/app/trading/discovery/__init__.py
@@ -2,20 +2,16 @@
 
 from __future__ import annotations
 
-from importlib import import_module
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from .sequential_trials import (
-        SequentialTrialSummary,
-        build_sequential_trial_summary,
-    )
-    from .validation import (
-        CostCalibrationRecord,
-        StrategyFactoryEvaluation,
-        ValidationTestResult,
-        build_strategy_factory_evaluation,
-    )
+from .sequential_trials import (
+    SequentialTrialSummary,
+    build_sequential_trial_summary,
+)
+from .validation import (
+    CostCalibrationRecord,
+    StrategyFactoryEvaluation,
+    ValidationTestResult,
+    build_strategy_factory_evaluation,
+)
 
 __all__ = [
     "CostCalibrationRecord",
@@ -25,28 +21,3 @@ __all__ = [
     "build_sequential_trial_summary",
     "build_strategy_factory_evaluation",
 ]
-
-_EXPORTS = {
-    "SequentialTrialSummary": (".sequential_trials", "SequentialTrialSummary"),
-    "build_sequential_trial_summary": (
-        ".sequential_trials",
-        "build_sequential_trial_summary",
-    ),
-    "CostCalibrationRecord": (".validation", "CostCalibrationRecord"),
-    "StrategyFactoryEvaluation": (".validation", "StrategyFactoryEvaluation"),
-    "ValidationTestResult": (".validation", "ValidationTestResult"),
-    "build_strategy_factory_evaluation": (
-        ".validation",
-        "build_strategy_factory_evaluation",
-    ),
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name not in _EXPORTS:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module_name, attribute = _EXPORTS[name]
-    module = import_module(module_name, __name__)
-    value = getattr(module, attribute)
-    globals()[name] = value
-    return value

--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
 from http.client import HTTPConnection, HTTPSConnection
-from typing import Any, TypeVar
 
 from scripts.historical_simulation_verification_modules import (
     artifact_verification as _artifact,
@@ -18,7 +16,6 @@ from scripts.historical_simulation_verification_modules import (
 )
 from scripts.historical_simulation_verification_modules import shared_runtime as _shared
 
-_T = TypeVar("_T")
 
 PRODUCTION_TOPIC_BY_ROLE = _shared.PRODUCTION_TOPIC_BY_ROLE
 TORGHUT_ENV_KEYS = _shared.TORGHUT_ENV_KEYS
@@ -45,30 +42,6 @@ DEFAULT_SIMULATION_ORDER_FEED_GROUP_ID = _shared.DEFAULT_SIMULATION_ORDER_FEED_G
 DEFAULT_SIMULATION_TA_GROUP_ID = _shared.DEFAULT_SIMULATION_TA_GROUP_ID
 MONITOR_PROFILE_DEFAULTS = _shared.MONITOR_PROFILE_DEFAULTS
 TRANSIENT_POSTGRES_ERROR_PATTERNS = _shared.TRANSIENT_POSTGRES_ERROR_PATTERNS
-
-_ORIGINAL_HTTP_CLICKHOUSE_QUERY = _shared._http_clickhouse_query
-_ORIGINAL_DEPLOYMENT_REPLICA_HEALTH = _shared._deployment_replica_health
-_ORIGINAL_FLINK_RUNTIME_HEALTH = _shared._flink_runtime_health
-_ORIGINAL_KSERVICE_ENV = _runtime._kservice_env
-_ORIGINAL_MONITOR_SNAPSHOT = _runtime._monitor_snapshot
-_ORIGINAL_PROGRESS_COMPONENT_SNAPSHOT = _runtime._progress_component_snapshot
-_ORIGINAL_CLICKHOUSE_TABLE_ACTIVITY = _runtime._clickhouse_table_activity
-_ORIGINAL_SIGNAL_SNAPSHOT = _runtime._signal_snapshot
-_ORIGINAL_SIMULATION_PROGRESS_SNAPSHOT = _runtime._simulation_progress_snapshot
-_ORIGINAL_ACTIVITY_STATE = _runtime._activity_state
-_ORIGINAL_RUNTIME_VERIFY = _runtime._runtime_verify
-_ORIGINAL_SCHEMA_REGISTRY_HEALTH = _runtime._schema_registry_health
-_ORIGINAL_HTTP_JSON_GET = _artifact._http_json_get
-_ORIGINAL_ANALYSIS_IMAGE_FRESHNESS = _artifact._analysis_image_freshness
-_ORIGINAL_ANALYSIS_TEMPLATE_NAMES = _artifact._analysis_template_names
-_ORIGINAL_ANALYSIS_TEMPLATE_IMAGE = _artifact._analysis_template_image
-_ORIGINAL_CURRENT_ACTIVITY_REPORT = _artifact._current_activity_report
-_ORIGINAL_MONITOR_RUN_COMPLETION = _artifact._monitor_run_completion
-_ORIGINAL_VERIFY_ISOLATION_GUARDS = _artifact._verify_isolation_guards
-_ORIGINAL_TEARDOWN_CLEAN = _artifact._teardown_clean
-_ORIGINAL_ARTIFACT_BUNDLE = _artifact._artifact_bundle
-_ORIGINAL_PATCH_TARGETS: dict[str, object] = {}
-_FACADE_PATCH_TARGETS: dict[str, object] = {}
 
 _as_mapping = _shared._as_mapping
 _as_text = _shared._as_text
@@ -99,118 +72,27 @@ _first_text = _shared._first_text
 _classify_restore_state_error = _shared._classify_restore_state_error
 
 
-def _sync_patch_targets() -> None:
-    patch_targets = {
-        "HTTPConnection": HTTPConnection,
-        "HTTPSConnection": HTTPSConnection,
-        "time": time,
-        "_kubectl_json": _kubectl_json,
-        "_deployment_replica_health": _deployment_replica_health,
-        "_flink_runtime_health": _flink_runtime_health,
-        "_http_json_get": _http_json_get,
-        "_monitor_snapshot": _monitor_snapshot,
-        "_signal_snapshot": _signal_snapshot,
-        "_progress_component_snapshot": _progress_component_snapshot,
-        "_simulation_progress_snapshot": _simulation_progress_snapshot,
-    }
-    for module in (_shared, _progress, _runtime, _artifact):
-        for name, value in patch_targets.items():
-            if hasattr(module, name):
-                facade = _FACADE_PATCH_TARGETS.get(name)
-                if facade is not None and value is facade:
-                    value = _ORIGINAL_PATCH_TARGETS[name]
-                setattr(module, name, value)
-
-
-def _delegate(func: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
-    _sync_patch_targets()
-    return func(*args, **kwargs)
-
-
-def _http_clickhouse_query(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_HTTP_CLICKHOUSE_QUERY, *args, **kwargs)
-
-
-def _deployment_replica_health(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_DEPLOYMENT_REPLICA_HEALTH, *args, **kwargs)
-
-
-def _flink_runtime_health(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_FLINK_RUNTIME_HEALTH, *args, **kwargs)
-
-
-def _kservice_env(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_KSERVICE_ENV, *args, **kwargs)
-
-
-def _monitor_snapshot(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_MONITOR_SNAPSHOT, *args, **kwargs)
-
-
-def _progress_component_snapshot(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_PROGRESS_COMPONENT_SNAPSHOT, *args, **kwargs)
-
-
-def _clickhouse_table_activity(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_CLICKHOUSE_TABLE_ACTIVITY, *args, **kwargs)
-
-
-def _signal_snapshot(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_SIGNAL_SNAPSHOT, *args, **kwargs)
-
-
-def _simulation_progress_snapshot(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_SIMULATION_PROGRESS_SNAPSHOT, *args, **kwargs)
-
-
-def _activity_state(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_ACTIVITY_STATE, *args, **kwargs)
-
-
-def _runtime_verify(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_RUNTIME_VERIFY, *args, **kwargs)
-
-
-def _schema_registry_health(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_SCHEMA_REGISTRY_HEALTH, *args, **kwargs)
-
-
-def _http_json_get(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_HTTP_JSON_GET, *args, **kwargs)
-
-
-def _analysis_image_freshness(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_ANALYSIS_IMAGE_FRESHNESS, *args, **kwargs)
-
-
-def _analysis_template_names(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_ANALYSIS_TEMPLATE_NAMES, *args, **kwargs)
-
-
-def _analysis_template_image(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_ANALYSIS_TEMPLATE_IMAGE, *args, **kwargs)
-
-
-def _current_activity_report(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_CURRENT_ACTIVITY_REPORT, *args, **kwargs)
-
-
-def _monitor_run_completion(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_MONITOR_RUN_COMPLETION, *args, **kwargs)
-
-
-def _verify_isolation_guards(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_VERIFY_ISOLATION_GUARDS, *args, **kwargs)
-
-
-def _teardown_clean(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_TEARDOWN_CLEAN, *args, **kwargs)
-
-
-def _artifact_bundle(*args: Any, **kwargs: Any) -> Any:
-    return _delegate(_ORIGINAL_ARTIFACT_BUNDLE, *args, **kwargs)
-
-
+_http_clickhouse_query = _shared._http_clickhouse_query
+_deployment_replica_health = _shared._deployment_replica_health
+_flink_runtime_health = _shared._flink_runtime_health
+_kservice_env = _runtime._kservice_env
+_monitor_snapshot = _progress._monitor_snapshot
+_progress_component_snapshot = _progress._progress_component_snapshot
+_clickhouse_table_activity = _progress._clickhouse_table_activity
+_signal_snapshot = _progress._signal_snapshot
+_simulation_progress_snapshot = _progress._simulation_progress_snapshot
+_activity_state = _progress._activity_state
+_runtime_verify = _runtime._runtime_verify
+_schema_registry_health = _runtime._schema_registry_health
+_http_json_get = _artifact._http_json_get
+_analysis_image_freshness = _artifact._analysis_image_freshness
+_analysis_template_names = _artifact._analysis_template_names
+_analysis_template_image = _artifact._analysis_template_image
+_current_activity_report = _artifact._current_activity_report
+_monitor_run_completion = _artifact._monitor_run_completion
+_verify_isolation_guards = _artifact._verify_isolation_guards
+_teardown_clean = _artifact._teardown_clean
+_artifact_bundle = _artifact._artifact_bundle
 _infer_monitor_profile = _runtime._infer_monitor_profile
 _monitor_settings = _runtime._monitor_settings
 _effective_terminal_signal_ts = _runtime._effective_terminal_signal_ts
@@ -219,29 +101,6 @@ _clickhouse_database_from_table_name = _runtime._clickhouse_database_from_table_
 _cursor_reached_terminal = _runtime._cursor_reached_terminal
 _classify_activity_snapshot = _runtime._classify_activity_snapshot
 _expected_schema_subjects = _artifact._expected_schema_subjects
-
-_ORIGINAL_PATCH_TARGETS.update(
-    {
-        "_deployment_replica_health": _ORIGINAL_DEPLOYMENT_REPLICA_HEALTH,
-        "_flink_runtime_health": _ORIGINAL_FLINK_RUNTIME_HEALTH,
-        "_http_json_get": _ORIGINAL_HTTP_JSON_GET,
-        "_monitor_snapshot": _ORIGINAL_MONITOR_SNAPSHOT,
-        "_progress_component_snapshot": _ORIGINAL_PROGRESS_COMPONENT_SNAPSHOT,
-        "_signal_snapshot": _ORIGINAL_SIGNAL_SNAPSHOT,
-        "_simulation_progress_snapshot": _ORIGINAL_SIMULATION_PROGRESS_SNAPSHOT,
-    }
-)
-_FACADE_PATCH_TARGETS.update(
-    {
-        "_deployment_replica_health": _deployment_replica_health,
-        "_flink_runtime_health": _flink_runtime_health,
-        "_http_json_get": _http_json_get,
-        "_monitor_snapshot": _monitor_snapshot,
-        "_progress_component_snapshot": _progress_component_snapshot,
-        "_signal_snapshot": _signal_snapshot,
-        "_simulation_progress_snapshot": _simulation_progress_snapshot,
-    }
-)
 
 __all__ = [
     "DEFAULT_COVERAGE_STRICT_RATIO",
@@ -317,7 +176,6 @@ __all__ = [
     "_schema_registry_health",
     "_signal_snapshot",
     "_simulation_progress_snapshot",
-    "_sync_patch_targets",
     "_teardown_clean",
     "_validate_dump_coverage",
     "_validate_us_equities_regular_profile",

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -2,19 +2,10 @@
 
 from __future__ import annotations
 
-import argparse
 import time
-from collections.abc import Sequence
 from http.client import HTTPConnection, HTTPSConnection
-from typing import Any
 
 from app.trading.paper_route_target_plan import paper_route_target_plan_targets
-from scripts.materialize_bounded_paper_route_targets_modules import (
-    dynamic_target_confirmation as _dynamic_target_confirmation,
-)
-from scripts.materialize_bounded_paper_route_targets_modules import (
-    target_materialization_core as _target_materialization_core,
-)
 from scripts.materialize_bounded_paper_route_targets_modules import (
     ACTIVE_TARGET_WINDOW_REQUIRED_BLOCKER,
     ACTIVE_TARGET_WINDOW_SKIP_REASON,
@@ -91,63 +82,6 @@ from scripts.materialize_bounded_paper_route_targets_modules import (
     build_report,
     main,
 )
-
-_ORIGINAL_FETCH_PLAN_URL_PAYLOAD = _fetch_plan_url_payload
-_ORIGINAL_FETCH_PLAN_URL_PAYLOAD_ONCE = _fetch_plan_url_payload_once
-_ORIGINAL_BUILD_REPORT = build_report
-_ORIGINAL_MAIN = main
-
-
-def _sync_patch_targets() -> None:
-    _target_materialization_core.HTTPConnection = HTTPConnection
-    _target_materialization_core.HTTPSConnection = HTTPSConnection
-    _target_materialization_core.TARGET_PLAN_RESPONSE_LIMIT_BYTES = (
-        TARGET_PLAN_RESPONSE_LIMIT_BYTES
-    )
-    _target_materialization_core.paper_route_target_plan_targets = (
-        paper_route_target_plan_targets
-    )
-    _target_materialization_core.time = time
-    _target_materialization_core._fetch_plan_url_payload = _fetch_plan_url_payload
-    _target_materialization_core._fetch_plan_url_payload_once = (
-        _fetch_plan_url_payload_once
-    )
-    _dynamic_target_confirmation.build_report = build_report
-    _dynamic_target_confirmation.paper_route_target_plan_targets = (
-        paper_route_target_plan_targets
-    )
-
-
-def _fetch_plan_url_payload_once(url: str, *, timeout_seconds: float) -> dict[str, Any]:
-    _sync_patch_targets()
-    return _ORIGINAL_FETCH_PLAN_URL_PAYLOAD_ONCE(url, timeout_seconds=timeout_seconds)
-
-
-def _fetch_plan_url_payload(
-    url: str,
-    *,
-    timeout_seconds: float,
-    attempts: int,
-    retry_backoff_seconds: float = 0.25,
-) -> dict[str, Any]:
-    _sync_patch_targets()
-    return _ORIGINAL_FETCH_PLAN_URL_PAYLOAD(
-        url,
-        timeout_seconds=timeout_seconds,
-        attempts=attempts,
-        retry_backoff_seconds=retry_backoff_seconds,
-    )
-
-
-def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
-    _sync_patch_targets()
-    return _ORIGINAL_BUILD_REPORT(args)
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    _sync_patch_targets()
-    return _ORIGINAL_MAIN(argv)
-
 
 __all__ = (
     "ACTIVE_TARGET_WINDOW_REQUIRED_BLOCKER",

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -351,361 +351,42 @@ from scripts.start_historical_simulation_modules import (  # noqa: F401
     _render_report,
     _monitor_snapshot,
     _signal_snapshot,
+    _clickhouse_query_configs,
+    _apply,
+    _assert_required_simulation_metadata_tables,
+    _configure_torghut_service_for_simulation,
+    _dump_topics,
+    _ensure_argocd_manual_before_runtime_mutation,
+    _ensure_clickhouse_database,
+    _ensure_clickhouse_runtime_tables,
+    _ensure_simulation_schema_subjects,
+    _ensure_topics,
+    _ensure_postgres_runtime_permissions,
+    _http_clickhouse_query,
+    _monitor_run_completion,
+    _prepare_argocd_for_run,
+    _replay_dump,
+    _resolve_warm_lane_runtime_postgres_config,
+    _restore_argocd_after_run,
+    _restore_ta_configuration,
+    _restore_torghut_env,
+    _reset_postgres_runtime_state,
+    _run_full_lifecycle,
+    _run_migrations,
+    _run_rollouts_analysis,
+    _runtime_verify,
+    _seed_simulation_trade_cursor,
+    _set_argocd_application_ignore_differences,
+    _set_argocd_application_sync_policy,
+    _set_argocd_automation_mode,
+    _simulation_schema_registry_subject_specs,
+    _teardown,
+    _upload_dump_to_cache,
+    _wait_for_clickhouse_database,
+    _wait_for_clickhouse_table,
+    _wait_for_torghut_service_revision_ready,
+    main,
 )
-
-from scripts.start_historical_simulation_modules import (
-    argocd_rollouts as _argocd_rollouts_module,
-    cli as _cli_module,
-    kafka_runtime as _kafka_runtime_module,
-    kubernetes_argocd as _kubernetes_argocd_module,
-    lifecycle as _lifecycle_module,
-    proof_artifacts as _proof_artifacts_module,
-    replay_execution as _replay_execution_module,
-    resource_planning as _resource_planning_module,
-    runtime_migrations as _runtime_migrations_module,
-    service_environment as _service_environment_module,
-    state_and_cache as _state_and_cache_module,
-    storage_and_database as _storage_and_database_module,
-    topic_dumping as _topic_dumping_module,
-)
-
-_ORIGINAL_APPLY = _replay_execution_module._apply
-_ORIGINAL_CLICKHOUSE_QUERY_CONFIGS = (
-    _storage_and_database_module._clickhouse_query_configs
-)
-_ORIGINAL_ASSERT_REQUIRED_SIMULATION_METADATA_TABLES = (
-    _runtime_migrations_module._assert_required_simulation_metadata_tables
-)
-_ORIGINAL_CONFIGURE_TA_FOR_SIMULATION = (
-    _runtime_migrations_module._configure_ta_for_simulation
-)
-_ORIGINAL_CONFIGURE_TORGHUT_SERVICE_FOR_SIMULATION = (
-    _runtime_migrations_module._configure_torghut_service_for_simulation
-)
-_ORIGINAL_DESIRED_TA_SIMULATION_CONFIG = (
-    _runtime_migrations_module._desired_ta_simulation_config
-)
-_ORIGINAL_DUMP_TOPICS = _topic_dumping_module._dump_topics
-_ORIGINAL_ENSURE_ARGOCD_MANUAL_BEFORE_RUNTIME_MUTATION = (
-    _argocd_rollouts_module._ensure_argocd_manual_before_runtime_mutation
-)
-_ORIGINAL_ENSURE_CLICKHOUSE_DATABASE = (
-    _storage_and_database_module._ensure_clickhouse_database
-)
-_ORIGINAL_ENSURE_CLICKHOUSE_RUNTIME_TABLES = (
-    _storage_and_database_module._ensure_clickhouse_runtime_tables
-)
-_ORIGINAL_ENSURE_POSTGRES_DATABASE = (
-    _storage_and_database_module._ensure_postgres_database
-)
-_ORIGINAL_ENSURE_POSTGRES_RUNTIME_PERMISSIONS = (
-    _storage_and_database_module._ensure_postgres_runtime_permissions
-)
-_ORIGINAL_ENSURE_SIMULATION_SCHEMA_SUBJECTS = (
-    _kafka_runtime_module._ensure_simulation_schema_subjects
-)
-_ORIGINAL_ENSURE_TOPICS = _kafka_runtime_module._ensure_topics
-_ORIGINAL_HTTP_CLICKHOUSE_QUERY = _storage_and_database_module._http_clickhouse_query
-_ORIGINAL_MAIN = _cli_module.main
-_ORIGINAL_MONITOR_RUN_COMPLETION = _lifecycle_module._monitor_run_completion
-_ORIGINAL_PREPARE_ARGOCD_FOR_RUN = _argocd_rollouts_module._prepare_argocd_for_run
-_ORIGINAL_REPLAY_DUMP = _replay_execution_module._replay_dump
-_ORIGINAL_REPORT_SIMULATION = _argocd_rollouts_module._report_simulation
-_ORIGINAL_RESOLVE_WARM_LANE_RUNTIME_POSTGRES_CONFIG = (
-    _service_environment_module._resolve_warm_lane_runtime_postgres_config
-)
-_ORIGINAL_RESTORE_ARGOCD_AFTER_RUN = _argocd_rollouts_module._restore_argocd_after_run
-_ORIGINAL_RESTORE_TA_CONFIGURATION = (
-    _runtime_migrations_module._restore_ta_configuration
-)
-_ORIGINAL_RESTORE_TORGHUT_ENV = _runtime_migrations_module._restore_torghut_env
-_ORIGINAL_RESET_POSTGRES_RUNTIME_STATE = (
-    _runtime_migrations_module._reset_postgres_runtime_state
-)
-_ORIGINAL_RUN_FULL_LIFECYCLE = _lifecycle_module._run_full_lifecycle
-_ORIGINAL_RUN_MIGRATIONS = _runtime_migrations_module._run_migrations
-_ORIGINAL_RUN_ROLLOUTS_ANALYSIS = _argocd_rollouts_module._run_rollouts_analysis
-_ORIGINAL_RUNTIME_VERIFY = _kafka_runtime_module._runtime_verify
-_ORIGINAL_SEED_SIMULATION_TRADE_CURSOR = (
-    _runtime_migrations_module._seed_simulation_trade_cursor
-)
-_ORIGINAL_SET_ARGOCD_APPLICATION_IGNORE_DIFFERENCES = (
-    _service_environment_module._set_argocd_application_ignore_differences
-)
-_ORIGINAL_SET_ARGOCD_APPLICATION_SYNC_POLICY = (
-    _kubernetes_argocd_module._set_argocd_application_sync_policy
-)
-_ORIGINAL_SET_ARGOCD_AUTOMATION_MODE = (
-    _kubernetes_argocd_module._set_argocd_automation_mode
-)
-_ORIGINAL_SIMULATION_SCHEMA_REGISTRY_SUBJECT_SPECS = (
-    _kafka_runtime_module._simulation_schema_registry_subject_specs
-)
-_ORIGINAL_TEARDOWN = _replay_execution_module._teardown
-_ORIGINAL_TORGHUT_SERVICE_ENV_FOR_SIMULATION = (
-    _runtime_migrations_module._torghut_service_env_for_simulation
-)
-_ORIGINAL_UPLOAD_DUMP_TO_CACHE = _state_and_cache_module._upload_dump_to_cache
-_ORIGINAL_WAIT_FOR_CLICKHOUSE_DATABASE = (
-    _storage_and_database_module._wait_for_clickhouse_database
-)
-_ORIGINAL_WAIT_FOR_CLICKHOUSE_TABLE = (
-    _storage_and_database_module._wait_for_clickhouse_table
-)
-_ORIGINAL_WAIT_FOR_TORGHUT_SERVICE_REVISION_READY = (
-    _argocd_rollouts_module._wait_for_torghut_service_revision_ready
-)
-
-
-def _bind(module: Any, **attrs: Any) -> None:
-    for name, value in attrs.items():
-        setattr(module, name, value)
-
-
-def _sync_patch_targets() -> None:
-    _bind(
-        _cli_module,
-        _apply=_apply,
-        _report_simulation=_report_simulation,
-        _run_full_lifecycle=_run_full_lifecycle,
-        _teardown=_teardown,
-    )
-    _bind(
-        _lifecycle_module,
-        _apply=_apply,
-        _build_strategy_proof_artifact=_build_strategy_proof_artifact,
-        _ensure_supported_binary=_ensure_supported_binary,
-        _monitor_run_completion=_monitor_run_completion,
-        _prepare_argocd_for_run=_prepare_argocd_for_run,
-        _read_argocd_application_sync_policy=_read_argocd_application_sync_policy,
-        _read_argocd_automation_mode=_read_argocd_automation_mode,
-        _read_named_argocd_application_sync_policy=_read_named_argocd_application_sync_policy,
-        _replay_dump=_replay_dump,
-        _report_simulation=_report_simulation,
-        _restore_argocd_after_run=_restore_argocd_after_run,
-        _run_rollouts_analysis=_run_rollouts_analysis,
-        _runtime_verify=_runtime_verify,
-        _save_json=_save_json,
-        _teardown=_teardown,
-        _update_run_state=_update_run_state,
-        _upsert_simulation_progress_row=_upsert_simulation_progress_row,
-        _wait_for_torghut_service_revision_ready=_wait_for_torghut_service_revision_ready,
-        SessionLocal=SessionLocal,
-        persist_completion_trace=persist_completion_trace,
-    )
-    _bind(
-        _replay_execution_module,
-        _acquire_simulation_runtime_lock=_acquire_simulation_runtime_lock,
-        _capture_cluster_state=_capture_cluster_state,
-        _configure_ta_for_simulation=_configure_ta_for_simulation,
-        _configure_torghut_service_for_simulation=_configure_torghut_service_for_simulation,
-        _dump_topics=_dump_topics,
-        _ensure_argocd_manual_before_runtime_mutation=_ensure_argocd_manual_before_runtime_mutation,
-        _ensure_clickhouse_database=_ensure_clickhouse_database,
-        _ensure_clickhouse_runtime_tables=_ensure_clickhouse_runtime_tables,
-        _ensure_directory=_ensure_directory,
-        _ensure_lz4_codec_available=_ensure_lz4_codec_available,
-        _ensure_postgres_database=_ensure_postgres_database,
-        _ensure_postgres_runtime_permissions=_ensure_postgres_runtime_permissions,
-        _ensure_simulation_schema_subjects=_ensure_simulation_schema_subjects,
-        _ensure_supported_binary=_ensure_supported_binary,
-        _ensure_topics=_ensure_topics,
-        _read_simulation_runtime_lock=_read_simulation_runtime_lock,
-        _producer_for_replay=_producer_for_replay,
-        _release_simulation_runtime_lock=_release_simulation_runtime_lock,
-        _reset_postgres_runtime_state=_reset_postgres_runtime_state,
-        _restart_ta_deployment=_restart_ta_deployment,
-        _restore_ta_configuration=_restore_ta_configuration,
-        _restore_torghut_env=_restore_torghut_env,
-        _run_migrations=_run_migrations,
-        _save_json=_save_json,
-        _seed_simulation_trade_cursor=_seed_simulation_trade_cursor,
-        _ta_runtime_reconfigure_required=_ta_runtime_reconfigure_required,
-        _torghut_service_reconfigure_required=_torghut_service_reconfigure_required,
-        _upsert_simulation_progress_row=_upsert_simulation_progress_row,
-        _upsert_simulation_runtime_context=_upsert_simulation_runtime_context,
-        _validate_dump_coverage=_validate_dump_coverage,
-    )
-    _bind(
-        _topic_dumping_module,
-        _consumer_for_dump=_consumer_for_dump,
-        _materialize_deterministic_dump=_materialize_deterministic_dump,
-        _reusable_dump_report=_reusable_dump_report,
-        _restore_cached_dump_if_available=_restore_cached_dump_if_available,
-        _save_json=_save_json,
-        _simulation_cache_client_from_env=_simulation_cache_client_from_env,
-        time=time,
-        _upload_dump_to_cache=_upload_dump_to_cache,
-        _upsert_simulation_progress_row=_upsert_simulation_progress_row,
-    )
-    _bind(
-        _kafka_runtime_module,
-        _http_request=_http_request,
-        _kafka_admin_client=_kafka_admin_client,
-        _kubectl_json=_kubectl_json,
-        _producer_for_replay=_producer_for_replay,
-        _read_configmap_key_ref=_read_configmap_key_ref,
-        _read_secret_key_ref=_read_secret_key_ref,
-        __file__=__file__,
-    )
-    _bind(
-        _runtime_migrations_module,
-        _assert_required_simulation_metadata_tables=_assert_required_simulation_metadata_tables,
-        _cache_metadata=_cache_metadata,
-        _desired_ta_simulation_config=_desired_ta_simulation_config,
-        _is_vector_extension_create_permission_error=_is_vector_extension_create_permission_error,
-        _kubectl_json=_kubectl_json,
-        _kubectl_patch=_kubectl_patch,
-        _remove_appledouble_sidecars=_remove_appledouble_sidecars,
-        _run_command=_run_command,
-        _run_alembic_upgrade=_run_alembic_upgrade,
-        _run_with_transient_postgres_retry=_run_with_transient_postgres_retry,
-        _torghut_service_env_for_simulation=_torghut_service_env_for_simulation,
-        psycopg=psycopg,
-        shutil=shutil,
-    )
-    _bind(
-        _argocd_rollouts_module,
-        _kubectl_apply=_kubectl_apply,
-        _kubectl_delete_if_exists=_kubectl_delete_if_exists,
-        _kubectl_json=_kubectl_json,
-        _run_command=_run_command,
-        _run_with_transient_postgres_retry=_run_with_transient_postgres_retry,
-        _read_argocd_application_sync_policy=_read_argocd_application_sync_policy,
-        _read_argocd_applicationset_entry=_read_argocd_applicationset_entry,
-        _read_argocd_automation_mode=_read_argocd_automation_mode,
-        _read_named_argocd_application_sync_policy=_read_named_argocd_application_sync_policy,
-        _runtime_verify=_runtime_verify,
-        _save_json=_save_json,
-        _set_argocd_application_ignore_differences=_set_argocd_application_ignore_differences,
-        _set_argocd_application_sync_policy=_set_argocd_application_sync_policy,
-        _set_argocd_automation_mode=_set_argocd_automation_mode,
-        _prepare_argocd_for_run=_prepare_argocd_for_run,
-        _wait_for_argocd_application_mode=_wait_for_argocd_application_mode,
-        _wait_for_torghut_service_revision_ready=_wait_for_torghut_service_revision_ready,
-    )
-    _bind(
-        _proof_artifacts_module,
-        _run_with_transient_postgres_retry=_run_with_transient_postgres_retry,
-        _save_json=_save_json,
-        build_completion_trace=build_completion_trace,
-        build_fill_price_error_budget_report_v1=build_fill_price_error_budget_report_v1,
-    )
-    _bind(
-        _storage_and_database_module,
-        _http_request=_http_request,
-        _http_clickhouse_query=_http_clickhouse_query,
-        _kubectl_json=_kubectl_json,
-        _postgres_extension_exists=_postgres_extension_exists,
-        _run_with_transient_postgres_retry=_run_with_transient_postgres_retry,
-        _save_json=_save_json,
-        HTTPConnection=simulation_verification.HTTPConnection,
-        HTTPSConnection=simulation_verification.HTTPSConnection,
-        psycopg=psycopg,
-    )
-    _bind(
-        _service_environment_module,
-        _kubectl_json=_kubectl_json,
-        _kubectl_patch=_kubectl_patch,
-        _kubectl_patch_json=_kubectl_patch_json,
-        _read_argocd_applicationset_entry=_read_argocd_applicationset_entry,
-        _read_named_argocd_application_sync_policy=_read_named_argocd_application_sync_policy,
-    )
-    _bind(
-        _kubernetes_argocd_module,
-        _kubectl_json=_kubectl_json,
-        _kubectl_json_global=_kubectl_json_global,
-        _kubectl_patch=_kubectl_patch,
-        _kubectl_patch_json=_kubectl_patch_json,
-        _run_command=_run_command,
-        time=time,
-    )
-    _bind(
-        _resource_planning_module,
-        _run_command=_run_command,
-        run_autonomous_lane=run_autonomous_lane,
-    )
-    _bind(
-        _state_and_cache_module,
-        _simulation_cache_client_from_env=_simulation_cache_client_from_env,
-        CephS3Client=CephS3Client,
-        time=time,
-    )
-
-
-def _delegate(target: Callable[..., Any]) -> Callable[..., Any]:
-    def _call(*args: Any, **kwargs: Any) -> Any:
-        _sync_patch_targets()
-        return target(*args, **kwargs)
-
-    return _call
-
-
-_apply = _delegate(_ORIGINAL_APPLY)
-_assert_required_simulation_metadata_tables = _delegate(
-    _ORIGINAL_ASSERT_REQUIRED_SIMULATION_METADATA_TABLES
-)
-_clickhouse_query_configs = _delegate(_ORIGINAL_CLICKHOUSE_QUERY_CONFIGS)
-_configure_ta_for_simulation = _delegate(_ORIGINAL_CONFIGURE_TA_FOR_SIMULATION)
-_configure_torghut_service_for_simulation = _delegate(
-    _ORIGINAL_CONFIGURE_TORGHUT_SERVICE_FOR_SIMULATION
-)
-_desired_ta_simulation_config = _delegate(_ORIGINAL_DESIRED_TA_SIMULATION_CONFIG)
-_dump_topics = _delegate(_ORIGINAL_DUMP_TOPICS)
-_ensure_argocd_manual_before_runtime_mutation = _delegate(
-    _ORIGINAL_ENSURE_ARGOCD_MANUAL_BEFORE_RUNTIME_MUTATION
-)
-_ensure_clickhouse_database = _delegate(_ORIGINAL_ENSURE_CLICKHOUSE_DATABASE)
-_ensure_clickhouse_runtime_tables = _delegate(
-    _ORIGINAL_ENSURE_CLICKHOUSE_RUNTIME_TABLES
-)
-_ensure_postgres_database = _delegate(_ORIGINAL_ENSURE_POSTGRES_DATABASE)
-_ensure_postgres_runtime_permissions = _delegate(
-    _ORIGINAL_ENSURE_POSTGRES_RUNTIME_PERMISSIONS
-)
-_ensure_simulation_schema_subjects = _delegate(
-    _ORIGINAL_ENSURE_SIMULATION_SCHEMA_SUBJECTS
-)
-_ensure_topics = _delegate(_ORIGINAL_ENSURE_TOPICS)
-_http_clickhouse_query = _delegate(_ORIGINAL_HTTP_CLICKHOUSE_QUERY)
-main = _delegate(_ORIGINAL_MAIN)
-_monitor_run_completion = _delegate(_ORIGINAL_MONITOR_RUN_COMPLETION)
-_prepare_argocd_for_run = _delegate(_ORIGINAL_PREPARE_ARGOCD_FOR_RUN)
-_replay_dump = _delegate(_ORIGINAL_REPLAY_DUMP)
-_report_simulation = _delegate(_ORIGINAL_REPORT_SIMULATION)
-_resolve_warm_lane_runtime_postgres_config = _delegate(
-    _ORIGINAL_RESOLVE_WARM_LANE_RUNTIME_POSTGRES_CONFIG
-)
-_reset_postgres_runtime_state = _delegate(_ORIGINAL_RESET_POSTGRES_RUNTIME_STATE)
-_restore_argocd_after_run = _delegate(_ORIGINAL_RESTORE_ARGOCD_AFTER_RUN)
-_restore_ta_configuration = _delegate(_ORIGINAL_RESTORE_TA_CONFIGURATION)
-_restore_torghut_env = _delegate(_ORIGINAL_RESTORE_TORGHUT_ENV)
-_run_full_lifecycle = _delegate(_ORIGINAL_RUN_FULL_LIFECYCLE)
-_run_migrations = _delegate(_ORIGINAL_RUN_MIGRATIONS)
-_run_rollouts_analysis = _delegate(_ORIGINAL_RUN_ROLLOUTS_ANALYSIS)
-_runtime_verify = _delegate(_ORIGINAL_RUNTIME_VERIFY)
-_seed_simulation_trade_cursor = _delegate(_ORIGINAL_SEED_SIMULATION_TRADE_CURSOR)
-_set_argocd_application_ignore_differences = _delegate(
-    _ORIGINAL_SET_ARGOCD_APPLICATION_IGNORE_DIFFERENCES
-)
-_set_argocd_application_sync_policy = _delegate(
-    _ORIGINAL_SET_ARGOCD_APPLICATION_SYNC_POLICY
-)
-_set_argocd_automation_mode = _delegate(_ORIGINAL_SET_ARGOCD_AUTOMATION_MODE)
-_simulation_schema_registry_subject_specs = _delegate(
-    _ORIGINAL_SIMULATION_SCHEMA_REGISTRY_SUBJECT_SPECS
-)
-_teardown = _delegate(_ORIGINAL_TEARDOWN)
-_torghut_service_env_for_simulation = _delegate(
-    _ORIGINAL_TORGHUT_SERVICE_ENV_FOR_SIMULATION
-)
-_upload_dump_to_cache = _delegate(_ORIGINAL_UPLOAD_DUMP_TO_CACHE)
-_wait_for_clickhouse_database = _delegate(_ORIGINAL_WAIT_FOR_CLICKHOUSE_DATABASE)
-_wait_for_clickhouse_table = _delegate(_ORIGINAL_WAIT_FOR_CLICKHOUSE_TABLE)
-_wait_for_torghut_service_revision_ready = _delegate(
-    _ORIGINAL_WAIT_FOR_TORGHUT_SERVICE_REVISION_READY
-)
-
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_apply_a.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_apply_a.py
@@ -67,23 +67,23 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
             with ExitStack() as stack:
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_supported_binary"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_lz4_codec_available"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                         return_value={"status": "acquired", "run_id": resources.run_id},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._capture_cluster_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                         return_value={
                             "ta_data": {
                                 "TA_GROUP_ID": "prod-ta-group",
@@ -95,101 +95,101 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                         return_value={"status": "ok"},
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_runtime_tables",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_runtime_tables",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_runtime_permissions",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_runtime_permissions",
                         return_value={"grants_applied": True},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._run_migrations",
+                        "scripts.start_historical_simulation_modules.replay_execution._run_migrations",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._reset_postgres_runtime_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._reset_postgres_runtime_state",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._seed_simulation_trade_cursor",
+                        "scripts.start_historical_simulation_modules.replay_execution._seed_simulation_trade_cursor",
                         return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._upsert_simulation_runtime_context",
+                        "scripts.start_historical_simulation_modules.replay_execution._upsert_simulation_runtime_context",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._dump_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._dump_topics",
                         return_value={"records": 1, "sha256": "abc"},
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._validate_dump_coverage",
+                        "scripts.start_historical_simulation_modules.replay_execution._validate_dump_coverage",
                         return_value={"coverage_ratio": 1.0},
                     ),
                 )
                 runtime_guard = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_argocd_manual_before_runtime_mutation",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_argocd_manual_before_runtime_mutation",
                         return_value={"managed": True, "changed": True},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ta_runtime_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._ta_runtime_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._torghut_service_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._torghut_service_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_ta_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_ta_for_simulation",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._restart_ta_deployment",
+                        "scripts.start_historical_simulation_modules.replay_execution._restart_ta_deployment",
                         return_value="nonce",
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_torghut_service_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_torghut_service_for_simulation",
                         return_value=None,
                     ),
                 )
@@ -252,25 +252,25 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
             with ExitStack() as stack:
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_supported_binary",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                         return_value={"status": "acquired", "run_id": resources.run_id},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._capture_cluster_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                         return_value={
                             "ta_data": {"TA_GROUP_ID": "torghut-ta-sim-default"}
                         },
@@ -278,84 +278,84 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                         return_value={"status": "ok"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_runtime_tables",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_runtime_tables",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_runtime_permissions",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_runtime_permissions",
                         return_value={"grants_applied": True},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._run_migrations",
+                        "scripts.start_historical_simulation_modules.replay_execution._run_migrations",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._reset_postgres_runtime_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._reset_postgres_runtime_state",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._seed_simulation_trade_cursor",
+                        "scripts.start_historical_simulation_modules.replay_execution._seed_simulation_trade_cursor",
                         return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._upsert_simulation_runtime_context",
+                        "scripts.start_historical_simulation_modules.replay_execution._upsert_simulation_runtime_context",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._dump_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._dump_topics",
                         return_value={"records": 1, "sha256": "abc"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._validate_dump_coverage",
+                        "scripts.start_historical_simulation_modules.replay_execution._validate_dump_coverage",
                         return_value={"coverage_ratio": 1.0},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ta_runtime_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._ta_runtime_reconfigure_required",
                         return_value=False,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._torghut_service_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._torghut_service_reconfigure_required",
                         return_value=False,
                     ),
                 )
                 configure_ta = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_ta_for_simulation"
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_ta_for_simulation"
                     ),
                 )
                 restart_ta = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._restart_ta_deployment",
+                        "scripts.start_historical_simulation_modules.replay_execution._restart_ta_deployment",
                         return_value=7,
                     ),
                 )
                 configure_service = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_torghut_service_for_simulation"
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_torghut_service_for_simulation"
                     ),
                 )
                 report = start_historical_simulation._apply(
@@ -469,7 +469,7 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
             raise AssertionError(f"unexpected kubectl args: {args}")
 
         with patch(
-            "scripts.start_historical_simulation._kubectl_json",
+            "scripts.start_historical_simulation_modules.service_environment._kubectl_json",
             side_effect=_kubectl_json_side_effect,
         ):
             resolved = _resolve_warm_lane_runtime_postgres_config(
@@ -530,25 +530,25 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
             with ExitStack() as stack:
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_supported_binary",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                         return_value={"status": "acquired", "run_id": resources.run_id},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._capture_cluster_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                         return_value={
                             "ta_data": {"TA_GROUP_ID": "torghut-ta-sim-default"}
                         },
@@ -556,91 +556,91 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                         return_value={"status": "ok"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_runtime_tables",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_runtime_tables",
                         return_value=None,
                     ),
                 )
                 ensure_permissions = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_runtime_permissions",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_runtime_permissions",
                         return_value={"grants_applied": True},
                     ),
                 )
                 run_migrations = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._run_migrations",
+                        "scripts.start_historical_simulation_modules.replay_execution._run_migrations",
                         return_value=None,
                     ),
                 )
                 reset_runtime_state = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._reset_postgres_runtime_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._reset_postgres_runtime_state",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._seed_simulation_trade_cursor",
+                        "scripts.start_historical_simulation_modules.replay_execution._seed_simulation_trade_cursor",
                         return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._upsert_simulation_runtime_context",
+                        "scripts.start_historical_simulation_modules.replay_execution._upsert_simulation_runtime_context",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._dump_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._dump_topics",
                         return_value={"records": 1, "sha256": "abc"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._validate_dump_coverage",
+                        "scripts.start_historical_simulation_modules.replay_execution._validate_dump_coverage",
                         return_value={"coverage_ratio": 1.0},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ta_runtime_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._ta_runtime_reconfigure_required",
                         return_value=False,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._torghut_service_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._torghut_service_reconfigure_required",
                         return_value=False,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_ta_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_ta_for_simulation",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._restart_ta_deployment",
+                        "scripts.start_historical_simulation_modules.replay_execution._restart_ta_deployment",
                         return_value=1,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_torghut_service_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_torghut_service_for_simulation",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._release_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._release_simulation_runtime_lock",
                         return_value={"status": "released", "run_id": resources.run_id},
                     ),
                 )
@@ -697,25 +697,25 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
             with ExitStack() as stack:
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_supported_binary",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                         return_value={"status": "acquired", "run_id": resources.run_id},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._capture_cluster_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                         return_value={
                             "ta_data": {
                                 "TA_GROUP_ID": "prod-ta-group",
@@ -725,95 +725,95 @@ class TestStartHistoricalSimulationApplyA(StartHistoricalSimulationTestCaseBase)
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                         return_value={"status": "ok"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_runtime_tables",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_runtime_tables",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_runtime_permissions",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_runtime_permissions",
                         return_value={"grants_applied": True},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._run_migrations",
+                        "scripts.start_historical_simulation_modules.replay_execution._run_migrations",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._reset_postgres_runtime_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._reset_postgres_runtime_state",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._seed_simulation_trade_cursor",
+                        "scripts.start_historical_simulation_modules.replay_execution._seed_simulation_trade_cursor",
                         return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._upsert_simulation_runtime_context",
+                        "scripts.start_historical_simulation_modules.replay_execution._upsert_simulation_runtime_context",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._dump_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._dump_topics",
                         return_value={"records": 1, "sha256": "abc"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._validate_dump_coverage",
+                        "scripts.start_historical_simulation_modules.replay_execution._validate_dump_coverage",
                         return_value={"coverage_ratio": 1.0},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ta_runtime_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._ta_runtime_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._torghut_service_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._torghut_service_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_ta_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_ta_for_simulation",
                         return_value=None,
                     ),
                 )
                 restart_ta = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._restart_ta_deployment",
+                        "scripts.start_historical_simulation_modules.replay_execution._restart_ta_deployment",
                         return_value="nonce",
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_torghut_service_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_torghut_service_for_simulation",
                         return_value=None,
                     ),
                 )

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_apply_b.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_apply_b.py
@@ -53,23 +53,23 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
             resources = replace(resources, output_root=Path(tmpdir))
             with (
                 patch(
-                    "scripts.start_historical_simulation._ensure_supported_binary",
+                    "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                     return_value=None,
                 ),
                 patch(
-                    "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                    "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                     return_value=None,
                 ),
                 patch(
-                    "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                    "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                     return_value={"status": "acquired", "run_id": resources.run_id},
                 ),
                 patch(
-                    "scripts.start_historical_simulation._capture_cluster_state",
+                    "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                     return_value={"ta_data": {"TA_GROUP_ID": "prod-ta-group"}},
                 ),
                 patch(
-                    "scripts.start_historical_simulation._release_simulation_runtime_lock",
+                    "scripts.start_historical_simulation_modules.replay_execution._release_simulation_runtime_lock",
                     return_value={"status": "released"},
                 ) as release_lock,
             ):
@@ -126,25 +126,25 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
             with ExitStack() as stack:
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_supported_binary",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                         return_value={"status": "acquired", "run_id": resources.run_id},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._capture_cluster_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                         return_value={
                             "ta_data": {
                                 "TA_GROUP_ID": "prod-ta-group",
@@ -156,95 +156,95 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                         return_value={"status": "ok"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_runtime_tables",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_runtime_tables",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_runtime_permissions",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_runtime_permissions",
                         return_value={"grants_applied": True},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._run_migrations",
+                        "scripts.start_historical_simulation_modules.replay_execution._run_migrations",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._reset_postgres_runtime_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._reset_postgres_runtime_state",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._seed_simulation_trade_cursor",
+                        "scripts.start_historical_simulation_modules.replay_execution._seed_simulation_trade_cursor",
                         return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._upsert_simulation_runtime_context",
+                        "scripts.start_historical_simulation_modules.replay_execution._upsert_simulation_runtime_context",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._dump_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._dump_topics",
                         return_value={"records": 1, "sha256": "abc"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._validate_dump_coverage",
+                        "scripts.start_historical_simulation_modules.replay_execution._validate_dump_coverage",
                         return_value={"coverage_ratio": 1.0},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ta_runtime_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._ta_runtime_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._torghut_service_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._torghut_service_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_ta_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_ta_for_simulation",
                         return_value=None,
                     ),
                 )
                 restart_ta = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._restart_ta_deployment",
+                        "scripts.start_historical_simulation_modules.replay_execution._restart_ta_deployment",
                         return_value="nonce",
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_torghut_service_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_torghut_service_for_simulation",
                         return_value=None,
                     ),
                 )
@@ -304,119 +304,119 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
             with ExitStack() as stack:
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_supported_binary",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                         return_value={"status": "acquired", "run_id": resources.run_id},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._capture_cluster_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                         return_value={"ta_data": {"TA_GROUP_ID": "prod-ta-group"}},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                         return_value={"status": "ok"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_runtime_tables",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_runtime_tables",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_database"
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_runtime_permissions",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_runtime_permissions",
                         return_value={"grants_applied": True},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._run_migrations",
+                        "scripts.start_historical_simulation_modules.replay_execution._run_migrations",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._reset_postgres_runtime_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._reset_postgres_runtime_state",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._seed_simulation_trade_cursor",
+                        "scripts.start_historical_simulation_modules.replay_execution._seed_simulation_trade_cursor",
                         return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._upsert_simulation_runtime_context",
+                        "scripts.start_historical_simulation_modules.replay_execution._upsert_simulation_runtime_context",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._dump_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._dump_topics",
                         return_value={"records": 1, "sha256": "abc"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._validate_dump_coverage",
+                        "scripts.start_historical_simulation_modules.replay_execution._validate_dump_coverage",
                         return_value={"coverage_ratio": 1.0},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ta_runtime_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._ta_runtime_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._torghut_service_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._torghut_service_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_ta_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_ta_for_simulation",
                         return_value=None,
                     ),
                 )
                 restart_ta = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._restart_ta_deployment",
+                        "scripts.start_historical_simulation_modules.replay_execution._restart_ta_deployment",
                         return_value="nonce",
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_torghut_service_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_torghut_service_for_simulation",
                         return_value=None,
                     ),
                 )
@@ -473,19 +473,19 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
             resources = replace(resources, output_root=Path(tmpdir))
             with (
                 patch(
-                    "scripts.start_historical_simulation._ensure_supported_binary",
+                    "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                     return_value=None,
                 ),
                 patch(
-                    "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                    "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                     return_value=None,
                 ),
                 patch(
-                    "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                    "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                     return_value={"status": "acquired", "run_id": resources.run_id},
                 ),
                 patch(
-                    "scripts.start_historical_simulation._capture_cluster_state",
+                    "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                     return_value={
                         "ta_data": {
                             "TA_GROUP_ID": "prod-ta-group",
@@ -495,11 +495,11 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
                     },
                 ),
                 patch(
-                    "scripts.start_historical_simulation._ensure_topics",
+                    "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                     side_effect=RuntimeError("topic_create_failed"),
                 ),
                 patch(
-                    "scripts.start_historical_simulation._release_simulation_runtime_lock"
+                    "scripts.start_historical_simulation_modules.replay_execution._release_simulation_runtime_lock"
                 ) as release_lock,
             ):
                 with self.assertRaisesRegex(RuntimeError, "topic_create_failed"):
@@ -542,7 +542,7 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
             return 200, ""
 
         with patch(
-            "scripts.start_historical_simulation._http_clickhouse_query",
+            "scripts.start_historical_simulation_modules.storage_and_database._http_clickhouse_query",
             side_effect=_fake_clickhouse_query,
         ):
             start_historical_simulation._ensure_clickhouse_runtime_tables(
@@ -604,7 +604,7 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.storage_and_database._kubectl_json",
                 return_value={
                     "subsets": [
                         {
@@ -617,7 +617,7 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
                 },
             ),
             patch(
-                "scripts.start_historical_simulation._http_clickhouse_query",
+                "scripts.start_historical_simulation_modules.storage_and_database._http_clickhouse_query",
                 side_effect=_fake_clickhouse_query,
             ),
         ):
@@ -688,10 +688,12 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
 
         with (
             patch(
-                "scripts.start_historical_simulation._http_clickhouse_query",
+                "scripts.start_historical_simulation_modules.storage_and_database._http_clickhouse_query",
                 side_effect=_fake_clickhouse_query,
             ),
-            patch("scripts.start_historical_simulation.time.sleep") as sleep_mock,
+            patch(
+                "scripts.start_historical_simulation_modules.storage_and_database.time.sleep"
+            ) as sleep_mock,
         ):
             start_historical_simulation._wait_for_clickhouse_table(
                 config=ClickHouseRuntimeConfig(
@@ -728,10 +730,12 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
 
         with (
             patch(
-                "scripts.start_historical_simulation._http_clickhouse_query",
+                "scripts.start_historical_simulation_modules.storage_and_database._http_clickhouse_query",
                 side_effect=_fake_clickhouse_query,
             ),
-            patch("scripts.start_historical_simulation.time.sleep") as sleep_mock,
+            patch(
+                "scripts.start_historical_simulation_modules.storage_and_database.time.sleep"
+            ) as sleep_mock,
         ):
             start_historical_simulation._wait_for_clickhouse_database(
                 config=ClickHouseRuntimeConfig(
@@ -814,7 +818,7 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
                 {"kafka.admin": SimpleNamespace(NewTopic=_FakeNewTopic)},
             ),
             patch(
-                "scripts.start_historical_simulation._kafka_admin_client",
+                "scripts.start_historical_simulation_modules.kafka_runtime._kafka_admin_client",
                 return_value=fake_admin,
             ),
         ):
@@ -917,7 +921,7 @@ class TestStartHistoricalSimulationApplyB(StartHistoricalSimulationTestCaseBase)
                 {"kafka.admin": SimpleNamespace(NewTopic=_FakeNewTopic)},
             ),
             patch(
-                "scripts.start_historical_simulation._kafka_admin_client",
+                "scripts.start_historical_simulation_modules.kafka_runtime._kafka_admin_client",
                 return_value=fake_admin,
             ),
         ):

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_argocd_a.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_argocd_a.py
@@ -246,17 +246,17 @@ class TestStartHistoricalSimulationArgocdA(StartHistoricalSimulationTestCaseBase
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_delete_if_exists",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._kubectl_delete_if_exists",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_apply",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._kubectl_apply",
                 side_effect=lambda namespace, payload: captured_apply.update(
                     {"namespace": namespace, "payload": payload}
                 ),
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._kubectl_json",
                 side_effect=_fake_kubectl_json,
             ),
         ):
@@ -394,11 +394,11 @@ class TestStartHistoricalSimulationArgocdA(StartHistoricalSimulationTestCaseBase
         }
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json_global",
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._kubectl_json_global",
                 side_effect=[payload_auto, payload_manual],
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_patch_json"
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._kubectl_patch_json"
             ) as patch_mock,
         ):
             report = _set_argocd_automation_mode(
@@ -445,10 +445,12 @@ class TestStartHistoricalSimulationArgocdA(StartHistoricalSimulationTestCaseBase
         }
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json_global",
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._kubectl_json_global",
                 side_effect=[payload_auto, payload_manual],
             ),
-            patch("scripts.start_historical_simulation._kubectl_patch") as patch_mock,
+            patch(
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._kubectl_patch"
+            ) as patch_mock,
         ):
             report = _set_argocd_application_sync_policy(
                 config=ArgocdAutomationConfig(
@@ -493,7 +495,7 @@ class TestStartHistoricalSimulationArgocdA(StartHistoricalSimulationTestCaseBase
         self.assertNotIn("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS", ignore_jq)
         with (
             patch(
-                "scripts.start_historical_simulation._read_argocd_applicationset_entry",
+                "scripts.start_historical_simulation_modules.service_environment._read_argocd_applicationset_entry",
                 side_effect=[
                     {
                         "pointer": "/spec/generators/0/list/elements/0",
@@ -510,7 +512,7 @@ class TestStartHistoricalSimulationArgocdA(StartHistoricalSimulationTestCaseBase
                 ],
             ),
             patch(
-                "scripts.start_historical_simulation._read_named_argocd_application_sync_policy",
+                "scripts.start_historical_simulation_modules.service_environment._read_named_argocd_application_sync_policy",
                 return_value={
                     "sync_policy": None,
                     "automation_mode": "manual",
@@ -518,7 +520,7 @@ class TestStartHistoricalSimulationArgocdA(StartHistoricalSimulationTestCaseBase
                 },
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_patch_json"
+                "scripts.start_historical_simulation_modules.service_environment._kubectl_patch_json"
             ) as patch_mock,
         ):
             report = (

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_argocd_b.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_argocd_b.py
@@ -184,14 +184,14 @@ class TestStartHistoricalSimulationArgocdB(StartHistoricalSimulationTestCaseBase
 
         with (
             patch(
-                "scripts.start_historical_simulation._read_argocd_automation_mode",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._read_argocd_automation_mode",
                 return_value={
                     "pointer": "/spec/generators/0/list/elements/0/automation",
                     "mode": "auto",
                 },
             ) as automation_read_mock,
             patch(
-                "scripts.start_historical_simulation._read_named_argocd_application_sync_policy",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._read_named_argocd_application_sync_policy",
                 side_effect=[
                     {
                         "sync_policy": {
@@ -220,19 +220,19 @@ class TestStartHistoricalSimulationArgocdB(StartHistoricalSimulationTestCaseBase
                 ],
             ) as application_read_mock,
             patch(
-                "scripts.start_historical_simulation._set_argocd_application_sync_policy",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._set_argocd_application_sync_policy",
                 side_effect=_set_application_sync_policy,
             ) as application_sync_mock,
             patch(
-                "scripts.start_historical_simulation._set_argocd_application_ignore_differences",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._set_argocd_application_ignore_differences",
                 side_effect=_set_ignore_differences,
             ) as ignore_differences_mock,
             patch(
-                "scripts.start_historical_simulation._set_argocd_automation_mode",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._set_argocd_automation_mode",
                 side_effect=_set_applicationset_mode,
             ) as applicationset_mock,
             patch(
-                "scripts.start_historical_simulation._wait_for_argocd_application_mode",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._wait_for_argocd_application_mode",
                 side_effect=_wait_application_mode,
             ) as application_mode_mock,
         ):
@@ -318,14 +318,14 @@ class TestStartHistoricalSimulationArgocdB(StartHistoricalSimulationTestCaseBase
         )
         with (
             patch(
-                "scripts.start_historical_simulation._read_argocd_automation_mode",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._read_argocd_automation_mode",
                 return_value={
                     "pointer": "/spec/generators/0/list/elements/0/automation",
                     "mode": "manual",
                 },
             ),
             patch(
-                "scripts.start_historical_simulation._read_named_argocd_application_sync_policy",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._read_named_argocd_application_sync_policy",
                 side_effect=[
                     {
                         "sync_policy": {
@@ -354,7 +354,7 @@ class TestStartHistoricalSimulationArgocdB(StartHistoricalSimulationTestCaseBase
                 ],
             ),
             patch(
-                "scripts.start_historical_simulation._prepare_argocd_for_run"
+                "scripts.start_historical_simulation_modules.argocd_rollouts._prepare_argocd_for_run"
             ) as prepare_mock,
         ):
             report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(
@@ -389,14 +389,14 @@ class TestStartHistoricalSimulationArgocdB(StartHistoricalSimulationTestCaseBase
         )
         with (
             patch(
-                "scripts.start_historical_simulation._read_argocd_automation_mode",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._read_argocd_automation_mode",
                 return_value={
                     "pointer": "/spec/generators/0/list/elements/0/automation",
                     "mode": "manual",
                 },
             ),
             patch(
-                "scripts.start_historical_simulation._read_named_argocd_application_sync_policy",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._read_named_argocd_application_sync_policy",
                 side_effect=[
                     {
                         "sync_policy": {
@@ -425,7 +425,7 @@ class TestStartHistoricalSimulationArgocdB(StartHistoricalSimulationTestCaseBase
                 ],
             ),
             patch(
-                "scripts.start_historical_simulation._prepare_argocd_for_run",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._prepare_argocd_for_run",
                 return_value={
                     "managed": True,
                     "changed": True,
@@ -513,19 +513,19 @@ class TestStartHistoricalSimulationArgocdB(StartHistoricalSimulationTestCaseBase
 
         with (
             patch(
-                "scripts.start_historical_simulation._set_argocd_automation_mode",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._set_argocd_automation_mode",
                 side_effect=_set_applicationset_mode,
             ) as applicationset_mock,
             patch(
-                "scripts.start_historical_simulation._set_argocd_application_sync_policy",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._set_argocd_application_sync_policy",
                 side_effect=_set_application_sync_policy,
             ) as application_mock,
             patch(
-                "scripts.start_historical_simulation._set_argocd_application_ignore_differences",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._set_argocd_application_ignore_differences",
                 side_effect=_set_ignore_differences,
             ) as ignore_differences_mock,
             patch(
-                "scripts.start_historical_simulation._wait_for_argocd_application_mode",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._wait_for_argocd_application_mode",
                 side_effect=_wait_application_mode,
             ) as application_mode_mock,
         ):

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_clickhouse.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_clickhouse.py
@@ -146,7 +146,8 @@ class TestStartHistoricalSimulationClickhouse(StartHistoricalSimulationTestCaseB
                 captured["closed"] = True
 
         with patch(
-            "scripts.historical_simulation_verification.HTTPConnection", _FakeConnection
+            "scripts.historical_simulation_verification_modules.shared_runtime.HTTPConnection",
+            _FakeConnection,
         ):
             status, body = _http_clickhouse_query(
                 config=ClickHouseRuntimeConfig(
@@ -217,11 +218,11 @@ class TestStartHistoricalSimulationClickhouse(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.historical_simulation_verification.HTTPConnection",
+                "scripts.historical_simulation_verification_modules.shared_runtime.HTTPConnection",
                 _FakeConnection,
             ),
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.shared_runtime._kubectl_json",
                 side_effect=_fake_kubectl_json,
             ),
         ):
@@ -248,7 +249,7 @@ class TestStartHistoricalSimulationClickhouse(StartHistoricalSimulationTestCaseB
             password="secret",
         )
         with patch(
-            "scripts.start_historical_simulation._kubectl_json",
+            "scripts.start_historical_simulation_modules.storage_and_database._kubectl_json",
             return_value={
                 "subsets": [
                     {
@@ -285,7 +286,7 @@ class TestStartHistoricalSimulationClickhouse(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.storage_and_database._kubectl_json",
                 return_value={
                     "subsets": [
                         {
@@ -298,7 +299,7 @@ class TestStartHistoricalSimulationClickhouse(StartHistoricalSimulationTestCaseB
                 },
             ),
             patch(
-                "scripts.start_historical_simulation._http_clickhouse_query",
+                "scripts.start_historical_simulation_modules.storage_and_database._http_clickhouse_query",
                 side_effect=_fake_clickhouse_query,
             ),
         ):
@@ -364,25 +365,25 @@ class TestStartHistoricalSimulationClickhouse(StartHistoricalSimulationTestCaseB
             with ExitStack() as stack:
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_supported_binary",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_supported_binary",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_lz4_codec_available",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_lz4_codec_available",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._acquire_simulation_runtime_lock",
+                        "scripts.start_historical_simulation_modules.replay_execution._acquire_simulation_runtime_lock",
                         return_value={"status": "acquired", "run_id": resources.run_id},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._capture_cluster_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._capture_cluster_state",
                         return_value={
                             "ta_data": {
                                 "TA_GROUP_ID": "prod-ta-group",
@@ -394,95 +395,95 @@ class TestStartHistoricalSimulationClickhouse(StartHistoricalSimulationTestCaseB
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_topics",
                         return_value={"status": "ok"},
                     ),
                 )
                 ensure_db = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_database"
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_clickhouse_runtime_tables",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_clickhouse_runtime_tables",
                         return_value=None,
                     ),
                 )
                 ensure_postgres_db = stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_database"
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_database"
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ensure_postgres_runtime_permissions",
+                        "scripts.start_historical_simulation_modules.replay_execution._ensure_postgres_runtime_permissions",
                         return_value={"grants_applied": True},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._run_migrations",
+                        "scripts.start_historical_simulation_modules.replay_execution._run_migrations",
                         return_value=None,
                     )
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._reset_postgres_runtime_state",
+                        "scripts.start_historical_simulation_modules.replay_execution._reset_postgres_runtime_state",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._seed_simulation_trade_cursor",
+                        "scripts.start_historical_simulation_modules.replay_execution._seed_simulation_trade_cursor",
                         return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._upsert_simulation_runtime_context",
+                        "scripts.start_historical_simulation_modules.replay_execution._upsert_simulation_runtime_context",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._dump_topics",
+                        "scripts.start_historical_simulation_modules.replay_execution._dump_topics",
                         return_value={"records": 1, "sha256": "abc"},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._validate_dump_coverage",
+                        "scripts.start_historical_simulation_modules.replay_execution._validate_dump_coverage",
                         return_value={"coverage_ratio": 1.0},
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._ta_runtime_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._ta_runtime_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._torghut_service_reconfigure_required",
+                        "scripts.start_historical_simulation_modules.replay_execution._torghut_service_reconfigure_required",
                         return_value=True,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_ta_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_ta_for_simulation",
                         return_value=None,
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._restart_ta_deployment",
+                        "scripts.start_historical_simulation_modules.replay_execution._restart_ta_deployment",
                         return_value="nonce",
                     ),
                 )
                 stack.enter_context(
                     patch(
-                        "scripts.start_historical_simulation._configure_torghut_service_for_simulation",
+                        "scripts.start_historical_simulation_modules.replay_execution._configure_torghut_service_for_simulation",
                         return_value=None,
                     ),
                 )

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_completion_policy.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_completion_policy.py
@@ -33,7 +33,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
             state_path.write_text(json.dumps({"ta_job_state": "running"}))
 
             with patch(
-                "scripts.start_historical_simulation._read_simulation_runtime_lock",
+                "scripts.start_historical_simulation_modules.replay_execution._read_simulation_runtime_lock",
                 return_value={"run_id": "sim-2"},
             ):
                 report = start_historical_simulation._teardown(
@@ -51,7 +51,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
         with TemporaryDirectory() as tmpdir:
             resources = replace(resources, output_root=Path(tmpdir))
             with patch(
-                "scripts.start_historical_simulation._release_simulation_runtime_lock",
+                "scripts.start_historical_simulation_modules.replay_execution._release_simulation_runtime_lock",
                 return_value={"status": "released", "run_id": resources.run_id},
             ) as release_lock:
                 report = start_historical_simulation._teardown(
@@ -79,25 +79,25 @@ class TestStartHistoricalSimulationCompletionPolicy(
 
             with (
                 patch(
-                    "scripts.start_historical_simulation._read_simulation_runtime_lock",
+                    "scripts.start_historical_simulation_modules.replay_execution._read_simulation_runtime_lock",
                     return_value={"run_id": resources.run_id},
                 ),
                 patch(
-                    "scripts.start_historical_simulation._release_simulation_runtime_lock",
+                    "scripts.start_historical_simulation_modules.replay_execution._release_simulation_runtime_lock",
                     return_value={"status": "released", "run_id": resources.run_id},
                 ) as release_lock,
                 patch(
-                    "scripts.start_historical_simulation._restore_ta_configuration"
+                    "scripts.start_historical_simulation_modules.runtime_migrations._restore_ta_configuration"
                 ) as restore_ta,
                 patch(
-                    "scripts.start_historical_simulation._restore_torghut_env"
+                    "scripts.start_historical_simulation_modules.runtime_migrations._restore_torghut_env"
                 ) as restore_env,
                 patch(
-                    "scripts.start_historical_simulation._restart_ta_deployment",
+                    "scripts.start_historical_simulation_modules.runtime_migrations._restart_ta_deployment",
                     return_value=11,
                 ) as restart_ta,
                 patch(
-                    "scripts.start_historical_simulation._ensure_supported_binary",
+                    "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                     return_value=None,
                 ),
             ):
@@ -553,7 +553,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
         )
         with (
             patch(
-                "scripts.historical_simulation_verification._monitor_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._monitor_snapshot",
                 return_value={
                     "trade_decisions": 10,
                     "executions": 5,
@@ -563,11 +563,11 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 },
             ),
             patch(
-                "scripts.historical_simulation_verification._signal_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._signal_snapshot",
                 return_value={"signal_rows": 10, "price_rows": 10},
             ),
             patch(
-                "scripts.historical_simulation_verification.time.sleep",
+                "scripts.historical_simulation_verification_modules.artifact_verification.time.sleep",
                 return_value=None,
             ),
         ):
@@ -609,7 +609,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
         )
         with (
             patch(
-                "scripts.historical_simulation_verification._monitor_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._monitor_snapshot",
                 return_value={
                     "trade_decisions": 12,
                     "executions": 12,
@@ -620,7 +620,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 },
             ),
             patch(
-                "scripts.historical_simulation_verification._signal_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._signal_snapshot",
                 return_value={
                     "signal_rows": 120,
                     "price_rows": 120,
@@ -629,7 +629,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 },
             ),
             patch(
-                "scripts.historical_simulation_verification.time.sleep",
+                "scripts.historical_simulation_verification_modules.artifact_verification.time.sleep",
                 return_value=None,
             ),
         ):
@@ -727,7 +727,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
             password=None,
         )
         with patch(
-            "scripts.historical_simulation_verification._simulation_progress_snapshot",
+            "scripts.historical_simulation_verification_modules.artifact_verification._simulation_progress_snapshot",
             return_value={
                 "components": {
                     "replay": {
@@ -805,7 +805,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
         )
         with (
             patch(
-                "scripts.historical_simulation_verification._progress_component_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._progress_component_snapshot",
                 return_value={
                     "torghut": {
                         "trade_decisions": 0,
@@ -822,7 +822,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 },
             ),
             patch(
-                "scripts.historical_simulation_verification._monitor_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._monitor_snapshot",
                 return_value={
                     "trade_decisions": 213,
                     "executions": 60,
@@ -832,7 +832,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 },
             ),
             patch(
-                "scripts.historical_simulation_verification._signal_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._signal_snapshot",
                 return_value={
                     "signal_rows": 1,
                     "price_rows": 1,
@@ -841,7 +841,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 },
             ),
             patch(
-                "scripts.historical_simulation_verification.time.sleep",
+                "scripts.historical_simulation_verification_modules.artifact_verification.time.sleep",
                 return_value=None,
             ),
         ):
@@ -896,7 +896,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
         )
         with (
             patch(
-                "scripts.historical_simulation_verification._monitor_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._monitor_snapshot",
                 side_effect=[
                     {
                         "trade_decisions": 0,
@@ -917,7 +917,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._signal_snapshot",
+                "scripts.historical_simulation_verification_modules.runtime_progress._signal_snapshot",
                 side_effect=[
                     {
                         "signal_rows": 120,
@@ -934,7 +934,7 @@ class TestStartHistoricalSimulationCompletionPolicy(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification.time.sleep",
+                "scripts.historical_simulation_verification_modules.artifact_verification.time.sleep",
                 return_value=None,
             ),
         ):

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_config.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_config.py
@@ -73,7 +73,7 @@ class TestStartHistoricalSimulationConfig(StartHistoricalSimulationTestCaseBase)
                 return None
 
         with patch(
-            "scripts.historical_simulation_verification.HTTPConnection",
+            "scripts.historical_simulation_verification_modules.artifact_verification.HTTPConnection",
             _FakeConnection,
         ):
             status, body = historical_simulation_verification._http_json_get(
@@ -200,7 +200,8 @@ class TestStartHistoricalSimulationConfig(StartHistoricalSimulationTestCaseBase)
                 captured["closed"] = True
 
         with patch(
-            "scripts.historical_simulation_verification.HTTPConnection", _FakeConnection
+            "scripts.historical_simulation_verification_modules.artifact_verification.HTTPConnection",
+            _FakeConnection,
         ):
             status, body = historical_simulation_verification._http_json_get(
                 "http://schema-registry:8081",
@@ -472,8 +473,9 @@ class TestStartHistoricalSimulationConfig(StartHistoricalSimulationTestCaseBase)
                 '{"type":"record","name":"Signal","fields":[]}', encoding="utf-8"
             )
 
-            with patch.object(
-                start_historical_simulation, "__file__", str(script_path)
+            with patch(
+                "scripts.start_historical_simulation_modules.kafka_runtime.__file__",
+                str(script_path),
             ):
                 specs = _simulation_schema_registry_subject_specs(resources=resources)
 

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_dump_cache_a.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_dump_cache_a.py
@@ -75,7 +75,7 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
             )
 
             with patch(
-                "scripts.start_historical_simulation._consumer_for_dump",
+                "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                 side_effect=AssertionError(
                     "expected dump reuse; consumer should not be constructed"
                 ),
@@ -134,7 +134,7 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
                     },
                 ),
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     side_effect=RuntimeError("dump_invoked"),
                 ),
                 self.assertRaisesRegex(RuntimeError, "dump_invoked"),
@@ -237,13 +237,13 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
             dump_path = Path(tmp_dir) / "source-dump.ndjson"
             with (
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     side_effect=AssertionError(
                         "expected durable cache restore; consumer should not be constructed"
                     ),
                 ),
                 patch(
-                    "scripts.start_historical_simulation._simulation_cache_client_from_env",
+                    "scripts.start_historical_simulation_modules.state_and_cache._simulation_cache_client_from_env",
                     return_value=(_FakeCephClient(), "argo-workflows"),
                 ),
             ):
@@ -347,13 +347,13 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
 
             with (
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     side_effect=AssertionError(
                         "expected durable cache restore; consumer should not be constructed"
                     ),
                 ),
                 patch(
-                    "scripts.start_historical_simulation._simulation_cache_client_from_env",
+                    "scripts.start_historical_simulation_modules.state_and_cache._simulation_cache_client_from_env",
                     return_value=(_FakeCephClient(), "argo-workflows"),
                 ),
             ):
@@ -429,7 +429,7 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
         with TemporaryDirectory() as tmp_dir:
             dump_path = Path(tmp_dir) / "source-dump.ndjson"
             with patch(
-                "scripts.start_historical_simulation._simulation_cache_client_from_env",
+                "scripts.start_historical_simulation_modules.state_and_cache._simulation_cache_client_from_env",
                 return_value=(_FakeCephClient(), "argo-workflows"),
             ):
                 report = start_historical_simulation._restore_cached_dump_if_available(
@@ -460,7 +460,7 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
             dump_path = Path(tmp_dir) / "source-dump.ndjson"
 
             with patch(
-                "scripts.start_historical_simulation._simulation_cache_client_from_env",
+                "scripts.start_historical_simulation_modules.state_and_cache._simulation_cache_client_from_env",
                 side_effect=AssertionError(
                     "non-hit cache decisions must not attempt restore"
                 ),
@@ -564,11 +564,11 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
 
             with (
                 patch(
-                    "scripts.start_historical_simulation._simulation_cache_client_from_env",
+                    "scripts.start_historical_simulation_modules.state_and_cache._simulation_cache_client_from_env",
                     side_effect=_fake_cache_client,
                 ),
                 patch(
-                    "scripts.start_historical_simulation.time.sleep",
+                    "scripts.start_historical_simulation_modules.state_and_cache.time.sleep",
                     return_value=None,
                 ),
             ):
@@ -702,11 +702,11 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
                     },
                 ),
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     return_value=_FakeConsumer(),
                 ),
                 patch(
-                    "scripts.start_historical_simulation._upload_dump_to_cache",
+                    "scripts.start_historical_simulation_modules.topic_dumping._upload_dump_to_cache",
                     side_effect=TimeoutError("timed out"),
                 ),
             ):
@@ -831,7 +831,7 @@ class TestStartHistoricalSimulationDumpCacheA(StartHistoricalSimulationTestCaseB
                     },
                 ),
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     return_value=fake_consumer,
                 ),
             ):

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_dump_cache_b.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_dump_cache_b.py
@@ -63,7 +63,7 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
                     clear=False,
                 ),
                 patch(
-                    "scripts.start_historical_simulation.subprocess.run",
+                    "scripts.start_historical_simulation_modules.service_environment.subprocess.run",
                     side_effect=_fake_run,
                 ),
             ):
@@ -202,7 +202,7 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
                     },
                 ),
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     return_value=_FakeConsumer(),
                 ),
             ):
@@ -335,7 +335,7 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
                     },
                 ),
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     return_value=fake_consumer,
                 ),
             ):
@@ -482,7 +482,7 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
                     },
                 ),
                 patch(
-                    "scripts.start_historical_simulation._consumer_for_dump",
+                    "scripts.start_historical_simulation_modules.topic_dumping._consumer_for_dump",
                     return_value=fake_consumer,
                 ),
             ):
@@ -625,7 +625,7 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
 
             producer = _FakeProducer()
             with patch(
-                "scripts.start_historical_simulation._producer_for_replay",
+                "scripts.start_historical_simulation_modules.replay_execution._producer_for_replay",
                 return_value=producer,
             ):
                 report = _replay_dump(
@@ -698,7 +698,7 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
 
             producer = _FakeProducer()
             with patch(
-                "scripts.start_historical_simulation._producer_for_replay",
+                "scripts.start_historical_simulation_modules.replay_execution._producer_for_replay",
                 return_value=producer,
             ):
                 report = _replay_dump(
@@ -787,10 +787,12 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_json",
                 return_value=current_configmap,
             ),
-            patch("scripts.start_historical_simulation._kubectl_patch") as patch_mock,
+            patch(
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_patch"
+            ) as patch_mock,
         ):
             _restore_ta_configuration(resources, state)
 
@@ -853,11 +855,11 @@ class TestStartHistoricalSimulationDumpCacheB(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_json",
                 return_value=service_payload,
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_patch",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_patch",
                 side_effect=lambda namespace, kind, name, patch: captured_patch.update(
                     {"namespace": namespace, "kind": kind, "name": name, "patch": patch}
                 ),

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_a.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_a.py
@@ -71,35 +71,38 @@ class TestStartHistoricalSimulationLifecycleA(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._ensure_supported_binary",
+                "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation._update_run_state",
+                "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                 return_value=None,
             ),
-            patch("scripts.start_historical_simulation._save_json", return_value=None),
             patch(
-                "scripts.start_historical_simulation.persist_completion_trace",
+                "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                return_value=None,
+            ),
+            patch(
+                "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                 return_value={},
             ),
             patch(
-                "scripts.start_historical_simulation.SessionLocal"
+                "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
             ) as mock_session_local,
             patch(
-                "scripts.start_historical_simulation._apply",
+                "scripts.start_historical_simulation_modules.lifecycle._apply",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._runtime_verify",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._runtime_verify",
                 return_value={"runtime_state": "ready"},
             ),
             patch(
-                "scripts.start_historical_simulation._replay_dump",
+                "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._monitor_run_completion",
+                "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                 return_value={
                     "status": "degraded",
                     "activity_classification": "decisions_absent",
@@ -107,11 +110,11 @@ class TestStartHistoricalSimulationLifecycleA(StartHistoricalSimulationTestCaseB
                 },
             ),
             patch(
-                "scripts.start_historical_simulation._report_simulation",
+                "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                 return_value={"status": "ok", "legacy_path_count": 0},
             ),
         ):
@@ -203,34 +206,37 @@ class TestStartHistoricalSimulationLifecycleA(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._update_run_state",
+                "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                 return_value=None,
             ),
-            patch("scripts.start_historical_simulation._save_json", return_value=None),
             patch(
-                "scripts.start_historical_simulation._prepare_argocd_for_run",
+                "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                return_value=None,
+            ),
+            patch(
+                "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._restore_argocd_after_run",
+                "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._apply",
+                "scripts.start_historical_simulation_modules.lifecycle._apply",
                 side_effect=RuntimeError(
                     "command_binary_not_found:/opt/venv/bin/alembic"
                 ),
             ),
             patch(
-                "scripts.start_historical_simulation._upsert_simulation_progress_row",
+                "scripts.start_historical_simulation_modules.lifecycle._upsert_simulation_progress_row",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation._runtime_sessionmaker",
+                "scripts.start_historical_simulation_modules.lifecycle._runtime_sessionmaker",
                 return_value=(lambda: _FakeSession(), fake_engine),
             ),
             patch(
-                "scripts.start_historical_simulation.persist_completion_trace",
+                "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                 side_effect=RuntimeError(
                     'relation "vnext_completion_gate_results" does not exist'
                 ),
@@ -314,45 +320,48 @@ class TestStartHistoricalSimulationLifecycleA(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._ensure_supported_binary",
+                "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation._update_run_state",
+                "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                 return_value=None,
             ),
-            patch("scripts.start_historical_simulation._save_json", return_value=None),
             patch(
-                "scripts.start_historical_simulation.persist_completion_trace",
+                "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                return_value=None,
+            ),
+            patch(
+                "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                 return_value={},
             ),
             patch(
-                "scripts.start_historical_simulation.SessionLocal"
+                "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
             ) as mock_session_local,
             patch(
-                "scripts.start_historical_simulation._prepare_argocd_for_run",
+                "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._restore_argocd_after_run",
+                "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._apply",
+                "scripts.start_historical_simulation_modules.lifecycle._apply",
                 side_effect=lambda **_: call_order.append("apply") or {"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._runtime_verify",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._runtime_verify",
                 side_effect=lambda **_: (
                     call_order.append("runtime_verify") or {"runtime_state": "ready"}
                 ),
             ),
             patch(
-                "scripts.start_historical_simulation._replay_dump",
+                "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                 side_effect=lambda **_: call_order.append("replay") or {"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._monitor_run_completion",
+                "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                 side_effect=lambda **_: (
                     call_order.append("monitor")
                     or {
@@ -371,11 +380,11 @@ class TestStartHistoricalSimulationLifecycleA(StartHistoricalSimulationTestCaseB
                 ),
             ),
             patch(
-                "scripts.start_historical_simulation._report_simulation",
+                "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                 side_effect=lambda **_: call_order.append("report") or {"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                 return_value={"status": "ok", "legacy_path_count": 0},
             ),
         ):

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_b.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_b.py
@@ -88,45 +88,48 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._ensure_supported_binary",
+                "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation._update_run_state",
+                "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                 return_value=None,
             ),
-            patch("scripts.start_historical_simulation._save_json", return_value=None),
             patch(
-                "scripts.start_historical_simulation.persist_completion_trace",
+                "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                return_value=None,
+            ),
+            patch(
+                "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                 return_value={},
             ),
             patch(
-                "scripts.start_historical_simulation.SessionLocal"
+                "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
             ) as mock_session_local,
             patch(
-                "scripts.start_historical_simulation._prepare_argocd_for_run",
+                "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._restore_argocd_after_run",
+                "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._apply",
+                "scripts.start_historical_simulation_modules.lifecycle._apply",
                 side_effect=lambda **_: call_order.append("apply") or {"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._runtime_verify",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._runtime_verify",
                 side_effect=lambda **_: (
                     call_order.append("runtime_verify") or {"runtime_state": "ready"}
                 ),
             ),
             patch(
-                "scripts.start_historical_simulation._replay_dump",
+                "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                 side_effect=lambda **_: call_order.append("replay") or {"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._monitor_run_completion",
+                "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                 side_effect=lambda **_: (
                     call_order.append("monitor")
                     or {
@@ -145,11 +148,11 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
                 ),
             ),
             patch(
-                "scripts.start_historical_simulation._report_simulation",
+                "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                 side_effect=lambda **_: call_order.append("report") or {"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation.run_autonomous_lane",
+                "scripts.start_historical_simulation_modules.resource_planning.run_autonomous_lane",
                 side_effect=lambda **kwargs: (
                     call_order.append("autonomy")
                     or SimpleNamespace(
@@ -194,7 +197,7 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
                 ),
             ) as autonomy_mock,
             patch(
-                "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                 return_value={"status": "ok", "legacy_path_count": 0},
             ),
         ):
@@ -286,57 +289,60 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
         with ExitStack() as stack:
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._ensure_supported_binary",
+                    "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                     return_value=None,
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._update_run_state",
+                    "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                     return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._save_json", return_value=None
+                    "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                    return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation.persist_completion_trace",
+                    "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                     return_value={},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._upsert_simulation_progress_row",
+                    "scripts.start_historical_simulation_modules.lifecycle._upsert_simulation_progress_row",
                     return_value=None,
                 ),
             )
             mock_session_local = stack.enter_context(
-                patch("scripts.start_historical_simulation.SessionLocal")
+                patch(
+                    "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
+                )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._prepare_argocd_for_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                     return_value={"managed": False},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._restore_argocd_after_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                     return_value={"managed": False},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._apply",
+                    "scripts.start_historical_simulation_modules.lifecycle._apply",
                     return_value={"status": "ok"},
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._run_rollouts_analysis",
+                    "scripts.start_historical_simulation_modules.lifecycle._run_rollouts_analysis",
                     side_effect=[
                         {"phase": "Successful"},
                         {"phase": "Failed"},
@@ -345,19 +351,19 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._runtime_verify",
+                    "scripts.start_historical_simulation_modules.lifecycle._runtime_verify",
                     return_value={"runtime_state": "ready"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._replay_dump",
+                    "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._monitor_run_completion",
+                    "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                     return_value={
                         "status": "ok",
                         "activity_classification": "success",
@@ -375,13 +381,13 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._report_simulation",
+                    "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                    "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                     return_value={"status": "ok", "legacy_path_count": 0},
                 ),
             )
@@ -475,51 +481,54 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
         with ExitStack() as stack:
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._ensure_supported_binary",
+                    "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                     return_value=None,
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._update_run_state",
+                    "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                     return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._save_json", return_value=None
+                    "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                    return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation.persist_completion_trace",
+                    "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                     return_value={},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._upsert_simulation_progress_row",
+                    "scripts.start_historical_simulation_modules.lifecycle._upsert_simulation_progress_row",
                     return_value=None,
                 ),
             )
             mock_session_local = stack.enter_context(
-                patch("scripts.start_historical_simulation.SessionLocal")
+                patch(
+                    "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
+                )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._read_argocd_automation_mode",
+                    "scripts.start_historical_simulation_modules.lifecycle._read_argocd_automation_mode",
                     return_value={"mode": "auto"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._read_named_argocd_application_sync_policy",
+                    "scripts.start_historical_simulation_modules.lifecycle._read_named_argocd_application_sync_policy",
                     return_value={"sync_policy": {"automated": {"enabled": True}}},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._read_argocd_application_sync_policy",
+                    "scripts.start_historical_simulation_modules.lifecycle._read_argocd_application_sync_policy",
                     return_value={
                         "sync_policy": {"automated": {"enabled": True}},
                         "automation_mode": "auto",
@@ -529,13 +538,13 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._prepare_argocd_for_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                     return_value={"managed": False},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._restore_argocd_after_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                     side_effect=lambda **_: (
                         call_order.append("argocd_restore") or {"managed": False}
                     ),
@@ -543,7 +552,7 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._wait_for_torghut_service_revision_ready",
+                    "scripts.start_historical_simulation_modules.lifecycle._wait_for_torghut_service_revision_ready",
                     return_value={
                         "ready": True,
                         "condition_ready": "True",
@@ -555,31 +564,31 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._apply",
+                    "scripts.start_historical_simulation_modules.lifecycle._apply",
                     return_value={"status": "ok"},
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._run_rollouts_analysis",
+                    "scripts.start_historical_simulation_modules.lifecycle._run_rollouts_analysis",
                     side_effect=_rollouts_side_effect,
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._runtime_verify",
+                    "scripts.start_historical_simulation_modules.lifecycle._runtime_verify",
                     return_value={"runtime_state": "ready"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._replay_dump",
+                    "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._monitor_run_completion",
+                    "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                     return_value={
                         "status": "ok",
                         "activity_classification": "success",
@@ -597,19 +606,19 @@ class TestStartHistoricalSimulationLifecycleB(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._report_simulation",
+                    "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                    "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                     return_value={"status": "ok", "legacy_path_count": 0},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._teardown",
+                    "scripts.start_historical_simulation_modules.lifecycle._teardown",
                     side_effect=lambda **_: call_order.append("teardown") or None,
                 ),
             )

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_c.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_c.py
@@ -88,51 +88,54 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
         with ExitStack() as stack:
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._ensure_supported_binary",
+                    "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                     return_value=None,
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._update_run_state",
+                    "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                     return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._save_json", return_value=None
+                    "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                    return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation.persist_completion_trace",
+                    "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                     return_value={},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._upsert_simulation_progress_row",
+                    "scripts.start_historical_simulation_modules.lifecycle._upsert_simulation_progress_row",
                     return_value=None,
                 ),
             )
             mock_session_local = stack.enter_context(
-                patch("scripts.start_historical_simulation.SessionLocal")
+                patch(
+                    "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
+                )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._read_argocd_automation_mode",
+                    "scripts.start_historical_simulation_modules.lifecycle._read_argocd_automation_mode",
                     return_value={"mode": "auto"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._read_named_argocd_application_sync_policy",
+                    "scripts.start_historical_simulation_modules.lifecycle._read_named_argocd_application_sync_policy",
                     return_value={"sync_policy": {"automated": {"enabled": True}}},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._read_argocd_application_sync_policy",
+                    "scripts.start_historical_simulation_modules.lifecycle._read_argocd_application_sync_policy",
                     return_value={
                         "sync_policy": {"automated": {"enabled": True}},
                         "automation_mode": "auto",
@@ -142,13 +145,13 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._prepare_argocd_for_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                     return_value={"managed": False},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._restore_argocd_after_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                     side_effect=lambda **_: (
                         call_order.append("argocd_restore") or {"managed": False}
                     ),
@@ -156,31 +159,31 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._apply",
+                    "scripts.start_historical_simulation_modules.lifecycle._apply",
                     return_value={"status": "ok"},
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._run_rollouts_analysis",
+                    "scripts.start_historical_simulation_modules.lifecycle._run_rollouts_analysis",
                     side_effect=_rollouts_side_effect,
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._runtime_verify",
+                    "scripts.start_historical_simulation_modules.lifecycle._runtime_verify",
                     return_value={"runtime_state": "ready"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._replay_dump",
+                    "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._monitor_run_completion",
+                    "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                     return_value={
                         "status": "ok",
                         "activity_classification": "success",
@@ -198,25 +201,25 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._report_simulation",
+                    "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                    "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                     return_value={"status": "ok", "legacy_path_count": 0},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._teardown",
+                    "scripts.start_historical_simulation_modules.lifecycle._teardown",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._wait_for_torghut_service_revision_ready",
+                    "scripts.start_historical_simulation_modules.lifecycle._wait_for_torghut_service_revision_ready",
                     return_value={
                         "ready": False,
                         "condition_ready": "Unknown",
@@ -313,75 +316,78 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
         with ExitStack() as stack:
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._ensure_supported_binary",
+                    "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                     return_value=None,
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._update_run_state",
+                    "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                     return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._save_json", return_value=None
+                    "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                    return_value=None,
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation.persist_completion_trace",
+                    "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                     return_value={},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._upsert_simulation_progress_row",
+                    "scripts.start_historical_simulation_modules.lifecycle._upsert_simulation_progress_row",
                     return_value=None,
                 ),
             )
             mock_session_local = stack.enter_context(
-                patch("scripts.start_historical_simulation.SessionLocal")
+                patch(
+                    "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
+                )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._prepare_argocd_for_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                     return_value={"managed": False},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._restore_argocd_after_run",
+                    "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                     return_value={"managed": False},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._apply",
+                    "scripts.start_historical_simulation_modules.lifecycle._apply",
                     return_value={"status": "ok"},
                 )
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._run_rollouts_analysis",
+                    "scripts.start_historical_simulation_modules.lifecycle._run_rollouts_analysis",
                     side_effect=_rollouts_side_effect,
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._runtime_verify",
+                    "scripts.start_historical_simulation_modules.lifecycle._runtime_verify",
                     return_value={"runtime_state": "ready"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._replay_dump",
+                    "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._monitor_run_completion",
+                    "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                     return_value={
                         "status": "ok",
                         "activity_classification": "success",
@@ -399,19 +405,19 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._report_simulation",
+                    "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                     return_value={"status": "ok"},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                    "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                     return_value={"status": "ok", "legacy_path_count": 0},
                 ),
             )
             stack.enter_context(
                 patch(
-                    "scripts.start_historical_simulation._teardown",
+                    "scripts.start_historical_simulation_modules.lifecycle._teardown",
                     return_value={"status": "ok"},
                 ),
             )
@@ -494,52 +500,57 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._ensure_supported_binary",
+                "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation._update_run_state",
+                "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                 return_value=None,
             ),
-            patch("scripts.start_historical_simulation._save_json", return_value=None),
             patch(
-                "scripts.start_historical_simulation.persist_completion_trace",
+                "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                return_value=None,
+            ),
+            patch(
+                "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                 return_value={},
             ),
             patch(
-                "scripts.start_historical_simulation._upsert_simulation_progress_row",
+                "scripts.start_historical_simulation_modules.lifecycle._upsert_simulation_progress_row",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation.SessionLocal"
+                "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
             ) as mock_session_local,
             patch(
-                "scripts.start_historical_simulation._prepare_argocd_for_run",
+                "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._restore_argocd_after_run",
+                "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._apply",
+                "scripts.start_historical_simulation_modules.lifecycle._apply",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._run_rollouts_analysis",
+                "scripts.start_historical_simulation_modules.lifecycle._run_rollouts_analysis",
                 return_value={"phase": "Failed"},
             ),
             patch(
-                "scripts.start_historical_simulation._runtime_verify",
+                "scripts.start_historical_simulation_modules.lifecycle._runtime_verify",
                 return_value={"runtime_state": "not_ready"},
             ),
-            patch("scripts.start_historical_simulation._replay_dump") as replay_dump,
             patch(
-                "scripts.start_historical_simulation._report_simulation",
+                "scripts.start_historical_simulation_modules.lifecycle._replay_dump"
+            ) as replay_dump,
+            patch(
+                "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                 return_value={"status": "ok", "legacy_path_count": 0},
             ),
         ):
@@ -622,49 +633,53 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.start_historical_simulation._ensure_supported_binary",
+                "scripts.start_historical_simulation_modules.lifecycle._ensure_supported_binary",
                 return_value=None,
             ),
             patch(
-                "scripts.start_historical_simulation._update_run_state",
+                "scripts.start_historical_simulation_modules.lifecycle._update_run_state",
                 return_value=None,
             ),
-            patch("scripts.start_historical_simulation._save_json", return_value=None),
             patch(
-                "scripts.start_historical_simulation.persist_completion_trace",
+                "scripts.start_historical_simulation_modules.lifecycle._save_json",
+                return_value=None,
+            ),
+            patch(
+                "scripts.start_historical_simulation_modules.lifecycle.persist_completion_trace",
                 return_value={},
             ),
             patch(
-                "scripts.start_historical_simulation.SessionLocal"
+                "scripts.start_historical_simulation_modules.lifecycle.SessionLocal"
             ) as mock_session_local,
             patch(
-                "scripts.start_historical_simulation._prepare_argocd_for_run",
+                "scripts.start_historical_simulation_modules.lifecycle._prepare_argocd_for_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._restore_argocd_after_run",
+                "scripts.start_historical_simulation_modules.lifecycle._restore_argocd_after_run",
                 return_value={"managed": False},
             ),
             patch(
-                "scripts.start_historical_simulation._apply",
+                "scripts.start_historical_simulation_modules.lifecycle._apply",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._runtime_verify",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._runtime_verify",
                 side_effect=[
                     {"runtime_state": "not_ready"},
                     {"runtime_state": "ready"},
                 ],
             ) as runtime_verify_mock,
             patch(
-                "scripts.start_historical_simulation.time.sleep", return_value=None
+                "scripts.start_historical_simulation_modules.argocd_rollouts.time.sleep",
+                return_value=None,
             ) as sleep_mock,
             patch(
-                "scripts.start_historical_simulation._replay_dump",
+                "scripts.start_historical_simulation_modules.lifecycle._replay_dump",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._monitor_run_completion",
+                "scripts.start_historical_simulation_modules.lifecycle._monitor_run_completion",
                 return_value={
                     "status": "ok",
                     "activity_classification": "success",
@@ -680,11 +695,11 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
                 },
             ),
             patch(
-                "scripts.start_historical_simulation._report_simulation",
+                "scripts.start_historical_simulation_modules.lifecycle._report_simulation",
                 return_value={"status": "ok"},
             ),
             patch(
-                "scripts.start_historical_simulation._build_strategy_proof_artifact",
+                "scripts.start_historical_simulation_modules.lifecycle._build_strategy_proof_artifact",
                 return_value={"status": "ok", "legacy_path_count": 0},
             ),
         ):
@@ -822,11 +837,11 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -837,7 +852,7 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -852,145 +867,3 @@ class TestStartHistoricalSimulationLifecycleC(StartHistoricalSimulationTestCaseB
         self.assertEqual(report["environment_state"], "complete")
         self.assertEqual(report["torghut_service"]["name"], "torghut-sim")
         self.assertTrue(all(report["ta_runtime_config"].values()))
-
-    def test_runtime_verify_rejects_simple_sim_runtime_without_order_feed_telemetry(
-        self,
-    ) -> None:
-        manifest = {
-            "window": {
-                "start": "2026-03-06T14:30:00Z",
-                "end": "2026-03-06T15:30:00Z",
-            }
-        }
-        resources = _build_resources(
-            "sim-2026-03-06-open-hour",
-            {
-                "dataset_id": "dataset-a",
-                "runtime": {
-                    "target_mode": "dedicated_service",
-                    "namespace": "torghut",
-                    "ta_configmap": "torghut-ta-sim-config",
-                    "ta_deployment": "torghut-ta-sim",
-                    "torghut_service": "torghut-sim",
-                },
-            },
-        )
-        kservice_payload = {
-            "spec": {
-                "template": {
-                    "spec": {
-                        "containers": [
-                            {
-                                "name": "user-container",
-                                "env": [
-                                    {"name": "TRADING_ENABLED", "value": "true"},
-                                    {
-                                        "name": "TRADING_PIPELINE_MODE",
-                                        "value": "simple",
-                                    },
-                                    {
-                                        "name": "TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED",
-                                        "value": "false",
-                                    },
-                                    {
-                                        "name": "TRADING_SIMULATION_ENABLED",
-                                        "value": "true",
-                                    },
-                                    {
-                                        "name": "TRADING_STRATEGY_RUNTIME_MODE",
-                                        "value": "scheduler_v3",
-                                    },
-                                    {
-                                        "name": "TRADING_STRATEGY_SCHEDULER_ENABLED",
-                                        "value": "true",
-                                    },
-                                    {
-                                        "name": "TRADING_SIGNAL_TABLE",
-                                        "value": resources.clickhouse_signal_table,
-                                    },
-                                    {
-                                        "name": "TRADING_PRICE_TABLE",
-                                        "value": resources.clickhouse_price_table,
-                                    },
-                                    {
-                                        "name": "TRADING_ORDER_FEED_ENABLED",
-                                        "value": "true",
-                                    },
-                                    {
-                                        "name": "TRADING_ORDER_FEED_TOPIC",
-                                        "value": resources.simulation_topic_by_role[
-                                            "order_updates"
-                                        ],
-                                    },
-                                    {
-                                        "name": "TRADING_ORDER_FEED_AUTO_OFFSET_RESET",
-                                        "value": "latest",
-                                    },
-                                    {
-                                        "name": "TRADING_SIMULATION_ORDER_UPDATES_TOPIC",
-                                        "value": resources.simulation_topic_by_role[
-                                            "order_updates"
-                                        ],
-                                    },
-                                    {
-                                        "name": "TRADING_SIMULATION_RUN_ID",
-                                        "value": resources.run_id,
-                                    },
-                                    {
-                                        "name": "TRADING_SIGNAL_ALLOWED_SOURCES",
-                                        "value": "ws,ta",
-                                    },
-                                ],
-                            }
-                        ]
-                    }
-                }
-            },
-            "status": {
-                "latestReadyRevisionName": "torghut-sim-00001",
-                "conditions": [{"type": "Ready", "status": "True"}],
-            },
-        }
-        ta_configmap_payload = {
-            "data": {
-                "TA_TRADES_TOPIC": resources.simulation_topic_by_role["trades"],
-                "TA_QUOTES_TOPIC": resources.simulation_topic_by_role["quotes"],
-                "TA_BARS1M_TOPIC": resources.simulation_topic_by_role["bars"],
-                "TA_MICROBARS_TOPIC": resources.simulation_topic_by_role[
-                    "ta_microbars"
-                ],
-                "TA_SIGNALS_TOPIC": resources.simulation_topic_by_role["ta_signals"],
-                "TA_CLICKHOUSE_URL": f"jdbc:clickhouse://clickhouse/{resources.clickhouse_db}",
-            }
-        }
-
-        with (
-            patch(
-                "scripts.historical_simulation_verification._kubectl_json",
-                side_effect=[kservice_payload, ta_configmap_payload],
-            ),
-            patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
-                return_value={
-                    "name": "torghut-sim-00001-deployment",
-                    "ready_replicas": 1,
-                    "available_replicas": 1,
-                    "replicas": 1,
-                },
-            ),
-            patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
-                return_value={
-                    "name": "torghut-ta-sim",
-                    "desired_state": "running",
-                    "lifecycle_state": "RUNNING",
-                    "job_manager_status": "DEPLOYED",
-                },
-            ),
-        ):
-            report = _runtime_verify(resources=resources, manifest=manifest)
-
-        trading_config = report["torghut_service"]["trading_config"]
-        self.assertEqual(report["runtime_state"], "not_ready")
-        self.assertFalse(trading_config["simple_order_feed_telemetry"])
-        self.assertFalse(trading_config["order_feed_auto_offset_reset"])

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_d.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_lifecycle_d.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from tests.historical_simulation.start_historical_simulation_base import (
+    StartHistoricalSimulationTestCaseBase,
+    _build_resources,
+    _runtime_verify,
+    patch,
+)
+
+
+class TestStartHistoricalSimulationLifecycleD(StartHistoricalSimulationTestCaseBase):
+    def test_runtime_verify_rejects_simple_sim_runtime_without_order_feed_telemetry(
+        self,
+    ) -> None:
+        manifest = {
+            "window": {
+                "start": "2026-03-06T14:30:00Z",
+                "end": "2026-03-06T15:30:00Z",
+            }
+        }
+        resources = _build_resources(
+            "sim-2026-03-06-open-hour",
+            {
+                "dataset_id": "dataset-a",
+                "runtime": {
+                    "target_mode": "dedicated_service",
+                    "namespace": "torghut",
+                    "ta_configmap": "torghut-ta-sim-config",
+                    "ta_deployment": "torghut-ta-sim",
+                    "torghut_service": "torghut-sim",
+                },
+            },
+        )
+        kservice_payload = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "user-container",
+                                "env": [
+                                    {"name": "TRADING_ENABLED", "value": "true"},
+                                    {
+                                        "name": "TRADING_PIPELINE_MODE",
+                                        "value": "simple",
+                                    },
+                                    {
+                                        "name": "TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED",
+                                        "value": "false",
+                                    },
+                                    {
+                                        "name": "TRADING_SIMULATION_ENABLED",
+                                        "value": "true",
+                                    },
+                                    {
+                                        "name": "TRADING_STRATEGY_RUNTIME_MODE",
+                                        "value": "scheduler_v3",
+                                    },
+                                    {
+                                        "name": "TRADING_STRATEGY_SCHEDULER_ENABLED",
+                                        "value": "true",
+                                    },
+                                    {
+                                        "name": "TRADING_SIGNAL_TABLE",
+                                        "value": resources.clickhouse_signal_table,
+                                    },
+                                    {
+                                        "name": "TRADING_PRICE_TABLE",
+                                        "value": resources.clickhouse_price_table,
+                                    },
+                                    {
+                                        "name": "TRADING_ORDER_FEED_ENABLED",
+                                        "value": "true",
+                                    },
+                                    {
+                                        "name": "TRADING_ORDER_FEED_TOPIC",
+                                        "value": resources.simulation_topic_by_role[
+                                            "order_updates"
+                                        ],
+                                    },
+                                    {
+                                        "name": "TRADING_ORDER_FEED_AUTO_OFFSET_RESET",
+                                        "value": "latest",
+                                    },
+                                    {
+                                        "name": "TRADING_SIMULATION_ORDER_UPDATES_TOPIC",
+                                        "value": resources.simulation_topic_by_role[
+                                            "order_updates"
+                                        ],
+                                    },
+                                    {
+                                        "name": "TRADING_SIMULATION_RUN_ID",
+                                        "value": resources.run_id,
+                                    },
+                                    {
+                                        "name": "TRADING_SIGNAL_ALLOWED_SOURCES",
+                                        "value": "ws,ta",
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "latestReadyRevisionName": "torghut-sim-00001",
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+        }
+        ta_configmap_payload = {
+            "data": {
+                "TA_TRADES_TOPIC": resources.simulation_topic_by_role["trades"],
+                "TA_QUOTES_TOPIC": resources.simulation_topic_by_role["quotes"],
+                "TA_BARS1M_TOPIC": resources.simulation_topic_by_role["bars"],
+                "TA_MICROBARS_TOPIC": resources.simulation_topic_by_role[
+                    "ta_microbars"
+                ],
+                "TA_SIGNALS_TOPIC": resources.simulation_topic_by_role["ta_signals"],
+                "TA_CLICKHOUSE_URL": f"jdbc:clickhouse://clickhouse/{resources.clickhouse_db}",
+            }
+        }
+
+        with (
+            patch(
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
+                side_effect=[kservice_payload, ta_configmap_payload],
+            ),
+            patch(
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
+                return_value={
+                    "name": "torghut-sim-00001-deployment",
+                    "ready_replicas": 1,
+                    "available_replicas": 1,
+                    "replicas": 1,
+                },
+            ),
+            patch(
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
+                return_value={
+                    "name": "torghut-ta-sim",
+                    "desired_state": "running",
+                    "lifecycle_state": "RUNNING",
+                    "job_manager_status": "DEPLOYED",
+                },
+            ),
+        ):
+            report = _runtime_verify(resources=resources, manifest=manifest)
+
+        trading_config = report["torghut_service"]["trading_config"]
+        self.assertEqual(report["runtime_state"], "not_ready")
+        self.assertFalse(trading_config["simple_order_feed_telemetry"])
+        self.assertFalse(trading_config["order_feed_auto_offset_reset"])

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_postgres.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_postgres.py
@@ -48,19 +48,19 @@ class TestStartHistoricalSimulationPostgres(StartHistoricalSimulationTestCaseBas
 
         with (
             patch(
-                "scripts.start_historical_simulation._run_command",
+                "scripts.start_historical_simulation_modules.resource_planning._run_command",
                 side_effect=_fake_run_command,
             ),
             patch(
-                "scripts.start_historical_simulation._run_with_transient_postgres_retry",
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._run_with_transient_postgres_retry",
                 side_effect=_fake_retry,
             ),
             patch(
-                "scripts.start_historical_simulation.shutil.which",
+                "scripts.start_historical_simulation_modules.resource_planning.shutil.which",
                 return_value="/usr/bin/alembic",
             ),
             patch(
-                "scripts.start_historical_simulation._assert_required_simulation_metadata_tables",
+                "scripts.start_historical_simulation_modules.runtime_migrations._assert_required_simulation_metadata_tables",
                 return_value=None,
             ),
         ):
@@ -136,15 +136,15 @@ class TestStartHistoricalSimulationPostgres(StartHistoricalSimulationTestCaseBas
 
         with (
             patch(
-                "scripts.start_historical_simulation.psycopg.connect",
+                "scripts.start_historical_simulation_modules.storage_and_database.psycopg.connect",
                 side_effect=_fake_connect,
             ),
             patch(
-                "scripts.start_historical_simulation._run_with_transient_postgres_retry",
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._run_with_transient_postgres_retry",
                 side_effect=_fake_retry,
             ),
             patch(
-                "scripts.start_historical_simulation._postgres_extension_exists",
+                "scripts.start_historical_simulation_modules.storage_and_database._postgres_extension_exists",
                 return_value=True,
             ),
         ):
@@ -236,11 +236,11 @@ class TestStartHistoricalSimulationPostgres(StartHistoricalSimulationTestCaseBas
 
         with (
             patch(
-                "scripts.start_historical_simulation.psycopg.connect",
+                "scripts.start_historical_simulation_modules.storage_and_database.psycopg.connect",
                 return_value=_FakeConnection(),
             ),
             patch(
-                "scripts.start_historical_simulation._run_with_transient_postgres_retry",
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._run_with_transient_postgres_retry",
                 side_effect=_fake_retry,
             ),
         ):
@@ -319,11 +319,11 @@ class TestStartHistoricalSimulationPostgres(StartHistoricalSimulationTestCaseBas
 
         with (
             patch(
-                "scripts.start_historical_simulation.psycopg.connect",
+                "scripts.start_historical_simulation_modules.storage_and_database.psycopg.connect",
                 return_value=_FakeConnection(),
             ),
             patch(
-                "scripts.start_historical_simulation._run_with_transient_postgres_retry",
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._run_with_transient_postgres_retry",
                 side_effect=_fake_retry,
             ),
         ):
@@ -411,11 +411,11 @@ class TestStartHistoricalSimulationPostgres(StartHistoricalSimulationTestCaseBas
 
         with (
             patch(
-                "scripts.start_historical_simulation.psycopg.connect",
+                "scripts.start_historical_simulation_modules.storage_and_database.psycopg.connect",
                 return_value=_FakeConnection(),
             ),
             patch(
-                "scripts.start_historical_simulation._run_with_transient_postgres_retry",
+                "scripts.start_historical_simulation_modules.kubernetes_argocd._run_with_transient_postgres_retry",
                 side_effect=_fake_retry,
             ),
         ):

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_runtime_verify_a.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_runtime_verify_a.py
@@ -44,11 +44,12 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._kubectl_json",
                 side_effect=[pending_service, ready_service],
             ),
             patch(
-                "scripts.start_historical_simulation.time.sleep", return_value=None
+                "scripts.start_historical_simulation_modules.argocd_rollouts.time.sleep",
+                return_value=None,
             ) as sleep_mock,
         ):
             report = _wait_for_torghut_service_revision_ready(
@@ -85,11 +86,12 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.argocd_rollouts._kubectl_json",
                 return_value=pending_service,
             ),
             patch(
-                "scripts.start_historical_simulation.time.sleep", return_value=None
+                "scripts.start_historical_simulation_modules.argocd_rollouts.time.sleep",
+                return_value=None,
             ) as sleep_mock,
         ):
             report = _wait_for_torghut_service_revision_ready(
@@ -202,11 +204,11 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -217,7 +219,7 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -346,11 +348,11 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -361,7 +363,7 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -511,11 +513,11 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -526,7 +528,7 @@ class TestStartHistoricalSimulationRuntimeVerifyA(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-options-ta-sim",
                     "desired_state": "running",

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_runtime_verify_b.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_runtime_verify_b.py
@@ -116,7 +116,7 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[
                     kservice_payload,
                     autonomy_configmap_payload,
@@ -124,7 +124,7 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -135,7 +135,7 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -249,11 +249,11 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -264,7 +264,7 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -378,11 +378,11 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -393,7 +393,7 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -506,11 +506,11 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -521,7 +521,7 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -634,11 +634,11 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -649,7 +649,7 @@ class TestStartHistoricalSimulationRuntimeVerifyB(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_runtime_verify_c.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_runtime_verify_c.py
@@ -113,11 +113,11 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -128,7 +128,7 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -137,7 +137,7 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
                 },
             ),
             patch(
-                "scripts.historical_simulation_verification._http_json_get",
+                "scripts.historical_simulation_verification_modules.artifact_verification._http_json_get",
                 side_effect=[(200, "[]"), (404, "{}"), (200, "{}")],
             ),
         ):
@@ -175,7 +175,7 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
         }
 
         with patch(
-            "scripts.historical_simulation_verification._kubectl_json",
+            "scripts.historical_simulation_verification_modules.shared_runtime._kubectl_json",
             return_value=deployment,
         ):
             health = historical_simulation_verification._flink_runtime_health(
@@ -332,16 +332,21 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[
                     kservice_payload,
                     ta_configmap_payload,
+                ],
+            ),
+            patch(
+                "scripts.historical_simulation_verification_modules.artifact_verification._kubectl_json",
+                side_effect=[
                     runtime_template_payload,
                     activity_template_payload,
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -352,7 +357,7 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -498,16 +503,21 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.runtime_health._kubectl_json",
                 side_effect=[
                     kservice_payload,
                     ta_configmap_payload,
+                ],
+            ),
+            patch(
+                "scripts.historical_simulation_verification_modules.artifact_verification._kubectl_json",
+                side_effect=[
                     runtime_template_payload,
                     activity_template_payload,
                 ],
-            ) as kubectl_json,
+            ) as analysis_kubectl_json,
             patch(
-                "scripts.historical_simulation_verification._deployment_replica_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._deployment_replica_health",
                 side_effect=[
                     {
                         "name": "torghut-sim-00001-deployment",
@@ -518,7 +528,7 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
                 ],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.runtime_health._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -530,7 +540,9 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
             report = _runtime_verify(resources=resources, manifest=manifest)
 
         self.assertEqual(report["analysis_images"]["reason"], "ok")
-        kubectl_calls = [call.args[1][2] for call in kubectl_json.call_args_list[2:]]
+        kubectl_calls = [
+            call.args[1][2] for call in analysis_kubectl_json.call_args_list
+        ]
         self.assertEqual(
             kubectl_calls, ["torghut-runtime-ready-v1", "torghut-sim-activity-v1"]
         )
@@ -591,11 +603,11 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.artifact_verification._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.artifact_verification._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -687,11 +699,11 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.artifact_verification._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.artifact_verification._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "suspended",
@@ -775,11 +787,11 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.artifact_verification._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.artifact_verification._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",
@@ -870,11 +882,11 @@ class TestStartHistoricalSimulationRuntimeVerifyC(
 
         with (
             patch(
-                "scripts.historical_simulation_verification._kubectl_json",
+                "scripts.historical_simulation_verification_modules.artifact_verification._kubectl_json",
                 side_effect=[kservice_payload, ta_configmap_payload],
             ),
             patch(
-                "scripts.historical_simulation_verification._flink_runtime_health",
+                "scripts.historical_simulation_verification_modules.artifact_verification._flink_runtime_health",
                 return_value={
                     "name": "torghut-ta-sim",
                     "desired_state": "running",

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_service_config.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_service_config.py
@@ -60,7 +60,7 @@ class TestStartHistoricalSimulationServiceConfig(StartHistoricalSimulationTestCa
             raise AssertionError(f"unexpected request path: {path}")
 
         with patch(
-            "scripts.start_historical_simulation._http_request",
+            "scripts.start_historical_simulation_modules.kafka_runtime._http_request",
             side_effect=_fake_http_request,
         ):
             report = _ensure_simulation_schema_subjects(
@@ -140,11 +140,11 @@ class TestStartHistoricalSimulationServiceConfig(StartHistoricalSimulationTestCa
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_json",
                 return_value=service_payload,
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_patch",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_patch",
                 side_effect=lambda namespace, kind, name, patch: captured_patch.update(
                     {"namespace": namespace, "kind": kind, "name": name, "patch": patch}
                 ),
@@ -313,11 +313,11 @@ class TestStartHistoricalSimulationServiceConfig(StartHistoricalSimulationTestCa
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_json",
                 return_value=service_payload,
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_patch",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_patch",
                 side_effect=lambda namespace, kind, name, patch: captured_patch.update(
                     {"namespace": namespace, "kind": kind, "name": name, "patch": patch}
                 ),
@@ -426,11 +426,11 @@ class TestStartHistoricalSimulationServiceConfig(StartHistoricalSimulationTestCa
 
         with (
             patch(
-                "scripts.start_historical_simulation._kubectl_json",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_json",
                 return_value=service_payload,
             ),
             patch(
-                "scripts.start_historical_simulation._kubectl_patch",
+                "scripts.start_historical_simulation_modules.runtime_migrations._kubectl_patch",
                 side_effect=lambda namespace, kind, name, patch: captured_patch.update(
                     {"namespace": namespace, "kind": kind, "name": name, "patch": patch}
                 ),

--- a/services/torghut/tests/materialize_bounded_paper_route_targets/support.py
+++ b/services/torghut/tests/materialize_bounded_paper_route_targets/support.py
@@ -20,6 +20,9 @@ from app.trading.paper_route_target_plan import (
     materialize_bounded_paper_route_target_plan,
 )
 from scripts import materialize_bounded_paper_route_targets as cli
+from scripts.materialize_bounded_paper_route_targets_modules import (
+    target_materialization_core,
+)
 
 HPAIRS_DYNAMIC_SELECTED_PLAN_SOURCE_CONFIRMATION = ",".join(
     cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCES
@@ -353,5 +356,6 @@ __all__: tuple[str, ...] = (
     "select",
     "sessionmaker",
     "sqlite_dsn",
+    "target_materialization_core",
     "timezone",
 )

--- a/services/torghut/tests/materialize_bounded_paper_route_targets/test_commit_dynamic_plan_filters_to_active_target_window_subset.py
+++ b/services/torghut/tests/materialize_bounded_paper_route_targets/test_commit_dynamic_plan_filters_to_active_target_window_subset.py
@@ -14,6 +14,7 @@ from tests.materialize_bounded_paper_route_targets.support import (
     cli,
     json,
     pytest,
+    target_materialization_core,
 )
 
 
@@ -36,7 +37,9 @@ def test_commit_dynamic_plan_filters_to_active_target_window_subset(
             )
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -101,7 +104,9 @@ def test_commit_dynamic_plan_requires_active_target_window_without_skip(
             "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -154,7 +159,9 @@ def test_commit_dynamic_confirmation_rejects_wrong_selected_plan_source(
             "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -316,7 +323,9 @@ def test_plan_url_fetch_requests_json_path_query_and_closes(
         200,
         json.dumps({"targets": [_hpairs_target()]}).encode("utf-8"),
     )
-    monkeypatch.setattr(cli, "HTTPConnection", _CapturingConnection)
+    monkeypatch.setattr(
+        target_materialization_core, "HTTPConnection", _CapturingConnection
+    )
 
     payload = cli._fetch_plan_url_payload_once(
         "http://torghut-sim.torghut.svc.cluster.local:8080/trading/paper-route-target-plan?target_limit=1",
@@ -355,7 +364,9 @@ def test_plan_url_fetch_reports_status_json_and_payload_errors(
 ) -> None:
     _CapturingConnection.instances = []
     _CapturingConnection.response = _FakeResponse(status, body)
-    monkeypatch.setattr(cli, "HTTPConnection", _CapturingConnection)
+    monkeypatch.setattr(
+        target_materialization_core, "HTTPConnection", _CapturingConnection
+    )
 
     payload = cli._fetch_plan_url_payload_once(
         "http://torghut-sim.torghut.svc.cluster.local/plan",
@@ -372,8 +383,12 @@ def test_plan_url_fetch_reports_oversized_response(
 ) -> None:
     _CapturingConnection.instances = []
     _CapturingConnection.response = _FakeResponse(200, b"abcdef")
-    monkeypatch.setattr(cli, "HTTPConnection", _CapturingConnection)
-    monkeypatch.setattr(cli, "TARGET_PLAN_RESPONSE_LIMIT_BYTES", 5)
+    monkeypatch.setattr(
+        target_materialization_core, "HTTPConnection", _CapturingConnection
+    )
+    monkeypatch.setattr(
+        target_materialization_core, "TARGET_PLAN_RESPONSE_LIMIT_BYTES", 5
+    )
 
     payload = cli._fetch_plan_url_payload_once(
         "http://torghut-sim.torghut.svc.cluster.local/plan",
@@ -388,7 +403,9 @@ def test_plan_url_fetch_reports_request_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _RaisingConnection.instances = []
-    monkeypatch.setattr(cli, "HTTPConnection", _RaisingConnection)
+    monkeypatch.setattr(
+        target_materialization_core, "HTTPConnection", _RaisingConnection
+    )
 
     payload = cli._fetch_plan_url_payload_once(
         "http://torghut-sim.torghut.svc.cluster.local/plan",
@@ -416,8 +433,14 @@ def test_plan_url_fetch_retries_and_records_attempt_count(
             return {"load_error": "temporary"}
         return {"targets": [_hpairs_target()]}
 
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload_once", fake_fetch_once)
-    monkeypatch.setattr(cli.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload_once", fake_fetch_once
+    )
+    monkeypatch.setattr(
+        target_materialization_core.time,
+        "sleep",
+        lambda seconds: sleeps.append(seconds),
+    )
 
     payload = cli._fetch_plan_url_payload(
         "http://torghut-sim.torghut.svc.cluster.local/plan",
@@ -435,11 +458,11 @@ def test_plan_url_fetch_records_failed_attempt_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        cli,
+        target_materialization_core,
         "_fetch_plan_url_payload_once",
         lambda *_, **__: {"load_error": "still-down"},
     )
-    monkeypatch.setattr(cli.time, "sleep", lambda _: None)
+    monkeypatch.setattr(target_materialization_core.time, "sleep", lambda _: None)
 
     payload = cli._fetch_plan_url_payload(
         "http://torghut-sim.torghut.svc.cluster.local/plan",
@@ -459,7 +482,9 @@ def test_plan_url_payload_without_materializable_plan_is_reported(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(
-        cli, "_fetch_plan_url_payload", lambda *_, **__: {"targets": []}
+        target_materialization_core,
+        "_fetch_plan_url_payload",
+        lambda *_, **__: {"targets": []},
     )
 
     exit_code, payload = _run_cli(

--- a/services/torghut/tests/materialize_bounded_paper_route_targets/test_commit_url_nested_plan_with_dynamic_confirmation_writes_targets.py
+++ b/services/torghut/tests/materialize_bounded_paper_route_targets/test_commit_url_nested_plan_with_dynamic_confirmation_writes_targets.py
@@ -9,6 +9,7 @@ from tests.materialize_bounded_paper_route_targets.support import (
     _tsmom_target,
     cli,
     pytest,
+    target_materialization_core,
 )
 
 
@@ -35,7 +36,9 @@ def test_commit_url_nested_plan_with_dynamic_confirmation_writes_targets(
             "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -98,7 +101,9 @@ def test_commit_dynamic_plan_skips_before_active_target_window_without_writes(
             "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -178,7 +183,9 @@ def test_commit_dynamic_source_collection_plan_skips_without_target_window(
             )
         }
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -252,7 +259,9 @@ def test_commit_dynamic_plan_confirms_strategy_lookup_alias_before_skip(
             )
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -322,7 +331,9 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_skips_before_ope
             )
         ),
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -394,7 +405,9 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_writes_when_open
             )
         ),
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -472,7 +485,9 @@ def test_commit_dynamic_plan_prefers_materializable_next_window_over_stale_hpair
             _hpairs_target(target_notional="75000")
         ),
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -535,7 +550,9 @@ def test_commit_dynamic_next_window_plan_filters_to_confirmed_hpairs_target(
             _hpairs_target(target_notional="75000"),
         ),
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -653,7 +670,9 @@ def test_commit_dynamic_source_allowlist_selects_active_next_window_over_closed_
             )
         ),
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -708,7 +727,9 @@ def test_commit_dynamic_next_window_plan_blocks_when_confirmed_target_is_absent(
     payload = {
         "next_paper_route_runtime_window_targets": _plan(_tsmom_target()),
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [

--- a/services/torghut/tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py
+++ b/services/torghut/tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py
@@ -20,6 +20,7 @@ from tests.materialize_bounded_paper_route_targets.support import (
     materialize_bounded_paper_route_target_plan,
     pytest,
     select,
+    target_materialization_core,
     timezone,
 )
 
@@ -607,7 +608,9 @@ def test_url_payload_prefers_nested_hpairs_materialization_plan(
             "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -673,7 +676,9 @@ def test_url_payload_accepts_trading_proofs_materialization_plan(
             "final_promotion_allowed": False,
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -726,7 +731,9 @@ def test_url_payload_prefers_bounded_plan_over_larger_source_collection_plan(
             "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
         },
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [
@@ -763,7 +770,9 @@ def test_source_collection_only_plan_blocks_materialization_before_db_write(
             ),
         ),
     }
-    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+    monkeypatch.setattr(
+        target_materialization_core, "_fetch_plan_url_payload", lambda *_, **__: payload
+    )
 
     exit_code, report = _run_cli(
         [

--- a/services/torghut/tests/test_main_api_refactor.py
+++ b/services/torghut/tests/test_main_api_refactor.py
@@ -8,7 +8,7 @@ from app import main as main_module
 from app.api import common as api_common
 from app.api import proofs as proofs_api
 from app.api.application import get_app
-from app.trading import TradingScheduler
+from app.trading.scheduler import TradingScheduler
 
 
 def _route_methods() -> dict[str, set[str]]:


### PR DESCRIPTION
## Summary

- Removed dynamic facade patch plumbing from Torghut historical simulation and bounded paper-route target scripts, replacing delegate wrappers with explicit owner-module exports.
- Moved historical simulation and materialization tests off facade patch targets and onto the modules that own the patched behavior.
- Removed lazy package export hooks in `app.trading`, `app.trading.discovery`, and `app.trading.alpha`, preserving public exports with explicit imports and breaking the alpha/discovery import cycle with function-local discovery imports.
- Split the oversized historical simulation lifecycle test file and fixed the remaining stale runtime-verification mock so CI shard 2 no longer calls real `kubectl`.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `python -m compileall -q app scripts tests/historical_simulation tests/materialize_bounded_paper_route_targets`
- `uv run --frozen pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-dynamic-attribute-hook,torghut-wildcard-import,torghut-custom-module-class --score=n app scripts`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base "$(git rev-parse origin/main)" <changed-python-files>`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen pytest tests/test_main_api_refactor.py tests/test_paper_route_evidence_adapter.py tests/test_jangar_continuity.py tests/fast_replay tests/whitepaper_autoresearch/test_autoresearch_runner_fast_replay.py tests/autoresearch_runner/test_replay_tape_preview.py tests/autoresearch_runner/test_staged_replay_frontier_default_resolvers_enable_bounded_real_path.py tests/tca_adaptive_policy tests/order_feed tests/historical_simulation tests/materialize_bounded_paper_route_targets`
- `uv run --frozen pytest tests/historical_simulation/test_start_historical_simulation_runtime_verify_c.py::TestStartHistoricalSimulationRuntimeVerifyC::test_runtime_verify_rejects_stale_analysis_template_images`
- CI shard 2 equivalent: `find tests -name 'test_*.py' ! -path 'tests/autoresearch_runner/*' -print | sort | awk -v shard=2 -v total=4 '((NR - 1) % total) == shard'`, then `uv run --frozen pytest -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report= <selected files>`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A - backend Python refactor only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
