### PR TITLE
fix(rook-ceph): keep three monitors in gitops

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -46,8 +46,8 @@ cephClusterSpec:
   dataDirHostPath: /var/lib/rook
 
   mon:
-    count: 2
-    # Run monitors on available control-plane nodes. Turin replaces the old
+    count: 3
+    # Run monitors across the available control-plane nodes. Turin replaces the old
     # ampone/talos-192-168-1-203 control-plane slot.
     allowMultiplePerNode: false
 


### PR DESCRIPTION
## Summary

- Keep the Rook CephCluster desired monitor count at 3 to match the live healthy quorum.
- Avoid an unnecessary monitor downscale while the cluster is still recovering degraded PGs.
- Keep the Turin monitor placement comment aligned with the three-node control-plane layout.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph > /tmp/rook-ceph-render.yaml`
- `kubectl --context galactic-tailscale apply --server-side --dry-run=server --field-manager=argocd-controller -f /tmp/rook-ceph-targeted-render.yaml`
- `bun run lint:argocd`
- Live readback before change: `CephCluster.spec.mon.count=3`, `ceph quorum_status` quorum names `a,e,h`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
