### PR TITLE
fix(torghut): collect configured proof evidence on runtime account

### DIFF
--- a/services/torghut/app/api/proofs_configured_collection.py
+++ b/services/torghut/app/api/proofs_configured_collection.py
@@ -61,6 +61,17 @@ def configured_strategy_paper_collection_hypothesis_id(strategy_name: str) -> st
     return f"configured-paper-collection:{strategy_name}"
 
 
+def configured_paper_collection_account_label() -> str:
+    account_label = str(settings.trading_account_label or "").strip()
+    return account_label or PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL
+
+
+def configured_strategy_paper_collection_symbol_actions(
+    symbols: Sequence[str],
+) -> dict[str, str]:
+    return {symbol.strip().upper(): "buy" for symbol in symbols if symbol.strip()}
+
+
 def configured_strategy_paper_collection_targets(
     session: Session,
     *,
@@ -77,6 +88,8 @@ def configured_strategy_paper_collection_targets(
         strategy_name = str(strategy.name).strip()
         if not strategy_name:
             continue
+        symbol_actions = configured_strategy_paper_collection_symbol_actions(symbols)
+        account_label = configured_paper_collection_account_label()
         target = {
             "hypothesis_id": configured_strategy_paper_collection_hypothesis_id(
                 strategy_name
@@ -87,8 +100,22 @@ def configured_strategy_paper_collection_targets(
             "strategy_lookup_names": [strategy_name],
             "strategy_family": str(strategy.universe_type or "").strip() or "static",
             "strategy_type": str(strategy.universe_type or "").strip() or "static",
-            "account_label": PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL,
-            "source_account_label": PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL,
+            "account_label": account_label,
+            "source_account_label": account_label,
+            "execution_account_label": account_label,
+            "paper_account_label": account_label,
+            "paper_route_runtime_account_label": account_label,
+            "bounded_collection_account_label": PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL,
+            "account_stage_runtime_identity": {
+                "account_label": PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL,
+                "source_account_label": account_label,
+                "execution_account_label": account_label,
+                "runtime_account_label": account_label,
+                "paper_account_label": account_label,
+                "paper_route_runtime_account_label": account_label,
+                "observed_stage": "paper",
+                "source_kind": "configured_simple_lane_paper_data_collection",
+            },
             "observed_stage": "paper",
             "source_kind": "configured_simple_lane_paper_data_collection",
             "source_plan_ref": "configured-simple-lane-paper-data-collection",
@@ -104,6 +131,11 @@ def configured_strategy_paper_collection_targets(
             "paper_route_probe_scope_authority": "configured_strategy_catalog",
             "paper_route_probe_symbols": symbols,
             "paper_route_probe_raw_target_symbols": symbols,
+            "paper_route_probe_symbol_actions": symbol_actions,
+            "target_symbol_actions": symbol_actions,
+            "symbol_actions": symbol_actions,
+            "paper_route_probe_symbol_quantities": {},
+            "target_symbol_quantities": {},
             "paper_route_probe_strategy_universe_fallback": True,
             "paper_route_probe_next_session_max_notional": max_notional,
             "paper_route_probe_effective_max_notional": max_notional,
@@ -140,6 +172,7 @@ def configured_paper_collection_target_plan(
     max_notional = _decimal_to_string(max_notional_value)
     if max_notional is None:
         return {}
+    account_label = configured_paper_collection_account_label()
     targets = configured_strategy_paper_collection_targets(
         session,
         max_notional=max_notional,
@@ -151,7 +184,9 @@ def configured_paper_collection_target_plan(
         "source": "configured_simple_lane_paper_data_collection",
         "source_ref": "configured-simple-lane-paper-data-collection",
         "target_count": len(targets),
-        "account_label": PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL,
+        "account_label": account_label,
+        "source_account_label": account_label,
+        "bounded_collection_account_label": PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL,
         "observed_stage": "paper",
         "paper_data_collection_authorized": True,
         "bounded_evidence_collection_authorized": True,
@@ -169,6 +204,8 @@ __all__ = [
     "configured_static_symbol_allowlist",
     "configured_strategy_paper_collection_symbols",
     "configured_strategy_paper_collection_hypothesis_id",
+    "configured_paper_collection_account_label",
+    "configured_strategy_paper_collection_symbol_actions",
     "configured_strategy_paper_collection_targets",
     "configured_paper_collection_target_plan",
 ]

--- a/services/torghut/app/trading/paper_route_target_plan/target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan/target_plan.py
@@ -35,6 +35,10 @@ PAPER_ROUTE_MATERIALIZATION_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
 
 PAPER_ROUTE_TARGET_NOTIONAL_SOURCE_DECISION_SEED_QTY = Decimal("1")
 
+CONFIGURED_SIMPLE_LANE_PAPER_COLLECTION_SOURCE_KIND = (
+    "configured_simple_lane_paper_data_collection"
+)
+
 
 @dataclass(frozen=True)
 class PaperRouteTargetPlanFetchClient:
@@ -113,6 +117,12 @@ def _target_from_proof_identity(proof: Mapping[str, Any]) -> dict[str, Any]:
         symbol_values = ()
     symbols = [str(item).strip().upper() for item in symbol_values if str(item).strip()]
     actions = _to_str_map(identity.get("target_symbol_actions"))
+    if (
+        not actions
+        and _safe_text(identity.get("source_kind"))
+        == CONFIGURED_SIMPLE_LANE_PAPER_COLLECTION_SOURCE_KIND
+    ):
+        actions = {symbol: "buy" for symbol in symbols}
     quantities = _to_str_map(identity.get("target_symbol_quantities"))
     return {
         "hypothesis_id": identity.get("hypothesis_id"),
@@ -129,6 +139,8 @@ def _target_from_proof_identity(proof: Mapping[str, Any]) -> dict[str, Any]:
         "source_plan_ref": identity.get("source_plan_ref"),
         "target_notional": identity.get("target_notional"),
         "source_decision_mode": identity.get("source_decision_mode"),
+        "target_symbol_actions": actions,
+        "target_symbol_quantities": quantities,
         "proof_target_authority": "trading_proofs",
         "bounded_collection_stage": "paper",
         "evidence_collection_stage": "paper",

--- a/services/torghut/app/trading/scheduler/target_plan_helpers/bounded_collection.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers/bounded_collection.py
@@ -11,9 +11,6 @@ from typing import Any, Literal, TypeAlias, cast
 from ...promotion_authority import target_capital_promotion_allowed
 from ...runtime_strategy_resolution import strategy_names_from_strategy_id
 
-
-logger = logging.getLogger(__name__)
-
 logger = logging.getLogger(__name__)
 
 _SIMPLE_ALLOWED_REJECT_REASONS = {
@@ -161,6 +158,7 @@ _BOUNDED_SIM_COLLECTION_RUNTIME_ACCOUNT_ALIAS_FIELDS = (
 _BOUNDED_SIM_COLLECTION_SOURCE_AUTHORIZATION_SCOPES = frozenset(
     {
         "bounded_paper_route_source_decision_collection_only",
+        "configured_strategy_catalog_evidence_collection_only",
         "source_window_evidence_collection_only",
     }
 )

--- a/services/torghut/app/trading/scheduler/target_plan_helpers/target_probe.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers/target_probe.py
@@ -63,6 +63,16 @@ def _target_requires_bounded_sim_collection_gate(target: Mapping[str, Any]) -> b
     return (
         _target_owns_bounded_sim_collection_account(target)
         or account_label == _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
+        or (
+            _safe_text(target.get("source_kind"))
+            == "configured_simple_lane_paper_data_collection"
+            and (
+                _target_truthy(target.get("bounded_evidence_collection_authorized"))
+                or _target_truthy(
+                    target.get("bounded_live_paper_collection_authorized")
+                )
+            )
+        )
     )
 
 

--- a/services/torghut/tests/api/test_trading_api_paper_route_cache.py
+++ b/services/torghut/tests/api/test_trading_api_paper_route_cache.py
@@ -273,9 +273,11 @@ class TestTradingApiPaperRouteCache(TradingApiTestCaseBase):
         self,
     ) -> None:
         original_mode = proofs_api.settings.trading_mode
+        original_account_label = proofs_api.settings.trading_account_label
         original_static_symbols_raw = proofs_api.settings.trading_static_symbols_raw
         try:
             proofs_api.settings.trading_mode = "live"
+            proofs_api.settings.trading_account_label = "PA3SX7FYNUTF"
             proofs_api.settings.trading_static_symbols_raw = "AAPL,NVDA"
             with self.session_local() as session:
                 session.add_all(
@@ -310,6 +312,7 @@ class TestTradingApiPaperRouteCache(TradingApiTestCaseBase):
                 )
         finally:
             proofs_api.settings.trading_mode = original_mode
+            proofs_api.settings.trading_account_label = original_account_label
             proofs_api.settings.trading_static_symbols_raw = original_static_symbols_raw
 
         self.assertGreaterEqual(plan["target_count"], 1)
@@ -321,12 +324,19 @@ class TestTradingApiPaperRouteCache(TradingApiTestCaseBase):
         self.assertIn("enabled-paper-collector", targets_by_name)
         self.assertNotIn("disabled-paper-collector", targets_by_name)
         target = targets_by_name["enabled-paper-collector"]
-        self.assertEqual(target["account_label"], "TORGHUT_SIM")
+        self.assertEqual(target["account_label"], "PA3SX7FYNUTF")
+        self.assertEqual(target["source_account_label"], "PA3SX7FYNUTF")
+        self.assertEqual(target["execution_account_label"], "PA3SX7FYNUTF")
+        self.assertEqual(target["bounded_collection_account_label"], "TORGHUT_SIM")
         self.assertEqual(
             target["hypothesis_id"],
             "configured-paper-collection:enabled-paper-collector",
         )
         self.assertEqual(target["paper_route_probe_symbols"], ["AAPL", "NVDA"])
+        self.assertEqual(
+            target["paper_route_probe_symbol_actions"],
+            {"AAPL": "buy", "NVDA": "buy"},
+        )
         self.assertEqual(target["paper_route_probe_next_session_max_notional"], "100")
         self.assertTrue(target["paper_data_collection_authorized"])
         self.assertFalse(target["final_promotion_authorized"])

--- a/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
+++ b/services/torghut/tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from app.trading.scheduler.target_plan_helpers import (
+    _target_requires_bounded_sim_collection_gate,
+)
 from tests.simple_pipeline.support import (
     Decimal,
     SimpleNamespace,
@@ -111,6 +114,26 @@ def test_configured_collection_target_reserves_account_with_source_plan_ref(
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+
+
+def test_configured_collection_runtime_account_still_uses_bounded_route() -> None:
+    target = _bounded_hpairs_target(
+        account_label="PA3SX7FYNUTF",
+        source_account_label="PA3SX7FYNUTF",
+        candidate_id="configured:breakout-continuation-long-v1",
+        hypothesis_id="configured-paper-collection:breakout-continuation-long-v1",
+        strategy_family="static",
+        strategy_name="breakout-continuation-long-v1",
+        runtime_strategy_name="breakout-continuation-long-v1",
+        source_kind="configured_simple_lane_paper_data_collection",
+        paper_route_probe_pair_balance_state="not_required",
+        paper_route_probe_symbols=["NVDA", "AVGO"],
+        paper_route_probe_symbol_actions={"NVDA": "buy", "AVGO": "buy"},
+        bounded_evidence_collection_authorized=True,
+        bounded_live_paper_collection_authorized=True,
+    )
+
+    assert _target_requires_bounded_sim_collection_gate(target)
 
 
 def test_target_runtime_account_and_window_helpers_cover_identity_edges() -> None:

--- a/services/torghut/tests/test_configured_paper_collection_targets.py
+++ b/services/torghut/tests/test_configured_paper_collection_targets.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.proofs_configured_collection import (
+    configured_strategy_paper_collection_targets,
+)
+from app.config import settings
+from app.models import Base, Strategy
+
+
+def test_configured_collection_targets_use_runtime_account_and_buy_actions(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings, "trading_account_label", "PA3SX7FYNUTF")
+    monkeypatch.setattr(
+        settings,
+        "trading_static_symbols_raw",
+        "NVDA,AVGO,AMD,MRVL,MU,COHR,LITE,WDC,STX,TSM",
+    )
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+    with session_factory() as session:
+        session.add(
+            Strategy(
+                name="breakout-continuation-long-v1",
+                description="configured AI collection fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["nvda", "avgo", "unused"],
+                max_notional_per_trade=Decimal("100"),
+            )
+        )
+        session.commit()
+
+        targets = configured_strategy_paper_collection_targets(
+            session,
+            max_notional="100",
+        )
+
+    assert len(targets) == 1
+    target = targets[0]
+    assert target["account_label"] == "PA3SX7FYNUTF"
+    assert target["source_account_label"] == "PA3SX7FYNUTF"
+    assert target["execution_account_label"] == "PA3SX7FYNUTF"
+    assert target["bounded_collection_account_label"] == "TORGHUT_SIM"
+    assert target["paper_route_probe_symbols"] == ["NVDA", "AVGO"]
+    assert target["target_symbol_actions"] == {"NVDA": "buy", "AVGO": "buy"}
+    assert target["paper_route_probe_symbol_actions"] == {
+        "NVDA": "buy",
+        "AVGO": "buy",
+    }
+    assert target["promotion_allowed"] is False
+    assert target["final_promotion_allowed"] is False
+    assert target["capital_promotion_allowed"] is False

--- a/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
+++ b/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
@@ -57,4 +57,9 @@ def test_proofs_payload_configured_collection_targets_keep_paper_stage() -> None
     assert target["observed_stage"] == "paper"
     assert target["source_plan_ref"] == "configured-simple-lane-paper-data-collection"
     assert target["paper_route_probe_symbols"] == ["AAPL", "AMZN"]
+    assert target["target_symbol_actions"] == {"AAPL": "buy", "AMZN": "buy"}
+    assert target["paper_route_probe_symbol_actions"] == {
+        "AAPL": "buy",
+        "AMZN": "buy",
+    }
     assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}


### PR DESCRIPTION
## Summary

- Point configured simple-lane proof collection targets at the configured runtime Alpaca paper account so source decisions, executions, TCA, and snapshots can satisfy the same proof window.
- Emit explicit long-only symbol actions for each configured AI-universe target and preserve those actions when `/trading/proofs` payloads are converted back into target plans.
- Keep configured collection on the bounded paper-route execution path without opening capital promotion, and allow its configured catalog collection scope.
- Add regression coverage for configured target generation, proof-payload action recovery, and bounded-route detection on runtime account labels.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_target_plan_proofs_payload.py tests/test_configured_paper_collection_targets.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_paper_route_cache.py::TestTradingApiPaperRouteCache::test_configured_paper_collection_plan_targets_enabled_strategy_universe -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_target_plan_proofs_payload.py tests/test_configured_paper_collection_targets.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py tests/api/test_trading_api_paper_route_cache.py::TestTradingApiPaperRouteCache::test_configured_paper_collection_plan_targets_enabled_strategy_universe -q`
- `cd services/torghut && uv run --frozen ruff check app/api/proofs_configured_collection.py app/trading/paper_route_target_plan/target_plan.py app/trading/scheduler/target_plan_helpers/bounded_collection.py app/trading/scheduler/target_plan_helpers/target_probe.py tests/api/test_trading_api_paper_route_cache.py tests/test_paper_route_target_plan_proofs_payload.py tests/test_configured_paper_collection_targets.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `cd services/torghut && uv run --frozen pytest tests/test_proofs_service.py tests/test_paper_route_target_plan.py tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app/api/proofs_configured_collection.py app/trading/paper_route_target_plan/target_plan.py app/trading/scheduler/target_plan_helpers/bounded_collection.py app/trading/scheduler/target_plan_helpers/target_probe.py tests/test_paper_route_target_plan_proofs_payload.py tests/test_configured_paper_collection_targets.py tests/simple_pipeline/test_pending_clean_window_baseline_still_reserves_paper_account.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev`
- Live readback: current Torghut DB has June 18 bounded paper-route decisions and executions labeled `PA3SX7FYNUTF`, confirming the old configured proof target label `TORGHUT_SIM` could not count runtime paper-account evidence.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
