### PR TITLE
fix(torghut): identify configured paper proofs

### DIFF
--- a/services/torghut/app/api/proofs_configured_collection.py
+++ b/services/torghut/app/api/proofs_configured_collection.py
@@ -57,6 +57,10 @@ def configured_strategy_paper_collection_symbols(strategy: Strategy) -> list[str
     return static_symbols
 
 
+def configured_strategy_paper_collection_hypothesis_id(strategy_name: str) -> str:
+    return f"configured-paper-collection:{strategy_name}"
+
+
 def configured_strategy_paper_collection_targets(
     session: Session,
     *,
@@ -74,7 +78,9 @@ def configured_strategy_paper_collection_targets(
         if not strategy_name:
             continue
         target = {
-            "hypothesis_id": None,
+            "hypothesis_id": configured_strategy_paper_collection_hypothesis_id(
+                strategy_name
+            ),
             "candidate_id": f"configured:{strategy_name}",
             "strategy_name": strategy_name,
             "runtime_strategy_name": strategy_name,
@@ -162,6 +168,7 @@ __all__ = [
     "strategy_universe_symbol_values",
     "configured_static_symbol_allowlist",
     "configured_strategy_paper_collection_symbols",
+    "configured_strategy_paper_collection_hypothesis_id",
     "configured_strategy_paper_collection_targets",
     "configured_paper_collection_target_plan",
 ]

--- a/services/torghut/tests/api/test_trading_api_paper_route_cache.py
+++ b/services/torghut/tests/api/test_trading_api_paper_route_cache.py
@@ -322,6 +322,10 @@ class TestTradingApiPaperRouteCache(TradingApiTestCaseBase):
         self.assertNotIn("disabled-paper-collector", targets_by_name)
         target = targets_by_name["enabled-paper-collector"]
         self.assertEqual(target["account_label"], "TORGHUT_SIM")
+        self.assertEqual(
+            target["hypothesis_id"],
+            "configured-paper-collection:enabled-paper-collector",
+        )
         self.assertEqual(target["paper_route_probe_symbols"], ["AAPL", "NVDA"])
         self.assertEqual(target["paper_route_probe_next_session_max_notional"], "100")
         self.assertTrue(target["paper_data_collection_authorized"])

--- a/services/torghut/tests/api/test_trading_api_paper_route_identity.py
+++ b/services/torghut/tests/api/test_trading_api_paper_route_identity.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from app.api import proofs as proofs_api
+
+from tests.api.trading_api_support import (
+    Strategy,
+    TradingApiTestCaseBase,
+    datetime,
+    timezone,
+)
+
+
+class TestTradingApiPaperRouteIdentity(TradingApiTestCaseBase):
+    def test_configured_paper_collection_proofs_have_identity_fields(self) -> None:
+        original_mode = proofs_api.settings.trading_mode
+        original_static_symbols_raw = proofs_api.settings.trading_static_symbols_raw
+        try:
+            proofs_api.settings.trading_mode = "live"
+            proofs_api.settings.trading_static_symbols_raw = "AAPL,NVDA"
+            with self.session_local() as session:
+                session.add(
+                    Strategy(
+                        name="identity-collector",
+                        description="identity collector",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=["AAPL", "NVDA"],
+                    )
+                )
+                session.commit()
+                live_submission_gate = (
+                    proofs_api._with_configured_paper_collection_targets(
+                        {},
+                        simple_lane_status={
+                            "paper_route_probe_enabled": True,
+                            "paper_route_probe_allow_live_mode": True,
+                            "paper_route_probe_max_notional": "100",
+                        },
+                        session=session,
+                    )
+                )
+                payload = proofs_api.build_proofs_payload(
+                    session,
+                    live_submission_gate=live_submission_gate,
+                    route_reacquisition_book={},
+                    generated_at=datetime(2026, 6, 18, 12, tzinfo=timezone.utc),
+                    kind="runtime_window",
+                    limit=20,
+                    window="next",
+                    full_audit=False,
+                    target_account_audit_available=True,
+                )
+        finally:
+            proofs_api.settings.trading_mode = original_mode
+            proofs_api.settings.trading_static_symbols_raw = original_static_symbols_raw
+
+        matching_proofs = [
+            proof
+            for proof in payload["proofs"]
+            if proof["identity"]["candidate_id"] == "configured:identity-collector"
+        ]
+        self.assertEqual(len(matching_proofs), 1)
+        proof = matching_proofs[0]
+        identity = proof["identity"]
+        self.assertEqual(
+            identity["hypothesis_id"],
+            "configured-paper-collection:identity-collector",
+        )
+        self.assertEqual(identity["strategy_name"], "identity-collector")
+        self.assertEqual(identity["runtime_strategy_name"], "identity-collector")
+        self.assertNotIn("missing-hypothesis", proof["proof_id"])
+        self.assertTrue(proof["window"]["start"])
+        self.assertTrue(proof["window"]["end"])


### PR DESCRIPTION
## Summary

- Adds deterministic non-authoritative hypothesis IDs for configured paper collection fallback targets.
- Preserves the collection-only contract by keeping promotion and final promotion blocked for these targets.
- Adds a regression proving `/trading/proofs` serialization has the identity fields required by post-deploy paper-route mirror verification.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/api/test_trading_api_paper_route_cache.py tests/api/test_trading_api_paper_route_identity.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main tests/api/test_trading_api_paper_route_cache.py tests/api/test_trading_api_paper_route_identity.py`
- `uv run --frozen python -m compileall app scripts`
- `uv run --frozen ruff format --check app tests scripts migrations && uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/api/test_trading_api_paper_route_cache.py tests/api/test_trading_api_paper_route_identity.py && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
