### PR TITLE
refactor(torghut): remove flatten script backchannel

### DIFF
--- a/services/torghut/scripts/paper_account_position_flattening/cli.py
+++ b/services/torghut/scripts/paper_account_position_flattening/cli.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from contextlib import nullcontext
 from typing import Any, cast
 
@@ -29,13 +28,6 @@ from .flatten_core import (
 from .lineage_execution import flatten_paper_account_positions
 
 
-def _facade_attr(name: str, fallback: Any) -> Any:
-    facade = sys.modules.get("scripts.flatten_paper_account_positions")
-    if facade is None:
-        return fallback
-    return getattr(facade, name, fallback)
-
-
 def main() -> int:
     args = _parse_args()
     max_gross_market_value = _decimal(
@@ -46,23 +38,9 @@ def main() -> int:
         args.limit_away_bps,
         default=DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS,
     )
-    client_factory = _facade_attr("TorghutAlpacaClient", TorghutAlpacaClient)
-    firewall_factory = _facade_attr("OrderFirewall", OrderFirewall)
-    session_factory_from_env = _facade_attr(
-        "_session_factory_from_env",
-        _session_factory_from_env,
-    )
-    snapshot_writer = _facade_attr(
-        "snapshot_account_and_positions",
-        snapshot_account_and_positions,
-    )
-    flatten_positions = _facade_attr(
-        "flatten_paper_account_positions",
-        flatten_paper_account_positions,
-    )
-    client = client_factory(paper=True, base_url=str(args.paper_base_url or ""))
-    firewall = firewall_factory(client)
-    session_factory, session_engine, database_dsn_env = session_factory_from_env(
+    client = TorghutAlpacaClient(paper=True, base_url=str(args.paper_base_url or ""))
+    firewall = OrderFirewall(client)
+    session_factory, session_engine, database_dsn_env = _session_factory_from_env(
         str(args.database_dsn_env or "DB_DSN")
     )
     try:
@@ -70,7 +48,7 @@ def main() -> int:
             session_factory() if args.persist_lineage else nullcontext(None)
         )
         with lineage_context as lineage_session:
-            payload = flatten_positions(
+            payload = flatten_paper_account_positions(
                 client=firewall,
                 account_label=str(args.account_label or ""),
                 expected_account_label=str(args.expected_account_label or ""),
@@ -92,7 +70,7 @@ def main() -> int:
                 and payload["account_label"] == payload["expected_account_label"]
             ):
                 with session_factory() as session:
-                    snapshot = snapshot_writer(
+                    snapshot = snapshot_account_and_positions(
                         session,
                         cast(Any, firewall),
                         str(args.account_label or ""),

--- a/services/torghut/scripts/paper_account_position_flattening/flatten_core.py
+++ b/services/torghut/scripts/paper_account_position_flattening/flatten_core.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 import urllib.error
 import urllib.request
 from collections.abc import Mapping, Sequence
@@ -587,9 +586,7 @@ def _session_factory_from_env(
 ) -> tuple[sessionmaker[Session], Engine | None, str]:
     resolved_env = dsn_env.strip() or "DB_DSN"
     if resolved_env == "DB_DSN":
-        facade = sys.modules.get("scripts.flatten_paper_account_positions")
-        session_local = getattr(facade, "SessionLocal", SessionLocal)
-        return session_local, None, resolved_env
+        return SessionLocal, None, resolved_env
     dsn = os.getenv(resolved_env)
     if not dsn:
         raise RuntimeError(

--- a/services/torghut/scripts/paper_account_position_flattening/lineage_execution.py
+++ b/services/torghut/scripts/paper_account_position_flattening/lineage_execution.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import hashlib
-import sys
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -35,13 +34,6 @@ from .flatten_core import (
     PaperFlattenClient,
     _normalize_positions,
 )
-
-
-def _facade_attr(name: str, fallback: Any) -> Any:
-    facade = sys.modules.get("scripts.flatten_paper_account_positions")
-    if facade is None:
-        return fallback
-    return getattr(facade, name, fallback)
 
 
 def _position_payload(position: FlattenPosition) -> dict[str, str | None]:
@@ -560,11 +552,7 @@ def flatten_paper_account_positions(
             lineage_persist_error: Exception | None = None
             if persist_lineage and lineage_session is not None:
                 try:
-                    persist_close_decision = _facade_attr(
-                        "_persist_close_decision",
-                        _persist_close_decision,
-                    )
-                    decision_row, source_lineage = persist_close_decision(
+                    decision_row, source_lineage = _persist_close_decision(
                         lineage_session,
                         account_label=normalized_label,
                         position=position,

--- a/services/torghut/tests/flatten_paper_account_positions/support.py
+++ b/services/torghut/tests/flatten_paper_account_positions/support.py
@@ -17,6 +17,13 @@ from sqlalchemy.orm import Session
 from app.models import Base, Execution, ExecutionOrderEvent, Strategy, TradeDecision
 from app.trading.models import StrategyDecision
 from scripts import flatten_paper_account_positions as flatten_script
+from scripts.paper_account_position_flattening import cli as flatten_cli
+from scripts.paper_account_position_flattening import (
+    flatten_core as flatten_core_module,
+)
+from scripts.paper_account_position_flattening import (
+    lineage_execution as flatten_lineage,
+)
 from scripts.flatten_paper_account_positions import (
     flatten_paper_account_positions,
 )
@@ -241,6 +248,9 @@ __all__ = [
     "cast",
     "create_engine",
     "datetime",
+    "flatten_cli",
+    "flatten_core_module",
+    "flatten_lineage",
     "flatten_paper_account_positions",
     "flatten_script",
     "json",

--- a/services/torghut/tests/flatten_paper_account_positions/test_cli_snapshot_guards.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_cli_snapshot_guards.py
@@ -6,6 +6,8 @@ from tests.flatten_paper_account_positions.support import (
     StringIO,
     _TestFlattenPaperAccountPositionsBase,
     datetime,
+    flatten_cli,
+    flatten_core_module,
     flatten_script,
     json,
     patch,
@@ -132,12 +134,12 @@ class TestFlattenPaperAccountCliSnapshotGuards(_TestFlattenPaperAccountPositions
         with (
             patch.dict("os.environ", {"SIM_DB_DSN": "sqlite+pysqlite:///:memory:"}),
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             patch.object(
-                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+                flatten_cli, "snapshot_account_and_positions", return_value=snapshot
             ) as snapshot_account,
             redirect_stdout(StringIO()) as output,
         ):
@@ -169,13 +171,13 @@ class TestFlattenPaperAccountCliSnapshotGuards(_TestFlattenPaperAccountPositions
 
         with (
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
-            patch.object(flatten_script, "SessionLocal") as session_local,
+            patch.object(flatten_core_module, "SessionLocal") as session_local,
             patch.object(
-                flatten_script, "snapshot_account_and_positions"
+                flatten_cli, "snapshot_account_and_positions"
             ) as snapshot_account,
             redirect_stdout(StringIO()) as output,
         ):
@@ -204,9 +206,9 @@ class TestFlattenPaperAccountCliSnapshotGuards(_TestFlattenPaperAccountPositions
 
         with (
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             redirect_stdout(StringIO()) as output,
         ):

--- a/services/torghut/tests/flatten_paper_account_positions/test_flatten_orders.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_flatten_orders.py
@@ -19,6 +19,7 @@ from tests.flatten_paper_account_positions.support import (
     _source_strategy,
     cast,
     datetime,
+    flatten_lineage,
     flatten_paper_account_positions,
     flatten_script,
     patch,
@@ -391,7 +392,7 @@ class TestFlattenPaperAccountFlattenOrders(_TestFlattenPaperAccountPositionsBase
         )
         with _memory_session() as session:
             with patch.object(
-                flatten_script,
+                flatten_lineage,
                 "_persist_close_decision",
                 side_effect=RuntimeError("db unavailable"),
             ):

--- a/services/torghut/tests/flatten_paper_account_positions/test_target_plan_readback.py
+++ b/services/torghut/tests/flatten_paper_account_positions/test_target_plan_readback.py
@@ -9,6 +9,8 @@ from tests.flatten_paper_account_positions.support import (
     StringIO,
     _TestFlattenPaperAccountPositionsBase,
     datetime,
+    flatten_cli,
+    flatten_core_module,
     flatten_script,
     json,
     patch,
@@ -121,9 +123,9 @@ class TestFlattenPaperAccountTargetPlanReadback(_TestFlattenPaperAccountPosition
 
         with (
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             redirect_stdout(StringIO()) as output,
         ):
@@ -154,15 +156,15 @@ class TestFlattenPaperAccountTargetPlanReadback(_TestFlattenPaperAccountPosition
 
         with (
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             patch.object(
-                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+                flatten_core_module, "SessionLocal", return_value=FakeSessionContext()
             ),
             patch.object(
-                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+                flatten_cli, "snapshot_account_and_positions", return_value=snapshot
             ) as snapshot_account,
             redirect_stdout(StringIO()) as output,
         ):
@@ -543,15 +545,15 @@ class TestFlattenPaperAccountTargetPlanReadback(_TestFlattenPaperAccountPosition
 
         with (
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             patch.object(
-                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+                flatten_core_module, "SessionLocal", return_value=FakeSessionContext()
             ),
             patch.object(
-                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+                flatten_cli, "snapshot_account_and_positions", return_value=snapshot
             ),
             patch.object(
                 flatten_script.urllib.request,
@@ -627,15 +629,15 @@ class TestFlattenPaperAccountTargetPlanReadback(_TestFlattenPaperAccountPosition
 
         with (
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             patch.object(
-                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+                flatten_core_module, "SessionLocal", return_value=FakeSessionContext()
             ),
             patch.object(
-                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+                flatten_cli, "snapshot_account_and_positions", return_value=snapshot
             ),
             patch.object(
                 flatten_script.urllib.request,
@@ -706,15 +708,15 @@ class TestFlattenPaperAccountTargetPlanReadback(_TestFlattenPaperAccountPosition
 
         with (
             patch.object(sys, "argv", argv),
-            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(flatten_cli, "TorghutAlpacaClient", return_value=client),
             patch.object(
-                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+                flatten_cli, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             patch.object(
-                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+                flatten_core_module, "SessionLocal", return_value=FakeSessionContext()
             ),
             patch.object(
-                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+                flatten_cli, "snapshot_account_and_positions", return_value=snapshot
             ),
             patch.object(
                 flatten_script.urllib.request,

--- a/services/torghut/tests/test_explicit_module_facade_exports.py
+++ b/services/torghut/tests/test_explicit_module_facade_exports.py
@@ -156,6 +156,21 @@ def test_generated_split_package_directories_are_absent() -> None:
     assert generated_package_dirs == []
 
 
+def test_flatten_package_does_not_patch_through_public_script_shim() -> None:
+    service_root = Path(__file__).resolve().parents[1]
+    flatten_package_root = (
+        service_root / "scripts" / "paper_account_position_flattening"
+    )
+    public_shim_module = "scripts.flatten_paper_account_positions"
+    shim_backchannel_paths = sorted(
+        str(path.relative_to(service_root))
+        for path in flatten_package_root.rglob("*.py")
+        if public_shim_module in path.read_text()
+    )
+
+    assert shim_backchannel_paths == []
+
+
 def test_historical_simulation_startup_module_entrypoint_exits_with_cli_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Removed `sys.modules["scripts.flatten_paper_account_positions"]` backchannels from the flatten CLI, session factory, and lineage persistence path.
- Retargeted flatten tests to patch the owning modules directly instead of monkeypatching the public script shim.
- Added an import-surface regression that rejects future flatten-package dependencies on the public `scripts.flatten_paper_account_positions` shim.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/flatten_paper_account_positions tests/test_explicit_module_facade_exports.py`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/flatten_paper_account_positions tests/test_explicit_module_facade_exports.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main` (100% changed-line coverage)
- `uv run --frozen ruff check app scripts tests`
- `uv run --frozen ruff format --check app scripts tests`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A - backend/service refactor only.

## Breaking Changes

None. The `scripts.flatten_paper_account_positions` CLI/import shim remains; only internal dependency lookup and tests moved to owning modules.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
