### PR TITLE
fix(torghut): separate bounded collection gate

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -22,8 +22,6 @@ spec:
         app: torghut-hyperliquid-runtime
     spec:
       serviceAccountName: torghut-runtime
-      nodeSelector:
-        kubernetes.io/arch: arm64
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
@@ -215,6 +215,10 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
     ) -> bool:
         if not self._bounded_live_paper_route_probe_decision_applies(decision):
             return False
+        collection_gate = live_submission_gate.get("bounded_live_paper_collection_gate")
+        if isinstance(collection_gate, Mapping):
+            collection_gate_mapping = cast(Mapping[str, Any], collection_gate)
+            return collection_gate_mapping.get("allowed") is True
         blocked_reasons = {
             str(reason).strip()
             for reason in cast(

--- a/services/torghut/app/trading/submission_council/__init__.py
+++ b/services/torghut/app/trading/submission_council/__init__.py
@@ -46,6 +46,10 @@ from .quant_health import (
     resolve_active_capital_stage,
     resolve_quant_health_url,
 )
+from .gate_payloads import (
+    bounded_live_paper_collection_gate_payload as _bounded_live_paper_collection_gate_payload,
+    common_submission_payload as _common_submission_payload,
+)
 from .runtime_summary import (
     runtime_ledger_aggregate_candidate_payloads as _runtime_ledger_aggregate_candidate_payloads,
     runtime_ledger_latest_payloads_per_symbol as _runtime_ledger_latest_payloads_per_symbol,
@@ -103,7 +107,6 @@ from .profit_readiness import (
 )
 from ..live_submit_activation import (
     live_submit_activation_blocker,
-    live_submit_activation_status,
 )
 
 
@@ -893,62 +896,6 @@ def _empty_submission_evidence_tuple(
     }
 
 
-def _common_submission_payload(context: _SubmissionGateContext) -> dict[str, object]:
-    return {
-        "configured_live_promotion": context.toggles.configured_live_promotion,
-        "autonomy_promotion_eligible": context.toggles.autonomy_promotion_eligible,
-        "autonomy_promotion_action": context.toggles.autonomy_promotion_action,
-        "drift_live_promotion_eligible": context.toggles.drift_live_promotion_eligible,
-        "promotion_eligible_total": context.totals.promotion_eligible_total,
-        "paper_probation_eligible_total": context.totals.paper_probation_eligible_total,
-        "dependency_quorum_decision": context.dependencies.decision,
-        **context.dependencies.runtime_window_import_health_gate,
-        "empirical_jobs_ready": context.dependencies.empirical_ready,
-        "dspy_live_ready": context.dependencies.dspy_live_ready,
-        "critical_toggle_parity": context.toggles.critical_toggle_parity,
-        "critical_toggle_parity_blocking_mismatches": context.toggles.blocking_toggle_mismatches,
-        "active_capital_stage": context.totals.active_capital_stage,
-        "quant_evidence": context.quant.evidence,
-        "quant_health_ref": _quant_health_ref(context),
-        "market_context_ref": context.market_context_ref,
-        "live_submit_activation": live_submit_activation_status(now=context.now),
-        **_runtime_ledger_payload(context.runtime_inputs.runtime_ledger),
-        "profit_lease_projection": context.profit_lease_projection,
-    }
-
-
-def _quant_health_ref(context: _SubmissionGateContext) -> dict[str, object]:
-    return {
-        "account": context.quant.evidence.get("account"),
-        "window": context.quant.evidence.get("window"),
-        "status": context.quant.evidence.get("status"),
-        "source_url": context.quant.evidence.get("source_url"),
-        "latest_metrics_updated_at": context.quant.evidence.get(
-            "latest_metrics_updated_at"
-        ),
-    }
-
-
-def _runtime_ledger_payload(
-    runtime_ledger: _SubmissionRuntimeLedgerContext,
-) -> dict[str, object]:
-    return {
-        "runtime_ledger_repair_candidates": runtime_ledger.repair_candidates,
-        "runtime_ledger_paper_probation_candidates": runtime_ledger.paper_probation_candidates,
-        "runtime_ledger_source_collection_candidates": runtime_ledger.source_collection_candidates,
-        "runtime_ledger_source_collection_candidate_total": len(
-            runtime_ledger.source_collection_candidates
-        ),
-        "runtime_ledger_source_collection_profit_target_candidate_total": len(
-            runtime_ledger.source_collection_profit_target_candidates
-        ),
-        "runtime_ledger_paper_probation_eligible_total": len(
-            runtime_ledger.paper_probation_candidates
-        ),
-        "runtime_ledger_paper_probation_import_plan": runtime_ledger.paper_probation_import_plan,
-    }
-
-
 def _live_submission_gate_payload(
     context: _SubmissionGateContext,
     *,
@@ -969,6 +916,10 @@ def _live_submission_gate_payload(
         "issued_at": selection.issued_at,
         "expires_at": selection.expires_at,
         **_common_submission_payload(context),
+        "bounded_live_paper_collection_gate": _bounded_live_paper_collection_gate_payload(
+            context,
+            blocked_reasons=blocked_reasons,
+        ),
         "reason_codes": selection.reason_codes,
         "segment_summary": {
             "segments": context.segment_summary,

--- a/services/torghut/app/trading/submission_council/gate_payloads.py
+++ b/services/torghut/app/trading/submission_council/gate_payloads.py
@@ -1,0 +1,186 @@
+"""Payload assembly helpers for live submission gates."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from .common import (
+    normalize_reason_codes,
+    safe_decimal,
+    safe_int,
+    settings,
+)
+from ..live_submit_activation import live_submit_activation_status
+
+
+_BOUNDED_LIVE_PAPER_COLLECTION_COMPATIBLE_BLOCKERS = frozenset(
+    {
+        "alpha_hypothesis_not_promotion_eligible",
+        "alpha_hypothesis_shadow_only",
+        "alpha_readiness_not_promotion_eligible",
+        "bounded_paper_route_evidence_collection_only",
+        "hypothesis_window_evidence_missing",
+        "live_runtime_ledger_required",
+        "paper_probation_evidence_collection_only",
+        "paper_route_runtime_ledger_import_pending",
+        "promotion_certificate_missing",
+        "runtime_ledger_profit_target_source_collection_pending",
+        "runtime_ledger_source_collection_only",
+        "runtime_ledger_source_collection_pending",
+        "runtime_ledger_source_window_evidence_pending",
+    }
+)
+
+
+def common_submission_payload(context: Any) -> dict[str, object]:
+    return {
+        "configured_live_promotion": context.toggles.configured_live_promotion,
+        "autonomy_promotion_eligible": context.toggles.autonomy_promotion_eligible,
+        "autonomy_promotion_action": context.toggles.autonomy_promotion_action,
+        "drift_live_promotion_eligible": context.toggles.drift_live_promotion_eligible,
+        "promotion_eligible_total": context.totals.promotion_eligible_total,
+        "paper_probation_eligible_total": context.totals.paper_probation_eligible_total,
+        "dependency_quorum_decision": context.dependencies.decision,
+        **context.dependencies.runtime_window_import_health_gate,
+        "empirical_jobs_ready": context.dependencies.empirical_ready,
+        "dspy_live_ready": context.dependencies.dspy_live_ready,
+        "critical_toggle_parity": context.toggles.critical_toggle_parity,
+        "critical_toggle_parity_blocking_mismatches": (
+            context.toggles.blocking_toggle_mismatches
+        ),
+        "active_capital_stage": context.totals.active_capital_stage,
+        "quant_evidence": context.quant.evidence,
+        "quant_health_ref": _quant_health_ref(context),
+        "market_context_ref": context.market_context_ref,
+        "live_submit_activation": live_submit_activation_status(now=context.now),
+        **_runtime_ledger_payload(context.runtime_inputs.runtime_ledger),
+        "profit_lease_projection": context.profit_lease_projection,
+    }
+
+
+def bounded_live_paper_collection_gate_payload(
+    context: Any,
+    *,
+    blocked_reasons: Sequence[str],
+) -> dict[str, object]:
+    runtime_ledger = context.runtime_inputs.runtime_ledger
+    import_plan = runtime_ledger.paper_probation_import_plan
+    source_collection_target_count = max(
+        len(runtime_ledger.source_collection_candidates),
+        safe_int(import_plan.get("source_collection_target_count")),
+        safe_int(import_plan.get("manifest_bounded_collection_target_count")),
+    )
+    profit_target_count = max(
+        len(runtime_ledger.source_collection_profit_target_candidates),
+        safe_int(import_plan.get("source_collection_profit_target_count")),
+    )
+    max_notional = safe_decimal(settings.trading_simple_paper_route_probe_max_notional)
+    activation = live_submit_activation_status(now=context.now)
+    hard_blockers = [
+        reason
+        for reason in blocked_reasons
+        if reason not in _BOUNDED_LIVE_PAPER_COLLECTION_COMPATIBLE_BLOCKERS
+    ]
+    blockers: list[str] = []
+    if not settings.trading_simple_paper_route_probe_enabled:
+        blockers.append("paper_route_probe_disabled")
+    if not settings.trading_simple_paper_route_probe_allow_live_mode:
+        blockers.append("live_paper_route_probe_collection_disabled")
+    if not settings.trading_simple_submit_enabled:
+        blockers.append("simple_submit_disabled")
+    if activation.get("configured") is not True:
+        blockers.append("live_submit_activation_missing")
+    elif activation.get("valid") is not True:
+        blockers.append(
+            str(activation.get("reason") or "live_submit_activation_invalid")
+        )
+    elif activation.get("expired") is True:
+        blockers.append(
+            str(activation.get("reason") or "live_submit_activation_expired")
+        )
+    if max_notional is None or max_notional <= 0:
+        blockers.append("paper_route_probe_notional_not_configured")
+    if source_collection_target_count <= 0:
+        blockers.append("source_collection_target_missing")
+    blockers.extend(hard_blockers)
+    normalized_blockers = normalize_reason_codes(blockers)
+    allowed = not normalized_blockers
+    market_session_open = getattr(context.state, "market_session_open", None)
+    active = allowed and market_session_open is True
+    if normalized_blockers:
+        reason = normalized_blockers[0]
+    elif active:
+        reason = "bounded_live_paper_collection_ready"
+    else:
+        reason = "bounded_live_paper_collection_waiting_for_session"
+    return {
+        "schema_version": "torghut.bounded-live-paper-collection-gate.v1",
+        "allowed": allowed,
+        "active": active,
+        "reason": reason,
+        "blocked_reasons": normalized_blockers,
+        "authority_scope": "bounded_evidence_collection_only",
+        "capital_promotion_allowed": False,
+        "final_authority_ok": False,
+        "capital_gate_allowed": False,
+        "capital_gate_blocked_reasons": list(blocked_reasons),
+        "collection_only_blockers": [
+            reason
+            for reason in blocked_reasons
+            if reason in _BOUNDED_LIVE_PAPER_COLLECTION_COMPATIBLE_BLOCKERS
+        ],
+        "hard_blockers": hard_blockers,
+        "source_collection_target_count": source_collection_target_count,
+        "source_collection_profit_target_count": profit_target_count,
+        "paper_route_probe_enabled": settings.trading_simple_paper_route_probe_enabled,
+        "paper_route_probe_allow_live_mode": (
+            settings.trading_simple_paper_route_probe_allow_live_mode
+        ),
+        "simple_submit_enabled": settings.trading_simple_submit_enabled,
+        "paper_route_probe_max_notional": str(max_notional or 0),
+        "live_submit_activation": activation,
+        "market_session_open": market_session_open,
+    }
+
+
+def _quant_health_ref(context: Any) -> dict[str, object]:
+    return {
+        "account": context.quant.evidence.get("account"),
+        "window": context.quant.evidence.get("window"),
+        "status": context.quant.evidence.get("status"),
+        "source_url": context.quant.evidence.get("source_url"),
+        "latest_metrics_updated_at": context.quant.evidence.get(
+            "latest_metrics_updated_at"
+        ),
+    }
+
+
+def _runtime_ledger_payload(runtime_ledger: Any) -> dict[str, object]:
+    return {
+        "runtime_ledger_repair_candidates": runtime_ledger.repair_candidates,
+        "runtime_ledger_paper_probation_candidates": (
+            runtime_ledger.paper_probation_candidates
+        ),
+        "runtime_ledger_source_collection_candidates": (
+            runtime_ledger.source_collection_candidates
+        ),
+        "runtime_ledger_source_collection_candidate_total": len(
+            runtime_ledger.source_collection_candidates
+        ),
+        "runtime_ledger_source_collection_profit_target_candidate_total": len(
+            runtime_ledger.source_collection_profit_target_candidates
+        ),
+        "runtime_ledger_paper_probation_eligible_total": len(
+            runtime_ledger.paper_probation_candidates
+        ),
+        "runtime_ledger_paper_probation_import_plan": (
+            runtime_ledger.paper_probation_import_plan
+        ),
+    }
+
+
+__all__ = [
+    "bounded_live_paper_collection_gate_payload",
+    "common_submission_payload",
+]

--- a/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
@@ -107,6 +107,34 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
                     gate,
                 )
             )
+            self.assertTrue(
+                pipeline._bounded_live_paper_route_probe_submission_allowed(
+                    decision,
+                    {
+                        **gate,
+                        "blocked_reasons": [
+                            *cast(list[str], gate["blocked_reasons"]),
+                            "empirical_jobs_not_ready",
+                        ],
+                        "bounded_live_paper_collection_gate": {
+                            "allowed": True,
+                            "authority_scope": "bounded_evidence_collection_only",
+                        },
+                    },
+                )
+            )
+            self.assertFalse(
+                pipeline._bounded_live_paper_route_probe_submission_allowed(
+                    decision,
+                    {
+                        **gate,
+                        "bounded_live_paper_collection_gate": {
+                            "allowed": False,
+                            "reason": "live_submit_activation_expired",
+                        },
+                    },
+                )
+            )
             self.assertFalse(
                 pipeline._bounded_live_paper_route_probe_submission_allowed(
                     decision,

--- a/services/torghut/tests/submission_council/support.py
+++ b/services/torghut/tests/submission_council/support.py
@@ -139,6 +139,10 @@ class SubmissionCouncilTestCase(TestCase):
             "trading_autonomy_allow_live_promotion": settings.trading_autonomy_allow_live_promotion,
             "trading_kill_switch_enabled": settings.trading_kill_switch_enabled,
             "trading_live_submit_activation_expires_at": settings.trading_live_submit_activation_expires_at,
+            "trading_simple_paper_route_probe_enabled": settings.trading_simple_paper_route_probe_enabled,
+            "trading_simple_paper_route_probe_allow_live_mode": settings.trading_simple_paper_route_probe_allow_live_mode,
+            "trading_simple_paper_route_probe_max_notional": settings.trading_simple_paper_route_probe_max_notional,
+            "trading_simple_submit_enabled": settings.trading_simple_submit_enabled,
             "trading_jangar_quant_health_url": settings.trading_jangar_quant_health_url,
             "trading_jangar_quant_health_required": settings.trading_jangar_quant_health_required,
             "trading_jangar_quant_window": settings.trading_jangar_quant_window,
@@ -169,6 +173,18 @@ class SubmissionCouncilTestCase(TestCase):
         ]
         settings.trading_live_submit_activation_expires_at = self._settings_snapshot[
             "trading_live_submit_activation_expires_at"
+        ]
+        settings.trading_simple_paper_route_probe_enabled = self._settings_snapshot[
+            "trading_simple_paper_route_probe_enabled"
+        ]
+        settings.trading_simple_paper_route_probe_allow_live_mode = (
+            self._settings_snapshot["trading_simple_paper_route_probe_allow_live_mode"]
+        )
+        settings.trading_simple_paper_route_probe_max_notional = (
+            self._settings_snapshot["trading_simple_paper_route_probe_max_notional"]
+        )
+        settings.trading_simple_submit_enabled = self._settings_snapshot[
+            "trading_simple_submit_enabled"
         ]
         settings.trading_jangar_quant_health_url = self._settings_snapshot[
             "trading_jangar_quant_health_url"

--- a/services/torghut/tests/submission_council/test_live_submission_gate.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate.py
@@ -82,6 +82,91 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
             "2000-01-01T00:00:00+00:00",
         )
 
+    def test_bounded_live_paper_collection_gate_fails_closed_without_explicit_contract(
+        self,
+    ) -> None:
+        from app.config import settings
+
+        settings.trading_simple_paper_route_probe_enabled = False
+        settings.trading_simple_paper_route_probe_allow_live_mode = False
+        settings.trading_simple_submit_enabled = False
+        settings.trading_simple_paper_route_probe_max_notional = 0
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                market_session_open=True,
+                last_autonomy_promotion_eligible=False,
+                last_autonomy_promotion_action=None,
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=45,
+            ),
+            hypothesis_summary={
+                "promotion_eligible_total": 0,
+                "capital_stage_totals": {"shadow": 1},
+                "dependency_quorum": {
+                    "decision": "allow",
+                    "reasons": [],
+                    "message": "ready",
+                },
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+        )
+
+        collection_gate = result["bounded_live_paper_collection_gate"]
+        self.assertFalse(collection_gate["allowed"])
+        self.assertEqual(collection_gate["reason"], "paper_route_probe_disabled")
+        self.assertIn("paper_route_probe_disabled", collection_gate["blocked_reasons"])
+        self.assertIn(
+            "live_paper_route_probe_collection_disabled",
+            collection_gate["blocked_reasons"],
+        )
+        self.assertIn("simple_submit_disabled", collection_gate["blocked_reasons"])
+        self.assertIn(
+            "live_submit_activation_missing", collection_gate["blocked_reasons"]
+        )
+        self.assertIn(
+            "paper_route_probe_notional_not_configured",
+            collection_gate["blocked_reasons"],
+        )
+
+    def test_bounded_live_paper_collection_gate_rejects_invalid_activation(
+        self,
+    ) -> None:
+        from app.config import settings
+
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
+        settings.trading_simple_submit_enabled = True
+        settings.trading_simple_paper_route_probe_max_notional = 100
+        settings.trading_live_submit_activation_expires_at = "not-a-date"
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                market_session_open=True,
+                last_autonomy_promotion_eligible=False,
+                last_autonomy_promotion_action=None,
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=45,
+            ),
+            hypothesis_summary={
+                "promotion_eligible_total": 0,
+                "capital_stage_totals": {"shadow": 1},
+                "dependency_quorum": {
+                    "decision": "allow",
+                    "reasons": [],
+                    "message": "ready",
+                },
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+        )
+
+        collection_gate = result["bounded_live_paper_collection_gate"]
+        self.assertFalse(collection_gate["allowed"])
+        self.assertIn(
+            "live_submit_activation_expiry_invalid",
+            collection_gate["blocked_reasons"],
+        )
+
     def test_build_live_submission_gate_payload_exports_runtime_window_health_inputs(
         self,
     ) -> None:

--- a/services/torghut/tests/submission_council/test_source_collection_candidates.py
+++ b/services/torghut/tests/submission_council/test_source_collection_candidates.py
@@ -27,6 +27,7 @@ from tests.submission_council.support import (
     datetime,
     patch,
     sessionmaker,
+    settings,
     timedelta,
     timezone,
 )
@@ -772,6 +773,11 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
     def test_live_gate_marks_source_collection_pending_without_probation(
         self,
     ) -> None:
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_simple_paper_route_probe_allow_live_mode = True
+        settings.trading_simple_paper_route_probe_max_notional = 100
+        settings.trading_simple_submit_enabled = True
+        settings.trading_live_submit_activation_expires_at = "2999-01-01T20:05:00Z"
         engine = create_engine(
             "sqlite+pysqlite:///:memory:",
             future=True,
@@ -874,6 +880,39 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
                     promotion_certificate_evidence=[],
                     session=session,
                 )
+                waiting_gate = build_live_submission_gate_payload(
+                    SimpleNamespace(
+                        market_session_open=False,
+                        last_autonomy_promotion_eligible=False,
+                        last_autonomy_promotion_action=None,
+                        drift_live_promotion_eligible=False,
+                        last_market_context_freshness_seconds=45,
+                        metrics=SimpleNamespace(
+                            feature_batch_rows_total=9,
+                            feature_null_rate={"price": 0.0},
+                            feature_staleness_ms_p95=250,
+                            feature_duplicate_ratio=0.0,
+                            decision_state_total={},
+                        ),
+                    ),
+                    hypothesis_summary={
+                        "summary": {
+                            "promotion_eligible_total": 0,
+                            "capital_stage_totals": {"shadow": 1},
+                            "dependency_quorum": {
+                                "decision": "allow",
+                                "reasons": [],
+                                "message": "ready",
+                            },
+                        },
+                        "items": [],
+                    },
+                    empirical_jobs_status={"ready": True, "status": "healthy"},
+                    dspy_runtime_status={"mode": "inactive"},
+                    quant_health_status=self._healthy_quant_status(),
+                    promotion_certificate_evidence=[],
+                    session=session,
+                )
 
         self.assertEqual(gate["paper_probation_eligible_total"], 0)
         self.assertEqual(gate["runtime_ledger_paper_probation_eligible_total"], 0)
@@ -883,6 +922,28 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
         self.assertIn(
             "runtime_ledger_profit_target_source_collection_pending",
             gate["blocked_reasons"],
+        )
+        self.assertFalse(gate["allowed"])
+        collection_gate = gate["bounded_live_paper_collection_gate"]
+        self.assertTrue(collection_gate["allowed"])
+        self.assertTrue(collection_gate["active"])
+        self.assertEqual(
+            collection_gate["reason"],
+            "bounded_live_paper_collection_ready",
+        )
+        self.assertEqual(
+            collection_gate["authority_scope"], "bounded_evidence_collection_only"
+        )
+        self.assertFalse(collection_gate["capital_promotion_allowed"])
+        self.assertFalse(collection_gate["final_authority_ok"])
+        self.assertEqual(collection_gate["blocked_reasons"], [])
+        self.assertEqual(collection_gate["paper_route_probe_max_notional"], "100")
+        waiting_collection_gate = waiting_gate["bounded_live_paper_collection_gate"]
+        self.assertTrue(waiting_collection_gate["allowed"])
+        self.assertFalse(waiting_collection_gate["active"])
+        self.assertEqual(
+            waiting_collection_gate["reason"],
+            "bounded_live_paper_collection_waiting_for_session",
         )
         self.assertEqual(gate["runtime_ledger_source_collection_candidate_total"], 1)
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Split the Torghut live-submit status into a capital promotion gate and an explicit bounded paper evidence-collection gate, so source-collection blockers do not masquerade as final capital authority.
- Teach direct submission to consume the explicit bounded collection gate while preserving the existing fail-closed fallback for older status payloads.
- Move shared submission-gate payload assembly into a small helper module to keep the submission council facade under the file-length gate.
- Remove the stale `arm64` node selector from `torghut-hyperliquid-runtime` so the multi-arch `lab/torghut` image can schedule on amd64 nodes.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/submission_council/test_live_submission_gate.py tests/submission_council/test_source_collection_candidates.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/submission_council/__init__.py app/trading/submission_council/gate_payloads.py app/trading/scheduler/submission_preparation/direct_submission.py tests/submission_council/support.py tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_live_submission_gate.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/submission_council/test_live_submission_gate.py::TestSubmissionCouncilLiveSubmissionGate::test_bounded_live_paper_collection_gate_fails_closed_without_explicit_contract tests/submission_council/test_live_submission_gate.py::TestSubmissionCouncilLiveSubmissionGate::test_bounded_live_paper_collection_gate_rejects_invalid_activation tests/submission_council/test_live_submission_gate.py::TestSubmissionCouncilLiveSubmissionGate::test_build_live_submission_gate_payload_blocks_after_live_submit_activation_expiry tests/submission_council/test_source_collection_candidates.py::TestSubmissionCouncilSourceCollectionCandidates::test_live_gate_marks_source_collection_pending_without_probation tests/pipeline/test_trading_pipeline_target_plan_source_b.py::TestTradingPipelineTargetPlanSourceB::test_live_bounded_paper_route_probe_bypasses_only_collection_blockers tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
