### PR TITLE
chore(torghut): roll hyperliquid runtime readiness fix

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618b
+        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618c
       labels:
         app: torghut-hyperliquid-runtime
     spec:


### PR DESCRIPTION
## Summary

- Rolls `torghut-hyperliquid-runtime` by bumping the pod-template config revision.
- Moves the live runtime deployment onto the promoted Torghut image containing the ingest-based readiness fix.
- Keeps existing runtime configuration, topics, services, and workload behavior unchanged.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
