### PR TITLE
fix(torghut): gate hyperliquid feed on clickhouse freshness

### DIFF
--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
@@ -19,19 +19,37 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import mu.KotlinLogging
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 private val clickHouseLogger = KotlinLogging.logger {}
+private val clickHouseIdentifierPattern = Regex("[A-Za-z_][A-Za-z0-9_]*")
+
+data class ClickHouseReadinessUpdate(
+  val ready: Boolean,
+  val tableIngestLagMs: Map<String, Long?>,
+)
 
 class ClickHouseSink(
   private val config: ClickHouseConfig,
   private val httpClient: HttpClient,
   private val metrics: HyperliquidMetrics,
   private val json: Json,
-  private val onReady: (Boolean) -> Unit = {},
+  private val network: String = "mainnet",
+  private val nowMs: () -> Long = { System.currentTimeMillis() },
+  private val onReady: (ClickHouseReadinessUpdate) -> Unit = {},
 ) {
   private val channel = Channel<RoutedEnvelope>(capacity = 10_000)
+  private val lastFreshnessCheckMs = AtomicLong(0)
+  private val tableFreshnessReady = AtomicBoolean(!config.enabled)
+
+  @Volatile
+  private var latestTableIngestLagMs: Map<String, Long?> = config.readyTables.associateWith { null }
 
   suspend fun enqueue(record: RoutedEnvelope) {
     if (!config.enabled) return
@@ -42,7 +60,7 @@ class ClickHouseSink(
     scope.launch(Dispatchers.IO) {
       if (!config.enabled) {
         metrics.setClickHouseReady(true)
-        onReady(true)
+        emitReadiness(true)
         return@launch
       }
       val batch = mutableListOf<RoutedEnvelope>()
@@ -68,12 +86,13 @@ class ClickHouseSink(
       val body = tableRecords.joinToString("\n") { json.encodeToString(rowFor(it)) }
       runCatching {
         insertRows(table, body)
+        refreshTableFreshnessIfDue()
       }.onSuccess {
-        metrics.setClickHouseReady(true)
-        onReady(true)
+        metrics.setClickHouseReady(it)
+        emitReadiness(it)
       }.onFailure { error ->
         metrics.setClickHouseReady(false)
-        onReady(false)
+        emitReadiness(false)
         metrics.recordClickHouseError(table)
         clickHouseLogger.warn(error) { "clickhouse insert failed table=$table records=${tableRecords.size}" }
       }
@@ -85,16 +104,83 @@ class ClickHouseSink(
     body: String,
   ) {
     val query = "INSERT INTO ${config.database}.$table FORMAT JSONEachRow"
+    executeClickHouse(query, body)
+  }
+
+  private suspend fun executeClickHouse(
+    query: String,
+    body: String? = null,
+  ): String {
     val response =
       httpClient.post("${config.httpUrl.trimEnd('/')}?query=${java.net.URLEncoder.encode(query, Charsets.UTF_8)}") {
         if (config.password.isNotEmpty()) basicAuth(config.username, config.password)
-        contentType(ContentType.Application.Json)
-        setBody(body)
+        if (body != null) {
+          contentType(ContentType.Application.Json)
+          setBody(body)
+        }
       }
+    val responseBody = response.bodyAsText()
     if (!response.status.isSuccess()) {
-      val responseBody = response.bodyAsText().take(256)
-      error("clickhouse_http_${response.status.value}:$responseBody")
+      error("clickhouse_http_${response.status.value}:${responseBody.take(256)}")
     }
+    return responseBody
+  }
+
+  private suspend fun refreshTableFreshnessIfDue(): Boolean {
+    if (!config.enabled) return true
+    val observedAt = nowMs()
+    val lastCheck = lastFreshnessCheckMs.get()
+    if (lastCheck > 0 && observedAt - lastCheck < config.freshnessCheckMs) return tableFreshnessReady.get()
+
+    return runCatching {
+      queryTableFreshness(observedAt)
+    }.fold(
+      onSuccess = { lags ->
+        latestTableIngestLagMs = lags
+        lags.forEach { (table, lagMs) -> metrics.setClickHouseTableIngestLagMs(table, lagMs) }
+        val fresh = lags.values.all { lagMs -> lagMs != null && lagMs in 0L..config.readyMaxAgeMs }
+        tableFreshnessReady.set(fresh)
+        lastFreshnessCheckMs.set(observedAt)
+        if (!fresh) clickHouseLogger.warn { "clickhouse table freshness stale lags_ms=$lags" }
+        fresh
+      },
+      onFailure = { error ->
+        tableFreshnessReady.set(false)
+        lastFreshnessCheckMs.set(observedAt)
+        clickHouseLogger.warn(error) { "clickhouse table freshness query failed" }
+        false
+      },
+    )
+  }
+
+  private suspend fun queryTableFreshness(observedAt: Long): Map<String, Long?> {
+    val database = clickHouseIdentifier(config.database)
+    val tables = config.readyTables.sorted().map(::clickHouseIdentifier)
+    val union =
+      tables.joinToString("\nUNION ALL\n") { table ->
+        "SELECT '$table' AS table, max(parseDateTimeBestEffort(ingest_ts)) AS latest_ingest " +
+          "FROM $database.$table WHERE network = ${sqlString(network)}"
+      }
+    val query =
+      """
+      SELECT table, if(isNull(latest_ingest), NULL, toUnixTimestamp64Milli(toDateTime64(latest_ingest, 3))) AS latest_ingest_ms
+      FROM (
+      $union
+      )
+      FORMAT JSONEachRow
+      """.trimIndent()
+    val observedRows = mutableMapOf<String, Long?>()
+    executeClickHouse(query)
+      .lineSequence()
+      .map { it.trim() }
+      .filter { it.isNotEmpty() }
+      .forEach { line ->
+        val row = json.decodeFromString<JsonObject>(line)
+        val table = row["table"]?.jsonPrimitive?.contentOrNull
+        val latestIngestMs = row["latest_ingest_ms"]?.jsonPrimitive?.longOrNull
+        if (table != null) observedRows[table] = latestIngestMs?.takeIf { it > 0 }?.let { observedAt - it }
+      }
+    return tables.associateWith { observedRows[it] }
   }
 
   private fun rowFor(record: RoutedEnvelope): JsonObject =
@@ -131,4 +217,15 @@ class ClickHouseSink(
       topic.endsWith(".status.v1") -> "hyperliquid_status"
       else -> "hyperliquid_raw"
     }
+
+  private fun emitReadiness(ready: Boolean) {
+    onReady(ClickHouseReadinessUpdate(ready = ready, tableIngestLagMs = latestTableIngestLagMs))
+  }
+
+  private fun clickHouseIdentifier(value: String): String {
+    require(clickHouseIdentifierPattern.matches(value)) { "Invalid ClickHouse identifier: $value" }
+    return value
+  }
+
+  private fun sqlString(value: String): String = "'${value.replace("\\", "\\\\").replace("'", "\\'")}'"
 }

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HealthServer.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HealthServer.kt
@@ -31,6 +31,7 @@ data class HyperliquidReadinessInfo(
   val clickhouse: Boolean,
   val clickhouseLastSuccessLagMs: Long?,
   val clickhouseLastFailureAgeMs: Long?,
+  val clickhouseTableIngestLagMs: Map<String, Long?>,
   val marketDataFresh: Boolean,
   val marketDataLastSeenLagMs: Map<String, Long?>,
   val marketDataMaxAgeMs: Long,

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
@@ -28,6 +28,8 @@ data class ClickHouseConfig(
   val flushMs: Long,
   val readyMaxAgeMs: Long,
   val failureHoldMs: Long,
+  val readyTables: Set<String> = setOf("hyperliquid_raw", "hyperliquid_candles"),
+  val freshnessCheckMs: Long = 30_000,
 )
 
 data class HyperliquidConfig(
@@ -64,6 +66,17 @@ data class HyperliquidConfig(
     private val supportedIntervals =
       setOf("1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "8h", "12h", "1d", "3d", "1w", "1M")
     private val supportedChannels = setOf("allMids", "trades", "l2Book", "bbo", "candle", "activeAssetCtx", "allDexsAssetCtxs")
+    private val supportedClickHouseReadyTables =
+      setOf(
+        "hyperliquid_raw",
+        "hyperliquid_trades",
+        "hyperliquid_l2_books",
+        "hyperliquid_bbo",
+        "hyperliquid_candles",
+        "hyperliquid_asset_contexts",
+        "hyperliquid_funding",
+        "hyperliquid_status",
+      )
 
     fun fromEnv(env: Map<String, String>? = null): HyperliquidConfig {
       val mergedEnv = env ?: mergeEnv()
@@ -150,6 +163,15 @@ data class HyperliquidConfig(
           flushMs = longEnv(mergedEnv, "CLICKHOUSE_FLUSH_MS", 1000).coerceAtLeast(250),
           readyMaxAgeMs = longEnv(mergedEnv, "CLICKHOUSE_READY_MAX_AGE_MS", 120_000).coerceAtLeast(1_000),
           failureHoldMs = longEnv(mergedEnv, "CLICKHOUSE_FAILURE_HOLD_MS", 60_000).coerceAtLeast(1_000),
+          readyTables =
+            csv(mergedEnv["CLICKHOUSE_READY_TABLES"] ?: "hyperliquid_raw,hyperliquid_candles")
+              .toSet()
+              .also { tables ->
+                if (tables.isEmpty()) error("CLICKHOUSE_READY_TABLES must include at least one table")
+                val unknown = tables.filterNot { it in supportedClickHouseReadyTables }
+                if (unknown.isNotEmpty()) error("Unsupported CLICKHOUSE_READY_TABLES: ${unknown.joinToString(",")}")
+              },
+          freshnessCheckMs = longEnv(mergedEnv, "CLICKHOUSE_FRESHNESS_CHECK_MS", 30_000).coerceAtLeast(1_000),
         )
 
       return HyperliquidConfig(

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
@@ -64,6 +64,10 @@ class HyperliquidFeedApp(
   private val marketCount = AtomicInteger(0)
   private val subscriptionCount = AtomicInteger(0)
   private val notReadySinceMs = AtomicLong(nowMs())
+
+  @Volatile
+  private var clickHouseTableIngestLagMs: Map<String, Long?> = config.clickHouse.readyTables.associateWith { null }
+
   private val httpClient =
     HttpClient(CIO) {
       install(WebSockets)
@@ -88,14 +92,15 @@ class HyperliquidFeedApp(
       }
       val producer = producerFactory(config)
       val clickHouseSink =
-        ClickHouseSink(config.clickHouse, httpClient, metrics, json) {
+        ClickHouseSink(config.clickHouse, httpClient, metrics, json, network = config.network) { update ->
           val observedAt = nowMs()
-          if (it) {
+          clickHouseTableIngestLagMs = update.tableIngestLagMs
+          if (update.ready) {
             clickHouseLastSuccessMs.set(observedAt)
           } else {
             clickHouseLastFailureMs.set(observedAt)
           }
-          clickHouseReady.set(it)
+          clickHouseReady.set(update.ready)
           updateReady()
         }
       val clickHouseJob = clickHouseSink.start(this)
@@ -154,6 +159,7 @@ class HyperliquidFeedApp(
       clickhouse = clickHouseReady.get(),
       clickhouseLastSuccessLagMs = clickHouseLastSuccessLagMs(),
       clickhouseLastFailureAgeMs = clickHouseLastFailureAgeMs(),
+      clickhouseTableIngestLagMs = clickHouseTableIngestLagMs,
       marketDataFresh = freshness.fresh,
       marketDataLastSeenLagMs = freshness.lastSeenLagMs,
       marketDataMaxAgeMs = config.readyEventMaxAgeMs,

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidMetrics.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidMetrics.kt
@@ -24,6 +24,7 @@ class HyperliquidMetrics(
   private val clickHouseErrors = ConcurrentHashMap<String, Counter>()
   private val dedupDrops = ConcurrentHashMap<String, Counter>()
   private val eventLastSeenEpochMs = ConcurrentHashMap<String, AtomicLong>()
+  private val clickHouseTableIngestLagMs = ConcurrentHashMap<String, AtomicLong>()
 
   val reconnects: Counter = registry.counter("torghut_hyperliquid_ws_reconnects_total")
   val wsConnectSuccess: Counter = registry.counter("torghut_hyperliquid_ws_connect_success_total")
@@ -95,6 +96,23 @@ class HyperliquidMetrics(
       .computeIfAbsent(table) {
         Counter.builder("torghut_hyperliquid_clickhouse_insert_errors_total").tag("table", it).register(registry)
       }.increment()
+  }
+
+  fun setClickHouseTableIngestLagMs(
+    table: String,
+    lagMs: Long?,
+  ) {
+    clickHouseTableIngestLagMs
+      .computeIfAbsent(table) {
+        val value = AtomicLong(-1)
+        Gauge
+          .builder("torghut_hyperliquid_clickhouse_table_ingest_lag_seconds", value) {
+            val observed = it.get()
+            if (observed < 0) -1.0 else observed.toDouble() / 1_000.0
+          }.tag("table", table)
+          .register(registry)
+        value
+      }.set(lagMs ?: -1)
   }
 
   fun recordDedupDrop(channel: String) {

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -19,7 +20,7 @@ class ClickHouseSinkTest {
   @Test
   fun `marks clickhouse not ready for non successful insert response`() =
     runBlocking {
-      val readySignals = mutableListOf<Boolean>()
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
       val client =
         HttpClient(
           MockEngine {
@@ -50,15 +51,124 @@ class ClickHouseSinkTest {
       sink.enqueue(candleRecord())
 
       withTimeout(1_000) {
-        while (readySignals.lastOrNull() != false) {
+        while (readySignals.lastOrNull()?.ready != false) {
           delay(10)
         }
       }
 
-      assertEquals(false, readySignals.last())
+      assertEquals(false, readySignals.last().ready)
       job.cancelAndJoin()
       client.close()
     }
+
+  @Test
+  fun `marks clickhouse not ready when table ingest freshness is stale`() =
+    runBlocking {
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            if (queryParam(request.url).startsWith("INSERT")) {
+              respond(content = "", status = HttpStatusCode.OK)
+            } else {
+              respond(
+                content =
+                  """
+                  {"table":"hyperliquid_candles","latest_ingest_ms":7000}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":7000}
+                  """.trimIndent(),
+                status = HttpStatusCode.OK,
+              )
+            }
+          },
+        )
+      val sink =
+        ClickHouseSink(
+          config = clickHouseConfig(readyMaxAgeMs = 1_000),
+          httpClient = client,
+          metrics = HyperliquidMetrics(SimpleMeterRegistry()),
+          json = Json,
+          nowMs = { 10_000 },
+          onReady = { readySignals += it },
+        )
+      val job = sink.start(this)
+
+      sink.enqueue(candleRecord())
+
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != false) {
+          delay(10)
+        }
+      }
+
+      assertEquals(false, readySignals.last().ready)
+      assertEquals(3_000, readySignals.last().tableIngestLagMs["hyperliquid_candles"])
+      job.cancelAndJoin()
+      client.close()
+    }
+
+  @Test
+  fun `marks clickhouse ready when insert succeeds and table ingest is fresh`() =
+    runBlocking {
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            if (queryParam(request.url).startsWith("INSERT")) {
+              respond(content = "", status = HttpStatusCode.OK)
+            } else {
+              respond(
+                content =
+                  """
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9500}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9400}
+                  """.trimIndent(),
+                status = HttpStatusCode.OK,
+              )
+            }
+          },
+        )
+      val sink =
+        ClickHouseSink(
+          config = clickHouseConfig(readyMaxAgeMs = 1_000),
+          httpClient = client,
+          metrics = HyperliquidMetrics(SimpleMeterRegistry()),
+          json = Json,
+          nowMs = { 10_000 },
+          onReady = { readySignals += it },
+        )
+      val job = sink.start(this)
+
+      sink.enqueue(candleRecord())
+
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != true) {
+          delay(10)
+        }
+      }
+
+      assertEquals(true, readySignals.last().ready)
+      assertEquals(500, readySignals.last().tableIngestLagMs["hyperliquid_candles"])
+      job.cancelAndJoin()
+      client.close()
+    }
+
+  private fun clickHouseConfig(readyMaxAgeMs: Long): ClickHouseConfig =
+    ClickHouseConfig(
+      enabled = true,
+      httpUrl = "http://clickhouse.local:8123",
+      database = "torghut",
+      username = "torghut",
+      password = "",
+      batchSize = 1,
+      flushMs = 1,
+      readyMaxAgeMs = readyMaxAgeMs,
+      failureHoldMs = 1_000,
+      readyTables = setOf("hyperliquid_raw", "hyperliquid_candles"),
+      freshnessCheckMs = 1,
+    )
+
+  private fun queryParam(url: Url): String = url.parameters["query"] ?: ""
 
   private fun candleRecord(): RoutedEnvelope =
     RoutedEnvelope(

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
@@ -49,6 +49,8 @@ class HyperliquidConfigTest {
           "KAFKA_SASL_PASSWORD" to "secret",
           "CLICKHOUSE_READY_MAX_AGE_MS" to "90000",
           "CLICKHOUSE_FAILURE_HOLD_MS" to "45000",
+          "CLICKHOUSE_READY_TABLES" to "hyperliquid_raw,hyperliquid_candles,hyperliquid_bbo",
+          "CLICKHOUSE_FRESHNESS_CHECK_MS" to "5000",
           "HYPERLIQUID_READY_REQUIRED_CHANNELS" to "raw,candle",
           "HYPERLIQUID_READY_EVENT_MAX_AGE_MS" to "120000",
         ),
@@ -56,6 +58,8 @@ class HyperliquidConfigTest {
 
     assertEquals(90_000, config.clickHouse.readyMaxAgeMs)
     assertEquals(45_000, config.clickHouse.failureHoldMs)
+    assertEquals(setOf("hyperliquid_raw", "hyperliquid_candles", "hyperliquid_bbo"), config.clickHouse.readyTables)
+    assertEquals(5_000, config.clickHouse.freshnessCheckMs)
     assertEquals(setOf("raw", "candle"), config.readyRequiredChannels)
     assertEquals(120_000, config.readyEventMaxAgeMs)
   }
@@ -119,5 +123,20 @@ class HyperliquidConfigTest {
       }
 
     assertTrue(error.message.orEmpty().contains("Unsupported HYPERLIQUID_READY_REQUIRED_CHANNELS"))
+  }
+
+  @Test
+  fun `rejects unknown clickhouse readiness tables`() {
+    val error =
+      assertFailsWith<IllegalStateException> {
+        HyperliquidConfig.fromEnv(
+          mapOf(
+            "KAFKA_SASL_PASSWORD" to "secret",
+            "CLICKHOUSE_READY_TABLES" to "hyperliquid_raw,system_tables",
+          ),
+        )
+      }
+
+    assertTrue(error.message.orEmpty().contains("Unsupported CLICKHOUSE_READY_TABLES"))
   }
 }


### PR DESCRIPTION
## Summary

- Gates Hyperliquid feed readiness on queryable ClickHouse table `ingest_ts` freshness, not only successful insert calls.
- Exposes per-table ClickHouse ingest lag in `/readyz` and Prometheus metrics.
- Adds config and tests for ClickHouse readiness tables and freshness check cadence.

## Related Issues

None

## Testing

- `./gradlew :hyperliquid-feed:test --tests ai.proompteng.dorvud.hyperliquid.ClickHouseSinkTest --tests ai.proompteng.dorvud.hyperliquid.HyperliquidConfigTest`
- `./gradlew :hyperliquid-feed:test`
- `./gradlew :hyperliquid-feed:check`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
