### PR TITLE
feat(gpu): share turin gpu with time slicing

### DIFF
--- a/argocd/applications/nvidia-gpu-operator/turin-nvidia-device-plugin.yaml
+++ b/argocd/applications/nvidia-gpu-operator/turin-nvidia-device-plugin.yaml
@@ -4,6 +4,22 @@ metadata:
   name: turin-nvidia-device-plugin
   namespace: gpu-operator
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: turin-nvidia-device-plugin-config
+  namespace: gpu-operator
+data:
+  config.yaml: |
+    version: v1
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        failRequestsGreaterThanOne: true
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 8
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -44,6 +60,8 @@ spec:
       app: turin-nvidia-device-plugin
   template:
     metadata:
+      annotations:
+        platform.proompteng.ai/gpu-sharing-config-version: turin-timeslicing-8
       labels:
         app: turin-nvidia-device-plugin
     spec:
@@ -88,9 +106,14 @@ spec:
               value: "true"
             - name: CDI_ANNOTATION_PREFIX
               value: cdi.k8s.io/
+            - name: CONFIG_FILE
+              value: /config/config.yaml
           securityContext:
             privileged: true
           volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
             - name: driver-install-dir
@@ -103,6 +126,9 @@ spec:
             - name: cdi-root
               mountPath: /var/run/cdi
       volumes:
+        - name: config
+          configMap:
+            name: turin-nvidia-device-plugin-config
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
## Summary

- Adds a Turin NVIDIA device-plugin config file that enables CUDA time-slicing with eight shared `nvidia.com/gpu` replicas.
- Mounts the config into the existing custom Turin-only device-plugin DaemonSet and points the plugin at it with `CONFIG_FILE`.
- Bumps the DaemonSet pod template annotation so Argo rolls the plugin and refreshes node allocatable GPU shares.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/nvidia-gpu-operator > /tmp/nvidia-gpu-operator.yaml`
- `kubeconform -strict -ignore-missing-schemas -summary /tmp/nvidia-gpu-operator.yaml`
- `kubectl --context galactic-tailscale apply --dry-run=server -f argocd/applications/nvidia-gpu-operator/turin-nvidia-device-plugin.yaml`
- `bun run lint:argocd`
- Full rendered server dry-run was attempted; it hit the existing Helm Job immutability issue for `gpu-operator-node-feature-discovery-prune`, outside this DaemonSet/ConfigMap change.

## Breaking Changes

Turin `nvidia.com/gpu` requests become shared time-sliced accesses. Time-slicing does not provide GPU memory or fault isolation, so only trusted local workloads should share the card.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
