### PR TITLE
fix(torghut): allow hyperliquid promotion automerge

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -28,6 +28,8 @@ on:
       - 'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
       - 'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
       - 'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+      - 'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml'
+      - 'argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml'
       - 'argocd/applications/torghut-options/catalog/deployment.yaml'
       - 'argocd/applications/torghut-options/enricher/deployment.yaml'
       - '.github/workflows/torghut-deploy-automerge.yml'
@@ -86,6 +88,8 @@ jobs:
             'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+            'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml'
+            'argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml'
             'argocd/applications/torghut-options/catalog/deployment.yaml'
             'argocd/applications/torghut-options/enricher/deployment.yaml'
           )

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, test } from 'bun:test'
+
+const releaseWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-release.yml', import.meta.url),
+  'utf8',
+)
+const deployAutomergeWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-deploy-automerge.yml', import.meta.url),
+  'utf8',
+)
+
+const countOccurrences = (haystack: string, needle: string): number => haystack.split(needle).length - 1
+
+describe('torghut-deploy-automerge workflow', () => {
+  test('allowlists every hyperliquid runtime manifest promoted by torghut-release', () => {
+    const promotedHyperliquidRuntimeManifests = [
+      'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml',
+      'argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml',
+    ]
+
+    for (const manifestPath of promotedHyperliquidRuntimeManifests) {
+      expect(releaseWorkflow).toContain(manifestPath)
+      expect(countOccurrences(deployAutomergeWorkflow, `'${manifestPath}'`)).toBeGreaterThanOrEqual(2)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Allow Torghut release promotion PRs to automerge when they update hyperliquid runtime deployment manifests.
- Add the hyperliquid runtime deployment and migration job manifests to the deploy-automerge trigger paths and allowlist.
- Add a regression test tying those promoted manifests to the automerge workflow allowlist.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
