### PR TITLE
fix(torghut): bound hyperliquid schema ddl wait

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
@@ -7,6 +7,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "-2"
 data:
   schema.sql: |-
+    SET distributed_ddl_output_mode = 'null_status_on_timeout';
+    SET distributed_ddl_task_timeout = 60;
+
     CREATE DATABASE IF NOT EXISTS torghut ON CLUSTER default;
 
     CREATE TABLE IF NOT EXISTS torghut.hyperliquid_ta_features ON CLUSTER default


### PR DESCRIPTION
## Summary

- Bounds the Hyperliquid runtime ClickHouse schema hook distributed DDL wait to 60 seconds.
- Uses `null_status_on_timeout` so inactive or slow distributed DDL replicas do not leave the Argo hook hanging indefinitely.
- Preserves the fixed `DateTime64` TTL cast from the prior rollout fix.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-ddl-timeout.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
