### PR TITLE
chore(torghut): roll hyperliquid feed liveness fix

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-top-volume-100-20260618c
+        proompteng.ai/config-revision: hyperliquid-feed-liveness-20260618a
       labels:
         app: torghut-hyperliquid-feed
     spec:


### PR DESCRIPTION
## Summary

- Bump the Hyperliquid feed deployment config revision so Argo creates a new ReplicaSet.
- Force the live feed pod to pull the already-published liveness-fix image from `latest`.
- Keep the rollout change isolated from code changes.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
