### PR TITLE
fix(torghut): make bounded paper closes marketable

### DIFF
--- a/services/torghut/app/trading/scheduler/submission_preparation/quote_routeability.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/quote_routeability.py
@@ -762,6 +762,9 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
         prepared_decision: StrategyDecision,
         snapshot: MarketSnapshot | None,
     ) -> tuple[StrategyDecision, Optional[MarketSnapshot]] | None:
+        prepared_decision = self._marketable_bounded_live_close_decision(
+            prepared_decision
+        )
         self.executor.sync_decision_state(
             request.session,
             request.decision_row,
@@ -786,3 +789,145 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
             )
             return None
         return prepared_decision, snapshot
+
+    @classmethod
+    def _marketable_bounded_live_close_decision(
+        cls,
+        decision: StrategyDecision,
+    ) -> StrategyDecision:
+        if not cls._bounded_live_close_order_needs_marketability(decision):
+            return decision
+        marketable_limit = cls._bounded_live_close_marketable_limit(decision)
+        if marketable_limit is None or marketable_limit <= 0:
+            return decision
+
+        original_limit = decision.limit_price
+        if (
+            decision.action == "sell"
+            and original_limit is not None
+            and original_limit <= marketable_limit
+        ):
+            return cls._bounded_live_close_decision_with_marketability_audit(
+                decision,
+                marketable_limit=marketable_limit,
+                adjusted=False,
+            )
+        if (
+            decision.action == "buy"
+            and original_limit is not None
+            and original_limit >= marketable_limit
+        ):
+            return cls._bounded_live_close_decision_with_marketability_audit(
+                decision,
+                marketable_limit=marketable_limit,
+                adjusted=False,
+            )
+
+        return cls._bounded_live_close_decision_with_marketability_audit(
+            decision.model_copy(
+                update={
+                    "order_type": "limit",
+                    "limit_price": marketable_limit,
+                }
+            ),
+            marketable_limit=marketable_limit,
+            adjusted=True,
+            original_order_type=decision.order_type,
+            original_limit_price=original_limit,
+        )
+
+    @staticmethod
+    def _bounded_live_close_order_needs_marketability(
+        decision: StrategyDecision,
+    ) -> bool:
+        params = decision.params
+        if params.get("bounded_live_paper_route_close") is True:
+            return True
+        simple_lane = mapping_value(params.get("simple_lane"))
+        if (
+            simple_lane is not None
+            and simple_lane.get("bounded_live_paper_route_close") is True
+        ):
+            return True
+        exit_metadata = mapping_value(params.get("paper_route_probe_exit"))
+        return (
+            exit_metadata is not None
+            and exit_metadata.get("live_bounded_paper_route_close") is True
+        )
+
+    @staticmethod
+    def _bounded_live_close_marketable_limit(
+        decision: StrategyDecision,
+    ) -> Decimal | None:
+        bid, ask = (
+            SimplePipelineSubmissionQuoteRouteabilityMixin._bounded_live_close_bid_ask(
+                decision.params
+            )
+        )
+        if decision.action == "sell":
+            return bid
+        if decision.action == "buy":
+            return ask
+        return None  # pragma: no cover - StrategyDecision constrains action.
+
+    @staticmethod
+    def _bounded_live_close_bid_ask(
+        params: Mapping[str, Any],
+    ) -> tuple[Decimal | None, Decimal | None]:
+        quote = mapping_value(params.get("price_snapshot")) or {}
+        routeability = mapping_value(params.get("quote_routeability")) or {}
+        bid = optional_decimal(quote.get("bid"))
+        if bid is None:
+            bid = optional_decimal(routeability.get("bid"))
+        if bid is None:
+            bid = optional_decimal(params.get("imbalance_bid_px"))
+        if bid is None:
+            bid = optional_decimal(params.get("bid"))
+        ask = optional_decimal(quote.get("ask"))
+        if ask is None:
+            ask = optional_decimal(routeability.get("ask"))
+        if ask is None:
+            ask = optional_decimal(params.get("imbalance_ask_px"))
+        if ask is None:
+            ask = optional_decimal(params.get("ask"))
+        return bid, ask
+
+    @staticmethod
+    def _bounded_live_close_decision_with_marketability_audit(
+        decision: StrategyDecision,
+        *,
+        marketable_limit: Decimal,
+        adjusted: bool,
+        original_order_type: str | None = None,
+        original_limit_price: Decimal | None = None,
+    ) -> StrategyDecision:
+        params = dict(decision.params)
+        bid, ask = (
+            SimplePipelineSubmissionQuoteRouteabilityMixin._bounded_live_close_bid_ask(
+                params
+            )
+        )
+        audit = {
+            "schema_version": "torghut.bounded-live-paper-close-order.v1",
+            "state": "marketable_limit_adjusted" if adjusted else "already_marketable",
+            "reason": "bounded_live_paper_route_close_requires_marketable_limit",
+            "action": decision.action,
+            "order_type": decision.order_type,
+            "limit_price": str(decision.limit_price)
+            if decision.limit_price is not None
+            else None,
+            "marketable_limit_price": str(marketable_limit),
+            "quote_bid": str(bid) if bid is not None else None,
+            "quote_ask": str(ask) if ask is not None else None,
+        }
+        if adjusted:
+            audit["original_order_type"] = original_order_type
+            audit["original_limit_price"] = (
+                str(original_limit_price) if original_limit_price is not None else None
+            )
+
+        params["bounded_live_paper_route_close_order"] = audit
+        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
+        simple_lane["bounded_live_paper_route_close_order"] = audit
+        params["simple_lane"] = simple_lane
+        return decision.model_copy(update={"params": params})

--- a/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
@@ -47,6 +47,209 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
             session_factory=session_local,
         )
 
+    def test_live_bounded_close_sell_limit_is_marketable_at_bid(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 17, 20, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("0.1671"),
+            order_type="limit",
+            limit_price=Decimal("298.19"),
+            params={
+                "bounded_live_paper_route_close": True,
+                "price_snapshot": {
+                    "bid": "298.17",
+                    "ask": "298.23",
+                },
+                "simple_lane": {
+                    "bounded_live_paper_route_close": True,
+                },
+            },
+        )
+
+        prepared = SimpleTradingPipeline._marketable_bounded_live_close_decision(
+            decision
+        )
+
+        self.assertEqual(prepared.order_type, "limit")
+        self.assertEqual(prepared.limit_price, Decimal("298.17"))
+        audit = cast(
+            dict[str, Any],
+            prepared.params["bounded_live_paper_route_close_order"],
+        )
+        self.assertEqual(audit["state"], "marketable_limit_adjusted")
+        self.assertEqual(audit["original_limit_price"], "298.19")
+        self.assertEqual(audit["marketable_limit_price"], "298.17")
+        simple_lane = cast(dict[str, Any], prepared.params["simple_lane"])
+        self.assertEqual(
+            simple_lane["bounded_live_paper_route_close_order"],
+            audit,
+        )
+
+    def test_live_bounded_close_buy_limit_is_marketable_at_ask(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 17, 20, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("0.1671"),
+            order_type="limit",
+            limit_price=Decimal("298.20"),
+            params={
+                "paper_route_probe_exit": {
+                    "live_bounded_paper_route_close": True,
+                },
+                "quote_routeability": {
+                    "bid": "298.17",
+                    "ask": "298.23",
+                },
+            },
+        )
+
+        prepared = SimpleTradingPipeline._marketable_bounded_live_close_decision(
+            decision
+        )
+
+        self.assertEqual(prepared.order_type, "limit")
+        self.assertEqual(prepared.limit_price, Decimal("298.23"))
+        audit = cast(
+            dict[str, Any],
+            prepared.params["bounded_live_paper_route_close_order"],
+        )
+        self.assertEqual(audit["state"], "marketable_limit_adjusted")
+        self.assertEqual(audit["original_limit_price"], "298.20")
+        self.assertEqual(audit["marketable_limit_price"], "298.23")
+
+    def test_live_bounded_close_simple_lane_marker_is_marketable(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 17, 20, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("0.1671"),
+            order_type="limit",
+            limit_price=Decimal("298.19"),
+            params={
+                "simple_lane": {
+                    "bounded_live_paper_route_close": True,
+                },
+                "price_snapshot": {
+                    "bid": "298.17",
+                    "ask": "298.23",
+                },
+            },
+        )
+
+        prepared = SimpleTradingPipeline._marketable_bounded_live_close_decision(
+            decision
+        )
+
+        self.assertEqual(prepared.limit_price, Decimal("298.17"))
+
+    def test_live_bounded_close_leaves_already_marketable_sell_limit(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 17, 20, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("0.1671"),
+            order_type="limit",
+            limit_price=Decimal("298.16"),
+            params={
+                "bounded_live_paper_route_close": True,
+                "price_snapshot": {
+                    "bid": "298.17",
+                    "ask": "298.23",
+                },
+            },
+        )
+
+        prepared = SimpleTradingPipeline._marketable_bounded_live_close_decision(
+            decision
+        )
+
+        self.assertEqual(prepared.limit_price, Decimal("298.16"))
+        audit = cast(
+            dict[str, Any],
+            prepared.params["bounded_live_paper_route_close_order"],
+        )
+        self.assertEqual(audit["state"], "already_marketable")
+
+    def test_live_bounded_close_leaves_already_marketable_buy_limit(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 17, 20, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("0.1671"),
+            order_type="limit",
+            limit_price=Decimal("298.24"),
+            params={
+                "bounded_live_paper_route_close": True,
+                "price_snapshot": {
+                    "bid": "298.17",
+                    "ask": "298.23",
+                },
+            },
+        )
+
+        prepared = SimpleTradingPipeline._marketable_bounded_live_close_decision(
+            decision
+        )
+
+        self.assertEqual(prepared.limit_price, Decimal("298.24"))
+        audit = cast(
+            dict[str, Any],
+            prepared.params["bounded_live_paper_route_close_order"],
+        )
+        self.assertEqual(audit["state"], "already_marketable")
+
+    def test_live_bounded_close_without_quote_leaves_decision_unchanged(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 17, 20, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("0.1671"),
+            order_type="limit",
+            limit_price=Decimal("298.19"),
+            params={
+                "bounded_live_paper_route_close": True,
+            },
+        )
+
+        prepared = SimpleTradingPipeline._marketable_bounded_live_close_decision(
+            decision
+        )
+
+        self.assertIs(prepared, decision)
+
+    def test_live_bounded_close_bid_ask_fallback_sources(self) -> None:
+        bid, ask = SimpleTradingPipeline._bounded_live_close_bid_ask(
+            {
+                "imbalance_bid_px": "298.17",
+                "imbalance_ask_px": "298.23",
+            }
+        )
+        self.assertEqual(bid, Decimal("298.17"))
+        self.assertEqual(ask, Decimal("298.23"))
+
+        bid, ask = SimpleTradingPipeline._bounded_live_close_bid_ask(
+            {
+                "bid": "298.11",
+                "ask": "298.29",
+            }
+        )
+        self.assertEqual(bid, Decimal("298.11"))
+        self.assertEqual(ask, Decimal("298.29"))
+
     def test_live_bounded_paper_route_close_bypasses_gate_and_tags_exit(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Make live bounded paper-route close submissions marketable by moving sell-to-close limits down to the executable bid and buy-to-close limits up to the executable ask.
- Persist a `torghut.bounded-live-paper-close-order.v1` audit payload on the decision and simple-lane metadata for operator/debug visibility.
- Add bounded-close regressions for sell, buy, and already-marketable close orders.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_bounded_live_close.py -q`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_probe_exits_a.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_probe_exits_b.py -q`
- `uv run --frozen pytest tests/pipeline/test_trading_pipeline_paper_route_quote_a.py tests/pipeline/test_trading_pipeline_paper_route_quote_b.py -q`
- `uv run --frozen ruff check app/trading/scheduler/submission_preparation/quote_routeability.py tests/pipeline/test_trading_pipeline_bounded_live_close.py`
- `uv run --frozen ruff format --check app/trading/scheduler/submission_preparation/quote_routeability.py tests/pipeline/test_trading_pipeline_bounded_live_close.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
