### PR TITLE
fix(torghut): keep hyperliquid shadow mode read-only

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/exchange.py
+++ b/services/torghut/app/hyperliquid_runtime/exchange.py
@@ -40,9 +40,10 @@ class ShadowHyperliquidExchange:
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
         _ = intent
         return OrderResult(
-            status="submitted",
+            status="rejected",
             exchange_order_id=None,
-            raw_response={"shadow": True},
+            raw_response={"shadow": True, "reason": "trading_disabled_shadow"},
+            rejection_reason="trading_disabled_shadow",
         )
 
     def reconcile_fills(self, market_id_by_coin: dict[str, str]) -> list[Fill]:

--- a/services/torghut/app/hyperliquid_runtime/risk.py
+++ b/services/torghut/app/hyperliquid_runtime/risk.py
@@ -114,6 +114,7 @@ def _blocked_reason(
     )
     checks = (
         (bool(config_errors), ",".join(config_errors)),
+        (not config.trading_enabled, "trading_disabled_shadow"),
         (signal.action not in {"buy", "sell"}, f"signal_{signal.action}"),
         (
             signal.feature.source_lag_seconds > config.signal_staleness_seconds,

--- a/services/torghut/tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py
@@ -44,8 +44,12 @@ def test_shadow_exchange_never_requires_private_keys() -> None:
         )
     )
 
-    assert result.status == "submitted"
-    assert result.raw_response == {"shadow": True}
+    assert result.status == "rejected"
+    assert result.rejection_reason == "trading_disabled_shadow"
+    assert result.raw_response == {
+        "shadow": True,
+        "reason": "trading_disabled_shadow",
+    }
 
 
 def test_tigerbeetle_journal_transfer_ids_are_deterministic() -> None:

--- a/services/torghut/tests/hyperliquid_runtime/test_risk_strategy.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_risk_strategy.py
@@ -53,7 +53,13 @@ def _feature(**overrides: object) -> FeatureSnapshot:
 
 
 def test_signal_and_risk_build_tiny_ioc_intent() -> None:
-    config = _config()
+    config = _config(
+        HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+        HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0x1111111111111111111111111111111111111111",
+        HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY=(
+            "0x2222222222222222222222222222222222222222222222222222222222222222"
+        ),
+    )
     signal = generate_signal(_feature(), parameter_version="test-v1")
     state = RiskState(
         gross_exposure_usd=Decimal("90"),
@@ -78,6 +84,25 @@ def test_signal_and_risk_build_tiny_ioc_intent() -> None:
     assert len(intent.cloid) == 34
 
 
+def test_risk_blocks_shadow_mode_before_order_path() -> None:
+    signal = generate_signal(_feature(), parameter_version="test-v1")
+    state = RiskState(
+        gross_exposure_usd=Decimal("0"),
+        daily_realized_pnl_usd=Decimal("0"),
+        open_order_markets=frozenset(),
+        dependencies=(
+            RuntimeDependencyStatus("clickhouse", True),
+            RuntimeDependencyStatus("exchange", True),
+        ),
+    )
+
+    verdict = evaluate_signal_risk(signal, state, _config())
+
+    assert not verdict.allowed
+    assert verdict.reason == "trading_disabled_shadow"
+    assert verdict.order_notional_usd == Decimal("0")
+
+
 def test_risk_blocks_mainnet_execution_config() -> None:
     signal = generate_signal(_feature(), parameter_version="test-v1")
     state = RiskState(
@@ -98,6 +123,13 @@ def test_risk_blocks_mainnet_execution_config() -> None:
 
 
 def test_risk_blocks_stale_dependency_and_duplicate_market() -> None:
+    config = _config(
+        HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+        HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0x1111111111111111111111111111111111111111",
+        HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY=(
+            "0x2222222222222222222222222222222222222222222222222222222222222222"
+        ),
+    )
     signal = generate_signal(_feature(), parameter_version="test-v1")
     state = RiskState(
         gross_exposure_usd=Decimal("0"),
@@ -106,7 +138,7 @@ def test_risk_blocks_stale_dependency_and_duplicate_market() -> None:
         dependencies=(RuntimeDependencyStatus("clickhouse", False, reason="stale"),),
     )
 
-    verdict = evaluate_signal_risk(signal, state, _config())
+    verdict = evaluate_signal_risk(signal, state, config)
 
     assert not verdict.allowed
     assert verdict.reason == "dependency_not_ready:clickhouse"

--- a/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
@@ -255,10 +255,13 @@ class _FakeClickHouse:
 
 
 class _FakeExchange:
-    def __init__(self) -> None:
+    def __init__(self, *, fills: bool = True) -> None:
         self.submitted: list[OrderIntent] = []
+        self._fills = fills
 
     def reconcile_fills(self, _market_id_by_coin: dict[str, str]) -> list[Fill]:
+        if not self._fills:
+            return []
         return [_fill()]
 
     def dependency_status(self) -> RuntimeDependencyStatus:
@@ -296,7 +299,13 @@ def test_runtime_service_orchestrates_signal_order_and_accounting(
         service_module, "HyperliquidRuntimeRepository", lambda _session: repository
     )
     service = HyperliquidRuntimeService(
-        config=_config(),
+        config=_config(
+            HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+            HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0x1111111111111111111111111111111111111111",
+            HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY=(
+                "0x2222222222222222222222222222222222222222222222222222222222222222"
+            ),
+        ),
         clickhouse=_FakeClickHouse(),  # type: ignore[arg-type]
         exchange=exchange,
         journal=journal,  # type: ignore[arg-type]
@@ -315,3 +324,34 @@ def test_runtime_service_orchestrates_signal_order_and_accounting(
     assert repository.orders[0][0].decision_id == "decision-id"
     assert repository.performance[0].reconciliation_status == "pass"
     assert journal.persisted
+
+
+def test_runtime_service_shadow_mode_does_not_submit_or_journal_orders(
+    monkeypatch: Any,
+) -> None:
+    repository = _FakeRepository(_FakeSession())
+    exchange = _FakeExchange(fills=False)
+    journal = _FakeJournal()
+    monkeypatch.setattr(
+        service_module, "HyperliquidRuntimeRepository", lambda _session: repository
+    )
+    service = HyperliquidRuntimeService(
+        config=_config(),
+        clickhouse=_FakeClickHouse(),  # type: ignore[arg-type]
+        exchange=exchange,
+        journal=journal,  # type: ignore[arg-type]
+    )
+    session = _FakeSession()
+
+    result = service.run_once(session)  # type: ignore[arg-type]
+
+    assert session.committed
+    assert result.markets_seen == 1
+    assert result.signals_written == 1
+    assert result.decisions_written == 1
+    assert result.orders_submitted == 0
+    assert result.blocked_decisions == 1
+    assert repository.decision.reason == "trading_disabled_shadow"
+    assert exchange.submitted == []
+    assert repository.orders == []
+    assert journal.persisted == []


### PR DESCRIPTION
## Summary

- Block Hyperliquid runtime shadow mode at the risk gate with `trading_disabled_shadow` before order submission.
- Return an explicit rejected shadow exchange result if the exchange path is called while trading is disabled.
- Add regression coverage for read-only shadow mode and keep enabled testnet order-path coverage explicit.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_runtime/test_risk_strategy.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
