### PR TITLE
fix(torghut): surface bounded paper route probe candidates

### DIFF
--- a/services/torghut/app/api/proof_floor_payloads/__init__.py
+++ b/services/torghut/app/api/proof_floor_payloads/__init__.py
@@ -2,20 +2,57 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
 from . import shared_context as _proof_floor
 from . import build_jangar_reliability_settlement_ref as _proof_refs
+from .paper_route_probe_targets import bounded_paper_route_probe_target_symbols
 from ..proxy import capture_module_exports
 
 _IMPLEMENTATION_MODULES: tuple[object, ...] = (
     _proof_floor,
     _proof_refs,
 )
-
-_build_profitability_proof_floor_payload: Any = getattr(
-    _proof_floor, "_build_profitability_proof_floor_payload"
+_build_simple_lane_status_payload: Any = getattr(
+    _proof_floor, "_build_simple_lane_status_payload"
 )
+
+
+def _build_profitability_proof_floor_payload(
+    *,
+    state: object,
+    torghut_revision: str | None,
+    live_submission_gate: Mapping[str, Any],
+    hypothesis_payload: Mapping[str, Any],
+    empirical_jobs_status: Mapping[str, Any],
+    quant_evidence: Mapping[str, Any],
+    market_context_status: Mapping[str, Any],
+    tca_summary: Mapping[str, Any],
+    simple_lane_status: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    return _proof_floor.build_profitability_proof_floor_receipt(
+        account_label=_proof_floor.settings.trading_account_label,
+        torghut_revision=torghut_revision,
+        trading_mode=_proof_floor.settings.trading_mode,
+        market_session_open=cast(
+            bool | None,
+            getattr(state, "market_session_open", None),
+        ),
+        live_submission_gate=live_submission_gate,
+        hypothesis_payload=hypothesis_payload,
+        empirical_jobs_status=empirical_jobs_status,
+        quant_evidence=quant_evidence,
+        market_context_status=market_context_status,
+        tca_summary=tca_summary,
+        simple_lane_status=simple_lane_status or _build_simple_lane_status_payload(),
+        paper_route_probe_target_symbols=bounded_paper_route_probe_target_symbols(
+            live_submission_gate
+        ),
+        tca_max_age_seconds=_proof_floor.PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS,
+    )
+
+
 _build_renewal_bond_profit_escrow_payload: Any = getattr(
     _proof_floor, "_build_renewal_bond_profit_escrow_payload"
 )

--- a/services/torghut/app/api/proof_floor_payloads/paper_route_probe_targets.py
+++ b/services/torghut/app/api/proof_floor_payloads/paper_route_probe_targets.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from typing import Any, cast
+
+from ...config import settings
+from ..common import (
+    shared_mapping_items,
+    shared_paper_route_target_plan_from_payload,
+)
+
+
+_PROMOTION_KEYS = (
+    "promotion_allowed",
+    "final_promotion_allowed",
+    "final_promotion_authorized",
+)
+
+
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float | Decimal):
+        return bool(value)
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _append_symbol(symbols: list[str], raw_symbol: object) -> None:
+    symbol = str(raw_symbol or "").strip().upper()
+    if symbol and symbol not in symbols:
+        symbols.append(symbol)
+
+
+def _symbols_from_target(target: Mapping[str, Any]) -> list[str]:
+    symbols: list[str] = []
+    for field in (
+        "paper_route_probe_symbols",
+        "paper_route_probe_raw_target_symbols",
+        "symbols",
+        "target_symbols",
+    ):
+        raw_symbols = target.get(field)
+        if isinstance(raw_symbols, str):
+            values: Sequence[object] = raw_symbols.split(",")
+        elif isinstance(raw_symbols, Sequence) and not isinstance(
+            raw_symbols,
+            (str, bytes, bytearray),
+        ):
+            values = cast(Sequence[object], raw_symbols)
+        else:
+            values = ()
+        for raw_symbol in values:
+            _append_symbol(symbols, raw_symbol)
+    for field in (
+        "paper_route_probe_symbol_actions",
+        "paper_route_probe_symbol_quantities",
+        "symbol_actions",
+        "target_symbol_actions",
+        "target_symbol_quantities",
+    ):
+        raw_mapping = target.get(field)
+        if not isinstance(raw_mapping, Mapping):
+            continue
+        for raw_symbol in cast(Mapping[object, object], raw_mapping):
+            _append_symbol(symbols, raw_symbol)
+    return symbols
+
+
+def bounded_paper_route_probe_target_symbols(
+    live_submission_gate: Mapping[str, Any],
+) -> list[str]:
+    plan = shared_paper_route_target_plan_from_payload(live_submission_gate)
+    targets = [
+        cast(Mapping[str, Any], target)
+        for target in shared_mapping_items(plan.get("targets"))
+    ]
+    if not targets:
+        return []
+
+    if any(_truthy(plan.get(key)) for key in _PROMOTION_KEYS):
+        return []
+
+    authorized_targets: list[Mapping[str, Any]] = []
+    for target in targets:
+        if any(_truthy(target.get(key)) for key in _PROMOTION_KEYS):
+            return []
+        if _truthy(target.get("bounded_live_paper_collection_authorized")) or _truthy(
+            target.get("source_collection_authorized")
+        ):
+            authorized_targets.append(target)
+    if not authorized_targets:
+        return []
+
+    symbols: list[str] = []
+    for target in authorized_targets:
+        for symbol in _symbols_from_target(target):
+            _append_symbol(symbols, symbol)
+    if symbols:
+        return symbols
+
+    for raw_symbol in settings.trading_static_symbols:
+        _append_symbol(symbols, raw_symbol)
+    return symbols
+
+
+__all__ = ["bounded_paper_route_probe_target_symbols"]

--- a/services/torghut/app/trading/proof_floor/receipt_builder.py
+++ b/services/torghut/app/trading/proof_floor/receipt_builder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from typing import Any
 
@@ -49,6 +49,7 @@ def build_profitability_proof_floor_receipt(
     market_context_status: Mapping[str, Any],
     tca_summary: Mapping[str, Any],
     simple_lane_status: Mapping[str, Any] | None = None,
+    paper_route_probe_target_symbols: Sequence[object] | None = None,
     now: datetime | None = None,
     tca_max_age_seconds: int = 86400,
 ) -> dict[str, object]:
@@ -739,6 +740,7 @@ def build_profitability_proof_floor_receipt(
         paper_route_probe_enabled=paper_route_probe_enabled,
         paper_route_probe_allow_live_mode=paper_route_probe_allow_live_mode,
         paper_route_probe_max_notional=paper_route_probe_max_notional,
+        paper_route_probe_target_symbols=paper_route_probe_target_symbols,
     )
     receipt["route_reacquisition_book"] = route_reacquisition_book
     receipt["paper_route_probe"] = route_reacquisition_book.get("paper_route_probe")

--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -94,6 +94,20 @@ def _sequence(value: object) -> Sequence[object]:
     return []
 
 
+def _symbol_list(value: object) -> list[str]:
+    symbols: list[str] = []
+    values: Sequence[object]
+    if isinstance(value, str):
+        values = value.split(",")
+    else:
+        values = _sequence(value)
+    for raw_symbol in values:
+        symbol = _text(raw_symbol).upper()
+        if symbol and symbol not in symbols:
+            symbols.append(symbol)
+    return symbols
+
+
 def _stable_ref(prefix: str, payload: Mapping[str, object]) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return f"{prefix}:{sha256(encoded.encode()).hexdigest()[:20]}"
@@ -517,6 +531,7 @@ def build_route_reacquisition_book(
     paper_route_probe_enabled: bool = False,
     paper_route_probe_allow_live_mode: bool = False,
     paper_route_probe_max_notional: object | None = None,
+    paper_route_probe_target_symbols: Sequence[object] | None = None,
 ) -> dict[str, object]:
     """Build a symbol-level route repair book from proof-floor source refs.
 
@@ -613,6 +628,10 @@ def build_route_reacquisition_book(
         for item in records
         if _paper_route_probe_eligible(item)
     ]
+    target_probe_symbols = _symbol_list(paper_route_probe_target_symbols)
+    for symbol in target_probe_symbols:
+        if symbol not in eligible_probe_symbols:
+            eligible_probe_symbols.append(symbol)
     probe_blockers = _paper_route_probe_blockers(
         trading_mode=trading_mode,
         market_session_open=market_session_open,
@@ -731,6 +750,12 @@ def build_route_reacquisition_book(
             "market_context_state": market_context_dimension.get("state"),
             "quant_ingestion_state": quant_dimension.get("state"),
             "alpha_readiness_state": alpha_dimension.get("state"),
+            "paper_route_probe_target_symbols": target_probe_symbols,
+            "paper_route_probe_target_symbol_source": (
+                "bounded_paper_route_collection_target_plan"
+                if target_probe_symbols
+                else None
+            ),
         },
         "rollback_target": {
             "paper_probe_notional_limit": "0",

--- a/services/torghut/app/trading/scheduler/paper_route_probe/probe_processing.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/probe_processing.py
@@ -586,8 +586,12 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
         strategy: Strategy | None,
         cap: Decimal | None,
     ) -> bool:
+        mode_allows_probe = settings.trading_mode == "paper" or (
+            settings.trading_mode == "live"
+            and settings.trading_simple_paper_route_probe_allow_live_mode
+        )
         return (
-            settings.trading_mode == "paper"
+            mode_allows_probe
             and settings.trading_simple_paper_route_probe_enabled
             and not _paper_route_probe_blocked_by_short_policy(decision)
             and decision.action in {"buy", "sell"}

--- a/services/torghut/app/trading/scheduler/source_collection/target_plan_fetch.py
+++ b/services/torghut/app/trading/scheduler/source_collection/target_plan_fetch.py
@@ -407,6 +407,8 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
         source = "local_target_plan_probe_symbols"
         if _target_truthy(target.get("paper_route_probe_strategy_universe_fallback")):
             source = "local_strategy_universe_target_plan_fallback"
+        elif _target_truthy(target.get("paper_route_probe_static_universe_fallback")):
+            source = "local_static_universe_target_plan_fallback"
         elif strategy is None:
             source = "local_target_plan_strategy_unresolved"
         return {
@@ -456,6 +458,39 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
                 )
             elif strategy_symbols:
                 scoped_symbols = raw_symbols & strategy_symbols
+
+        static_symbols = {
+            symbol
+            for raw in settings.trading_static_symbols
+            if (symbol := str(raw).strip().upper())
+        }
+        target_promoted = any(
+            _target_truthy(normalized.get(key))
+            for key in (
+                "promotion_allowed",
+                "capital_promotion_allowed",
+                "final_promotion_allowed",
+                "final_promotion_authorized",
+            )
+        )
+        if (
+            not raw_symbols
+            and _target_bounded_collection_authorized(normalized)
+            and not target_promoted
+            and static_symbols
+        ):
+            raw_symbols = set(static_symbols)
+            scoped_symbols = set(static_symbols)
+            normalized.setdefault("paper_route_probe_raw_target_symbols", [])
+            normalized.setdefault("paper_route_probe_static_universe_fallback", True)
+            normalized.setdefault(
+                "paper_route_probe_static_universe_symbols",
+                sorted(static_symbols),
+            )
+            normalized.setdefault(
+                "paper_route_probe_scope_authority",
+                "static_trading_universe",
+            )
 
         if raw_symbols and not _target_symbols(normalized):
             normalized["paper_route_probe_symbols"] = sorted(raw_symbols)

--- a/services/torghut/tests/api/test_trading_api_paper_route_status_symbols.py
+++ b/services/torghut/tests/api/test_trading_api_paper_route_status_symbols.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from app.api import proof_floor_payloads
+from app.api.proof_floor_payloads.paper_route_probe_targets import (
+    bounded_paper_route_probe_target_symbols,
+)
+from app.config import settings
+
+
+def test_bounded_probe_targets_fall_back_to_static_symbols_without_promotion() -> None:
+    original_static_symbols = settings.trading_static_symbols_raw
+    try:
+        settings.trading_static_symbols_raw = "AAPL,nvda,AAPL"
+        symbols = bounded_paper_route_probe_target_symbols(
+            {
+                "runtime_ledger_paper_probation_import_plan": {
+                    "promotion_allowed": False,
+                    "final_promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                    "targets": [
+                        {
+                            "source_collection_authorized": True,
+                            "bounded_live_paper_collection_authorized": True,
+                            "promotion_allowed": False,
+                            "final_promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                        }
+                    ],
+                }
+            }
+        )
+    finally:
+        settings.trading_static_symbols_raw = original_static_symbols
+
+    assert symbols == ["AAPL", "NVDA"]
+
+
+def test_bounded_probe_targets_return_explicit_symbols() -> None:
+    symbols = bounded_paper_route_probe_target_symbols(
+        {
+            "runtime_ledger_paper_probation_import_plan": {
+                "targets": [
+                    {
+                        "source_collection_authorized": True,
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                        "final_promotion_authorized": False,
+                        "paper_route_probe_symbols": "aapl,msft",
+                        "target_symbols": ["NVDA"],
+                        "paper_route_probe_symbol_actions": {"amzn": "buy"},
+                    }
+                ],
+            }
+        }
+    )
+
+    assert symbols == ["AAPL", "MSFT", "NVDA", "AMZN"]
+
+
+def test_bounded_probe_targets_return_empty_without_targets_or_authorization() -> None:
+    assert bounded_paper_route_probe_target_symbols({}) == []
+    assert (
+        bounded_paper_route_probe_target_symbols(
+            {
+                "runtime_ledger_paper_probation_import_plan": {
+                    "targets": [{"source_collection_authorized": False}]
+                }
+            }
+        )
+        == []
+    )
+
+
+def test_bounded_probe_targets_block_plan_promotion() -> None:
+    assert (
+        bounded_paper_route_probe_target_symbols(
+            {
+                "runtime_ledger_paper_probation_import_plan": {
+                    "promotion_allowed": Decimal("1"),
+                    "targets": [
+                        {
+                            "source_collection_authorized": True,
+                            "paper_route_probe_symbols": ["AAPL"],
+                        }
+                    ],
+                }
+            }
+        )
+        == []
+    )
+
+
+def test_bounded_probe_target_symbols_do_not_fall_back_when_promotion_allowed() -> None:
+    original_static_symbols = settings.trading_static_symbols_raw
+    try:
+        settings.trading_static_symbols_raw = "AAPL,NVDA"
+        symbols = bounded_paper_route_probe_target_symbols(
+            {
+                "runtime_ledger_paper_probation_import_plan": {
+                    "promotion_allowed": False,
+                    "final_promotion_allowed": False,
+                    "targets": [
+                        {
+                            "source_collection_authorized": True,
+                            "bounded_live_paper_collection_authorized": True,
+                            "promotion_allowed": True,
+                            "final_promotion_allowed": False,
+                        }
+                    ],
+                }
+            }
+        )
+    finally:
+        settings.trading_static_symbols_raw = original_static_symbols
+
+    assert symbols == []
+
+
+def test_profitability_payload_injects_bounded_probe_target_symbols(
+    monkeypatch,
+) -> None:
+    original_static_symbols = settings.trading_static_symbols_raw
+    captured: dict[str, object] = {}
+
+    def fake_receipt(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    try:
+        settings.trading_static_symbols_raw = "AAPL,NVDA"
+        monkeypatch.setattr(
+            proof_floor_payloads._proof_floor,
+            "build_profitability_proof_floor_receipt",
+            fake_receipt,
+        )
+
+        payload = proof_floor_payloads.build_profitability_proof_floor_payload(
+            state=SimpleNamespace(market_session_open=False),
+            torghut_revision="rev-test",
+            live_submission_gate={
+                "runtime_ledger_paper_probation_import_plan": {
+                    "promotion_allowed": False,
+                    "final_promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                    "targets": [
+                        {
+                            "source_collection_authorized": True,
+                            "bounded_live_paper_collection_authorized": True,
+                            "promotion_allowed": False,
+                            "final_promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                        }
+                    ],
+                }
+            },
+            hypothesis_payload={},
+            empirical_jobs_status={},
+            quant_evidence={},
+            market_context_status={},
+            tca_summary={},
+            simple_lane_status={"paper_route_probe_enabled": True},
+        )
+    finally:
+        settings.trading_static_symbols_raw = original_static_symbols
+
+    assert payload == {"ok": True}
+    assert captured["paper_route_probe_target_symbols"] == ["AAPL", "NVDA"]

--- a/services/torghut/tests/profitability_proof_floor/test_live_degraded_evidence_routes_to_repair_only.py
+++ b/services/torghut/tests/profitability_proof_floor/test_live_degraded_evidence_routes_to_repair_only.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from app.trading.route_reacquisition import build_route_reacquisition_book
+
 from tests.profitability_proof_floor.support import (
     Any,
     Mapping,
@@ -127,6 +129,84 @@ def test_live_degraded_evidence_routes_to_repair_only() -> None:
             "strategy_family": "intraday_continuation",
         }
     ]
+
+
+def test_bounded_paper_target_symbols_feed_route_probe_without_promotion() -> None:
+    simple_lane_status = {
+        **_simple_lane_status(),
+        "paper_route_probe_enabled": True,
+        "paper_route_probe_allow_live_mode": True,
+        "paper_route_probe_max_notional": "100",
+    }
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="PA3SX7FYNUTF",
+        torghut_revision="torghut-01274",
+        trading_mode="live",
+        market_session_open=False,
+        live_submission_gate={
+            "allowed": False,
+            "reason": "live_submit_activation_expired",
+            "blocked_reasons": ["live_submit_activation_expired"],
+            "capital_stage": "shadow",
+        },
+        hypothesis_payload={
+            "summary": {
+                "hypotheses_total": 0,
+                "promotion_eligible_total": 0,
+                "rollback_required_total": 0,
+                "state_totals": {},
+            },
+            "items": [],
+        },
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary={
+            "order_count": 0,
+            "last_computed_at": None,
+            "filled_execution_count": 0,
+        },
+        simple_lane_status=simple_lane_status,
+        paper_route_probe_target_symbols=["aapl", "NVDA", "AAPL"],
+        now=NOW,
+    )
+
+    route_book = cast(Mapping[str, Any], receipt["route_reacquisition_book"])
+    probe = cast(Mapping[str, Any], route_book["paper_route_probe"])
+    summary = cast(Mapping[str, Any], route_book["summary"])
+    source_refs = cast(Mapping[str, Any], route_book["source_refs"])
+
+    assert receipt["capital_state"] == "zero_notional"
+    assert receipt["route_state"] == "repair_only"
+    assert probe["promotion_authority"] is False
+    assert probe["active"] is False
+    assert probe["next_session_max_notional"] == "100"
+    assert probe["eligible_symbols"] == ["AAPL", "NVDA"]
+    assert probe["blocking_reasons"] == ["session_closed"]
+    assert summary["paper_route_probe_eligible_symbols"] == ["AAPL", "NVDA"]
+    assert source_refs["paper_route_probe_target_symbols"] == ["AAPL", "NVDA"]
+    assert source_refs["paper_route_probe_target_symbol_source"] == (
+        "bounded_paper_route_collection_target_plan"
+    )
+
+
+def test_route_probe_accepts_comma_separated_target_symbols() -> None:
+    route_book = build_route_reacquisition_book(
+        proof_floor_receipt={
+            "account_label": "PA3SX7FYNUTF",
+            "generated_at": NOW,
+            "proof_dimensions": [],
+        },
+        trading_mode="live",
+        market_session_open=True,
+        paper_route_probe_enabled=True,
+        paper_route_probe_allow_live_mode=True,
+        paper_route_probe_max_notional="100",
+        paper_route_probe_target_symbols="msft,TSLA,MSFT",
+    )
+
+    probe = cast(Mapping[str, Any], route_book["paper_route_probe"])
+    assert probe["eligible_symbols"] == ["MSFT", "TSLA"]
 
 
 def test_alpha_repair_targets_flow_to_route_reacquisition_records() -> None:

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -185,6 +185,95 @@ def test_live_bounded_paper_route_target_blocks_without_activation(
         )
 
 
+def test_bounded_paper_route_target_uses_static_universe_without_promotion() -> None:
+    static_symbols_before = settings.trading_static_symbols_raw
+    try:
+        settings.trading_static_symbols_raw = "AAPL,nvda,AAPL"
+        target = _bounded_hpairs_target(
+            paper_route_probe_symbols=[],
+            target_symbols=[],
+            symbols=[],
+            paper_route_target_account_audit_state={},
+            source_decision_readiness=None,
+            promotion_allowed=False,
+            capital_promotion_allowed=False,
+            final_promotion_allowed=False,
+            final_promotion_authorized=False,
+        )
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=[],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+
+        resolved = pipeline._paper_route_target_with_local_probe_contract(
+            target,
+            strategies=[strategy],
+        )
+
+        assert resolved["paper_route_probe_symbols"] == ["AAPL", "NVDA"]
+        assert resolved["paper_route_probe_static_universe_fallback"] is True
+        assert resolved["paper_route_probe_static_universe_symbols"] == ["AAPL", "NVDA"]
+        assert (
+            resolved["paper_route_probe_scope_authority"] == "static_trading_universe"
+        )
+        readiness = resolved["source_decision_readiness"]
+        assert readiness["ready"] is True
+        assert readiness["source"] == "local_static_universe_target_plan_fallback"
+        assert readiness["blockers"] == []
+        assert readiness["raw_probe_symbols"] == ["AAPL", "NVDA"]
+        assert readiness["scoped_probe_symbols"] == ["AAPL", "NVDA"]
+        assert readiness["matched_strategy"]["strategy_name"] == (
+            "microbar-cross-sectional-pairs-v1"
+        )
+    finally:
+        settings.trading_static_symbols_raw = static_symbols_before
+
+
+def test_bounded_paper_route_static_universe_does_not_override_promotion() -> None:
+    static_symbols_before = settings.trading_static_symbols_raw
+    try:
+        settings.trading_static_symbols_raw = "AAPL,NVDA"
+        target = _bounded_hpairs_target(
+            paper_route_probe_symbols=[],
+            target_symbols=[],
+            symbols=[],
+            paper_route_target_account_audit_state={},
+            source_decision_readiness=None,
+            promotion_allowed=True,
+            capital_promotion_allowed=False,
+            final_promotion_allowed=False,
+            final_promotion_authorized=False,
+        )
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=[],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+
+        resolved = pipeline._paper_route_target_with_local_probe_contract(
+            target,
+            strategies=[strategy],
+        )
+
+        assert resolved["paper_route_probe_symbols"] == []
+        assert "paper_route_probe_static_universe_fallback" not in resolved
+        assert resolved["source_decision_readiness"]["ready"] is False
+        assert resolved["source_decision_readiness"]["blockers"] == [
+            "paper_route_probe_symbol_missing"
+        ]
+    finally:
+        settings.trading_static_symbols_raw = static_symbols_before
+
+
 def test_live_bounded_paper_route_source_collection_contract_blockers() -> None:
     probe_allow_live_before = settings.trading_simple_paper_route_probe_allow_live_mode
     submit_enabled_before = settings.trading_simple_submit_enabled
@@ -230,6 +319,39 @@ def test_live_bounded_paper_route_source_collection_contract_blockers() -> None:
         )
         settings.trading_simple_paper_route_probe_max_notional = (
             probe_max_notional_before
+        )
+
+
+def test_live_bounded_paper_route_probe_context_precondition_allows_live_mode() -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    probe_allow_live_before = settings.trading_simple_paper_route_probe_allow_live_mode
+    try:
+        settings.trading_mode = "live"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        proof_floor = {"market_window": {"session_open": True}}
+
+        assert pipeline._paper_route_probe_context_preconditions(
+            proof_floor=proof_floor,
+            decision=_routeability_decision(symbol="AAPL"),
+            strategy=None,
+            cap=Decimal("100"),
+        )
+
+        settings.trading_simple_paper_route_probe_allow_live_mode = False
+        assert not pipeline._paper_route_probe_context_preconditions(
+            proof_floor=proof_floor,
+            decision=_routeability_decision(symbol="AAPL"),
+            strategy=None,
+            cap=Decimal("100"),
+        )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_simple_paper_route_probe_allow_live_mode = (
+            probe_allow_live_before
         )
 
 


### PR DESCRIPTION
## Summary

- Derives bounded paper-route probe symbols from the live target plan and passes them into the proof-floor route reacquisition book.
- Allows the paper-route probe precondition in live mode only when `TRADING_SIMPLE_PAPER_ROUTE_PROBE_ALLOW_LIVE_MODE` is enabled.
- Adds a static trading-universe fallback for bounded collection targets that have no explicit symbols and no promotion authority.

## Related Issues

None

## Testing

- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/profitability_proof_floor/test_live_degraded_evidence_routes_to_repair_only.py tests/api/test_trading_api_paper_route_status_symbols.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/api/proof_floor_payloads/__init__.py app/api/proof_floor_payloads/paper_route_probe_targets.py app/trading/proof_floor/receipt_builder.py app/trading/route_reacquisition.py app/trading/scheduler/paper_route_probe/probe_processing.py app/trading/scheduler/source_collection/target_plan_fetch.py tests/profitability_proof_floor/test_live_degraded_evidence_routes_to_repair_only.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/api/test_trading_api_paper_route_status_symbols.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
