### PR TITLE
fix(torghut): filter hyperliquid latest features before aggregate

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
@@ -110,6 +110,10 @@ data:
       argMax(open_interest_usd, event_ts) AS open_interest_usd,
       argMax(regime, event_ts) AS regime,
       argMax(source_lag_seconds, event_ts) AS source_lag_seconds
-    FROM torghut.hyperliquid_ta_features
-    WHERE event_ts >= now() - INTERVAL 2 HOUR
+    FROM
+    (
+      SELECT *
+      FROM torghut.hyperliquid_ta_features
+      WHERE event_ts >= now() - INTERVAL 2 HOUR
+    )
     GROUP BY network, market_id;


### PR DESCRIPTION
## Summary

- Fixes the Hyperliquid runtime latest-features ClickHouse view by filtering source rows before aggregation.
- Preserves the output `event_ts` column while avoiding aggregate-alias substitution in `WHERE`.
- Unblocks the runtime schema hook after the materialized view succeeds.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-latest-features-view.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
