### PR TITLE
fix(torghut): allow bounded paper close recovery

### DIFF
--- a/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
@@ -542,7 +542,13 @@ class SimplePipelinePaperRouteProbeRetryDecisionMixin(PaperRouteProbeRuntime):
         return decisions
 
     def _paper_route_probe_exit_scan_ready(self, now: datetime) -> bool:
-        if settings.trading_mode != "paper":
+        live_bounded_collection = (
+            settings.trading_mode == "live"
+            and settings.trading_simple_submit_enabled
+            and settings.trading_simple_paper_route_probe_enabled
+            and settings.trading_simple_paper_route_probe_allow_live_mode
+        )
+        if settings.trading_mode != "paper" and not live_bounded_collection:
             return False
         if not settings.trading_simple_paper_route_probe_enabled:
             return False

--- a/services/torghut/app/trading/scheduler/pipeline/decision_lifecycle.py
+++ b/services/torghut/app/trading/scheduler/pipeline/decision_lifecycle.py
@@ -339,6 +339,9 @@ class TradingPipelineDecisionLifecycleMixin(TradingPipelineBase):
                     session=context.session,
                     decision=decision,
                     decision_row=decision_row,
+                    strategy=strategy,
+                    account=context.account,
+                    positions=context.positions,
                 )
                 or not self._submit_decision_execution(
                     session=context.session,

--- a/services/torghut/app/trading/scheduler/pipeline/submission_policy.py
+++ b/services/torghut/app/trading/scheduler/pipeline/submission_policy.py
@@ -613,6 +613,7 @@ class TradingPipelineSubmissionPolicyMixin(TradingPipelineBase):
         session: Session,
         decision: StrategyDecision,
         decision_row: TradeDecision,
+        **_submission_context: Any,
     ) -> bool:
         if not settings.trading_enabled:
             self._block_decision_submission(

--- a/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import timezone
 from decimal import Decimal
 from typing import Any, cast
 
@@ -30,6 +31,7 @@ from .shared import (
     SubmissionDecisionContext,
     SubmitRejectionRequest,
     TradingSubmissionRequest,
+    logger,
 )
 from .quote_sizing import SimplePipelineSubmissionQuoteSizingMixin
 from .quote_routeability import SimplePipelineSubmissionQuoteRouteabilityMixin
@@ -50,6 +52,8 @@ _LIVE_GATE_BOUNDED_PAPER_ROUTE_BYPASS_REASONS = frozenset(
         "runtime_ledger_source_window_evidence_pending",
     }
 )
+
+_BOUNDED_PAPER_ROUTE_CLOSE_SOURCE = "filled_bounded_paper_route_collection_executions"
 
 
 class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
@@ -149,6 +153,9 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
             session=legacy_kwargs["session"],
             decision=legacy_kwargs["decision"],
             decision_row=legacy_kwargs["decision_row"],
+            strategy=legacy_kwargs.get("strategy"),
+            account=legacy_kwargs.get("account"),
+            positions=legacy_kwargs.get("positions"),
         )
 
     def _trading_enabled_submission_allowed(
@@ -189,8 +196,8 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
         if settings.trading_mode == "live":
             live_submission_gate = self._live_submission_gate(session=request.session)
             if not bool(live_submission_gate.get("allowed", False)):
-                if self._bounded_live_paper_route_probe_submission_allowed(
-                    request.decision,
+                if self._bounded_live_paper_route_probe_request_allowed(
+                    request,
                     live_submission_gate,
                 ):
                     return True
@@ -208,6 +215,31 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
                 return False
         return True
 
+    def _bounded_live_paper_route_probe_request_allowed(
+        self,
+        request: TradingSubmissionRequest,
+        live_submission_gate: Mapping[str, Any],
+    ) -> bool:
+        if self._bounded_live_paper_route_probe_submission_allowed(
+            request.decision,
+            live_submission_gate,
+        ):
+            return True
+        close_metadata = self._bounded_live_paper_route_close_metadata(request)
+        if close_metadata is None:
+            return False
+        if not self._bounded_live_paper_route_collection_gate_allows(
+            live_submission_gate
+        ):
+            return False
+        request.decision.params.update(close_metadata)
+        self.executor.update_decision_params(
+            request.session,
+            request.decision_row,
+            close_metadata,
+        )
+        return True
+
     def _bounded_live_paper_route_probe_submission_allowed(
         self,
         decision: StrategyDecision,
@@ -215,6 +247,14 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
     ) -> bool:
         if not self._bounded_live_paper_route_probe_decision_applies(decision):
             return False
+        return self._bounded_live_paper_route_collection_gate_allows(
+            live_submission_gate
+        )
+
+    @staticmethod
+    def _bounded_live_paper_route_collection_gate_allows(
+        live_submission_gate: Mapping[str, Any],
+    ) -> bool:
         collection_gate = live_submission_gate.get("bounded_live_paper_collection_gate")
         if isinstance(collection_gate, Mapping):
             collection_gate_mapping = cast(Mapping[str, Any], collection_gate)
@@ -230,6 +270,124 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
         if not blocked_reasons:
             return False
         return blocked_reasons.issubset(_LIVE_GATE_BOUNDED_PAPER_ROUTE_BYPASS_REASONS)
+
+    def _bounded_live_paper_route_close_metadata(
+        self,
+        request: TradingSubmissionRequest,
+    ) -> dict[str, Any] | None:
+        if not self._bounded_live_paper_route_close_mode_enabled(request.decision):
+            return None
+        exposure = self._bounded_live_paper_route_close_exposure(request)
+        if exposure is None:
+            return None
+        lineage = dict(cast(Mapping[str, Any], getattr(exposure, "lineage", {}) or {}))
+        exit_metadata = {
+            "mode": "paper_route_exit",
+            "source": _BOUNDED_PAPER_ROUTE_CLOSE_SOURCE,
+            "symbol": getattr(exposure, "symbol"),
+            "strategy_id": str(getattr(getattr(exposure, "strategy"), "id")),
+            "db_open_qty": str(getattr(exposure, "exit_qty")),
+            "db_open_signed_qty": str(getattr(exposure, "net_qty")),
+            "db_open_side": "long" if getattr(exposure, "net_qty") > 0 else "short",
+            "exit_minute_after_open": getattr(exposure, "exit_minute_after_open", None),
+            "session_open": getattr(exposure, "session_open").isoformat(),
+            "latest_entry_at": (
+                getattr(exposure, "latest_entry_at").isoformat()
+                if getattr(exposure, "latest_entry_at", None) is not None
+                else None
+            ),
+            "live_bounded_paper_route_close": True,
+            **lineage,
+        }
+        simple_lane = request.decision.params.get("simple_lane")
+        if isinstance(simple_lane, Mapping):
+            simple_lane_payload = dict(cast(Mapping[str, Any], simple_lane))
+        else:
+            simple_lane_payload = {}
+        simple_lane_payload.update(
+            {
+                "bounded_live_paper_route_close": True,
+                "submit_path": "bounded_paper_route_collection",
+            }
+        )
+        metadata: dict[str, Any] = {
+            "paper_route_probe_exit": exit_metadata,
+            "simple_lane": simple_lane_payload,
+            "bounded_live_paper_route_close": True,
+            "bounded_paper_route_submit_path": "bounded_paper_route_collection",
+        }
+        for key in ("source_decision_mode", "profit_proof_eligible"):
+            if key in lineage:
+                metadata[key] = lineage[key]
+        return metadata
+
+    def _bounded_live_paper_route_close_mode_enabled(
+        self,
+        decision: StrategyDecision,
+    ) -> bool:
+        return (
+            settings.trading_mode == "live"
+            and settings.trading_simple_submit_enabled
+            and settings.trading_simple_paper_route_probe_enabled
+            and settings.trading_simple_paper_route_probe_allow_live_mode
+            and self._paper_route_probe_exit_metadata(decision) is None
+            and bounded_paper_route_collection_entry_metadata(decision.params) is None
+            and decision.action in {"buy", "sell"}
+            and decision.qty > 0
+        )
+
+    def _bounded_live_paper_route_close_exposure(
+        self,
+        request: TradingSubmissionRequest,
+    ) -> Any | None:
+        exposures_fn = getattr(self, "_paper_route_probe_exit_exposures", None)
+        if not callable(exposures_fn):
+            return None
+        try:
+            exposures = exposures_fn(
+                session=request.session,
+                now=self._trading_now().astimezone(timezone.utc),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to inspect bounded paper-route close exposure "
+                "decision_id=%s symbol=%s",
+                request.decision_row.id,
+                request.decision.symbol,
+            )
+            return None
+        if not isinstance(exposures, Mapping):
+            return None
+        exposure_mapping = cast(Mapping[Any, Any], exposures)
+        for exposure in exposure_mapping.values():
+            if not self._bounded_live_paper_route_close_matches_exposure(
+                request.decision,
+                exposure,
+            ):
+                continue
+            return exposure
+        return None
+
+    @staticmethod
+    def _bounded_live_paper_route_close_matches_exposure(
+        decision: StrategyDecision,
+        exposure: Any,
+    ) -> bool:
+        strategy = getattr(exposure, "strategy", None)
+        if str(getattr(strategy, "id", "")).strip() != str(decision.strategy_id):
+            return False
+        if str(getattr(exposure, "symbol", "")).strip().upper() != decision.symbol:
+            return False
+        if str(getattr(exposure, "exit_source", "") or "").strip() != (
+            _BOUNDED_PAPER_ROUTE_CLOSE_SOURCE
+        ):
+            return False
+        if getattr(exposure, "exit_action", None) != decision.action:
+            return False
+        exit_qty = getattr(exposure, "exit_qty", Decimal("0"))
+        if not isinstance(exit_qty, Decimal):
+            exit_qty = Decimal(str(exit_qty))
+        return decision.qty <= exit_qty
 
     def _bounded_live_paper_route_probe_profit_floor_allowed(
         self,

--- a/services/torghut/app/trading/scheduler/submission_preparation/shared.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/shared.py
@@ -46,6 +46,9 @@ class TradingSubmissionRequest:
     session: Session
     decision: StrategyDecision
     decision_row: TradeDecision
+    strategy: Strategy | None = None
+    account: dict[str, str] | None = None
+    positions: list[dict[str, Any]] | None = None
 
 
 @dataclass(frozen=True)

--- a/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+from tests.pipeline.trading_pipeline_base import (
+    Any,
+    Decimal,
+    DecisionEngine,
+    FakeAlpacaClient,
+    FakeIngestor,
+    OrderExecutor,
+    OrderFirewall,
+    Reconciler,
+    RiskEngine,
+    SimpleTradingPipeline,
+    SimpleNamespace,
+    Strategy,
+    StrategyDecision,
+    TradingPipelineTestCaseBase,
+    TradingState,
+    UniverseResolver,
+    cast,
+    datetime,
+    patch,
+    select,
+    timezone,
+)
+
+from app.trading.scheduler.submission_preparation.shared import (
+    TradingSubmissionRequest,
+)
+
+
+class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
+    @staticmethod
+    def _pipeline(session_local: Any) -> SimpleTradingPipeline:
+        return SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=session_local,
+        )
+
+    def test_live_bounded_paper_route_close_bypasses_gate_and_tags_exit(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_simple_submit_enabled": (
+                config.settings.trading_simple_submit_enabled
+            ),
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+        }
+        config.settings.trading_mode = "live"
+        config.settings.trading_enabled = True
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_allow_live_mode = True
+        self._seed_filled_paper_route_probe_entry(
+            source_decision_mode="bounded_paper_route_collection",
+            profit_proof_eligible=True,
+            source_candidate_ids=("candidate-pairs-a",),
+            source_hypothesis_ids=("H-PAIRS-01",),
+            source_strategy_names=("microbar-cross-sectional-pairs-v1",),
+        )
+        try:
+            pipeline = self._pipeline(self.session_local)
+            gate = {
+                "allowed": False,
+                "blocked_reasons": [
+                    "alpha_readiness_not_promotion_eligible",
+                    "runtime_ledger_source_collection_pending",
+                ],
+                "bounded_live_paper_collection_gate": {
+                    "allowed": True,
+                    "authority_scope": "bounded_evidence_collection_only",
+                },
+            }
+            proof_floor = {
+                "route_state": "repair_only",
+                "capital_state": "paper",
+                "max_notional": "100",
+                "market_window": {"session_open": True},
+                "blocking_reasons": ["runtime_ledger_source_collection_pending"],
+                "route_reacquisition_book": {
+                    "summary": {"paper_route_probe_eligible_symbols": ["AAPL"]}
+                },
+            }
+            with self.session_local() as session:
+                strategy = session.execute(select(Strategy)).scalar_one()
+                decision = StrategyDecision(
+                    strategy_id=str(strategy.id),
+                    symbol="AAPL",
+                    event_ts=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
+                    timeframe="1Min",
+                    action="sell",
+                    qty=Decimal("2"),
+                    rationale="strategy-close-existing-bounded-collection-position",
+                    params={
+                        "simple_lane": {
+                            "quantity_resolution": {
+                                "reason": "sell_reducing_long_fractional_allowed",
+                                "short_increasing": False,
+                            }
+                        }
+                    },
+                )
+                decision_row = OrderExecutor().ensure_decision(
+                    session,
+                    decision,
+                    strategy,
+                    "paper",
+                )
+
+                with (
+                    patch.object(
+                        SimpleTradingPipeline,
+                        "_live_submission_gate",
+                        return_value=gate,
+                    ),
+                    patch.object(
+                        SimpleTradingPipeline,
+                        "_profitability_proof_floor",
+                        return_value=proof_floor,
+                    ),
+                    patch(
+                        "app.trading.scheduler.simple_pipeline.trading_now",
+                        return_value=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
+                    ),
+                ):
+                    self.assertTrue(
+                        pipeline._is_trading_submission_allowed(
+                            TradingSubmissionRequest(
+                                session=session,
+                                decision=decision,
+                                decision_row=decision_row,
+                            )
+                        )
+                    )
+
+                session.refresh(decision_row)
+                decision_json = cast(dict[str, Any], decision_row.decision_json)
+                params = cast(dict[str, Any], decision_json["params"])
+                exit_metadata = cast(
+                    dict[str, Any],
+                    params["paper_route_probe_exit"],
+                )
+                simple_lane = cast(dict[str, Any], params["simple_lane"])
+
+            self.assertEqual(exit_metadata["mode"], "paper_route_exit")
+            self.assertEqual(
+                exit_metadata["source"],
+                "filled_bounded_paper_route_collection_executions",
+            )
+            self.assertEqual(exit_metadata["db_open_qty"], "2.00000000")
+            self.assertEqual(exit_metadata["db_open_side"], "long")
+            self.assertTrue(exit_metadata["live_bounded_paper_route_close"])
+            self.assertEqual(
+                exit_metadata["source_candidate_ids"],
+                ["candidate-pairs-a"],
+            )
+            self.assertTrue(simple_lane["bounded_live_paper_route_close"])
+            self.assertEqual(
+                simple_lane["submit_path"],
+                "bounded_paper_route_collection",
+            )
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_simple_submit_enabled = original[
+                "trading_simple_submit_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_enabled = original[
+                "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
+            ]
+
+    def test_live_unlinked_close_still_blocks_on_capital_gate(self) -> None:
+        from app import config
+
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_simple_submit_enabled": (
+                config.settings.trading_simple_submit_enabled
+            ),
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+        }
+        config.settings.trading_mode = "live"
+        config.settings.trading_enabled = True
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_allow_live_mode = True
+        try:
+            pipeline = self._pipeline(self.session_local)
+            gate = {
+                "allowed": False,
+                "reason": "alpha_readiness_not_promotion_eligible",
+                "blocked_reasons": ["alpha_readiness_not_promotion_eligible"],
+                "bounded_live_paper_collection_gate": {
+                    "allowed": True,
+                    "authority_scope": "bounded_evidence_collection_only",
+                },
+            }
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="unlinked-live-close",
+                    description="unlinked close must not bypass live capital gate",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
+                )
+                session.add(strategy)
+                session.commit()
+                session.refresh(strategy)
+                decision = StrategyDecision(
+                    strategy_id=str(strategy.id),
+                    symbol="AAPL",
+                    event_ts=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
+                    timeframe="1Min",
+                    action="sell",
+                    qty=Decimal("2"),
+                    rationale="unlinked-close",
+                    params={},
+                )
+                decision_row = OrderExecutor().ensure_decision(
+                    session,
+                    decision,
+                    strategy,
+                    "paper",
+                )
+
+                with patch.object(
+                    SimpleTradingPipeline,
+                    "_live_submission_gate",
+                    return_value=gate,
+                ):
+                    self.assertFalse(
+                        pipeline._is_trading_submission_allowed(
+                            TradingSubmissionRequest(
+                                session=session,
+                                decision=decision,
+                                decision_row=decision_row,
+                            )
+                        )
+                    )
+
+                session.refresh(decision_row)
+                decision_json = cast(dict[str, Any], decision_row.decision_json)
+
+            self.assertEqual(
+                decision_json["submission_stage"],
+                "blocked_live_submission_gate",
+            )
+            self.assertNotIn("paper_route_probe_exit", decision_json.get("params", {}))
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_simple_submit_enabled = original[
+                "trading_simple_submit_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_enabled = original[
+                "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
+            ]
+
+    def test_live_bounded_paper_route_close_respects_collection_gate(self) -> None:
+        from app import config
+
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_simple_submit_enabled": (
+                config.settings.trading_simple_submit_enabled
+            ),
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+        }
+        config.settings.trading_mode = "live"
+        config.settings.trading_enabled = True
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_allow_live_mode = True
+        self._seed_filled_paper_route_probe_entry(
+            source_decision_mode="bounded_paper_route_collection",
+            profit_proof_eligible=True,
+        )
+        try:
+            pipeline = self._pipeline(self.session_local)
+            gate = {
+                "allowed": False,
+                "reason": "alpha_readiness_not_promotion_eligible",
+                "blocked_reasons": ["empirical_jobs_not_ready"],
+            }
+            with self.session_local() as session:
+                strategy = session.execute(select(Strategy)).scalar_one()
+                decision = StrategyDecision(
+                    strategy_id=str(strategy.id),
+                    symbol="AAPL",
+                    event_ts=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
+                    timeframe="1Min",
+                    action="sell",
+                    qty=Decimal("2"),
+                    rationale="close-blocked-when-bounded-gate-denies",
+                    params={},
+                )
+                decision_row = OrderExecutor().ensure_decision(
+                    session,
+                    decision,
+                    strategy,
+                    "paper",
+                )
+
+                with patch.object(
+                    SimpleTradingPipeline,
+                    "_live_submission_gate",
+                    return_value=gate,
+                ):
+                    self.assertFalse(
+                        pipeline._is_trading_submission_allowed(
+                            TradingSubmissionRequest(
+                                session=session,
+                                decision=decision,
+                                decision_row=decision_row,
+                            )
+                        )
+                    )
+
+                session.refresh(decision_row)
+                decision_json = cast(dict[str, Any], decision_row.decision_json)
+
+            self.assertEqual(
+                decision_json["submission_stage"],
+                "blocked_live_submission_gate",
+            )
+            self.assertNotIn("paper_route_probe_exit", decision_json.get("params", {}))
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_simple_submit_enabled = original[
+                "trading_simple_submit_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_enabled = original[
+                "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
+            ]
+
+    def test_bounded_paper_route_close_exposure_lookup_fail_closed(self) -> None:
+        pipeline = self._pipeline(self.session_local)
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="lookup-fail-closed",
+                description="lookup failures must not authorize closes",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                rationale="lookup-fail-closed",
+                params={},
+            )
+            decision_row = OrderExecutor().ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            request = TradingSubmissionRequest(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+            )
+
+            with patch.object(
+                pipeline,
+                "_paper_route_probe_exit_exposures",
+                None,
+            ):
+                self.assertIsNone(
+                    pipeline._bounded_live_paper_route_close_exposure(request)
+                )
+            with patch.object(
+                pipeline,
+                "_paper_route_probe_exit_exposures",
+                side_effect=RuntimeError("boom"),
+            ):
+                self.assertIsNone(
+                    pipeline._bounded_live_paper_route_close_exposure(request)
+                )
+            with patch.object(
+                pipeline,
+                "_paper_route_probe_exit_exposures",
+                return_value=[],
+            ):
+                self.assertIsNone(
+                    pipeline._bounded_live_paper_route_close_exposure(request)
+                )
+
+    def test_bounded_paper_route_close_matches_only_linked_exposure(self) -> None:
+        source = "filled_bounded_paper_route_collection_executions"
+        pipeline = self._pipeline(self.session_local)
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="linked-close-match",
+                description="close matching fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                rationale="linked-close-match",
+                params={},
+            )
+            decision_row = OrderExecutor().ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            request = TradingSubmissionRequest(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+            )
+            wrong_strategy = SimpleNamespace(
+                strategy=SimpleNamespace(id="wrong"),
+                symbol="AAPL",
+                exit_source=source,
+                exit_action="sell",
+                exit_qty=Decimal("2"),
+            )
+            matching = SimpleNamespace(
+                strategy=SimpleNamespace(id=strategy.id),
+                symbol="AAPL",
+                exit_source=source,
+                exit_action="sell",
+                exit_qty="2",
+            )
+            wrong_symbol = SimpleNamespace(
+                strategy=SimpleNamespace(id=strategy.id),
+                symbol="MSFT",
+                exit_source=source,
+                exit_action="sell",
+                exit_qty=Decimal("2"),
+            )
+            wrong_source = SimpleNamespace(
+                strategy=SimpleNamespace(id=strategy.id),
+                symbol="AAPL",
+                exit_source="manual_close",
+                exit_action="sell",
+                exit_qty=Decimal("2"),
+            )
+            wrong_action = SimpleNamespace(
+                strategy=SimpleNamespace(id=strategy.id),
+                symbol="AAPL",
+                exit_source=source,
+                exit_action="buy",
+                exit_qty=Decimal("2"),
+            )
+
+            self.assertFalse(
+                pipeline._bounded_live_paper_route_close_matches_exposure(
+                    decision,
+                    wrong_symbol,
+                )
+            )
+            self.assertFalse(
+                pipeline._bounded_live_paper_route_close_matches_exposure(
+                    decision,
+                    wrong_source,
+                )
+            )
+            self.assertFalse(
+                pipeline._bounded_live_paper_route_close_matches_exposure(
+                    decision,
+                    wrong_action,
+                )
+            )
+            with patch.object(
+                pipeline,
+                "_paper_route_probe_exit_exposures",
+                return_value={"wrong": wrong_strategy, "match": matching},
+            ):
+                self.assertIs(
+                    pipeline._bounded_live_paper_route_close_exposure(request),
+                    matching,
+                )

--- a/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_a.py
@@ -273,6 +273,88 @@ class TestTradingPipelineProbeExitsA(TradingPipelineTestCaseBase):
             ],
         )
 
+    def test_live_bounded_collection_scans_explicit_probe_exit_after_exit_minute(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "trading_simple_submit_enabled": (
+                config.settings.trading_simple_submit_enabled
+            ),
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
+            "trading_simple_paper_route_probe_allow_live_mode": (
+                config.settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+        }
+        config.settings.trading_mode = "live"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_allow_live_mode = True
+        self._seed_filled_paper_route_probe_entry(
+            source_decision_mode=BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+            profit_proof_eligible=True,
+            source_candidate_ids=("candidate-pairs-a",),
+            source_hypothesis_ids=("H-PAIRS-01",),
+            source_strategy_names=("microbar-cross-sectional-pairs-v1",),
+        )
+        try:
+            pipeline = SimpleTradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            pipeline._is_market_session_open = lambda _now=None: True
+            with (
+                self.session_local() as session,
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+                ),
+            ):
+                decisions = pipeline._paper_route_probe_exit_decisions(session=session)
+
+            self.assertEqual(len(decisions), 1)
+            decision = decisions[0]
+            self.assertEqual(decision.action, "sell")
+            self.assertEqual(decision.qty, Decimal("2.00000000"))
+            exit_metadata = cast(
+                dict[str, Any],
+                decision.params["paper_route_probe_exit"],
+            )
+            self.assertEqual(exit_metadata["mode"], "paper_route_exit")
+            self.assertEqual(
+                exit_metadata["source"],
+                "filled_bounded_paper_route_collection_executions",
+            )
+            self.assertEqual(
+                exit_metadata["source_candidate_ids"],
+                ["candidate-pairs-a"],
+            )
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_simple_submit_enabled = original[
+                "trading_simple_submit_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_enabled = original[
+                "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
+                "trading_simple_paper_route_probe_allow_live_mode"
+            ]
+
     def test_simple_pipeline_closes_short_paper_route_probe_with_buy_exit(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Enables live bounded paper collection to submit risk-reducing closes for exposure that came from bounded paper-route collection, without opening the full capital gate.
- Persists `paper_route_probe_exit` metadata onto qualifying close decisions so the close fill remains linked evidence instead of an untagged sell.
- Allows the explicit probe-exit scanner to run in live bounded paper mode and adds regressions for allowed bounded closes and blocked unlinked closes.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_probe_exits_a.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q`
- `cd services/torghut && bash -lc 'set -euo pipefail; SHARD_INDEX=3; SHARD_TOTAL=4; TEST_FILES=(); while IFS= read -r f; do TEST_FILES+=("$f"); done < <(find tests -name "test_*.py" ! -path "tests/autoresearch_runner/*" -print | sort | awk -v shard="${SHARD_INDEX}" -v total="${SHARD_TOTAL}" "((NR - 1) % total) == shard"); COVERAGE_FILE=.coverage.local3 uv run --frozen pytest --maxfail=1 -q "${TEST_FILES[@]}"'`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base e6222c60a75d4c921cab28f63fa8051aebd19be4 app/trading/scheduler/paper_route_probe/retry_decisions.py app/trading/scheduler/pipeline/decision_lifecycle.py app/trading/scheduler/submission_preparation/direct_submission.py app/trading/scheduler/submission_preparation/shared.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_probe_exits_a.py`
- `cd services/torghut && uv run --frozen coverage erase && uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.local.xml tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_probe_exits_a.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q && GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.local.xml --threshold 90`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/submission_preparation/direct_submission.py app/trading/scheduler/paper_route_probe/retry_decisions.py app/trading/scheduler/submission_preparation/shared.py app/trading/scheduler/pipeline/decision_lifecycle.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_probe_exits_a.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/submission_preparation/direct_submission.py app/trading/scheduler/paper_route_probe/retry_decisions.py app/trading/scheduler/submission_preparation/shared.py app/trading/scheduler/pipeline/decision_lifecycle.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_probe_exits_a.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
