### PR TITLE
refactor(torghut): clean whitepaper test suppressions

### DIFF
--- a/services/torghut/tests/test_backfill_whitepaper_semantic_index.py
+++ b/services/torghut/tests/test_backfill_whitepaper_semantic_index.py
@@ -37,6 +37,27 @@ class _FakeWorkflow:
         del source_scope
         return [text] if text else []
 
+    @staticmethod
+    def _download_pdf(_url: str) -> bytes:
+        return b"%PDF-1.4 fake"
+
+    @staticmethod
+    def _extract_pdf_text(_bytes: bytes) -> dict[str, object]:
+        return {
+            "full_text": "downloaded full text",
+            "metadata": {"pages": 1},
+        }
+
+    def _upsert_whitepaper_content(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+        full_text: str,
+        extraction_meta: dict[str, object],
+    ) -> None:
+        del session, run, full_text, extraction_meta
+
     def index_full_text_semantic_content(
         self, session: Session, *, run_id: str, full_text: str
     ) -> dict[str, int]:
@@ -157,13 +178,6 @@ class TestBackfillWhitepaperSemanticIndex(TestCase):
             }
             session.commit()
 
-        raising_workflow._download_pdf = lambda _url: b"%PDF-1.4 fake"  # type: ignore[attr-defined]
-        raising_workflow._extract_pdf_text = lambda _bytes: {  # type: ignore[attr-defined]
-            "full_text": "downloaded full text",
-            "metadata": {"pages": 1},
-        }
-        raising_workflow._upsert_whitepaper_content = lambda *args, **kwargs: None  # type: ignore[attr-defined]
-
         with (
             patch(
                 "scripts.backfill_whitepaper_semantic_index.SessionLocal",
@@ -194,13 +208,6 @@ class TestBackfillWhitepaperSemanticIndex(TestCase):
             }
             session.commit()
 
-        workflow._download_pdf = lambda _url: b"%PDF-1.4 fake"  # type: ignore[attr-defined]
-        workflow._extract_pdf_text = lambda _bytes: {  # type: ignore[attr-defined]
-            "full_text": "downloaded full text",
-            "metadata": {"pages": 1},
-        }
-        workflow._upsert_whitepaper_content = lambda *args, **kwargs: None  # type: ignore[attr-defined]
-
         with (
             patch(
                 "scripts.backfill_whitepaper_semantic_index.SessionLocal",
@@ -230,13 +237,6 @@ class TestBackfillWhitepaperSemanticIndex(TestCase):
                 "attachment_url": "https://example.com/paper.pdf"
             }
             session.commit()
-
-        workflow._download_pdf = lambda _url: b"%PDF-1.4 fake"  # type: ignore[attr-defined]
-        workflow._extract_pdf_text = lambda _bytes: {  # type: ignore[attr-defined]
-            "full_text": "downloaded full text",
-            "metadata": {"pages": 1},
-        }
-        workflow._upsert_whitepaper_content = lambda *args, **kwargs: None  # type: ignore[attr-defined]
 
         with (
             patch(

--- a/services/torghut/tests/whitepaper_workflow/support.py
+++ b/services/torghut/tests/whitepaper_workflow/support.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 
+from collections.abc import Mapping
 import json
 import os
 import tempfile
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, cast
+from typing import Any, Protocol, cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -93,7 +94,7 @@ class _FakeKafkaConsumer:
         self.commit_calls += 1
 
 
-class _FakeKafkaSession:
+class _FakeKafkaSession(Session):
     def __init__(self) -> None:
         self.commit_calls = 0
         self.rollback_calls = 0
@@ -114,6 +115,171 @@ class _FakeInngestClient:
         payload = dict(data) if isinstance(data, dict) else {}
         self.events.append(payload)
         return [f"evt-{len(self.events)}"]
+
+
+class _DownloadPdfHandler(Protocol):
+    def __call__(self, url: str) -> bytes: ...
+
+
+class _SubmitAgentsAgentrunHandler(Protocol):
+    def __call__(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]: ...
+
+
+class _EnqueueFinalizedInngestEventHandler(Protocol):
+    def __call__(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+    ) -> bool: ...
+
+
+class _IndexSynthesisSemanticContentHandler(Protocol):
+    def __call__(
+        self,
+        session: Session,
+        *,
+        run_id: str,
+    ) -> dict[str, Any]: ...
+
+
+class _EmbedTextsHandler(Protocol):
+    def __call__(self, texts: list[str]) -> tuple[str, int, list[list[float]]]: ...
+
+
+def _default_download_pdf(_url: str) -> bytes:
+    return b"%PDF-1.7 sample"
+
+
+def _default_submit_agents_agentrun(
+    _payload: Mapping[str, Any],
+    *,
+    idempotency_key: str,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "resource": {
+            "metadata": {"name": f"agentrun-{idempotency_key}", "uid": "uid-1"},
+            "status": {"phase": "Pending"},
+        },
+    }
+
+
+class _TestWhitepaperWorkflowService(WhitepaperWorkflowService):
+    def __init__(
+        self,
+        *,
+        download_pdf_handler: _DownloadPdfHandler | None = None,
+        submit_agents_agentrun_handler: _SubmitAgentsAgentrunHandler | None = None,
+    ) -> None:
+        self.ceph_client = None
+        self.inngest_client = None
+        self.download_pdf_handler = download_pdf_handler or _default_download_pdf
+        self.submit_agents_agentrun_handler = (
+            submit_agents_agentrun_handler or _default_submit_agents_agentrun
+        )
+        self.enqueue_finalized_inngest_event_handler: (
+            _EnqueueFinalizedInngestEventHandler | None
+        ) = None
+        self.index_synthesis_semantic_content_handler: (
+            _IndexSynthesisSemanticContentHandler | None
+        ) = None
+        self.embed_texts_handler: _EmbedTextsHandler | None = None
+
+    def _download_pdf(self, url: str) -> bytes:
+        return self.download_pdf_handler(url)
+
+    def _submit_agents_agentrun(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        return self.submit_agents_agentrun_handler(
+            payload,
+            idempotency_key=idempotency_key,
+        )
+
+    def _enqueue_finalized_inngest_event(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+    ) -> bool:
+        if self.enqueue_finalized_inngest_event_handler is None:
+            return super()._enqueue_finalized_inngest_event(session, run=run)
+        return self.enqueue_finalized_inngest_event_handler(session, run=run)
+
+    def index_synthesis_semantic_content(
+        self,
+        session: Session,
+        *,
+        run_id: str,
+    ) -> dict[str, Any]:
+        if self.index_synthesis_semantic_content_handler is None:
+            return super().index_synthesis_semantic_content(session, run_id=run_id)
+        return self.index_synthesis_semantic_content_handler(session, run_id=run_id)
+
+    def _embed_texts(self, texts: list[str]) -> tuple[str, int, list[list[float]]]:
+        if self.embed_texts_handler is None:
+            return super()._embed_texts(texts)
+        return self.embed_texts_handler(texts)
+
+    def structured_output_list(
+        self, payload: Mapping[str, Any], *, key: str
+    ) -> list[dict[str, Any]]:
+        return self._structured_output_list(payload, key=key)
+
+    def compiled_experiment_specs_from_templates(
+        self,
+        *,
+        run_id: str,
+        claims: list[dict[str, Any]],
+        relations: list[dict[str, Any]],
+        templates: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        return self._compiled_experiment_specs_from_templates(
+            run_id=run_id,
+            claims=claims,
+            relations=relations,
+            templates=templates,
+        )
+
+    def inferred_contradiction_events(
+        self, relations: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return self._inferred_contradiction_events(relations)
+
+    def build_verdict_gating_payload(self, verdict_payload: Mapping[str, Any]) -> Any:
+        return self._build_verdict_gating_payload(verdict_payload)
+
+    def sync_structured_research_outputs(
+        self,
+        session: Session,
+        run: WhitepaperAnalysisRun,
+        payload: Mapping[str, Any],
+    ) -> None:
+        self._sync_structured_research_outputs(session, run, payload)
+
+    def persist_semantic_chunks_and_embeddings(
+        self,
+        session: Session,
+        *,
+        run: WhitepaperAnalysisRun,
+        source_scope: str,
+        chunks: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return self._persist_semantic_chunks_and_embeddings(
+            session,
+            run=run,
+            source_scope=source_scope,
+            chunks=chunks,
+        )
 
 
 class _FakeKafkaWorkflowService:
@@ -196,8 +362,6 @@ Attachment: {attachment_url}
         return payload
 
 
-__all__: tuple[str, ...] = ()
-
 __all__: tuple[str, ...] = (
     "Any",
     "Base",
@@ -230,6 +394,7 @@ __all__: tuple[str, ...] = (
     "_FakeKafkaSession",
     "_FakeKafkaWorkflowService",
     "_TestWhitepaperWorkflowBase",
+    "_TestWhitepaperWorkflowService",
     "_profile_ids_for_family",
     "build_whitepaper_run_id",
     "candidate_specs_module",

--- a/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
+++ b/services/torghut/tests/whitepaper_workflow/test_marker_and_attachment_parsing.py
@@ -21,6 +21,7 @@ from tests.whitepaper_workflow.support import (
     _FakeCephClient,
     _FakeInngestClient,
     _TestWhitepaperWorkflowBase,
+    _TestWhitepaperWorkflowService,
     _profile_ids_for_family,
     build_whitepaper_run_id,
     candidate_specs_module,
@@ -162,12 +163,16 @@ https://example.com/paper.pdf
             fake_ceph = _FakeCephClient()
             mock_from_env.side_effect = [None, fake_ceph]
 
-            service = WhitepaperWorkflowService()
-            service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
+            with patch.object(
+                WhitepaperWorkflowService,
+                "_download_pdf",
+                return_value=b"%PDF-1.7 sample",
+            ):
+                service = WhitepaperWorkflowService()
 
-            outcome = service._store_issue_pdf(
-                attachment_url="https://example.com/paper.pdf"
-            )
+                outcome = service._store_issue_pdf(
+                    attachment_url="https://example.com/paper.pdf"
+                )
 
             self.assertEqual(mock_from_env.call_count, 2)
             self.assertEqual(outcome.ceph_bucket, "fresh-bucket")
@@ -176,9 +181,8 @@ https://example.com/paper.pdf
     def test_dispatch_uses_github_issue_number_from_issue_url_for_replay_payloads(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
 
         submitted_payloads: list[dict[str, Any]] = []
 
@@ -194,7 +198,7 @@ https://example.com/paper.pdf
                 },
             }
 
-        service._submit_agents_agentrun = _fake_submit  # type: ignore[method-assign]
+        service.submit_agents_agentrun_handler = _fake_submit
         replay_payload = self._issue_payload(issue_number=900000004)
         replay_issue = cast(dict[str, Any], replay_payload["issue"])
         replay_issue["html_url"] = "https://github.com/proompteng/lab/issues/3592"
@@ -225,18 +229,8 @@ https://example.com/paper.pdf
             self.assertEqual(kickoff.reason, "comment_without_requeue_keyword")
 
     def test_ingest_and_finalize_flow(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "ok": True,
-                "resource": {
-                    "metadata": {"name": f"agentrun-{idempotency_key}", "uid": "uid-1"},
-                    "status": {"phase": "Pending"},
-                },
-            }
-        )
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -318,18 +312,8 @@ https://example.com/paper.pdf
             self.assertEqual(pr_row.pr_number, 1234)
 
     def test_finalize_preserves_explicit_implementation_plan_md(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "ok": True,
-                "resource": {
-                    "metadata": {"name": f"agentrun-{idempotency_key}", "uid": "uid-1"},
-                    "status": {"phase": "Pending"},
-                },
-            }
-        )
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -378,21 +362,17 @@ https://example.com/paper.pdf
     def test_finalize_falls_back_to_local_indexing_when_finalize_enqueue_fails(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
         os.environ["WHITEPAPER_SEMANTIC_INDEXING_ENABLED"] = "true"
         os.environ["WHITEPAPER_INNGEST_ENABLED"] = "true"
         service.set_inngest_client(cast(Any, _FakeInngestClient()))
 
         indexed_run_ids: list[str] = []
-        service._enqueue_finalized_inngest_event = lambda _session, *, run: False  # type: ignore[method-assign]
-        service.index_synthesis_semantic_content = (  # type: ignore[method-assign]
-            lambda _session, *, run_id: (
-                indexed_run_ids.append(run_id)
-                or {"run_id": run_id, "indexed_chunks": 0}
-            )
+        service.enqueue_finalized_inngest_event_handler = lambda _session, *, run: False
+        service.index_synthesis_semantic_content_handler = lambda _session, *, run_id: (
+            indexed_run_ids.append(run_id) or {"run_id": run_id, "indexed_chunks": 0}
         )
 
         with Session(self.engine) as session:
@@ -427,18 +407,8 @@ https://example.com/paper.pdf
             self.assertEqual(indexed_run_ids, [run_row.run_id])
 
     def test_finalize_persists_claim_graph_and_compiled_experiments(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "ok": True,
-                "resource": {
-                    "metadata": {"name": f"agentrun-{idempotency_key}", "uid": "uid-1"},
-                    "status": {"phase": "Pending"},
-                },
-            }
-        )
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -558,16 +528,16 @@ https://example.com/paper.pdf
     def test_structured_output_helpers_cover_direct_nested_and_gating_merge(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
-        direct = service._structured_output_list(  # type: ignore[attr-defined]
+        service = _TestWhitepaperWorkflowService()
+        direct = service.structured_output_list(
             {"claims": [{"claim_id": "claim-1"}]},
             key="claims",
         )
-        nested = service._structured_output_list(  # type: ignore[attr-defined]
+        nested = service.structured_output_list(
             {"synthesis": {"claims": [{"claim_id": "claim-2"}]}},
             key="claims",
         )
-        compiled = service._compiled_experiment_specs_from_templates(  # type: ignore[attr-defined]
+        compiled = service.compiled_experiment_specs_from_templates(
             run_id="run-1",
             claims=[{"claim_id": "claim-1"}],
             relations=[],
@@ -580,7 +550,7 @@ https://example.com/paper.pdf
                 }
             ],
         )
-        contradictions = service._inferred_contradiction_events(  # type: ignore[attr-defined]
+        contradictions = service.inferred_contradiction_events(
             [
                 {
                     "relation_id": "rel-ignore",
@@ -599,7 +569,7 @@ https://example.com/paper.pdf
                 },
             ]
         )
-        merged = service._build_verdict_gating_payload(  # type: ignore[attr-defined]
+        merged = service.build_verdict_gating_payload(
             {"dspy_eval_report": {"score": 0.8}}
         )
 
@@ -613,8 +583,8 @@ https://example.com/paper.pdf
     def test_structured_outputs_compile_claims_when_experiment_specs_are_absent(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
-        compiled = service._compiled_experiment_specs_from_templates(  # type: ignore[attr-defined]
+        service = _TestWhitepaperWorkflowService()
+        compiled = service.compiled_experiment_specs_from_templates(
             run_id="run-claim-compiler",
             claims=[
                 {
@@ -654,9 +624,8 @@ https://example.com/paper.pdf
         )
 
     def test_sync_structured_outputs_skips_incomplete_records(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
 
         with Session(self.engine) as session:
@@ -674,7 +643,7 @@ https://example.com/paper.pdf
                 )
             ).scalar_one()
 
-            service._sync_structured_research_outputs(  # type: ignore[attr-defined]
+            service.sync_structured_research_outputs(
                 session,
                 run_row,
                 {
@@ -747,20 +716,17 @@ https://example.com/paper.pdf
             )
 
     def test_finalize_run_propagates_synthesis_indexing_failures(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
         os.environ["WHITEPAPER_SEMANTIC_INDEXING_ENABLED"] = "true"
         os.environ["WHITEPAPER_INNGEST_ENABLED"] = "true"
         service.set_inngest_client(cast(Any, _FakeInngestClient()))
 
-        service._enqueue_finalized_inngest_event = lambda _session, *, run: False  # type: ignore[method-assign]
-        service.index_synthesis_semantic_content = (  # type: ignore[method-assign]
-            lambda _session, *, run_id: (_ for _ in ()).throw(
-                RuntimeError(f"index failure for run {run_id}")
-            )
-        )
+        service.enqueue_finalized_inngest_event_handler = lambda _session, *, run: False
+        service.index_synthesis_semantic_content_handler = lambda _session, *, run_id: (
+            _ for _ in ()
+        ).throw(RuntimeError(f"index failure for run {run_id}"))
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(

--- a/services/torghut/tests/whitepaper_workflow/test_persist_semantic_chunks_does_not_delete_until_embeddings_ready.py
+++ b/services/torghut/tests/whitepaper_workflow/test_persist_semantic_chunks_does_not_delete_until_embeddings_ready.py
@@ -9,9 +9,9 @@ from tests.whitepaper_workflow.support import (
     WhitepaperEngineeringTrigger,
     WhitepaperRolloutTransition,
     WhitepaperViabilityVerdict,
-    WhitepaperWorkflowService,
     _FakeCephClient,
     _TestWhitepaperWorkflowBase,
+    _TestWhitepaperWorkflowService,
     cast,
     os,
     patch,
@@ -25,9 +25,8 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
     def test_persist_semantic_chunks_does_not_delete_until_embeddings_ready(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -56,13 +55,11 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
                 return _DummyResult()
 
             with patch.object(session, "execute", side_effect=_fake_execute):
-                service._embed_texts = (  # type: ignore[method-assign]
-                    lambda _texts: (_ for _ in ()).throw(
-                        RuntimeError("embedding service unavailable")
-                    )
+                service.embed_texts_handler = lambda _texts: (_ for _ in ()).throw(
+                    RuntimeError("embedding service unavailable")
                 )
                 with self.assertRaises(RuntimeError):
-                    service._persist_semantic_chunks_and_embeddings(
+                    service.persist_semantic_chunks_and_embeddings(
                         session,
                         run=run_row,
                         source_scope="synthesis",
@@ -72,18 +69,8 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
             self.assertEqual(statement_log, [])
 
     def test_finalize_merges_dspy_eval_report_into_verdict_gating(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "ok": True,
-                "resource": {
-                    "metadata": {"name": f"agentrun-{idempotency_key}", "uid": "uid-1"},
-                    "status": {"phase": "Pending"},
-                },
-            }
-        )
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -129,23 +116,20 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
     def test_finalize_auto_dispatches_engineering_candidate_and_scales_live(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
         os.environ["WHITEPAPER_ENGINEERING_AUTO_DISPATCH_ENABLED"] = "true"
         os.environ["WHITEPAPER_ENGINEERING_ROLLOUT_PROFILE"] = "automatic"
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "resource": {
-                    "metadata": {
-                        "name": f"engineering-{idempotency_key}",
-                        "uid": "uid-eng",
-                    },
-                    "status": {"phase": "Pending"},
-                }
+        service.submit_agents_agentrun_handler = lambda _payload, *, idempotency_key: {
+            "resource": {
+                "metadata": {
+                    "name": f"engineering-{idempotency_key}",
+                    "uid": "uid-eng",
+                },
+                "status": {"phase": "Pending"},
             }
-        )
+        }
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -218,9 +202,8 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
     def test_finalize_uses_persisted_verdict_fields_for_deterministic_reason_codes(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
         os.environ["WHITEPAPER_ENGINEERING_AUTO_DISPATCH_ENABLED"] = "true"
 
@@ -304,9 +287,8 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
             self.assertEqual(trigger_row.decision, "suppressed")
 
     def test_finalize_retry_preserves_existing_engineering_dispatch(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
         os.environ["WHITEPAPER_ENGINEERING_AUTO_DISPATCH_ENABLED"] = "true"
         os.environ["WHITEPAPER_ENGINEERING_ROLLOUT_PROFILE"] = "automatic"
@@ -327,7 +309,7 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
                 }
             }
 
-        service._submit_agents_agentrun = _fake_submit  # type: ignore[method-assign]
+        service.submit_agents_agentrun_handler = _fake_submit
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -397,22 +379,19 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
     def test_manual_approval_dispatches_non_eligible_run_with_audit_fields(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
         os.environ["WHITEPAPER_ENGINEERING_AUTO_DISPATCH_ENABLED"] = "true"
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "resource": {
-                    "metadata": {
-                        "name": f"manual-{idempotency_key}",
-                        "uid": "uid-manual",
-                    },
-                    "status": {"phase": "Pending"},
-                }
+        service.submit_agents_agentrun_handler = lambda _payload, *, idempotency_key: {
+            "resource": {
+                "metadata": {
+                    "name": f"manual-{idempotency_key}",
+                    "uid": "uid-manual",
+                },
+                "status": {"phase": "Pending"},
             }
-        )
+        }
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -492,22 +471,19 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
     def test_manual_approval_automatic_rollout_blocks_and_rolls_back_on_gate_failure(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
         os.environ["WHITEPAPER_ENGINEERING_AUTO_DISPATCH_ENABLED"] = "true"
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "resource": {
-                    "metadata": {
-                        "name": f"manual-{idempotency_key}",
-                        "uid": "uid-manual",
-                    },
-                    "status": {"phase": "Pending"},
-                }
+        service.submit_agents_agentrun_handler = lambda _payload, *, idempotency_key: {
+            "resource": {
+                "metadata": {
+                    "name": f"manual-{idempotency_key}",
+                    "uid": "uid-manual",
+                },
+                "status": {"phase": "Pending"},
             }
-        )
+        }
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -579,18 +555,8 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
             self.assertTrue(any(row.status == "halted" for row in rollout_rows))
 
     def test_build_whitepaper_prompt_requires_implementation_plan_md(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "ok": True,
-                "resource": {
-                    "metadata": {"name": f"agentrun-{idempotency_key}", "uid": "uid-1"},
-                    "status": {"phase": "Pending"},
-                },
-            }
-        )
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -605,9 +571,8 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
             self.assertIn("implementation_plan_md", agentrun_row.prompt_text or "")
 
     def test_marker_subject_tags_and_analysis_mode_are_persisted(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
 
         with Session(self.engine) as session:
@@ -649,18 +614,8 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
             )
 
     def test_analysis_only_prompt_omits_pr_requirement(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
-        service._submit_agents_agentrun = (  # type: ignore[method-assign]
-            lambda _payload, *, idempotency_key: {
-                "ok": True,
-                "resource": {
-                    "metadata": {"name": f"agentrun-{idempotency_key}", "uid": "uid-1"},
-                    "status": {"phase": "Pending"},
-                },
-            }
-        )
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -683,12 +638,12 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
             self.assertNotIn("Open a PR from a codex/* branch", prompt_text)
 
     def test_failed_run_replay_is_idempotent_without_duplicate_rows(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         os.environ["WHITEPAPER_AGENTRUN_AUTO_DISPATCH"] = "false"
 
         with Session(self.engine) as session:
             service.ceph_client = None
-            service._download_pdf = lambda _url: b"%PDF-1.7 first"  # type: ignore[method-assign]
+            service.download_pdf_handler = lambda _url: b"%PDF-1.7 first"
             first = service.ingest_github_issue_event(
                 session,
                 self._issue_payload(),
@@ -700,7 +655,7 @@ class TestPersistSemanticChunksDoesNotDeleteUntilEmbeddingsReady(
             session.commit()
 
             service.ceph_client = _FakeCephClient()
-            service._download_pdf = lambda _url: b"%PDF-1.7 retry"  # type: ignore[method-assign]
+            service.download_pdf_handler = lambda _url: b"%PDF-1.7 retry"
             replay = service.ingest_github_issue_event(
                 session,
                 self._issue_payload(),

--- a/services/torghut/tests/whitepaper_workflow/test_same_pdf_across_issues_reuses_existing_run_without_duplication.py
+++ b/services/torghut/tests/whitepaper_workflow/test_same_pdf_across_issues_reuses_existing_run_without_duplication.py
@@ -16,6 +16,7 @@ from tests.whitepaper_workflow.support import (
     _FakeKafkaSession,
     _FakeKafkaWorkflowService,
     _TestWhitepaperWorkflowBase,
+    _TestWhitepaperWorkflowService,
     cast,
     json,
     os,
@@ -30,9 +31,10 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
     def test_same_pdf_across_issues_reuses_existing_run_without_duplication(
         self,
     ) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService(
+            download_pdf_handler=lambda _url: b"%PDF-1.7 identical-content",
+        )
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 identical-content"  # type: ignore[method-assign]
 
         submit_attempts = {"count": 0}
 
@@ -51,7 +53,7 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
                 },
             }
 
-        service._submit_agents_agentrun = _fake_submit  # type: ignore[method-assign]
+        service.submit_agents_agentrun_handler = _fake_submit
 
         with Session(self.engine) as session:
             first = service.ingest_github_issue_event(
@@ -117,7 +119,7 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
         ingestor._consumer = consumer
         session = _FakeKafkaSession()
 
-        counters = ingestor.ingest_once(session)  # type: ignore[arg-type]
+        counters = ingestor.ingest_once(session)
         self.assertEqual(counters["messages_total"], 2)
         self.assertEqual(counters["accepted_total"], 1)
         self.assertEqual(counters["failed_total"], 1)
@@ -139,7 +141,7 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
         ingestor._consumer = consumer
         session = _FakeKafkaSession()
 
-        counters = ingestor.ingest_once(session)  # type: ignore[arg-type]
+        counters = ingestor.ingest_once(session)
         self.assertEqual(counters["messages_total"], 2)
         self.assertEqual(counters["accepted_total"], 1)
         self.assertEqual(counters["ignored_total"], 1)
@@ -166,9 +168,8 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
         self.assertTrue(kwargs["follow_redirects"])
 
     def test_comment_requeue_reuses_existing_run_without_duplication(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
 
         submit_attempts = {"count": 0}
 
@@ -187,7 +188,7 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
                 }
             }
 
-        service._submit_agents_agentrun = _fake_submit  # type: ignore[method-assign]
+        service.submit_agents_agentrun_handler = _fake_submit
 
         with Session(self.engine) as session:
             kickoff = service.ingest_github_issue_event(
@@ -223,9 +224,8 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
             self.assertEqual(len(agentruns), 2)
 
     def test_inngest_requeue_uses_new_enqueue_key_per_attempt(self) -> None:
-        service = WhitepaperWorkflowService()
+        service = _TestWhitepaperWorkflowService()
         service.ceph_client = _FakeCephClient()
-        service._download_pdf = lambda _url: b"%PDF-1.7 sample"  # type: ignore[method-assign]
         os.environ["WHITEPAPER_INNGEST_ENABLED"] = "true"
         fake_inngest = _FakeInngestClient()
         service.set_inngest_client(cast(Any, fake_inngest))


### PR DESCRIPTION
## Summary

- Added a typed `_TestWhitepaperWorkflowService` for whitepaper workflow tests with explicit hooks for fake PDF download, AgentRun submission, Inngest finalize enqueue, semantic indexing, and embeddings.
- Refactored whitepaper workflow tests to use typed hooks and public wrapper helpers instead of assigning over private methods.
- Removed all `type: ignore` suppressions from `tests/whitepaper_workflow` and the adjacent whitepaper semantic-index backfill test.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check app scripts tests && uv run --frozen ruff check app scripts tests`
- `cd services/torghut && uv run --frozen pytest tests/whitepaper_workflow tests/test_backfill_whitepaper_semantic_index.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-private-pyright-suppression,torghut-wildcard-ruff-noqa,torghut-blanket-pylint-disable,torghut-dynamic-attribute-hook,torghut-wildcard-import,torghut-custom-module-class,torghut-test-compat-wrapper --score=n app scripts tests`
- `cd services/torghut && uv run --frozen python -m compileall -q app scripts tests`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
