### PR TITLE
fix(torghut): recover options ta kafka startup

### DIFF
--- a/argocd/applications/torghut-options/ta/configmap.yaml
+++ b/argocd/applications/torghut-options/ta/configmap.yaml
@@ -29,7 +29,7 @@ data:
   TA_STATUS_TOPIC: "torghut.options.ta.status.v1"
   TA_GROUP_ID: "torghut-options-ta-2026-03-08"
   TA_CLIENT_ID: "torghut-options-ta-r8"
-  TA_AUTO_OFFSET_RESET: "earliest"
+  TA_AUTO_OFFSET_RESET: "latest"
   TA_CHECKPOINT_DIR: "s3a://flink-checkpoints/torghut/options-technical-analysis"
   TA_SAVEPOINT_DIR: "s3a://flink-checkpoints/torghut/options-technical-analysis/savepoints"
   TA_CHECKPOINT_INTERVAL_MS: "60000"

--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
   imagePullPolicy: IfNotPresent
-  restartNonce: 14
+  restartNonce: 15
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -18,8 +18,8 @@ spec:
     execution.checkpointing.externalized-checkpoint-retention: RETAIN_ON_CANCELLATION
     taskmanager.numberOfTaskSlots: "2"
     restart-strategy.type: fixed-delay
-    restart-strategy.fixed-delay.attempts: "5"
-    restart-strategy.fixed-delay.delay: 5 s
+    restart-strategy.fixed-delay.attempts: "60"
+    restart-strategy.fixed-delay.delay: 10 s
     execution.checkpointing.unaligned: "true"
     execution.checkpointing.tolerable-failed-checkpoints: "3"
     metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -184,6 +184,19 @@ describe('Torghut manifest scheduling', () => {
     expect(resources).not.toContain('externalsecret.yaml')
   })
 
+  it('keeps options TA recoverable across transient Kafka source startup failures', () => {
+    const config = parseManifest('argocd/applications/torghut-options/ta/configmap.yaml')
+    const data = getAtPath(config, ['data'])
+    expect(data.TA_AUTO_OFFSET_RESET).toBe('latest')
+
+    const deployment = parseManifest('argocd/applications/torghut-options/ta/flinkdeployment.yaml')
+    const spec = getAtPath(deployment, ['spec'])
+    const flinkConfiguration = getAtPath(spec, ['flinkConfiguration'])
+    expect(spec.restartNonce).toBe(15)
+    expect(flinkConfiguration['restart-strategy.fixed-delay.attempts']).toBe('60')
+    expect(flinkConfiguration['restart-strategy.fixed-delay.delay']).toBe('10 s')
+  })
+
   it('keeps whitepaper autoresearch off the serving pod resource envelope', () => {
     const manifest = parseManifest('argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml')
     const template = getAtPath(manifest, ['spec', 'templates', 0])


### PR DESCRIPTION
## Summary

- Recover the failed options TA Flink job by bumping `restartNonce`.
- Start options TA from `latest` for partitions without committed offsets instead of replaying from `earliest` on live startup.
- Increase the fixed-delay restart budget from 5 attempts to 60 attempts with a 10s delay so transient Kafka position/metadata timeouts do not permanently fail the FlinkDeployment.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-options >/tmp/torghut-options-render.yaml`
- `bun run lint:argocd`
- `git diff --check`
- Live readback before this fix showed `torghut-options-ta` failed with `Timeout of 60000ms expired before the position for partition torghut.options.quotes.v1-6 could be determined`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
