### PR TITLE
fix(torghut): tighten dorvud image builds

### DIFF
--- a/.github/workflows/torghut-hyperliquid-feed-build-push.yaml
+++ b/.github/workflows/torghut-hyperliquid-feed-build-push.yaml
@@ -9,21 +9,21 @@ on:
     branches:
       - main
     paths:
-      - 'services/dorvud/**'
+      - 'services/dorvud/gradle/**'
+      - 'services/dorvud/gradlew'
+      - 'services/dorvud/gradle.properties'
+      - 'services/dorvud/settings.gradle.kts'
+      - 'services/dorvud/build.gradle.kts'
+      - 'services/dorvud/platform/**'
+      - 'services/dorvud/hyperliquid-feed/**'
       - '.github/workflows/torghut-hyperliquid-feed-build-push.yaml'
-  workflow_run:
-    workflows:
-      - dorvud-ci
-    types:
-      - completed
 
 jobs:
   build-platform:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        github.event_name == 'push'
       }}
     strategy:
       fail-fast: false

--- a/.github/workflows/torghut-ta-build-push.yaml
+++ b/.github/workflows/torghut-ta-build-push.yaml
@@ -9,23 +9,25 @@ on:
     branches:
       - main
     paths:
-      - 'services/dorvud/**'
+      - 'services/dorvud/gradle/**'
+      - 'services/dorvud/gradlew'
+      - 'services/dorvud/gradle.properties'
+      - 'services/dorvud/settings.gradle.kts'
+      - 'services/dorvud/build.gradle.kts'
+      - 'services/dorvud/platform/**'
+      - 'services/dorvud/flink-integration/**'
+      - 'services/dorvud/technical-analysis/**'
+      - 'services/dorvud/technical-analysis-flink/**'
       - 'packages/scripts/src/torghut/release-contract.ts'
       - 'packages/scripts/src/shared/docker.ts'
       - '.github/workflows/torghut-ta-build-push.yaml'
-  workflow_run:
-    workflows:
-      - dorvud-ci
-    types:
-      - completed
 
 jobs:
   build-platform:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        github.event_name == 'push'
       }}
     strategy:
       fail-fast: false

--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -9,23 +9,23 @@ on:
     branches:
       - main
     paths:
-      - 'services/dorvud/**'
+      - 'services/dorvud/gradle/**'
+      - 'services/dorvud/gradlew'
+      - 'services/dorvud/gradle.properties'
+      - 'services/dorvud/settings.gradle.kts'
+      - 'services/dorvud/build.gradle.kts'
+      - 'services/dorvud/platform/**'
+      - 'services/dorvud/websockets/**'
       - 'packages/scripts/src/torghut/release-contract.ts'
       - 'packages/scripts/src/shared/docker.ts'
       - '.github/workflows/torghut-ws-build-push.yaml'
-  workflow_run:
-    workflows:
-      - dorvud-ci
-    types:
-      - completed
 
 jobs:
   build-platform:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        github.event_name == 'push'
       }}
     strategy:
       fail-fast: false

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -14,6 +14,10 @@ const wsWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-ws-build-push.yaml', import.meta.url),
   'utf8',
 )
+const hyperliquidFeedWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-hyperliquid-feed-build-push.yaml', import.meta.url),
+  'utf8',
+)
 const ciWorkflow = readFileSync(new URL('../../../../../.github/workflows/torghut-ci.yml', import.meta.url), 'utf8')
 const pullRequestWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/pull-request.yml', import.meta.url),
@@ -77,9 +81,24 @@ describe('torghut build-push workflow', () => {
   })
 
   it('publishes and contracts TA and WS images as amd64 and arm64 from direct pushes', () => {
-    for (const serviceWorkflow of [taWorkflow, wsWorkflow]) {
+    const serviceWorkflows = [
+      {
+        workflow: taWorkflow,
+        servicePath: 'services/dorvud/technical-analysis-flink/**',
+      },
+      {
+        workflow: wsWorkflow,
+        servicePath: 'services/dorvud/websockets/**',
+      },
+    ]
+
+    for (const { workflow: serviceWorkflow, servicePath } of serviceWorkflows) {
       expect(serviceWorkflow).toContain('push:')
-      expect(serviceWorkflow).toContain("- 'services/dorvud/**'")
+      expect(serviceWorkflow).toContain(`- '${servicePath}'`)
+      expect(serviceWorkflow).toContain("- 'services/dorvud/platform/**'")
+      expect(serviceWorkflow).toContain("- 'services/dorvud/settings.gradle.kts'")
+      expect(serviceWorkflow).not.toContain("- 'services/dorvud/**'")
+      expect(serviceWorkflow).not.toContain('workflow_run:')
       expect(serviceWorkflow).toContain("github.event_name == 'push'")
       expect(serviceWorkflow).toContain('runner: arc-amd64')
       expect(serviceWorkflow).toContain('runner: arc-arm64')
@@ -101,6 +120,21 @@ describe('torghut build-push workflow', () => {
         "--platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'",
       )
     }
+  })
+
+  it('builds Hyperliquid feed images only for feed or shared Dorvud changes', () => {
+    expect(hyperliquidFeedWorkflow).toContain('push:')
+    expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/hyperliquid-feed/**'")
+    expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/platform/**'")
+    expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/settings.gradle.kts'")
+    expect(hyperliquidFeedWorkflow).not.toContain("- 'services/dorvud/**'")
+    expect(hyperliquidFeedWorkflow).not.toContain('workflow_run:')
+    expect(hyperliquidFeedWorkflow).toContain("github.event_name == 'push'")
+    expect(hyperliquidFeedWorkflow).toContain('runner: arc-amd64')
+    expect(hyperliquidFeedWorkflow).toContain('runner: arc-arm64')
+    expect(hyperliquidFeedWorkflow).toContain('platforms: ${{ matrix.platform }}')
+    expect(hyperliquidFeedWorkflow).toContain('name: Verify multi-arch image manifest')
+    expect(hyperliquidFeedWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')
   })
 
   it('defines native amd64 and arm64 GitHub runner scale sets for Torghut image builds', () => {

--- a/services/dorvud/technical-analysis-flink/Dockerfile
+++ b/services/dorvud/technical-analysis-flink/Dockerfile
@@ -9,6 +9,7 @@ COPY technical-analysis ./technical-analysis
 COPY technical-analysis-flink ./technical-analysis-flink
 COPY websockets ./websockets
 COPY flink-integration ./flink-integration
+COPY hyperliquid-feed ./hyperliquid-feed
 
 RUN chmod +x ./gradlew
 RUN ./gradlew :technical-analysis-flink:uberJar --no-daemon

--- a/services/dorvud/websockets/Dockerfile
+++ b/services/dorvud/websockets/Dockerfile
@@ -9,6 +9,7 @@ COPY flink-integration ./flink-integration
 COPY websockets ./websockets
 COPY technical-analysis ./technical-analysis
 COPY technical-analysis-flink ./technical-analysis-flink
+COPY hyperliquid-feed ./hyperliquid-feed
 
 RUN chmod +x ./gradlew
 RUN ./gradlew :websockets:installDist --no-daemon


### PR DESCRIPTION
## Summary

- Copy the `hyperliquid-feed` Gradle module into TA and WS Docker build workspaces so root `settings.gradle.kts` can configure every declared project.
- Narrow Torghut TA, WS, and Hyperliquid feed image build triggers to direct main pushes for their owning module or shared Dorvud build inputs.
- Remove the broad `dorvud-ci` workflow-run fanout that rebuilt unrelated images and add workflow tests for the scoped multi-arch build contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `docker build --target build -f services/dorvud/technical-analysis-flink/Dockerfile services/dorvud`
- `docker build --target build -f services/dorvud/websockets/Dockerfile services/dorvud`
- From `services/dorvud`: `./gradlew :technical-analysis-flink:test :websockets:test --no-daemon`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
