### PR TITLE
refactor(torghut): clean scheduler api suppressions

### DIFF
--- a/services/torghut/app/api/status_helpers.py
+++ b/services/torghut/app/api/status_helpers.py
@@ -11,7 +11,6 @@ from .common import (
     JangarDependencyQuorumStatus,
     Mapping,
     SQLAlchemyError,
-    Session,
     SessionLocal,
     TRADING_STATUS_READ_BUDGET_SECONDS,
     TradingScheduler,
@@ -100,7 +99,7 @@ class _TradingStatusReadBudget:
         }
 
 
-def _rollback_status_read_session(session: Session, *, context: str) -> None:
+def _rollback_status_read_session(session: object, *, context: str) -> None:
     rollback = getattr(session, "rollback", None)
     if not callable(rollback):
         return
@@ -111,7 +110,7 @@ def _rollback_status_read_session(session: Session, *, context: str) -> None:
 
 
 def _apply_status_read_statement_timeout(
-    session: Session,
+    session: object,
     *,
     milliseconds: int,
 ) -> None:
@@ -123,7 +122,9 @@ def _apply_status_read_statement_timeout(
         dialect = getattr(getattr(bind, "dialect", None), "name", "")
         if dialect == "postgresql":
             timeout_ms = max(1, int(milliseconds))
-            session.execute(text(f"SET LOCAL statement_timeout = {timeout_ms}"))
+            execute = getattr(session, "execute", None)
+            if callable(execute):
+                execute(text(f"SET LOCAL statement_timeout = {timeout_ms}"))
     except SQLAlchemyError:
         raise
     except Exception:

--- a/services/torghut/tests/api/test_trading_api_forecast_options.py
+++ b/services/torghut/tests/api/test_trading_api_forecast_options.py
@@ -120,7 +120,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _OptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=[" aapl ", "MSFT", "AAPL", ""],
         )
 
@@ -153,7 +153,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _FallbackOptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL", "MSFT"],
         )
 
@@ -185,7 +185,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _OptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
         )
 
         self.assertEqual(payload["scope"], "global")
@@ -245,7 +245,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _PostgresRuntimeLedgerPortfolioSummarySession()
 
         payload = _daily_runtime_ledger_portfolio_summary(
-            session=fake_session,  # type: ignore[arg-type]
+            session=fake_session,
             account_label="TORGHUT_SIM",
             stage_scope="paper",
             observed_at=datetime(2026, 6, 1, 12, tzinfo=timezone.utc),
@@ -263,7 +263,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
             return_value={"order_count": 0},
         ) as build_tca:
             payload = health_checks_api._load_tca_summary(
-                fake_session,  # type: ignore[arg-type]
+                fake_session,
                 scheduler=None,
             )
 
@@ -279,7 +279,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
             return_value={"ok": True, "metrics": {"total_reviews": 0}},
         ) as build_llm:
             payload = vnext_helpers_api._load_llm_evaluation(
-                fake_session,  # type: ignore[arg-type]
+                fake_session,
             )
 
         self.assertTrue(payload["ok"])
@@ -303,24 +303,24 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
                 self.calls.append(str(statement))
                 raise SQLAlchemyError("statement timeout")
 
-        status_helpers_api._rollback_status_read_session(  # type: ignore[arg-type]
+        status_helpers_api._rollback_status_read_session(
             SimpleNamespace(),
             context="missing rollback",
         )
-        status_helpers_api._rollback_status_read_session(  # type: ignore[arg-type]
+        status_helpers_api._rollback_status_read_session(
             FailingRollbackSession(),
             context="failing rollback",
         )
-        status_helpers_api._apply_status_read_statement_timeout(  # type: ignore[arg-type]
+        status_helpers_api._apply_status_read_statement_timeout(
             SimpleNamespace(),
             milliseconds=500,
         )
-        status_helpers_api._apply_status_read_statement_timeout(  # type: ignore[arg-type]
+        status_helpers_api._apply_status_read_statement_timeout(
             BrokenBindSession(),
             milliseconds=500,
         )
         with self.assertRaises(SQLAlchemyError):
-            status_helpers_api._apply_status_read_statement_timeout(  # type: ignore[arg-type]
+            status_helpers_api._apply_status_read_statement_timeout(
                 TimeoutSession(),
                 milliseconds=500,
             )
@@ -335,7 +335,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
             ),
         ):
             payload = health_checks_api._load_tca_summary(
-                fake_session,  # type: ignore[arg-type]
+                fake_session,
                 scheduler=None,
             )
 
@@ -355,7 +355,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
             ),
         ):
             payload = vnext_helpers_api._load_llm_evaluation(
-                fake_session,  # type: ignore[arg-type]
+                fake_session,
             )
 
         self.assertFalse(payload["ok"])
@@ -401,11 +401,11 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _FailingOptionsFreshnessSession()
 
         first = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL"],
         )
         second = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL"],
         )
 
@@ -434,7 +434,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _TimedOutAggregateOptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL", "MSFT"],
         )
 
@@ -464,7 +464,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _TimedOutBoundedOptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL", "MSFT"],
         )
 
@@ -514,7 +514,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _OptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL"],
         )
 
@@ -540,7 +540,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _FallbackOptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL", "MSFT"],
         )
 
@@ -577,7 +577,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _FallbackOptionsFreshnessRequiresRollbackSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL"],
         )
 
@@ -597,7 +597,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
         fake_session = _FallbackOptionsFreshnessBlankSymbolSession()
 
         payload = _load_options_catalog_freshness_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             route_symbols=["AAPL", "MSFT"],
         )
 
@@ -643,7 +643,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
                 ),
             ):
                 payload = health_checks_api._build_tigerbeetle_ledger_status(
-                    fake_session,  # type: ignore[arg-type]
+                    fake_session,
                 )
         finally:
             settings.tigerbeetle_required = original_required
@@ -697,7 +697,7 @@ class TestTradingApiForecastOptions(TradingApiTestCaseBase):
                 ),
             ):
                 payload = health_checks_api._build_tigerbeetle_ledger_status(
-                    fake_session,  # type: ignore[arg-type]
+                    fake_session,
                 )
         finally:
             settings.tigerbeetle_required = original_required

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import json
@@ -61,6 +62,32 @@ class _OrderFirewallStub:
 class _PipelineStub:
     def __init__(self) -> None:
         self.order_firewall = _OrderFirewallStub()
+
+
+_EmergencyStopReasonCollector = Callable[[], tuple[list[str], float, float | None]]
+
+
+class _TestTradingScheduler(TradingScheduler):
+    def __init__(
+        self,
+        *,
+        market_open: bool = True,
+        emergency_stop_reasons: _EmergencyStopReasonCollector | None = None,
+    ) -> None:
+        super().__init__()
+        self.pipeline_stub = _PipelineStub()
+        self._market_open = market_open
+        self._emergency_stop_reasons = emergency_stop_reasons
+        object.__setattr__(self, "_pipeline", self.pipeline_stub)
+
+    def _is_market_session_open(self, now: datetime | None = None) -> bool:
+        _ = now
+        return self._market_open
+
+    def _collect_emergency_stop_reasons(self) -> tuple[list[str], float, float | None]:
+        if self._emergency_stop_reasons is not None:
+            return self._emergency_stop_reasons()
+        return super()._collect_emergency_stop_reasons()
 
 
 class TestTradingSchedulerSafety(TestCase):
@@ -510,9 +537,7 @@ class TestTradingSchedulerSafety(TestCase):
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
             config.settings.trading_rollback_signal_lag_seconds_limit = 5
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
-            scheduler._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+            scheduler = _TestTradingScheduler(market_open=True)
             scheduler.state.metrics.signal_lag_seconds = 7
 
             scheduler._evaluate_safety_controls()
@@ -522,7 +547,7 @@ class TestTradingSchedulerSafety(TestCase):
             self.assertIn(
                 "signal_lag_exceeded", scheduler.state.emergency_stop_reason or ""
             )
-            self.assertEqual(scheduler._pipeline.order_firewall.cancel_all_calls, 1)  # type: ignore[union-attr]
+            self.assertEqual(scheduler.pipeline_stub.order_firewall.cancel_all_calls, 1)
             evidence_path = Path(scheduler.state.rollback_incident_evidence_path or "")
             self.assertTrue(evidence_path.exists())
             payload = json.loads(evidence_path.read_text(encoding="utf-8"))
@@ -533,16 +558,14 @@ class TestTradingSchedulerSafety(TestCase):
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
             config.settings.trading_rollback_signal_lag_seconds_limit = 5
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
-            scheduler._is_market_session_open = lambda _now=None: False  # type: ignore[method-assign]
+            scheduler = _TestTradingScheduler(market_open=False)
             scheduler.state.metrics.signal_lag_seconds = 7
 
             scheduler._evaluate_safety_controls()
 
             self.assertFalse(scheduler.state.emergency_stop_active)
             self.assertEqual(scheduler.state.rollback_incidents_total, 0)
-            self.assertEqual(scheduler._pipeline.order_firewall.cancel_all_calls, 0)  # type: ignore[union-attr]
+            self.assertEqual(scheduler.pipeline_stub.order_firewall.cancel_all_calls, 0)
 
     def test_critical_no_signal_streak_is_suppressed_when_market_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -555,9 +578,7 @@ class TestTradingSchedulerSafety(TestCase):
             config.settings.trading_signal_market_closed_expected_reasons_raw = (
                 "no_signals_in_window,cursor_tail_stable,empty_batch_advanced"
             )
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
-            scheduler._is_market_session_open = lambda _now=None: False  # type: ignore[method-assign]
+            scheduler = _TestTradingScheduler(market_open=False)
             scheduler.state.metrics.no_signal_reason_streak = {
                 "no_signals_in_window": 3
             }
@@ -581,9 +602,7 @@ class TestTradingSchedulerSafety(TestCase):
                 "cursor_tail_stable,empty_batch_advanced"
             )
             config.settings.trading_signal_bootstrap_grace_seconds = 180
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
-            scheduler._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+            scheduler = _TestTradingScheduler(market_open=True)
             scheduler.state.signal_bootstrap_started_at = datetime.now(timezone.utc)
             scheduler.state.signal_bootstrap_completed_at = None
             scheduler.state.metrics.no_signal_reason_streak = {
@@ -609,9 +628,7 @@ class TestTradingSchedulerSafety(TestCase):
                 "cursor_tail_stable,empty_batch_advanced"
             )
             config.settings.trading_signal_bootstrap_grace_seconds = 180
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
-            scheduler._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+            scheduler = _TestTradingScheduler(market_open=True)
             scheduler.state.signal_bootstrap_started_at = datetime.now(
                 timezone.utc
             ) - timedelta(seconds=181)
@@ -636,9 +653,7 @@ class TestTradingSchedulerSafety(TestCase):
             config.settings.trading_emergency_stop_enabled = True
             config.settings.trading_emergency_stop_recovery_cycles = 2
             config.settings.trading_rollback_signal_lag_seconds_limit = 5
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
-            scheduler._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+            scheduler = _TestTradingScheduler(market_open=True)
             scheduler.state.metrics.signal_lag_seconds = 7
 
             scheduler._evaluate_safety_controls()
@@ -662,8 +677,7 @@ class TestTradingSchedulerSafety(TestCase):
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
             config.settings.trading_emergency_stop_recovery_cycles = 1
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
+            scheduler = _TestTradingScheduler()
             scheduler.state.emergency_stop_active = True
             scheduler.state.emergency_stop_reason = "max_drawdown_exceeded:0.1200"
             scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
@@ -688,8 +702,7 @@ class TestTradingSchedulerSafety(TestCase):
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
             config.settings.trading_rollback_max_drawdown_limit = 0.08
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
+            scheduler = _TestTradingScheduler()
             scheduler.state.last_autonomy_gates = str(gate_path)
 
             scheduler._evaluate_safety_controls()
@@ -703,8 +716,7 @@ class TestTradingSchedulerSafety(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = False
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
+            scheduler = _TestTradingScheduler()
             scheduler.state.emergency_stop_active = True
             scheduler.state.emergency_stop_reason = "signal_lag_exceeded:1234"
             scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
@@ -715,7 +727,7 @@ class TestTradingSchedulerSafety(TestCase):
             self.assertFalse(scheduler.state.emergency_stop_active)
             self.assertIsNone(scheduler.state.emergency_stop_reason)
             self.assertIsNone(scheduler.state.emergency_stop_triggered_at)
-            self.assertEqual(scheduler._pipeline.order_firewall.cancel_all_calls, 0)  # type: ignore[union-attr]
+            self.assertEqual(scheduler.pipeline_stub.order_firewall.cancel_all_calls, 0)
 
     def test_split_emergency_stop_reasons_normalizes_and_dedupes(self) -> None:
         reason = (
@@ -768,8 +780,17 @@ class TestTradingSchedulerSafety(TestCase):
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
             config.settings.trading_emergency_stop_recovery_cycles = 1
-            scheduler = TradingScheduler()
-            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
+            scheduler = _TestTradingScheduler(
+                emergency_stop_reasons=lambda: (
+                    [
+                        " signal_lag_exceeded:7 ",
+                        "max_drawdown_exceeded:0.1100",
+                        "signal_lag_exceeded:7",
+                    ],
+                    0.0,
+                    None,
+                )
+            )
             scheduler.state.emergency_stop_active = True
             scheduler.state.emergency_stop_reason = (
                 " signal_staleness_streak_exceeded:no_signals_in_window ;"
@@ -777,15 +798,6 @@ class TestTradingSchedulerSafety(TestCase):
             )
             scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
             scheduler.state.metrics.signal_lag_seconds = 0
-            scheduler._collect_emergency_stop_reasons = lambda: (
-                [
-                    " signal_lag_exceeded:7 ",
-                    "max_drawdown_exceeded:0.1100",
-                    "signal_lag_exceeded:7",
-                ],
-                0.0,
-                None,
-            )
 
             scheduler._evaluate_safety_controls()
 


### PR DESCRIPTION
## Summary

- Replaces scheduler safety private pipeline and market-session monkeypatches with a reusable `_TestTradingScheduler` harness.
- Removes all `type: ignore[arg-type]` suppressions from `test_trading_api_forecast_options.py`.
- Narrows the production status-read helper contract for optional `rollback` and statement-timeout hooks to accept generic objects, matching its fail-safe runtime behavior.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app tests/test_trading_scheduler_safety.py tests/api/test_trading_api_forecast_options.py`
- `uv run --frozen ruff check app tests/test_trading_scheduler_safety.py tests/api/test_trading_api_forecast_options.py`
- `uv run --frozen pytest tests/test_trading_scheduler_safety.py tests/api/test_trading_api_forecast_options.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app scripts tests`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-private-pyright-suppression,torghut-wildcard-ruff-noqa,torghut-blanket-pylint-disable,torghut-dynamic-attribute-hook,torghut-wildcard-import,torghut-custom-module-class,torghut-test-compat-wrapper --score=n app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/api/status_helpers.py tests/api/test_trading_api_forecast_options.py tests/test_trading_scheduler_safety.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
