### PR TITLE
fix(headlamp): pin multi-arch image

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: e905c4feec57a67536b36543b8cf3d3026ed1debec369dac12736fee490fa4e0
+  tag: 8eb9e769d8793e6a8880c8006f46a3235cb8e68f22eefbab8350f5dc04999b39
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:


### PR DESCRIPTION
## Summary

- Pin Headlamp GitOps to the newly published multi-arch Headlamp image index.
- Preserve node-agnostic scheduling by using an image digest that supports both linux/amd64 and linux/arm64.
- Unblock the Headlamp Deployment from the current ImagePullBackOff on amd64 nodes.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp > /tmp/headlamp-render.yaml`
- `yq e 'select(.kind == "Deployment" and .metadata.name == "headlamp") | .spec.template.spec.containers[] | select(.name == "headlamp").image' /tmp/headlamp-render.yaml`
- `bun run lint:argocd`
- `git diff --check`
- `crane manifest registry.ide-newton.ts.net/lab/headlamp@sha256:8eb9e769d8793e6a8880c8006f46a3235cb8e68f22eefbab8350f5dc04999b39 | jq -e '[.manifests[] | select(.platform.os=="linux") | .platform.architecture] | sort == ["amd64","arm64"]'`
- Temporary cluster image-pull smoke succeeded on amd64 `turin` and arm64 `talos-192-168-1-85`; both pods printed `ok-*` and the namespace was deleted.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
