### PR TITLE
refactor(torghut): type test database fakes

### DIFF
--- a/services/torghut/app/api/readiness_helpers/refresh_universe_state_for_readiness.py
+++ b/services/torghut/app/api/readiness_helpers/refresh_universe_state_for_readiness.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 
 from .shared_context import (
     Mapping,
     SQLAlchemyError,
     Sequence,
-    Session,
     SessionLocal,
     TradingScheduler,
     ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS as _ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS,
@@ -68,6 +67,18 @@ class _SchemaGraphLineageStatus:
     @property
     def ready(self) -> bool:
         return not self.errors
+
+
+class _ReadinessAccountScopeSession(Protocol):
+    def execute(
+        self,
+        statement: Any,
+        params: Mapping[str, object] | None = None,
+    ) -> Any: ...
+
+
+class _ReadinessDatabaseSession(_ReadinessAccountScopeSession, Protocol):
+    def connection(self) -> Any: ...
 
 
 def _refresh_universe_state_for_readiness(
@@ -135,7 +146,7 @@ def _resolve_universe_resolver_for_readiness(scheduler: TradingScheduler) -> Any
 
 
 def _execute_readiness_account_scope_query(
-    session: Session,
+    session: _ReadinessAccountScopeSession,
     sql: str,
     *,
     table_names: Sequence[str] | None = None,
@@ -151,7 +162,9 @@ def _execute_readiness_account_scope_query(
     ]
 
 
-def _check_account_scope_invariants_bounded(session: Session) -> dict[str, object]:
+def _check_account_scope_invariants_bounded(
+    session: _ReadinessAccountScopeSession,
+) -> dict[str, object]:
     """Validate account-scope invariants using bounded catalog reads only.
 
     SQLAlchemy's generic inspector can reflect PostgreSQL domains while reading
@@ -200,7 +213,7 @@ def _account_scope_table_names(
 
 
 def _account_scope_catalog_snapshot(
-    session: Session,
+    session: _ReadinessAccountScopeSession,
     *,
     table_names: Sequence[str],
 ) -> _AccountScopeCatalogSnapshot:
@@ -217,7 +230,7 @@ def _account_scope_catalog_snapshot(
 
 
 def _account_scope_columns_by_table(
-    session: Session,
+    session: _ReadinessAccountScopeSession,
     table_names: Sequence[str],
 ) -> dict[str, set[str]]:
     column_rows = _execute_readiness_account_scope_query(
@@ -244,7 +257,7 @@ def _account_scope_columns_by_table(
 
 
 def _account_scope_unique_indexes_by_table(
-    session: Session,
+    session: _ReadinessAccountScopeSession,
     table_names: Sequence[str],
 ) -> dict[str, list[tuple[str, set[str]]]]:
     unique_index_rows = _execute_readiness_account_scope_query(
@@ -281,7 +294,7 @@ def _account_scope_unique_indexes_by_table(
 
 
 def _account_scope_index_names_by_table(
-    session: Session,
+    session: _ReadinessAccountScopeSession,
     table_names: Sequence[str],
 ) -> dict[str, list[str]]:
     all_index_rows = _execute_readiness_account_scope_query(
@@ -308,7 +321,7 @@ def _account_scope_index_names_by_table(
 
 
 def _account_scope_legacy_constraints_by_table(
-    session: Session,
+    session: _ReadinessAccountScopeSession,
     table_names: Sequence[str],
 ) -> dict[str, set[str]]:
     legacy_constraint_rows = _execute_readiness_account_scope_query(
@@ -465,7 +478,9 @@ def _finalize_account_scope_checks(
     return checks
 
 
-def _evaluate_database_contract(session: Session) -> dict[str, object]:
+def _evaluate_database_contract(
+    session: _ReadinessDatabaseSession,
+) -> dict[str, object]:
     """Collect schema and account-scope readiness checks used by /readyz and /db-check."""
     checked_at = datetime.now(timezone.utc).isoformat()
 
@@ -542,7 +557,7 @@ def _database_contract_error(
 
 
 def _database_contract_account_scope(
-    session: Session,
+    session: _ReadinessDatabaseSession,
 ) -> tuple[dict[str, object], list[str]]:
     try:
         account_scope_checks = dict(_check_account_scope_invariants_bounded(session))

--- a/services/torghut/app/db.py
+++ b/services/torghut/app/db.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Optional, Protocol, cast
 
 from alembic.config import Config as AlembicConfig
 from alembic.runtime.migration import MigrationContext
@@ -45,6 +45,15 @@ SessionLocal = sessionmaker(
     expire_on_commit=False,
     future=True,
 )
+
+
+class _PingSession(Protocol):
+    def execute(self, statement: Any) -> Any: ...
+
+
+class _SchemaCheckSession(_PingSession, Protocol):
+    def connection(self) -> Any: ...
+
 
 # Simple metadata table to confirm connectivity and seed future migrations.
 metadata = MetaData()
@@ -256,7 +265,7 @@ def ensure_schema() -> None:
     Base.metadata.create_all(bind=engine, checkfirst=True)
 
 
-def ping(session: Session) -> Optional[int]:
+def ping(session: _PingSession) -> Optional[int]:
     """Run a lightweight SELECT 1 for health checks."""
 
     result = session.execute(text("SELECT 1"))
@@ -467,7 +476,7 @@ def _schema_heads_signature(heads: tuple[str, ...]) -> str:
 _POSTGRES_SCHEMA_HEAD_STATEMENT_TIMEOUT_MS = 750
 
 
-def _current_schema_heads(session: Session) -> list[str]:
+def _current_schema_heads(session: _SchemaCheckSession) -> list[str]:
     connection = session.connection()
     dialect_name = str(
         getattr(getattr(connection, "dialect", None), "name", "")
@@ -492,7 +501,7 @@ def _current_schema_heads(session: Session) -> list[str]:
     return sorted(str(head) for head in context.get_current_heads())
 
 
-def check_schema_current(session: Session) -> dict[str, object]:
+def check_schema_current(session: _SchemaCheckSession) -> dict[str, object]:
     """Report Alembic head alignment for readiness and diagnostics."""
 
     ping(session)

--- a/services/torghut/tests/api/test_trading_api_db_contract.py
+++ b/services/torghut/tests/api/test_trading_api_db_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from app.api import readiness_helpers as readiness_helpers_api
 
 from tests.api.trading_api_support import (
@@ -20,6 +22,18 @@ from tests.api.trading_api_support import (
     settings,
     timezone,
 )
+
+
+class _FakeDatabaseContractSession:
+    def execute(
+        self,
+        statement: object,
+        params: Mapping[str, object] | None = None,
+    ) -> object:
+        raise AssertionError(f"unexpected database contract SQL: {statement} {params}")
+
+    def connection(self) -> object:
+        raise AssertionError("unexpected database contract connection")
 
 
 class TestTradingApiDbContract(TradingApiTestCaseBase):
@@ -533,7 +547,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         fake_session = FakeSession()
         payload = readiness_helpers_api._check_account_scope_invariants_bounded(
             fake_session
-        )  # type: ignore[arg-type]
+        )
 
         self.assertTrue(payload["account_scope_ready"])
         self.assertEqual(payload["account_scope_errors"], [])
@@ -634,7 +648,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         try:
             payload = readiness_helpers_api._check_account_scope_invariants_bounded(
                 FakeSession()
-            )  # type: ignore[arg-type]
+            )
         finally:
             settings.trading_multi_account_enabled = original_multi
 
@@ -684,7 +698,9 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
                     "canceling statement due to statement timeout"
                 ),
             ):
-                payload = readiness_helpers_api._evaluate_database_contract(object())  # type: ignore[arg-type]
+                payload = readiness_helpers_api._evaluate_database_contract(
+                    _FakeDatabaseContractSession()
+                )
         finally:
             settings.trading_multi_account_enabled = original_multi
 
@@ -720,7 +736,9 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
                     "canceling statement due to statement timeout"
                 ),
             ):
-                payload = readiness_helpers_api._evaluate_database_contract(object())  # type: ignore[arg-type]
+                payload = readiness_helpers_api._evaluate_database_contract(
+                    _FakeDatabaseContractSession()
+                )
         finally:
             settings.trading_multi_account_enabled = original_multi
 

--- a/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
+++ b/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.request import Request
+
 from tests.config.support import (
     FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD,
     Path,
@@ -91,7 +93,11 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
         self.assertEqual(settings.trading_drift_rollback_reason_codes, {"x", "y"})
 
     def test_feature_flags_override_runtime_toggles(self) -> None:
-        def _mock_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        def _mock_urlopen(
+            request: Request,
+            _timeout: object,
+        ) -> _MockFlagResponse:
+            assert request.data is not None
             payload = json.loads(request.data.decode("utf-8"))
             key = payload.get("flagKey")
             values = {
@@ -151,7 +157,11 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
     def test_feature_flags_use_flipt_evaluate_contract(self) -> None:
         requests: list[dict[str, object]] = []
 
-        def _mock_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        def _mock_urlopen(
+            request: Request,
+            _timeout: object,
+        ) -> _MockFlagResponse:
+            assert request.data is not None
             requests.append(
                 {
                     "url": request.full_url,
@@ -199,7 +209,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
     def test_feature_flag_failures_short_circuit_remaining_remote_lookups(self) -> None:
         call_count = 0
 
-        def _mock_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        def _mock_urlopen(_request: Request, _timeout: object) -> _MockFlagResponse:
             nonlocal call_count
             call_count += 1
             raise RuntimeError("network")
@@ -234,7 +244,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             def read(self) -> bytes:
                 return b'{"enabled":"yes"}'
 
-        def _mock_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        def _mock_urlopen(_request: Request, _timeout: object) -> _Response:
             nonlocal call_count
             call_count += 1
             return _Response()

--- a/services/torghut/tests/hyperliquid_runtime/test_risk_strategy.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_risk_strategy.py
@@ -26,30 +26,28 @@ def _config(**overrides: object) -> HyperliquidRuntimeConfig:
     return HyperliquidRuntimeConfig.from_env(env)
 
 
-def _feature(**overrides: object) -> FeatureSnapshot:
-    values: dict[str, object] = {
-        "market_id": "hl:perp:cash:cash:AAPL",
-        "coin": "cash:AAPL",
-        "dex": "cash",
-        "event_ts": datetime(2026, 6, 18, tzinfo=timezone.utc),
-        "price": Decimal("200"),
-        "momentum_1m_bps": Decimal("3"),
-        "momentum_3m_bps": Decimal("7"),
-        "momentum_5m_bps": Decimal("12"),
-        "momentum_15m_bps": Decimal("20"),
-        "momentum_1h_bps": Decimal("45"),
-        "volatility_bps": Decimal("60"),
-        "vwap_distance_bps": Decimal("5"),
-        "spread_bps": Decimal("4"),
-        "book_imbalance": Decimal("0.10"),
-        "liquidity_usd": Decimal("500000"),
-        "funding_rate": Decimal("0.0001"),
-        "open_interest_usd": Decimal("1000000"),
-        "regime": "trend",
-        "source_lag_seconds": 10,
-    }
-    values.update(overrides)
-    return FeatureSnapshot(**values)  # type: ignore[arg-type]
+def _feature() -> FeatureSnapshot:
+    return FeatureSnapshot(
+        market_id="hl:perp:cash:cash:AAPL",
+        coin="cash:AAPL",
+        dex="cash",
+        event_ts=datetime(2026, 6, 18, tzinfo=timezone.utc),
+        price=Decimal("200"),
+        momentum_1m_bps=Decimal("3"),
+        momentum_3m_bps=Decimal("7"),
+        momentum_5m_bps=Decimal("12"),
+        momentum_15m_bps=Decimal("20"),
+        momentum_1h_bps=Decimal("45"),
+        volatility_bps=Decimal("60"),
+        vwap_distance_bps=Decimal("5"),
+        spread_bps=Decimal("4"),
+        book_imbalance=Decimal("0.10"),
+        liquidity_usd=Decimal("500000"),
+        funding_rate=Decimal("0.0001"),
+        open_interest_usd=Decimal("1000000"),
+        regime="trend",
+        source_lag_seconds=10,
+    )
 
 
 def test_signal_and_risk_build_tiny_ioc_intent() -> None:

--- a/services/torghut/tests/test_db.py
+++ b/services/torghut/tests/test_db.py
@@ -256,7 +256,7 @@ class TestDbSchemaCurrent(TestCase):
             ),
             patch("app.db.MigrationContext") as mock_migration_context,
         ):
-            status = app_db.check_schema_current(fake_session)  # type: ignore[arg-type]
+            status = app_db.check_schema_current(fake_session)
 
         self.assertTrue(status["schema_current"])
         self.assertEqual(status["current_heads"], ["0011_demo_alpha", "0012_demo_beta"])
@@ -323,7 +323,7 @@ class TestDbSchemaCurrent(TestCase):
             ),
             patch("app.db.MigrationContext") as mock_migration_context,
         ):
-            status = app_db.check_schema_current(FakeSession())  # type: ignore[arg-type]
+            status = app_db.check_schema_current(FakeSession())
 
         self.assertEqual(status["current_heads"], [])
         self.assertEqual(status["schema_missing_heads"], ["0011_demo"])

--- a/services/torghut/tests/test_freshness_carry.py
+++ b/services/torghut/tests/test_freshness_carry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
@@ -13,34 +14,55 @@ from app.trading.freshness_carry import (
 NOW = datetime(2026, 5, 13, 9, 15, tzinfo=timezone.utc)
 
 
-def _base_inputs() -> dict[str, object]:
-    return {
-        "account_label": "PA3SX7FYNUTF",
-        "window": "15m",
-        "source_serving_repair_receipt_ledger": {
+def _build(
+    *,
+    source_serving_repair_receipt_ledger: Mapping[str, Any] | None = None,
+    route_warrant_exchange: Mapping[str, Any] | None = None,
+    clickhouse_ta_status: Mapping[str, Any] | None = None,
+    tca_summary: Mapping[str, Any] | None = None,
+    empirical_jobs_status: Mapping[str, Any] | None = None,
+    market_context_status: Mapping[str, Any] | None = None,
+    quant_evidence: Mapping[str, Any] | None = None,
+    live_submission_gate: Mapping[str, Any] | None = None,
+    now: datetime | None = NOW,
+) -> dict[str, object]:
+    return build_freshness_carry_ledger(
+        account_label="PA3SX7FYNUTF",
+        window="15m",
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger
+        if source_serving_repair_receipt_ledger is not None
+        else {
             "schema_version": "torghut.source-serving-repair-receipt-ledger.v1",
             "ledger_id": "source-serving:current",
             "source_serving_state": "converged",
             "generated_at": NOW.isoformat(),
             "reason_codes": [],
         },
-        "route_warrant_exchange": {
+        route_warrant_exchange=route_warrant_exchange
+        if route_warrant_exchange is not None
+        else {
             "schema_version": "torghut.route-warrant-exchange.v1",
             "warrant_id": "route-warrant:current",
             "warrant_state": "paper_candidate",
             "max_notional": "25",
         },
-        "clickhouse_ta_status": {
+        clickhouse_ta_status=clickhouse_ta_status
+        if clickhouse_ta_status is not None
+        else {
             "state": "current",
             "latest_signal_at": (NOW - timedelta(seconds=30)).isoformat(),
             "source_ref": "torghut.ta_signals",
         },
-        "tca_summary": {
+        tca_summary=tca_summary
+        if tca_summary is not None
+        else {
             "order_count": 24,
             "expected_shortfall_coverage": "0.75",
             "last_computed_at": (NOW - timedelta(minutes=5)).isoformat(),
         },
-        "empirical_jobs_status": {
+        empirical_jobs_status=empirical_jobs_status
+        if empirical_jobs_status is not None
+        else {
             "ready": True,
             "status": "healthy",
             "authority": "empirical",
@@ -48,7 +70,9 @@ def _base_inputs() -> dict[str, object]:
             "missing_jobs": [],
             "ineligible_jobs": [],
         },
-        "market_context_status": {
+        market_context_status=market_context_status
+        if market_context_status is not None
+        else {
             "last_checked_at": (NOW - timedelta(seconds=20)).isoformat(),
             "last_freshness_seconds": 20,
             "max_staleness_seconds": 900,
@@ -56,23 +80,21 @@ def _base_inputs() -> dict[str, object]:
             "alert_active": False,
             "last_symbol": "AAPL",
         },
-        "quant_evidence": {
+        quant_evidence=quant_evidence
+        if quant_evidence is not None
+        else {
             "ok": True,
             "required": True,
             "window": "15m",
         },
-        "live_submission_gate": {
+        live_submission_gate=live_submission_gate
+        if live_submission_gate is not None
+        else {
             "allowed": True,
             "reason": "ok",
         },
-        "now": NOW,
-    }
-
-
-def _build(**overrides: object) -> dict[str, object]:
-    payload = _base_inputs()
-    payload.update(overrides)
-    return build_freshness_carry_ledger(**payload)  # type: ignore[arg-type]
+        now=now,
+    )
 
 
 def _dimension(ledger: dict[str, object], dimension_id: str) -> dict[str, Any]:

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -6,11 +6,12 @@ import os
 import sys
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
-from typing import Iterator
+from typing import Iterator, Protocol, cast
 from unittest import TestCase
 from unittest.mock import patch
 
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from app.options_lane.alpaca import (
     AlpacaOptionsClient,
@@ -81,8 +82,8 @@ class _FakeCountRepository(OptionsRepository):
         self.fake_session = session
 
     @contextmanager
-    def session(self) -> Iterator[_FakeCountSession]:  # type: ignore[override]
-        yield self.fake_session
+    def session(self) -> Iterator[Session]:
+        yield cast(Session, self.fake_session)
 
 
 class _NoCountRepository:
@@ -125,6 +126,29 @@ class _FakeProducer:
 class _FakeAlpacaClient:
     def __init__(self, **_: object) -> None:
         pass
+
+
+class _CatalogStatusServiceModule(Protocol):
+    def _publish_status(
+        self,
+        *,
+        status_value: str,
+        observed_at: datetime,
+        error_code: str | None = None,
+        error_detail: str | None = None,
+    ) -> None: ...
+
+
+class _EnricherStatusServiceModule(Protocol):
+    def _publish_status(
+        self,
+        *,
+        status_value: str,
+        observed_at: datetime,
+        error_code: str | None = None,
+        error_detail: str | None = None,
+        backlog: int | None = None,
+    ) -> None: ...
 
 
 class TestOptionsLaneSession(TestCase):
@@ -229,9 +253,12 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
             return importlib.import_module(module_name)
 
     def test_catalog_status_heartbeat_skips_contract_table_counts(self) -> None:
-        service = self._import_service("app.options_lane.catalog_service")
+        service = cast(
+            _CatalogStatusServiceModule,
+            self._import_service("app.options_lane.catalog_service"),
+        )
 
-        service._publish_status(  # type: ignore[attr-defined]
+        service._publish_status(
             status_value="ok",
             observed_at=datetime(2026, 3, 9, 15, 0, tzinfo=timezone.utc),
         )
@@ -245,9 +272,12 @@ class TestOptionsServiceStatusHeartbeat(TestCase):
         self.assertIsNone(payload["hot_contracts"])
 
     def test_enricher_status_heartbeat_skips_contract_table_counts(self) -> None:
-        service = self._import_service("app.options_lane.enricher_service")
+        service = cast(
+            _EnricherStatusServiceModule,
+            self._import_service("app.options_lane.enricher_service"),
+        )
 
-        service._publish_status(  # type: ignore[attr-defined]
+        service._publish_status(
             status_value="ok",
             observed_at=datetime(2026, 3, 9, 15, 0, tzinfo=timezone.utc),
             backlog=11,

--- a/services/torghut/tests/test_simple_risk.py
+++ b/services/torghut/tests/test_simple_risk.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Literal
 from unittest import TestCase
 
 from app.trading.models import StrategyDecision
@@ -17,7 +18,7 @@ class TestSimpleRisk(TestCase):
     def _decision(
         self,
         *,
-        action: str = "buy",
+        action: Literal["buy", "sell"] = "buy",
         qty: str = "1",
         price: str = "100",
     ) -> StrategyDecision:
@@ -26,7 +27,7 @@ class TestSimpleRisk(TestCase):
             symbol="AAPL",
             event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
             timeframe="1Min",
-            action=action,  # type: ignore[arg-type]
+            action=action,
             qty=Decimal(qty),
             rationale="simple-risk-test",
             params={"price": price},


### PR DESCRIPTION
## Summary

- Narrows Torghut DB readiness and schema-check helpers from concrete SQLAlchemy `Session` parameters to structural session protocols.
- Replaces fake DB/session/type helper suppressions across config, API DB contract, options lane, freshness-carry, Hyperliquid risk, simple-risk, and schema tests.
- Removes all suppression comments from the touched files while preserving existing readiness and test behavior.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/db.py app/api/readiness_helpers/refresh_universe_state_for_readiness.py tests/config/test_parses_signal_staleness_critical_reasons.py tests/api/test_trading_api_db_contract.py tests/test_options_lane.py tests/test_db.py tests/hyperliquid_runtime/test_risk_strategy.py tests/test_simple_risk.py tests/test_freshness_carry.py`
- `uv run --frozen pytest tests/config/test_parses_signal_staleness_critical_reasons.py tests/api/test_trading_api_db_contract.py tests/test_options_lane.py tests/test_db.py tests/hyperliquid_runtime/test_risk_strategy.py tests/test_simple_risk.py tests/test_freshness_carry.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall -q app/db.py app/api/readiness_helpers/refresh_universe_state_for_readiness.py tests/config/test_parses_signal_staleness_critical_reasons.py tests/api/test_trading_api_db_contract.py tests/test_options_lane.py tests/test_db.py tests/hyperliquid_runtime/test_risk_strategy.py tests/test_simple_risk.py tests/test_freshness_carry.py`
- `uv run --frozen python scripts/pylint_torghut_quality.py --diff --base-ref origin/main`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen python scripts/check_diff_coverage.py --base-ref origin/main`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
