### PR TITLE
refactor(torghut): type order and ledger fakes

### DIFF
--- a/services/torghut/tests/order_idempotency/support.py
+++ b/services/torghut/tests/order_idempotency/support.py
@@ -93,6 +93,34 @@ class FakeAlpacaClient:
         return []
 
 
+class FilledAlpacaClient(FakeAlpacaClient):
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        order = super().submit_order(
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            order_type=order_type,
+            time_in_force=time_in_force,
+            limit_price=limit_price,
+            stop_price=stop_price,
+            extra_params=extra_params,
+        )
+        order["filled_qty"] = str(qty)
+        order["filled_avg_price"] = "101"
+        order["status"] = "filled"
+        return order
+
+
 class ConflictingOrderClient(FakeAlpacaClient):
     def list_orders(self, status: str = "all") -> list[dict[str, str]]:
         if status != "open":
@@ -301,24 +329,6 @@ class _TestOrderIdempotencyBase(TestCase):
         settings.trading_mode = self._orig_trading_mode
 
 
-__all__ = (
-    "FakeAlpacaClient",
-    "ConflictingOrderClient",
-    "HeldInventoryClient",
-    "PositionLookupUnavailableClient",
-    "PositionLookupNoneClient",
-    "PositionLookupUnavailableHeldInventoryClient",
-    "PartiallyHeldInventoryClient",
-    "AccountShortingDisabledClient",
-    "SymbolNotShortableClient",
-    "SymbolNotEasyToBorrowClient",
-    "AccountMetadataUnavailableClient",
-    "AccountShortingUnknownClient",
-    "AssetMetadataUnavailableClient",
-    "AssetShortabilityUnknownClient",
-    "AccountMetadataUnavailableClientWithLongPosition",
-)
-
 __all__: tuple[str, ...] = (
     "AccountMetadataUnavailableClient",
     "AccountMetadataUnavailableClientWithLongPosition",
@@ -333,6 +343,7 @@ __all__: tuple[str, ...] = (
     "ExecutionOrderEvent",
     "ExecutionTCAMetric",
     "FakeAlpacaClient",
+    "FilledAlpacaClient",
     "HeldInventoryClient",
     "LeanExecutionAdapter",
     "OrderExecutor",

--- a/services/torghut/tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py
+++ b/services/torghut/tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py
@@ -6,6 +6,7 @@ from tests.order_idempotency.support import (
     Decimal,
     ExecutionTCAMetric,
     FakeAlpacaClient,
+    FilledAlpacaClient,
     OrderExecutor,
     SimulationExecutionAdapter,
     Strategy,
@@ -124,16 +125,8 @@ class TestSimulationSubmitOrderWithoutPriceKeepsLegacyFallback(
                 session, decision, strategy, "paper"
             )
 
-            class FilledClient(FakeAlpacaClient):
-                def submit_order(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-                    order = super().submit_order(*args, **kwargs)
-                    order["filled_qty"] = "2"
-                    order["filled_avg_price"] = "101"
-                    order["status"] = "filled"
-                    return order
-
             execution = executor.submit_order(
-                session, FilledClient(), decision, decision_row, "paper"
+                session, FilledAlpacaClient(), decision, decision_row, "paper"
             )
             assert execution is not None
             raw_order = execution.raw_order
@@ -259,16 +252,8 @@ class TestSimulationSubmitOrderWithoutPriceKeepsLegacyFallback(
                 session, decision, strategy, "paper"
             )
 
-            class FilledClient(FakeAlpacaClient):
-                def submit_order(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-                    order = super().submit_order(*args, **kwargs)
-                    order["filled_qty"] = "2"
-                    order["filled_avg_price"] = "101"
-                    order["status"] = "filled"
-                    return order
-
             execution = executor.submit_order(
-                session, FilledClient(), decision, decision_row, "paper"
+                session, FilledAlpacaClient(), decision, decision_row, "paper"
             )
             assert execution is not None
             raw_order = execution.raw_order

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -135,10 +135,16 @@ class TestTigerBeetleClient(TestCase):
         self.assertIn("RuntimeError: boom", health.last_error or "")
 
     def test_health_closes_owned_client(self) -> None:
+        class _ClosableFakeTigerBeetleClient(FakeTigerBeetleClient):
+            def __init__(self) -> None:
+                super().__init__()
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
         settings = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
-        client = FakeTigerBeetleClient()
-        closed: list[bool] = []
-        client.close = lambda: closed.append(True)  # type: ignore[attr-defined]
+        client = _ClosableFakeTigerBeetleClient()
 
         with patch(
             "app.trading.tigerbeetle_client.create_tigerbeetle_client",
@@ -147,7 +153,7 @@ class TestTigerBeetleClient(TestCase):
             health = check_tigerbeetle_health(settings)
 
         self.assertTrue(health.ok)
-        self.assertEqual(closed, [True])
+        self.assertTrue(client.closed)
 
     def test_create_tigerbeetle_client_uses_normalized_settings(self) -> None:
         settings = Settings(
@@ -408,9 +414,9 @@ class TestTigerBeetleClient(TestCase):
             def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
                 self.exited = True
 
-        client = object.__new__(RealTigerBeetleClient)
+        client: RealTigerBeetleClient = object.__new__(RealTigerBeetleClient)
         owned = _ExitOnly()
-        client._client = owned  # type: ignore[attr-defined]
+        client._client = owned
 
         client.close()
 


### PR DESCRIPTION
## Summary

- Added a typed `FilledAlpacaClient` order-idempotency fake and reused it instead of local untyped subclasses.
- Replaced TigerBeetle close monkeypatching with a fake client that exposes a real `close()` method.
- Removed a stale duplicate `__all__` export block from order-idempotency test support.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check tests/order_idempotency/support.py tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py tests/test_tigerbeetle_client.py`
- `uv run --frozen pytest tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py tests/test_tigerbeetle_client.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen python -m compileall -q tests/order_idempotency tests/test_tigerbeetle_client.py`
- `uv run --frozen python scripts/pylint_torghut_quality.py --diff --base-ref origin/main`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py tests/test_tigerbeetle_client.py`
- `uv run --frozen python scripts/check_diff_coverage.py --base-ref origin/main`
- `rg -n "type: ignore|pyright:|ruff: noqa|source_segment|exec\\(compile|__compat_module_segments__|globals\\(\\)\\.update|sys\\.modules\\[" tests/order_idempotency tests/test_tigerbeetle_client.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
