### PR TITLE
fix(torghut): load hyperliquid market context

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/clickhouse.py
+++ b/services/torghut/app/hyperliquid_runtime/clickhouse.py
@@ -32,33 +32,67 @@ class ClickHouseRuntimeReader:
     def load_catalog_rows(self) -> list[dict[str, object]]:
         database = _identifier(self._config.clickhouse_database)
         network = _sql_string(self._config.market_data_network)
-        limit = max(1, self._config.max_markets_per_cycle * 4)
+        limit = max(1000, self._config.max_markets_per_cycle * 20)
         query = f"""
+        WITH
+          latest_catalog AS (
+            SELECT
+              *,
+              row_number() OVER (
+                PARTITION BY market_id
+                ORDER BY parseDateTimeBestEffort(event_ts) DESC, seq DESC
+              ) AS rn
+            FROM {database}.hyperliquid_market_catalog
+            WHERE network = {network}
+              AND market_type = 'perp'
+              AND market_id IS NOT NULL
+          ),
+          latest_context AS (
+            SELECT
+              *,
+              row_number() OVER (
+                PARTITION BY market_id
+                ORDER BY parseDateTimeBestEffort(event_ts) DESC, seq DESC
+              ) AS rn
+            FROM {database}.hyperliquid_asset_contexts
+            WHERE network = {network}
+              AND market_type = 'perp'
+              AND market_id IS NOT NULL
+          )
         SELECT
-          market_id,
-          coin,
-          dex,
-          network,
-          market_type,
-          payload,
-          JSONExtractString(payload, 'dayNtlVlm') AS dayNtlVlm,
-          JSONExtractString(payload, 'markPx') AS markPx,
-          JSONExtractString(payload, 'midPx') AS midPx,
-          JSONExtractString(payload, 'openInterest') AS openInterest,
-          JSONExtractInt(payload, 'maxLeverage') AS maxLeverage
-        FROM (
-          SELECT
-            *,
-            row_number() OVER (
-              PARTITION BY market_id
-              ORDER BY parseDateTimeBestEffort(event_ts) DESC, seq DESC
-            ) AS rn
-          FROM {database}.hyperliquid_market_catalog
-          WHERE network = {network}
-            AND market_type = 'perp'
-            AND market_id IS NOT NULL
-        )
-        WHERE rn = 1
+          c.market_id AS market_id,
+          c.coin AS coin,
+          c.dex AS dex,
+          c.network AS network,
+          c.market_type AS market_type,
+          c.payload AS payload,
+          COALESCE(
+            NULLIF(JSONExtractString(JSONExtractRaw(a.payload, 'ctx'), 'dayNtlVlm'), ''),
+            JSONExtractString(c.payload, 'dayNtlVlm')
+          ) AS dayNtlVlm,
+          COALESCE(
+            NULLIF(JSONExtractString(JSONExtractRaw(a.payload, 'ctx'), 'markPx'), ''),
+            JSONExtractString(c.payload, 'markPx')
+          ) AS markPx,
+          COALESCE(
+            NULLIF(JSONExtractString(JSONExtractRaw(a.payload, 'ctx'), 'midPx'), ''),
+            JSONExtractString(c.payload, 'midPx')
+          ) AS midPx,
+          COALESCE(
+            NULLIF(JSONExtractString(JSONExtractRaw(a.payload, 'ctx'), 'openInterest'), ''),
+            JSONExtractString(c.payload, 'openInterest')
+          ) AS openInterest,
+          if(
+            JSONExtractInt(c.payload, 'maxLeverage') != 0,
+            JSONExtractInt(c.payload, 'maxLeverage'),
+            JSONExtractInt(JSONExtractRaw(c.payload, 'raw'), 'maxLeverage')
+          ) AS maxLeverage
+        FROM latest_catalog AS c
+        LEFT JOIN latest_context AS a
+          ON c.market_id = a.market_id
+          AND a.rn = 1
+        WHERE c.rn = 1
+        ORDER BY toFloat64OrZero(dayNtlVlm) DESC
         LIMIT {limit}
         """
         return self.query_json_each_row(query)

--- a/services/torghut/app/hyperliquid_runtime/universe.py
+++ b/services/torghut/app/hyperliquid_runtime/universe.py
@@ -10,22 +10,74 @@ from .models import AssetClass, HyperliquidMarket
 
 
 _COMMODITY_COINS = {
+    "BRENTOIL",
+    "BRENT",
+    "CL",
+    "COPPER",
     "GOLD",
+    "NATGAS",
     "SILVER",
     "WTI",
-    "BRENT",
-    "COPPER",
-    "NATGAS",
+}
+_FX_COINS = {
+    "AUD",
+    "CAD",
+    "CHF",
+    "CNH",
+    "EUR",
+    "GBP",
+    "JPY",
 }
 _INDEX_COINS = {
-    "USA500",
-    "SPX",
+    "DJI",
+    "EWY",
     "NAS100",
     "NDX",
-    "US30",
-    "DJI",
-    "RUSSELL",
     "RUT",
+    "RUSSELL",
+    "SP500",
+    "SPX",
+    "USA500",
+    "US30",
+    "USATECH",
+    "XYZ100",
+}
+_STOCK_COINS = {
+    "AAPL",
+    "AMD",
+    "AMZN",
+    "ARM",
+    "AVGO",
+    "BB",
+    "CBRS",
+    "COIN",
+    "CRCL",
+    "CRWV",
+    "GOOGL",
+    "HOOD",
+    "INTC",
+    "LITE",
+    "META",
+    "MRVL",
+    "MSFT",
+    "MSTR",
+    "MU",
+    "NBIS",
+    "NVDA",
+    "ORCL",
+    "PLTR",
+    "RKLB",
+    "SMSN",
+    "SNDK",
+    "TSLA",
+    "WDC",
+}
+_VETTED_PREIPO_COINS = {
+    "BIRD",
+    "OPENAI",
+    "PURRDAT",
+    "SKHX",
+    "SPCX",
 }
 _STOCK_PREFIX = "cash:"
 _PREIPO_DEXES = {"xyz", "preipo"}
@@ -116,19 +168,22 @@ def classify_asset(
     """Classify public Hyperliquid perps into V1 allowed equity-like buckets."""
 
     normalized_coin = coin.strip()
-    symbol = normalized_coin.removeprefix(_STOCK_PREFIX).upper()
+    symbol = normalized_coin.removeprefix(_STOCK_PREFIX).split(":")[-1].upper()
     normalized_dex = dex.strip().lower()
-    if normalized_dex in _PREIPO_DEXES:
-        return "preipo"
     payload_class = _payload_asset_class(payload)
     if payload_class in {"stocks", "indices", "preipo"}:
         return cast(AssetClass, payload_class)
-    if symbol in _COMMODITY_COINS:
+    if symbol in _COMMODITY_COINS or symbol in _FX_COINS:
         return None
     if symbol in _INDEX_COINS:
         return "indices"
     if normalized_coin.startswith(_STOCK_PREFIX):
         return "stocks"
+    if normalized_dex in _PREIPO_DEXES:
+        if symbol in _VETTED_PREIPO_COINS:
+            return "preipo"
+        if symbol in _STOCK_COINS:
+            return "stocks"
     return None
 
 

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -89,13 +89,17 @@ def test_clickhouse_reader_parses_queries_status_and_features(
                 '"liquidity_usd":"500000","funding_rate":"0.0001",'
                 '"open_interest_usd":"1000000","regime":"trend","source_lag_seconds":"7"}\n'
             )
-        return '{"market_id":"hl:perp:cash:cash:AAPL","coin":"cash:AAPL","payload":"{}"}\n\n'
+        return (
+            '{"market_id":"hl:perp:cash:cash:AAPL","coin":"cash:AAPL",'
+            '"payload":"{}","dayNtlVlm":"500000","markPx":"200"}\n\n'
+        )
 
     monkeypatch.setattr(clickhouse_module, "_request_clickhouse", fake_request)
     reader = ClickHouseRuntimeReader(_config())
 
     catalog = reader.load_catalog_rows()
     assert catalog[0]["coin"] == "cash:AAPL"
+    assert catalog[0]["dayNtlVlm"] == "500000"
     assert reader.load_feature_rows([]) == []
     features = reader.load_feature_rows(["hl:perp:cash:cash:AAPL"])
     status = reader.status()
@@ -107,6 +111,8 @@ def test_clickhouse_reader_parses_queries_status_and_features(
         "hyperliquid_candles",
         "hyperliquid_runtime_latest_features",
     }
+    assert any("hyperliquid_asset_contexts" in query for query in queries)
+    assert any("JSONExtractRaw(a.payload, 'ctx')" in query for query in queries)
     assert any("FORMAT JSONEachRow" in query for query in queries)
 
 

--- a/services/torghut/tests/hyperliquid_runtime/test_universe.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_universe.py
@@ -7,10 +7,16 @@ from app.hyperliquid_runtime.universe import classify_asset, select_equity_like_
 
 def test_classifies_equity_like_perps_only() -> None:
     assert classify_asset(coin="cash:AAPL", dex="cash") == "stocks"
+    assert classify_asset(coin="xyz:AAPL", dex="xyz") == "stocks"
     assert classify_asset(coin="USA500", dex="default") == "indices"
+    assert classify_asset(coin="xyz:SP500", dex="xyz") == "indices"
     assert classify_asset(coin="OPENAI", dex="xyz") == "preipo"
+    assert classify_asset(coin="xyz:OPENAI", dex="xyz") == "preipo"
     assert classify_asset(coin="BTC", dex="default") is None
     assert classify_asset(coin="GOLD", dex="cash") is None
+    assert classify_asset(coin="xyz:BRENTOIL", dex="xyz") is None
+    assert classify_asset(coin="xyz:JPY", dex="xyz") is None
+    assert classify_asset(coin="xyz:NOTVETTED", dex="xyz") is None
 
 
 def test_selects_liquid_allowed_markets_by_volume() -> None:


### PR DESCRIPTION
## Summary

- Joins latest Hyperliquid asset contexts into the runtime catalog read so `dayNtlVlm`, mark, mid, and open interest are available for market selection.
- Expands the bounded catalog read so lower-volume equity markets are not dropped before Python universe classification.
- Tightens `xyz` classification to vetted stock, index, and pre-IPO symbols while excluding commodities and FX.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_universe.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_risk_strategy.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live ClickHouse query using the patched catalog/context shape returned 44 selected equity-like markets from current data.
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
