### PR TITLE
fix(torghut): bound hyperliquid runtime clickhouse hook

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   schema.sql: |-
     SET distributed_ddl_output_mode = 'null_status_on_timeout';
-    SET distributed_ddl_task_timeout = 60;
+    SET distributed_ddl_task_timeout = 10;
 
     CREATE DATABASE IF NOT EXISTS torghut ON CLUSTER default;
 
@@ -87,50 +87,6 @@ data:
       FROM torghut.hyperliquid_candles
       WHERE channel = 'candle'
         AND market_type = 'perp'
-        AND JSONExtractString(payload, 'i') IN ('1m', '3m', '5m', '15m', '1h')
-    );
-
-    INSERT INTO torghut.hyperliquid_ta_features
-    SELECT
-      now64(3) AS ingest_ts,
-      _event_ts AS event_ts,
-      network,
-      coalesce(market_id, symbol) AS market_id,
-      coalesce(coin, symbol) AS coin,
-      coalesce(dex, 'default') AS dex,
-      JSONExtractString(payload, 'i') AS interval,
-      toFloat64OrZero(JSONExtractString(payload, 'c')) AS price,
-      if(interval = '1m', _return_bps, 0) AS momentum_1m_bps,
-      if(interval = '3m', _return_bps, 0) AS momentum_3m_bps,
-      if(interval = '5m', _return_bps, 0) AS momentum_5m_bps,
-      if(interval = '15m', _return_bps, 0) AS momentum_15m_bps,
-      if(interval = '1h', _return_bps, 0) AS momentum_1h_bps,
-      _range_bps AS volatility_bps,
-      _vwap_distance_bps AS vwap_distance_bps,
-      0 AS spread_bps,
-      0 AS book_imbalance,
-      toFloat64OrZero(JSONExtractString(payload, 'v')) * price AS liquidity_usd,
-      0 AS funding_rate,
-      0 AS open_interest_usd,
-      multiIf(_return_bps > 8, 'trend_up', _return_bps < -8, 'trend_down', 'range') AS regime,
-      greatest(0, dateDiff('second', toDateTime(_event_ts), now())) AS source_lag_seconds
-    FROM
-    (
-      SELECT
-        *,
-        toDateTime64(parseDateTimeBestEffort(event_ts), 3, 'UTC') AS _event_ts,
-        toFloat64OrZero(JSONExtractString(payload, 'o')) AS _open,
-        toFloat64OrZero(JSONExtractString(payload, 'h')) AS _high,
-        toFloat64OrZero(JSONExtractString(payload, 'l')) AS _low,
-        toFloat64OrZero(JSONExtractString(payload, 'c')) AS _close,
-        if(_open = 0, 0, 10000 * (_close - _open) / _open) AS _return_bps,
-        if(_close = 0, 0, 10000 * (_high - _low) / _close) AS _range_bps,
-        ((_high + _low + _close) / 3) AS _typical_price,
-        if(_typical_price = 0, 0, 10000 * (_close - _typical_price) / _typical_price) AS _vwap_distance_bps
-      FROM torghut.hyperliquid_candles
-      WHERE channel = 'candle'
-        AND market_type = 'perp'
-        AND toDateTime64(parseDateTimeBestEffort(event_ts), 3, 'UTC') >= now() - INTERVAL 2 HOUR
         AND JSONExtractString(payload, 'i') IN ('1m', '3m', '5m', '15m', '1h')
     );
 

--- a/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-job.yaml
@@ -8,15 +8,15 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  backoffLimit: 6
-  activeDeadlineSeconds: 900
+  backoffLimit: 0
+  activeDeadlineSeconds: 240
   ttlSecondsAfterFinished: 600
   template:
     metadata:
       labels:
         app: torghut-hyperliquid-runtime-clickhouse-schema
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       serviceAccountName: torghut-runtime
       containers:
         - name: schema
@@ -27,25 +27,64 @@ spec:
             - -ec
           args:
             - |
-              deadline=$((SECONDS + 300))
-              until clickhouse-client \
-                --host torghut-clickhouse.torghut.svc.cluster.local \
-                --port 9000 \
-                --user "${CLICKHOUSE_USERNAME}" \
-                --password "${CLICKHOUSE_PASSWORD}" \
-                --query 'SELECT 1'; do
-                if [ "${SECONDS}" -ge "${deadline}" ]; then
-                  echo "ClickHouse did not become ready in time" >&2
+              set -euo pipefail
+              CLICKHOUSE_CLIENT=(
+                clickhouse-client
+                --port 9000
+                --user "${CLICKHOUSE_USERNAME}"
+                --password "${CLICKHOUSE_PASSWORD}"
+                --connect_timeout 5
+                --send_timeout 30
+                --receive_timeout 60
+              )
+              PRIMARY_HOST=torghut-clickhouse.torghut.svc.cluster.local
+              REQUIRED_OBJECTS=(
+                hyperliquid_ta_features
+                hyperliquid_ta_features_candle_mv
+                hyperliquid_runtime_latest_features
+              )
+              REQUIRED_OBJECT_LIST="'${REQUIRED_OBJECTS[0]}'"
+              for object in "${REQUIRED_OBJECTS[@]:1}"; do
+                REQUIRED_OBJECT_LIST="${REQUIRED_OBJECT_LIST},'${object}'"
+              done
+
+              wait_for_host() {
+                local host="$1"
+                local deadline=$((SECONDS + 90))
+                until "${CLICKHOUSE_CLIENT[@]}" --host "${host}" --query 'SELECT 1'; do
+                  if [ "${SECONDS}" -ge "${deadline}" ]; then
+                    echo "ClickHouse host ${host} did not become ready in time" >&2
+                    exit 1
+                  fi
+                  sleep 5
+                done
+              }
+
+              object_count() {
+                local host="$1"
+                "${CLICKHOUSE_CLIENT[@]}" --host "${host}" --query \
+                  "SELECT count() FROM system.tables WHERE database='torghut' AND name IN (${REQUIRED_OBJECT_LIST})"
+              }
+
+              wait_for_host "${PRIMARY_HOST}"
+              mapfile -t HOSTS < <(
+                "${CLICKHOUSE_CLIENT[@]}" --host "${PRIMARY_HOST}" --query \
+                  "SELECT DISTINCT host_name FROM system.clusters WHERE cluster='default' ORDER BY host_name"
+              )
+              if [ "${#HOSTS[@]}" -eq 0 ]; then
+                HOSTS=("${PRIMARY_HOST}")
+              fi
+
+              sed -E 's/ ON CLUSTER default//g' /schema/schema.sql > /tmp/schema-local.sql
+              for host in "${HOSTS[@]}"; do
+                wait_for_host "${host}"
+                timeout 90s "${CLICKHOUSE_CLIENT[@]}" --host "${host}" --multiquery < /tmp/schema-local.sql
+                count="$(object_count "${host}")"
+                if [ "${count}" -ne "${#REQUIRED_OBJECTS[@]}" ]; then
+                  echo "ClickHouse host ${host} has ${count}/${#REQUIRED_OBJECTS[@]} required Hyperliquid runtime objects" >&2
                   exit 1
                 fi
-                sleep 5
               done
-              clickhouse-client \
-                --host torghut-clickhouse.torghut.svc.cluster.local \
-                --port 9000 \
-                --user "${CLICKHOUSE_USERNAME}" \
-                --password "${CLICKHOUSE_PASSWORD}" \
-                --multiquery < /schema/schema.sql
           env:
             - name: CLICKHOUSE_USERNAME
               value: torghut

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -172,6 +172,34 @@ describe('Torghut manifest scheduling', () => {
     ).toBe('hyperliquid-feed-clickhouse-optional-20260618b')
   })
 
+  it('bounds Hyperliquid runtime ClickHouse schema hooks so Argo syncs cannot hang on distributed DDL', () => {
+    const job = parseManifest('argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-job.yaml')
+    const container = getAtPath(job, ['spec', 'template', 'spec', 'containers', 0])
+    const args = Array.isArray(container.args) ? container.args.join('\n') : ''
+
+    expect(getAtPath(job, ['spec']).backoffLimit).toBe(0)
+    expect(getAtPath(job, ['spec']).activeDeadlineSeconds).toBe(240)
+    expect(getAtPath(job, ['spec', 'template', 'spec']).restartPolicy).toBe('Never')
+    expect(args).toContain('set -euo pipefail')
+    expect(args).toContain('--connect_timeout 5')
+    expect(args).toContain('--send_timeout 30')
+    expect(args).toContain('--receive_timeout 60')
+    expect(args).toContain("SELECT DISTINCT host_name FROM system.clusters WHERE cluster='default' ORDER BY host_name")
+    expect(args).toContain("sed -E 's/ ON CLUSTER default//g' /schema/schema.sql > /tmp/schema-local.sql")
+    expect(args).toContain(
+      'timeout 90s "${CLICKHOUSE_CLIENT[@]}" --host "${host}" --multiquery < /tmp/schema-local.sql',
+    )
+    expect(args).toContain(
+      'ClickHouse host ${host} has ${count}/${#REQUIRED_OBJECTS[@]} required Hyperliquid runtime objects',
+    )
+
+    const schema = parseManifest('argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml')
+    const data = getAtPath(schema, ['data'])
+    expect(data['schema.sql']).toContain('SET distributed_ddl_task_timeout = 10;')
+    expect(data['schema.sql']).toContain("SET distributed_ddl_output_mode = 'null_status_on_timeout';")
+    expect(data['schema.sql']).not.toContain('INSERT INTO torghut.hyperliquid_ta_features')
+  })
+
   it('keeps Hyperliquid runtime shadow mode free of optional execution secret drift', () => {
     const runtimeConfig = parseManifest('argocd/applications/torghut-hyperliquid-runtime/configmap.yaml')
     const runtimeData = getAtPath(runtimeConfig, ['data'])


### PR DESCRIPTION
## Summary

- Bound the `torghut-hyperliquid-runtime` ClickHouse schema sync hook with no retries, a 240s deadline, and explicit ClickHouse client timeouts.
- Apply runtime schema DDL per ClickHouse host without distributed DDL waits, matching the safer feed hook pattern.
- Remove sync-time TA feature backfill from the Argo hook and add regression coverage so the hook cannot drift back to a hanging shape.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
