### PR TITLE
fix(torghut): gate hyperliquid readiness on ingest freshness

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/clickhouse.py
+++ b/services/torghut/app/hyperliquid_runtime/clickhouse.py
@@ -137,16 +137,16 @@ class ClickHouseRuntimeReader:
         query = f"""
         SELECT
           'hyperliquid_candles' AS name,
-          max(parseDateTimeBestEffort(event_ts)) AS observed_at,
+          max(parseDateTimeBestEffort(ingest_ts)) AS observed_at,
           dateDiff('second', observed_at, now()) AS lag_seconds
         FROM {database}.hyperliquid_candles
         WHERE network = {_sql_string(self._config.market_data_network)}
         UNION ALL
         SELECT
-          'hyperliquid_runtime_latest_features' AS name,
-          max(event_ts) AS observed_at,
+          'hyperliquid_ta_features' AS name,
+          max(ingest_ts) AS observed_at,
           dateDiff('second', observed_at, now()) AS lag_seconds
-        FROM {database}.hyperliquid_runtime_latest_features
+        FROM {database}.hyperliquid_ta_features
         WHERE network = {_sql_string(self._config.market_data_network)}
         FORMAT JSONEachRow
         """
@@ -268,7 +268,7 @@ def _dependency_from_row(
 ) -> RuntimeDependencyStatus:
     observed_at = _optional_datetime(row.get("observed_at"))
     lag_seconds = int(_decimal(row.get("lag_seconds")))
-    ready = observed_at is not None and lag_seconds <= staleness_seconds
+    ready = observed_at is not None and 0 <= lag_seconds <= staleness_seconds
     reason = None if ready else "stale_or_missing"
     return RuntimeDependencyStatus(
         name=_string(row.get("name")),

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -77,7 +77,7 @@ def test_clickhouse_reader_parses_queries_status_and_features(
         if "UNION ALL" in query:
             return (
                 '{"name":"hyperliquid_candles","observed_at":"2026-06-18T00:00:00Z","lag_seconds":7}\n'
-                '{"name":"hyperliquid_runtime_latest_features","observed_at":"2026-06-18T00:00:00","lag_seconds":8}\n'
+                '{"name":"hyperliquid_ta_features","observed_at":"2026-06-18T00:00:00","lag_seconds":8}\n'
             )
         if "runtime_latest_features" in query and "SELECT" in query:
             return (
@@ -109,11 +109,30 @@ def test_clickhouse_reader_parses_queries_status_and_features(
     assert status.ready
     assert {dependency.name for dependency in status.statuses} == {
         "hyperliquid_candles",
-        "hyperliquid_runtime_latest_features",
+        "hyperliquid_ta_features",
     }
     assert any("hyperliquid_asset_contexts" in query for query in queries)
     assert any("JSONExtractRaw(a.payload, 'ctx')" in query for query in queries)
+    assert any("max(parseDateTimeBestEffort(ingest_ts))" in query for query in queries)
+    assert any("FROM torghut.hyperliquid_ta_features" in query for query in queries)
     assert any("FORMAT JSONEachRow" in query for query in queries)
+
+
+def test_clickhouse_status_rejects_future_event_lag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_request(**_kwargs: object) -> str:
+        return (
+            '{"name":"hyperliquid_candles","observed_at":"2026-06-18T00:00:00Z","lag_seconds":-120}\n'
+            '{"name":"hyperliquid_ta_features","observed_at":"2026-06-18T00:00:00Z","lag_seconds":2}\n'
+        )
+
+    monkeypatch.setattr(clickhouse_module, "_request_clickhouse", fake_request)
+
+    status = ClickHouseRuntimeReader(_config()).status()
+
+    assert not status.ready
+    assert status.statuses[0].reason == "stale_or_missing"
 
 
 def test_clickhouse_status_reports_query_failure(


### PR DESCRIPTION
## Summary

- Gate Hyperliquid runtime ClickHouse readiness on `ingest_ts` freshness instead of candle close `event_ts`.
- Check `hyperliquid_ta_features` directly for feature ingestion freshness.
- Reject negative lag values so future candle close timestamps cannot mark stale data healthy.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_universe.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_risk_strategy.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
