### PR TITLE
fix(torghut): enforce hyperliquid clickhouse freshness readiness

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -59,6 +59,6 @@ data:
   CLICKHOUSE_FLUSH_MS: "500"
   CLICKHOUSE_REQUEST_TIMEOUT_MS: "10000"
   CLICKHOUSE_ENABLED_TABLES: "hyperliquid_raw,hyperliquid_market_catalog,hyperliquid_trades,hyperliquid_l2_books,hyperliquid_bbo,hyperliquid_candles,hyperliquid_asset_contexts,hyperliquid_funding,hyperliquid_status"
-  CLICKHOUSE_READY_TABLES: "hyperliquid_raw,hyperliquid_trades,hyperliquid_l2_books,hyperliquid_bbo,hyperliquid_candles,hyperliquid_asset_contexts,hyperliquid_status"
+  CLICKHOUSE_READY_TABLES: "hyperliquid_raw,hyperliquid_trades,hyperliquid_l2_books,hyperliquid_bbo,hyperliquid_candles,hyperliquid_asset_contexts"
   CLICKHOUSE_READY_MAX_AGE_MS: "120000"
   CLICKHOUSE_FAILURE_HOLD_MS: "60000"

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-feed-full-clickhouse-20260618a
+        proompteng.ai/config-revision: hyperliquid-feed-freshness-ready-20260618a
       labels:
         app: torghut-hyperliquid-feed
     spec:

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
@@ -92,8 +92,8 @@ class ClickHouseSink(
         insertRows(table, body)
         refreshTableFreshnessIfDue()
       }.onSuccess {
-        metrics.setClickHouseReady(true)
-        emitReadiness(ready = true, tableFreshnessReady = it)
+        metrics.setClickHouseReady(it)
+        emitReadiness(ready = it, tableFreshnessReady = it)
       }.onFailure { error ->
         metrics.setClickHouseReady(false)
         emitReadiness(ready = false, tableFreshnessReady = false)

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
@@ -229,7 +229,7 @@ class ClickHouseSinkTest {
     }
 
   @Test
-  fun `keeps clickhouse ready and reports table freshness separately when inserts succeed but freshness is stale`() =
+  fun `marks clickhouse not ready when inserts succeed but freshness is stale`() =
     runBlocking {
       val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
       val client =
@@ -268,7 +268,7 @@ class ClickHouseSinkTest {
         }
       }
 
-      assertEquals(true, readySignals.last().ready)
+      assertEquals(false, readySignals.last().ready)
       assertEquals(false, readySignals.last().tableFreshnessReady)
       assertEquals(3_000, readySignals.last().tableIngestLagMs["hyperliquid_candles"])
       job.cancelAndJoin()


### PR DESCRIPTION
## Summary

- Make ClickHouse table freshness part of the Hyperliquid feed readiness contract again.
- Keep all ClickHouse history tables enabled while using only high-frequency streaming tables for readiness gates.
- Roll the feed pod template to apply the corrected readiness behavior and readiness table set.

## Related Issues

None

## Testing

- `./gradlew :hyperliquid-feed:test --tests 'ai.proompteng.dorvud.hyperliquid.ClickHouseSinkTest' --tests 'ai.proompteng.dorvud.hyperliquid.HyperliquidConfigTest'`
- `./gradlew :hyperliquid-feed:check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
