### PR TITLE
fix(torghut): clamp close-only exit sizing

### DIFF
--- a/services/torghut/app/trading/simple_risk.py
+++ b/services/torghut/app/trading/simple_risk.py
@@ -141,6 +141,34 @@ def position_value_for_symbol(
     return total
 
 
+def _close_only_adjusted_decision(
+    decision: StrategyDecision,
+    *,
+    current_qty: Decimal,
+) -> tuple[StrategyDecision, dict[str, str | bool]]:
+    if not isinstance(decision.params.get("position_exit"), Mapping):
+        return decision, {}
+    requested_qty = _resolve_decimal(decision.qty)
+    if requested_qty is None or requested_qty <= 0:
+        return decision, {}
+    action = decision.action.strip().lower()
+    close_qty: Decimal | None = None
+    if action == "sell" and current_qty > 0:
+        close_qty = current_qty
+    elif action == "buy" and current_qty < 0:
+        close_qty = abs(current_qty)
+    if close_qty is None or requested_qty <= close_qty:
+        return decision, {}
+    return (
+        decision.model_copy(update={"qty": close_qty}),
+        {
+            "close_only_qty_clamped": True,
+            "close_only_requested_qty": str(requested_qty),
+            "close_only_position_qty": str(close_qty),
+        },
+    )
+
+
 def prepare_simple_decision(
     *,
     decision: StrategyDecision,
@@ -234,6 +262,10 @@ def _build_simple_risk_context(
 ) -> tuple[_SimpleRiskContext | None, SimpleRiskPreparation | None]:
     price = _extract_decision_price(decision)
     current_qty = position_qty_for_symbol(positions, decision.symbol)
+    decision, close_only_diagnostics = _close_only_adjusted_decision(
+        decision,
+        current_qty=current_qty,
+    )
     resolution = resolve_quantity_resolution(
         decision.symbol,
         action=decision.action,
@@ -257,6 +289,7 @@ def _build_simple_risk_context(
         "min_qty": str(min_qty),
         "quantity_resolution": resolution.to_payload(),
     }
+    diagnostics.update(close_only_diagnostics)
     if price is None or price <= 0:
         diagnostics["price"] = None if price is None else str(price)
         return None, _rejected_simple_risk_preparation(

--- a/services/torghut/tests/test_simple_risk.py
+++ b/services/torghut/tests/test_simple_risk.py
@@ -407,6 +407,132 @@ class TestSimpleRisk(TestCase):
         self.assertFalse(result.approved)
         self.assertEqual(result.reject_reason, "shorting_not_allowed_for_asset")
 
+    def test_position_exit_sell_closes_fractional_long_without_short_increase(
+        self,
+    ) -> None:
+        decision = self._decision(action="sell", qty="1382", price="298.82")
+        decision = decision.model_copy(
+            update={
+                "rationale": "position_stop_loss_exit",
+                "params": {
+                    "price": "298.82",
+                    "position_exit": {"type": "long_stop_loss_bps"},
+                },
+            }
+        )
+
+        result = prepare_simple_decision(
+            decision=decision,
+            account={"buying_power": "0", "equity": "10000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "0.1671", "side": "long"}],
+            fractional_equities_enabled=True,
+            allow_shorts=True,
+            max_notional_per_order=Decimal("100"),
+            max_notional_per_symbol=Decimal("250"),
+            max_gross_exposure_pct_equity=Decimal("0.05"),
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("0.1671"))
+        self.assertEqual(result.notional, Decimal("49.932822"))
+        self.assertEqual(result.diagnostics["close_only_requested_qty"], "1382")
+        self.assertEqual(result.diagnostics["close_only_position_qty"], "0.1671")
+        quantity_resolution = result.decision.params["simple_lane"][
+            "quantity_resolution"
+        ]
+        self.assertEqual(
+            quantity_resolution["reason"],
+            "sell_reducing_long_fractional_allowed",
+        )
+        self.assertFalse(quantity_resolution["short_increasing"])
+
+    def test_position_exit_sell_already_reducing_long_does_not_clamp(
+        self,
+    ) -> None:
+        decision = self._decision(action="sell", qty="0.1000", price="100")
+        decision = decision.model_copy(
+            update={
+                "rationale": "position_stop_loss_exit",
+                "params": {
+                    "price": "100",
+                    "position_exit": {"type": "long_stop_loss_bps"},
+                },
+            }
+        )
+
+        result = prepare_simple_decision(
+            decision=decision,
+            account={"buying_power": "0", "equity": "10000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "0.1671", "side": "long"}],
+            fractional_equities_enabled=True,
+            allow_shorts=True,
+            max_notional_per_order=Decimal("100"),
+            max_notional_per_symbol=Decimal("250"),
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("0.1000"))
+        self.assertNotIn("close_only_requested_qty", result.diagnostics)
+
+    def test_position_exit_zero_qty_remains_invalid_without_close_only_clamp(
+        self,
+    ) -> None:
+        decision = self._decision(action="sell", qty="0", price="100")
+        decision = decision.model_copy(
+            update={
+                "rationale": "position_stop_loss_exit",
+                "params": {
+                    "price": "100",
+                    "position_exit": {"type": "long_stop_loss_bps"},
+                },
+            }
+        )
+
+        result = prepare_simple_decision(
+            decision=decision,
+            account={"buying_power": "0", "equity": "10000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "0.1671", "side": "long"}],
+            fractional_equities_enabled=True,
+            allow_shorts=True,
+            max_notional_per_order=Decimal("100"),
+            max_notional_per_symbol=Decimal("250"),
+        )
+
+        self.assertFalse(result.approved)
+        self.assertEqual(result.reject_reason, "qty_below_min_after_clamp")
+        self.assertNotIn("close_only_requested_qty", result.diagnostics)
+
+    def test_position_exit_buy_covers_fractional_short_without_new_exposure(
+        self,
+    ) -> None:
+        decision = self._decision(action="buy", qty="5", price="100")
+        decision = decision.model_copy(
+            update={
+                "rationale": "position_stop_loss_exit",
+                "params": {
+                    "price": "100",
+                    "position_exit": {"type": "short_stop_loss_bps"},
+                },
+            }
+        )
+
+        result = prepare_simple_decision(
+            decision=decision,
+            account={"buying_power": "0", "equity": "10000", "cash": "0"},
+            positions=[{"symbol": "AAPL", "qty": "0.2500", "side": "short"}],
+            fractional_equities_enabled=True,
+            allow_shorts=True,
+            max_notional_per_order=Decimal("100"),
+            max_notional_per_symbol=Decimal("250"),
+            max_gross_exposure_pct_equity=Decimal("0.05"),
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("0.2500"))
+        self.assertEqual(result.diagnostics["buying_power_required_notional"], "0")
+        self.assertEqual(result.diagnostics["close_only_requested_qty"], "5")
+        self.assertEqual(result.diagnostics["close_only_position_qty"], "0.2500")
+
     def test_buying_power_required_notional_ignores_non_increasing_exposure(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Clamp explicit `position_exit` orders to the current held quantity before simple-risk quantity resolution runs.
- Preserve close-only audit fields so oversized stop-loss requests remain visible without being treated as new short exposure.
- Add regressions for fractional long close and fractional short cover paths.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_simple_risk.py -q`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_probe_exits_a.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q`
- `uv run --frozen ruff format --check app/trading/simple_risk.py tests/test_simple_risk.py`
- `uv run --frozen ruff check app/trading/simple_risk.py tests/test_simple_risk.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/simple_risk.py tests/test_simple_risk.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
