### PR TITLE
fix(torghut): allow external secret store access

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -280,6 +280,7 @@ spec:
                   - ClientSideApplyMigration=false
                 managedNamespaceMetadata:
                   labels:
+                    external-secrets.proompteng.ai/enabled: "true"
                     pod-security.kubernetes.io/enforce: privileged
                     pod-security.kubernetes.io/audit: privileged
                     pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary

- Adds the External Secrets opt-in label to the GitOps-managed `torghut` namespace metadata.
- Allows the Hyperliquid testnet runtime `ExternalSecret` to use the `onepassword-infra` ClusterSecretStore.
- Keeps the change scoped to namespace authorization; no secret values are added.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
