### PR TITLE
fix(torghut): gate hyperliquid testnet execution universe

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/README.md
+++ b/argocd/applications/torghut-hyperliquid-runtime/README.md
@@ -8,6 +8,9 @@ V1 defaults to shadow mode:
 - Operational state is written to the Hyperliquid-specific Postgres tables from migration `0054`.
 - TigerBeetle transfer refs are planned deterministically for submitted holds, fills, fees, realized PnL, and releases.
 - Mainnet execution is blocked in config validation and code.
+- When trading is enabled, the runtime filters the selected mainnet market-data universe through Hyperliquid testnet
+  perp metadata before any feature can produce an order. If testnet metadata is stale, unavailable, or has no matching
+  equity-like markets, readiness fails and no orders are submitted.
 
 To enable tiny testnet orders, create and authorize a Hyperliquid testnet API/agent wallet for the dedicated testnet account. Store the main account address and authorized API wallet private key in the 1Password item `hyperliquid-testnet` in the `infra` vault with fields:
 
@@ -29,10 +32,12 @@ Shadow mode does not require Hyperliquid execution credentials. Keep the Externa
 GitOps while `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`; otherwise a missing optional 1Password item degrades the
 Argo app even though the runtime is correctly serving read-only readiness.
 
-After `reconcile` reports the bootstrap as ready, open a GitOps PR that adds the `torghut-hyperliquid-testnet`
-ExternalSecret to `kustomization.yaml` and sets `HYPERLIQUID_RUNTIME_TRADING_ENABLED` to `true` in
-`configmap.yaml`. Keep the default caps unless a separate rollout approves a larger envelope. The runtime must
-continue to report `execution_network=testnet`; mainnet execution is rejected by config validation.
+After `check` reports the 1Password item is present, open a GitOps PR that adds `externalsecret.yaml` to
+`kustomization.yaml` while keeping `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`. Merge and wait for Argo to sync, then
+run `scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile`. After `reconcile` reports the Kubernetes
+Secret as ready, open the trading-enable PR that sets `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true` in `configmap.yaml`.
+Keep the default caps unless a separate rollout approves a larger envelope. The runtime must continue to report
+`execution_network=testnet`; mainnet execution is rejected by config validation.
 
 Acceptance checks:
 

--- a/argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: torghut-hyperliquid-testnet
+  namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-infra
+  target:
+    name: torghut-hyperliquid-testnet
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: account-address
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: hyperliquid-testnet/account-address
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+    - secretKey: api-wallet-private-key
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: hyperliquid-testnet/api-wallet-private-key
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -179,6 +179,32 @@ describe('Torghut manifest scheduling', () => {
     const resources = kustomization.resources
     expect(resources).toBeArray()
     expect(resources).not.toContain('externalsecret.yaml')
+
+    const externalSecret = parseManifest('argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml')
+    expect(externalSecret.kind).toBe('ExternalSecret')
+    expect(getAtPath(externalSecret, ['metadata']).name).toBe('torghut-hyperliquid-testnet')
+    expect(getAtPath(externalSecret, ['spec', 'secretStoreRef'])).toMatchObject({
+      kind: 'ClusterSecretStore',
+      name: 'onepassword-infra',
+    })
+    expect(getAtPath(externalSecret, ['spec', 'target'])).toMatchObject({
+      name: 'torghut-hyperliquid-testnet',
+      creationPolicy: 'Owner',
+      deletionPolicy: 'Retain',
+    })
+    const secretData = getAtPath(externalSecret, ['spec']).data
+    expect(secretData).toContainEqual(
+      expect.objectContaining({
+        secretKey: 'account-address',
+        remoteRef: expect.objectContaining({ key: 'hyperliquid-testnet/account-address' }),
+      }),
+    )
+    expect(secretData).toContainEqual(
+      expect.objectContaining({
+        secretKey: 'api-wallet-private-key',
+        remoteRef: expect.objectContaining({ key: 'hyperliquid-testnet/api-wallet-private-key' }),
+      }),
+    )
   })
 
   it('keeps options TA recoverable across transient Kafka source startup failures', () => {

--- a/scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh
+++ b/scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 VAULT="${HYPERLIQUID_TESTNET_1PASSWORD_VAULT:-infra}"
 ITEM="${HYPERLIQUID_TESTNET_1PASSWORD_ITEM:-hyperliquid-testnet}"
+EXTERNALSECRET_MANIFEST="argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml"
 
 usage() {
   cat <<EOF
@@ -215,6 +216,14 @@ PY
 reconcile_external_secret() {
   check_item
   require_command kubectl
+  if ! kubectl -n torghut get externalsecret torghut-hyperliquid-testnet >/dev/null 2>&1; then
+    cat >&2 <<EOF
+ExternalSecret is not live yet.
+Add ${EXTERNALSECRET_MANIFEST} to argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml,
+merge the GitOps PR, wait for Argo to sync, then rerun '$0 reconcile'.
+EOF
+    exit 1
+  fi
   kubectl -n torghut annotate externalsecret torghut-hyperliquid-testnet \
     "force-sync=$(date +%s)" \
     --overwrite

--- a/services/torghut/app/hyperliquid_runtime/exchange.py
+++ b/services/torghut/app/hyperliquid_runtime/exchange.py
@@ -5,10 +5,20 @@ from __future__ import annotations
 import importlib
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Protocol, cast
+from typing import Any, Mapping, Protocol, cast
 
 from .config import HyperliquidRuntimeConfig
-from .models import Fill, OrderIntent, OrderResult, OrderStatus, RuntimeDependencyStatus
+from .models import (
+    Fill,
+    HyperliquidMarket,
+    OrderIntent,
+    OrderResult,
+    OrderStatus,
+    RuntimeDependencyStatus,
+)
+
+
+_EXECUTION_UNIVERSE_REFRESH_SECONDS = 300
 
 
 class HyperliquidExchange(Protocol):
@@ -20,6 +30,13 @@ class HyperliquidExchange(Protocol):
 
     def reconcile_fills(self, market_id_by_coin: dict[str, str]) -> list[Fill]:
         """Read current account fills from the dedicated testnet account."""
+        ...
+
+    def filter_supported_markets(
+        self,
+        markets: tuple[HyperliquidMarket, ...],
+    ) -> tuple[tuple[HyperliquidMarket, ...], RuntimeDependencyStatus]:
+        """Return markets currently supported by the execution venue."""
         ...
 
     def dependency_status(self) -> RuntimeDependencyStatus:
@@ -51,6 +68,21 @@ class ShadowHyperliquidExchange:
         self._observed_at = datetime.now(timezone.utc)
         return []
 
+    def filter_supported_markets(
+        self,
+        markets: tuple[HyperliquidMarket, ...],
+    ) -> tuple[tuple[HyperliquidMarket, ...], RuntimeDependencyStatus]:
+        self._observed_at = datetime.now(timezone.utc)
+        return (
+            markets,
+            RuntimeDependencyStatus(
+                name="hyperliquid_execution_universe_shadow",
+                ready=True,
+                observed_at=self._observed_at,
+                lag_seconds=0,
+            ),
+        )
+
     def dependency_status(self) -> RuntimeDependencyStatus:
         return RuntimeDependencyStatus(
             name="hyperliquid_exchange_shadow",
@@ -80,6 +112,20 @@ class UnavailableHyperliquidExchange:
         _ = market_id_by_coin
         return []
 
+    def filter_supported_markets(
+        self,
+        markets: tuple[HyperliquidMarket, ...],
+    ) -> tuple[tuple[HyperliquidMarket, ...], RuntimeDependencyStatus]:
+        _ = markets
+        return (
+            (),
+            RuntimeDependencyStatus(
+                name="hyperliquid_execution_universe",
+                ready=False,
+                reason=",".join(self._reasons),
+            ),
+        )
+
     def dependency_status(self) -> RuntimeDependencyStatus:
         return RuntimeDependencyStatus(
             name="hyperliquid_exchange",
@@ -104,6 +150,8 @@ class HyperliquidSdkExchange:
         self._sdk_exchange: Any | None = None
         self._sdk_info: Any | None = None
         self._last_exchange_read_at: datetime | None = None
+        self._last_execution_universe_at: datetime | None = None
+        self._execution_universe_by_dex: dict[str, frozenset[str]] = {}
 
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
         exchange = self._exchange()
@@ -135,6 +183,56 @@ class HyperliquidSdkExchange:
             for fill in raw_fills
             if _fill_coin(fill) in market_id_by_coin
         ]
+
+    def filter_supported_markets(
+        self,
+        markets: tuple[HyperliquidMarket, ...],
+    ) -> tuple[tuple[HyperliquidMarket, ...], RuntimeDependencyStatus]:
+        if not markets:
+            return (
+                (),
+                RuntimeDependencyStatus(
+                    name="hyperliquid_execution_universe",
+                    ready=True,
+                    observed_at=datetime.now(timezone.utc),
+                    lag_seconds=0,
+                ),
+            )
+        try:
+            self._refresh_execution_universe(markets)
+        except Exception as exc:
+            if not self._execution_universe_cache_is_fresh():
+                return (
+                    (),
+                    RuntimeDependencyStatus(
+                        name="hyperliquid_execution_universe",
+                        ready=False,
+                        reason=f"execution_market_metadata_unavailable:{type(exc).__name__}",
+                    ),
+                )
+        supported = tuple(
+            market
+            for market in markets
+            if market.coin
+            in self._execution_universe_by_dex.get(_sdk_dex(market.dex), frozenset())
+        )
+        observed_at = self._last_execution_universe_at
+        lag_seconds = (
+            int((datetime.now(timezone.utc) - observed_at).total_seconds())
+            if observed_at is not None
+            else None
+        )
+        ready = bool(supported)
+        return (
+            supported,
+            RuntimeDependencyStatus(
+                name="hyperliquid_execution_universe",
+                ready=ready,
+                observed_at=observed_at,
+                lag_seconds=lag_seconds,
+                reason=None if ready else "no_execution_supported_markets",
+            ),
+        )
 
     def dependency_status(self) -> RuntimeDependencyStatus:
         if self._last_exchange_read_at is None:
@@ -190,6 +288,47 @@ class HyperliquidSdkExchange:
         if from_str is None:
             return raw
         return from_str(raw)
+
+    def _refresh_execution_universe(
+        self,
+        markets: tuple[HyperliquidMarket, ...],
+    ) -> None:
+        if self._execution_universe_cache_is_fresh():
+            return
+        by_dex: dict[str, frozenset[str]] = {}
+        for dex in sorted({_sdk_dex(market.dex) for market in markets}):
+            meta: object = self._info().meta(dex=dex)
+            universe: object = (
+                cast(Mapping[str, object], meta).get("universe")
+                if isinstance(meta, dict)
+                else None
+            )
+            coins: set[str] = set()
+            if isinstance(universe, list):
+                for asset in cast(list[object], universe):
+                    if not isinstance(asset, dict):
+                        continue
+                    asset_map = cast(Mapping[str, object], asset)
+                    name = str(asset_map.get("name") or "").strip()
+                    if name:
+                        coins.add(name)
+            by_dex[dex] = frozenset(coins)
+        observed_at = datetime.now(timezone.utc)
+        self._execution_universe_by_dex = by_dex
+        self._last_execution_universe_at = observed_at
+        self._last_exchange_read_at = observed_at
+
+    def _execution_universe_cache_is_fresh(self) -> bool:
+        if self._last_execution_universe_at is None:
+            return False
+        max_age_seconds = min(
+            _EXECUTION_UNIVERSE_REFRESH_SECONDS,
+            max(1, self._config.exchange_staleness_seconds),
+        )
+        age_seconds = (
+            datetime.now(timezone.utc) - self._last_execution_universe_at
+        ).total_seconds()
+        return age_seconds <= max_age_seconds
 
 
 def exchange_from_config(config: HyperliquidRuntimeConfig) -> HyperliquidExchange:
@@ -271,6 +410,13 @@ def _fill_from_payload(
 
 def _fill_coin(payload: dict[str, object]) -> str:
     return str(payload.get("coin") or "").strip()
+
+
+def _sdk_dex(dex: str) -> str:
+    cleaned = dex.strip()
+    if cleaned in {"", "default"}:
+        return ""
+    return cleaned
 
 
 def _decimal(value: object) -> Decimal:

--- a/services/torghut/app/hyperliquid_runtime/service.py
+++ b/services/torghut/app/hyperliquid_runtime/service.py
@@ -80,21 +80,31 @@ class HyperliquidRuntimeService:
             max_markets=self._config.max_markets_per_cycle,
         )
         repository.upsert_markets(markets)
-        features = self._clickhouse.load_feature_rows(
-            [market.market_id for market in markets]
+        execution_markets, execution_universe_status = (
+            self._exchange.filter_supported_markets(tuple(markets))
+        )
+        features = (
+            self._clickhouse.load_feature_rows(
+                [market.market_id for market in execution_markets]
+            )
+            if execution_markets
+            else []
         )
         fills = self._exchange.reconcile_fills(
-            {market.coin: market.market_id for market in markets}
+            {market.coin: market.market_id for market in execution_markets}
         )
         fill_count = repository.upsert_fills(fills)
         for fill in fills:
             self._journal.persist_refs(session, self._journal.fill_events(fill))
         exchange_status = self._exchange.dependency_status()
-        dependencies = clickhouse_status.statuses + (exchange_status,)
+        dependencies = clickhouse_status.statuses + (
+            execution_universe_status,
+            exchange_status,
+        )
         return _CycleContext(
             session=session,
             repository=repository,
-            markets=tuple(markets),
+            markets=execution_markets,
             features=tuple(features),
             dependencies=dependencies,
             risk_state=repository.risk_state(dependencies=dependencies),

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -22,6 +22,7 @@ from app.hyperliquid_runtime.exchange import (
 from app.hyperliquid_runtime.metrics import HyperliquidRuntimeMetrics
 from app.hyperliquid_runtime.models import (
     CycleResult,
+    HyperliquidMarket,
     OrderIntent,
     RuntimeDependencyStatus,
 )
@@ -50,6 +51,27 @@ def _intent() -> OrderIntent:
         cloid="0x1234567890abcdef1234567890abcdef",
         reduce_only=False,
         decision_id="decision",
+    )
+
+
+def _market(
+    *,
+    coin: str = "cash:AAPL",
+    dex: str = "cash",
+    market_id: str = "hl:perp:cash:cash:AAPL",
+) -> HyperliquidMarket:
+    return HyperliquidMarket(
+        market_id=market_id,
+        coin=coin,
+        dex=dex,
+        asset_class="stocks",
+        network="mainnet",
+        day_notional_volume_usd=Decimal("500000"),
+        mark_price=Decimal("200"),
+        mid_price=None,
+        open_interest_usd=Decimal("1000000"),
+        max_leverage=3,
+        payload={},
     )
 
 
@@ -210,11 +232,19 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
 ) -> None:
     shadow = ShadowHyperliquidExchange()
     assert shadow.reconcile_fills({"cash:AAPL": "hl:perp:cash:cash:AAPL"}) == []
+    shadow_markets, shadow_status = shadow.filter_supported_markets((_market(),))
+    assert shadow_markets == (_market(),)
+    assert shadow_status.ready
     shadow.schedule_dead_man_cancel(seconds_from_now=30)
     assert shadow.dependency_status().ready
 
     unavailable = UnavailableHyperliquidExchange(["missing_secret"])
     assert not unavailable.dependency_status().ready
+    unavailable_markets, unavailable_status = unavailable.filter_supported_markets(
+        (_market(),)
+    )
+    assert unavailable_markets == ()
+    assert not unavailable_status.ready
     with pytest.raises(RuntimeError, match="hyperliquid_exchange_unavailable"):
         unavailable.submit_ioc_limit(_intent())
     unavailable.schedule_dead_man_cancel(seconds_from_now=30)
@@ -258,6 +288,25 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
                 {"coin": "BTC", "side": "A", "px": "1", "sz": "1", "time": 0},
             ]
 
+        def meta(self, dex: str = "") -> dict[str, object]:
+            meta_dexes = sdk_calls.setdefault("meta_dexes", [])
+            assert isinstance(meta_dexes, list)
+            meta_dexes.append(dex)
+            if dex == "":
+                return {
+                    "universe": [
+                        "malformed-asset",
+                        {"name": "SPX"},
+                    ]
+                }
+            return {
+                "universe": [
+                    "malformed-asset",
+                    {"name": "cash:AAPL"},
+                    {"name": "cash:TSLA"},
+                ]
+            }
+
     class FakeCloid:
         @staticmethod
         def from_str(raw: str) -> str:
@@ -280,10 +329,36 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     )
     sdk_exchange = HyperliquidSdkExchange(config)
 
+    supported_markets, universe_status = sdk_exchange.filter_supported_markets(
+        (
+            _market(),
+            _market(
+                coin="SPX",
+                dex="default",
+                market_id="hl:perp:default:SPX",
+            ),
+            _market(
+                coin="cash:UNSUPPORTED",
+                market_id="hl:perp:cash:cash:UNSUPPORTED",
+            ),
+        )
+    )
+    cached_markets, cached_status = sdk_exchange.filter_supported_markets((_market(),))
+    empty_markets, empty_status = sdk_exchange.filter_supported_markets(())
     result = sdk_exchange.submit_ioc_limit(_intent())
     fills = sdk_exchange.reconcile_fills({"cash:AAPL": "hl:perp:cash:cash:AAPL"})
     sdk_exchange.schedule_dead_man_cancel(seconds_from_now=30)
 
+    assert supported_markets == (
+        _market(),
+        _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
+    )
+    assert universe_status.ready
+    assert cached_markets == (_market(),)
+    assert cached_status.ready
+    assert empty_markets == ()
+    assert empty_status.ready
+    assert sdk_calls["meta_dexes"] == ["", "cash"]
     assert result.status == "accepted"
     assert result.exchange_order_id == "42"
     assert sdk_calls["order"]  # SDK received a real order payload.
@@ -291,6 +366,38 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     assert fills[0].fee_usd == Decimal("0.02")
     assert sdk_exchange.dependency_status().ready
     assert isinstance(exchange_from_config(config), HyperliquidSdkExchange)
+
+
+def test_sdk_execution_universe_reports_metadata_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeInfo:
+        def __init__(self, _url: str, *, skip_ws: bool) -> None:
+            assert skip_ws
+
+        def meta(self, dex: str = "") -> dict[str, object]:
+            _ = dex
+            raise TimeoutError("metadata unavailable")
+
+    def fake_import(name: str) -> object:
+        if name == "hyperliquid.info":
+            return SimpleNamespace(Info=FakeInfo)
+        raise AssertionError(f"unexpected import {name}")
+
+    monkeypatch.setattr(exchange_module.importlib, "import_module", fake_import)
+    sdk_exchange = HyperliquidSdkExchange(
+        _config(
+            HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+            HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0xabc",
+            HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY="0xdef",
+        )
+    )
+
+    supported_markets, status = sdk_exchange.filter_supported_markets((_market(),))
+
+    assert supported_markets == ()
+    assert not status.ready
+    assert status.reason == "execution_market_metadata_unavailable:TimeoutError"
 
 
 def test_order_result_status_variants() -> None:

--- a/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
@@ -255,9 +255,28 @@ class _FakeClickHouse:
 
 
 class _FakeExchange:
-    def __init__(self, *, fills: bool = True) -> None:
+    def __init__(self, *, fills: bool = True, supports_markets: bool = True) -> None:
         self.submitted: list[OrderIntent] = []
         self._fills = fills
+        self._supports_markets = supports_markets
+
+    def filter_supported_markets(
+        self,
+        markets: tuple[HyperliquidMarket, ...],
+    ) -> tuple[tuple[HyperliquidMarket, ...], RuntimeDependencyStatus]:
+        if self._supports_markets:
+            return (
+                markets,
+                RuntimeDependencyStatus("hyperliquid_execution_universe", True),
+            )
+        return (
+            (),
+            RuntimeDependencyStatus(
+                "hyperliquid_execution_universe",
+                False,
+                reason="no_execution_supported_markets",
+            ),
+        )
 
     def reconcile_fills(self, _market_id_by_coin: dict[str, str]) -> list[Fill]:
         if not self._fills:
@@ -352,6 +371,47 @@ def test_runtime_service_shadow_mode_does_not_submit_or_journal_orders(
     assert result.orders_submitted == 0
     assert result.blocked_decisions == 1
     assert repository.decision.reason == "trading_disabled_shadow"
+    assert exchange.submitted == []
+    assert repository.orders == []
+    assert journal.persisted == []
+
+
+def test_runtime_service_blocks_when_no_testnet_execution_markets(
+    monkeypatch: Any,
+) -> None:
+    repository = _FakeRepository(_FakeSession())
+    exchange = _FakeExchange(fills=False, supports_markets=False)
+    journal = _FakeJournal()
+    monkeypatch.setattr(
+        service_module, "HyperliquidRuntimeRepository", lambda _session: repository
+    )
+    service = HyperliquidRuntimeService(
+        config=_config(
+            HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+            HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0x1111111111111111111111111111111111111111",
+            HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY=(
+                "0x2222222222222222222222222222222222222222222222222222222222222222"
+            ),
+        ),
+        clickhouse=_FakeClickHouse(),  # type: ignore[arg-type]
+        exchange=exchange,
+        journal=journal,  # type: ignore[arg-type]
+    )
+    session = _FakeSession()
+
+    result = service.run_once(session)  # type: ignore[arg-type]
+
+    assert session.committed
+    assert result.markets_seen == 0
+    assert result.signals_written == 0
+    assert result.decisions_written == 0
+    assert result.orders_submitted == 0
+    assert any(
+        dependency.name == "hyperliquid_execution_universe"
+        and not dependency.ready
+        and dependency.reason == "no_execution_supported_markets"
+        for dependency in result.dependency_statuses
+    )
     assert exchange.submitted == []
     assert repository.orders == []
     assert journal.persisted == []


### PR DESCRIPTION
## Summary

- Adds a runtime execution-universe gate so enabled Hyperliquid trading only considers markets present in fresh testnet perp metadata.
- Keeps shadow mode unchanged while adding a dormant 1Password-backed `ExternalSecret` manifest for the testnet wallet path.
- Updates the bootstrap helper and README so credential rollout stays GitOps-controlled before `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py tests/hyperliquid_runtime/test_risk_strategy.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_universe.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`
- `bun run lint:argocd`
- `git diff --check`
- Live readback: `kubectl -n argocd get application torghut-hyperliquid-runtime -o wide`
- Live readback: `kubectl -n torghut rollout status deploy/torghut-hyperliquid-runtime --timeout=180s`
- Live readback: `scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh status || true`
- Live readback: Hyperliquid testnet Info API currently returns HTTP 504 for `{"type":"meta","dex":"cash"}`, so real testnet order enablement remains gated.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
