### PR TITLE
fix(torghut): bound hyperliquid clickhouse schema hook

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "-2"
 data:
   schema.sql: |-
-    SET distributed_ddl_task_timeout = 45;
+    SET distributed_ddl_task_timeout = 10;
     SET distributed_ddl_output_mode = 'null_status_on_timeout';
 
     CREATE DATABASE IF NOT EXISTS torghut ON CLUSTER default;

--- a/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-job.yaml
@@ -9,7 +9,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   backoffLimit: 6
-  activeDeadlineSeconds: 900
+  activeDeadlineSeconds: 360
   ttlSecondsAfterFinished: 600
   template:
     metadata:
@@ -36,7 +36,7 @@ spec:
                 --password "${CLICKHOUSE_PASSWORD}"
                 --connect_timeout 5
                 --send_timeout 30
-                --receive_timeout 120
+                --receive_timeout 60
               )
               deadline=$((SECONDS + 300))
               until "${CLICKHOUSE_CLIENT[@]}" --query 'SELECT 1'; do
@@ -46,7 +46,7 @@ spec:
                 fi
                 sleep 5
               done
-              "${CLICKHOUSE_CLIENT[@]}" --multiquery < /schema/schema.sql
+              timeout 240s "${CLICKHOUSE_CLIENT[@]}" --multiquery < /schema/schema.sql
           env:
             - name: CLICKHOUSE_USERNAME
               value: torghut

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -127,16 +127,16 @@ describe('Torghut manifest scheduling', () => {
     const container = getAtPath(job, ['spec', 'template', 'spec', 'containers', 0])
     const args = Array.isArray(container.args) ? container.args.join('\n') : ''
 
-    expect(getAtPath(job, ['spec']).activeDeadlineSeconds).toBe(900)
+    expect(getAtPath(job, ['spec']).activeDeadlineSeconds).toBe(360)
     expect(args).toContain('set -euo pipefail')
     expect(args).toContain('--connect_timeout 5')
     expect(args).toContain('--send_timeout 30')
-    expect(args).toContain('--receive_timeout 120')
-    expect(args).toContain('"${CLICKHOUSE_CLIENT[@]}" --multiquery < /schema/schema.sql')
+    expect(args).toContain('--receive_timeout 60')
+    expect(args).toContain('timeout 240s "${CLICKHOUSE_CLIENT[@]}" --multiquery < /schema/schema.sql')
 
     const schema = parseManifest('argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-configmap.yaml')
     const data = getAtPath(schema, ['data'])
-    expect(data['schema.sql']).toContain('SET distributed_ddl_task_timeout = 45;')
+    expect(data['schema.sql']).toContain('SET distributed_ddl_task_timeout = 10;')
     expect(data['schema.sql']).toContain("SET distributed_ddl_output_mode = 'null_status_on_timeout';")
   })
 


### PR DESCRIPTION
## Summary

- Reduces Hyperliquid ClickHouse distributed DDL wait from 45 seconds to 10 seconds per statement.
- Adds a hard 240-second shell timeout around the schema multiquery and lowers the hook job deadline to 360 seconds.
- Updates the manifest guard so schema hooks stay bounded during Argo syncs.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`
- `bun run lint:argocd`
- `git diff --check`
- `kubectl -n torghut exec torghut-hyperliquid-clickhouse-schema-kr86v -- /bin/bash -lc 'command -v timeout && timeout --version | head -n 1'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
