### PR TITLE
chore(torghut): roll hyperliquid runtime schema fix

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618d
+        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618e
       labels:
         app: torghut-hyperliquid-runtime
     spec:


### PR DESCRIPTION
## Summary

- Bump the Hyperliquid runtime Deployment `config-revision` to force a new pod rollout.
- Pick up the Torghut image containing migration `0055_hyperliquid_tigerbeetle_ref_u128`.
- Run the existing Argo migration hooks through GitOps; runtime config and secrets stay unchanged.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
