### PR TITLE
feat(home): bootstrap private media repo

### DIFF
--- a/argocd/applications/volume-snapshot-controller/kustomization.yaml
+++ b/argocd/applications/volume-snapshot-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=v8.6.0
+  - https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=v8.6.0
+  - snapshot-classes.yaml

--- a/argocd/applications/volume-snapshot-controller/snapshot-classes.yaml
+++ b/argocd/applications/volume-snapshot-controller/snapshot-classes.yaml
@@ -1,0 +1,23 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: rook-ceph-block
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: rook-ceph.rbd.csi.ceph.com
+deletionPolicy: Delete
+parameters:
+  clusterID: rook-ceph
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: rook-cephfs
+driver: rook-ceph.cephfs.csi.ceph.com
+deletionPolicy: Delete
+parameters:
+  clusterID: rook-ceph
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph

--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -24,6 +24,8 @@ spec:
                   automation: manual
                   enabled: "true"
                   managedNamespaceMetadata:
+                    labels:
+                      external-secrets.proompteng.ai/enabled: "true"
                     annotations:
                       # Prevent accidental namespace deletion when an app stops managing the Namespace object.
                       argocd.argoproj.io/sync-options: Prune=false

--- a/argocd/applicationsets/home-repo-credentials.yaml
+++ b/argocd/applicationsets/home-repo-credentials.yaml
@@ -1,0 +1,40 @@
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: SSHKey
+metadata:
+  name: home-repo-deploy-key
+  namespace: argocd
+spec:
+  keyType: ed25519
+  comment: argocd-home-repo@galactic
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-repo
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "9"
+spec:
+  refreshPolicy: CreatedOnce
+  target:
+    name: home-repo
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repository
+      type: Opaque
+      data:
+        name: home
+        type: git
+        url: git@github.com:gregkonush/home.git
+        sshPrivateKey: "{{ .privateKey }}"
+        sshPublicKey: "{{ .publicKey }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: SSHKey
+          name: home-repo-deploy-key

--- a/argocd/applicationsets/home-root.yaml
+++ b/argocd/applicationsets/home-root.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: home-root
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: git@github.com:gregkonush/home.git
+    targetRevision: main
+    path: argocd
+  syncPolicy:
+    automated:
+      enabled: true
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+      refresh: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+      - PruneLast=true
+      - ClientSideApplyMigration=false

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -83,6 +83,13 @@ spec:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: auto
                 enabled: "true"
+              - name: volume-snapshot-controller
+                path: argocd/applications/volume-snapshot-controller
+                namespace: kube-system
+                annotations:
+                  argocd.argoproj.io/sync-wave: "-1"
+                automation: auto
+                enabled: "true"
               - name: feature-flags
                 path: argocd/applications/feature-flags
                 namespace: feature-flags


### PR DESCRIPTION
## Summary

- Adds root-managed External Secrets SSH key generation for the private `gregkonush/home` Argo repository.
- Adds the `home-root` Argo CD Application with auto-sync, prune, and self-heal.
- Adds the external-snapshotter controller and Rook RBD/CephFS `VolumeSnapshotClass` resources.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl --context galactic-tailscale apply --dry-run=server -f argocd/applicationsets/home-repo-credentials.yaml -f argocd/applicationsets/home-root.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/volume-snapshot-controller > /tmp/lab-snapshot.yaml`
- `kubeconform -strict -ignore-missing-schemas -summary /tmp/lab-snapshot.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
