### PR TITLE
chore(torghut): clarify hyperliquid credential bootstrap

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/README.md
+++ b/argocd/applications/torghut-hyperliquid-runtime/README.md
@@ -17,16 +17,28 @@ To enable tiny testnet orders, create and authorize a Hyperliquid testnet API/ag
 Use the repo bootstrap helper after signing in to 1Password CLI:
 
 ```bash
+scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh status
 scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh create
 scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile
 ```
 
-Then set `HYPERLIQUID_RUNTIME_TRADING_ENABLED` to `true` in `configmap.yaml`. Keep the default caps unless a separate rollout approves a larger envelope. The runtime must continue to report `execution_network=testnet`; mainnet execution is rejected by config validation.
+`status` is safe to run repeatedly. It reports only whether the 1Password item, required fields, ExternalSecret,
+and target Kubernetes Secret exist; it does not print credential values.
+
+Until the 1Password item exists and the ExternalSecret is Ready, Argo may report this app as degraded even when
+the runtime pod is healthy in shadow mode. Do not hide that health signal. It is the guard that prevents calling
+the order path ready before credentials exist.
+
+After `reconcile` reports the bootstrap as ready, open a GitOps PR that sets
+`HYPERLIQUID_RUNTIME_TRADING_ENABLED` to `true` in `configmap.yaml`. Keep the default caps unless a separate
+rollout approves a larger envelope. The runtime must continue to report `execution_network=testnet`; mainnet
+execution is rejected by config validation.
 
 Acceptance checks:
 
 - `kubectl -n argocd get application torghut-hyperliquid-runtime`
 - `kubectl -n torghut rollout status deploy/torghut-hyperliquid-runtime --timeout=180s`
 - `kubectl -n torghut get externalsecret torghut-hyperliquid-testnet`
+- `kubectl -n torghut get secret torghut-hyperliquid-testnet`
 - `kubectl -n torghut exec deploy/torghut-hyperliquid-runtime -- curl -fsS localhost:8182/readyz`
 - `kubectl -n torghut exec deploy/torghut-hyperliquid-runtime -- curl -fsS localhost:8182/metrics`

--- a/scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh
+++ b/scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh
@@ -7,6 +7,7 @@ ITEM="${HYPERLIQUID_TESTNET_1PASSWORD_ITEM:-hyperliquid-testnet}"
 usage() {
   cat <<EOF
 Usage:
+  $0 status
   $0 check
   $0 create
   $0 reconcile
@@ -45,6 +46,86 @@ check_item() {
   op read --no-newline "op://${VAULT}/${ITEM}/account-address" >/dev/null
   op read --no-newline "op://${VAULT}/${ITEM}/api-wallet-private-key" >/dev/null
   echo "1Password item is present: op://${VAULT}/${ITEM}"
+}
+
+status() {
+  local ready=true
+
+  if command -v op >/dev/null 2>&1 && op whoami >/dev/null 2>&1; then
+    echo "1Password CLI: signed in"
+    if op item get "${ITEM}" --vault "${VAULT}" --format json >/dev/null 2>&1; then
+      echo "1Password item: present at op://${VAULT}/${ITEM}"
+    else
+      echo "1Password item: missing at op://${VAULT}/${ITEM}"
+      ready=false
+    fi
+
+    for field in account-address api-wallet-private-key; do
+      if op read --no-newline "op://${VAULT}/${ITEM}/${field}" >/dev/null 2>&1; then
+        echo "1Password field ${field}: present"
+      else
+        echo "1Password field ${field}: missing"
+        ready=false
+      fi
+    done
+  else
+    echo "1Password CLI: not signed in"
+    ready=false
+  fi
+
+  if command -v kubectl >/dev/null 2>&1; then
+    local external_secret_status=""
+    local external_secret_reason=""
+    local external_secret_message=""
+
+    if kubectl -n torghut get externalsecret torghut-hyperliquid-testnet >/dev/null 2>&1; then
+      external_secret_status="$(
+        kubectl -n torghut get externalsecret torghut-hyperliquid-testnet \
+          -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.status}{end}' 2>/dev/null || true
+      )"
+      external_secret_reason="$(
+        kubectl -n torghut get externalsecret torghut-hyperliquid-testnet \
+          -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.reason}{end}' 2>/dev/null || true
+      )"
+      external_secret_message="$(
+        kubectl -n torghut get externalsecret torghut-hyperliquid-testnet \
+          -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.message}{end}' 2>/dev/null || true
+      )"
+
+      echo "ExternalSecret Ready: ${external_secret_status:-Unknown}"
+      if [[ -n "${external_secret_reason}" ]]; then
+        echo "ExternalSecret reason: ${external_secret_reason}"
+      fi
+      if [[ -n "${external_secret_message}" ]]; then
+        echo "ExternalSecret message: ${external_secret_message}"
+      fi
+
+      if [[ "${external_secret_status}" != "True" ]]; then
+        ready=false
+      fi
+    else
+      echo "ExternalSecret: missing in namespace torghut"
+      ready=false
+    fi
+
+    if kubectl -n torghut get secret torghut-hyperliquid-testnet >/dev/null 2>&1; then
+      echo "Kubernetes Secret: present"
+    else
+      echo "Kubernetes Secret: missing"
+      ready=false
+    fi
+  else
+    echo "kubectl: missing"
+    ready=false
+  fi
+
+  if [[ "${ready}" == "true" ]]; then
+    echo "Hyperliquid testnet secret bootstrap: ready"
+    return 0
+  fi
+
+  echo "Hyperliquid testnet secret bootstrap: not ready"
+  return 1
 }
 
 create_item() {
@@ -137,10 +218,18 @@ reconcile_external_secret() {
   kubectl -n torghut annotate externalsecret torghut-hyperliquid-testnet \
     "force-sync=$(date +%s)" \
     --overwrite
-  kubectl -n torghut get externalsecret torghut-hyperliquid-testnet
+  if ! kubectl -n torghut wait --for=condition=Ready externalsecret/torghut-hyperliquid-testnet --timeout=120s; then
+    echo "ExternalSecret did not become Ready after reconcile." >&2
+    status || true
+    exit 1
+  fi
+  status
 }
 
 case "${1:-}" in
+  status)
+    status
+    ;;
   check)
     check_item
     ;;


### PR DESCRIPTION
## Summary

- Adds a safe `status` command to the Hyperliquid testnet 1Password bootstrap helper.
- Makes `reconcile` wait for the ExternalSecret to become Ready before reporting success.
- Documents that the runtime app should remain visibly degraded until the testnet credential item resolves.

## Related Issues

None

## Testing

- `bash -n scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh && scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh --help`
- `shellcheck scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh`
- `scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh status` returned not ready, with 1Password not signed in, ExternalSecret `SecretSyncedError`, and missing target Secret.
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
