### PR TITLE
refactor(torghut): type decision runtime fakes

### DIFF
--- a/services/torghut/tests/decisions/support.py
+++ b/services/torghut/tests/decisions/support.py
@@ -28,6 +28,8 @@ from app.trading.features import extract_signal_features
 from app.trading.models import SignalEnvelope, StrategyDecision
 from app.trading.prices import MarketSnapshot, PriceFetcher
 from app.trading.strategy_runtime import (
+    FeatureVectorV3,
+    PluginEvaluationResult,
     StrategyContext,
     StrategyIntent,
     StrategyRegistry,
@@ -40,19 +42,21 @@ class _BuyPlugin:
     version = "1.0.0"
     required_features = ("price",)
 
-    def evaluate(  # type: ignore[no-untyped-def]
-        self, context: StrategyContext, features
-    ) -> StrategyIntent:
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction="buy",
-            confidence=Decimal("0.90"),
-            target_notional=Decimal("100"),
-            horizon=context.timeframe,
-            explain=("buy_signal",),
-            feature_snapshot_hash=features.normalization_hash,
-            required_features=self.required_features,
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> PluginEvaluationResult:
+        return PluginEvaluationResult(
+            intent=StrategyIntent(
+                strategy_id=context.strategy_id,
+                symbol=context.symbol,
+                direction="buy",
+                confidence=Decimal("0.90"),
+                target_notional=Decimal("100"),
+                horizon=context.timeframe,
+                explain=("buy_signal",),
+                feature_snapshot_hash=features.normalization_hash,
+                required_features=self.required_features,
+            )
         )
 
 
@@ -61,28 +65,30 @@ class _SellPlugin:
     version = "1.0.0"
     required_features = ("price",)
 
-    def evaluate(  # type: ignore[no-untyped-def]
-        self, context: StrategyContext, features
-    ) -> StrategyIntent:
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction="sell",
-            confidence=Decimal("0.40"),
-            target_notional=Decimal("200"),
-            horizon=context.timeframe,
-            explain=("sell_signal",),
-            feature_snapshot_hash=features.normalization_hash,
-            required_features=self.required_features,
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> PluginEvaluationResult:
+        return PluginEvaluationResult(
+            intent=StrategyIntent(
+                strategy_id=context.strategy_id,
+                symbol=context.symbol,
+                direction="sell",
+                confidence=Decimal("0.40"),
+                target_notional=Decimal("200"),
+                horizon=context.timeframe,
+                explain=("sell_signal",),
+                feature_snapshot_hash=features.normalization_hash,
+                required_features=self.required_features,
+            )
         )
 
-
-__all__: tuple[str, ...] = ()
 
 __all__: tuple[str, ...] = (
     "Decimal",
     "DecisionEngine",
+    "FeatureVectorV3",
     "MarketSnapshot",
+    "PluginEvaluationResult",
     "PriceFetcher",
     "SignalEnvelope",
     "SimpleNamespace",

--- a/services/torghut/tests/decisions/test_decision_engine_core.py
+++ b/services/torghut/tests/decisions/test_decision_engine_core.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from tests.decisions.support import (
     Decimal,
     DecisionEngine,
+    FeatureVectorV3,
     MarketSnapshot,
+    PluginEvaluationResult,
     PriceFetcher,
     SignalEnvelope,
     Strategy,
@@ -77,10 +79,12 @@ class TestDecisionEngineCore(TestCase):
 
     def test_price_snapshot_attached_when_fetched(self) -> None:
         class DummyFetcher(PriceFetcher):
-            def fetch_price(self, signal: SignalEnvelope):  # type: ignore[override]
+            def fetch_price(self, signal: SignalEnvelope) -> Decimal | None:
                 return None
 
-            def fetch_market_snapshot(self, signal: SignalEnvelope):  # type: ignore[override]
+            def fetch_market_snapshot(
+                self, signal: SignalEnvelope
+            ) -> MarketSnapshot | None:
                 return MarketSnapshot(
                     symbol=signal.symbol,
                     as_of=signal.event_ts,
@@ -535,17 +539,21 @@ class TestDecisionEngineCore(TestCase):
             version = "1.0.0"
             required_features = ("price",)
 
-            def evaluate(self, context: StrategyContext, features) -> StrategyIntent:  # type: ignore[no-untyped-def]
-                return StrategyIntent(
-                    strategy_id=context.strategy_id,
-                    symbol=context.symbol,
-                    direction="sell",
-                    confidence=Decimal("0.40"),
-                    target_notional=Decimal("50"),
-                    horizon=context.timeframe,
-                    explain=("sell_signal",),
-                    feature_snapshot_hash=features.normalization_hash,
-                    required_features=self.required_features,
+            def evaluate(
+                self, context: StrategyContext, features: FeatureVectorV3
+            ) -> PluginEvaluationResult:
+                return PluginEvaluationResult(
+                    intent=StrategyIntent(
+                        strategy_id=context.strategy_id,
+                        symbol=context.symbol,
+                        direction="sell",
+                        confidence=Decimal("0.40"),
+                        target_notional=Decimal("50"),
+                        horizon=context.timeframe,
+                        explain=("sell_signal",),
+                        feature_snapshot_hash=features.normalization_hash,
+                        required_features=self.required_features,
+                    )
                 )
 
         engine = DecisionEngine(price_fetcher=None)

--- a/services/torghut/tests/strategy_runtime/support.py
+++ b/services/torghut/tests/strategy_runtime/support.py
@@ -28,6 +28,7 @@ from app.trading.strategy_runtime import (
     MicrobarCrossSectionalLongPlugin,
     MicrobarCrossSectionalPairsPlugin,
     MicrobarCrossSectionalShortPlugin,
+    PluginEvaluationResult,
     StrategyContext,
     StrategyDefinition,
     StrategyIntent,
@@ -48,7 +49,9 @@ class _FailingPlugin:
     version = "1.0.0"
     required_features = ("macd",)
 
-    def evaluate(self, context: StrategyContext, features):  # type: ignore[no-untyped-def]
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> PluginEvaluationResult:
         _ = context
         _ = features
         raise RuntimeError("boom")
@@ -59,19 +62,21 @@ class _BuyPlugin:
     version = "1.0.0"
     required_features = ("price",)
 
-    def evaluate(  # type: ignore[no-untyped-def]
-        self, context: StrategyContext, features
-    ) -> StrategyIntent:
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction="buy",
-            confidence=Decimal("0.90"),
-            target_notional=Decimal("100"),
-            horizon=context.timeframe,
-            explain=("buy_signal",),
-            feature_snapshot_hash=features.normalization_hash,
-            required_features=self.required_features,
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> PluginEvaluationResult:
+        return PluginEvaluationResult(
+            intent=StrategyIntent(
+                strategy_id=context.strategy_id,
+                symbol=context.symbol,
+                direction="buy",
+                confidence=Decimal("0.90"),
+                target_notional=Decimal("100"),
+                horizon=context.timeframe,
+                explain=("buy_signal",),
+                feature_snapshot_hash=features.normalization_hash,
+                required_features=self.required_features,
+            )
         )
 
 
@@ -80,19 +85,21 @@ class _SellPlugin:
     version = "1.0.0"
     required_features = ("price",)
 
-    def evaluate(  # type: ignore[no-untyped-def]
-        self, context: StrategyContext, features
-    ) -> StrategyIntent:
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction="sell",
-            confidence=Decimal("0.40"),
-            target_notional=Decimal("200"),
-            horizon=context.timeframe,
-            explain=("sell_signal",),
-            feature_snapshot_hash=features.normalization_hash,
-            required_features=self.required_features,
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> PluginEvaluationResult:
+        return PluginEvaluationResult(
+            intent=StrategyIntent(
+                strategy_id=context.strategy_id,
+                symbol=context.symbol,
+                direction="sell",
+                confidence=Decimal("0.40"),
+                target_notional=Decimal("200"),
+                horizon=context.timeframe,
+                explain=("sell_signal",),
+                feature_snapshot_hash=features.normalization_hash,
+                required_features=self.required_features,
+            )
         )
 
 
@@ -114,8 +121,6 @@ def _test_feature_vector(
     )
 
 
-__all__: tuple[str, ...] = ()
-
 __all__: tuple[str, ...] = (
     "Decimal",
     "FeatureNormalizationError",
@@ -125,6 +130,7 @@ __all__: tuple[str, ...] = (
     "MicrobarCrossSectionalLongPlugin",
     "MicrobarCrossSectionalPairsPlugin",
     "MicrobarCrossSectionalShortPlugin",
+    "PluginEvaluationResult",
     "SignalEnvelope",
     "Strategy",
     "StrategyCatalogConfig",

--- a/services/torghut/tests/strategy_runtime/test_runtime_reversion_and_registry.py
+++ b/services/torghut/tests/strategy_runtime/test_runtime_reversion_and_registry.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from tests.strategy_runtime.support import (
     Decimal,
+    FeatureVectorV3,
     GateTrace,
     LegacyMacdRsiPlugin,
+    PluginEvaluationResult,
     SignalEnvelope,
     Strategy,
     StrategyConfig,
+    StrategyContext,
     StrategyRegistry,
     StrategyRuntime,
     StrategyTrace,
@@ -651,10 +654,12 @@ class TestStrategyRuntimeReversionAndRegistry(TestCase):
             version = "1.0.0"
             required_features = ("price", "not_in_feature_contract")
 
-            def evaluate(self, context, features):  # type: ignore[no-untyped-def]
+            def evaluate(
+                self, context: StrategyContext, features: FeatureVectorV3
+            ) -> PluginEvaluationResult:
                 _ = context
                 _ = features
-                return None
+                return PluginEvaluationResult(intent=None)
 
         strategy = Strategy(
             id=uuid.uuid4(),


### PR DESCRIPTION
## Summary

- Typed decision-engine and strategy-runtime test plugins against `PluginEvaluationResult` and `FeatureVectorV3`.
- Replaced `PriceFetcher` fake override ignores with exact return annotations.
- Removed redundant empty `__all__` assignments from touched test support modules.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check tests/decisions/support.py tests/decisions/test_decision_engine_core.py tests/strategy_runtime/support.py tests/strategy_runtime/test_runtime_reversion_and_registry.py`
- `uv run --frozen pytest tests/decisions tests/strategy_runtime/test_runtime_reversion_and_registry.py`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/decisions tests/strategy_runtime/test_runtime_reversion_and_registry.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall -q tests/decisions tests/strategy_runtime/support.py tests/strategy_runtime/test_runtime_reversion_and_registry.py`
- `uv run --frozen python scripts/pylint_torghut_quality.py --diff --base-ref origin/main`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen python scripts/check_diff_coverage.py --base-ref origin/main`
- `rg -n "type: ignore|pyright:|ruff: noqa|source_segment|exec\\(compile|__compat_module_segments__|globals\\(\\)\\.update|sys\\.modules\\[" tests/decisions tests/strategy_runtime`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
