### PR TITLE
refactor(torghut): consolidate migration test loading

### DIFF
--- a/services/torghut/tests/migration_testing.py
+++ b/services/torghut/tests/migration_testing.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from importlib.machinery import SourceFileLoader
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_MIGRATIONS_ROOT = Path(__file__).resolve().parents[1] / "migrations" / "versions"
+
+
+def load_migration_module(filename: str) -> ModuleType:
+    path = _MIGRATIONS_ROOT / filename
+    if not path.is_file():
+        raise AssertionError(f"migration_not_found:{filename}")
+
+    revision = filename.partition("_")[0]
+    module_name = f"torghut_migration_{revision}"
+    loader = SourceFileLoader(module_name, str(path))
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    if spec is None:
+        raise AssertionError(f"failed_to_load_migration:{filename}")
+
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module

--- a/services/torghut/tests/test_autoresearch_candidate_spec_migration.py
+++ b/services/torghut/tests/test_autoresearch_candidate_spec_migration.py
@@ -1,24 +1,11 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0031_autoresearch_candidate_spec_epoch_uniqueness.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0031", path)
-    if spec is None or spec.loader is None:  # pragma: no cover - importlib guard
-        raise AssertionError("failed_to_load_migration_0031")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0031_autoresearch_candidate_spec_epoch_uniqueness.py"
 
 
 class _FakeOp:
@@ -51,7 +38,7 @@ class TestAutoresearchCandidateSpecMigration(TestCase):
     def test_upgrade_drops_existing_unique_constraint_before_epoch_scoped_index(
         self,
     ) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         fake_op = _FakeOp()
         original_op = module.op
         try:
@@ -84,7 +71,7 @@ class TestAutoresearchCandidateSpecMigration(TestCase):
         )
 
     def test_downgrade_restores_candidate_spec_unique_constraint(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         fake_op = _FakeOp()
         original_op = module.op
         try:

--- a/services/torghut/tests/test_autoresearch_portfolio_latest_index_migration.py
+++ b/services/torghut/tests/test_autoresearch_portfolio_latest_index_migration.py
@@ -1,30 +1,17 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0046_autoresearch_portfolio_latest_index.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0046", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0046")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0046_autoresearch_portfolio_latest_index.py"
 
 
 class TestAutoresearchPortfolioLatestIndexMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(module.revision, "0046_autoresearch_portfolio_latest_index")
         self.assertEqual(
@@ -33,7 +20,7 @@ class TestAutoresearchPortfolioLatestIndexMigration(TestCase):
         )
 
     def test_upgrade_adds_created_at_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.return_value = []
@@ -52,7 +39,7 @@ class TestAutoresearchPortfolioLatestIndexMigration(TestCase):
         )
 
     def test_downgrade_drops_existing_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.return_value = [

--- a/services/torghut/tests/test_hyperliquid_tigerbeetle_ref_u128_migration.py
+++ b/services/torghut/tests/test_hyperliquid_tigerbeetle_ref_u128_migration.py
@@ -1,32 +1,20 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
+
+from tests.migration_testing import load_migration_module
 
 import sqlalchemy as sa
 
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0055_hyperliquid_tigerbeetle_ref_u128.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0055", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0055")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+MIGRATION_FILENAME = "0055_hyperliquid_tigerbeetle_ref_u128.py"
 
 
 class TestHyperliquidTigerBeetleRefU128Migration(TestCase):
     def test_revision_follows_hyperliquid_runtime_migration(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(
             module.revision,
@@ -35,7 +23,7 @@ class TestHyperliquidTigerBeetleRefU128Migration(TestCase):
         self.assertEqual(module.down_revision, "0054_hyperliquid_runtime")
 
     def test_upgrade_widens_integer_transfer_id_to_numeric_39(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True
@@ -71,7 +59,7 @@ class TestHyperliquidTigerBeetleRefU128Migration(TestCase):
         self.assertEqual(kwargs["postgresql_using"], "transfer_id::numeric(39, 0)")
 
     def test_upgrade_skips_when_columns_are_already_numeric_39(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True

--- a/services/torghut/tests/test_options_catalog_active_underlying_index_migration.py
+++ b/services/torghut/tests/test_options_catalog_active_underlying_index_migration.py
@@ -1,30 +1,17 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 from unittest.mock import patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0032_options_catalog_active_underlying_index.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0032", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0032")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0032_options_catalog_active_underlying_index.py"
 
 
 class TestOptionsCatalogActiveUnderlyingIndexMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(
             module.revision, "0032_options_catalog_active_underlying_index"
@@ -36,7 +23,7 @@ class TestOptionsCatalogActiveUnderlyingIndexMigration(TestCase):
     def test_upgrade_adds_partial_covering_index_for_active_route_symbols(
         self,
     ) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         with patch.object(module.op, "create_index") as create_index:
             module.upgrade()
@@ -58,7 +45,7 @@ class TestOptionsCatalogActiveUnderlyingIndexMigration(TestCase):
         )
 
     def test_downgrade_drops_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         with patch.object(module.op, "drop_index") as drop_index:
             module.downgrade()

--- a/services/torghut/tests/test_paper_route_audit_bounded_read_indexes_migration.py
+++ b/services/torghut/tests/test_paper_route_audit_bounded_read_indexes_migration.py
@@ -1,36 +1,23 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0045_paper_route_audit_bounded_read_indexes.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0045", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0045")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0045_paper_route_audit_bounded_read_indexes.py"
 
 
 class TestPaperRouteAuditBoundedReadIndexesMigration(TestCase):
     def test_index_names_fit_postgres_identifier_limit(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         for index_name, _table_name, _columns in module._INDEXES:
             self.assertLessEqual(len(index_name), 63, index_name)
 
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(
             module.revision,
@@ -42,7 +29,7 @@ class TestPaperRouteAuditBoundedReadIndexesMigration(TestCase):
         )
 
     def test_upgrade_adds_source_proof_read_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.return_value = []
@@ -69,7 +56,7 @@ class TestPaperRouteAuditBoundedReadIndexesMigration(TestCase):
         )
 
     def test_downgrade_drops_source_proof_read_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.side_effect = [

--- a/services/torghut/tests/test_paper_route_source_activity_latest_index_migration.py
+++ b/services/torghut/tests/test_paper_route_source_activity_latest_index_migration.py
@@ -1,30 +1,17 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0051_paper_route_source_activity_latest_index.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0051", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0051")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0051_paper_route_source_activity_latest_index.py"
 
 
 class TestPaperRouteSourceActivityLatestIndexMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(
             module.revision,
@@ -36,12 +23,12 @@ class TestPaperRouteSourceActivityLatestIndexMigration(TestCase):
         )
 
     def test_index_name_fits_postgres_identifier_limit(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertLessEqual(len(module.INDEX_NAME), 63)
 
     def test_upgrade_adds_latest_source_activity_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.return_value = []
@@ -68,7 +55,7 @@ class TestPaperRouteSourceActivityLatestIndexMigration(TestCase):
         )
 
     def test_downgrade_drops_latest_source_activity_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.return_value = [{"name": module.INDEX_NAME}]

--- a/services/torghut/tests/test_proof_read_timeout_indexes_migration.py
+++ b/services/torghut/tests/test_proof_read_timeout_indexes_migration.py
@@ -1,30 +1,17 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0052_proof_read_timeout_indexes.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0052", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0052")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0052_proof_read_timeout_indexes.py"
 
 
 class TestProofReadTimeoutIndexesMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(module.revision, "0052_proof_read_timeout_indexes")
         self.assertEqual(
@@ -33,13 +20,13 @@ class TestProofReadTimeoutIndexesMigration(TestCase):
         )
 
     def test_index_names_fit_postgres_identifier_limit(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         for index_name, _table_name, _create_sql in module._INDEXES:
             self.assertLessEqual(len(index_name), 63, index_name)
 
     def test_upgrade_adds_concurrent_timeout_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = MagicMock()
         bind.dialect.name = "postgresql"
         inspector = MagicMock()
@@ -61,7 +48,7 @@ class TestProofReadTimeoutIndexesMigration(TestCase):
         self.assertIn("ix_trade_decisions_created_id", executed_sql)
 
     def test_downgrade_drops_concurrent_timeout_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = MagicMock()
         bind.dialect.name = "postgresql"
         inspector = MagicMock()

--- a/services/torghut/tests/test_runtime_ledger_status_index_migration.py
+++ b/services/torghut/tests/test_runtime_ledger_status_index_migration.py
@@ -1,36 +1,23 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 from unittest.mock import patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0041_runtime_ledger_status_index.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0041", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0041")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0041_runtime_ledger_status_index.py"
 
 
 class TestRuntimeLedgerStatusIndexMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(module.revision, "0041_runtime_ledger_status_index")
         self.assertEqual(module.down_revision, "0040_order_feed_fill_delta_basis")
 
     def test_upgrade_adds_hypothesis_ordering_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         with patch.object(module.op, "execute") as execute:
             module.upgrade()
@@ -47,7 +34,7 @@ class TestRuntimeLedgerStatusIndexMigration(TestCase):
         self.assertIn("created_at DESC", sql)
 
     def test_downgrade_drops_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         with patch.object(module.op, "execute") as execute:
             module.downgrade()

--- a/services/torghut/tests/test_status_read_timeout_indexes_migration.py
+++ b/services/torghut/tests/test_status_read_timeout_indexes_migration.py
@@ -1,30 +1,18 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0048_status_read_timeout_indexes.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0048", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0048")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0048_status_read_timeout_indexes.py"
 
 
 class TestStatusReadTimeoutIndexesMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(module.revision, "0048_status_read_timeout_indexes")
         self.assertEqual(
@@ -33,13 +21,13 @@ class TestStatusReadTimeoutIndexesMigration(TestCase):
         )
 
     def test_index_names_fit_postgres_identifier_limit(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         for index_name, _table_name, _create_sql in module._INDEXES:
             self.assertLessEqual(len(index_name), 63, index_name)
 
     def test_upgrade_adds_postgres_status_read_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True
@@ -61,7 +49,7 @@ class TestStatusReadTimeoutIndexesMigration(TestCase):
         self.assertIn("WHERE status = 'active'", sql)
 
     def test_upgrade_skips_non_postgres(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
 
         with (
@@ -73,7 +61,7 @@ class TestStatusReadTimeoutIndexesMigration(TestCase):
         execute.assert_not_called()
 
     def test_downgrade_drops_existing_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True

--- a/services/torghut/tests/test_status_readiness_bounded_read_indexes_migration.py
+++ b/services/torghut/tests/test_status_readiness_bounded_read_indexes_migration.py
@@ -1,30 +1,17 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0043_status_readiness_bounded_read_indexes.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0043", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0043")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0043_status_readiness_bounded_read_indexes.py"
 
 
 class TestStatusReadinessBoundedReadIndexesMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(module.revision, "0043_status_readiness_bounded_read_indexes")
         self.assertEqual(
@@ -32,7 +19,7 @@ class TestStatusReadinessBoundedReadIndexesMigration(TestCase):
         )
 
     def test_upgrade_adds_bounded_status_read_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.return_value = []
@@ -60,7 +47,7 @@ class TestStatusReadinessBoundedReadIndexesMigration(TestCase):
         )
 
     def test_downgrade_drops_existing_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         inspector = MagicMock()
         inspector.has_table.return_value = True
         inspector.get_indexes.return_value = [

--- a/services/torghut/tests/test_strategy_hypothesis_governance_migration.py
+++ b/services/torghut/tests/test_strategy_hypothesis_governance_migration.py
@@ -1,24 +1,11 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
 from unittest import TestCase
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0021_strategy_hypothesis_governance.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0021", path)
-    if spec is None or spec.loader is None:  # pragma: no cover - importlib guard
-        raise AssertionError("failed_to_load_migration_0021")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0021_strategy_hypothesis_governance.py"
 
 
 class _FakeInspector:
@@ -66,7 +53,7 @@ class _FakeOp:
 
 class TestStrategyHypothesisGovernanceMigration(TestCase):
     def test_upgrade_skips_existing_tables_and_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         fake_op = _FakeOp()
         fake_inspector = _FakeInspector(
             {
@@ -111,7 +98,7 @@ class TestStrategyHypothesisGovernanceMigration(TestCase):
         self.assertEqual(fake_op.create_index_calls, [])
 
     def test_downgrade_skips_absent_tables_and_indexes(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         fake_op = _FakeOp()
         fake_inspector = _FakeInspector({})
         original_op = module.op

--- a/services/torghut/tests/test_tigerbeetle_reconciliation_compact_status_migration.py
+++ b/services/torghut/tests/test_tigerbeetle_reconciliation_compact_status_migration.py
@@ -1,30 +1,18 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0050_tigerbeetle_reconciliation_compact_status.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0050", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0050")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0050_tigerbeetle_reconciliation_compact_status.py"
 
 
 class TestTigerBeetleReconciliationCompactStatusMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(
             module.revision,
@@ -36,7 +24,7 @@ class TestTigerBeetleReconciliationCompactStatusMigration(TestCase):
         )
 
     def test_upgrade_adds_compact_status_columns(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True
@@ -59,7 +47,7 @@ class TestTigerBeetleReconciliationCompactStatusMigration(TestCase):
         )
 
     def test_upgrade_skips_existing_compact_status_columns(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True
@@ -82,7 +70,7 @@ class TestTigerBeetleReconciliationCompactStatusMigration(TestCase):
         add_column.assert_not_called()
 
     def test_downgrade_drops_compact_status_columns(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True

--- a/services/torghut/tests/test_tigerbeetle_reconciliation_status_lookup_migration.py
+++ b/services/torghut/tests/test_tigerbeetle_reconciliation_status_lookup_migration.py
@@ -1,30 +1,18 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from tests.migration_testing import load_migration_module
 
-def _load_migration_module() -> ModuleType:
-    path = (
-        Path(__file__).resolve().parents[1]
-        / "migrations"
-        / "versions"
-        / "0049_tigerbeetle_reconciliation_status_lookup.py"
-    )
-    spec = importlib.util.spec_from_file_location("torghut_migration_0049", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError("failed_to_load_migration_0049")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+
+MIGRATION_FILENAME = "0049_tigerbeetle_reconciliation_status_lookup.py"
 
 
 class TestTigerBeetleReconciliationStatusLookupMigration(TestCase):
     def test_revision_follows_current_head(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertEqual(
             module.revision,
@@ -33,12 +21,12 @@ class TestTigerBeetleReconciliationStatusLookupMigration(TestCase):
         self.assertEqual(module.down_revision, "0048_status_read_timeout_indexes")
 
     def test_index_name_fits_postgres_identifier_limit(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
 
         self.assertLessEqual(len(module.INDEX_NAME), 63)
 
     def test_upgrade_adds_reconciliation_status_lookup_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True
@@ -56,7 +44,7 @@ class TestTigerBeetleReconciliationStatusLookupMigration(TestCase):
         self.assertIn("started_at DESC", sql)
 
     def test_upgrade_skips_non_postgres(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
 
         with (
@@ -68,7 +56,7 @@ class TestTigerBeetleReconciliationStatusLookupMigration(TestCase):
         execute.assert_not_called()
 
     def test_downgrade_drops_index(self) -> None:
-        module = _load_migration_module()
+        module = load_migration_module(MIGRATION_FILENAME)
         bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
         inspector = MagicMock()
         inspector.has_table.return_value = True


### PR DESCRIPTION
## Summary

- Added a shared `tests.migration_testing.load_migration_module` helper for Alembic revision modules.
- Replaced 13 repeated migration-test `importlib`/`ModuleType` loader blocks with `MIGRATION_FILENAME` constants and the shared helper.
- Kept the existing migration revision, upgrade, and downgrade assertions intact while removing duplicated dynamic loader boilerplate.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/*migration*.py`
- `uv run --frozen ruff check tests/migration_testing.py tests/*migration*.py`
- `uv run --frozen ruff format --check tests/migration_testing.py tests/*migration*.py`
- `uv run --frozen python -m compileall -q tests/migration_testing.py tests/test_*migration*.py`
- `uv run --frozen python scripts/pylint_torghut_quality.py --diff --base-ref origin/main`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `git diff --check`
- `git diff --cached --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
