### PR TITLE
refactor(torghut): clean alpaca client suppressions

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from dataclasses import asdict, is_dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Protocol, cast
 from uuid import UUID
 
 from alpaca.common.exceptions import APIError
@@ -37,6 +37,26 @@ class OrderFirewallViolation(PermissionError):
     """Raised when broker mutation methods are called outside OrderFirewall."""
 
 
+class _TradingClientLike(Protocol):
+    def get_account(self) -> Any: ...
+
+    def get_all_positions(self) -> Iterable[Any]: ...
+
+    def get_orders(self, filter: Any | None = None) -> Iterable[Any]: ...
+
+    def get_order_by_id(self, order_id: str) -> Any: ...
+
+    def submit_order(self, order_data: Any) -> Any: ...
+
+    def cancel_order_by_id(self, order_id: str) -> Any: ...
+
+    def cancel_orders(self) -> Iterable[Any]: ...
+
+
+class _StockDataClientLike(Protocol):
+    def get_stock_bars(self, request_params: StockBarsRequest) -> Any: ...
+
+
 class _TradingMutationGuardProxy:
     """Expose non-mutating trading methods while blocking direct order mutations."""
 
@@ -44,7 +64,7 @@ class _TradingMutationGuardProxy:
         {"submit_order", "cancel_order_by_id", "cancel_orders"}
     )
 
-    def __init__(self, trading_client: TradingClient) -> None:
+    def __init__(self, trading_client: _TradingClientLike) -> None:
         self._trading_client = trading_client
 
     def __getattr__(self, name: str) -> Any:
@@ -62,8 +82,8 @@ class TorghutAlpacaClient:
         api_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        trading_client: Optional[TradingClient] = None,
-        data_client: Optional[StockHistoricalDataClient] = None,
+        trading_client: _TradingClientLike | None = None,
+        data_client: _StockDataClientLike | None = None,
         paper: Optional[bool] = None,
     ) -> None:
         key = api_key or settings.apca_api_key_id
@@ -75,7 +95,7 @@ class TorghutAlpacaClient:
         self.endpoint_class = "paper" if use_paper else "live"
 
         # Default to paper trading; override URL if provided.
-        raw_trading_client = trading_client or TradingClient(
+        raw_trading_client: _TradingClientLike = trading_client or TradingClient(
             api_key=key,
             secret_key=secret,
             paper=use_paper,
@@ -85,7 +105,7 @@ class TorghutAlpacaClient:
         self.trading = _TradingMutationGuardProxy(raw_trading_client)
 
         # Market Data v2 (stocks).
-        self.data = data_client or StockHistoricalDataClient(
+        self.data: _StockDataClientLike = data_client or StockHistoricalDataClient(
             api_key=key,
             secret_key=secret,
             url_override=data_base,

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, List
+from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
 
+from alpaca.data.requests import StockBarsRequest
+from alpaca.trading.requests import GetOrdersRequest
+
 from app.alpaca_client import OrderFirewallViolation, TorghutAlpacaClient
+from app.alpaca_client import OrderFirewallToken
 from app.config import settings
 from app.trading.firewall import OrderFirewall
 
@@ -20,18 +24,21 @@ class DummyModel:
 
 class DummyTradingClient:
     def __init__(self) -> None:
-        self.cancelled: List[str] = []
+        self.cancelled: list[str] = []
 
-    def get_account(self):  # type: ignore[override]
+    def get_account(self) -> DummyModel:
         return DummyModel(equity="10000", cash="5000", buying_power="20000")
 
-    def get_all_positions(self):  # type: ignore[override]
+    def get_all_positions(self) -> list[DummyModel]:
         return [DummyModel(symbol="AAPL", qty="1")]
 
-    def get_orders(self, filter=None):  # type: ignore[override]
+    def get_orders(self, filter: GetOrdersRequest | None = None) -> list[DummyModel]:
         return [DummyModel(id="order-1", symbol="AAPL", uuid_id=uuid.uuid4())]
 
-    def submit_order(self, order_data):  # type: ignore[override]
+    def get_order_by_id(self, order_id: str) -> DummyModel:
+        return DummyModel(id=order_id, symbol="AAPL")
+
+    def submit_order(self, order_data: Any) -> DummyModel:
         return DummyModel(
             id="order-123",
             symbol=order_data.symbol,
@@ -42,22 +49,27 @@ class DummyTradingClient:
             status="accepted",
         )
 
-    def cancel_order_by_id(self, order_id):  # type: ignore[override]
+    def cancel_order_by_id(self, order_id: str) -> None:
         self.cancelled.append(order_id)
 
-    def cancel_orders(self):  # type: ignore[override]
+    def cancel_orders(self) -> list[DummyModel]:
         return [DummyModel(id="order-1"), DummyModel(id="order-2")]
+
+
+class DummyBarsResponse:
+    def __init__(self, data: dict[str, list[DummyModel]]) -> None:
+        self.data = data
 
 
 class DummyDataClient:
     def __init__(self) -> None:
-        self.requested = []
+        self.requested: list[StockBarsRequest] = []
 
-    def get_stock_bars(self, request):  # type: ignore[override]
-        self.requested.append(request)
-        return type(
-            "Obj", (), {"data": {"AAPL": [DummyModel(symbol="AAPL", open=1, close=2)]}}
-        )()
+    def get_stock_bars(self, request_params: StockBarsRequest) -> DummyBarsResponse:
+        self.requested.append(request_params)
+        return DummyBarsResponse(
+            data={"AAPL": [DummyModel(symbol="AAPL", open=1, close=2)]}
+        )
 
 
 class TestAlpacaClient(TestCase):
@@ -106,7 +118,7 @@ class TestAlpacaClient(TestCase):
 
     def test_get_order_by_client_order_id_falls_back_to_client_id(self) -> None:
         class TradingClientWithClientId(DummyTradingClient):
-            def get_order_by_client_id(self, client_id: str):  # type: ignore[override]
+            def get_order_by_client_id(self, client_id: str) -> DummyModel:
                 return DummyModel(id="order-xyz", client_order_id=client_id)
 
         client = TorghutAlpacaClient(
@@ -148,7 +160,7 @@ class TestAlpacaClient(TestCase):
                 qty=1,
                 order_type="market",
                 time_in_force="day",
-                firewall_token=object(),  # type: ignore[arg-type]
+                firewall_token=cast(OrderFirewallToken, object()),
             )
 
     def test_raw_trading_client_proxy_blocks_mutations(self) -> None:


### PR DESCRIPTION
## Summary

- Narrows `TorghutAlpacaClient` injected dependencies to explicit trading and market-data protocols.
- Replaces the Alpaca test fakes with typed protocol-compatible fakes.
- Removes every `type: ignore` suppression from `tests/test_alpaca_client.py` without weakening the firewall negative test.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/alpaca_client.py tests/test_alpaca_client.py`
- `uv run --frozen pytest tests/test_alpaca_client.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-private-pyright-suppression,torghut-wildcard-ruff-noqa,torghut-blanket-pylint-disable,torghut-dynamic-attribute-hook,torghut-wildcard-import,torghut-custom-module-class,torghut-test-compat-wrapper --score=n app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/alpaca_client.py tests/test_alpaca_client.py`
- `uv run --frozen pyright tests/test_alpaca_client.py --pythonversion 3.12`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/test_alpaca_client.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
