### PR TITLE
fix(torghut): keep hyperliquid clickhouse sink current

### DIFF
--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
@@ -12,9 +12,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -65,16 +66,17 @@ class ClickHouseSink(
       }
       val batch = mutableListOf<RoutedEnvelope>()
       while (isActive) {
-        val first = channel.receiveCatching().getOrNull()
-        if (first != null) batch += first
-        val deadline = System.currentTimeMillis() + config.flushMs
-        while (batch.size < config.batchSize && System.currentTimeMillis() < deadline) {
-          val next = channel.tryReceive().getOrNull() ?: break
+        val first = channel.receiveCatching().getOrNull() ?: continue
+        batch += first
+        val deadline = nowMs() + config.flushMs
+        while (batch.size < config.batchSize) {
+          val remainingMs = deadline - nowMs()
+          if (remainingMs <= 0) break
+          val next =
+            withTimeoutOrNull(remainingMs) {
+              channel.receiveCatching().getOrNull()
+            } ?: break
           batch += next
-        }
-        if (batch.isEmpty()) {
-          delay(config.flushMs)
-          continue
         }
         flush(batch.toList())
         batch.clear()
@@ -111,18 +113,22 @@ class ClickHouseSink(
     query: String,
     body: String? = null,
   ): String {
-    val response =
-      httpClient.post("${config.httpUrl.trimEnd('/')}?query=${java.net.URLEncoder.encode(query, Charsets.UTF_8)}") {
-        if (config.password.isNotEmpty()) basicAuth(config.username, config.password)
-        if (body != null) {
-          contentType(ContentType.Application.Json)
-          setBody(body)
+    val responseBody =
+      withTimeout(config.requestTimeoutMs) {
+        val response =
+          httpClient.post("${config.httpUrl.trimEnd('/')}?query=${java.net.URLEncoder.encode(query, Charsets.UTF_8)}") {
+            if (config.password.isNotEmpty()) basicAuth(config.username, config.password)
+            if (body != null) {
+              contentType(ContentType.Application.Json)
+              setBody(body)
+            }
+          }
+        val responseBody = response.bodyAsText()
+        if (!response.status.isSuccess()) {
+          error("clickhouse_http_${response.status.value}:${responseBody.take(256)}")
         }
+        responseBody
       }
-    val responseBody = response.bodyAsText()
-    if (!response.status.isSuccess()) {
-      error("clickhouse_http_${response.status.value}:${responseBody.take(256)}")
-    }
     return responseBody
   }
 

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
@@ -26,6 +26,7 @@ data class ClickHouseConfig(
   val password: String,
   val batchSize: Int,
   val flushMs: Long,
+  val requestTimeoutMs: Long,
   val readyMaxAgeMs: Long,
   val failureHoldMs: Long,
   val readyTables: Set<String> = setOf("hyperliquid_raw", "hyperliquid_candles"),
@@ -160,6 +161,7 @@ data class HyperliquidConfig(
           password = mergedEnv["CLICKHOUSE_PASSWORD"] ?: "",
           batchSize = intEnv(mergedEnv, "CLICKHOUSE_BATCH_SIZE", 250).coerceIn(1, 5000),
           flushMs = longEnv(mergedEnv, "CLICKHOUSE_FLUSH_MS", 1000).coerceAtLeast(250),
+          requestTimeoutMs = longEnv(mergedEnv, "CLICKHOUSE_REQUEST_TIMEOUT_MS", 10_000).coerceAtLeast(1_000),
           readyMaxAgeMs = longEnv(mergedEnv, "CLICKHOUSE_READY_MAX_AGE_MS", 120_000).coerceAtLeast(1_000),
           failureHoldMs = longEnv(mergedEnv, "CLICKHOUSE_FAILURE_HOLD_MS", 60_000).coerceAtLeast(1_000),
           readyTables =

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
+import io.ktor.http.content.TextContent
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -15,6 +16,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ClickHouseSinkTest {
   @Test
@@ -38,6 +40,7 @@ class ClickHouseSinkTest {
               password = "",
               batchSize = 1,
               flushMs = 1,
+              requestTimeoutMs = 1_000,
               readyMaxAgeMs = 1_000,
               failureHoldMs = 1_000,
             ),
@@ -57,6 +60,168 @@ class ClickHouseSinkTest {
       }
 
       assertEquals(false, readySignals.last().ready)
+      job.cancelAndJoin()
+      client.close()
+    }
+
+  @Test
+  fun `batches records during flush window before inserting`() =
+    runBlocking {
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
+      val insertBodies = mutableListOf<String>()
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            if (queryParam(request.url).startsWith("INSERT")) {
+              insertBodies += (request.body as TextContent).text
+              respond(content = "", status = HttpStatusCode.OK)
+            } else {
+              respond(
+                content =
+                  """
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900}
+                  """.trimIndent(),
+                status = HttpStatusCode.OK,
+              )
+            }
+          },
+        )
+      val sink =
+        ClickHouseSink(
+          config = clickHouseConfig(readyMaxAgeMs = 1_000, batchSize = 10, flushMs = 50),
+          httpClient = client,
+          metrics = HyperliquidMetrics(SimpleMeterRegistry()),
+          json = Json,
+          nowMs = { 10_000 },
+          onReady = { readySignals += it },
+        )
+      val job = sink.start(this)
+
+      repeat(3) { sink.enqueue(candleRecord(seq = it.toLong() + 1)) }
+
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != true) {
+          delay(10)
+        }
+      }
+
+      assertEquals(1, insertBodies.size)
+      assertEquals(
+        3,
+        insertBodies
+          .single()
+          .lineSequence()
+          .filter { it.isNotBlank() }
+          .count(),
+      )
+      job.cancelAndJoin()
+      client.close()
+    }
+
+  @Test
+  fun `times out a stalled clickhouse request and marks not ready`() =
+    runBlocking {
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
+      var insertAttempts = 0
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            if (queryParam(request.url).startsWith("INSERT")) {
+              insertAttempts += 1
+              if (insertAttempts == 1) {
+                delay(5_000)
+              }
+              respond(content = "", status = HttpStatusCode.OK)
+            } else {
+              respond(
+                content =
+                  """
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900}
+                  """.trimIndent(),
+                status = HttpStatusCode.OK,
+              )
+            }
+          },
+        )
+      val sink =
+        ClickHouseSink(
+          config = clickHouseConfig(readyMaxAgeMs = 1_000, requestTimeoutMs = 100),
+          httpClient = client,
+          metrics = HyperliquidMetrics(SimpleMeterRegistry()),
+          json = Json,
+          nowMs = { 10_000 },
+          onReady = { readySignals += it },
+        )
+      val job = sink.start(this)
+
+      sink.enqueue(candleRecord(seq = 1))
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != false) {
+          delay(10)
+        }
+      }
+
+      assertEquals(1, insertAttempts)
+      assertTrue(job.isActive)
+      job.cancelAndJoin()
+      client.close()
+    }
+
+  @Test
+  fun `continues draining records after a clickhouse insert failure`() =
+    runBlocking {
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
+      var insertAttempts = 0
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            if (queryParam(request.url).startsWith("INSERT")) {
+              insertAttempts += 1
+              if (insertAttempts == 1) {
+                respond(content = "replica unavailable", status = HttpStatusCode.InternalServerError)
+              } else {
+                respond(content = "", status = HttpStatusCode.OK)
+              }
+            } else {
+              respond(
+                content =
+                  """
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900}
+                  """.trimIndent(),
+                status = HttpStatusCode.OK,
+              )
+            }
+          },
+        )
+      val sink =
+        ClickHouseSink(
+          config = clickHouseConfig(readyMaxAgeMs = 1_000),
+          httpClient = client,
+          metrics = HyperliquidMetrics(SimpleMeterRegistry()),
+          json = Json,
+          nowMs = { 10_000 },
+          onReady = { readySignals += it },
+        )
+      val job = sink.start(this)
+
+      sink.enqueue(candleRecord(seq = 1))
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != false) {
+          delay(10)
+        }
+      }
+
+      sink.enqueue(candleRecord(seq = 2))
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != true) {
+          delay(10)
+        }
+      }
+
+      assertEquals(2, insertAttempts)
       job.cancelAndJoin()
       client.close()
     }
@@ -154,14 +319,28 @@ class ClickHouseSinkTest {
     }
 
   private fun clickHouseConfig(readyMaxAgeMs: Long): ClickHouseConfig =
+    clickHouseConfig(
+      readyMaxAgeMs = readyMaxAgeMs,
+      batchSize = 1,
+      flushMs = 1,
+      requestTimeoutMs = 1_000,
+    )
+
+  private fun clickHouseConfig(
+    readyMaxAgeMs: Long,
+    batchSize: Int = 1,
+    flushMs: Long = 1,
+    requestTimeoutMs: Long = 1_000,
+  ): ClickHouseConfig =
     ClickHouseConfig(
       enabled = true,
       httpUrl = "http://clickhouse.local:8123",
       database = "torghut",
       username = "torghut",
       password = "",
-      batchSize = 1,
-      flushMs = 1,
+      batchSize = batchSize,
+      flushMs = flushMs,
+      requestTimeoutMs = requestTimeoutMs,
       readyMaxAgeMs = readyMaxAgeMs,
       failureHoldMs = 1_000,
       readyTables = setOf("hyperliquid_raw", "hyperliquid_candles"),
@@ -170,7 +349,7 @@ class ClickHouseSinkTest {
 
   private fun queryParam(url: Url): String = url.parameters["query"] ?: ""
 
-  private fun candleRecord(): RoutedEnvelope =
+  private fun candleRecord(seq: Long = 1): RoutedEnvelope =
     RoutedEnvelope(
       topic = "torghut.hyperliquid.candles.v1",
       key = "hl:perp:cash:cash:AAPL",
@@ -187,7 +366,7 @@ class ClickHouseSinkTest {
           dex = "cash",
           coin = "cash:AAPL",
           spotIndex = null,
-          seq = 1,
+          seq = seq,
           source = "ws",
           payload =
             buildJsonObject {

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
@@ -49,6 +49,7 @@ class HyperliquidConfigTest {
           "KAFKA_SASL_PASSWORD" to "secret",
           "CLICKHOUSE_READY_MAX_AGE_MS" to "90000",
           "CLICKHOUSE_FAILURE_HOLD_MS" to "45000",
+          "CLICKHOUSE_REQUEST_TIMEOUT_MS" to "7000",
           "CLICKHOUSE_READY_TABLES" to "hyperliquid_raw,hyperliquid_candles,hyperliquid_bbo",
           "CLICKHOUSE_FRESHNESS_CHECK_MS" to "5000",
           "HYPERLIQUID_READY_REQUIRED_CHANNELS" to "raw,candle",
@@ -58,6 +59,7 @@ class HyperliquidConfigTest {
 
     assertEquals(90_000, config.clickHouse.readyMaxAgeMs)
     assertEquals(45_000, config.clickHouse.failureHoldMs)
+    assertEquals(7_000, config.clickHouse.requestTimeoutMs)
     assertEquals(setOf("hyperliquid_raw", "hyperliquid_candles", "hyperliquid_bbo"), config.clickHouse.readyTables)
     assertEquals(5_000, config.clickHouse.freshnessCheckMs)
     assertEquals(setOf("raw", "candle"), config.readyRequiredChannels)


### PR DESCRIPTION
## Summary

- Fix the Hyperliquid feed ClickHouse sink so it batches records across the configured flush window instead of flushing immediately on momentary channel gaps.
- Add a bounded ClickHouse HTTP request timeout to prevent one stalled insert or freshness query from pinning the sink loop.
- Add regression coverage for batching, timeout readiness failure, insert-failure recovery, and timeout config parsing.

## Related Issues

None

## Testing

- `./gradlew :hyperliquid-feed:test --tests 'ai.proompteng.dorvud.hyperliquid.ClickHouseSinkTest' --tests 'ai.proompteng.dorvud.hyperliquid.HyperliquidConfigTest'`
- `./gradlew :hyperliquid-feed:test`
- `./gradlew :hyperliquid-feed:check`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
