### PR TITLE
refactor(torghut): remove runtime facade backchannels

### DIFF
--- a/services/torghut/app/trading/order_feed/repair_order_feed_execution_links.py
+++ b/services/torghut/app/trading/order_feed/repair_order_feed_execution_links.py
@@ -34,6 +34,8 @@ from .classify_source_window_drop import (
     raw_event_with_linkage_blockers as _raw_event_with_linkage_blockers,
 )
 from .normalize_order_feed_record import (
+    apply_order_event_to_execution,
+    latest_order_event_for_execution,
     link_order_events_to_execution,
 )
 
@@ -118,24 +120,12 @@ def _update_trade_decision_from_execution(*args: Any, **kwargs: Any) -> None:
     update_trade_decision(*args, **kwargs)
 
 
-def _order_feed_facade() -> Any:
-    import importlib
+def _stable_execution_source_offset(value: object) -> int:
+    from .resolve_execution_linkage_for_identity import (
+        stable_execution_source_offset,
+    )
 
-    return importlib.import_module(__package__ or "app.trading.order_feed")
-
-
-def _facade_latest_order_event_for_execution(*args: Any, **kwargs: Any) -> Any:
-    return _order_feed_facade().latest_order_event_for_execution(*args, **kwargs)
-
-
-def _facade_apply_order_event_to_execution(
-    *args: Any, **kwargs: Any
-) -> tuple[bool, bool]:
-    return _order_feed_facade().apply_order_event_to_execution(*args, **kwargs)
-
-
-def _facade_stable_execution_source_offset(value: object) -> int:
-    return _order_feed_facade()._stable_execution_source_offset(value)
+    return stable_execution_source_offset(value)
 
 
 def repair_order_feed_execution_links(
@@ -413,13 +403,11 @@ def repair_order_feed_execution_states(
         "out_of_order_events_skipped": 0,
     }
     for execution in executions:
-        latest_event = _facade_latest_order_event_for_execution(session, execution)
+        latest_event = latest_order_event_for_execution(session, execution)
         if latest_event is None:
             continue
         counters["latest_event_found"] += 1
-        updated, out_of_order = _facade_apply_order_event_to_execution(
-            execution, latest_event
-        )
+        updated, out_of_order = apply_order_event_to_execution(execution, latest_event)
         if out_of_order:
             counters["out_of_order_events_skipped"] += 1
             continue
@@ -654,11 +642,11 @@ def backfill_order_feed_events_from_executions(
         "skipped_source_offset_collision": 0,
     }
     for execution in executions:
-        if _facade_latest_order_event_for_execution(session, execution) is not None:
+        if latest_order_event_for_execution(session, execution) is not None:
             counters["skipped_existing_event"] += 1
             continue
 
-        source_offset = _facade_stable_execution_source_offset(execution.id)
+        source_offset = _stable_execution_source_offset(execution.id)
         if _source_offset_in_use(
             session,
             source_topic=EXECUTION_RAW_ORDER_SOURCE_TOPIC,

--- a/services/torghut/app/trading/submission_council/certificate_loading.py
+++ b/services/torghut/app/trading/submission_council/certificate_loading.py
@@ -15,7 +15,6 @@ from .common import (
     CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT as _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT,
     CERTIFICATE_EVIDENCE_WINDOW_LIMIT as _CERTIFICATE_EVIDENCE_WINDOW_LIMIT,
     coerce_aware_datetime as _coerce_aware_datetime,
-    compat_symbol as _compat_symbol,
     maybe_set_runtime_ledger_status_statement_timeout as _maybe_set_runtime_ledger_status_statement_timeout,
     normalize_reason_codes as _normalize_reason_codes,
     rollback_runtime_ledger_status_session as _rollback_runtime_ledger_status_session,
@@ -63,10 +62,7 @@ def _load_latest_certificate_evidence(
     evidence: list[dict[str, object]] = []
     try:
         for hypothesis_id in normalized_ids:
-            _compat_symbol(
-                "_maybe_set_runtime_ledger_status_statement_timeout",
-                _maybe_set_runtime_ledger_status_statement_timeout,
-            )(session)
+            _maybe_set_runtime_ledger_status_statement_timeout(session)
             metric_windows = list(
                 session.execute(
                     select(StrategyHypothesisMetricWindow)
@@ -82,10 +78,7 @@ def _load_latest_certificate_evidence(
             )
             candidate_rows: list[dict[str, object]] = []
             for metric_window in metric_windows:
-                _compat_symbol(
-                    "_maybe_set_runtime_ledger_status_statement_timeout",
-                    _maybe_set_runtime_ledger_status_statement_timeout,
-                )(session)
+                _maybe_set_runtime_ledger_status_statement_timeout(session)
                 promotion_decision = (
                     session.execute(
                         select(StrategyPromotionDecision)
@@ -105,10 +98,7 @@ def _load_latest_certificate_evidence(
                 )
 
                 runtime_ledger_bucket = None
-                _compat_symbol(
-                    "_maybe_set_runtime_ledger_status_statement_timeout",
-                    _maybe_set_runtime_ledger_status_statement_timeout,
-                )(session)
+                _maybe_set_runtime_ledger_status_statement_timeout(session)
                 ledger_rows = list(
                     session.execute(
                         select(StrategyRuntimeLedgerBucket)

--- a/services/torghut/app/trading/submission_council/common.py
+++ b/services/torghut/app/trading/submission_council/common.py
@@ -6,12 +6,11 @@ import hashlib
 import json
 import logging
 import os
-import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from threading import Lock
-from typing import Any, NamedTuple, Protocol, TypeVar, cast
+from typing import Any, NamedTuple, Protocol, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
@@ -75,8 +74,6 @@ from ..tca import build_tca_gate_inputs
 
 
 logger = logging.getLogger("app.trading.submission_council")
-
-_CompatSymbol = TypeVar("_CompatSymbol")
 
 _CAPITAL_STAGE_ORDER = (
     "shadow",
@@ -152,13 +149,6 @@ _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES = frozenset(
         "expected_market_closed_staleness",
     }
 )
-
-
-def _compat_symbol(name: str, fallback: _CompatSymbol) -> _CompatSymbol:
-    facade = sys.modules.get("app.trading.submission_council")
-    if facade is None:
-        return fallback
-    return cast(_CompatSymbol, getattr(facade, name, fallback))
 
 
 def _safe_int(value: object) -> int:
@@ -452,7 +442,6 @@ __all__ = [
     "_bounded_paper_route_probe_notional",
     "_certificate_evidence_reason_codes",
     "_coerce_aware_datetime",
-    "_compat_symbol",
     "_decimal_text",
     "_maybe_set_runtime_ledger_status_statement_timeout",
     "_normalize_reason_codes",
@@ -500,7 +489,6 @@ __all__ = [
     "sql_text",
     "strategy_names_from_strategy_id",
     "summarize_hypothesis_runtime_statuses",
-    "sys",
     "timedelta",
     "timezone",
     "urlencode",
@@ -518,7 +506,6 @@ certificate_evidence_reason_codes = _certificate_evidence_reason_codes
 CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT = _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT
 CERTIFICATE_EVIDENCE_WINDOW_LIMIT = _CERTIFICATE_EVIDENCE_WINDOW_LIMIT
 coerce_aware_datetime = _coerce_aware_datetime
-compat_symbol = _compat_symbol
 decimal_text = _decimal_text
 LIVE_SUBMISSION_BLOCKING_TOGGLE_MISMATCHES = _LIVE_SUBMISSION_BLOCKING_TOGGLE_MISMATCHES
 maybe_set_runtime_ledger_status_statement_timeout = (

--- a/services/torghut/app/trading/submission_council/profit_readiness.py
+++ b/services/torghut/app/trading/submission_council/profit_readiness.py
@@ -25,7 +25,6 @@ from .common import (
     PROMOTION_SCALAR_COUNT_LIMIT as _PROMOTION_SCALAR_COUNT_LIMIT,
     PROMOTION_TABLE_COUNT_SCAN_LIMIT as _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
     PortfolioPromotionRow as _PortfolioPromotionRow,
-    compat_symbol as _compat_symbol,
     maybe_set_runtime_ledger_status_statement_timeout as _maybe_set_runtime_ledger_status_statement_timeout,
     rollback_runtime_ledger_status_session as _rollback_runtime_ledger_status_session,
     safe_int as _safe_int,
@@ -93,10 +92,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
     ready_refs: set[str] = set()
     ready_source_candidate_ids: set[str] = set()
     for row in portfolio_rows:
-        current_oracle_passed = _compat_symbol(
-            "_autoresearch_portfolio_current_oracle_passed",
-            _autoresearch_portfolio_current_oracle_passed,
-        )(row)
+        current_oracle_passed = _autoresearch_portfolio_current_oracle_passed(row)
         if (
             row.status in _AUTORESEARCH_PORTFOLIO_READY_STATUSES
             and current_oracle_passed

--- a/services/torghut/app/trading/submission_council/quant_health.py
+++ b/services/torghut/app/trading/submission_council/quant_health.py
@@ -25,7 +25,6 @@ from .common import (
     RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES as _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES,
     TYPED_QUANT_HEALTH_PATH as _TYPED_QUANT_HEALTH_PATH,
     coerce_aware_datetime as _coerce_aware_datetime,
-    compat_symbol as _compat_symbol,
     safe_attr_text as _safe_attr_text,
     safe_bool as _safe_bool,
     safe_int as _safe_int,
@@ -437,7 +436,7 @@ def load_quant_evidence_status(
         request = Request(
             request_url, method="GET", headers={"accept": "application/json"}
         )
-        with _compat_symbol("urlopen", urlopen)(
+        with urlopen(
             request, timeout=settings.trading_jangar_control_plane_timeout_seconds
         ) as response:
             status_code = int(getattr(response, "status", 200))

--- a/services/torghut/app/trading/submission_council/runtime_summary.py
+++ b/services/torghut/app/trading/submission_council/runtime_summary.py
@@ -13,7 +13,6 @@ from .common import (
     CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT as _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT,
     CERTIFICATE_EVIDENCE_WINDOW_LIMIT as _CERTIFICATE_EVIDENCE_WINDOW_LIMIT,
     coerce_aware_datetime as _coerce_aware_datetime,
-    compat_symbol as _compat_symbol,
     decimal_text as _decimal_text,
     normalize_reason_codes as _normalize_reason_codes,
     safe_decimal as _safe_decimal,
@@ -50,27 +49,19 @@ def build_hypothesis_runtime_summary(
         load_latest_runtime_ledger_summary as _load_latest_runtime_ledger_summary,
     )
 
-    registry = _compat_symbol("load_hypothesis_registry", load_hypothesis_registry)()
+    registry = load_hypothesis_registry()
     if dependency_quorum is None:
-        dependency_quorum = _compat_symbol(
-            "resolve_hypothesis_dependency_quorum",
-            resolve_hypothesis_dependency_quorum,
-        )(registry)
+        dependency_quorum = resolve_hypothesis_dependency_quorum(registry)
     runtime_ledger_summary = _load_latest_runtime_ledger_summary(
         session,
         hypothesis_ids=[item.hypothesis_id for item in registry.items],
     )
-    compile_statuses = _compat_symbol(
-        "compile_hypothesis_runtime_statuses",
-        compile_hypothesis_runtime_statuses,
-    )
-    build_tca_inputs = _compat_symbol("build_tca_gate_inputs", build_tca_gate_inputs)
-    items = compile_statuses(
+    items = compile_hypothesis_runtime_statuses(
         registry=registry,
         state=state,
         tca_summary=tca_summary
         if tca_summary is not None
-        else build_tca_inputs(
+        else build_tca_gate_inputs(
             session=session,
             account_label=settings.trading_account_label,
         ),

--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from scripts.hpairs_source_proof_census_audit import (
     argparse,
     json,
-    sys,
     Mapping,
     Sequence,
     Set,
@@ -112,7 +111,6 @@ from scripts.hpairs_source_proof_census_audit.shared_context import (
 __all__ = [
     "argparse",
     "json",
-    "sys",
     "Mapping",
     "Sequence",
     "Set",

--- a/services/torghut/scripts/hpairs_source_proof_census_audit/__init__.py
+++ b/services/torghut/scripts/hpairs_source_proof_census_audit/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from .shared_context import (
     argparse,
     json,
-    sys,
     Mapping,
     Sequence,
     Set,
@@ -88,7 +87,6 @@ from .parse_timestamp import main
 __all__ = [
     "argparse",
     "json",
-    "sys",
     "Mapping",
     "Sequence",
     "Set",

--- a/services/torghut/scripts/hpairs_source_proof_census_audit/shared_context.py
+++ b/services/torghut/scripts/hpairs_source_proof_census_audit/shared_context.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -158,13 +157,6 @@ _ECONOMICS_BLOCKERS = frozenset(
         EXECUTION_ECONOMICS_MISSING_BLOCKER,
     }
 )
-
-
-def _facade_attr(name: str, fallback: object) -> object:
-    facade = sys.modules.get("scripts.audit_hpairs_source_proof_census")
-    if facade is None:
-        return fallback
-    return getattr(facade, name, fallback)
 
 
 @dataclass(frozen=True)
@@ -364,13 +356,10 @@ def load_dsn_rows(
 ) -> CensusSourceRows:
     """Read only the bounded H-PAIRS source rows needed for the census."""
 
-    create_engine_fn = cast(Any, _facade_attr("create_engine", create_engine))
-    sessionmaker_fn = cast(Any, _facade_attr("sessionmaker", sessionmaker))
-    load_rows = cast(Any, _facade_attr("_load_session_rows", _load_session_rows))
-    engine = create_engine_fn(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
-    session_factory = sessionmaker_fn(bind=engine)
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
+    session_factory = sessionmaker(bind=engine)
     with session_factory() as session:
-        return load_rows(
+        return _load_session_rows(
             session,
             identity=identity,
             started_at=started_at,
@@ -547,11 +536,7 @@ def _load_session_rows(
         _source_window_row(row) for row in session.scalars(source_window_stmt).all()
     ]
 
-    load_authority_rows = cast(
-        Any,
-        _facade_attr("load_runtime_authority_rows", load_runtime_authority_rows),
-    )
-    ledger_rows = load_authority_rows(
+    ledger_rows = load_runtime_authority_rows(
         session,
         hypothesis_id=identity.hypothesis_id,
         candidate_id=identity.candidate_id,
@@ -815,7 +800,6 @@ __all__: tuple[str, ...] = (
     "_PRIMARY_LIFECYCLE_BLOCKERS",
     "_SOURCE_REF_BLOCKERS",
     "_authority_scope_rows",
-    "_facade_attr",
     "_load_session_rows",
     "_source_account_label",
     "_sqlalchemy_dsn",
@@ -837,6 +821,5 @@ __all__: tuple[str, ...] = (
     "parse_args",
     "select",
     "sessionmaker",
-    "sys",
     "timezone",
 )

--- a/services/torghut/scripts/runtime_ledger_proof_packet/io_artifacts.py
+++ b/services/torghut/scripts/runtime_ledger_proof_packet/io_artifacts.py
@@ -6,7 +6,6 @@ import argparse
 import hashlib
 import json
 import os
-import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
@@ -34,17 +33,8 @@ def _load_json_object(path: Path) -> dict[str, Any]:
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
 
 
-def _public_wrapper_attr(name: str) -> Any:
-    public_module = sys.modules.get("scripts.assemble_runtime_ledger_proof_packet")
-    if public_module is None:
-        return None
-    return getattr(public_module, name, None)
-
-
 def _urlopen(url: str, *, timeout_seconds: float) -> Any:
-    public_urlopen = _public_wrapper_attr("urlopen")
-    opener = public_urlopen if public_urlopen is not None else urlopen
-    return opener(url, timeout=timeout_seconds)
+    return urlopen(url, timeout=timeout_seconds)
 
 
 def _load_json_url(url: str, *, timeout_seconds: float) -> dict[str, Any]:
@@ -181,15 +171,6 @@ def _ceph_client_from_env() -> tuple[_ObjectStoreClient | None, str]:
 
 
 def _resolve_ceph_client_from_env() -> tuple[_ObjectStoreClient | None, str]:
-    public_ceph_client_from_env = _public_wrapper_attr("_ceph_client_from_env")
-    if (
-        public_ceph_client_from_env is not None
-        and public_ceph_client_from_env is not _ceph_client_from_env
-    ):
-        return cast(
-            tuple[_ObjectStoreClient | None, str],
-            public_ceph_client_from_env(),
-        )
     return _ceph_client_from_env()
 
 
@@ -356,18 +337,8 @@ def _load_optional_json_object(
     if path is not None:
         return _load_json_object(path)
     if url:
-        public_load_json_url = _public_wrapper_attr("_load_json_url")
-        load_json_url = (
-            public_load_json_url
-            if public_load_json_url is not None
-            and public_load_json_url is not _load_json_url
-            else _load_json_url
-        )
         try:
-            return cast(
-                dict[str, Any],
-                load_json_url(url, timeout_seconds=timeout_seconds),
-            )
+            return _load_json_url(url, timeout_seconds=timeout_seconds)
         except (HTTPError, URLError, TimeoutError) as exc:
             if unavailable_source_name is None:
                 raise

--- a/services/torghut/tests/api/test_trading_api_status_metadata.py
+++ b/services/torghut/tests/api/test_trading_api_status_metadata.py
@@ -101,11 +101,11 @@ class TestTradingApiStatusMetadata(TradingApiTestCaseBase):
                 "app.api.status_helpers.load_hypothesis_registry", return_value=registry
             ),
             patch(
-                "app.trading.submission_council.load_hypothesis_registry",
+                "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                 return_value=registry,
             ),
             patch(
-                "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                 return_value=runtime_items,
             ),
         ):

--- a/services/torghut/tests/api/test_trading_api_zero_notional_replay.py
+++ b/services/torghut/tests/api/test_trading_api_zero_notional_replay.py
@@ -723,6 +723,10 @@ class TestTradingApiZeroNotionalReplay(TradingApiTestCaseBase):
                     ),
                 ),
                 patch(
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
+                    return_value=SimpleNamespace(items=[registry_item]),
+                ),
+                patch(
                     "app.trading.submission_council.load_hypothesis_registry",
                     return_value=SimpleNamespace(items=[registry_item]),
                 ),

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_default_one_day_packet_is_smoke_not_authority.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_default_one_day_packet_is_smoke_not_authority.py
@@ -17,6 +17,8 @@ from tests.assemble_runtime_ledger_proof_packet.support import (
     tempfile,
 )
 
+from scripts.runtime_ledger_proof_packet import io_artifacts as packet_io_artifacts
+
 
 class TestDefaultOneDayPacketIsSmokeNotAuthority(_TestRuntimeLedgerProofPacketBase):
     def test_default_one_day_packet_is_smoke_not_authority(self) -> None:
@@ -517,7 +519,7 @@ class TestDefaultOneDayPacketIsSmokeNotAuthority(_TestRuntimeLedgerProofPacketBa
             completion_path.write_text(json.dumps(_completion()), encoding="utf-8")
 
             with patch.object(
-                packet,
+                packet_io_artifacts,
                 "_ceph_client_from_env",
                 return_value=(fake_client, "torghut-empirical-artifacts"),
             ):
@@ -673,7 +675,7 @@ class TestDefaultOneDayPacketIsSmokeNotAuthority(_TestRuntimeLedgerProofPacketBa
             )
 
             with patch.object(
-                packet,
+                packet_io_artifacts,
                 "_ceph_client_from_env",
                 return_value=(None, "torghut-empirical-artifacts"),
             ):
@@ -751,7 +753,7 @@ class TestDefaultOneDayPacketIsSmokeNotAuthority(_TestRuntimeLedgerProofPacketBa
             completion_path.write_text(json.dumps(_completion()), encoding="utf-8")
 
             with patch.object(
-                packet,
+                packet_io_artifacts,
                 "_ceph_client_from_env",
                 return_value=(fake_client, "torghut-empirical-artifacts"),
             ):

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_json_loaders_require_objects_and_support_urls.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_json_loaders_require_objects_and_support_urls.py
@@ -33,23 +33,28 @@ class TestJsonLoadersRequireObjectsAndSupportUrls(_TestRuntimeLedgerProofPacketB
             def read(self) -> bytes:
                 return json.dumps(self.body).encode("utf-8")
 
-        with patch.object(packet, "urlopen", return_value=_Response({"ok": True})):
+        with patch(
+            "scripts.runtime_ledger_proof_packet.io_artifacts.urlopen",
+            return_value=_Response({"ok": True}),
+        ):
             self.assertEqual(
                 packet._load_json_url(
                     "http://example.invalid/status.json", timeout_seconds=1
                 ),
                 {"ok": True},
             )
-        with patch.object(packet, "urlopen", return_value=_Response(["bad"])):
+        with patch(
+            "scripts.runtime_ledger_proof_packet.io_artifacts.urlopen",
+            return_value=_Response(["bad"]),
+        ):
             with self.assertRaisesRegex(ValueError, "json_object_required"):
                 packet._load_json_url(
                     "http://example.invalid/status.json",
                     timeout_seconds=1,
                 )
         http_error_url = "http://example.invalid/degraded.json"
-        with patch.object(
-            packet,
-            "urlopen",
+        with patch(
+            "scripts.runtime_ledger_proof_packet.io_artifacts.urlopen",
             side_effect=HTTPError(
                 url=http_error_url,
                 code=503,
@@ -69,9 +74,8 @@ class TestJsonLoadersRequireObjectsAndSupportUrls(_TestRuntimeLedgerProofPacketB
                     "http_error": True,
                 },
             )
-        with patch.object(
-            packet,
-            "urlopen",
+        with patch(
+            "scripts.runtime_ledger_proof_packet.io_artifacts.urlopen",
             side_effect=HTTPError(
                 url=http_error_url,
                 code=503,
@@ -82,9 +86,8 @@ class TestJsonLoadersRequireObjectsAndSupportUrls(_TestRuntimeLedgerProofPacketB
         ):
             with self.assertRaises(HTTPError):
                 packet._load_json_url(http_error_url, timeout_seconds=1)
-        with patch.object(
-            packet,
-            "_load_json_url",
+        with patch(
+            "scripts.runtime_ledger_proof_packet.io_artifacts._load_json_url",
             side_effect=HTTPError(
                 url=http_error_url,
                 code=503,

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_packet_accepts_alternate_runtime_plan_and_completion_gate_shapes.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_packet_accepts_alternate_runtime_plan_and_completion_gate_shapes.py
@@ -486,7 +486,10 @@ class TestPacketAcceptsAlternateRuntimePlanAndCompletionGateShapes(
             output_path = tmp_path / "packet.json"
             import_path.write_text(json.dumps(_runtime_import()), encoding="utf-8")
 
-            with patch.object(packet, "urlopen", side_effect=open_url):
+            with patch(
+                "scripts.runtime_ledger_proof_packet.io_artifacts.urlopen",
+                side_effect=open_url,
+            ):
                 exit_code = packet.main(
                     [
                         "--service-base-url",
@@ -550,7 +553,10 @@ class TestPacketAcceptsAlternateRuntimePlanAndCompletionGateShapes(
             output_path = tmp_path / "packet.json"
             import_path.write_text(json.dumps(_runtime_import()), encoding="utf-8")
 
-            with patch.object(packet, "urlopen", side_effect=open_url):
+            with patch(
+                "scripts.runtime_ledger_proof_packet.io_artifacts.urlopen",
+                side_effect=open_url,
+            ):
                 exit_code = packet.main(
                     [
                         "--status-service-base-url",
@@ -628,7 +634,10 @@ class TestPacketAcceptsAlternateRuntimePlanAndCompletionGateShapes(
             output_path = tmp_path / "packet.json"
             import_path.write_text(json.dumps(_runtime_import()), encoding="utf-8")
 
-            with patch.object(packet, "urlopen", side_effect=open_url):
+            with patch(
+                "scripts.runtime_ledger_proof_packet.io_artifacts.urlopen",
+                side_effect=open_url,
+            ):
                 exit_code = packet.main(
                     [
                         "--status-service-base-url",

--- a/services/torghut/tests/audit_hpairs_source_proof_census/test_load_session_rows_keeps_target_only_when_no_canonical_refs.py
+++ b/services/torghut/tests/audit_hpairs_source_proof_census/test_load_session_rows_keeps_target_only_when_no_canonical_refs.py
@@ -38,7 +38,7 @@ def test_load_session_rows_keeps_target_only_when_no_canonical_refs() -> None:
     )
 
     with patch(
-        "scripts.audit_hpairs_source_proof_census.load_runtime_authority_rows",
+        "scripts.hpairs_source_proof_census_audit.shared_context.load_runtime_authority_rows",
         return_value=[],
     ):
         rows = census._load_session_rows(
@@ -123,7 +123,7 @@ def test_load_session_rows_adds_linked_source_account_windows() -> None:
     )
 
     with patch(
-        "scripts.audit_hpairs_source_proof_census.load_runtime_authority_rows",
+        "scripts.hpairs_source_proof_census_audit.shared_context.load_runtime_authority_rows",
         return_value=[],
     ):
         rows = census._load_session_rows(

--- a/services/torghut/tests/audit_hpairs_source_proof_census/test_missing_tca_costs_are_economics_missing.py
+++ b/services/torghut/tests/audit_hpairs_source_proof_census/test_missing_tca_costs_are_economics_missing.py
@@ -5,6 +5,9 @@ from typing import cast
 
 import pytest
 
+from scripts.hpairs_source_proof_census_audit import (
+    shared_context as census_shared_context,
+)
 from tests.audit_hpairs_source_proof_census.support import (
     AUTHORITY_EXPLICIT_COSTS_BLOCKER,
     AUTHORITY_OPEN_POSITIONS_BLOCKER,
@@ -324,7 +327,9 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(
             return ScalarResult(self.scalar_results.pop(0))
 
     monkeypatch.setattr(
-        census, "load_runtime_authority_rows", lambda *args, **kwargs: [ledger_bucket]
+        census_shared_context,
+        "load_runtime_authority_rows",
+        lambda *args, **kwargs: [ledger_bucket],
     )
 
     rows = census._load_session_rows(
@@ -377,9 +382,15 @@ def test_dsn_loader_opens_session_and_delegates(
         ) -> None:
             return None
 
-    monkeypatch.setattr(census, "create_engine", lambda dsn, **kwargs: f"engine:{dsn}")
-    monkeypatch.setattr(census, "sessionmaker", lambda bind: lambda: FakeSession())
-    monkeypatch.setattr(census, "_load_session_rows", lambda *args, **kwargs: expected)
+    monkeypatch.setattr(
+        census_shared_context, "create_engine", lambda dsn, **kwargs: f"engine:{dsn}"
+    )
+    monkeypatch.setattr(
+        census_shared_context, "sessionmaker", lambda bind: lambda: FakeSession()
+    )
+    monkeypatch.setattr(
+        census_shared_context, "_load_session_rows", lambda *args, **kwargs: expected
+    )
 
     rows = census.load_dsn_rows(
         "sqlite:///:memory:", identity=identity, started_at=None, ended_at=None
@@ -417,10 +428,14 @@ def test_dsn_loader_sqlalchemy_dsn_uses_installed_psycopg_driver(
         captured["kwargs"] = kwargs
         return f"engine:{dsn}"
 
-    monkeypatch.setattr(census, "create_engine", fake_create_engine)
-    monkeypatch.setattr(census, "sessionmaker", lambda bind: lambda: FakeSession())
+    monkeypatch.setattr(census_shared_context, "create_engine", fake_create_engine)
     monkeypatch.setattr(
-        census, "_load_session_rows", lambda *args, **kwargs: census.CensusSourceRows()
+        census_shared_context, "sessionmaker", lambda bind: lambda: FakeSession()
+    )
+    monkeypatch.setattr(
+        census_shared_context,
+        "_load_session_rows",
+        lambda *args, **kwargs: census.CensusSourceRows(),
     )
 
     census.load_dsn_rows(

--- a/services/torghut/tests/order_feed/support.py
+++ b/services/torghut/tests/order_feed/support.py
@@ -4,6 +4,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+import importlib
 from types import SimpleNamespace
 
 from sqlalchemy import create_engine, func, select
@@ -54,6 +55,10 @@ from app.trading.order_feed import (
     repair_order_feed_execution_links,
     repair_order_feed_execution_states,
     repair_order_feed_fill_deltas,
+)
+
+order_feed_repair_module = importlib.import_module(
+    "app.trading.order_feed.repair_order_feed_execution_links"
 )
 
 
@@ -278,6 +283,7 @@ __all__ = [
     "merge_execution_raw_order_update",
     "normalize_order_feed_record",
     "order_feed_module",
+    "order_feed_repair_module",
     "patch",
     "persist_order_event",
     "repair_order_feed_execution_links",

--- a/services/torghut/tests/order_feed/test_order_feed_backfill_and_cursor_a.py
+++ b/services/torghut/tests/order_feed/test_order_feed_backfill_and_cursor_a.py
@@ -18,6 +18,7 @@ from tests.order_feed.support import (
     datetime,
     func,
     order_feed_module,
+    order_feed_repair_module,
     patch,
     repair_order_feed_execution_links,
     repair_order_feed_execution_states,
@@ -266,7 +267,7 @@ class TestOrderFeedBackfillAndCursorA(OrderFeedTestCase):
                 client_order_id="race-client",
             )
             with patch.object(
-                order_feed_module,
+                order_feed_repair_module,
                 "latest_order_event_for_execution",
                 return_value=ExecutionOrderEvent(
                     event_fingerprint="race-existing",
@@ -299,7 +300,7 @@ class TestOrderFeedBackfillAndCursorA(OrderFeedTestCase):
             )
             session.commit()
             with patch.object(
-                order_feed_module,
+                order_feed_repair_module,
                 "_stable_execution_source_offset",
                 return_value=77,
             ):

--- a/services/torghut/tests/order_feed/test_order_feed_repair_links_a.py
+++ b/services/torghut/tests/order_feed/test_order_feed_repair_links_a.py
@@ -10,6 +10,7 @@ from tests.order_feed.support import (
     Session,
     datetime,
     order_feed_module,
+    order_feed_repair_module,
     patch,
     repair_order_feed_execution_links,
     repair_order_feed_execution_states,
@@ -252,12 +253,12 @@ class TestOrderFeedRepairLinksA(OrderFeedTestCase):
 
             with (
                 patch.object(
-                    order_feed_module,
+                    order_feed_repair_module,
                     "latest_order_event_for_execution",
                     side_effect=[None, linked_events[1], linked_events[2]],
                 ) as latest_event,
                 patch.object(
-                    order_feed_module,
+                    order_feed_repair_module,
                     "apply_order_event_to_execution",
                     side_effect=[(False, True), (False, False)],
                 ) as apply_event,

--- a/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_a.py
+++ b/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_a.py
@@ -118,11 +118,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council.load_hypothesis_registry",
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                     return_value=registry,
                 ),
                 patch(
-                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    "app.trading.submission_council.runtime_summary.resolve_hypothesis_dependency_quorum",
                     return_value=JangarDependencyQuorumStatus(
                         decision="allow",
                         reasons=[],
@@ -130,11 +130,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
                     ),
                 ),
                 patch(
-                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                     return_value=runtime_items,
                 ),
                 patch(
-                    "app.trading.submission_council.build_tca_gate_inputs",
+                    "app.trading.submission_council.runtime_summary.build_tca_gate_inputs",
                     return_value={},
                 ),
             ):
@@ -289,11 +289,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council.load_hypothesis_registry",
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                     return_value=registry,
                 ),
                 patch(
-                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    "app.trading.submission_council.runtime_summary.resolve_hypothesis_dependency_quorum",
                     return_value=JangarDependencyQuorumStatus(
                         decision="allow",
                         reasons=[],
@@ -301,11 +301,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
                     ),
                 ),
                 patch(
-                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                     return_value=runtime_items,
                 ),
                 patch(
-                    "app.trading.submission_council.build_tca_gate_inputs",
+                    "app.trading.submission_council.runtime_summary.build_tca_gate_inputs",
                     return_value={},
                 ),
             ):
@@ -436,11 +436,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council.load_hypothesis_registry",
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                     return_value=registry,
                 ),
                 patch(
-                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    "app.trading.submission_council.runtime_summary.resolve_hypothesis_dependency_quorum",
                     return_value=JangarDependencyQuorumStatus(
                         decision="allow",
                         reasons=[],
@@ -448,11 +448,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
                     ),
                 ),
                 patch(
-                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                     return_value=runtime_items,
                 ),
                 patch(
-                    "app.trading.submission_council.build_tca_gate_inputs",
+                    "app.trading.submission_council.runtime_summary.build_tca_gate_inputs",
                     return_value={},
                 ),
             ):
@@ -605,7 +605,7 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
             session.commit()
 
             with patch(
-                "app.trading.submission_council.load_hypothesis_registry",
+                "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                 return_value=registry,
             ):
                 gate = build_live_submission_gate_payload(
@@ -809,7 +809,7 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
             session.commit()
 
             with patch(
-                "app.trading.submission_council._maybe_set_runtime_ledger_status_statement_timeout",
+                "app.trading.submission_council.certificate_loading._maybe_set_runtime_ledger_status_statement_timeout",
                 side_effect=SQLAlchemyError("statement timeout"),
             ):
                 evidence = _load_latest_certificate_evidence(

--- a/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_b.py
+++ b/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_b.py
@@ -95,11 +95,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council.load_hypothesis_registry",
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                     return_value=registry,
                 ),
                 patch(
-                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    "app.trading.submission_council.runtime_summary.resolve_hypothesis_dependency_quorum",
                     return_value=JangarDependencyQuorumStatus(
                         decision="allow",
                         reasons=[],
@@ -107,11 +107,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
                     ),
                 ),
                 patch(
-                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                     return_value=runtime_items,
                 ),
                 patch(
-                    "app.trading.submission_council.build_tca_gate_inputs",
+                    "app.trading.submission_council.runtime_summary.build_tca_gate_inputs",
                     return_value={},
                 ),
             ):
@@ -333,11 +333,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council.load_hypothesis_registry",
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                     return_value=registry,
                 ),
                 patch(
-                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    "app.trading.submission_council.runtime_summary.resolve_hypothesis_dependency_quorum",
                     return_value=JangarDependencyQuorumStatus(
                         decision="allow",
                         reasons=[],
@@ -345,11 +345,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
                     ),
                 ),
                 patch(
-                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                     return_value=runtime_items,
                 ),
                 patch(
-                    "app.trading.submission_council.build_tca_gate_inputs",
+                    "app.trading.submission_council.runtime_summary.build_tca_gate_inputs",
                     return_value={},
                 ),
             ):
@@ -460,11 +460,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council.load_hypothesis_registry",
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                     return_value=registry,
                 ),
                 patch(
-                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    "app.trading.submission_council.runtime_summary.resolve_hypothesis_dependency_quorum",
                     return_value=JangarDependencyQuorumStatus(
                         decision="allow",
                         reasons=[],
@@ -472,11 +472,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
                     ),
                 ),
                 patch(
-                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                     return_value=runtime_items,
                 ),
                 patch(
-                    "app.trading.submission_council.build_tca_gate_inputs",
+                    "app.trading.submission_council.runtime_summary.build_tca_gate_inputs",
                     return_value={},
                 ),
             ):
@@ -566,11 +566,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council.load_hypothesis_registry",
+                    "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                     return_value=registry,
                 ),
                 patch(
-                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    "app.trading.submission_council.runtime_summary.resolve_hypothesis_dependency_quorum",
                     return_value=JangarDependencyQuorumStatus(
                         decision="allow",
                         reasons=[],
@@ -578,11 +578,11 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
                     ),
                 ),
                 patch(
-                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    "app.trading.submission_council.runtime_summary.compile_hypothesis_runtime_statuses",
                     return_value=runtime_items,
                 ),
                 patch(
-                    "app.trading.submission_council.build_tca_gate_inputs",
+                    "app.trading.submission_council.runtime_summary.build_tca_gate_inputs",
                     return_value={},
                 ),
             ):

--- a/services/torghut/tests/submission_council/test_profit_readiness_a.py
+++ b/services/torghut/tests/submission_council/test_profit_readiness_a.py
@@ -440,7 +440,7 @@ class TestSubmissionCouncilProfitReadinessA(SubmissionCouncilTestCase):
 
             with (
                 patch(
-                    "app.trading.submission_council._autoresearch_portfolio_current_oracle_passed",
+                    "app.trading.submission_council.profit_readiness._autoresearch_portfolio_current_oracle_passed",
                     return_value=True,
                 ),
                 patch.object(

--- a/services/torghut/tests/submission_council/test_quant_health.py
+++ b/services/torghut/tests/submission_council/test_quant_health.py
@@ -153,7 +153,7 @@ class TestSubmissionCouncilQuantHealth(SubmissionCouncilTestCase):
                 }
             )
 
-        with patch("app.trading.submission_council.urlopen", fake_urlopen):
+        with patch("app.trading.submission_council.quant_health.urlopen", fake_urlopen):
             status = load_quant_evidence_status(account_label="paper")
             cached_status = load_quant_evidence_status(account_label="paper")
 
@@ -207,7 +207,7 @@ class TestSubmissionCouncilQuantHealth(SubmissionCouncilTestCase):
             del request, timeout
             return _FakeQuantHealthResponse(payloads.pop(0))
 
-        with patch("app.trading.submission_council.urlopen", fake_urlopen):
+        with patch("app.trading.submission_council.quant_health.urlopen", fake_urlopen):
             empty_status = load_quant_evidence_status(account_label="paper")
             stage_status = load_quant_evidence_status(account_label="paper")
             stale_status = load_quant_evidence_status(account_label="paper")
@@ -246,7 +246,7 @@ class TestSubmissionCouncilQuantHealth(SubmissionCouncilTestCase):
                 }
             )
 
-        with patch("app.trading.submission_council.urlopen", fake_urlopen):
+        with patch("app.trading.submission_council.quant_health.urlopen", fake_urlopen):
             status = load_quant_evidence_status(account_label="paper")
 
         self.assertTrue(status["ok"])
@@ -276,7 +276,7 @@ class TestSubmissionCouncilQuantHealth(SubmissionCouncilTestCase):
             del request, timeout
             raise RuntimeError("network unavailable")
 
-        with patch("app.trading.submission_council.urlopen", fake_urlopen):
+        with patch("app.trading.submission_council.quant_health.urlopen", fake_urlopen):
             status = load_quant_evidence_status(account_label="paper")
 
         self.assertTrue(status["ok"])

--- a/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
+++ b/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
@@ -54,7 +54,7 @@ class TestSubmissionCouncilRuntimeCertificateMerge(SubmissionCouncilTestCase):
 
         with session_local() as session:
             with patch(
-                "app.trading.submission_council.load_hypothesis_registry",
+                "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                 return_value=registry,
             ):
                 gate = build_live_submission_gate_payload(

--- a/services/torghut/tests/submission_council/test_runtime_ledger_repair_candidates.py
+++ b/services/torghut/tests/submission_council/test_runtime_ledger_repair_candidates.py
@@ -257,7 +257,7 @@ class TestSubmissionCouncilRuntimeLedgerRepairCandidates(SubmissionCouncilTestCa
             session.commit()
 
             with patch(
-                "app.trading.submission_council.load_hypothesis_registry",
+                "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                 return_value=registry,
             ):
                 gate = build_live_submission_gate_payload(

--- a/services/torghut/tests/submission_council/test_source_collection_candidates.py
+++ b/services/torghut/tests/submission_council/test_source_collection_candidates.py
@@ -844,7 +844,7 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
             session.commit()
 
             with patch(
-                "app.trading.submission_council.load_hypothesis_registry",
+                "app.trading.submission_council.runtime_summary.load_hypothesis_registry",
                 return_value=registry,
             ):
                 gate = build_live_submission_gate_payload(

--- a/services/torghut/tests/test_explicit_module_facade_exports.py
+++ b/services/torghut/tests/test_explicit_module_facade_exports.py
@@ -143,6 +143,36 @@ def test_app_and_script_import_surfaces_do_not_ship_runtime_compat_modules() -> 
     assert compat_module_paths == []
 
 
+def test_owner_modules_do_not_patch_through_public_wrappers() -> None:
+    service_root = Path(__file__).resolve().parents[1]
+    forbidden_by_path = {
+        "scripts/runtime_ledger_proof_packet/io_artifacts.py": (
+            "_public_wrapper_attr",
+            "scripts.assemble_runtime_ledger_proof_packet",
+        ),
+        "scripts/hpairs_source_proof_census_audit/shared_context.py": (
+            "_facade_attr",
+            "scripts.audit_hpairs_source_proof_census",
+        ),
+        "app/trading/submission_council/common.py": (
+            "_compat_symbol",
+            "compat_symbol =",
+            'sys.modules.get("app.trading.submission_council")',
+        ),
+        "app/trading/order_feed/repair_order_feed_execution_links.py": (
+            "_order_feed_facade",
+            "_facade_latest_order_event_for_execution",
+            "_facade_apply_order_event_to_execution",
+            "_facade_stable_execution_source_offset",
+        ),
+    }
+
+    for relative_path, forbidden_tokens in forbidden_by_path.items():
+        source = (service_root / relative_path).read_text(encoding="utf-8")
+        for token in forbidden_tokens:
+            assert token not in source, f"{relative_path} still contains {token}"
+
+
 def test_generated_split_package_directories_are_absent() -> None:
     service_root = Path(__file__).resolve().parents[1]
     split_package_suffix = "_" + "modules"


### PR DESCRIPTION
## Summary

- Removed remaining runtime backchannels where owner modules reached through public wrapper/facade modules for proof-packet IO, HPAIRS source-proof census, submission-council helpers, and order-feed repair.
- Retargeted tests to patch the owning implementation modules instead of package/script facades.
- Added an import-surface regression check that forbids these wrapper backchannel helpers from returning.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app scripts tests`
- `uv run --frozen ruff format --check app scripts tests`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/test_explicit_module_facade_exports.py tests/assemble_runtime_ledger_proof_packet tests/audit_hpairs_source_proof_census tests/submission_council tests/order_feed/test_order_feed_repair_links_a.py tests/order_feed/test_order_feed_repair_links_b.py tests/order_feed/test_order_feed_backfill_and_cursor_a.py tests/api/test_trading_api_zero_notional_replay.py tests/api/test_trading_api_status_metadata.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
