### PR TITLE
refactor(torghut): clean hyperliquid runtime suppressions

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/ledger.py
+++ b/services/torghut/app/hyperliquid_runtime/ledger.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from decimal import Decimal
 
 from sqlalchemy import text
-from sqlalchemy.orm import Session
 
 from app.trading.tigerbeetle_ids import stable_u128, u128_decimal
 from app.trading.tigerbeetle_ledger_model import (
@@ -27,6 +27,7 @@ from app.trading.tigerbeetle_ledger_model import (
 )
 
 from .models import Fill, OrderIntent, OrderResult
+from .runtime_session import RuntimeSession
 
 
 @dataclass(frozen=True)
@@ -154,8 +155,8 @@ class HyperliquidTigerBeetleJournal:
 
     def persist_refs(
         self,
-        session: Session,
-        events: list[HyperliquidJournalEvent],
+        session: RuntimeSession,
+        events: Sequence[HyperliquidJournalEvent],
     ) -> int:
         count = 0
         for event in events:

--- a/services/torghut/app/hyperliquid_runtime/repository.py
+++ b/services/torghut/app/hyperliquid_runtime/repository.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 from typing import Iterable
 
 from sqlalchemy import text
-from sqlalchemy.orm import Session
 
 from .models import (
     DecisionRecord,
@@ -22,12 +21,13 @@ from .models import (
     RuntimeDependencyStatus,
     Signal,
 )
+from .runtime_session import RuntimeSession
 
 
 class HyperliquidRuntimeRepository:
     """Persistence facade for runtime tables created by migration 0054."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: RuntimeSession) -> None:
         self._session = session
 
     def upsert_markets(self, markets: Iterable[HyperliquidMarket]) -> None:

--- a/services/torghut/app/hyperliquid_runtime/runtime_session.py
+++ b/services/torghut/app/hyperliquid_runtime/runtime_session.py
@@ -1,0 +1,20 @@
+"""Session contract used by the isolated Hyperliquid runtime lane."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class RuntimeSession(Protocol):
+    """Small SQLAlchemy session surface required by one runtime cycle."""
+
+    def execute(self, statement: Any, params: Any | None = None) -> Any:
+        """Execute a SQL statement."""
+        ...
+
+    def commit(self) -> None:
+        """Commit the current transaction."""
+        ...
+
+
+__all__ = ["RuntimeSession"]

--- a/services/torghut/app/hyperliquid_runtime/service.py
+++ b/services/torghut/app/hyperliquid_runtime/service.py
@@ -2,21 +2,24 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Protocol
 
-from sqlalchemy.orm import Session
-
-from .clickhouse import ClickHouseRuntimeReader
+from .clickhouse import ClickHouseStatus
 from .config import HyperliquidRuntimeConfig
 from .exchange import HyperliquidExchange
-from .ledger import HyperliquidTigerBeetleJournal
+from .ledger import HyperliquidJournalEvent
 from .models import (
     CycleResult,
     DecisionRecord,
+    Fill,
     FeatureSnapshot,
     HyperliquidMarket,
+    OrderIntent,
+    OrderResult,
     PerformanceSnapshot,
     RiskState,
     RuntimeDependencyStatus,
@@ -25,8 +28,49 @@ from .models import (
 )
 from .repository import HyperliquidRuntimeRepository
 from .risk import build_order_intent, evaluate_signal_risk
+from .runtime_session import RuntimeSession
 from .strategy import generate_signal
 from .universe import select_equity_like_markets
+
+
+class HyperliquidRuntimeClickHouse(Protocol):
+    """ClickHouse read surface required by one runtime cycle."""
+
+    def status(self) -> ClickHouseStatus:
+        """Return feed readiness."""
+        ...
+
+    def load_catalog_rows(self) -> list[dict[str, object]]:
+        """Load candidate market catalog rows."""
+        ...
+
+    def load_feature_rows(self, market_ids: list[str]) -> list[FeatureSnapshot]:
+        """Load latest feature rows for selected markets."""
+        ...
+
+
+class HyperliquidRuntimeJournal(Protocol):
+    """TigerBeetle journal surface required by one runtime cycle."""
+
+    def fill_events(self, fill: Fill) -> Sequence[HyperliquidJournalEvent]:
+        """Build journal events for a fill."""
+        ...
+
+    def order_events(
+        self,
+        intent: OrderIntent,
+        result: OrderResult,
+    ) -> Sequence[HyperliquidJournalEvent]:
+        """Build journal events for an order."""
+        ...
+
+    def persist_refs(
+        self,
+        session: RuntimeSession,
+        events: Sequence[HyperliquidJournalEvent],
+    ) -> int:
+        """Persist journal event references."""
+        ...
 
 
 class HyperliquidRuntimeService:
@@ -36,16 +80,16 @@ class HyperliquidRuntimeService:
         self,
         *,
         config: HyperliquidRuntimeConfig,
-        clickhouse: ClickHouseRuntimeReader,
+        clickhouse: HyperliquidRuntimeClickHouse,
         exchange: HyperliquidExchange,
-        journal: HyperliquidTigerBeetleJournal,
+        journal: HyperliquidRuntimeJournal,
     ) -> None:
         self._config = config
         self._clickhouse = clickhouse
         self._exchange = exchange
         self._journal = journal
 
-    def run_once(self, session: Session) -> CycleResult:
+    def run_once(self, session: RuntimeSession) -> CycleResult:
         observed_at = datetime.now(timezone.utc)
         repository = HyperliquidRuntimeRepository(session)
         context = self._load_cycle_context(session, repository)
@@ -68,7 +112,7 @@ class HyperliquidRuntimeService:
 
     def _load_cycle_context(
         self,
-        session: Session,
+        session: RuntimeSession,
         repository: HyperliquidRuntimeRepository,
     ) -> _CycleContext:
         clickhouse_status = self._clickhouse.status()
@@ -218,7 +262,7 @@ def _decision_record(
 
 @dataclass(frozen=True)
 class _CycleContext:
-    session: Session
+    session: RuntimeSession
     repository: HyperliquidRuntimeRepository
     markets: tuple[HyperliquidMarket, ...]
     features: tuple[FeatureSnapshot, ...]

--- a/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any
+
+from pytest import MonkeyPatch
 
 from app.hyperliquid_runtime import service as service_module
+from app.hyperliquid_runtime.clickhouse import ClickHouseStatus
 from app.hyperliquid_runtime.config import HyperliquidRuntimeConfig
+from app.hyperliquid_runtime.ledger import HyperliquidJournalEvent
 from app.hyperliquid_runtime.models import (
     DecisionRecord,
     FeatureSnapshot,
@@ -18,6 +22,7 @@ from app.hyperliquid_runtime.models import (
     RuntimeDependencyStatus,
 )
 from app.hyperliquid_runtime.repository import HyperliquidRuntimeRepository
+from app.hyperliquid_runtime.runtime_session import RuntimeSession
 from app.hyperliquid_runtime.service import HyperliquidRuntimeService
 from app.hyperliquid_runtime.strategy import generate_signal
 
@@ -31,30 +36,28 @@ def _config(**overrides: str) -> HyperliquidRuntimeConfig:
     return HyperliquidRuntimeConfig.from_env(env)
 
 
-def _feature(**overrides: object) -> FeatureSnapshot:
-    values: dict[str, object] = {
-        "market_id": "hl:perp:cash:cash:AAPL",
-        "coin": "cash:AAPL",
-        "dex": "cash",
-        "event_ts": datetime(2026, 6, 18, tzinfo=timezone.utc),
-        "price": Decimal("200"),
-        "momentum_1m_bps": Decimal("3"),
-        "momentum_3m_bps": Decimal("7"),
-        "momentum_5m_bps": Decimal("12"),
-        "momentum_15m_bps": Decimal("20"),
-        "momentum_1h_bps": Decimal("45"),
-        "volatility_bps": Decimal("60"),
-        "vwap_distance_bps": Decimal("5"),
-        "spread_bps": Decimal("4"),
-        "book_imbalance": Decimal("0.10"),
-        "liquidity_usd": Decimal("500000"),
-        "funding_rate": Decimal("0.0001"),
-        "open_interest_usd": Decimal("1000000"),
-        "regime": "trend",
-        "source_lag_seconds": 10,
-    }
-    values.update(overrides)
-    return FeatureSnapshot(**values)  # type: ignore[arg-type]
+def _feature() -> FeatureSnapshot:
+    return FeatureSnapshot(
+        market_id="hl:perp:cash:cash:AAPL",
+        coin="cash:AAPL",
+        dex="cash",
+        event_ts=datetime(2026, 6, 18, tzinfo=timezone.utc),
+        price=Decimal("200"),
+        momentum_1m_bps=Decimal("3"),
+        momentum_3m_bps=Decimal("7"),
+        momentum_5m_bps=Decimal("12"),
+        momentum_15m_bps=Decimal("20"),
+        momentum_1h_bps=Decimal("45"),
+        volatility_bps=Decimal("60"),
+        vwap_distance_bps=Decimal("5"),
+        spread_bps=Decimal("4"),
+        book_imbalance=Decimal("0.10"),
+        liquidity_usd=Decimal("500000"),
+        funding_rate=Decimal("0.0001"),
+        open_interest_usd=Decimal("1000000"),
+        regime="trend",
+        source_lag_seconds=10,
+    )
 
 
 def _market() -> HyperliquidMarket:
@@ -115,7 +118,7 @@ class _MappingResult:
     def one(self) -> dict[str, object]:
         return self._rows[0]
 
-    def __iter__(self) -> Any:
+    def __iter__(self) -> Iterator[dict[str, object]]:
         return iter(self._rows)
 
 
@@ -143,7 +146,7 @@ class _FakeSession:
 
 def test_repository_writes_runtime_tables_and_reads_risk_state() -> None:
     session = _FakeSession()
-    repository = HyperliquidRuntimeRepository(session)  # type: ignore[arg-type]
+    repository = HyperliquidRuntimeRepository(session)
     signal = generate_signal(_feature(), parameter_version="test-v1")
 
     repository.upsert_markets([_market()])
@@ -232,12 +235,11 @@ class _FakeRepository:
 
 
 class _FakeClickHouse:
-    def status(self) -> Any:
-        return type(
-            "Status",
-            (),
-            {"statuses": (RuntimeDependencyStatus("clickhouse", True),)},
-        )()
+    def status(self) -> ClickHouseStatus:
+        return ClickHouseStatus(
+            ready=True,
+            statuses=(RuntimeDependencyStatus("clickhouse", True),),
+        )
 
     def load_catalog_rows(self) -> list[dict[str, object]]:
         return [
@@ -296,20 +298,38 @@ class _FakeExchange:
 
 class _FakeJournal:
     def __init__(self) -> None:
-        self.persisted: list[object] = []
+        self.persisted: list[HyperliquidJournalEvent] = []
 
-    def fill_events(self, fill: Fill) -> list[object]:
-        return [("fill", fill.fill_hash)]
+    def fill_events(self, fill: Fill) -> list[HyperliquidJournalEvent]:
+        return [_journal_event(fill.fill_hash, "fill")]
 
-    def order_events(self, intent: OrderIntent, _result: OrderResult) -> list[object]:
-        return [("order", intent.cloid)]
+    def order_events(
+        self, intent: OrderIntent, _result: OrderResult
+    ) -> list[HyperliquidJournalEvent]:
+        return [_journal_event(intent.cloid, "order")]
 
-    def persist_refs(self, _session: _FakeSession, events: list[object]) -> None:
+    def persist_refs(
+        self,
+        _session: RuntimeSession,
+        events: Sequence[HyperliquidJournalEvent],
+    ) -> int:
         self.persisted.extend(events)
+        return len(events)
+
+
+def _journal_event(source_id: str, transfer_kind: str) -> HyperliquidJournalEvent:
+    return HyperliquidJournalEvent(
+        source_id=source_id,
+        transfer_kind=transfer_kind,
+        amount_usd=Decimal("1"),
+        debit_account_key="testnet:debit",
+        credit_account_key="testnet:credit",
+        transfer_code=1,
+    )
 
 
 def test_runtime_service_orchestrates_signal_order_and_accounting(
-    monkeypatch: Any,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     repository = _FakeRepository(_FakeSession())
     exchange = _FakeExchange()
@@ -325,13 +345,13 @@ def test_runtime_service_orchestrates_signal_order_and_accounting(
                 "0x2222222222222222222222222222222222222222222222222222222222222222"
             ),
         ),
-        clickhouse=_FakeClickHouse(),  # type: ignore[arg-type]
+        clickhouse=_FakeClickHouse(),
         exchange=exchange,
-        journal=journal,  # type: ignore[arg-type]
+        journal=journal,
     )
     session = _FakeSession()
 
-    result = service.run_once(session)  # type: ignore[arg-type]
+    result = service.run_once(session)
 
     assert session.committed
     assert result.markets_seen == 1
@@ -346,7 +366,7 @@ def test_runtime_service_orchestrates_signal_order_and_accounting(
 
 
 def test_runtime_service_shadow_mode_does_not_submit_or_journal_orders(
-    monkeypatch: Any,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     repository = _FakeRepository(_FakeSession())
     exchange = _FakeExchange(fills=False)
@@ -356,13 +376,13 @@ def test_runtime_service_shadow_mode_does_not_submit_or_journal_orders(
     )
     service = HyperliquidRuntimeService(
         config=_config(),
-        clickhouse=_FakeClickHouse(),  # type: ignore[arg-type]
+        clickhouse=_FakeClickHouse(),
         exchange=exchange,
-        journal=journal,  # type: ignore[arg-type]
+        journal=journal,
     )
     session = _FakeSession()
 
-    result = service.run_once(session)  # type: ignore[arg-type]
+    result = service.run_once(session)
 
     assert session.committed
     assert result.markets_seen == 1
@@ -377,7 +397,7 @@ def test_runtime_service_shadow_mode_does_not_submit_or_journal_orders(
 
 
 def test_runtime_service_blocks_when_no_testnet_execution_markets(
-    monkeypatch: Any,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     repository = _FakeRepository(_FakeSession())
     exchange = _FakeExchange(fills=False, supports_markets=False)
@@ -393,13 +413,13 @@ def test_runtime_service_blocks_when_no_testnet_execution_markets(
                 "0x2222222222222222222222222222222222222222222222222222222222222222"
             ),
         ),
-        clickhouse=_FakeClickHouse(),  # type: ignore[arg-type]
+        clickhouse=_FakeClickHouse(),
         exchange=exchange,
-        journal=journal,  # type: ignore[arg-type]
+        journal=journal,
     )
     session = _FakeSession()
 
-    result = service.run_once(session)  # type: ignore[arg-type]
+    result = service.run_once(session)
 
     assert session.committed
     assert result.markets_seen == 0


### PR DESCRIPTION
## Summary

- Adds a narrow `RuntimeSession` protocol for the Hyperliquid runtime lane instead of requiring concrete SQLAlchemy sessions in repository/service/journal boundaries.
- Changes the runtime service to depend on structural ClickHouse and TigerBeetle journal contracts.
- Replaces loose test fakes and eight-plus `type: ignore[arg-type]` suppressions in `tests/hyperliquid_runtime/test_service_repository.py` with typed fake status, session, and journal events.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/hyperliquid_runtime/service.py app/hyperliquid_runtime/repository.py app/hyperliquid_runtime/ledger.py app/hyperliquid_runtime/runtime_session.py tests/hyperliquid_runtime/test_service_repository.py`
- `uv run --frozen pytest tests/hyperliquid_runtime/test_service_repository.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall -q app/hyperliquid_runtime tests/hyperliquid_runtime/test_service_repository.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/hyperliquid_runtime/service.py app/hyperliquid_runtime/repository.py app/hyperliquid_runtime/ledger.py app/hyperliquid_runtime/runtime_session.py tests/hyperliquid_runtime/test_service_repository.py`
- `uv run --frozen pylint --load-plugins=scripts.pylint_torghut_quality --disable=all --enable=torghut-generated-split-filename,torghut-dynamic-globals-reexport,torghut-compat-module-wrapper,torghut-compat-module-registry,torghut-module-class-mutation,torghut-module-replacement,torghut-private-pyright-suppression,torghut-wildcard-ruff-noqa,torghut-blanket-pylint-disable,torghut-dynamic-attribute-hook,torghut-wildcard-import,torghut-custom-module-class,torghut-test-compat-wrapper --score=n app scripts tests`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/hyperliquid_runtime/test_service_repository.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; N/A for this typed runtime/test cleanup.
