### PR TITLE
refactor(torghut): remove raw payload internals

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -322,11 +322,15 @@ class TorghutAlpacaClient:
             if isinstance(raw, Mapping):
                 return cast(Mapping[object, Any], raw)
             raise TypeError(f"Unsupported model_dump payload type: {type(raw)}")
-        if hasattr(model, "__dict__"):
-            return {k: v for k, v in model.__dict__.items() if not k.startswith("_")}
         if isinstance(model, Mapping):
             return cast(Mapping[object, Any], model)
-        raise TypeError(f"Unsupported model type: {type(model)}")
+        try:
+            raw_vars = cast(Mapping[str, Any], vars(model))
+        except TypeError as exc:
+            raise TypeError(f"Unsupported model type: {type(model)}") from exc
+        return {
+            key: value for key, value in raw_vars.items() if not key.startswith("_")
+        }
 
     @staticmethod
     def _parse_timeframe(value: str) -> TimeFrame:

--- a/services/torghut/app/api/trading_misc/shared_context.py
+++ b/services/torghut/app/api/trading_misc/shared_context.py
@@ -840,7 +840,7 @@ def trading_metrics(session: Session = Depends(get_session)) -> dict[str, object
         hypothesis_summary=hypothesis_summary,
     )
     return {
-        "metrics": metrics.__dict__,
+        "metrics": metrics.to_payload(),
         "build": {
             "version": BUILD_VERSION,
             "commit": main_runtime_value("BUILD_COMMIT"),

--- a/services/torghut/app/api/trading_misc/trading_autonomy.py
+++ b/services/torghut/app/api/trading_misc/trading_autonomy.py
@@ -697,7 +697,7 @@ def prometheus_metrics(session: Session = Depends(get_session)) -> Response:
     )
     payload = render_trading_metrics(
         {
-            **metrics.__dict__,
+            **metrics.to_payload(),
             "tca_summary": tca_summary,
             "route_provenance": _load_route_provenance_summary(session),
             "hypothesis_state_total": hypothesis_summary.get("state_totals", {}),

--- a/services/torghut/app/api/trading_status.py
+++ b/services/torghut/app/api/trading_status.py
@@ -747,7 +747,7 @@ def trading_status() -> dict[str, object]:
             "event_total": dict(state.metrics.domain_telemetry_event_total),
             "dropped_total": dict(state.metrics.domain_telemetry_dropped_total),
         },
-        "metrics": state.metrics.__dict__,
+        "metrics": state.metrics.to_payload(),
         "llm": scheduler.llm_status(),
         "llm_evaluation": llm_evaluation,
         "tca": tca_summary,

--- a/services/torghut/app/logging_config.py
+++ b/services/torghut/app/logging_config.py
@@ -100,7 +100,7 @@ class JsonFormatter(logging.Formatter):
         }
         extras = {
             key: value
-            for key, value in record.__dict__.items()
+            for key, value in vars(record).items()
             if key not in _STANDARD_RECORD_FIELDS and not key.startswith("_")
         }
         if extras:

--- a/services/torghut/app/trading/runtime_ledger_proof_policy.py
+++ b/services/torghut/app/trading/runtime_ledger_proof_policy.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from decimal import Decimal, InvalidOperation
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 
 RuntimeLedgerProofMode = Literal["smoke", "probation", "authority"]
@@ -240,7 +240,7 @@ def runtime_ledger_proof_policy_from_env(
     environ: Mapping[str, str] | None = None,
 ) -> RuntimeLedgerProofPolicy:
     source = os.environ if environ is None else environ
-    values = DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.__dict__.copy()
+    values: dict[str, Any] = asdict(DEFAULT_RUNTIME_LEDGER_PROOF_POLICY)
     raw_mode = source.get("TORGHUT_RUNTIME_LEDGER_PROOF_MODE")
     if raw_mode is not None and raw_mode.strip():
         values["proof_mode"] = normalize_runtime_ledger_proof_mode(raw_mode)

--- a/services/torghut/app/trading/scheduler/state/metrics.py
+++ b/services/torghut/app/trading/scheduler/state/metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, Optional, cast
 
@@ -603,7 +603,8 @@ class _TradingMetricsMethods(TradingMetricsFields):
 
 @dataclass
 class TradingMetrics(_TradingMetricsMethods):
-    pass
+    def to_payload(self) -> dict[str, object]:
+        return cast(dict[str, object], asdict(self))
 
 
 @dataclass

--- a/services/torghut/scripts/backtest_tsmom_stooq.py
+++ b/services/torghut/scripts/backtest_tsmom_stooq.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import asdict
 from datetime import date
 from typing import Optional
 
@@ -97,7 +98,7 @@ def main() -> int:
 
     config_payload = {
         key: (value.isoformat() if isinstance(value, date) else value)
-        for key, value in cfg.__dict__.items()
+        for key, value in asdict(cfg).items()
     }
     payload = {
         "config": config_payload,

--- a/services/torghut/tests/execution_policy/support.py
+++ b/services/torghut/tests/execution_policy/support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 
+from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal
 from unittest import TestCase
@@ -25,7 +26,7 @@ def _config(**overrides: object) -> ExecutionPolicyConfig:
         backoff_multiplier=2.0,
         backoff_max_seconds=1.0,
     )
-    return ExecutionPolicyConfig(**{**base.__dict__, **overrides})
+    return replace(base, **overrides)
 
 
 def _decision(

--- a/services/torghut/tests/runtime_closure/test_bundle_generation_and_replay.py
+++ b/services/torghut/tests/runtime_closure/test_bundle_generation_and_replay.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from tests.runtime_closure.support import (
     json,
     subprocess,
@@ -10,7 +12,6 @@ from tests.runtime_closure.support import (
     runtime_closure,
     runtime_closure_replay_analysis,
     RuntimeClosurePolicy,
-    StrategyAutoresearchProgram,
     StrategyObjective,
     build_mlx_snapshot_manifest,
     PORTFOLIO_CANDIDATE_SCHEMA_VERSION,
@@ -352,32 +353,29 @@ data:
                 + "\n",
                 encoding="utf-8",
             )
-            program = _program()
-            program = StrategyAutoresearchProgram(
-                **{
-                    **program.__dict__,
-                    "objective": StrategyObjective(
-                        target_net_pnl_per_day=Decimal("500"),
-                        min_active_day_ratio=Decimal("1.0"),
-                        min_positive_day_ratio=Decimal("0.6"),
-                        min_daily_notional=Decimal("300000"),
-                        max_best_day_share=Decimal("0.3"),
-                        max_worst_day_loss=Decimal("350"),
-                        max_drawdown=Decimal("900"),
-                        require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal("0"),
-                        stop_when_objective_met=True,
-                    ),
-                    "runtime_closure_policy": RuntimeClosurePolicy(
-                        enabled=True,
-                        execute_parity_replay=True,
-                        execute_approval_replay=True,
-                        parity_window="full_window",
-                        approval_window="holdout",
-                        shadow_validation_mode="require_live_evidence",
-                        promotion_target="shadow",
-                    ),
-                }
+            program = replace(
+                _program(),
+                objective=StrategyObjective(
+                    target_net_pnl_per_day=Decimal("500"),
+                    min_active_day_ratio=Decimal("1.0"),
+                    min_positive_day_ratio=Decimal("0.6"),
+                    min_daily_notional=Decimal("300000"),
+                    max_best_day_share=Decimal("0.3"),
+                    max_worst_day_loss=Decimal("350"),
+                    max_drawdown=Decimal("900"),
+                    require_every_day_active=True,
+                    min_regime_slice_pass_rate=Decimal("0"),
+                    stop_when_objective_met=True,
+                ),
+                runtime_closure_policy=RuntimeClosurePolicy(
+                    enabled=True,
+                    execute_parity_replay=True,
+                    execute_approval_replay=True,
+                    parity_window="full_window",
+                    approval_window="holdout",
+                    shadow_validation_mode="require_live_evidence",
+                    promotion_target="shadow",
+                ),
             )
             best_candidate = {
                 "candidate_id": "cand-1",

--- a/services/torghut/tests/runtime_closure/test_execution_stress_gates.py
+++ b/services/torghut/tests/runtime_closure/test_execution_stress_gates.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from tests.runtime_closure.support import (
     Decimal,
     Path,
     TemporaryDirectory,
     runtime_closure,
     RuntimeClosurePolicy,
-    StrategyAutoresearchProgram,
     StrategyObjective,
     build_mlx_snapshot_manifest,
     RuntimeClosureExecutionContext,
@@ -427,19 +428,17 @@ data:
                 + "\n",
                 encoding="utf-8",
             )
-            program = StrategyAutoresearchProgram(
-                **{
-                    **_program().__dict__,
-                    "runtime_closure_policy": RuntimeClosurePolicy(
-                        enabled=True,
-                        execute_parity_replay=False,
-                        execute_approval_replay=False,
-                        parity_window="full_window",
-                        approval_window="holdout",
-                        shadow_validation_mode="skip",
-                        promotion_target="shadow",
-                    ),
-                }
+            program = replace(
+                _program(),
+                runtime_closure_policy=RuntimeClosurePolicy(
+                    enabled=True,
+                    execute_parity_replay=False,
+                    execute_approval_replay=False,
+                    parity_window="full_window",
+                    approval_window="holdout",
+                    shadow_validation_mode="skip",
+                    promotion_target="shadow",
+                ),
             )
             best_candidate = {
                 "candidate_id": "cand-1",
@@ -519,31 +518,29 @@ data:
                 + "\n",
                 encoding="utf-8",
             )
-            program = StrategyAutoresearchProgram(
-                **{
-                    **_program().__dict__,
-                    "objective": StrategyObjective(
-                        target_net_pnl_per_day=Decimal("500"),
-                        min_active_day_ratio=Decimal("1.0"),
-                        min_positive_day_ratio=Decimal("0.6"),
-                        min_daily_notional=Decimal("300000"),
-                        max_best_day_share=Decimal("0.3"),
-                        max_worst_day_loss=Decimal("350"),
-                        max_drawdown=Decimal("900"),
-                        require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal("0"),
-                        stop_when_objective_met=True,
-                    ),
-                    "runtime_closure_policy": RuntimeClosurePolicy(
-                        enabled=True,
-                        execute_parity_replay=True,
-                        execute_approval_replay=True,
-                        parity_window="full_window",
-                        approval_window="holdout",
-                        shadow_validation_mode="skip",
-                        promotion_target="shadow",
-                    ),
-                }
+            program = replace(
+                _program(),
+                objective=StrategyObjective(
+                    target_net_pnl_per_day=Decimal("500"),
+                    min_active_day_ratio=Decimal("1.0"),
+                    min_positive_day_ratio=Decimal("0.6"),
+                    min_daily_notional=Decimal("300000"),
+                    max_best_day_share=Decimal("0.3"),
+                    max_worst_day_loss=Decimal("350"),
+                    max_drawdown=Decimal("900"),
+                    require_every_day_active=True,
+                    min_regime_slice_pass_rate=Decimal("0"),
+                    stop_when_objective_met=True,
+                ),
+                runtime_closure_policy=RuntimeClosurePolicy(
+                    enabled=True,
+                    execute_parity_replay=True,
+                    execute_approval_replay=True,
+                    parity_window="full_window",
+                    approval_window="holdout",
+                    shadow_validation_mode="skip",
+                    promotion_target="shadow",
+                ),
             )
             best_candidate = {
                 "candidate_id": "cand-1",

--- a/services/torghut/tests/runtime_closure/test_shadow_artifacts.py
+++ b/services/torghut/tests/runtime_closure/test_shadow_artifacts.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from tests.runtime_closure.support import (
     json,
     Decimal,
     Path,
     TemporaryDirectory,
     RuntimeClosurePolicy,
-    StrategyAutoresearchProgram,
     StrategyObjective,
     build_mlx_snapshot_manifest,
     RuntimeClosureExecutionContext,
@@ -64,31 +65,29 @@ data:
                 + "\n",
                 encoding="utf-8",
             )
-            program = StrategyAutoresearchProgram(
-                **{
-                    **_program().__dict__,
-                    "objective": StrategyObjective(
-                        target_net_pnl_per_day=Decimal("500"),
-                        min_active_day_ratio=Decimal("1.0"),
-                        min_positive_day_ratio=Decimal("0.6"),
-                        min_daily_notional=Decimal("300000"),
-                        max_best_day_share=Decimal("0.3"),
-                        max_worst_day_loss=Decimal("350"),
-                        max_drawdown=Decimal("900"),
-                        require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal("0"),
-                        stop_when_objective_met=True,
-                    ),
-                    "runtime_closure_policy": RuntimeClosurePolicy(
-                        enabled=True,
-                        execute_parity_replay=True,
-                        execute_approval_replay=True,
-                        parity_window="full_window",
-                        approval_window="holdout",
-                        shadow_validation_mode="require_live_evidence",
-                        promotion_target="shadow",
-                    ),
-                }
+            program = replace(
+                _program(),
+                objective=StrategyObjective(
+                    target_net_pnl_per_day=Decimal("500"),
+                    min_active_day_ratio=Decimal("1.0"),
+                    min_positive_day_ratio=Decimal("0.6"),
+                    min_daily_notional=Decimal("300000"),
+                    max_best_day_share=Decimal("0.3"),
+                    max_worst_day_loss=Decimal("350"),
+                    max_drawdown=Decimal("900"),
+                    require_every_day_active=True,
+                    min_regime_slice_pass_rate=Decimal("0"),
+                    stop_when_objective_met=True,
+                ),
+                runtime_closure_policy=RuntimeClosurePolicy(
+                    enabled=True,
+                    execute_parity_replay=True,
+                    execute_approval_replay=True,
+                    parity_window="full_window",
+                    approval_window="holdout",
+                    shadow_validation_mode="require_live_evidence",
+                    promotion_target="shadow",
+                ),
             )
             best_candidate = {
                 "candidate_id": "cand-1",
@@ -234,31 +233,29 @@ data:
                 + "\n",
                 encoding="utf-8",
             )
-            program = StrategyAutoresearchProgram(
-                **{
-                    **_program().__dict__,
-                    "objective": StrategyObjective(
-                        target_net_pnl_per_day=Decimal("500"),
-                        min_active_day_ratio=Decimal("1.0"),
-                        min_positive_day_ratio=Decimal("0.6"),
-                        min_daily_notional=Decimal("300000"),
-                        max_best_day_share=Decimal("0.3"),
-                        max_worst_day_loss=Decimal("350"),
-                        max_drawdown=Decimal("900"),
-                        require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal("0"),
-                        stop_when_objective_met=True,
-                    ),
-                    "runtime_closure_policy": RuntimeClosurePolicy(
-                        enabled=True,
-                        execute_parity_replay=True,
-                        execute_approval_replay=True,
-                        parity_window="full_window",
-                        approval_window="holdout",
-                        shadow_validation_mode="require_live_evidence",
-                        promotion_target="shadow",
-                    ),
-                }
+            program = replace(
+                _program(),
+                objective=StrategyObjective(
+                    target_net_pnl_per_day=Decimal("500"),
+                    min_active_day_ratio=Decimal("1.0"),
+                    min_positive_day_ratio=Decimal("0.6"),
+                    min_daily_notional=Decimal("300000"),
+                    max_best_day_share=Decimal("0.3"),
+                    max_worst_day_loss=Decimal("350"),
+                    max_drawdown=Decimal("900"),
+                    require_every_day_active=True,
+                    min_regime_slice_pass_rate=Decimal("0"),
+                    stop_when_objective_met=True,
+                ),
+                runtime_closure_policy=RuntimeClosurePolicy(
+                    enabled=True,
+                    execute_parity_replay=True,
+                    execute_approval_replay=True,
+                    parity_window="full_window",
+                    approval_window="holdout",
+                    shadow_validation_mode="require_live_evidence",
+                    promotion_target="shadow",
+                ),
             )
             best_candidate = {
                 "candidate_id": "cand-1",

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -22,6 +22,13 @@ class DummyModel:
         return self._data
 
 
+class AttributeOnlyModel:
+    def __init__(self) -> None:
+        self.equity = "12000"
+        self.cash = "3000"
+        self._internal_cache = "hidden"
+
+
 class DummyTradingClient:
     def __init__(self) -> None:
         self.cancelled: list[str] = []
@@ -115,6 +122,43 @@ class TestAlpacaClient(TestCase):
 
         cancelled = firewall.cancel_all_orders()
         self.assertEqual(len(cancelled), 2)
+
+    def test_attribute_only_model_payload_uses_public_vars(self) -> None:
+        class AttributeOnlyTradingClient(DummyTradingClient):
+            def get_account(self) -> AttributeOnlyModel:
+                return AttributeOnlyModel()
+
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=AttributeOnlyTradingClient(),
+            data_client=DummyDataClient(),
+        )
+
+        self.assertEqual(
+            client.get_account(),
+            {
+                "cash": "3000",
+                "equity": "12000",
+            },
+        )
+
+    def test_unsupported_model_payload_raises_type_error(self) -> None:
+        class UnsupportedAccountTradingClient(DummyTradingClient):
+            def get_account(self) -> object:
+                return object()
+
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=UnsupportedAccountTradingClient(),
+            data_client=DummyDataClient(),
+        )
+
+        with self.assertRaisesRegex(TypeError, "Unsupported model type"):
+            client.get_account()
 
     def test_get_order_by_client_order_id_falls_back_to_client_id(self) -> None:
         class TradingClientWithClientId(DummyTradingClient):

--- a/services/torghut/tests/test_backtest_tsmom_stooq.py
+++ b/services/torghut/tests/test_backtest_tsmom_stooq.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from app.trading.alpha.tsmom import TSMOMConfig
+from scripts import backtest_tsmom_stooq as cli
+
+
+def test_main_serializes_config_from_dataclass_payload(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    output_path = tmp_path / "summary.json"
+    index = pd.to_datetime(["2026-01-01", "2026-01-02"])
+
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda: argparse.Namespace(
+            symbols="spy.us",
+            start="2026-01-01",
+            end="2026-01-02",
+            lookback=3,
+            vol_lookback=2,
+            target_vol=0.02,
+            max_gross=1.5,
+            allow_shorts=True,
+            cost_bps=7.5,
+            json=str(output_path),
+            csv=None,
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "fetch_stooq_daily",
+        lambda *_args, **_kwargs: argparse.Namespace(
+            close=pd.Series([100.0, 101.0], index=index)
+        ),
+    )
+
+    def fake_backtest(
+        prices: pd.DataFrame, config: TSMOMConfig
+    ) -> tuple[pd.Series, pd.DataFrame]:
+        assert list(prices.columns) == ["spy.us"]
+        assert config.start is not None
+        assert config.end is not None
+        return (
+            pd.Series([1.0, 1.1], index=index, name="equity"),
+            pd.DataFrame(index=index),
+        )
+
+    monkeypatch.setattr(cli, "backtest_tsmom", fake_backtest)
+    monkeypatch.setattr(cli, "summarize_equity_curve", lambda _equity: {"sharpe": 1})
+    monkeypatch.setattr(cli, "to_jsonable", lambda summary: summary)
+
+    assert cli.main() == 0
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["config"] == {
+        "cost_bps_per_turnover": 7.5,
+        "end": "2026-01-02",
+        "long_only": False,
+        "lookback_days": 3,
+        "max_gross_leverage": 1.5,
+        "start": "2026-01-01",
+        "target_daily_vol": 0.02,
+        "vol_lookback_days": 2,
+    }
+    assert payload["summary"] == {"sharpe": 1}

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import cast
 from unittest import TestCase
 
 from app.metrics import render_trading_metrics
@@ -9,13 +10,23 @@ from app.trading.strategy_runtime import RuntimeObservation
 
 
 class TestTradingMetrics(TestCase):
+    def test_metrics_payload_is_detached_from_mutable_state(self) -> None:
+        metrics = TradingMetrics()
+        metrics.no_signal_reason_total["cursor_ahead_of_stream"] = 1
+
+        payload = metrics.to_payload()
+        reason_total = cast(dict[str, int], payload["no_signal_reason_total"])
+        reason_total["cursor_ahead_of_stream"] = 9
+
+        self.assertEqual(metrics.no_signal_reason_total["cursor_ahead_of_stream"], 1)
+
     def test_no_signal_reason_and_streak_are_exported(self) -> None:
         metrics = TradingMetrics()
         metrics.record_no_signal("cursor_ahead_of_stream")
         metrics.no_signal_streak = 2
         metrics.no_signal_reason_streak["cursor_ahead_of_stream"] = 1
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_no_signal_reason_total{reason="cursor_ahead_of_stream"} 1',
@@ -36,7 +47,7 @@ class TestTradingMetrics(TestCase):
         metrics.record_signal_staleness_alert("empty_batch_advanced")
         metrics.signal_lag_seconds = 61
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_signal_staleness_alert_total{reason="empty_batch_advanced"} 1',
@@ -66,7 +77,7 @@ class TestTradingMetrics(TestCase):
         metrics.market_session_open = 0
         metrics.signal_continuity_actionable = 1
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_signal_expected_staleness_total{reason="no_signals_in_window"} 1',
@@ -126,7 +137,7 @@ class TestTradingMetrics(TestCase):
         metrics.llm_escalate_total = 1
         metrics.llm_policy_fallback_total = 2
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_llm_market_context_reason_total{reason="market_context_domain_error"} 1',
@@ -166,7 +177,7 @@ class TestTradingMetrics(TestCase):
 
         payload = render_trading_metrics(
             {
-                **metrics.__dict__,
+                **metrics.to_payload(),
                 "hypothesis_state_total": {"blocked": 1, "shadow": 2},
                 "hypothesis_capital_stage_total": {"shadow": 3},
                 "alpha_readiness_hypotheses_total": 3,
@@ -206,7 +217,7 @@ class TestTradingMetrics(TestCase):
         )
         metrics.record_rejected_signal_event("missing_executable_quote")
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_decision_reject_reason_total{reason="qty_below_min"} 1',
@@ -234,7 +245,7 @@ class TestTradingMetrics(TestCase):
         metrics.record_decision_state("blocked")
         metrics.observe_planned_decision_age(17)
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_submission_block_total{reason="capital_stage_shadow"} 1',
@@ -268,7 +279,7 @@ class TestTradingMetrics(TestCase):
             deterministic_veto=True,
         )
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_llm_committee_requests_total{role="risk_critic"} 1',
@@ -291,7 +302,7 @@ class TestTradingMetrics(TestCase):
         metrics.order_feed_events_persisted_total = 2
         metrics.order_feed_duplicates_total = 1
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn("torghut_trading_order_feed_messages_total 3", payload)
         self.assertIn("torghut_trading_order_feed_events_persisted_total 2", payload)
@@ -304,7 +315,7 @@ class TestTradingMetrics(TestCase):
         metrics.execution_advisor_fallback_total["advisor_timeout"] = 1
         metrics.execution_advisor_fallback_total["advisor_state_stale"] = 4
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_execution_advisor_usage_total{status="applied"} 2',
@@ -329,7 +340,7 @@ class TestTradingMetrics(TestCase):
         metrics.domain_telemetry_event_total["torghut.execution.submitted"] = 2
         metrics.domain_telemetry_dropped_total["disabled"] = 5
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_domain_telemetry_event_total{event="torghut.decision.generated"} 3',
@@ -348,7 +359,7 @@ class TestTradingMetrics(TestCase):
         metrics = TradingMetrics()
         payload = render_trading_metrics(
             {
-                **metrics.__dict__,
+                **metrics.to_payload(),
                 "tca_summary": {
                     "order_count": 3,
                     "avg_slippage_bps": 12.5,
@@ -399,7 +410,7 @@ class TestTradingMetrics(TestCase):
         metrics.record_lean_strategy_shadow("pass")
         metrics.record_lean_canary_breach("fallback_ratio_exceeded")
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_lean_request_total{operation="submit_order"} 4',
@@ -436,7 +447,7 @@ class TestTradingMetrics(TestCase):
         metrics = TradingMetrics()
         payload = render_trading_metrics(
             {
-                **metrics.__dict__,
+                **metrics.to_payload(),
                 "allocator_multiplier_total": {
                     "vol=high|trend=up|liq=tight|stress|0.75": 3
                 },
@@ -451,7 +462,7 @@ class TestTradingMetrics(TestCase):
         metrics = TradingMetrics()
         payload = render_trading_metrics(
             {
-                **metrics.__dict__,
+                **metrics.to_payload(),
                 "route_provenance": {
                     "total": 25,
                     "missing": 1,
@@ -482,7 +493,7 @@ class TestTradingMetrics(TestCase):
         metrics.strategy_runtime_isolated_failures_total = 1
         metrics.strategy_runtime_fallback_total = 2
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_strategy_events_total{strategy_id="legacy-1"} 5', payload
@@ -513,7 +524,7 @@ class TestTradingMetrics(TestCase):
         metrics.forecast_calibration_error["chronos|AAPL|1m"] = "0.07"
         metrics.forecast_route_selection_total["chronos|AAPL|1m|trend"] = 5
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_forecast_router_inference_latency_ms{model_family="chronos"} 98',
@@ -573,7 +584,7 @@ class TestTradingMetrics(TestCase):
         metrics.feature_duplicate_ratio = 0.2
         metrics.feature_schema_mismatch_total = 2
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn('torghut_trading_feature_null_rate{field="price"} 0.5', payload)
         self.assertIn("torghut_trading_feature_staleness_ms_p95 1234", payload)
@@ -588,7 +599,7 @@ class TestTradingMetrics(TestCase):
         metrics.evidence_continuity_last_success_ts_seconds = 1700000100
         metrics.evidence_continuity_last_failed_runs = 2
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn("torghut_trading_evidence_continuity_checks_total 3", payload)
         self.assertIn("torghut_trading_evidence_continuity_failures_total 1", payload)
@@ -618,7 +629,7 @@ class TestTradingMetrics(TestCase):
         metrics.runtime_regime_gate_blocked_total["abstain"] = 1
         metrics.recalibration_runs_total["queued"] = 1
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_calibration_coverage_error{symbol="all",horizon="autonomy"} 0.02',
@@ -663,7 +674,7 @@ class TestTradingMetrics(TestCase):
         metrics.decision_regime_resolution_source_total["hmm"] = 1
         metrics.decision_regime_resolution_fallback_total["hmm_unknown"] = 2
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_decision_regime_resolution_source_total{source="allocator"} 3',
@@ -682,7 +693,7 @@ class TestTradingMetrics(TestCase):
         metrics = TradingMetrics()
         metrics.trading_shorts_enabled = 1
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_shorts_enabled{service="torghut"} 1',
@@ -710,7 +721,7 @@ class TestTradingMetrics(TestCase):
         metrics.simulation_position_state_total["short"] = 1
         metrics.simulation_preflight_failure_total["schema_registry_not_ready"] = 1
 
-        payload = render_trading_metrics(metrics.__dict__)
+        payload = render_trading_metrics(metrics.to_payload())
 
         self.assertIn(
             'torghut_trading_feature_quality_reject_reason_total{reason="non_monotonic_progression"} 1',

--- a/services/torghut/tests/test_ta_replay_runner.py
+++ b/services/torghut/tests/test_ta_replay_runner.py
@@ -116,16 +116,16 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         }
 
     def _coverage(self) -> dict[str, object]:
-        return argparse.Namespace(
-            status="insufficient_ta_signal_days",
-            summary={
+        return {
+            "status": "insufficient_ta_signal_days",
+            "summary": {
                 "required_trading_days": 25,
                 "ta_signals_days": 9,
                 "ta_microbars_days": 19,
                 "missing_signal_days_vs_required": 16,
                 "microbar_only_day_count": 2,
             },
-        ).__dict__
+        }
 
     def _complete_coverage(self) -> dict[str, object]:
         return {

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -25,10 +25,7 @@ from app.trading.tigerbeetle_ledger_model import (
     TigerBeetleTransferSpec,
 )
 
-
-class _Event:
-    def __init__(self, **kwargs: object) -> None:
-        self.__dict__.update(kwargs)
+_TigerBeetleEvent = SimpleNamespace
 
 
 class TestTigerBeetleClient(TestCase):
@@ -190,8 +187,8 @@ class TestTigerBeetleClient(TestCase):
 
         fake_module = SimpleNamespace(
             ClientSync=_BlockingSync,
-            Account=_Event,
-            Transfer=_Event,
+            Account=_TigerBeetleEvent,
+            Transfer=_TigerBeetleEvent,
         )
         with (
             patch.dict(sys.modules, {"tigerbeetle": fake_module}),
@@ -241,8 +238,8 @@ class TestTigerBeetleClient(TestCase):
 
         fake_module = SimpleNamespace(
             ClientSync=_BlockingHealthSync,
-            Account=_Event,
-            Transfer=_Event,
+            Account=_TigerBeetleEvent,
+            Transfer=_TigerBeetleEvent,
         )
         with (
             patch.dict(sys.modules, {"tigerbeetle": fake_module}),
@@ -281,8 +278,8 @@ class TestTigerBeetleClient(TestCase):
 
         fake_module = SimpleNamespace(
             ClientSync=_BlockingConnectSync,
-            Account=_Event,
-            Transfer=_Event,
+            Account=_TigerBeetleEvent,
+            Transfer=_TigerBeetleEvent,
         )
         with (
             patch.dict(sys.modules, {"tigerbeetle": fake_module}),
@@ -348,8 +345,8 @@ class TestTigerBeetleClient(TestCase):
 
         fake_module = SimpleNamespace(
             ClientSync=_FakeSync,
-            Account=_Event,
-            Transfer=_Event,
+            Account=_TigerBeetleEvent,
+            Transfer=_TigerBeetleEvent,
         )
         with (
             patch.dict(sys.modules, {"tigerbeetle": fake_module}),


### PR DESCRIPTION
## Summary

- Added `TradingMetrics.to_payload()` and moved metrics/status endpoints plus Prometheus rendering tests off direct `.__dict__` access.
- Replaced raw dataclass/object cloning with explicit `asdict`, `replace`, and `vars` usage in runtime proof policy loading, Stooq backtest config serialization, Alpaca payload extraction, logging extras, and runtime-closure fixtures.
- Added regression coverage for detached metrics payloads, Alpaca attribute-only and unsupported models, and Stooq config JSON serialization.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_alpaca_client.py tests/test_backtest_tsmom_stooq.py tests/test_metrics.py tests/test_runtime_ledger_proof_policy.py tests/api/test_trading_api_status_metadata.py tests/test_logging_config.py tests/test_tigerbeetle_client.py tests/execution_policy tests/runtime_closure`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/test_alpaca_client.py tests/test_backtest_tsmom_stooq.py tests/test_metrics.py tests/test_runtime_ledger_proof_policy.py tests/api/test_trading_api_status_metadata.py tests/test_logging_config.py tests/test_tigerbeetle_client.py tests/execution_policy tests/runtime_closure`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff check app scripts tests`
- `uv run --frozen ruff format --check app scripts tests`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/pylint_torghut_quality.py --diff --base-ref origin/main`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
