### PR TITLE
fix(torghut): reserve configured collection targets

### DIFF
--- a/services/torghut/app/trading/paper_route_target_plan/target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan/target_plan.py
@@ -124,6 +124,7 @@ def _target_from_proof_identity(proof: Mapping[str, Any]) -> dict[str, Any]:
         or identity.get("strategy_name"),
         "account_label": identity.get("account_label"),
         "source_account_label": identity.get("source_account_label"),
+        "observed_stage": identity.get("observed_stage") or "paper",
         "source_kind": identity.get("source_kind"),
         "source_plan_ref": identity.get("source_plan_ref"),
         "target_notional": identity.get("target_notional"),

--- a/services/torghut/app/trading/scheduler/target_plan_helpers/bounded_collection.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers/bounded_collection.py
@@ -79,6 +79,7 @@ _BOUNDED_SIM_COLLECTION_SOURCE_KIND = "paper_route_probe_runtime_observed"
 _BOUNDED_SIM_COLLECTION_SOURCE_KINDS = frozenset(
     {
         _BOUNDED_SIM_COLLECTION_SOURCE_KIND,
+        "configured_simple_lane_paper_data_collection",
         "runtime_ledger_source_collection_candidate",
     }
 )
@@ -465,7 +466,10 @@ def _bounded_sim_collection_authorization_blockers(
     target: Mapping[str, Any],
 ) -> list[str]:
     blockers: list[str] = []
-    if _safe_text(target.get("source_manifest_ref")) is None:
+    if (
+        _safe_text(target.get("source_manifest_ref")) is None
+        and _safe_text(target.get("source_plan_ref")) is None
+    ):
         blockers.append("bounded_sim_collection_source_manifest_missing")
     if not _target_bounded_collection_authorized(target):
         blockers.append("bounded_sim_collection_authorization_missing")

--- a/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
+++ b/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
@@ -64,6 +64,55 @@ def test_pending_clean_window_baseline_still_reserves_paper_account(
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
 
 
+def test_configured_collection_target_reserves_account_with_source_plan_ref(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        now = datetime(2026, 6, 18, 13, 45, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            candidate_id="configured:microbar-cross-sectional-pairs-v1",
+            hypothesis_id=(
+                "configured-paper-collection:microbar-cross-sectional-pairs-v1"
+            ),
+            source_kind="configured_simple_lane_paper_data_collection",
+            source_manifest_ref=None,
+            source_plan_ref="configured-simple-lane-paper-data-collection",
+            bounded_evidence_collection_scope=None,
+            paper_route_probe_window_start="2026-06-18T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-18T20:00:00+00:00",
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL", "AMZN"},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        blockers = _bounded_sim_collection_blockers(
+            target,
+            account_label="TORGHUT_SIM",
+        )
+
+        assert "bounded_sim_collection_source_kind_required" not in blockers
+        assert "bounded_sim_collection_source_manifest_missing" not in blockers
+        assert pipeline._paper_route_target_plan_reserves_account(
+            allowed_symbols={"AAPL", "AMZN"},
+        )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+
+
 def test_target_runtime_account_and_window_helpers_cover_identity_edges() -> None:
     target = {
         "account_label": "OTHER",

--- a/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
+++ b/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from app.trading.paper_route_target_plan import (
+    paper_route_target_plan_from_payload,
+    paper_route_target_plan_probe_symbols,
+)
+from app.trading.runtime_decision_authority import (
+    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+)
+
+
+def test_proofs_payload_configured_collection_targets_keep_paper_stage() -> None:
+    plan = paper_route_target_plan_from_payload(
+        {
+            "schema_version": "torghut.proofs.v1",
+            "proofs": [
+                {
+                    "identity": {
+                        "account_label": "TORGHUT_SIM",
+                        "candidate_id": (
+                            "configured:microbar-cross-sectional-pairs-v1"
+                        ),
+                        "hypothesis_id": (
+                            "configured-paper-collection:"
+                            "microbar-cross-sectional-pairs-v1"
+                        ),
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_decision_mode": (
+                            BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+                        ),
+                        "source_kind": ("configured_simple_lane_paper_data_collection"),
+                        "source_plan_ref": (
+                            "configured-simple-lane-paper-data-collection"
+                        ),
+                        "strategy_family": "microbar_cross_sectional_pairs_v1",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "target_notional": "100",
+                    },
+                    "symbols": ["AAPL", "AMZN"],
+                    "window": {
+                        "start": "2026-06-18T13:30:00+00:00",
+                        "end": "2026-06-18T20:00:00+00:00",
+                    },
+                    "account_state": {
+                        "blockers": [],
+                        "clean_baseline": True,
+                    },
+                }
+            ],
+        }
+    )
+
+    assert plan["source"] == "trading_proofs_endpoint"
+    assert plan["target_count"] == 1
+    target = plan["targets"][0]
+    assert target["observed_stage"] == "paper"
+    assert target["source_plan_ref"] == "configured-simple-lane-paper-data-collection"
+    assert target["paper_route_probe_symbols"] == ["AAPL", "AMZN"]
+    assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}


### PR DESCRIPTION
## Summary

- Treat configured simple-lane paper data collection targets as bounded collection source targets.
- Allow `source_plan_ref` to satisfy the collection-only source anchor when no manifest ref exists.
- Preserve `observed_stage=paper` when proof payloads are converted into scheduler target plans.
- Add regressions for live-shaped configured collection proof plans and account reservation.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_target_plan.py tests/test_paper_route_target_plan_proofs_payload.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py -q`
- `uv run --frozen ruff check app/trading/scheduler/target_plan_helpers/bounded_collection.py app/trading/paper_route_target_plan/target_plan.py tests/test_paper_route_target_plan.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `uv run --frozen ruff format --check app/trading/scheduler/target_plan_helpers/bounded_collection.py app/trading/paper_route_target_plan/target_plan.py tests/test_paper_route_target_plan.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
