### PR TITLE
fix(torghut): restore hyperliquid testnet externalsecret

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/README.md
+++ b/argocd/applications/torghut-hyperliquid-runtime/README.md
@@ -29,14 +29,14 @@ scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile
 `status` is safe to run repeatedly. It reports only whether the 1Password item, required fields, ExternalSecret,
 and target Kubernetes Secret exist; it does not print credential values.
 
-Shadow mode does not require Hyperliquid execution credentials. Keep the ExternalSecret out of steady-state
-GitOps while `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`; otherwise a missing optional 1Password item degrades the
-Argo app even though the runtime is correctly serving read-only readiness.
+Shadow mode does not require Hyperliquid execution credentials, but this app now includes the ExternalSecret because
+`op://infra/hyperliquid-testnet` exists with the required fields. Keep `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`
+until `reconcile` reports the Kubernetes Secret as ready and the exchange-side testnet account is funded or authorized.
 
-After `check` reports the 1Password item is present, open a GitOps PR that adds `externalsecret.yaml` to
-`kustomization.yaml` while keeping `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`. Merge and wait for Argo to sync, then
-run `scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile`. After `reconcile` reports the Kubernetes
-Secret as ready, open the trading-enable PR that sets `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true` in `configmap.yaml`.
+After `check` reports the 1Password item is present, keep `externalsecret.yaml` in `kustomization.yaml` while
+`HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`. Merge and wait for Argo to sync, then run
+`scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile`. After `reconcile` reports the Kubernetes Secret
+as ready, open the trading-enable PR that sets `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true` in `configmap.yaml`.
 Keep the default caps unless a separate rollout approves a larger envelope. The runtime must continue to report
 `execution_network=testnet`; mainnet execution is rejected by config validation.
 

--- a/argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - clickhouse-schema-configmap.yaml
   - clickhouse-schema-job.yaml
   - db-migrations-job.yaml
+  - externalsecret.yaml
   - deployment.yaml
   - service.yaml
   - pdb.yaml

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -200,7 +200,7 @@ describe('Torghut manifest scheduling', () => {
     expect(data['schema.sql']).not.toContain('INSERT INTO torghut.hyperliquid_ta_features')
   })
 
-  it('keeps Hyperliquid runtime shadow mode free of optional execution secret drift', () => {
+  it('keeps Hyperliquid runtime shadow mode wired to a gated execution secret', () => {
     const runtimeConfig = parseManifest('argocd/applications/torghut-hyperliquid-runtime/configmap.yaml')
     const runtimeData = getAtPath(runtimeConfig, ['data'])
     expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('false')
@@ -233,7 +233,7 @@ describe('Torghut manifest scheduling', () => {
     const kustomization = parseManifest('argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml')
     const resources = kustomization.resources
     expect(resources).toBeArray()
-    expect(resources).not.toContain('externalsecret.yaml')
+    expect(resources).toContain('externalsecret.yaml')
 
     const externalSecret = parseManifest('argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml')
     expect(externalSecret.kind).toBe('ExternalSecret')
@@ -262,7 +262,7 @@ describe('Torghut manifest scheduling', () => {
     )
   })
 
-  it('documents the Hyperliquid testnet credential check before enabling the ExternalSecret', () => {
+  it('documents the Hyperliquid testnet credential check before enabling trading', () => {
     const readme = readFileSync(join(repoRoot, 'argocd/applications/torghut-hyperliquid-runtime/README.md'), 'utf8')
     const bootstrapScript = readFileSync(
       join(repoRoot, 'scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh'),
@@ -274,7 +274,8 @@ describe('Torghut manifest scheduling', () => {
     expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh create')
     expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh reconcile')
     expect(readme).toContain('After `check` reports the 1Password item is present')
-    expect(readme).toContain('Keep the ExternalSecret out of steady-state')
+    expect(readme).toContain('keep `externalsecret.yaml` in `kustomization.yaml`')
+    expect(readme).toContain('Keep `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`')
     expect(bootstrapScript).toContain('$0 check')
     expect(bootstrapScript).toContain('check_item()')
   })


### PR DESCRIPTION
## Summary

- Restores `externalsecret.yaml` to the Hyperliquid runtime GitOps app now that `op://infra/hyperliquid-testnet` exists.
- Keeps `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false` while the Kubernetes Secret is reconciled.
- Updates runtime docs and manifest tests to reflect the new credential-gated shadow-mode state.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-render-externalsecret.yaml && rg -n '^kind: ExternalSecret$|name: torghut-hyperliquid-testnet|HYPERLIQUID_RUNTIME_TRADING_ENABLED|optional: true' /tmp/torghut-hyperliquid-runtime-render-externalsecret.yaml`
- `bun run lint:argocd`
- `git diff --check`
- `op read --no-newline op://infra/hyperliquid-testnet/account-address >/dev/null && op read --no-newline op://infra/hyperliquid-testnet/api-wallet-private-key >/dev/null`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
