### PR TITLE
refactor(torghut): clarify submission authority status

### DIFF
--- a/services/torghut/app/api/trading_status.py
+++ b/services/torghut/app/api/trading_status.py
@@ -79,6 +79,9 @@ from .status_helpers import (
 from .trading_misc import (
     build_consumer_evidence_receipt_projection as _build_consumer_evidence_receipt_projection,
 )
+from app.trading.submission_authority import (
+    build_submission_authority_status as _build_submission_authority_status,
+)
 from .vnext_helpers import build_autonomy_bridge_status as _build_autonomy_bridge_status
 
 _TradingStatusReadBudget = TradingStatusReadBudget
@@ -326,6 +329,10 @@ def trading_status() -> dict[str, object]:
             )
     simple_lane_reject_reason_totals = _simple_lane_reject_reason_totals(state)
     simple_lane_status = _build_simple_lane_status_payload()
+    submission_authority = _build_submission_authority_status(
+        live_submission_gate,
+        simple_lane_status=simple_lane_status,
+    )
     proof_floor = _build_profitability_proof_floor_payload(
         state=state,
         torghut_revision=str(shadow_first_runtime["active_revision"]),
@@ -592,6 +599,7 @@ def trading_status() -> dict[str, object]:
         },
         "running": state.running,
         "live_submission_gate": live_submission_gate,
+        "submission_authority": submission_authority,
         "tigerbeetle_ledger": tigerbeetle_ledger,
         "portfolio_runtime_ledger_summary": runtime_ledger_portfolio_summary,
         "runtime_ledger_profit_distance_readback": (

--- a/services/torghut/app/trading/submission_authority.py
+++ b/services/torghut/app/trading/submission_authority.py
@@ -1,0 +1,180 @@
+"""Operator-facing submission authority status."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+
+def build_submission_authority_status(
+    live_submission_gate: Mapping[str, Any],
+    *,
+    simple_lane_status: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    """Summarize the effective submit authority without changing gate decisions."""
+
+    bounded_gate = _mapping(
+        live_submission_gate.get("bounded_live_paper_collection_gate")
+    )
+    simple_lane = _mapping(simple_lane_status)
+    capital_allowed = _bool(live_submission_gate.get("allowed"))
+    bounded_allowed = _bool(bounded_gate.get("allowed"))
+    bounded_active = _bool(bounded_gate.get("active"))
+    effective_mode = _effective_submit_mode(
+        capital_allowed=capital_allowed,
+        bounded_allowed=bounded_allowed,
+        bounded_active=bounded_active,
+    )
+    return {
+        "schema_version": "torghut.submission-authority.v1",
+        "effective_submit_mode": effective_mode,
+        "can_submit_now": effective_mode
+        in {"capital_promotion", "bounded_live_paper_collection"},
+        "authority_scope": _authority_scope(
+            effective_mode=effective_mode,
+            bounded_gate=bounded_gate,
+        ),
+        "reason": _effective_reason(
+            effective_mode=effective_mode,
+            live_submission_gate=live_submission_gate,
+            bounded_gate=bounded_gate,
+        ),
+        "capital_promotion_gate": {
+            "allowed": capital_allowed,
+            "reason": _text(live_submission_gate.get("reason"), "unknown"),
+            "blocked_reasons": _strings(live_submission_gate.get("blocked_reasons")),
+            "capital_stage": _optional_text(live_submission_gate.get("capital_stage")),
+            "capital_state": _optional_text(live_submission_gate.get("capital_state")),
+            "certificate_id": _optional_text(
+                live_submission_gate.get("certificate_id")
+            ),
+        },
+        "bounded_collection_gate": {
+            "allowed": bounded_allowed,
+            "active": bounded_active,
+            "reason": _text(bounded_gate.get("reason"), "not_configured"),
+            "blocked_reasons": _strings(bounded_gate.get("blocked_reasons")),
+            "authority_scope": _text(
+                bounded_gate.get("authority_scope"),
+                "bounded_evidence_collection_only",
+            ),
+            "source_collection_target_count": _int(
+                bounded_gate.get("source_collection_target_count")
+            ),
+            "source_collection_profit_target_count": _int(
+                bounded_gate.get("source_collection_profit_target_count")
+            ),
+            "paper_route_probe_max_notional": _optional_text(
+                bounded_gate.get("paper_route_probe_max_notional")
+            ),
+            "market_session_open": bounded_gate.get("market_session_open"),
+            "capital_gate_blocked_reasons": _strings(
+                bounded_gate.get("capital_gate_blocked_reasons")
+            ),
+            "collection_only_blockers": _strings(
+                bounded_gate.get("collection_only_blockers")
+            ),
+            "hard_blockers": _strings(bounded_gate.get("hard_blockers")),
+        },
+        "simple_lane_contract": {
+            "submit_enabled": _bool(simple_lane.get("submit_enabled")),
+            "paper_route_probe_enabled": _bool(
+                simple_lane.get("paper_route_probe_enabled")
+            ),
+            "paper_route_probe_allow_live_mode": _bool(
+                simple_lane.get("paper_route_probe_allow_live_mode")
+            ),
+            "max_notional_per_order": simple_lane.get("max_notional_per_order"),
+            "max_notional_per_symbol": simple_lane.get("max_notional_per_symbol"),
+            "max_gross_exposure_pct_equity": simple_lane.get(
+                "max_gross_exposure_pct_equity"
+            ),
+        },
+    }
+
+
+def _effective_submit_mode(
+    *,
+    capital_allowed: bool,
+    bounded_allowed: bool,
+    bounded_active: bool,
+) -> str:
+    if capital_allowed:
+        return "capital_promotion"
+    if bounded_active:
+        return "bounded_live_paper_collection"
+    if bounded_allowed:
+        return "bounded_live_paper_collection_waiting_for_session"
+    return "blocked"
+
+
+def _authority_scope(
+    *,
+    effective_mode: str,
+    bounded_gate: Mapping[str, Any],
+) -> str:
+    if effective_mode == "capital_promotion":
+        return "capital_promotion"
+    if effective_mode.startswith("bounded_live_paper_collection"):
+        return _text(
+            bounded_gate.get("authority_scope"),
+            "bounded_evidence_collection_only",
+        )
+    return "none"
+
+
+def _effective_reason(
+    *,
+    effective_mode: str,
+    live_submission_gate: Mapping[str, Any],
+    bounded_gate: Mapping[str, Any],
+) -> str:
+    if effective_mode.startswith("bounded_live_paper_collection"):
+        return _text(bounded_gate.get("reason"), "bounded_collection_gate_unknown")
+    return _text(live_submission_gate.get("reason"), "unknown")
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _bool(value: object) -> bool:
+    return value is True
+
+
+def _int(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _optional_text(value: object) -> str | None:
+    text = str(value).strip() if value is not None else ""
+    return text or None
+
+
+def _text(value: object, default: str) -> str:
+    return _optional_text(value) or default
+
+
+def _strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    strings: list[str] = []
+    for item in cast(list[object], value):
+        text = _optional_text(item)
+        if text:
+            strings.append(text)
+    return strings
+
+
+__all__ = ["build_submission_authority_status"]

--- a/services/torghut/tests/api/test_trading_api_status_consumer_evidence.py
+++ b/services/torghut/tests/api/test_trading_api_status_consumer_evidence.py
@@ -51,6 +51,22 @@ class TestTradingApiStatusConsumerEvidence(TradingApiTestCaseBase):
         self.assertEqual(float(tca_summary["avg_expected_shortfall_bps_p95"]), 5.0)
         self.assertEqual(float(tca_summary["avg_realized_shortfall_bps"]), 1.2)
         self.assertEqual(float(tca_summary["avg_divergence_bps"]), 0.7)
+        submission_authority = payload["submission_authority"]
+        self.assertEqual(
+            submission_authority["schema_version"],
+            "torghut.submission-authority.v1",
+        )
+        self.assertIn(
+            submission_authority["effective_submit_mode"],
+            {
+                "blocked",
+                "bounded_live_paper_collection",
+                "bounded_live_paper_collection_waiting_for_session",
+                "capital_promotion",
+            },
+        )
+        self.assertIn("capital_promotion_gate", submission_authority)
+        self.assertIn("bounded_collection_gate", submission_authority)
 
     def test_trading_status_reports_latest_persisted_decision_timestamp(self) -> None:
         with self.session_local() as session:

--- a/services/torghut/tests/test_submission_authority.py
+++ b/services/torghut/tests/test_submission_authority.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from app.trading.submission_authority import build_submission_authority_status
+
+
+def test_submission_authority_surfaces_bounded_collection_submit_mode() -> None:
+    status = build_submission_authority_status(
+        {
+            "allowed": False,
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "blocked_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "runtime_ledger_source_collection_pending",
+            ],
+            "capital_stage": "shadow",
+            "capital_state": "blocked",
+            "bounded_live_paper_collection_gate": {
+                "allowed": True,
+                "active": True,
+                "reason": "bounded_live_paper_collection_ready",
+                "authority_scope": "bounded_evidence_collection_only",
+                "source_collection_target_count": 1,
+                "source_collection_profit_target_count": 1,
+                "paper_route_probe_max_notional": "100",
+                "market_session_open": True,
+                "capital_gate_blocked_reasons": [
+                    "alpha_readiness_not_promotion_eligible",
+                    "runtime_ledger_source_collection_pending",
+                ],
+                "collection_only_blockers": [
+                    "alpha_readiness_not_promotion_eligible",
+                    "runtime_ledger_source_collection_pending",
+                ],
+                "hard_blockers": [],
+            },
+        },
+        simple_lane_status={
+            "submit_enabled": True,
+            "paper_route_probe_enabled": True,
+            "paper_route_probe_allow_live_mode": True,
+            "max_notional_per_order": 100.0,
+            "max_notional_per_symbol": 250.0,
+            "max_gross_exposure_pct_equity": 0.05,
+        },
+    )
+
+    assert status["effective_submit_mode"] == "bounded_live_paper_collection"
+    assert status["can_submit_now"] is True
+    assert status["authority_scope"] == "bounded_evidence_collection_only"
+    assert status["reason"] == "bounded_live_paper_collection_ready"
+    assert status["capital_promotion_gate"] == {
+        "allowed": False,
+        "reason": "alpha_readiness_not_promotion_eligible",
+        "blocked_reasons": [
+            "alpha_readiness_not_promotion_eligible",
+            "runtime_ledger_source_collection_pending",
+        ],
+        "capital_stage": "shadow",
+        "capital_state": "blocked",
+        "certificate_id": None,
+    }
+    assert status["bounded_collection_gate"]["hard_blockers"] == []
+    assert status["bounded_collection_gate"]["source_collection_target_count"] == 1
+    assert status["simple_lane_contract"]["max_notional_per_order"] == 100.0
+    assert "promotion_allowed" not in status
+    assert "final_promotion_allowed" not in status
+
+
+def test_submission_authority_blocks_on_hard_bounded_collection_blocker() -> None:
+    status = build_submission_authority_status(
+        {
+            "allowed": False,
+            "reason": "empirical_jobs_not_ready",
+            "blocked_reasons": ["empirical_jobs_not_ready"],
+            "bounded_live_paper_collection_gate": {
+                "allowed": False,
+                "active": False,
+                "reason": "empirical_jobs_not_ready",
+                "blocked_reasons": ["empirical_jobs_not_ready"],
+                "authority_scope": "bounded_evidence_collection_only",
+                "hard_blockers": ["empirical_jobs_not_ready"],
+            },
+        },
+        simple_lane_status={"submit_enabled": True},
+    )
+
+    assert status["effective_submit_mode"] == "blocked"
+    assert status["can_submit_now"] is False
+    assert status["authority_scope"] == "none"
+    assert status["reason"] == "empirical_jobs_not_ready"
+    assert status["bounded_collection_gate"]["hard_blockers"] == [
+        "empirical_jobs_not_ready"
+    ]
+
+
+def test_submission_authority_prefers_capital_promotion_when_allowed() -> None:
+    status = build_submission_authority_status(
+        {
+            "allowed": True,
+            "reason": "live_submission_allowed",
+            "blocked_reasons": [],
+            "capital_stage": "live",
+            "capital_state": "authorized",
+            "certificate_id": "cert-1",
+            "bounded_live_paper_collection_gate": {
+                "allowed": True,
+                "active": True,
+                "reason": "bounded_live_paper_collection_ready",
+            },
+        },
+        simple_lane_status={"submit_enabled": True},
+    )
+
+    assert status["effective_submit_mode"] == "capital_promotion"
+    assert status["can_submit_now"] is True
+    assert status["authority_scope"] == "capital_promotion"
+    assert status["reason"] == "live_submission_allowed"
+    assert status["capital_promotion_gate"]["certificate_id"] == "cert-1"


### PR DESCRIPTION
## Summary

- Add an operator-facing `submission_authority` status contract that separates capital-promotion authority from bounded paper-route collection authority.
- Expose the contract on `/trading/status` next to the existing raw `live_submission_gate`.
- Add regression coverage for bounded collection, hard blockers, capital-promotion precedence, and API payload presence.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_submission_authority.py tests/api/test_trading_api_status_consumer_evidence.py -q`
- `uv run --frozen ruff format --check app/trading/submission_authority.py app/api/trading_status.py tests/test_submission_authority.py tests/api/test_trading_api_status_consumer_evidence.py`
- `uv run --frozen ruff check app/trading/submission_authority.py app/api/trading_status.py tests/test_submission_authority.py tests/api/test_trading_api_status_consumer_evidence.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/submission_authority.py app/api/trading_status.py tests/test_submission_authority.py tests/api/test_trading_api_status_consumer_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `argocd app wait torghut --sync --health --operation --timeout 600`
- `kubectl get pods -n torghut -o json | jq -r '.items[] | select([.status.containerStatuses[]?.state.waiting?.reason] | any(. == "ImagePullBackOff" or . == "ErrImagePull" or . == "CrashLoopBackOff")) | [.metadata.name, (.status.containerStatuses[]?.state.waiting?.reason // "")] | @tsv'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
