### PR TITLE
fix(torghut): keep hyperliquid runtime loop alive

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/api.py
+++ b/services/torghut/app/hyperliquid_runtime/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
@@ -17,6 +18,8 @@ from .ledger import HyperliquidTigerBeetleJournal
 from .metrics import HyperliquidRuntimeMetrics
 from .models import CycleResult
 from .service import HyperliquidRuntimeService, runtime_readiness
+
+logger = logging.getLogger(__name__)
 
 
 class RuntimeAppState:
@@ -98,7 +101,10 @@ def metrics() -> Response:
 
 async def _runtime_loop() -> None:
     while True:
-        await asyncio.to_thread(_run_one_cycle)
+        try:
+            await asyncio.to_thread(_run_one_cycle)
+        except Exception:
+            logger.exception("Hyperliquid runtime cycle failed")
         await asyncio.sleep(runtime_state.config.poll_interval_seconds)
 
 

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -394,6 +395,33 @@ def test_api_run_one_cycle_success_and_failure(monkeypatch: pytest.MonkeyPatch) 
     assert failing_session.rolled_back
     assert failing_session.closed
     assert state.latest_error == "RuntimeError:cycle_failed"
+
+
+def test_runtime_loop_continues_after_cycle_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    state = SimpleNamespace(
+        config=_config(HYPERLIQUID_RUNTIME_POLL_INTERVAL_SECONDS="1")
+    )
+
+    async def fake_to_thread(_func: object) -> None:
+        calls.append("cycle")
+        if calls.count("cycle") == 1:
+            raise RuntimeError("cycle_failed")
+        raise asyncio.CancelledError
+
+    async def fake_sleep(_seconds: float) -> None:
+        calls.append("sleep")
+
+    monkeypatch.setattr(runtime_api, "runtime_state", state)
+    monkeypatch.setattr(runtime_api.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(runtime_api.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(runtime_api._runtime_loop())
+
+    assert calls == ["cycle", "sleep", "cycle"]
 
 
 def test_runtime_readiness_stale_cycle() -> None:


### PR DESCRIPTION
## Summary

- Keeps the Hyperliquid runtime background loop alive after a single cycle failure.
- Logs failed cycles while preserving the existing readiness/error state.
- Adds a regression test proving the loop sleeps and retries after a failed cycle.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_universe.py tests/hyperliquid_runtime/test_risk_strategy.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
