### PR TITLE
fix(torghut): release hyperliquid runtime image manifests

### DIFF
--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -288,6 +288,8 @@ jobs:
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml \
+            argocd/applications/torghut-hyperliquid-runtime/deployment.yaml \
+            argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml \
             argocd/applications/torghut-options/catalog/deployment.yaml \
             argocd/applications/torghut-options/enricher/deployment.yaml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -331,6 +333,8 @@ jobs:
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+            argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+            argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml
           body: |
@@ -341,7 +345,7 @@ jobs:
             - Image tag: `${{ steps.meta.outputs.tag }}`
             - Image digest: `${{ steps.digest.outputs.digest }}`
             - Migration change detected under `services/torghut/migrations/**`
-            - Manifests: core Torghut, simulation, jobs/workflows, options catalog, options enricher
+            - Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher
             - Added `do-not-automerge`; manual DB migration approval required before merge
 
       - name: Create deploy pull request (auto-merge eligible)
@@ -378,6 +382,8 @@ jobs:
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+            argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+            argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml
           body: |
@@ -387,7 +393,7 @@ jobs:
             - Source commit: `${{ steps.meta.outputs.source_sha }}`
             - Image tag: `${{ steps.meta.outputs.tag }}`
             - Image digest: `${{ steps.digest.outputs.digest }}`
-            - Manifests: core Torghut, simulation, jobs/workflows, options catalog, options enricher
+            - Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher
 
       - name: No manifest changes detected
         if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'

--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut:latest
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6df2c963672811759ddb1d90cffec5f7a739d4cca4d1f03553ee354fb6f35de9
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -50,6 +50,10 @@ spec:
               done
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
+            - name: TORGHUT_COMMIT
+              value: 4e0efd3ce5eef2fa73e5539a6c433cce050946ff
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:6df2c963672811759ddb1d90cffec5f7a739d4cca4d1f03553ee354fb6f35de9
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut:latest
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6df2c963672811759ddb1d90cffec5f7a739d4cca4d1f03553ee354fb6f35de9
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -44,6 +44,10 @@ spec:
             - configMapRef:
                 name: torghut-hyperliquid-runtime-config
           env:
+            - name: TORGHUT_COMMIT
+              value: 4e0efd3ce5eef2fa73e5539a6c433cce050946ff
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:6df2c963672811759ddb1d90cffec5f7a739d4cca4d1f03553ee354fb6f35de9
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -177,6 +177,31 @@ describe('Torghut manifest scheduling', () => {
     const runtimeData = getAtPath(runtimeConfig, ['data'])
     expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('false')
 
+    const runtimeDeployment = parseManifest('argocd/applications/torghut-hyperliquid-runtime/deployment.yaml')
+    const runtimeContainer = getAtPath(runtimeDeployment, ['spec', 'template', 'spec', 'containers', 0])
+    expect(String(runtimeContainer.image)).toMatch(/^registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:[0-9a-f]{64}$/)
+    expect(String(runtimeContainer.image)).not.toContain(':latest')
+    const runtimeEnv = runtimeContainer.env
+    expect(runtimeEnv).toContainEqual(
+      expect.objectContaining({
+        name: 'TORGHUT_COMMIT',
+        value: expect.stringMatching(/^[0-9a-f]{40}$/),
+      }),
+    )
+    expect(runtimeEnv).toContainEqual(
+      expect.objectContaining({
+        name: 'TORGHUT_IMAGE_DIGEST',
+        value: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      }),
+    )
+
+    const runtimeMigrationJob = parseManifest('argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml')
+    const migrationContainer = getAtPath(runtimeMigrationJob, ['spec', 'template', 'spec', 'containers', 0])
+    expect(String(migrationContainer.image)).toMatch(
+      /^registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:[0-9a-f]{64}$/,
+    )
+    expect(String(migrationContainer.image)).not.toContain(':latest')
+
     const kustomization = parseManifest('argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml')
     const resources = kustomization.resources
     expect(resources).toBeArray()

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -26,6 +26,8 @@ const createFixture = () => {
   const paperAccountFlattenManifestPath = join(dir, 'paper-account-flatten-cronjob.yaml')
   const whitepaperSemanticBackfillManifestPath = join(dir, 'whitepaper-semantic-backfill-job.yaml')
   const tigerBeetleSmokeManifestPath = join(dir, 'tigerbeetle-smoke-job.yaml')
+  const hyperliquidRuntimeManifestPath = join(dir, 'hyperliquid-runtime-deployment.yaml')
+  const hyperliquidRuntimeMigrationManifestPath = join(dir, 'hyperliquid-runtime-db-migrations-job.yaml')
   const optionsCatalogManifestPath = join(dir, 'options-catalog-deployment.yaml')
   const optionsEnricherManifestPath = join(dir, 'options-enricher-deployment.yaml')
   writeFileSync(
@@ -150,6 +152,42 @@ spec:
       'utf8',
     )
   }
+  writeFileSync(
+    hyperliquidRuntimeManifestPath,
+    `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: torghut-hyperliquid-runtime
+          image: registry.ide-newton.ts.net/lab/torghut:latest
+          env:
+            - name: TORGHUT_COMMIT
+              value: old-commit
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:1111111111111111111111111111111111111111111111111111111111111111
+`,
+    'utf8',
+  )
+  writeFileSync(
+    hyperliquidRuntimeMigrationManifestPath,
+    `apiVersion: batch/v1
+kind: Job
+spec:
+  template:
+    spec:
+      containers:
+        - name: migrate
+          image: registry.ide-newton.ts.net/lab/torghut:latest
+          env:
+            - name: TORGHUT_COMMIT
+              value: old-commit
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:1111111111111111111111111111111111111111111111111111111111111111
+`,
+    'utf8',
+  )
   return {
     dir,
     serviceManifestPath,
@@ -170,6 +208,8 @@ spec:
     paperAccountFlattenManifestPath,
     whitepaperSemanticBackfillManifestPath,
     tigerBeetleSmokeManifestPath,
+    hyperliquidRuntimeManifestPath,
+    hyperliquidRuntimeMigrationManifestPath,
     optionsCatalogManifestPath,
     optionsEnricherManifestPath,
   }
@@ -204,6 +244,8 @@ const updateOptionsForFixture = (
   paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
   whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
   tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
+  hyperliquidRuntimeManifestPath: relative(repoRoot, fixture.hyperliquidRuntimeManifestPath),
+  hyperliquidRuntimeMigrationManifestPath: relative(repoRoot, fixture.hyperliquidRuntimeMigrationManifestPath),
   optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
   optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
   ...overrides,
@@ -283,6 +325,8 @@ describe('update-manifests', () => {
     const paperAccountFlattenManifest = readFileSync(fixture.paperAccountFlattenManifestPath, 'utf8')
     const whitepaperSemanticBackfillManifest = readFileSync(fixture.whitepaperSemanticBackfillManifestPath, 'utf8')
     const tigerBeetleSmokeManifest = readFileSync(fixture.tigerBeetleSmokeManifestPath, 'utf8')
+    const hyperliquidRuntimeManifest = readFileSync(fixture.hyperliquidRuntimeManifestPath, 'utf8')
+    const hyperliquidRuntimeMigrationManifest = readFileSync(fixture.hyperliquidRuntimeMigrationManifestPath, 'utf8')
     const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
     const optionsEnricherManifest = readFileSync(fixture.optionsEnricherManifestPath, 'utf8')
     expect(serviceManifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
@@ -323,6 +367,8 @@ describe('update-manifests', () => {
       paperAccountFlattenManifest,
       whitepaperSemanticBackfillManifest,
       tigerBeetleSmokeManifest,
+      hyperliquidRuntimeManifest,
+      hyperliquidRuntimeMigrationManifest,
     ]) {
       expect(manifest).toContain(
         'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
@@ -331,6 +377,8 @@ describe('update-manifests', () => {
     }
     expect(whitepaperAutoresearchWorkflowManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(empiricalPromotionRenewalManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(hyperliquidRuntimeManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(hyperliquidRuntimeMigrationManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     for (const manifest of [optionsCatalogManifest, optionsEnricherManifest]) {
       expect(manifest).toContain(
         'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
@@ -342,7 +390,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(20)
+    expect(result.changedPaths.length).toBe(22)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -364,7 +412,7 @@ describe('update-manifests', () => {
       expect(manifest).toContain('value: old-version')
       expect(manifest).toContain('value: old-commit')
     }
-    expect(result.changedPaths.length).toBe(18)
+    expect(result.changedPaths.length).toBe(20)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -34,6 +34,9 @@ const defaultPaperAccountFlattenManifestPath = 'argocd/applications/torghut/pape
 const defaultWhitepaperSemanticBackfillManifestPath =
   'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
 const defaultTigerBeetleSmokeManifestPath = 'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+const defaultHyperliquidRuntimeManifestPath = 'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml'
+const defaultHyperliquidRuntimeMigrationManifestPath =
+  'argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml'
 const defaultOptionsCatalogManifestPath = 'argocd/applications/torghut-options/catalog/deployment.yaml'
 const defaultOptionsEnricherManifestPath = 'argocd/applications/torghut-options/enricher/deployment.yaml'
 const defaultRequiredImagePlatforms = 'linux/amd64,linux/arm64'
@@ -64,6 +67,8 @@ type UpdateManifestsOptions = {
   paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
+  hyperliquidRuntimeManifestPath?: string
+  hyperliquidRuntimeMigrationManifestPath?: string
   includeOptionsManifests?: boolean
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
@@ -95,6 +100,8 @@ type CliOptions = {
   paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
+  hyperliquidRuntimeManifestPath?: string
+  hyperliquidRuntimeMigrationManifestPath?: string
   includeOptionsManifests?: boolean
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
@@ -371,6 +378,16 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.tigerBeetleSmokeManifestPath ?? defaultTigerBeetleSmokeManifestPath,
     'torghut-tigerbeetle-smoke image reference',
   )
+  const hyperliquidRuntime = updateImageOnlyManifest(
+    options,
+    options.hyperliquidRuntimeManifestPath ?? defaultHyperliquidRuntimeManifestPath,
+    'torghut-hyperliquid-runtime image reference',
+  )
+  const hyperliquidRuntimeMigration = updateImageOnlyManifest(
+    options,
+    options.hyperliquidRuntimeMigrationManifestPath ?? defaultHyperliquidRuntimeMigrationManifestPath,
+    'torghut-hyperliquid-runtime-db-migrations image reference',
+  )
   const includeOptionsManifests = options.includeOptionsManifests ?? true
   const optionalResults = includeOptionsManifests
     ? [
@@ -411,6 +428,8 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     paperAccountFlatten,
     whitepaperSemanticBackfill,
     tigerBeetleSmoke,
+    hyperliquidRuntime,
+    hyperliquidRuntimeMigration,
     ...optionalResults,
   ]
     .filter((entry) => entry.changed)
@@ -456,6 +475,8 @@ Options:
   --paper-account-flatten-manifest-path <path>
   --whitepaper-semantic-backfill-manifest-path <path>
   --tigerbeetle-smoke-manifest-path <path>
+  --hyperliquid-runtime-manifest-path <path>
+  --hyperliquid-runtime-migration-manifest-path <path>
   --include-options-manifests
   --options-catalog-manifest-path <path>
   --options-enricher-manifest-path <path>`)
@@ -556,6 +577,12 @@ Options:
       case '--tigerbeetle-smoke-manifest-path':
         options.tigerBeetleSmokeManifestPath = value
         break
+      case '--hyperliquid-runtime-manifest-path':
+        options.hyperliquidRuntimeManifestPath = value
+        break
+      case '--hyperliquid-runtime-migration-manifest-path':
+        options.hyperliquidRuntimeMigrationManifestPath = value
+        break
       case '--include-options-manifests':
         options.includeOptionsManifests = true
         break
@@ -636,6 +663,10 @@ const main = (cliOptions?: CliOptions) => {
       parsed.whitepaperSemanticBackfillManifestPath ?? process.env.TORGHUT_WHITEPAPER_SEMANTIC_BACKFILL_MANIFEST_PATH,
     tigerBeetleSmokeManifestPath:
       parsed.tigerBeetleSmokeManifestPath ?? process.env.TORGHUT_TIGERBEETLE_SMOKE_MANIFEST_PATH,
+    hyperliquidRuntimeManifestPath:
+      parsed.hyperliquidRuntimeManifestPath ?? process.env.TORGHUT_HYPERLIQUID_RUNTIME_MANIFEST_PATH,
+    hyperliquidRuntimeMigrationManifestPath:
+      parsed.hyperliquidRuntimeMigrationManifestPath ?? process.env.TORGHUT_HYPERLIQUID_RUNTIME_MIGRATION_MANIFEST_PATH,
     includeOptionsManifests:
       parsed.includeOptionsManifests ?? parseOptionalBooleanEnv(process.env.TORGHUT_INCLUDE_OPTIONS_MANIFESTS),
     optionsCatalogManifestPath: parsed.optionsCatalogManifestPath ?? process.env.TORGHUT_OPTIONS_CATALOG_MANIFEST_PATH,


### PR DESCRIPTION
## Summary

- Pin `torghut-hyperliquid-runtime` Deployment and migration Job to the promoted Torghut image digest instead of mutable `latest`.
- Extend Torghut release automation so future promotions update Hyperliquid runtime manifests and include them in release PRs.
- Add script and manifest scheduling regression coverage for runtime digest pinning and release manifest updates.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
