### PR TITLE
chore(torghut): roll hyperliquid feed deployment

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-top-volume-100-20260618a
+        proompteng.ai/config-revision: hyperliquid-top-volume-100-20260618b
       labels:
         app: torghut-hyperliquid-feed
     spec:


### PR DESCRIPTION
## Summary

- Bumps the `torghut-hyperliquid-feed` pod-template config revision annotation.
- Forces the GitOps deployment to roll and reload the synced readiness ConfigMap.
- Allows the pod to pull the rebuilt `torghut-hyperliquid-feed:latest` image after the feed readiness hardening merge.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed >/tmp/torghut-hyperliquid-feed-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
