### PR TITLE
fix(torghut): cast hyperliquid feature ttl timestamp

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
@@ -37,7 +37,7 @@ data:
     ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/hyperliquid_ta_features', '{replica}', ingest_ts)
     PARTITION BY toDate(event_ts)
     ORDER BY (network, market_id, interval, event_ts)
-    TTL event_ts + INTERVAL 90 DAY
+    TTL toDateTime(event_ts) + INTERVAL 90 DAY
     SETTINGS index_granularity = 8192;
 
     CREATE MATERIALIZED VIEW IF NOT EXISTS torghut.hyperliquid_ta_features_candle_mv ON CLUSTER default


### PR DESCRIPTION
## Summary

- Fixes the Hyperliquid runtime ClickHouse schema hook that failed in-cluster on `DateTime64` TTL validation.
- Keeps millisecond `event_ts` storage/query precision and casts only the TTL expression to `DateTime`.
- Unblocks the GitOps rollout for `torghut-hyperliquid-runtime`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-ttl-fix.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
