### PR TITLE
chore(torghut): roll hyperliquid runtime shadow fix

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618e
+        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618f
       labels:
         app: torghut-hyperliquid-runtime
     spec:


### PR DESCRIPTION
## Summary

- Bump the Hyperliquid runtime deployment pod-template revision to pull the Torghut image built from `7ace6e5a`.
- Keep the rollout scoped to the isolated Hyperliquid runtime deployment; no Alpaca or legacy Torghut manifests change.
- Main `torghut-build-push` run `27744353142` published and verified the multi-arch image before this rollout.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`
- `bun run lint:argocd`
- `git diff --check`
- GitHub Actions `torghut-build-push` run `27744353142` completed successfully for `7ace6e5a`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
