### PR TITLE
revert(torghut): keep hyperliquid testnet secret gated

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - clickhouse-schema-configmap.yaml
   - clickhouse-schema-job.yaml
   - db-migrations-job.yaml
-  - externalsecret.yaml
   - deployment.yaml
   - service.yaml
   - pdb.yaml

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -200,7 +200,7 @@ describe('Torghut manifest scheduling', () => {
     expect(data['schema.sql']).not.toContain('INSERT INTO torghut.hyperliquid_ta_features')
   })
 
-  it('keeps Hyperliquid runtime shadow mode wired to an optional testnet execution secret', () => {
+  it('keeps Hyperliquid runtime shadow mode free of optional execution secret drift', () => {
     const runtimeConfig = parseManifest('argocd/applications/torghut-hyperliquid-runtime/configmap.yaml')
     const runtimeData = getAtPath(runtimeConfig, ['data'])
     expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('false')
@@ -222,30 +222,6 @@ describe('Torghut manifest scheduling', () => {
         value: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
       }),
     )
-    expect(runtimeEnv).toContainEqual(
-      expect.objectContaining({
-        name: 'HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS',
-        valueFrom: {
-          secretKeyRef: {
-            name: 'torghut-hyperliquid-testnet',
-            key: 'account-address',
-            optional: true,
-          },
-        },
-      }),
-    )
-    expect(runtimeEnv).toContainEqual(
-      expect.objectContaining({
-        name: 'HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY',
-        valueFrom: {
-          secretKeyRef: {
-            name: 'torghut-hyperliquid-testnet',
-            key: 'api-wallet-private-key',
-            optional: true,
-          },
-        },
-      }),
-    )
 
     const runtimeMigrationJob = parseManifest('argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml')
     const migrationContainer = getAtPath(runtimeMigrationJob, ['spec', 'template', 'spec', 'containers', 0])
@@ -257,7 +233,7 @@ describe('Torghut manifest scheduling', () => {
     const kustomization = parseManifest('argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml')
     const resources = kustomization.resources
     expect(resources).toBeArray()
-    expect(resources).toContain('externalsecret.yaml')
+    expect(resources).not.toContain('externalsecret.yaml')
 
     const externalSecret = parseManifest('argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml')
     expect(externalSecret.kind).toBe('ExternalSecret')


### PR DESCRIPTION
## Summary

- Reverts PR #11159 so the runtime ExternalSecret manifest stays staged but out of steady-state GitOps.
- Restores the documented shadow-mode behavior: optional deployment secret refs stay present, but missing 1Password testnet credentials do not degrade Argo.
- Keeps the manifest scheduling contract asserting `externalsecret.yaml` is excluded until the `hyperliquid-testnet` 1Password item exists.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`
- `bun run lint:argocd`
- `git diff --check`
- Live readback: `kubectl -n external-secrets logs deploy/external-secrets --since=20m | rg -n "torghut-hyperliquid-testnet|hyperliquid-testnet"`
- Live readback: `kubectl -n torghut exec deploy/torghut-hyperliquid-runtime -- curl -fsS localhost:8182/readyz`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
