### PR TITLE
fix(torghut): surface empirical renewal child failures

### DIFF
--- a/services/torghut/scripts/empirical_promotion_renewal/run_runtime_window_import_target.py
+++ b/services/torghut/scripts/empirical_promotion_renewal/run_runtime_window_import_target.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 import yaml
 
@@ -50,6 +50,48 @@ from .offline_replay_triage_candidates_from_rank import (
     runtime_window_import_payload_proof_blockers as _runtime_window_import_payload_proof_blockers,
     runtime_window_source_collection_materialization_blocked_result as _runtime_window_source_collection_materialization_blocked_result,
 )
+
+
+_CHILD_OUTPUT_MAX_CHARS = 20_000
+
+
+def _write_child_stream(context: str, stream_name: str, output: str | None) -> None:
+    if not output:
+        return
+    text = output
+    if len(text) > _CHILD_OUTPUT_MAX_CHARS:
+        text = (
+            f"... truncated to last {_CHILD_OUTPUT_MAX_CHARS} chars ...\n"
+            f"{text[-_CHILD_OUTPUT_MAX_CHARS:]}"
+        )
+    if not text.endswith("\n"):
+        text = f"{text}\n"
+    sys.stderr.write(
+        f"{context}_{stream_name}_begin\n{text}{context}_{stream_name}_end\n"
+    )
+    sys.stderr.flush()
+
+
+def run_captured_child(
+    command: Sequence[str],
+    *,
+    context: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            list(command),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        command_name = str(command[1]) if len(command) > 1 else str(command[0])
+        sys.stderr.write(
+            f"{context}_failed exit_code={exc.returncode} command={command_name}\n"
+        )
+        _write_child_stream(context, "stdout", exc.stdout)
+        _write_child_stream(context, "stderr", exc.stderr)
+        raise RuntimeError(f"{context}_failed: exit_code={exc.returncode}") from exc
 
 
 def _renewal_root_export(name: str, fallback: Any) -> Any:
@@ -267,7 +309,7 @@ def _run_runtime_window_import_target(
         command.extend(
             ["--delay-adjusted-depth-stress-report-ref", delay_depth_report_ref]
         )
-    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    result = run_captured_child(command, context="runtime_window_import_child")
     payload = json.loads(result.stdout)
     if not isinstance(payload, Mapping):
         raise RuntimeError("runtime_window_import_payload_not_mapping")
@@ -386,7 +428,7 @@ def main() -> int:
         str(output_dir),
         "--json",
     ]
-    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    result = run_captured_child(command, context="empirical_promotion_jobs_child")
     runtime_window_import = _run_runtime_window_import(
         args=args,
         manifest=manifest,

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -86,6 +86,7 @@ from scripts.empirical_promotion_renewal.raise_if_runtime_window_target_plan_imp
     runtime_window_targets_from_plan as _runtime_window_targets_from_plan,
 )
 from scripts.empirical_promotion_renewal.run_runtime_window_import_target import (
+    run_captured_child as _run_captured_child,
     run_runtime_window_import_target as _run_runtime_window_import_target,
 )
 from scripts.empirical_promotion_renewal.runtime_window_targets import (
@@ -145,7 +146,7 @@ def main() -> int:
         str(output_dir),
         "--json",
     ]
-    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    result = _run_captured_child(command, context="empirical_promotion_jobs_child")
     runtime_window_import = _run_runtime_window_import(
         args=args,
         manifest=manifest,

--- a/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_child_process.py
+++ b/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_child_process.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+import importlib
+from io import StringIO
+import subprocess
+
+from tests.run_empirical_promotion_jobs.support import (
+    MagicMock,
+    RunEmpiricalPromotionJobsTestCase,
+    SimpleNamespace,
+    datetime,
+    json,
+    patch,
+    renewal,
+    timezone,
+)
+
+renewal_target = importlib.import_module(
+    "scripts.empirical_promotion_renewal.run_runtime_window_import_target"
+)
+
+
+class TestRunEmpiricalPromotionJobsRuntimeWindowChildProcess(
+    RunEmpiricalPromotionJobsTestCase
+):
+    def test_runtime_window_import_surfaces_child_process_output(self) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref=str(hypothesis_path),
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+        args = SimpleNamespace(
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_target_plan_settlement_seconds=0,
+        )
+        child_error = subprocess.CalledProcessError(
+            returncode=7,
+            cmd=["python", "scripts/import_hypothesis_runtime_windows.py"],
+            output="child stdout detail",
+            stderr="child stderr detail",
+        )
+        stderr = StringIO()
+
+        with (
+            patch.object(renewal.subprocess, "run", side_effect=child_error),
+            redirect_stderr(stderr),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_import_child_failed: exit_code=7",
+            ),
+        ):
+            renewal._run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 5, 26, 21, 23, tzinfo=timezone.utc),
+            )
+
+        output = stderr.getvalue()
+        self.assertIn("runtime_window_import_child_failed exit_code=7", output)
+        self.assertIn("runtime_window_import_child_stdout_begin", output)
+        self.assertIn("child stdout detail", output)
+        self.assertIn("runtime_window_import_child_stderr_begin", output)
+        self.assertIn("child stderr detail", output)
+
+    def test_child_stream_skips_empty_output_and_truncates_large_output(self) -> None:
+        stderr = StringIO()
+        oversized_output = (
+            "dropped-prefix"
+            + ("a" * renewal_target._CHILD_OUTPUT_MAX_CHARS)
+            + "retained-suffix"
+        )
+
+        with redirect_stderr(stderr):
+            renewal_target._write_child_stream("child", "stdout", None)
+            renewal_target._write_child_stream("child", "stdout", oversized_output)
+
+        output = stderr.getvalue()
+        self.assertIn("child_stdout_begin", output)
+        self.assertIn("truncated to last 20000 chars", output)
+        self.assertNotIn("dropped-prefix", output)
+        self.assertIn("retained-suffix", output)
+
+    def test_split_module_main_wraps_empirical_promotion_child_process(self) -> None:
+        args = SimpleNamespace(
+            output_dir=str(self.tmp_dir),
+            run_id_prefix="renew",
+            strategy_spec_ref="microbar_cross_sectional_pairs_v1@research",
+            hpairs_source_proof_census_file=None,
+            json=True,
+            runtime_window_import=False,
+        )
+        session_context = MagicMock()
+        session_context.__enter__.return_value = object()
+        session_context.__exit__.return_value = None
+        child_result = SimpleNamespace(stdout=json.dumps({"status": "ok"}))
+        stdout = StringIO()
+
+        with (
+            patch.object(renewal_target, "_parse_args", return_value=args),
+            patch.object(renewal_target, "SessionLocal", return_value=session_context),
+            patch.object(
+                renewal_target, "_load_latest_empirical_job_rows", return_value=[]
+            ),
+            patch.object(renewal_target, "_latest_authoritative_rows", return_value={}),
+            patch.object(
+                renewal_target, "_runtime_version_ref", return_value="runtime-v1"
+            ),
+            patch.object(
+                renewal_target,
+                "build_renewal_manifest",
+                return_value={"schema_version": "test", "run_id": "renew-1"},
+            ),
+            patch.object(
+                renewal_target, "run_captured_child", return_value=child_result
+            ) as run_mock,
+            patch.object(
+                renewal_target, "_run_runtime_window_import", return_value=None
+            ),
+            redirect_stdout(stdout),
+        ):
+            self.assertEqual(renewal_target.main(), 0)
+
+        run_mock.assert_called_once()
+        command = run_mock.call_args.args[0]
+        self.assertIn("scripts/run_empirical_promotion_jobs.py", command)
+        self.assertEqual(
+            run_mock.call_args.kwargs["context"],
+            "empirical_promotion_jobs_child",
+        )
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["empirical_promotion"], {"status": "ok"})


### PR DESCRIPTION
## Summary

- Surface captured stdout/stderr when empirical renewal child scripts fail.
- Reuse the failure wrapper for `run_empirical_promotion_jobs.py` and runtime-window import children.
- Add regression coverage proving child process output is emitted before the renewal helper raises.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py`
- `uv run --frozen ruff check scripts/empirical_promotion_renewal/run_runtime_window_import_target.py scripts/renew_latest_empirical_promotion_jobs.py tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py`
- `uv run --frozen ruff format --check scripts/empirical_promotion_renewal/run_runtime_window_import_target.py scripts/renew_latest_empirical_promotion_jobs.py tests/run_empirical_promotion_jobs/test_runtime_window_blockers.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv sync --frozen --extra dev`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
