### PR TITLE
chore(torghut): promote ws image 73073860

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:3a3362eb080225aeaa9e1ee3fe650d916f034175feeb0f02328992d4c5bd9f33
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7148da0dfbf4325212e62742c24ecc6d11836b6e27b3e35f497692922cc2046c
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -53,9 +53,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-2d1507c1
+              value: main-73073860
             - name: TORGHUT_WS_COMMIT
-              value: 2d1507c141e1c56fd12a8df96dd6b8f7f7ae336a
+              value: 730738603113979ce315bd2522965977fb4c53f7
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:3a3362eb080225aeaa9e1ee3fe650d916f034175feeb0f02328992d4c5bd9f33
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7148da0dfbf4325212e62742c24ecc6d11836b6e27b3e35f497692922cc2046c
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-2d1507c1
+              value: main-73073860
             - name: TORGHUT_WS_COMMIT
-              value: 2d1507c141e1c56fd12a8df96dd6b8f7f7ae336a
+              value: 730738603113979ce315bd2522965977fb4c53f7
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `730738603113979ce315bd2522965977fb4c53f7`
- Image tag: `73073860`
- Image digest: `sha256:7148da0dfbf4325212e62742c24ecc6d11836b6e27b3e35f497692922cc2046c`