### PR TITLE
fix(torghut): use hyperliquid candle event timestamp directly

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
@@ -48,7 +48,7 @@ data:
     AS
     SELECT
       now64(3) AS ingest_ts,
-      toDateTime64(parseDateTimeBestEffort(event_ts), 3, 'UTC') AS event_ts,
+      event_ts,
       network,
       coalesce(market_id, symbol) AS market_id,
       coalesce(coin, symbol) AS coin,
@@ -68,7 +68,7 @@ data:
       0 AS funding_rate,
       0 AS open_interest_usd,
       multiIf(_return_bps > 8, 'trend_up', _return_bps < -8, 'trend_down', 'range') AS regime,
-      greatest(0, dateDiff('second', toDateTime(parseDateTimeBestEffort(event_ts)), now())) AS source_lag_seconds
+      greatest(0, dateDiff('second', toDateTime(event_ts), now())) AS source_lag_seconds
     FROM
     (
       SELECT


### PR DESCRIPTION
## Summary

- Fixes the Hyperliquid runtime ClickHouse materialized view for the live `hyperliquid_candles.event_ts` type.
- Uses the existing `DateTime64` event timestamp directly instead of reparsing it as a string.
- Keeps source-lag calculation by casting the timestamp to `DateTime` only for `dateDiff`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-event-ts-fix.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
