### PR TITLE
fix(torghut): resolve configured collection runtime imports

### DIFF
--- a/services/torghut/app/trading/runtime_window_import/evidence_gates.py
+++ b/services/torghut/app/trading/runtime_window_import/evidence_gates.py
@@ -34,6 +34,9 @@ from .common import (
 )
 
 
+_CONFIGURED_PAPER_COLLECTION_HYPOTHESIS_PREFIX = "configured-paper-collection:"
+
+
 @dataclass(frozen=True)
 class RuntimeWindowProofBlockerRequest:
     promotion_blocking_reasons: Sequence[str]
@@ -699,15 +702,54 @@ def runtime_promotion_blocking_reasons(
     return reasons
 
 
+def _normalized_hypothesis_id(value: str) -> str:
+    return value.strip().replace("_", "-").upper()
+
+
+def _manifest_ref_hypothesis_id(source_manifest_ref: str | None) -> str | None:
+    if source_manifest_ref is None:
+        return None
+    normalized = source_manifest_ref.strip().replace("\\", "/")
+    if not normalized:
+        return None
+    filename = normalized.rsplit("/", 1)[-1]
+    stem = filename.rsplit(".", 1)[0].strip()
+    if not stem:
+        return None
+    return _normalized_hypothesis_id(stem)
+
+
+def _manifest_from_source_ref(
+    *,
+    registry: HypothesisRegistryLoadResult,
+    source_manifest_ref: str | None,
+) -> HypothesisManifest | None:
+    manifest_hypothesis_id = _manifest_ref_hypothesis_id(source_manifest_ref)
+    if manifest_hypothesis_id is None:
+        return None
+    for item in registry.items:
+        if _normalized_hypothesis_id(item.hypothesis_id) == manifest_hypothesis_id:
+            return item
+    return None
+
+
 def resolve_hypothesis_manifest(
     *,
     hypothesis_id: str,
     strategy_family: str | None = None,
+    source_manifest_ref: str | None = None,
 ) -> tuple[HypothesisRegistryLoadResult, HypothesisManifest]:
     registry = load_hypothesis_registry(raise_on_error=True)
     manifest = next(
         (item for item in registry.items if item.hypothesis_id == hypothesis_id), None
     )
+    if manifest is None and hypothesis_id.startswith(
+        _CONFIGURED_PAPER_COLLECTION_HYPOTHESIS_PREFIX
+    ):
+        manifest = _manifest_from_source_ref(
+            registry=registry,
+            source_manifest_ref=source_manifest_ref,
+        )
     if manifest is None:
         raise RuntimeError(f"hypothesis_manifest_not_found:{hypothesis_id}")
     if not strategy_family_matches(manifest=manifest, strategy_family=strategy_family):

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -85,6 +85,29 @@ RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing
 RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER = (
     "runtime_ledger_execution_tca_refs_missing"
 )
+CONFIGURED_PAPER_COLLECTION_HYPOTHESIS_PREFIX = "configured-paper-collection:"
+CONFIGURED_SIMPLE_LANE_PAPER_SOURCE_KIND = (
+    "configured_simple_lane_paper_data_collection"
+)
+
+
+def _manifest_strategy_family_for_resolution(
+    *,
+    hypothesis_id: str,
+    strategy_family: str,
+    source_kind: str,
+    source_manifest_ref: str,
+) -> str | None:
+    normalized_strategy_family = strategy_family.strip() or None
+    if (
+        hypothesis_id.startswith(CONFIGURED_PAPER_COLLECTION_HYPOTHESIS_PREFIX)
+        and source_kind == CONFIGURED_SIMPLE_LANE_PAPER_SOURCE_KIND
+        and source_manifest_ref.strip()
+    ):
+        return None
+    return normalized_strategy_family
+
+
 RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER = (
     "runtime_ledger_authority_class_missing"
 )
@@ -7510,9 +7533,19 @@ def main() -> int:
     ]
     window_start = _parse_dt(args.window_start)
     window_end = _parse_dt(args.window_end)
+    source_kind = args.source_kind.strip() or (
+        "simulation_paper_runtime" if args.observed_stage == "paper" else "live_runtime"
+    )
+    manifest_strategy_family = _manifest_strategy_family_for_resolution(
+        hypothesis_id=args.hypothesis_id,
+        strategy_family=args.strategy_family,
+        source_kind=source_kind,
+        source_manifest_ref=args.source_manifest_ref,
+    )
     _, manifest = resolve_hypothesis_manifest(
         hypothesis_id=args.hypothesis_id,
-        strategy_family=args.strategy_family.strip() or None,
+        strategy_family=manifest_strategy_family,
+        source_manifest_ref=args.source_manifest_ref.strip() or None,
     )
     target_metadata = _parse_target_metadata(
         str(getattr(args, "target_metadata_json", "") or "")
@@ -7525,9 +7558,6 @@ def main() -> int:
         getattr(manifest, "strategy_id", None),
     )
     source_activity_symbols = _target_metadata_source_symbols(target_metadata)
-    source_kind = args.source_kind.strip() or (
-        "simulation_paper_runtime" if args.observed_stage == "paper" else "live_runtime"
-    )
     allow_authoritative_runtime_ledger_materialization = (
         _source_kind_allows_runtime_ledger_materialization(
             source_kind=source_kind,
@@ -8122,5 +8152,6 @@ __all__ = [
     "_retarget_runtime_ledger_tca_rows",
     "_query_timestamps",
     "_source_activity_missing_summary",
+    "_manifest_strategy_family_for_resolution",
     "main",
 ]

--- a/services/torghut/tests/runtime_window_import/test_runtime_window_config.py
+++ b/services/torghut/tests/runtime_window_import/test_runtime_window_config.py
@@ -21,6 +21,10 @@ from tests.runtime_window_import.runtime_window_import_base import (
     patch,
     timezone,
 )
+from app.trading.runtime_window_import import resolve_hypothesis_manifest
+from scripts.import_hypothesis_runtime_windows import (
+    _manifest_strategy_family_for_resolution,
+)
 
 
 class TestRuntimeWindowImportConfig(RuntimeWindowImportTestCaseBase):
@@ -233,6 +237,62 @@ class TestRuntimeWindowImportConfig(RuntimeWindowImportTestCaseBase):
             args.target_metadata_json, '{"paper_probation_authorized":true}'
         )
         self.assertEqual(args.json, True)
+
+    def test_configured_paper_collection_alias_resolves_source_manifest_ref(
+        self,
+    ) -> None:
+        _, manifest = resolve_hypothesis_manifest(
+            hypothesis_id="configured-paper-collection:breakout-continuation-long-v1",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+        )
+
+        self.assertEqual(manifest.hypothesis_id, "H-PAIRS-01")
+
+    def test_configured_paper_collection_alias_requires_source_manifest_ref(
+        self,
+    ) -> None:
+        source_refs = [
+            None,
+            "",
+            "config/trading/hypotheses/.json",
+            "config/trading/hypotheses/missing.json",
+        ]
+
+        for source_ref in source_refs:
+            kwargs = {}
+            if source_ref is not None:
+                kwargs["source_manifest_ref"] = source_ref
+            with self.subTest(source_ref=source_ref):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "hypothesis_manifest_not_found:"
+                    "configured-paper-collection:breakout-continuation-long-v1",
+                ):
+                    resolve_hypothesis_manifest(
+                        hypothesis_id=(
+                            "configured-paper-collection:breakout-continuation-long-v1"
+                        ),
+                        **kwargs,
+                    )
+
+    def test_configured_paper_collection_import_uses_source_manifest_family(
+        self,
+    ) -> None:
+        family = _manifest_strategy_family_for_resolution(
+            hypothesis_id="configured-paper-collection:breakout-continuation-long-v1",
+            strategy_family="breakout_continuation_long_v1",
+            source_kind="configured_simple_lane_paper_data_collection",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+        )
+        normal_family = _manifest_strategy_family_for_resolution(
+            hypothesis_id="H-PAIRS-01",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_kind="paper_runtime_observed",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+        )
+
+        self.assertIsNone(family)
+        self.assertEqual(normal_family, "microbar_cross_sectional_pairs")
 
     def test_source_row_lineage_accepts_plural_target_plan_ids(self) -> None:
         row = {


### PR DESCRIPTION
## Summary

- Resolve configured paper-collection hypothesis aliases through their source-controlled hypothesis manifest ref.
- Keep configured collection imports non-promotional while allowing runtime strategy-family metadata to differ from the backing manifest family.
- Add regression coverage for the live failure shape seen in empirical renewal.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/runtime_window_import/test_runtime_window_config.py -k 'configured_paper_collection or parse_args_accepts_dataset_snapshot_ref'`
- `uv run --frozen pytest tests/run_empirical_promotion_jobs/test_runtime_window_child_process.py tests/run_empirical_promotion_jobs/test_runtime_window_import_a.py tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py tests/runtime_window_import/test_runtime_window_config.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/runtime_window_import/evidence_gates.py scripts/import_hypothesis_runtime_windows.py tests/runtime_window_import/test_runtime_window_config.py`
- `uv run --frozen ruff format --check app/trading/runtime_window_import/evidence_gates.py scripts/import_hypothesis_runtime_windows.py tests/runtime_window_import/test_runtime_window_config.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
