### PR TITLE
chore(torghut): roll hyperliquid runtime loop fix

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618c
+        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618d
       labels:
         app: torghut-hyperliquid-runtime
     spec:


### PR DESCRIPTION
## Summary

- Bump the Hyperliquid runtime Deployment `config-revision` to force a new pod rollout.
- Pick up the Torghut image built from `fix(torghut): keep hyperliquid runtime loop alive`.
- Leave runtime config, secrets, and existing Torghut services unchanged.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
