### PR TITLE
fix(torghut): keep hyperliquid feed ready during clickhouse lag

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -52,6 +52,7 @@ data:
   TOPIC_FUNDING: "torghut.hyperliquid.funding.v1"
   TOPIC_STATUS: "torghut.hyperliquid.status.v1"
   CLICKHOUSE_ENABLED: "true"
+  CLICKHOUSE_REQUIRED_FOR_READINESS: "false"
   CLICKHOUSE_HTTP_URL: "http://torghut-clickhouse.torghut.svc.cluster.local:8123"
   CLICKHOUSE_DATABASE: "torghut"
   CLICKHOUSE_USERNAME: "torghut"

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-feed-clickhouse-timeout-20260618a
+        proompteng.ai/config-revision: hyperliquid-feed-clickhouse-optional-20260618b
       labels:
         app: torghut-hyperliquid-feed
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -163,11 +163,13 @@ describe('Torghut manifest scheduling', () => {
     expect(readyTables).toEqual(['hyperliquid_candles'])
     expect(readyTables.every((table) => enabledTables.includes(table))).toBe(true)
     expect(data.CLICKHOUSE_REQUEST_TIMEOUT_MS).toBe('30000')
+    expect(data.CLICKHOUSE_ENABLED).toBe('true')
+    expect(data.CLICKHOUSE_REQUIRED_FOR_READINESS).toBe('false')
 
     const deployment = parseManifest('argocd/applications/torghut-hyperliquid-feed/deployment.yaml')
     expect(
       getAtPath(deployment, ['spec', 'template', 'metadata', 'annotations'])['proompteng.ai/config-revision'],
-    ).toBe('hyperliquid-feed-clickhouse-timeout-20260618a')
+    ).toBe('hyperliquid-feed-clickhouse-optional-20260618b')
   })
 
   it('keeps Hyperliquid runtime shadow mode free of optional execution secret drift', () => {

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
@@ -20,6 +20,7 @@ data class HyperliquidTopics(
 
 data class ClickHouseConfig(
   val enabled: Boolean,
+  val requiredForReadiness: Boolean,
   val httpUrl: String,
   val database: String,
   val username: String,
@@ -158,6 +159,7 @@ data class HyperliquidConfig(
       val clickHouse =
         ClickHouseConfig(
           enabled = mergedEnv["CLICKHOUSE_ENABLED"]?.toBooleanStrictOrNull() ?: true,
+          requiredForReadiness = mergedEnv["CLICKHOUSE_REQUIRED_FOR_READINESS"]?.toBooleanStrictOrNull() ?: true,
           httpUrl = mergedEnv["CLICKHOUSE_HTTP_URL"] ?: "http://torghut-clickhouse.torghut.svc.cluster.local:8123",
           database = mergedEnv["CLICKHOUSE_DATABASE"] ?: "torghut",
           username = mergedEnv["CLICKHOUSE_USERNAME"] ?: "torghut",

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
@@ -310,7 +310,15 @@ class HyperliquidFeedApp(
   }
 
   private fun updateReady() {
-    val isReady = wsReady.get() && kafkaReady.get() && clickHouseFresh() && marketDataFresh() && catalogReady.get()
+    val isReady =
+      hyperliquidReadinessReady(
+        wsReady = wsReady.get(),
+        kafkaReady = kafkaReady.get(),
+        clickHouseFresh = clickHouseFresh(),
+        clickHouseRequiredForReadiness = config.clickHouse.requiredForReadiness,
+        marketDataFresh = marketDataFresh(),
+        catalogReady = catalogReady.get(),
+      )
     markReady(isReady)
   }
 
@@ -363,6 +371,20 @@ class HyperliquidFeedApp(
     metrics.setMarketDataReady(eventFreshnessSnapshot().fresh)
   }
 }
+
+internal fun hyperliquidReadinessReady(
+  wsReady: Boolean,
+  kafkaReady: Boolean,
+  clickHouseFresh: Boolean,
+  clickHouseRequiredForReadiness: Boolean,
+  marketDataFresh: Boolean,
+  catalogReady: Boolean,
+): Boolean =
+  wsReady &&
+    kafkaReady &&
+    (!clickHouseRequiredForReadiness || clickHouseFresh) &&
+    marketDataFresh &&
+    catalogReady
 
 fun main() =
   runBlocking {

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
@@ -34,6 +34,7 @@ class ClickHouseSinkTest {
           config =
             ClickHouseConfig(
               enabled = true,
+              requiredForReadiness = true,
               httpUrl = "http://clickhouse.local:8123",
               database = "torghut",
               username = "torghut",
@@ -378,6 +379,7 @@ class ClickHouseSinkTest {
   ): ClickHouseConfig =
     ClickHouseConfig(
       enabled = true,
+      requiredForReadiness = true,
       httpUrl = "http://clickhouse.local:8123",
       database = "torghut",
       username = "torghut",

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
@@ -50,6 +50,7 @@ class HyperliquidConfigTest {
           "CLICKHOUSE_READY_MAX_AGE_MS" to "90000",
           "CLICKHOUSE_FAILURE_HOLD_MS" to "45000",
           "CLICKHOUSE_REQUEST_TIMEOUT_MS" to "7000",
+          "CLICKHOUSE_REQUIRED_FOR_READINESS" to "false",
           "CLICKHOUSE_ENABLED_TABLES" to "hyperliquid_raw,hyperliquid_candles,hyperliquid_bbo",
           "CLICKHOUSE_READY_TABLES" to "hyperliquid_raw,hyperliquid_candles,hyperliquid_bbo",
           "CLICKHOUSE_FRESHNESS_CHECK_MS" to "5000",
@@ -61,6 +62,7 @@ class HyperliquidConfigTest {
     assertEquals(90_000, config.clickHouse.readyMaxAgeMs)
     assertEquals(45_000, config.clickHouse.failureHoldMs)
     assertEquals(7_000, config.clickHouse.requestTimeoutMs)
+    assertFalse(config.clickHouse.requiredForReadiness)
     assertEquals(setOf("hyperliquid_raw", "hyperliquid_candles", "hyperliquid_bbo"), config.clickHouse.enabledTables)
     assertEquals(setOf("hyperliquid_raw", "hyperliquid_candles", "hyperliquid_bbo"), config.clickHouse.readyTables)
     assertEquals(5_000, config.clickHouse.freshnessCheckMs)

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedAppHealthTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedAppHealthTest.kt
@@ -30,4 +30,32 @@ class HyperliquidFeedAppHealthTest {
     app.stop()
     assertFalse(app.isAlive())
   }
+
+  @Test
+  fun `optional clickhouse mirror does not block readiness when feed path is healthy`() {
+    assertTrue(
+      hyperliquidReadinessReady(
+        wsReady = true,
+        kafkaReady = true,
+        clickHouseFresh = false,
+        clickHouseRequiredForReadiness = false,
+        marketDataFresh = true,
+        catalogReady = true,
+      ),
+    )
+  }
+
+  @Test
+  fun `required clickhouse mirror blocks readiness when stale`() {
+    assertFalse(
+      hyperliquidReadinessReady(
+        wsReady = true,
+        kafkaReady = true,
+        clickHouseFresh = false,
+        clickHouseRequiredForReadiness = true,
+        marketDataFresh = true,
+        catalogReady = true,
+      ),
+    )
+  }
 }


### PR DESCRIPTION
## Summary

- Adds an explicit `CLICKHOUSE_REQUIRED_FOR_READINESS` Hyperliquid feed config so ClickHouse mirror health can remain observable without hard-blocking WebSocket/Kafka readiness.
- Sets the live Torghut Hyperliquid feed manifest to keep ClickHouse enabled but non-blocking for readiness, with a rollout annotation bump.
- Adds Kotlin and manifest regression coverage for the new readiness contract.

## Related Issues

None

## Testing

- `./gradlew :hyperliquid-feed:test --tests "ai.proompteng.dorvud.hyperliquid.HyperliquidConfigTest" --tests "ai.proompteng.dorvud.hyperliquid.HyperliquidFeedAppHealthTest"`
- `./gradlew :hyperliquid-feed:test`
- `./gradlew :hyperliquid-feed:build`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`
- `bun run lint:argocd`
- `git diff --check origin/main HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
