### PR TITLE
fix(torghut): isolate scheduler cursor commits

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline/run_cycle.py
+++ b/services/torghut/app/trading/scheduler/pipeline/run_cycle.py
@@ -123,6 +123,10 @@ class TradingPipelineRunCycleMixin(TradingPipelineBase):
         self._session_context_warmup_day: date | None = None
         self._runtime_window_account_snapshot_day: date | None = None
 
+    def _commit_signal_cursor(self, batch: SignalBatch) -> None:
+        with self.session_factory() as cursor_session:
+            self.ingestor.commit_cursor(cursor_session, batch)
+
     def run_once(self) -> None:
         self._label_mature_rejected_signal_outcome_events()
         with self.session_factory() as session:
@@ -142,7 +146,7 @@ class TradingPipelineRunCycleMixin(TradingPipelineBase):
                     return
             context = self._build_run_context(session)
             if context is None:
-                self.ingestor.commit_cursor(session, batch)
+                self._commit_signal_cursor(batch)
                 return
             account_snapshot, account, positions, allowed_symbols = context
             quality_signals = self._quality_gate_signals(
@@ -167,7 +171,7 @@ class TradingPipelineRunCycleMixin(TradingPipelineBase):
                     allowed_symbols=allowed_symbols,
                 )
             )
-            self.ingestor.commit_cursor(session, batch)
+            self._commit_signal_cursor(batch)
 
     def _prepare_run_once(self, session: Session) -> list[Strategy]:
         self._ingest_order_feed(session)

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -239,7 +239,7 @@ class SimpleTradingPipeline(
                 return
             context = self._build_run_context(session)
             if context is None:
-                self.ingestor.commit_cursor(session, batch)
+                self._commit_signal_cursor(batch)
                 return
             account_snapshot, account, positions, allowed_symbols = context
             self._process_paper_route_probe_exit_decisions(
@@ -271,7 +271,7 @@ class SimpleTradingPipeline(
                     "paper-route evidence collection owns account=%s",
                     self.account_label,
                 )
-                self.ingestor.commit_cursor(session, batch)
+                self._commit_signal_cursor(batch)
                 return
             quality_signals = self._quality_gate_signals(
                 signals=batch.signals,
@@ -300,7 +300,7 @@ class SimpleTradingPipeline(
                 positions=positions,
                 allowed_symbols=allowed_symbols,
             )
-            self.ingestor.commit_cursor(session, batch)
+            self._commit_signal_cursor(batch)
 
     def _fetch_signal_batch(
         self,

--- a/services/torghut/tests/pipeline/test_trading_pipeline_cursor_commit.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_cursor_commit.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from tests.pipeline.trading_pipeline_base import (
+    Decimal,
+    DecisionEngine,
+    FakeAlpacaClient,
+    FakeIngestor,
+    OrderExecutor,
+    OrderFirewall,
+    Reconciler,
+    RiskEngine,
+    Session,
+    SignalBatch,
+    SignalEnvelope,
+    SimpleTradingPipeline,
+    Strategy,
+    TradingPipeline,
+    TradingPipelineTestCaseBase,
+    TradingState,
+    UniverseResolver,
+    datetime,
+    patch,
+    timezone,
+)
+
+
+class SessionRecordingIngestor(FakeIngestor):
+    def __init__(self, signals: list[SignalEnvelope]) -> None:
+        super().__init__(signals)
+        self.fetch_session_id: int | None = None
+        self.commit_session_ids: list[int] = []
+
+    def fetch_signals(
+        self,
+        session: Session,
+        *,
+        symbols: set[str] | None = None,
+        timeframes: set[str] | None = None,
+    ) -> SignalBatch:
+        self.fetch_session_id = id(session)
+        return super().fetch_signals(
+            session,
+            symbols=symbols,
+            timeframes=timeframes,
+        )
+
+    def commit_cursor(self, session: Session, batch: SignalBatch) -> None:
+        self.commit_session_ids.append(id(session))
+        super().commit_cursor(session, batch)
+
+
+class TestTradingPipelineCursorCommit(TradingPipelineTestCaseBase):
+    def test_simple_pipeline_commits_cursor_with_fresh_session(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 6, 18, 15, 0, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 6, 18, 15, 0, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            seq=1,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+        ingestor = SessionRecordingIngestor([signal])
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=ingestor,
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        strategy = Strategy(
+            name="demo",
+            description="cursor commit session isolation",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+
+        with (
+            patch.object(pipeline, "_label_mature_rejected_signal_outcome_events"),
+            patch.object(pipeline, "_prepare_run_once", return_value=[strategy]),
+            patch.object(pipeline, "_capture_runtime_window_account_snapshot_if_due"),
+            patch.object(pipeline, "_warm_session_context_from_open"),
+            patch.object(
+                pipeline, "_bounded_paper_route_signal_scope", return_value=None
+            ),
+            patch.object(pipeline, "_build_run_context", return_value=None),
+        ):
+            pipeline.run_once()
+
+        self.assertIsNotNone(ingestor.fetch_session_id)
+        self.assertEqual(ingestor.committed_batches, 1)
+        self.assertEqual(len(ingestor.commit_session_ids), 1)
+        self.assertNotEqual(ingestor.fetch_session_id, ingestor.commit_session_ids[0])
+
+    def test_full_pipeline_commits_cursor_with_fresh_session_when_context_missing(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 6, 18, 15, 1, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 6, 18, 15, 1, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            seq=2,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+        ingestor = SessionRecordingIngestor([signal])
+        pipeline = TradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=ingestor,
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        strategy = Strategy(
+            name="demo",
+            description="cursor commit session isolation",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+
+        with (
+            patch.object(pipeline, "_label_mature_rejected_signal_outcome_events"),
+            patch.object(pipeline, "_prepare_run_once", return_value=[strategy]),
+            patch.object(pipeline, "_capture_runtime_window_account_snapshot_if_due"),
+            patch.object(pipeline, "_warm_session_context_from_open"),
+            patch.object(pipeline, "_build_run_context", return_value=None),
+        ):
+            pipeline.run_once()
+
+        self.assertIsNotNone(ingestor.fetch_session_id)
+        self.assertEqual(ingestor.committed_batches, 1)
+        self.assertEqual(len(ingestor.commit_session_ids), 1)
+        self.assertNotEqual(ingestor.fetch_session_id, ingestor.commit_session_ids[0])


### PR DESCRIPTION
## Summary

- Isolates scheduler cursor persistence into a fresh short SQLAlchemy session.
- Updates both the standard and simple Torghut scheduler loops to avoid reusing long-lived decision sessions for `trade_cursor` writes.
- Adds a regression test proving `SimpleTradingPipeline.run_once()` commits cursor state with a different session than signal fetch/decision orchestration.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_cursor_commit.py -q`
- `uv run --frozen pytest tests/test_simple_risk.py -q`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_probe_exits_a.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_cursor_commit.py tests/test_simple_risk.py tests/pipeline/test_trading_pipeline_probe_exits_a.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q`
- `uv run --frozen ruff format --check app/trading/scheduler/pipeline/run_cycle.py app/trading/scheduler/simple_pipeline.py tests/pipeline/test_trading_pipeline_cursor_commit.py`
- `uv run --frozen ruff check app/trading/scheduler/pipeline/run_cycle.py app/trading/scheduler/simple_pipeline.py tests/pipeline/test_trading_pipeline_cursor_commit.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/scheduler/pipeline/run_cycle.py app/trading/scheduler/simple_pipeline.py tests/pipeline/test_trading_pipeline_cursor_commit.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
