### PR TITLE
fix(torghut): repair hyperliquid tigerbeetle ref ids

### DIFF
--- a/services/torghut/migrations/versions/0055_hyperliquid_tigerbeetle_ref_u128.py
+++ b/services/torghut/migrations/versions/0055_hyperliquid_tigerbeetle_ref_u128.py
@@ -1,0 +1,61 @@
+"""Repair Hyperliquid TigerBeetle u128 ref columns.
+
+Revision ID: 0055_hyperliquid_tigerbeetle_ref_u128
+Revises: 0054_hyperliquid_runtime
+Create Date: 2026-06-18 06:58:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0055_hyperliquid_tigerbeetle_ref_u128"
+down_revision = "0054_hyperliquid_runtime"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "hyperliquid_runtime_tigerbeetle_refs"
+NUMERIC_39_COLUMNS = (
+    "transfer_id",
+    "debit_account_id",
+    "credit_account_id",
+    "amount",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    if not inspector.has_table(TABLE_NAME):
+        return
+
+    columns = {column["name"]: column for column in inspector.get_columns(TABLE_NAME)}
+    for column_name in NUMERIC_39_COLUMNS:
+        column = columns.get(column_name)
+        if column is None or _is_numeric_39(column["type"]):
+            continue
+        op.alter_column(
+            TABLE_NAME,
+            column_name,
+            existing_type=column["type"],
+            type_=sa.Numeric(39, 0),
+            existing_nullable=False,
+            postgresql_using=f"{column_name}::numeric(39, 0)",
+        )
+
+
+def downgrade() -> None:
+    """Do not narrow u128 refs back to integer storage."""
+
+
+def _is_numeric_39(column_type: object) -> bool:
+    return (
+        isinstance(column_type, sa.Numeric)
+        and column_type.precision == 39
+        and column_type.scale == 0
+    )

--- a/services/torghut/tests/test_hyperliquid_tigerbeetle_ref_u128_migration.py
+++ b/services/torghut/tests/test_hyperliquid_tigerbeetle_ref_u128_migration.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import sqlalchemy as sa
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0055_hyperliquid_tigerbeetle_ref_u128.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0055", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0055")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestHyperliquidTigerBeetleRefU128Migration(TestCase):
+    def test_revision_follows_hyperliquid_runtime_migration(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(
+            module.revision,
+            "0055_hyperliquid_tigerbeetle_ref_u128",
+        )
+        self.assertEqual(module.down_revision, "0054_hyperliquid_runtime")
+
+    def test_upgrade_widens_integer_transfer_id_to_numeric_39(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_columns.return_value = [
+            {"name": "transfer_id", "type": sa.Integer(), "nullable": False},
+            {
+                "name": "debit_account_id",
+                "type": sa.Numeric(39, 0),
+                "nullable": False,
+            },
+            {
+                "name": "credit_account_id",
+                "type": sa.Numeric(39, 0),
+                "nullable": False,
+            },
+            {"name": "amount", "type": sa.Numeric(39, 0), "nullable": False},
+        ]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "alter_column") as alter_column,
+        ):
+            module.upgrade()
+
+        alter_column.assert_called_once()
+        _, column_name = alter_column.call_args.args
+        kwargs = alter_column.call_args.kwargs
+        self.assertEqual(column_name, "transfer_id")
+        self.assertIsInstance(kwargs["type_"], sa.Numeric)
+        self.assertEqual(kwargs["type_"].precision, 39)
+        self.assertEqual(kwargs["type_"].scale, 0)
+        self.assertEqual(kwargs["postgresql_using"], "transfer_id::numeric(39, 0)")
+
+    def test_upgrade_skips_when_columns_are_already_numeric_39(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_columns.return_value = [
+            {"name": column_name, "type": sa.Numeric(39, 0), "nullable": False}
+            for column_name in module.NUMERIC_39_COLUMNS
+        ]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "alter_column") as alter_column,
+        ):
+            module.upgrade()
+
+        alter_column.assert_not_called()


### PR DESCRIPTION
## Summary

- Add migration `0055_hyperliquid_tigerbeetle_ref_u128` to repair Hyperliquid TigerBeetle ref storage.
- Convert any non-`numeric(39,0)` `hyperliquid_runtime_tigerbeetle_refs` u128 columns, including the live `transfer_id` mismatch.
- Add a regression test for the integer-to-`numeric(39,0)` migration path and already-correct no-op path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen pytest tests/test_hyperliquid_tigerbeetle_ref_u128_migration.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
