### PR TITLE
refactor(torghut): remove owner facade backchannels

### DIFF
--- a/services/torghut/app/config/common.py
+++ b/services/torghut/app/config/common.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
@@ -185,14 +184,6 @@ def urlopen(request: _HttpRequest, timeout: float) -> _HttpResponseHandle:
     return _HttpResponseHandle(connection, response)
 
 
-def _feature_flag_urlopen() -> FeatureFlagUrlopen:
-    config_module = sys.modules.get("app.config")
-    candidate = getattr(config_module, "urlopen", None) if config_module else None
-    if callable(candidate):
-        return cast(FeatureFlagUrlopen, candidate)
-    return urlopen
-
-
 def _build_boolean_feature_flag_request(
     request: BooleanFeatureFlagRequest,
 ) -> tuple[_HttpRequest, float]:
@@ -260,7 +251,7 @@ def resolve_boolean_feature_flag(
 ) -> tuple[bool, bool]:
     http_request, timeout_seconds = _build_boolean_feature_flag_request(request)
     try:
-        with _feature_flag_urlopen()(http_request, timeout_seconds) as response:
+        with urlopen(http_request, timeout_seconds) as response:
             return _parse_boolean_feature_flag_response(
                 request=request,
                 status=int(getattr(response, "status", 200)),

--- a/services/torghut/app/trading/completion/effective_row_status.py
+++ b/services/torghut/app/trading/completion/effective_row_status.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import sys
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, cast
 
@@ -78,13 +77,7 @@ def build_doc29_completion_status(
     current_git_revision: str | None,
     current_image_digest: str | None,
 ) -> dict[str, Any]:
-    completion_root = sys.modules.get('app.trading.completion')
-    matrix_loader = (
-        getattr(completion_root, 'load_doc29_completion_matrix', load_doc29_completion_matrix)
-        if completion_root is not None
-        else load_doc29_completion_matrix
-    )
-    matrix = matrix_loader()
+    matrix = load_doc29_completion_matrix()
     gate_definition_by_id = {str(gate['gate_id']): gate for gate in cast(list[dict[str, Any]], matrix['gates'])}
     latest_rows = _latest_completion_rows(session)
     empirical_jobs_status = build_empirical_jobs_status(

--- a/services/torghut/app/trading/execution/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_core_methods.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 import time
 from collections.abc import Mapping
 from decimal import Decimal
@@ -68,13 +67,6 @@ from .order_executor_core_support import (
     unknown_position_sell_inventory_conflict as _unknown_position_sell_inventory_conflict,
     validate_pre_submit_request as _validate_pre_submit_request,
 )
-
-
-def _execution_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.execution")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 if TYPE_CHECKING:
@@ -459,8 +451,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
                 order_response=order_payload,
             )
         )
-        sync_order = _execution_root_export("sync_order_to_db", sync_order_to_db)
-        return sync_order(
+        return sync_order_to_db(
             session,
             order_payload,
             trade_decision_id=str(decision_row.id),

--- a/services/torghut/app/trading/hypotheses/runtime_ledger_row_rank.py
+++ b/services/torghut/app/trading/hypotheses/runtime_ledger_row_rank.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -158,13 +157,6 @@ _runtime_text = getattr(_extract_stage_renewal_bonds_private_68, "_runtime_text"
 _weighted_decimal_average = getattr(
     _extract_stage_renewal_bonds_private_68, "_weighted_decimal_average"
 )
-
-
-def _hypotheses_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.hypotheses")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 def _runtime_ledger_row_rank(
@@ -627,8 +619,7 @@ def load_jangar_dependency_quorum(
         if omit_torghut_consumer_evidence:
             headers["x-torghut-consumer-evidence-mode"] = "omit"
         request = Request(status_url, method="GET", headers=headers)
-        open_url = _hypotheses_root_export("urlopen", urlopen)
-        with open_url(
+        with urlopen(
             request, timeout=settings.trading_jangar_control_plane_timeout_seconds
         ) as response:
             if response.status < 200 or response.status >= 300:

--- a/services/torghut/app/trading/hypotheses/shared_context.py
+++ b/services/torghut/app/trading/hypotheses/shared_context.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -467,13 +466,6 @@ def hypothesis_registry_requires_dependency_capability(
     return False
 
 
-def _hypotheses_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.hypotheses")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
-
-
 def resolve_hypothesis_dependency_quorum(
     registry: HypothesisRegistryLoadResult,
 ) -> JangarDependencyQuorumStatus:
@@ -483,15 +475,9 @@ def resolve_hypothesis_dependency_quorum(
         registry,
         "jangar_dependency_quorum",
     ):
-        from .runtime_ledger_row_rank import (
-            load_jangar_dependency_quorum as default_load_jangar_dependency_quorum,
-        )
+        from .runtime_ledger_row_rank import load_jangar_dependency_quorum
 
-        load_dependency_quorum = _hypotheses_root_export(
-            "load_jangar_dependency_quorum",
-            default_load_jangar_dependency_quorum,
-        )
-        return load_dependency_quorum()
+        return load_jangar_dependency_quorum()
     return JangarDependencyQuorumStatus(
         decision="allow",
         reasons=["torghut_dependency_quorum_not_required"],
@@ -840,7 +826,6 @@ __all__: tuple[str, ...] = (
     "_empty_payload_dict_list",
     "_extract_stage_trust",
     "_first_matching_reason",
-    "_hypotheses_root_export",
     "_is_dependency_required",
     "_normalize_dependency_capability",
     "_optional_bool",
@@ -882,7 +867,6 @@ __all__: tuple[str, ...] = (
     "sequence",
     "settings",
     "stable_string_list",
-    "sys",
     "timedelta",
     "timezone",
     "urlopen",

--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -26,13 +25,6 @@ from .shared_context import (
     simulation_fetch_window as _simulation_fetch_window,
     logger,
 )
-
-
-def _ingest_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.ingest")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 def _qualified_table_name(table: str) -> str:
@@ -178,8 +170,7 @@ class _ClickHouseSignalIngestorCoreMethods(_ClickHouseSignalIngestorCoreBase):
                 no_signal_reason="clickhouse_url_missing",
             )
 
-        now_provider = _ingest_root_export("trading_now", trading_now)
-        poll_started_at = now_provider(account_label=self.account_label)
+        poll_started_at = trading_now(account_label=self.account_label)
         query_window_start: datetime | None = None
         scoped_symbols = _normalized_signal_symbols(symbols)
         scoped_timeframes = _normalized_signal_timeframes(timeframes)

--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import re
-import sys
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Mapping, Optional, cast
 
@@ -32,13 +31,6 @@ from .clickhouse_signal_ingestor_core_methods import (
 from .clickhouse_signal_ingestor_market_methods import (
     ClickHouseSignalIngestorMarketMethods as _ClickHouseSignalIngestorMarketMethods,
 )
-
-
-def _ingest_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.ingest")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 if TYPE_CHECKING:
@@ -90,8 +82,7 @@ class _ClickHouseSignalIngestorPersistenceMethods(
             if cursor_at.tzinfo is None:
                 cursor_at = cursor_at.replace(tzinfo=timezone.utc)
             if self.simulation_mode and cursor_at <= SIMULATION_CURSOR_BASELINE:
-                now_provider = _ingest_root_export("trading_now", trading_now)
-                return now_provider(account_label=self.account_label), None, None
+                return trading_now(account_label=self.account_label), None, None
             if self.simulation_mode:
                 normalized_cursor = normalize_simulation_cursor(cursor_at)
                 if normalized_cursor is not None and normalized_cursor != cursor_at:
@@ -99,8 +90,7 @@ class _ClickHouseSignalIngestorPersistenceMethods(
             return cursor_at, cursor_row.cursor_seq, cursor_row.cursor_symbol
 
         if self.simulation_mode:
-            now_provider = _ingest_root_export("trading_now", trading_now)
-            return now_provider(account_label=self.account_label), None, None
+            return trading_now(account_label=self.account_label), None, None
 
         lookback = timedelta(minutes=self.initial_lookback_minutes)
         return datetime.now(timezone.utc) - lookback, None, None

--- a/services/torghut/app/trading/llm/dspy_compile/workflow/resolve_promotion_gate_snapshot.py
+++ b/services/torghut/app/trading/llm/dspy_compile/workflow/resolve_promotion_gate_snapshot.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -72,13 +71,6 @@ _sanitize_idempotency_key = getattr(
 )
 _to_bool = getattr(_shared_context_private_33, "_to_bool")
 _to_float = getattr(_shared_context_private_33, "_to_float")
-
-
-def _workflow_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.llm.dspy_compile.workflow")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 def _resolve_promotion_gate_snapshot(
@@ -673,11 +665,7 @@ def _submit_and_persist_remote_dspy_lane(
     state: _DSPyWorkflowState,
     context: _DSPyLaneContext,
 ) -> None:
-    submit_agent_run = _workflow_root_export(
-        "submit_agents_agentrun",
-        submit_agents_agentrun,
-    )
-    response_payload = submit_agent_run(
+    response_payload = submit_agents_agentrun(
         base_url=request.base_url,
         payload=context.payload,
         idempotency_key=context.idempotency_key,
@@ -710,11 +698,7 @@ def _wait_for_dspy_lane_terminal_phase(
     request: _DSPyWorkflowRequest,
     response_payload: Mapping[str, Any],
 ) -> str:
-    wait_for_status = _workflow_root_export(
-        "wait_for_agents_agentrun_terminal_status",
-        wait_for_agents_agentrun_terminal_status,
-    )
-    return wait_for_status(
+    return wait_for_agents_agentrun_terminal_status(
         base_url=request.base_url,
         agent_run_id=_extract_submitted_agentrun_id(response_payload),
         namespace=request.namespace,

--- a/services/torghut/app/trading/scheduler/governance/governance_mixin_decision_methods.py
+++ b/services/torghut/app/trading/scheduler/governance/governance_mixin_decision_methods.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -26,13 +25,6 @@ from .shared_context import (
     resolve_autonomy_artifact_root as _resolve_autonomy_artifact_root,
     logger,
 )
-
-
-def _governance_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.scheduler.governance")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 if TYPE_CHECKING:
@@ -397,11 +389,7 @@ class _TradingSchedulerGovernanceDecisionMethods(
         query_start = batch.query_start or start
         query_end = batch.query_end or now
         try:
-            persist_no_signal_run = _governance_root_export(
-                "upsert_autonomy_no_signal_run",
-                upsert_autonomy_no_signal_run,
-            )
-            self.state.last_autonomy_run_id = persist_no_signal_run(
+            self.state.last_autonomy_run_id = upsert_autonomy_no_signal_run(
                 session_factory=self._pipeline.session_factory,
                 query_start=query_start,
                 query_end=query_end,
@@ -593,10 +581,7 @@ class _TradingSchedulerGovernanceDecisionMethods(
         if self._pipeline is None:
             raise RuntimeError("trading_pipeline_not_initialized")
         try:
-            lane_runner = _governance_root_export(
-                "run_autonomous_lane", run_autonomous_lane
-            )
-            return lane_runner(
+            return run_autonomous_lane(
                 signals_path=signals_path,
                 strategy_config_path=strategy_config_path,
                 gate_policy_path=gate_policy_path,

--- a/services/torghut/app/trading/scheduler/governance/governance_mixin_lifecycle_methods.py
+++ b/services/torghut/app/trading/scheduler/governance/governance_mixin_lifecycle_methods.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from collections.abc import Mapping
 from datetime import datetime
 from decimal import Decimal
@@ -39,13 +38,6 @@ from .shared_context import (
     resolve_autonomy_artifact_root as _resolve_autonomy_artifact_root,
     logger,
 )
-
-
-def _governance_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.scheduler.governance")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 if TYPE_CHECKING:
@@ -536,10 +528,7 @@ class _TradingSchedulerGovernanceLifecycleMethods(
             return None
 
     def _governance_now(self) -> datetime:
-        now_provider = _governance_root_export("trading_now", trading_now)
-        return now_provider(
-            account_label=getattr(self._pipeline, "account_label", None)
-        )
+        return trading_now(account_label=getattr(self._pipeline, "account_label", None))
 
     def _trigger_emergency_stop(
         self,
@@ -705,10 +694,7 @@ class _TradingSchedulerGovernanceLifecycleMethods(
         if self._pipeline is None:
             raise RuntimeError("trading_pipeline_not_initialized")
         with self._pipeline.session_factory() as session:
-            continuity_check = _governance_root_export(
-                "evaluate_evidence_continuity", evaluate_evidence_continuity
-            )
-            report = continuity_check(
+            report = evaluate_evidence_continuity(
                 session,
                 run_limit=settings.trading_evidence_continuity_run_limit,
             )

--- a/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, cast
+from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -143,13 +142,6 @@ _runtime_ledger_ref_matches_expected_bucket = getattr(
 )
 
 
-def _tigerbeetle_reconcile_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.trading.tigerbeetle_reconcile")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
-
-
 def latest_tigerbeetle_reconciliation_status_payload(
     session: Session,
     *,
@@ -252,13 +244,7 @@ def reconcile_tigerbeetle_transfers(
     tb_client: TigerBeetleClientProtocol | None = None
     try:
         if refs:
-            client_factory = _tigerbeetle_reconcile_root_export(
-                "create_tigerbeetle_client",
-                create_tigerbeetle_client,
-            )
-            tb_client = client or client_factory(settings_obj)
-            if tb_client is None:
-                raise RuntimeError("tigerbeetle_client_unavailable")
+            tb_client = client or create_tigerbeetle_client(settings_obj)
             looked_up = tb_client.lookup_transfers(
                 [int(ref.transfer_id) for ref in refs]
             )

--- a/services/torghut/app/whitepapers/workflow/shared_context.py
+++ b/services/torghut/app/whitepapers/workflow/shared_context.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 import re
-import sys
 import tempfile
 import uuid
 from dataclasses import dataclass
@@ -121,22 +120,6 @@ def _http_request_bytes(
     follow_redirects: bool = False,
     max_redirects: int = 5,
 ) -> tuple[int, dict[str, str], bytes]:
-    root_http_request_bytes = _whitepaper_root_export("_http_request_bytes", None)
-    if (
-        root_http_request_bytes is not None
-        and root_http_request_bytes is not _http_request_bytes
-    ):
-        return root_http_request_bytes(
-            url,
-            method=method,
-            headers=headers,
-            body=body,
-            timeout_seconds=timeout_seconds,
-            max_response_bytes=max_response_bytes,
-            follow_redirects=follow_redirects,
-            max_redirects=max_redirects,
-        )
-
     current_url = url
     current_method = method
     current_body = body
@@ -357,42 +340,16 @@ def _sorted_unique(values: list[str]) -> list[str]:
     return ordered
 
 
-def _whitepaper_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("app.whitepapers.workflow")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
-
-
-def _whitepaper_root_flag(name: str, env_name: str, *, default: bool) -> bool:
-    root_value = _whitepaper_root_export(name, None)
-    if root_value is not None and root_value is not globals().get(name):
-        return bool(root_value())
-    return _bool_env(env_name, default=default)
-
-
 def whitepaper_workflow_enabled() -> bool:
-    return _whitepaper_root_flag(
-        "whitepaper_workflow_enabled",
-        "WHITEPAPER_WORKFLOW_ENABLED",
-        default=False,
-    )
+    return _bool_env("WHITEPAPER_WORKFLOW_ENABLED", default=False)
 
 
 def whitepaper_inngest_enabled() -> bool:
-    return _whitepaper_root_flag(
-        "whitepaper_inngest_enabled",
-        "WHITEPAPER_INNGEST_ENABLED",
-        default=False,
-    )
+    return _bool_env("WHITEPAPER_INNGEST_ENABLED", default=False)
 
 
 def whitepaper_kafka_enabled() -> bool:
-    return _whitepaper_root_flag(
-        "whitepaper_kafka_enabled",
-        "WHITEPAPER_KAFKA_ENABLED",
-        default=False,
-    )
+    return _bool_env("WHITEPAPER_KAFKA_ENABLED", default=False)
 
 
 def whitepaper_semantic_indexing_enabled() -> bool:
@@ -784,8 +741,6 @@ __all__: tuple[str, ...] = (
     "_sorted_unique",
     "_str_env",
     "_whitepaper_ceph_bucket_name",
-    "_whitepaper_root_export",
-    "_whitepaper_root_flag",
     "annotations",
     "asyncio",
     "bool_env",
@@ -836,7 +791,6 @@ __all__: tuple[str, ...] = (
     "select",
     "sorted_unique",
     "str_env",
-    "sys",
     "tempfile",
     "text",
     "timezone",

--- a/services/torghut/scripts/empirical_promotion_renewal/raise_if_runtime_window_target_plan_import.py
+++ b/services/torghut/scripts/empirical_promotion_renewal/raise_if_runtime_window_target_plan_import.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import time as wall_time
 import urllib.error
 import urllib.request
@@ -34,13 +33,6 @@ from .parse_runtime_window_target_spec import (
     read_runtime_window_target_plan as _read_runtime_window_target_plan,
     runtime_window_target_plan_from_payload as _runtime_window_target_plan_from_payload,
 )
-
-
-def _renewal_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("scripts.renew_latest_empirical_promotion_jobs")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 def _raise_if_runtime_window_target_plan_import_blocked(
@@ -651,8 +643,7 @@ def _latest_autoresearch_runtime_window_targets(
         int(getattr(args, "runtime_window_autoresearch_scan_limit", 20) or 20),
     )
     statuses = _runtime_window_autoresearch_statuses(args)
-    session_factory = _renewal_root_export("SessionLocal", SessionLocal)
-    with session_factory() as session:
+    with SessionLocal() as session:
         rows = (
             session.execute(
                 select(AutoresearchEpoch)
@@ -666,11 +657,7 @@ def _latest_autoresearch_runtime_window_targets(
             .scalars()
             .all()
         )
-    runtime_window_targets_from_autoresearch_epochs = _renewal_root_export(
-        "_runtime_window_targets_from_autoresearch_epochs",
-        _runtime_window_targets_from_autoresearch_epochs,
-    )
-    return runtime_window_targets_from_autoresearch_epochs(args=args, epochs=rows)
+    return _runtime_window_targets_from_autoresearch_epochs(args=args, epochs=rows)
 
 
 # Public aliases used by split-module consumers.

--- a/services/torghut/scripts/empirical_promotion_renewal/run_runtime_window_import_target.py
+++ b/services/torghut/scripts/empirical_promotion_renewal/run_runtime_window_import_target.py
@@ -94,13 +94,6 @@ def run_captured_child(
         raise RuntimeError(f"{context}_failed: exit_code={exc.returncode}") from exc
 
 
-def _renewal_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("scripts.renew_latest_empirical_promotion_jobs")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
-
-
 def _run_runtime_window_import_target(
     *,
     args: argparse.Namespace,
@@ -113,22 +106,14 @@ def _run_runtime_window_import_target(
     now: datetime,
     allow_source_activity_window: bool = False,
 ) -> dict[str, Any]:
-    read_runtime_window_manifest = _renewal_root_export(
-        "_read_runtime_window_manifest",
-        _read_runtime_window_manifest,
-    )
-    runtime_manifest = read_runtime_window_manifest(target.source_manifest_ref)
+    runtime_manifest = _read_runtime_window_manifest(target.source_manifest_ref)
     window_selection = "explicit_or_default"
     target_plan_window = _runtime_window_target_plan_bounds(target)
     if target_plan_window is not None:
         window_start, window_end = target_plan_window
         window_selection = "target_plan_window"
     elif allow_source_activity_window:
-        latest_source_activity_window = _renewal_root_export(
-            "_latest_source_activity_window",
-            _latest_source_activity_window,
-        )
-        source_activity_window = latest_source_activity_window(
+        source_activity_window = _latest_source_activity_window(
             target=target,
             runtime_manifest=runtime_manifest,
         )

--- a/services/torghut/scripts/empirical_promotion_renewal/runtime_window_targets.py
+++ b/services/torghut/scripts/empirical_promotion_renewal/runtime_window_targets.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -51,13 +50,6 @@ from .raise_if_runtime_window_target_plan_import import (
 )
 
 
-def _renewal_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("scripts.renew_latest_empirical_promotion_jobs")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
-
-
 def _run_runtime_window_import_target(*args: Any, **kwargs: Any) -> dict[str, Any]:
     from .run_runtime_window_import_target import (
         run_runtime_window_import_target,
@@ -90,11 +82,7 @@ def _runtime_window_targets(
     args: argparse.Namespace,
 ) -> list[RuntimeWindowImportTarget]:
     specs = [str(item) for item in getattr(args, "runtime_window_target", []) or []]
-    runtime_window_plan_targets = _renewal_root_export(
-        "_runtime_window_plan_targets",
-        _runtime_window_plan_targets,
-    )
-    plan_targets = runtime_window_plan_targets(args)
+    plan_targets = _runtime_window_plan_targets(args)
     plan_required = bool(getattr(args, "runtime_window_target_plan_required", False))
     if plan_required:
         plan_ref_count = _runtime_window_target_plan_ref_count(args)
@@ -104,18 +92,12 @@ def _runtime_window_targets(
             raise RuntimeError("runtime_window_target_plan_required_but_empty")
     plan_exclusive = bool(getattr(args, "runtime_window_target_plan_exclusive", False))
     fallback_enabled = not plan_exclusive
-    latest_autoresearch_runtime_window_targets = _renewal_root_export(
-        "_latest_autoresearch_runtime_window_targets",
-        _latest_autoresearch_runtime_window_targets,
-    )
-    registry_runtime_window_targets = _renewal_root_export(
-        "_registry_runtime_window_targets",
-        _registry_runtime_window_targets,
-    )
     autoresearch_targets = (
-        latest_autoresearch_runtime_window_targets(args) if fallback_enabled else []
+        _latest_autoresearch_runtime_window_targets(args) if fallback_enabled else []
     )
-    registry_targets = registry_runtime_window_targets(args) if fallback_enabled else []
+    registry_targets = (
+        _registry_runtime_window_targets(args) if fallback_enabled else []
+    )
     if (
         not specs
         and not plan_targets

--- a/services/torghut/scripts/strategy_autoresearch_loop/load_yaml.py
+++ b/services/torghut/scripts/strategy_autoresearch_loop/load_yaml.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
@@ -46,13 +45,6 @@ from .shared_context import (
     _select_effective_replay_tape_window,
     _string,
 )
-
-
-def _strategy_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("scripts.run_strategy_autoresearch_loop")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -278,12 +270,8 @@ def _maybe_materialize_run_replay_tape(
                 ),
             }
         )
-        select_effective_replay_tape_window = _strategy_root_export(
-            "_select_effective_replay_tape_window",
-            _select_effective_replay_tape_window,
-        )
         selected_start, selected_end, latest_window_receipt = (
-            select_effective_replay_tape_window(
+            _select_effective_replay_tape_window(
                 args=window_args,
                 symbols=snapshot_symbols,
                 requested_start_date=_iso_date(full_window_start_date),

--- a/services/torghut/scripts/strategy_autoresearch_loop/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/strategy_autoresearch_loop/run_strategy_autoresearch_loop.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, cast
@@ -75,13 +74,6 @@ from .write_portfolio_outputs import (
     _write_exact_replay_ledger_ranking,
     _write_exact_replay_ledger_remediation,
 )
-
-
-def _strategy_loop_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("scripts.run_strategy_autoresearch_loop")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
@@ -373,11 +365,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 summary.get("exact_replay_ledger_remediation")
             )
             try:
-                frontier_runner = _strategy_loop_root_export(
-                    "run_consistent_profitability_frontier",
-                    run_consistent_profitability_frontier,
-                )
-                frontier_payload = frontier_runner(
+                frontier_payload = run_consistent_profitability_frontier(
                     _frontier_args(
                         args=frontier_base_args,
                         program=program,

--- a/services/torghut/scripts/strategy_autoresearch_loop/write_portfolio_outputs.py
+++ b/services/torghut/scripts/strategy_autoresearch_loop/write_portfolio_outputs.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, cast
@@ -59,13 +58,6 @@ from .write_results_tsv import (
     _summary_promotion_readiness_for_outputs,
     _write_results_tsv,
 )
-
-
-def _strategy_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("scripts.run_strategy_autoresearch_loop")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
 
 
 def _write_portfolio_outputs(
@@ -511,22 +503,14 @@ def _persist_run_outputs(
         proposal_scores=proposal_scores,
         history=history,
     )
-    mlx_export_writer = _strategy_root_export(
-        "write_mlx_notebook_exports",
-        write_mlx_notebook_exports,
-    )
-    mlx_exports = mlx_export_writer(
+    mlx_exports = write_mlx_notebook_exports(
         run_root=run_root,
         manifest=manifest,
         descriptors=descriptors,
         proposal_scores=proposal_scores,
         proposal_diagnostics=proposal_diagnostics,
     )
-    notebook_writer = _strategy_root_export(
-        "write_autoresearch_notebooks",
-        write_autoresearch_notebooks,
-    )
-    notebook_paths = notebook_writer(run_root)
+    notebook_paths = write_autoresearch_notebooks(run_root)
     exact_replay_ledger_ranking = _write_exact_replay_ledger_ranking(
         run_root=run_root,
         program=program,
@@ -578,11 +562,7 @@ def _persist_run_outputs(
         ),
     }
     best_candidate = cast(dict[str, Any] | None, summary["best_candidate"])
-    portfolio_writer = _strategy_root_export(
-        "_write_portfolio_outputs",
-        _write_portfolio_outputs,
-    )
-    portfolio, portfolio_outputs = portfolio_writer(
+    portfolio, portfolio_outputs = _write_portfolio_outputs(
         run_root=run_root,
         program=program,
     )
@@ -590,11 +570,7 @@ def _persist_run_outputs(
     summary["best_portfolio_candidate"] = (
         portfolio.to_payload() if portfolio is not None else None
     )
-    runtime_closure_writer = _strategy_root_export(
-        "write_runtime_closure_bundle",
-        write_runtime_closure_bundle,
-    )
-    runtime_closure = runtime_closure_writer(
+    runtime_closure = write_runtime_closure_bundle(
         run_root=run_root,
         runner_run_id=runner_run_id,
         program=program,

--- a/services/torghut/scripts/strategy_autoresearch_loop/write_results_tsv.py
+++ b/services/torghut/scripts/strategy_autoresearch_loop/write_results_tsv.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, cast
@@ -122,15 +121,8 @@ def _strategy_name_from_strategy_id(strategy_id: str) -> str:
     return base.replace("_", "-") if base else ""
 
 
-def _strategy_root_export(name: str, fallback: Any) -> Any:
-    root_module = sys.modules.get("scripts.run_strategy_autoresearch_loop")
-    if root_module is None:
-        return fallback
-    return getattr(root_module, name, fallback)
-
-
 def _hypothesis_manifest_rows() -> list[dict[str, str]]:
-    repo_root = Path(_strategy_root_export("_REPO_ROOT", _REPO_ROOT))
+    repo_root = Path(_REPO_ROOT)
     hypothesis_dir = repo_root / "services/torghut/config/trading/hypotheses"
     rows: list[dict[str, str]] = []
     if not hypothesis_dir.exists():

--- a/services/torghut/tests/api/test_trading_api_status_consumer_evidence.py
+++ b/services/torghut/tests/api/test_trading_api_status_consumer_evidence.py
@@ -110,7 +110,9 @@ class TestTradingApiStatusConsumerEvidence(TradingApiTestCaseBase):
             return {}
 
         with (
-            patch("app.trading.hypotheses.urlopen") as jangar_status_fetch,
+            patch(
+                "app.trading.hypotheses.runtime_ledger_row_rank.urlopen"
+            ) as jangar_status_fetch,
             patch(
                 "app.api.status_helpers._load_llm_evaluation",
                 side_effect=_load_llm_evaluation,

--- a/services/torghut/tests/completion_trace/test_runtime_and_doc_completion_matrices_match.py
+++ b/services/torghut/tests/completion_trace/test_runtime_and_doc_completion_matrices_match.py
@@ -158,7 +158,7 @@ class TestRuntimeAndDocCompletionMatricesMatch(_TestCompletionTraceBase):
     def test_doc29_completion_status_all_satisfied_stays_status_only(self) -> None:
         with self.session_local() as session:
             with patch(
-                "app.trading.completion.load_doc29_completion_matrix",
+                "app.trading.completion.effective_row_status.load_doc29_completion_matrix",
                 return_value={
                     "doc_id": "doc29",
                     "design_doc_path": "docs/torghut/design-system/v6/29-completion-matrix-2026-03-07.yaml",

--- a/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
+++ b/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
@@ -112,7 +112,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             }
             return _MockFlagResponse({"enabled": values.get(key, False)})
 
-        with patch("app.config.urlopen", side_effect=_mock_urlopen):
+        with patch("app.config.common.urlopen", side_effect=_mock_urlopen):
             settings = Settings(
                 TRADING_ENABLED=True,
                 TRADING_EMERGENCY_STOP_ENABLED=False,
@@ -170,7 +170,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             )
             return _MockFlagResponse({"enabled": None})
 
-        with patch("app.config.urlopen", side_effect=_mock_urlopen):
+        with patch("app.config.common.urlopen", side_effect=_mock_urlopen):
             Settings(
                 TRADING_ENABLED=False,
                 TRADING_UNIVERSE_SOURCE="static",
@@ -191,7 +191,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             self.assertEqual(payload.get("context"), {})
 
     def test_feature_flag_failures_fallback_to_env_values(self) -> None:
-        with patch("app.config.urlopen", side_effect=RuntimeError("network")):
+        with patch("app.config.common.urlopen", side_effect=RuntimeError("network")):
             settings = Settings(
                 TRADING_ENABLED=False,
                 TRADING_EMERGENCY_STOP_ENABLED=False,
@@ -214,7 +214,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             call_count += 1
             raise RuntimeError("network")
 
-        with patch("app.config.urlopen", side_effect=_mock_urlopen):
+        with patch("app.config.common.urlopen", side_effect=_mock_urlopen):
             Settings(
                 TRADING_ENABLED=False,
                 TRADING_EMERGENCY_STOP_ENABLED=False,
@@ -249,7 +249,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             call_count += 1
             return _Response()
 
-        with patch("app.config.urlopen", side_effect=_mock_urlopen):
+        with patch("app.config.common.urlopen", side_effect=_mock_urlopen):
             Settings(
                 TRADING_ENABLED=False,
                 TRADING_EMERGENCY_STOP_ENABLED=False,

--- a/services/torghut/tests/hypotheses/test_compile_hypothesis_runtime_statuses_blocks_bounded_hpairs_collection_on_stale_signal_lag.py
+++ b/services/torghut/tests/hypotheses/test_compile_hypothesis_runtime_statuses_blocks_bounded_hpairs_collection_on_stale_signal_lag.py
@@ -721,7 +721,9 @@ class TestCompileHypothesisRuntimeStatusesBlocksBoundedHpairsCollectionOnStaleSi
                 "jangar_dependency_quorum",
             )
         )
-        with patch("app.trading.hypotheses.urlopen") as urlopen_mock:
+        with patch(
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen"
+        ) as urlopen_mock:
             status = resolve_hypothesis_dependency_quorum(registry)
 
         urlopen_mock.assert_not_called()
@@ -771,7 +773,7 @@ class TestCompileHypothesisRuntimeStatusesBlocksBoundedHpairsCollectionOnStaleSi
             )
         )
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "dependency_quorum": {

--- a/services/torghut/tests/hypotheses/test_load_jangar_dependency_quorum_prefers_dependency_quorum_contract.py
+++ b/services/torghut/tests/hypotheses/test_load_jangar_dependency_quorum_prefers_dependency_quorum_contract.py
@@ -21,7 +21,7 @@ class TestLoadJangarDependencyQuorumPrefersDependencyQuorumContract(
         settings.trading_jangar_control_plane_cache_ttl_seconds = 0
         settings.trading_jangar_control_plane_timeout_seconds = 1.0
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "dependency_quorum": {
@@ -97,7 +97,7 @@ class TestLoadJangarDependencyQuorumPrefersDependencyQuorumContract(
             ],
         }
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "generated_at": "2026-05-14T16:10:00Z",
@@ -137,7 +137,7 @@ class TestLoadJangarDependencyQuorumPrefersDependencyQuorumContract(
             "fresh_until": "2026-05-14T16:30:00Z",
         }
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "generated_at": "2026-05-14T16:10:00Z",
@@ -169,7 +169,7 @@ class TestLoadJangarDependencyQuorumPrefersDependencyQuorumContract(
         )
         settings.trading_jangar_control_plane_cache_ttl_seconds = 0
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "dependency_quorum": {
@@ -199,7 +199,7 @@ class TestLoadJangarDependencyQuorumPrefersDependencyQuorumContract(
         )
         settings.trading_jangar_control_plane_cache_ttl_seconds = 30
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "dependency_quorum": {
@@ -229,7 +229,7 @@ class TestLoadJangarDependencyQuorumPrefersDependencyQuorumContract(
         )
         settings.trading_jangar_control_plane_cache_ttl_seconds = 0
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "workflows": {
@@ -263,7 +263,7 @@ class TestLoadJangarDependencyQuorumPrefersDependencyQuorumContract(
             "board_id": "verify-trust-foreclosure-board:ready-test",
         }
         with patch(
-            "app.trading.hypotheses.urlopen",
+            "app.trading.hypotheses.runtime_ledger_row_rank.urlopen",
             return_value=_FakeHttpResponse(
                 {
                     "status": "ok",

--- a/services/torghut/tests/llm_dspy_workflow/test_compile_result_is_deterministic.py
+++ b/services/torghut/tests/llm_dspy_workflow/test_compile_result_is_deterministic.py
@@ -402,11 +402,11 @@ class TestCompileResultIsDeterministic(_TestLLMDSPyWorkflowBase):
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with Session(self.engine) as session:
@@ -507,11 +507,11 @@ class TestCompileResultIsDeterministic(_TestLLMDSPyWorkflowBase):
             lane_overrides["promote"].pop("artifactHash", None)
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ):
                     with Session(self.engine) as session:
@@ -597,11 +597,11 @@ class TestCompileResultIsDeterministic(_TestLLMDSPyWorkflowBase):
                 )
 
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                     side_effect=responses,
                 ) as submit_mock:
                     with patch(
-                        "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                        "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                         side_effect=[
                             "succeeded",
                             "succeeded",
@@ -660,11 +660,11 @@ class TestCompileResultIsDeterministic(_TestLLMDSPyWorkflowBase):
         ]
 
         with patch(
-            "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+            "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
             side_effect=submit_side_effects,
         ) as submit_mock:
             with patch(
-                "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                 side_effect=["succeeded", "succeeded"],
             ) as wait_mock:
                 with self.assertRaisesRegex(RuntimeError, "submit_failed"):
@@ -741,11 +741,11 @@ class TestCompileResultIsDeterministic(_TestLLMDSPyWorkflowBase):
         ]
 
         with patch(
-            "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+            "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
             side_effect=responses,
         ) as submit_mock:
             with patch(
-                "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                 side_effect=["failed"],
             ) as wait_mock:
                 with self.assertRaisesRegex(

--- a/services/torghut/tests/llm_dspy_workflow/test_orchestrate_dspy_agentrun_workflow_blocks_promotion_on_gate_failure.py
+++ b/services/torghut/tests/llm_dspy_workflow/test_orchestrate_dspy_agentrun_workflow_blocks_promotion_on_gate_failure.py
@@ -62,11 +62,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with self.assertRaisesRegex(
@@ -162,11 +162,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with Session(self.engine) as session:
@@ -247,11 +247,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with self.assertRaisesRegex(
@@ -324,11 +324,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with self.assertRaisesRegex(
@@ -408,11 +408,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with self.assertRaisesRegex(
@@ -489,11 +489,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with self.assertRaisesRegex(
@@ -587,11 +587,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with self.assertRaisesRegex(
@@ -668,11 +668,11 @@ class TestOrchestrateDspyAgentrunWorkflowBlocksPromotionOnGateFailure(
             )
 
             with patch(
-                "app.trading.llm.dspy_compile.workflow.submit_agents_agentrun",
+                "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.submit_agents_agentrun",
                 side_effect=responses,
             ) as submit_mock:
                 with patch(
-                    "app.trading.llm.dspy_compile.workflow.wait_for_agents_agentrun_terminal_status",
+                    "app.trading.llm.dspy_compile.workflow.resolve_promotion_gate_snapshot.wait_for_agents_agentrun_terminal_status",
                     side_effect=["succeeded", "succeeded", "succeeded"],
                 ) as wait_mock:
                     with self.assertRaisesRegex(

--- a/services/torghut/tests/order_feed/test_order_feed_core.py
+++ b/services/torghut/tests/order_feed/test_order_feed_core.py
@@ -297,7 +297,7 @@ class TestOrderFeedCore(OrderFeedTestCase):
                     return_value=client,
                 ),
                 patch(
-                    "app.trading.tigerbeetle_reconcile.create_tigerbeetle_client",
+                    "app.trading.tigerbeetle_reconcile.latest_tigerbeetle_reconciliation_status_p.create_tigerbeetle_client",
                     return_value=client,
                 ),
             ):

--- a/services/torghut/tests/order_idempotency/test_decision_hash_stable_for_same_intent.py
+++ b/services/torghut/tests/order_idempotency/test_decision_hash_stable_for_same_intent.py
@@ -387,7 +387,9 @@ class TestDecisionHashStableForSameIntent(_TestOrderIdempotencyBase):
 
             alpaca_client = FakeAlpacaClient()
 
-            with patch("app.trading.execution.sync_order_to_db") as sync_mock:
+            with patch(
+                "app.trading.execution.order_executor_core_methods.sync_order_to_db"
+            ) as sync_mock:
                 sync_mock.side_effect = RuntimeError("db write failed")
                 with self.assertRaises(RuntimeError):
                     executor.submit_order(

--- a/services/torghut/tests/renew_latest_empirical_promotion_jobs/test_explicit_live_target_does_not_suppress_paper_plan_target.py
+++ b/services/torghut/tests/renew_latest_empirical_promotion_jobs/test_explicit_live_target_does_not_suppress_paper_plan_target.py
@@ -52,8 +52,9 @@ class TestExplicitLiveTargetDoesNotSuppressPaperPlanTarget(
             runtime_window_targets_from_registry=False,
         )
 
-        with patch.object(
-            renew, "_runtime_window_plan_targets", return_value=[paper_target]
+        with patch(
+            "scripts.empirical_promotion_renewal.runtime_window_targets._runtime_window_plan_targets",
+            return_value=[paper_target],
         ):
             targets = renew._runtime_window_targets(args)
 
@@ -561,9 +562,8 @@ class TestExplicitLiveTargetDoesNotSuppressPaperPlanTarget(
         args = argparse.Namespace(runtime_window_target_plan_settlement_seconds=0)
 
         with (
-            patch.object(
-                renew,
-                "_read_runtime_window_manifest",
+            patch(
+                "scripts.empirical_promotion_renewal.run_runtime_window_import_target._read_runtime_window_manifest",
                 return_value={"candidate_id": "c88421d619759b2cfaa6f4d0"},
             ),
             patch.object(renew.subprocess, "run") as run,

--- a/services/torghut/tests/run_empirical_promotion_jobs/test_empirical_job_core.py
+++ b/services/torghut/tests/run_empirical_promotion_jobs/test_empirical_job_core.py
@@ -703,14 +703,12 @@ class TestRunEmpiricalPromotionJobsCore(RunEmpiricalPromotionJobsTestCase):
         )
 
         with (
-            patch.object(
-                renewal,
-                "_latest_autoresearch_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
                 side_effect=AssertionError("autoresearch fallback should be skipped"),
             ),
-            patch.object(
-                renewal,
-                "_registry_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._registry_runtime_window_targets",
                 side_effect=AssertionError("registry fallback should be skipped"),
             ),
         ):
@@ -762,9 +760,8 @@ class TestRunEmpiricalPromotionJobsCore(RunEmpiricalPromotionJobsTestCase):
             runtime_window_source_kind="paper_runtime_observed",
         )
 
-        with patch.object(
-            renewal,
-            "_latest_autoresearch_runtime_window_targets",
+        with patch(
+            "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
             return_value=[fallback_target],
         ) as latest_autoresearch:
             targets = renewal._runtime_window_targets(args)
@@ -810,14 +807,12 @@ class TestRunEmpiricalPromotionJobsCore(RunEmpiricalPromotionJobsTestCase):
         )
 
         with (
-            patch.object(
-                renewal,
-                "_latest_autoresearch_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
                 side_effect=AssertionError("autoresearch fallback should not run"),
             ),
-            patch.object(
-                renewal,
-                "_registry_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._registry_runtime_window_targets",
                 side_effect=AssertionError("registry fallback should not run"),
             ),
             self.assertRaisesRegex(

--- a/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py
+++ b/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py
@@ -173,9 +173,8 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowImportB(
 
         with (
             patch.object(renewal.subprocess, "run", return_value=completed) as run_mock,
-            patch.object(
-                renewal,
-                "_latest_source_activity_window",
+            patch(
+                "scripts.empirical_promotion_renewal.run_runtime_window_import_target._latest_source_activity_window",
                 return_value=source_window,
             ) as source_window_mock,
         ):
@@ -245,9 +244,8 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowImportB(
 
         with (
             patch.object(renewal.subprocess, "run", return_value=completed),
-            patch.object(
-                renewal,
-                "_latest_source_activity_window",
+            patch(
+                "scripts.empirical_promotion_renewal.run_runtime_window_import_target._latest_source_activity_window",
                 return_value=(
                     datetime(2026, 5, 15, 13, 30, tzinfo=timezone.utc),
                     datetime(2026, 5, 15, 20, 0, tzinfo=timezone.utc),
@@ -329,9 +327,8 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowImportB(
 
         with (
             patch.object(renewal.subprocess, "run", return_value=completed) as run_mock,
-            patch.object(
-                renewal,
-                "_latest_source_activity_window",
+            patch(
+                "scripts.empirical_promotion_renewal.run_runtime_window_import_target._latest_source_activity_window",
                 return_value=(
                     datetime(2026, 5, 15, 13, 30, tzinfo=timezone.utc),
                     datetime(2026, 5, 15, 20, 0, tzinfo=timezone.utc),
@@ -429,14 +426,12 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowImportB(
                 "run",
                 side_effect=AssertionError("future target window should not import"),
             ),
-            patch.object(
-                renewal,
-                "_latest_autoresearch_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
                 side_effect=AssertionError("autoresearch fallback should not run"),
             ),
-            patch.object(
-                renewal,
-                "_registry_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._registry_runtime_window_targets",
                 side_effect=AssertionError("registry fallback should not run"),
             ),
         ):
@@ -568,14 +563,12 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowImportB(
                 "run",
                 side_effect=AssertionError("future target window should not import"),
             ),
-            patch.object(
-                renewal,
-                "_latest_autoresearch_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
                 side_effect=AssertionError("autoresearch fallback should not run"),
             ),
-            patch.object(
-                renewal,
-                "_registry_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._registry_runtime_window_targets",
                 side_effect=AssertionError("registry fallback should not run"),
             ),
         ):

--- a/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_b.py
+++ b/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_b.py
@@ -232,11 +232,12 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowTargetPlanB(
                 side_effect=[transient, transient],
             ) as urlopen,
             patch.object(renewal.wall_time, "sleep") as sleep,
-            patch.object(
-                renewal,
-                "_latest_autoresearch_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
             ) as latest,
-            patch.object(renewal, "_registry_runtime_window_targets") as registry,
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._registry_runtime_window_targets",
+            ) as registry,
             self.assertRaisesRegex(
                 RuntimeError,
                 "runtime_window_target_plan_required_but_empty",
@@ -561,7 +562,10 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowTargetPlanB(
             runtime_window_strategy_name="",
         )
 
-        with patch.object(renewal, "SessionLocal", return_value=fake_session):
+        with patch(
+            "scripts.empirical_promotion_renewal.raise_if_runtime_window_target_plan_import.SessionLocal",
+            return_value=fake_session,
+        ):
             targets = renewal._latest_autoresearch_runtime_window_targets(args)
 
         self.assertIsNotNone(fake_session.statement)

--- a/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_multi_ref.py
+++ b/services/torghut/tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_multi_ref.py
@@ -88,11 +88,12 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowTargetPlanMultiRef(
                 "urlopen",
                 side_effect=[_empty_proofs_response(), live_status_plan],
             ) as urlopen,
-            patch.object(
-                renewal,
-                "_latest_autoresearch_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
             ) as latest,
-            patch.object(renewal, "_registry_runtime_window_targets") as registry,
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._registry_runtime_window_targets",
+            ) as registry,
         ):
             targets = renewal._runtime_window_targets(_runtime_window_plan_args())
 
@@ -114,11 +115,12 @@ class TestRunEmpiricalPromotionJobsRuntimeWindowTargetPlanMultiRef(
                 "urlopen",
                 side_effect=[_empty_proofs_response(), _empty_proofs_response()],
             ) as urlopen,
-            patch.object(
-                renewal,
-                "_latest_autoresearch_runtime_window_targets",
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._latest_autoresearch_runtime_window_targets",
             ) as latest,
-            patch.object(renewal, "_registry_runtime_window_targets") as registry,
+            patch(
+                "scripts.empirical_promotion_renewal.runtime_window_targets._registry_runtime_window_targets",
+            ) as registry,
             self.assertRaisesRegex(
                 RuntimeError,
                 "runtime_window_target_plan_required_but_empty",

--- a/services/torghut/tests/signal_ingest/test_parse_envelope_row.py
+++ b/services/torghut/tests/signal_ingest/test_parse_envelope_row.py
@@ -289,7 +289,7 @@ class TestParseEnvelopeRow(_TestSignalIngestBase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
                     return_value=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
                 ) as mocked_trading_now,
             ):
@@ -316,7 +316,7 @@ class TestParseEnvelopeRow(_TestSignalIngestBase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
                     return_value=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
                 ) as mocked_trading_now,
             ):
@@ -395,9 +395,13 @@ class TestParseEnvelopeRow(_TestSignalIngestBase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
                     return_value=latest_signal,
                 ) as mocked_trading_now,
+                patch(
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
+                    return_value=latest_signal,
+                ),
             ):
                 session.add(
                     TradeCursor(
@@ -436,7 +440,11 @@ class TestParseEnvelopeRow(_TestSignalIngestBase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
+                    return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
+                ),
+                patch(
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
                     return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
                 ),
             ):
@@ -492,7 +500,11 @@ class TestParseEnvelopeRow(_TestSignalIngestBase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
+                    return_value=latest_signal,
+                ),
+                patch(
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
                     return_value=latest_signal,
                 ),
             ):
@@ -550,7 +562,11 @@ class TestParseEnvelopeRow(_TestSignalIngestBase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
+                    return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
+                ),
+                patch(
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
                     return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
                 ),
             ):
@@ -595,7 +611,11 @@ class TestParseEnvelopeRow(_TestSignalIngestBase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
+                    return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
+                ),
+                patch(
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
                     return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
                 ),
             ):

--- a/services/torghut/tests/strategy_autoresearch/test_autoresearch_helpers.py
+++ b/services/torghut/tests/strategy_autoresearch/test_autoresearch_helpers.py
@@ -137,7 +137,9 @@ class TestStrategyAutoresearchHelpers(StrategyAutoresearchTestCase):
     def test_runtime_window_plan_helpers_surface_missing_handoffs(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            with patch.object(runner, "_REPO_ROOT", root):
+            with patch(
+                "scripts.strategy_autoresearch_loop.write_results_tsv._REPO_ROOT", root
+            ):
                 self.assertEqual(runner._hypothesis_manifest_rows(), [])
 
             hypothesis_dir = root / "services/torghut/config/trading/hypotheses"
@@ -168,7 +170,9 @@ class TestStrategyAutoresearchHelpers(StrategyAutoresearchTestCase):
                 encoding="utf-8",
             )
 
-            with patch.object(runner, "_REPO_ROOT", root):
+            with patch(
+                "scripts.strategy_autoresearch_loop.write_results_tsv._REPO_ROOT", root
+            ):
                 rows = runner._hypothesis_manifest_rows()
                 self.assertEqual(
                     [row["hypothesis_id"] for row in rows],
@@ -442,19 +446,19 @@ class TestStrategyAutoresearchHelpers(StrategyAutoresearchTestCase):
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop._write_portfolio_outputs",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs._write_portfolio_outputs",
                     return_value=(portfolio, portfolio_outputs),
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.write_runtime_closure_bundle",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs.write_runtime_closure_bundle",
                     return_value=RuntimeSummary(),
                 ) as write_runtime_closure,
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.write_mlx_notebook_exports",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs.write_mlx_notebook_exports",
                     return_value={},
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.write_autoresearch_notebooks",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs.write_autoresearch_notebooks",
                     return_value=[],
                 ),
             ):
@@ -606,19 +610,19 @@ class TestStrategyAutoresearchHelpers(StrategyAutoresearchTestCase):
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop._write_portfolio_outputs",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs._write_portfolio_outputs",
                     return_value=(None, {}),
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.write_runtime_closure_bundle",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs.write_runtime_closure_bundle",
                     return_value=RuntimeSummary(),
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.write_mlx_notebook_exports",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs.write_mlx_notebook_exports",
                     return_value={},
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.write_autoresearch_notebooks",
+                    "scripts.strategy_autoresearch_loop.write_portfolio_outputs.write_autoresearch_notebooks",
                     return_value=[],
                 ),
             ):

--- a/services/torghut/tests/strategy_autoresearch/test_autoresearch_loop_a.py
+++ b/services/torghut/tests/strategy_autoresearch/test_autoresearch_loop_a.py
@@ -434,11 +434,11 @@ class TestStrategyAutoresearchLoopA(StrategyAutoresearchTestCase):
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                    "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                     side_effect=responses,
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                     return_value=iter(signal_rows),
                 ),
             ):
@@ -644,7 +644,7 @@ class TestStrategyAutoresearchLoopA(StrategyAutoresearchTestCase):
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop._select_effective_replay_tape_window",
+                    "scripts.strategy_autoresearch_loop.load_yaml._select_effective_replay_tape_window",
                     return_value=(
                         date(2026, 3, 23),
                         date(2026, 3, 23),
@@ -652,11 +652,11 @@ class TestStrategyAutoresearchLoopA(StrategyAutoresearchTestCase):
                     ),
                 ) as select_window,
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                     return_value=iter(signal_rows),
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                    "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                     side_effect=run_frontier,
                 ),
             ):
@@ -747,7 +747,7 @@ class TestStrategyAutoresearchLoopA(StrategyAutoresearchTestCase):
             )
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 side_effect=ValueError(
                     "strategy_not_found:breakout-continuation-long-v1"
                 ),

--- a/services/torghut/tests/strategy_autoresearch/test_autoresearch_loop_b.py
+++ b/services/torghut/tests/strategy_autoresearch/test_autoresearch_loop_b.py
@@ -291,11 +291,11 @@ class TestStrategyAutoresearchLoopB(StrategyAutoresearchTestCase):
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                    "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                     side_effect=responses,
                 ),
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                     return_value=iter(signal_rows),
                 ),
             ):
@@ -506,7 +506,7 @@ class TestStrategyAutoresearchLoopB(StrategyAutoresearchTestCase):
                 return response
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 side_effect=_frontier_side_effect,
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
@@ -642,7 +642,7 @@ class TestStrategyAutoresearchLoopB(StrategyAutoresearchTestCase):
             }
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 side_effect=[
                     frontier_payload,
                     AssertionError("loop should stop after discarded objective hit"),
@@ -701,7 +701,7 @@ class TestStrategyAutoresearchLoopB(StrategyAutoresearchTestCase):
             )
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 side_effect=RuntimeError("frontier blew up"),
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
@@ -774,7 +774,7 @@ class TestStrategyAutoresearchLoopB(StrategyAutoresearchTestCase):
             }
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 return_value=frontier_payload,
             ) as mock_frontier:
                 payload = runner.run_strategy_autoresearch_loop(args)
@@ -872,7 +872,7 @@ class TestStrategyAutoresearchLoopB(StrategyAutoresearchTestCase):
             ]
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                "scripts.strategy_autoresearch_loop.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 side_effect=frontier_responses,
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)

--- a/services/torghut/tests/strategy_autoresearch/test_autoresearch_replay_materialization.py
+++ b/services/torghut/tests/strategy_autoresearch/test_autoresearch_replay_materialization.py
@@ -441,7 +441,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
             ]
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                 return_value=iter(signal_rows),
             ):
                 stats, receipt = runner._maybe_materialize_run_replay_tape(
@@ -504,7 +504,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
             )
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.replay_mod._http_query",
+                "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._http_query",
                 side_effect=AssertionError("clickhouse should not be queried"),
             ):
                 stats = runner._maybe_write_signal_bundle(
@@ -564,7 +564,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop._select_effective_replay_tape_window",
+                    "scripts.strategy_autoresearch_loop.load_yaml._select_effective_replay_tape_window",
                     return_value=(
                         date(2026, 3, 23),
                         date(2026, 3, 23),
@@ -572,7 +572,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
                     ),
                 ) as select_window,
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                     return_value=iter(signal_rows),
                 ),
             ):
@@ -670,7 +670,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop._select_effective_replay_tape_window",
+                    "scripts.strategy_autoresearch_loop.load_yaml._select_effective_replay_tape_window",
                     return_value=(
                         date(2026, 3, 2),
                         date(2026, 3, 27),
@@ -678,7 +678,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
                     ),
                 ) as select_window,
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                     return_value=iter(signal_rows),
                 ),
             ):
@@ -770,7 +770,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
 
             with (
                 patch(
-                    "scripts.run_strategy_autoresearch_loop._select_effective_replay_tape_window",
+                    "scripts.strategy_autoresearch_loop.load_yaml._select_effective_replay_tape_window",
                     return_value=(
                         date(2026, 3, 2),
                         date(2026, 3, 27),
@@ -778,7 +778,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
                     ),
                 ) as select_window,
                 patch(
-                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                     return_value=iter(signal_rows),
                 ),
             ):
@@ -837,7 +837,7 @@ class TestStrategyAutoresearchReplayMaterialization(StrategyAutoresearchTestCase
             ]
 
             with patch(
-                "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                "scripts.strategy_autoresearch_loop.load_yaml.replay_mod._iter_signal_rows",
                 return_value=iter(signal_rows),
             ):
                 with self.assertRaisesRegex(

--- a/services/torghut/tests/test_explicit_module_facade_exports.py
+++ b/services/torghut/tests/test_explicit_module_facade_exports.py
@@ -173,6 +173,18 @@ def test_owner_modules_do_not_patch_through_public_wrappers() -> None:
             assert token not in source, f"{relative_path} still contains {token}"
 
 
+def test_app_and_script_modules_do_not_use_public_root_backchannels() -> None:
+    service_root = Path(__file__).resolve().parents[1]
+    offenders = sorted(
+        str(path.relative_to(service_root))
+        for tree_name in ("app", "scripts")
+        for path in (service_root / tree_name).rglob("*.py")
+        if "sys.modules.get(" in path.read_text(encoding="utf-8")
+    )
+
+    assert offenders == []
+
+
 def test_generated_split_package_directories_are_absent() -> None:
     service_root = Path(__file__).resolve().parents[1]
     split_package_suffix = "_" + "modules"

--- a/services/torghut/tests/test_logging_config.py
+++ b/services/torghut/tests/test_logging_config.py
@@ -119,14 +119,16 @@ class TestLoggingConfig(TestCase):
 
         with (
             patch(
-                "app.whitepapers.workflow.whitepaper_workflow_enabled",
+                "app.whitepapers.workflow.whitepaper_workflow_service.whitepaper_workflow_enabled",
                 return_value=True,
             ),
             patch(
-                "app.whitepapers.workflow.whitepaper_kafka_enabled",
+                "app.whitepapers.workflow.whitepaper_workflow_service.whitepaper_kafka_enabled",
                 return_value=True,
             ),
-            patch("app.whitepapers.workflow.logger.info") as mock_info,
+            patch(
+                "app.whitepapers.workflow.whitepaper_workflow_service.logger.info"
+            ) as mock_info,
         ):
             counters = ingestor.ingest_once(cast(Any, session))
 

--- a/services/torghut/tests/test_trading_ingest.py
+++ b/services/torghut/tests/test_trading_ingest.py
@@ -108,7 +108,10 @@ def test_fetch_signals_closes_cursor_transaction_before_clickhouse_query() -> No
 
     with (
         session_local() as session,
-        patch("app.trading.ingest.trading_now", return_value=now),
+        patch(
+            "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
+            return_value=now,
+        ),
     ):
         ingestor.session = session
         ingestor.fetch_signals(session)
@@ -146,7 +149,10 @@ def test_scoped_timeout_returns_only_non_authority_last_good_fallback() -> None:
 
     with (
         session_local() as session,
-        patch("app.trading.ingest.trading_now", return_value=now),
+        patch(
+            "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
+            return_value=now,
+        ),
     ):
         batch = ingestor.fetch_signals(
             session,

--- a/services/torghut/tests/tigerbeetle_reconcile/test_reconciliation_passes_when_postgres_refs_match_tigerbeetle.py
+++ b/services/torghut/tests/tigerbeetle_reconcile/test_reconciliation_passes_when_postgres_refs_match_tigerbeetle.py
@@ -86,7 +86,7 @@ class TestReconciliationPassesWhenPostgresRefsMatchTigerbeetle(
             client.transfers[1001] = _transfer()
 
             with patch(
-                "app.trading.tigerbeetle_reconcile.create_tigerbeetle_client",
+                "app.trading.tigerbeetle_reconcile.latest_tigerbeetle_reconciliation_status_p.create_tigerbeetle_client",
                 return_value=client,
             ):
                 payload = reconcile_tigerbeetle_transfers(

--- a/services/torghut/tests/trading_scheduler_autonomy/test_append_runtime_governance_ignores_stale_rollback_evidence_when_not_triggered.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_append_runtime_governance_ignores_stale_rollback_evidence_when_not_triggered.py
@@ -322,7 +322,7 @@ class TestAppendRuntimeGovernanceIgnoresStaleRollbackEvidenceWhenNotTriggered(
             }
 
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=_fake_run_autonomous_lane_with_canary_failure,
             ):
                 with patch(

--- a/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
@@ -85,7 +85,7 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
                 "metrics": {"max_drawdown": "0.25"},
             }
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -241,7 +241,7 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
                 clear=False,
             ):
                 with patch(
-                    "app.trading.scheduler.governance.run_autonomous_lane",
+                    "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                     side_effect=self._fake_run_autonomous_lane(deps),
                 ):
                     scheduler._run_autonomous_cycle()
@@ -267,7 +267,7 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
                 approval_token=None,
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(_deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -638,7 +638,7 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
             }
 
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 with patch(
@@ -700,7 +700,7 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
             }
 
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 with patch(

--- a/services/torghut/tests/trading_scheduler_autonomy/test_run_autonomous_cycle_uses_live_promotion_when_token_present.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_run_autonomous_cycle_uses_live_promotion_when_token_present.py
@@ -37,7 +37,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
             )
             scheduler.state.drift_last_outcome_path = str(outcome_path)
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -53,7 +53,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 approval_token=None,
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -71,7 +71,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 approval_token="live-approve-token",
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -89,7 +89,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 approval_token=None,
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -105,7 +105,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 approval_token=None,
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -127,7 +127,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 approval_token=None,
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -171,7 +171,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 approval_token=None,
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle(
@@ -202,7 +202,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 approval_token=None,
             )
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -268,7 +268,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 },
             }
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -363,7 +363,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 },
             }
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -394,11 +394,11 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 no_signal_reason="cursor_ahead_of_stream",
             )
             with patch(
-                "app.trading.scheduler.governance.upsert_autonomy_no_signal_run",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.upsert_autonomy_no_signal_run",
                 return_value="no-signal-run-id",
             ) as persist_no_signal:
                 with patch(
-                    "app.trading.scheduler.governance.run_autonomous_lane",
+                    "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                     side_effect=RuntimeError("should_not_run"),
                 ):
                     scheduler._run_autonomous_cycle()
@@ -449,15 +449,15 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
             with (
                 patch.object(settings, "trading_simulation_enabled", True),
                 patch(
-                    "app.trading.scheduler.governance.trading_now",
+                    "app.trading.scheduler.governance.governance_mixin_lifecycle_methods.trading_now",
                     return_value=simulation_now,
                 ),
                 patch(
-                    "app.trading.scheduler.governance.upsert_autonomy_no_signal_run",
+                    "app.trading.scheduler.governance.governance_mixin_decision_methods.upsert_autonomy_no_signal_run",
                     return_value="no-signal-run-id",
                 ) as persist_no_signal,
                 patch(
-                    "app.trading.scheduler.governance.run_autonomous_lane",
+                    "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                     side_effect=RuntimeError("should_not_run"),
                 ),
             ):
@@ -481,7 +481,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
             scheduler.state.last_ingest_reason = "stale-no-signal"
 
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=self._fake_run_autonomous_lane(deps),
             ):
                 scheduler._run_autonomous_cycle()
@@ -505,7 +505,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 no_signal_reason="cursor_ahead_of_stream",
             )
             with patch(
-                "app.trading.scheduler.governance.upsert_autonomy_no_signal_run",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.upsert_autonomy_no_signal_run",
                 return_value="no-signal-run-id",
             ):
                 scheduler._run_autonomous_cycle()
@@ -521,7 +521,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
             )
 
             with patch(
-                "app.trading.scheduler.governance.upsert_autonomy_no_signal_run",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.upsert_autonomy_no_signal_run",
                 return_value="no-signal-run-id",
             ):
                 scheduler._run_autonomous_cycle()
@@ -550,7 +550,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 no_signal_lag_seconds=61.2,
             )
             with patch(
-                "app.trading.scheduler.governance.upsert_autonomy_no_signal_run",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.upsert_autonomy_no_signal_run",
                 return_value="no-signal-run-id",
             ):
                 scheduler._run_autonomous_cycle()
@@ -588,7 +588,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
                 market_session_open=False,
             )
             with patch(
-                "app.trading.scheduler.governance.upsert_autonomy_no_signal_run",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.upsert_autonomy_no_signal_run",
                 return_value="no-signal-run-id",
             ):
                 scheduler._run_autonomous_cycle()
@@ -629,7 +629,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
             scheduler.state.last_autonomy_promotion_action = "promote"
             scheduler.state.last_autonomy_promotion_eligible = True
             with patch(
-                "app.trading.scheduler.governance.run_autonomous_lane",
+                "app.trading.scheduler.governance.governance_mixin_decision_methods.run_autonomous_lane",
                 side_effect=RuntimeError("lane_failed"),
             ):
                 scheduler._run_autonomous_cycle()
@@ -658,7 +658,7 @@ class TestRunAutonomousCycleUsesLivePromotionWhenTokenPresent(
             )
             settings.trading_evidence_continuity_run_limit = 3
             with patch(
-                "app.trading.scheduler.governance.evaluate_evidence_continuity"
+                "app.trading.scheduler.governance.governance_mixin_lifecycle_methods.evaluate_evidence_continuity"
             ) as mock_check:
                 mock_check.return_value = SimpleNamespace(
                     checked_at=datetime(2026, 2, 19, 1, 0, tzinfo=timezone.utc),

--- a/services/torghut/tests/whitepaper_workflow/test_same_pdf_across_issues_reuses_existing_run_without_duplication.py
+++ b/services/torghut/tests/whitepaper_workflow/test_same_pdf_across_issues_reuses_existing_run_without_duplication.py
@@ -150,7 +150,9 @@ class TestSamePdfAcrossIssuesReusesExistingRunWithoutDuplication(
         self.assertEqual(session.commit_calls, 1)
         self.assertEqual(session.rollback_calls, 1)
 
-    @patch("app.whitepapers.workflow._http_request_bytes")
+    @patch(
+        "app.whitepapers.workflow.whitepaper_workflow_api_methods._http_request_bytes"
+    )
     def test_download_pdf_requests_redirect_following(
         self, mock_http_request: Any
     ) -> None:

--- a/services/torghut/tests/zz_signal_ingest_timeout/test_signal_ingest_timeout.py
+++ b/services/torghut/tests/zz_signal_ingest_timeout/test_signal_ingest_timeout.py
@@ -76,7 +76,11 @@ class TestSignalIngestTimeout(TestCase):
             with (
                 session_local() as session,
                 patch(
-                    "app.trading.ingest.trading_now",
+                    "app.trading.ingest.clickhouse_signal_ingestor_core_methods.trading_now",
+                    return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
+                ),
+                patch(
+                    "app.trading.ingest.clickhouse_signal_ingestor_persistence_methods.trading_now",
                     return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
                 ),
             ):


### PR DESCRIPTION
## Summary

- Removed the remaining Torghut app/scripts owner backchannels that looked up public package roots with `sys.modules.get(...)` or `_root_export` helpers.
- Retargeted tests to patch the owning modules directly for config, completion, execution, hypotheses, ingest, DSPy workflow, governance, TigerBeetle reconcile, whitepaper workflow, empirical renewal, and strategy autoresearch.
- Added a regression that fails if app/scripts reintroduce `sys.modules.get(...)` public-root patch backchannels.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app scripts tests`
- `uv run --frozen ruff format --check app scripts tests`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/test_explicit_module_facade_exports.py tests/config/test_parses_signal_staleness_critical_reasons.py tests/completion_trace/test_runtime_and_doc_completion_matrices_match.py tests/order_idempotency/test_decision_hash_stable_for_same_intent.py tests/hypotheses/test_load_jangar_dependency_quorum_prefers_dependency_quorum_contract.py tests/hypotheses/test_compile_hypothesis_runtime_statuses_blocks_bounded_hpairs_collection_on_stale_signal_lag.py tests/api/test_trading_api_status_consumer_evidence.py tests/test_trading_ingest.py tests/signal_ingest/test_parse_envelope_row.py tests/zz_signal_ingest_timeout/test_signal_ingest_timeout.py tests/trading_scheduler_autonomy tests/strategy_autoresearch tests/llm_dspy_workflow tests/tigerbeetle_reconcile/test_reconciliation_passes_when_postgres_refs_match_tigerbeetle.py tests/order_feed/test_order_feed_core.py tests/test_logging_config.py tests/whitepaper_workflow/test_same_pdf_across_issues_reuses_existing_run_without_duplication.py tests/whitepaper_workflow/test_marker_and_attachment_parsing.py tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_multi_ref.py tests/run_empirical_promotion_jobs/test_runtime_window_target_plan_b.py tests/run_empirical_promotion_jobs/test_runtime_window_import_b.py tests/run_empirical_promotion_jobs/test_empirical_job_core.py tests/renew_latest_empirical_promotion_jobs/test_explicit_live_target_does_not_suppress_paper_plan_target.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
