### PR TITLE
chore(torghut): roll hyperliquid feed readiness fix

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-top-volume-100-20260618b
+        proompteng.ai/config-revision: hyperliquid-top-volume-100-20260618c
       labels:
         app: torghut-hyperliquid-feed
     spec:


### PR DESCRIPTION
## Summary

- Rolls `torghut-hyperliquid-feed` by bumping the pod-template config revision.
- Moves the live feed Deployment onto the newly built image containing ClickHouse table freshness readiness.
- Leaves feed coverage, topics, ClickHouse schema, and runtime configuration unchanged.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
