### PR TITLE
chore(torghut): roll hyperliquid runtime deployment

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618a
+        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618b
       labels:
         app: torghut-hyperliquid-runtime
     spec:


### PR DESCRIPTION
## Summary

- Bump the Hyperliquid runtime pod-template revision to force a GitOps-managed rollout.
- Keep the runtime image, config, ExternalSecret, and existing Torghut services unchanged.
- Pull the already-published `registry.ide-newton.ts.net/lab/torghut:latest` image that includes the market-context catalog fix.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
