### PR TITLE
fix(torghut): raise hyperliquid clickhouse write timeout

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -57,7 +57,7 @@ data:
   CLICKHOUSE_USERNAME: "torghut"
   CLICKHOUSE_BATCH_SIZE: "1000"
   CLICKHOUSE_FLUSH_MS: "500"
-  CLICKHOUSE_REQUEST_TIMEOUT_MS: "10000"
+  CLICKHOUSE_REQUEST_TIMEOUT_MS: "30000"
   CLICKHOUSE_ENABLED_TABLES: "hyperliquid_market_catalog,hyperliquid_candles,hyperliquid_asset_contexts,hyperliquid_funding,hyperliquid_status"
   CLICKHOUSE_READY_TABLES: "hyperliquid_candles"
   CLICKHOUSE_READY_MAX_AGE_MS: "120000"

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-feed-live-pressure-20260618a
+        proompteng.ai/config-revision: hyperliquid-feed-clickhouse-timeout-20260618a
       labels:
         app: torghut-hyperliquid-feed
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -162,11 +162,12 @@ describe('Torghut manifest scheduling', () => {
     ])
     expect(readyTables).toEqual(['hyperliquid_candles'])
     expect(readyTables.every((table) => enabledTables.includes(table))).toBe(true)
+    expect(data.CLICKHOUSE_REQUEST_TIMEOUT_MS).toBe('30000')
 
     const deployment = parseManifest('argocd/applications/torghut-hyperliquid-feed/deployment.yaml')
     expect(
       getAtPath(deployment, ['spec', 'template', 'metadata', 'annotations'])['proompteng.ai/config-revision'],
-    ).toBe('hyperliquid-feed-live-pressure-20260618a')
+    ).toBe('hyperliquid-feed-clickhouse-timeout-20260618a')
   })
 
   it('keeps Hyperliquid runtime shadow mode free of optional execution secret drift', () => {


### PR DESCRIPTION
## Summary

- Raise the Hyperliquid feed ClickHouse write timeout from 10s to 30s to stop readiness flapping during small candle inserts.
- Roll the feed deployment with a new config revision annotation.
- Pin the timeout in the Torghut manifest scheduling guard.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
