### PR TITLE
fix(rook-ceph): remove temporary recovery tuning

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -30,18 +30,6 @@ cephClusterSpec:
       osd_pool_default_size: "2"
       osd_pool_default_min_size: "1"
       mon_data_avail_warn: "20"
-    osd:
-      # Use Ceph's mClock recovery-biased profile while Turin rebuilds
-      # the recreated 24 TB OSDs.
-      osd_mclock_profile: "high_recovery_ops"
-      # Allow the temporary recovery/backfill limits below to take effect
-      # while the OSDs run with the mClock scheduler.
-      osd_mclock_override_recovery_settings: "true"
-      # Temporarily raise recovery/backfill concurrency while Turin rebuilds
-      # the recreated 24 TB OSDs.
-      osd_max_backfills: "3"
-      osd_recovery_max_single_start: "3"
-      osd_recovery_max_active: "3"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Removes the temporary Rook-Ceph OSD recovery tuning used during Turin's recreated 24 TB OSD backfill.
- Leaves steady-state pool defaults and monitor configuration unchanged.
- Keeps scrub/deep-scrub recovery under normal Ceph scheduling instead of the recovery-biased mClock profile.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-post-recovery-render.yaml`
- `rg -n "osd_mclock_profile|osd_mclock_override_recovery_settings|osd_max_backfills|osd_recovery_max_single_start|osd_recovery_max_active" argocd/applications/rook-ceph/cluster-values.yaml /tmp/rook-ceph-post-recovery-render.yaml || true`
- `bun run lint:argocd`
- `kubectl --context galactic-tailscale apply --server-side --force-conflicts --dry-run=server -f /tmp/rook-ceph-post-recovery-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
