### PR TITLE
docs(torghut): document hyperliquid testnet credential check

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/README.md
+++ b/argocd/applications/torghut-hyperliquid-runtime/README.md
@@ -21,6 +21,7 @@ Use the repo bootstrap helper after signing in to 1Password CLI:
 
 ```bash
 scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh status
+scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh check
 scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh create
 scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile
 ```

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -262,6 +262,23 @@ describe('Torghut manifest scheduling', () => {
     )
   })
 
+  it('documents the Hyperliquid testnet credential check before enabling the ExternalSecret', () => {
+    const readme = readFileSync(join(repoRoot, 'argocd/applications/torghut-hyperliquid-runtime/README.md'), 'utf8')
+    const bootstrapScript = readFileSync(
+      join(repoRoot, 'scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh'),
+      'utf8',
+    )
+
+    expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh status')
+    expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh check')
+    expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh create')
+    expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh reconcile')
+    expect(readme).toContain('After `check` reports the 1Password item is present')
+    expect(readme).toContain('Keep the ExternalSecret out of steady-state')
+    expect(bootstrapScript).toContain('$0 check')
+    expect(bootstrapScript).toContain('check_item()')
+  })
+
   it('keeps options TA recoverable across transient Kafka source startup failures', () => {
     const config = parseManifest('argocd/applications/torghut-options/ta/configmap.yaml')
     const data = getAtPath(config, ['data'])


### PR DESCRIPTION
## Summary

- Documents the required Hyperliquid testnet credential `check` step before creating or reconciling the optional ExternalSecret.
- Adds a manifest scheduling regression test that keeps the README aligned with the bootstrap helper commands.
- Keeps the steady-state runtime manifest free of the Hyperliquid testnet ExternalSecret while trading remains disabled.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-render-bootstrap-hardening.yaml && ! rg -q '^kind: ExternalSecret$' /tmp/torghut-hyperliquid-runtime-render-bootstrap-hardening.yaml && rg -n 'HYPERLIQUID_RUNTIME_TRADING_ENABLED|optional: true|torghut-hyperliquid-testnet' /tmp/torghut-hyperliquid-runtime-render-bootstrap-hardening.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
