### PR TITLE
refactor(torghut): clean hpairs runtime suppressions

### DIFF
--- a/services/torghut/app/trading/submission_council/certificate_eval.py
+++ b/services/torghut/app/trading/submission_council/certificate_eval.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from .common import (
     Any,
     Mapping,
+    RuntimeLedgerReadSession,
     SQLAlchemyError,
     Sequence,
-    Session,
     StrategyHypothesis,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
@@ -349,7 +349,7 @@ def _default_lineage_ref(
 
 
 def _attach_lineage_refs(
-    session: Session,
+    session: RuntimeLedgerReadSession,
     *,
     evaluated_rows: Sequence[Mapping[str, object]],
 ) -> list[dict[str, object]]:

--- a/services/torghut/app/trading/submission_council/certificate_loading.py
+++ b/services/torghut/app/trading/submission_council/certificate_loading.py
@@ -6,9 +6,9 @@ from .common import (
     Any,
     Decimal,
     Mapping,
+    RuntimeLedgerReadSession,
     SQLAlchemyError,
     Sequence,
-    Session,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
     StrategyRuntimeLedgerBucket,
@@ -48,7 +48,7 @@ from .runtime_certificates import (
 
 
 def _load_latest_certificate_evidence(
-    session: Session,
+    session: RuntimeLedgerReadSession,
     *,
     hypothesis_ids: Sequence[str],
     now: datetime | None = None,

--- a/services/torghut/app/trading/submission_council/common.py
+++ b/services/torghut/app/trading/submission_council/common.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from threading import Lock
-from typing import Any, NamedTuple, TypeVar, cast
+from typing import Any, NamedTuple, Protocol, TypeVar, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
@@ -130,6 +130,12 @@ _CERTIFICATE_EVIDENCE_WINDOW_LIMIT = _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT
 _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT = 16
 _PROMOTION_SCALAR_COUNT_LIMIT = _PROMOTION_TABLE_COUNT_SCAN_LIMIT
 _PROMOTION_PORTFOLIO_SAMPLE_LIMIT = _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT
+
+
+class RuntimeLedgerReadSession(Protocol):
+    """Minimal read-session surface used by runtime-ledger status probes."""
+
+    def execute(self, statement: Any, *args: Any, **kwargs: Any) -> Any: ...
 
 
 class _PortfolioPromotionRow(NamedTuple):
@@ -284,7 +290,7 @@ def _runtime_ledger_status_query_timeout_ms() -> int:
     )
 
 
-def _maybe_set_runtime_ledger_status_statement_timeout(session: Session) -> None:
+def _maybe_set_runtime_ledger_status_statement_timeout(session: object) -> None:
     get_bind = getattr(session, "get_bind", None)
     if callable(get_bind):
         try:
@@ -294,14 +300,17 @@ def _maybe_set_runtime_ledger_status_statement_timeout(session: Session) -> None
                 return
         except Exception:
             pass
-    session.execute(
+    execute = getattr(session, "execute", None)
+    if not callable(execute):
+        return
+    execute(
         sql_text(
             f"SET LOCAL statement_timeout = {_runtime_ledger_status_query_timeout_ms()}"
         )
     )
 
 
-def _rollback_runtime_ledger_status_session(session: Session) -> None:
+def _rollback_runtime_ledger_status_session(session: object) -> None:
     rollback = getattr(session, "rollback", None)
     if not callable(rollback):
         return
@@ -404,6 +413,7 @@ __all__ = [
     "Request",
     "ResearchCandidate",
     "ResearchPromotion",
+    "RuntimeLedgerReadSession",
     "SQLAlchemyError",
     "Sequence",
     "Session",

--- a/services/torghut/app/trading/submission_council/profit_readiness.py
+++ b/services/torghut/app/trading/submission_council/profit_readiness.py
@@ -12,6 +12,7 @@ from .common import (
     Mapping,
     ResearchCandidate,
     ResearchPromotion,
+    RuntimeLedgerReadSession,
     SQLAlchemyError,
     Sequence,
     Session,
@@ -300,7 +301,7 @@ def _build_profit_data_readiness_summary(
 
 
 def _load_persisted_profit_rejection_summary(
-    session: Session,
+    session: RuntimeLedgerReadSession,
     *,
     account_label: str | None,
     now: datetime,

--- a/services/torghut/app/trading/submission_council/repair_candidates.py
+++ b/services/torghut/app/trading/submission_council/repair_candidates.py
@@ -6,9 +6,9 @@ from .common import (
     Any,
     Decimal,
     Mapping,
+    RuntimeLedgerReadSession,
     SQLAlchemyError,
     Sequence,
-    Session,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
     StrategyRuntimeLedgerBucket,
@@ -56,7 +56,7 @@ from .runtime_certificates import (
 
 
 def _load_runtime_ledger_repair_candidates(
-    session: Session,
+    session: RuntimeLedgerReadSession,
     *,
     registry_items: Sequence[Mapping[str, object]],
     limit: int = _RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT,

--- a/services/torghut/app/trading/submission_council/runtime_certificates.py
+++ b/services/torghut/app/trading/submission_council/runtime_certificates.py
@@ -6,9 +6,9 @@ from .common import (
     Decimal,
     Mapping,
     POST_COST_PNL_BASIS,
+    RuntimeLedgerReadSession,
     SQLAlchemyError,
     Sequence,
-    Session,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
     StrategyRuntimeLedgerBucket,
@@ -240,7 +240,7 @@ def _mark_runtime_certificate_rejected(
 
 
 def _load_latest_runtime_ledger_summary(
-    session: Session,
+    session: RuntimeLedgerReadSession,
     *,
     hypothesis_ids: Sequence[str],
 ) -> dict[str, object]:

--- a/services/torghut/tests/audit_hpairs_source_proof_census/support.py
+++ b/services/torghut/tests/audit_hpairs_source_proof_census/support.py
@@ -246,8 +246,6 @@ class _FakeReadSession:
         return _FakeResult(self._scalar_results.pop(0))
 
 
-__all__: tuple[str, ...] = ()
-
 __all__: tuple[str, ...] = (
     "AUTHORITY_EXPLICIT_COSTS_BLOCKER",
     "AUTHORITY_OPEN_POSITIONS_BLOCKER",

--- a/services/torghut/tests/audit_hpairs_source_proof_census/test_missing_tca_costs_are_economics_missing.py
+++ b/services/torghut/tests/audit_hpairs_source_proof_census/test_missing_tca_costs_are_economics_missing.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from types import TracebackType
+from typing import cast
+
+import pytest
+
 from tests.audit_hpairs_source_proof_census.support import (
     AUTHORITY_EXPLICIT_COSTS_BLOCKER,
     AUTHORITY_OPEN_POSITIONS_BLOCKER,
@@ -71,7 +76,10 @@ def test_runtime_bucket_aggregate_only_is_source_refs_missing() -> None:
     )
 
 
-def test_json_output_is_stable_and_cli_reads_fixture(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+def test_json_output_is_stable_and_cli_reads_fixture(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     path = tmp_path / "fixture.json"
     path.write_text(json.dumps(_fixture()))
 
@@ -156,7 +164,9 @@ def test_too_few_source_backed_days_are_distribution_missing() -> None:
     assert census.AUTHORITY_TRADING_DAYS_BLOCKER in report["blockers"]
 
 
-def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_session_loader_normalizes_bounded_sqlalchemy_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from types import SimpleNamespace
 
     start = datetime(2026, 5, 1, 14, tzinfo=timezone.utc)
@@ -318,7 +328,7 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
     )
 
     rows = census._load_session_rows(
-        FakeSession(),  # type: ignore[arg-type]
+        cast(census.Session, FakeSession()),
         identity=census.CensusIdentity(
             hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
             candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
@@ -343,7 +353,9 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
     assert rows.runtime_ledger_buckets[0]["id"] == "ledger-0"
 
 
-def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_dsn_loader_opens_session_and_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     identity = census.CensusIdentity(
         hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
         candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
@@ -357,7 +369,12 @@ def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: i
         def __enter__(self) -> "FakeSession":
             return self
 
-        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
             return None
 
     monkeypatch.setattr(census, "create_engine", lambda dsn, **kwargs: f"engine:{dsn}")
@@ -371,7 +388,9 @@ def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: i
     assert rows is expected
 
 
-def test_dsn_loader_sqlalchemy_dsn_uses_installed_psycopg_driver(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_dsn_loader_sqlalchemy_dsn_uses_installed_psycopg_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     identity = census.CensusIdentity(
         hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
         candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
@@ -385,7 +404,12 @@ def test_dsn_loader_sqlalchemy_dsn_uses_installed_psycopg_driver(monkeypatch) ->
         def __enter__(self) -> "FakeSession":
             return self
 
-        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
             return None
 
     def fake_create_engine(dsn: str, **kwargs: object) -> str:
@@ -422,7 +446,10 @@ def test_dsn_loader_sqlalchemy_dsn_uses_installed_psycopg_driver(monkeypatch) ->
     )
 
 
-def test_main_reports_read_errors_as_json(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+def test_main_reports_read_errors_as_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     missing = tmp_path / "missing.json"
 
     exit_code = census.main(["--fixture-json", str(missing)])

--- a/services/torghut/tests/submission_council/test_runtime_ledger_reads.py
+++ b/services/torghut/tests/submission_council/test_runtime_ledger_reads.py
@@ -216,7 +216,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         fake_session = _FailingRuntimeLedgerStatusSession()
 
         summary = _load_latest_runtime_ledger_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             hypothesis_ids=["H-PAIRS-01"],
         )
 
@@ -238,7 +238,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         fake_session = _FailingRuntimeLedgerStatusSession()
 
         evidence = _load_latest_certificate_evidence(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             hypothesis_ids=["H-PAIRS-01"],
         )
 
@@ -384,7 +384,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         fake_session = _FailingRuntimeLedgerStatusSession()
 
         rows = _attach_lineage_refs(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             evaluated_rows=[
                 {
                     "candidate_id": "candidate-timeout",
@@ -407,7 +407,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         fake_session = _FailingRuntimeLedgerStatusSession()
 
         summary = _load_persisted_profit_rejection_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             account_label="PA3SX7FYNUTF",
             now=datetime(2026, 6, 1, tzinfo=timezone.utc),
         )
@@ -427,13 +427,18 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         fake_session = _RaisingBindRuntimeLedgerStatusSession()
 
         _maybe_set_runtime_ledger_status_statement_timeout(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
         )
 
         self.assertEqual(
             fake_session.calls,
             ["SET LOCAL statement_timeout = 2500"],
         )
+
+    def test_runtime_ledger_status_timeout_helper_ignores_non_executable_object(
+        self,
+    ) -> None:
+        _maybe_set_runtime_ledger_status_statement_timeout(object())
 
     def test_runtime_ledger_status_timeout_helper_uses_configured_timeout(
         self,
@@ -445,7 +450,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
             {"TORGHUT_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS": "3250"},
         ):
             _maybe_set_runtime_ledger_status_statement_timeout(
-                fake_session,  # type: ignore[arg-type]
+                fake_session,
             )
 
         self.assertEqual(
@@ -478,7 +483,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         self,
     ) -> None:
         _rollback_runtime_ledger_status_session(
-            _NoRollbackRuntimeLedgerStatusSession(),  # type: ignore[arg-type]
+            _NoRollbackRuntimeLedgerStatusSession(),
         )
 
     def test_load_latest_runtime_ledger_summary_fails_closed_when_rollback_fails(
@@ -487,7 +492,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         fake_session = _RollbackFailingRuntimeLedgerStatusSession()
 
         summary = _load_latest_runtime_ledger_summary(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             hypothesis_ids=["H-PAIRS-01"],
         )
 
@@ -509,7 +514,7 @@ class TestSubmissionCouncilRuntimeLedgerReads(SubmissionCouncilTestCase):
         fake_session = _FailingRuntimeLedgerStatusSession()
 
         candidates = _load_runtime_ledger_repair_candidates(
-            fake_session,  # type: ignore[arg-type]
+            fake_session,
             registry_items=[
                 {
                     "hypothesis_id": "H-PAIRS-01",

--- a/services/torghut/tests/test_verify_hpairs_runtime_authority.py
+++ b/services/torghut/tests/test_verify_hpairs_runtime_authority.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import cast
 from unittest.mock import patch
 
@@ -222,13 +222,13 @@ def test_bucket_loader_applies_identity_and_window_filters() -> None:
     class FakeSession:
         statement = None
 
-        def scalars(self, statement):  # type: ignore[no-untyped-def]
+        def scalars(self, statement: object) -> FakeScalars:
             self.statement = statement
             return FakeScalars()
 
     session = FakeSession()
     rows = load_runtime_authority_rows(
-        session,  # type: ignore[arg-type]
+        cast(Session, session),
         observed_stage="paper",
         started_at=datetime(2026, 5, 1, 12, 0),
         ended_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
@@ -246,14 +246,16 @@ def test_runtime_authority_row_instances_are_accepted() -> None:
     assert row_payload["row_refs"] == ["row-00"]
 
     row_data = _row(0)
+    bucket_started_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    bucket_ended_at = bucket_started_at + timedelta(hours=6)
     row = RuntimeAuthorityEvidenceRow(
         row_id=str(row_data["id"]),
         run_id=str(row_data["run_id"]),
         candidate_id=str(row_data["candidate_id"]),
         hypothesis_id=str(row_data["hypothesis_id"]),
         observed_stage=str(row_data["observed_stage"]),
-        bucket_started_at=row_data["bucket_started_at"],  # type: ignore[arg-type]
-        bucket_ended_at=row_data["bucket_ended_at"],  # type: ignore[arg-type]
+        bucket_started_at=bucket_started_at,
+        bucket_ended_at=bucket_ended_at,
         account_label=str(row_data["account_label"]),
         runtime_strategy_name=str(row_data["runtime_strategy_name"]),
         strategy_family=str(row_data["strategy_family"]),
@@ -276,7 +278,7 @@ def test_runtime_authority_row_instances_are_accepted() -> None:
         cost_model_hash_counts={"cost-hash": 20},
         lineage_hash_counts={"lineage-hash": 20},
         blockers=(),
-        payload=row_data["payload"],  # type: ignore[arg-type]
+        payload=_source_payload(0),
     )
     object_report = build_runtime_authority_report([row])
 
@@ -783,12 +785,19 @@ def test_output_is_stable_json() -> None:
     assert decoded["schema_version"] == "torghut.hpairs-runtime-authority-proof.v1"
 
 
-def test_cli_parses_window_filters_and_fail_on_blockers(capsys) -> None:  # type: ignore[no-untyped-def]
+def test_cli_parses_window_filters_and_fail_on_blockers(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     class FakeSession:
         def __enter__(self) -> "FakeSession":
             return self
 
-        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
             return None
 
     with (
@@ -818,7 +827,9 @@ def test_cli_parses_window_filters_and_fail_on_blockers(capsys) -> None:  # type
     assert payload["final_authority_ok"] is False
 
 
-def test_cli_reports_database_read_errors(capsys) -> None:  # type: ignore[no-untyped-def]
+def test_cli_reports_database_read_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     with patch.object(
         cli, "SessionLocal", side_effect=SQLAlchemyError("db unavailable")
     ):
@@ -830,12 +841,19 @@ def test_cli_reports_database_read_errors(capsys) -> None:  # type: ignore[no-un
     assert AUTHORITY_READ_ERROR_BLOCKER in payload["blockers"]
 
 
-def test_cli_emits_read_only_report_from_session_fixture(capsys) -> None:  # type: ignore[no-untyped-def]
+def test_cli_emits_read_only_report_from_session_fixture(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     class FakeSession:
         def __enter__(self) -> "FakeSession":
             return self
 
-        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
             return None
 
     with (
@@ -855,12 +873,19 @@ def test_cli_emits_read_only_report_from_session_fixture(capsys) -> None:  # typ
     assert payload["final_authority_ok"] is True
 
 
-def test_cli_parses_window_arguments_and_fails_on_blockers(capsys) -> None:  # type: ignore[no-untyped-def]
+def test_cli_parses_window_arguments_and_fails_on_blockers(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     class FakeSession:
         def __enter__(self) -> "FakeSession":
             return self
 
-        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
             return None
 
     with (
@@ -886,12 +911,19 @@ def test_cli_parses_window_arguments_and_fails_on_blockers(capsys) -> None:  # t
     assert payload["window"]["ended_at"] == "2026-05-02T16:00:00Z"
 
 
-def test_cli_reports_read_error_as_blocker(capsys) -> None:  # type: ignore[no-untyped-def]
+def test_cli_reports_read_error_as_blocker(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     class FakeSession:
         def __enter__(self) -> "FakeSession":
             raise SQLAlchemyError("database unavailable")
 
-        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
             return None
 
     with patch.object(cli, "SessionLocal", return_value=FakeSession()):


### PR DESCRIPTION
## Summary

- Adds a narrow runtime-ledger read-session protocol for submission-council status readers so timeout and rollback helpers no longer require concrete SQLAlchemy `Session` objects.
- Removes HPairs runtime authority and source-proof census test suppressions by typing pytest fixtures, fake context managers, and fake read sessions directly.
- Removes the duplicate empty `__all__` assignment from the HPairs source-proof census test support module.
- Drops all local suppression comments from the touched runtime authority, census, and runtime-ledger read-session test files.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app scripts tests`
- `uv run --frozen pytest tests/test_verify_hpairs_runtime_authority.py tests/audit_hpairs_source_proof_census/test_missing_tca_costs_are_economics_missing.py tests/submission_council/test_runtime_ledger_reads.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-private-pyright-suppression,torghut-wildcard-ruff-noqa,torghut-blanket-pylint-disable,torghut-dynamic-attribute-hook,torghut-wildcard-import,torghut-custom-module-class,torghut-test-compat-wrapper --score=n app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/submission_council/certificate_eval.py app/trading/submission_council/certificate_loading.py app/trading/submission_council/common.py app/trading/submission_council/profit_readiness.py app/trading/submission_council/repair_candidates.py app/trading/submission_council/runtime_certificates.py tests/audit_hpairs_source_proof_census/support.py tests/audit_hpairs_source_proof_census/test_missing_tca_costs_are_economics_missing.py tests/submission_council/test_runtime_ledger_reads.py tests/test_verify_hpairs_runtime_authority.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
