### PR TITLE
fix(dorvud): drop malformed alpaca status frames

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
@@ -138,10 +138,11 @@ object AlpacaMapper {
     feed: String,
     isFinal: Boolean,
     source: String = "ws",
-  ): Envelope<JsonElement> =
-    Envelope(
+  ): Envelope<JsonElement>? {
+    val parsedEventTs = runCatching { Instant.parse(eventTs) }.getOrNull() ?: return null
+    return Envelope(
       ingestTs = Instant.now(),
-      eventTs = Instant.parse(eventTs),
+      eventTs = parsedEventTs,
       feed = feed,
       channel = channel,
       symbol = symbol,
@@ -150,4 +151,5 @@ object AlpacaMapper {
       isFinal = isFinal,
       source = source,
     )
+  }
 }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -123,5 +124,17 @@ class AlpacaMapperTest {
     assertEquals("AAPL", payload["underlying_symbol"]?.toString()?.trim('"'))
     assertEquals("2.84", payload["price"]?.toString())
     assertEquals("1.0", payload["size"]?.toString())
+  }
+
+  @Test
+  fun `drops malformed options status frame instead of throwing`() {
+    val msg =
+      """{"T":"s","S":"AAPL260618C00100000","statusCode":"error","statusMessage":"bad symbol","t":"[ERROR: (java.lang.IllegalStateException) 'gen' is expected to be a string]"}"""
+    val decoded = AlpacaMapper.decode(msg)
+    assertTrue(decoded is AlpacaStatus)
+
+    val env = AlpacaMapper.toEnvelope(decoded, AlpacaMarketType.OPTIONS, "opra") { 1 }
+
+    assertNull(env)
   }
 }


### PR DESCRIPTION
## Summary

- Drop malformed Alpaca websocket frames with invalid event timestamps instead of throwing from `AlpacaMapper`.
- Prevent malformed options status/error payloads from tearing down the Dorvud websocket session and holding readiness at 503.
- Add a regression test for the live malformed options status frame shape.

## Related Issues

None

## Testing

- `./gradlew :websockets:test --tests ai.proompteng.dorvud.ws.AlpacaMapperTest`
- `./gradlew :websockets:test`
- `./gradlew :websockets:build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
