### PR TITLE
feat(torghut): enable hyperliquid testnet trading

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/README.md
+++ b/argocd/applications/torghut-hyperliquid-runtime/README.md
@@ -2,12 +2,14 @@
 
 This app runs the isolated Hyperliquid testnet trading lane. It does not replace the existing Torghut or Alpaca services.
 
-V1 defaults to shadow mode:
+V1 runs as a testnet-only trading lane:
 
 - Public market and signal state comes from ClickHouse Hyperliquid feed tables.
 - Operational state is written to the Hyperliquid-specific Postgres tables from migration `0054`.
 - TigerBeetle transfer refs are planned deterministically for submitted holds, fills, fees, realized PnL, and releases.
 - Mainnet execution is blocked in config validation and code.
+- Tiny testnet orders are enabled after the ExternalSecret is ready and the dedicated Hyperliquid testnet account is
+  funded. Keep the default risk caps unless a separate rollout approves a larger envelope.
 - When trading is enabled, the runtime filters the selected mainnet market-data universe through Hyperliquid testnet
   perp metadata before any feature can produce an order. If testnet metadata is stale, unavailable, or has no matching
   equity-like markets, readiness fails and no orders are submitted.
@@ -17,7 +19,7 @@ To enable tiny testnet orders, create and authorize a Hyperliquid testnet API/ag
 - `account-address`
 - `api-wallet-private-key`
 
-Use the repo bootstrap helper after signing in to 1Password CLI:
+Use the repo bootstrap helper after authorizing the 1Password CLI prompt:
 
 ```bash
 scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh status
@@ -29,16 +31,10 @@ scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile
 `status` is safe to run repeatedly. It reports only whether the 1Password item, required fields, ExternalSecret,
 and target Kubernetes Secret exist; it does not print credential values.
 
-Shadow mode does not require Hyperliquid execution credentials, but this app now includes the ExternalSecret because
-`op://infra/hyperliquid-testnet` exists with the required fields. Keep `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`
-until `reconcile` reports the Kubernetes Secret as ready and the exchange-side testnet account is funded or authorized.
-
-After `check` reports the 1Password item is present, keep `externalsecret.yaml` in `kustomization.yaml` while
-`HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`. Merge and wait for Argo to sync, then run
-`scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh reconcile`. After `reconcile` reports the Kubernetes Secret
-as ready, open the trading-enable PR that sets `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true` in `configmap.yaml`.
-Keep the default caps unless a separate rollout approves a larger envelope. The runtime must continue to report
-`execution_network=testnet`; mainnet execution is rejected by config validation.
+This app includes the ExternalSecret because `op://infra/hyperliquid-testnet` exists with the required fields.
+Before enabling trading, `reconcile` must report the Kubernetes Secret as ready and the exchange-side testnet account
+must be funded or authorized. Trading is now enabled with `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true`; the runtime must
+continue to report `execution_network=testnet`, and mainnet execution is rejected by config validation.
 
 Acceptance checks:
 

--- a/argocd/applications/torghut-hyperliquid-runtime/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/configmap.yaml
@@ -10,8 +10,8 @@ data:
   LOG_LEVEL: INFO
   LOG_FORMAT: json
   HYPERLIQUID_RUNTIME_ENABLED: "true"
-  # Shadow mode is the production-safe default. Set this true only after the testnet wallet secret exists.
-  HYPERLIQUID_RUNTIME_TRADING_ENABLED: "false"
+  # Testnet-only execution is enabled after the ExternalSecret is ready and the dedicated account is funded.
+  HYPERLIQUID_RUNTIME_TRADING_ENABLED: "true"
   HYPERLIQUID_RUNTIME_EXECUTION_NETWORK: testnet
   HYPERLIQUID_RUNTIME_MARKET_DATA_NETWORK: mainnet
   HYPERLIQUID_RUNTIME_EXCHANGE_API_URL: https://api.hyperliquid-testnet.xyz

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618f
+        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618g
       labels:
         app: torghut-hyperliquid-runtime
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -200,10 +200,10 @@ describe('Torghut manifest scheduling', () => {
     expect(data['schema.sql']).not.toContain('INSERT INTO torghut.hyperliquid_ta_features')
   })
 
-  it('keeps Hyperliquid runtime shadow mode wired to a gated execution secret', () => {
+  it('keeps Hyperliquid runtime testnet trading wired to a gated execution secret', () => {
     const runtimeConfig = parseManifest('argocd/applications/torghut-hyperliquid-runtime/configmap.yaml')
     const runtimeData = getAtPath(runtimeConfig, ['data'])
-    expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('false')
+    expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('true')
 
     const runtimeDeployment = parseManifest('argocd/applications/torghut-hyperliquid-runtime/deployment.yaml')
     const runtimeContainer = getAtPath(runtimeDeployment, ['spec', 'template', 'spec', 'containers', 0])
@@ -262,7 +262,7 @@ describe('Torghut manifest scheduling', () => {
     )
   })
 
-  it('documents the Hyperliquid testnet credential check before enabling trading', () => {
+  it('documents the Hyperliquid testnet credential and funding gate', () => {
     const readme = readFileSync(join(repoRoot, 'argocd/applications/torghut-hyperliquid-runtime/README.md'), 'utf8')
     const bootstrapScript = readFileSync(
       join(repoRoot, 'scripts/torghut/bootstrap-hyperliquid-testnet-1password.sh'),
@@ -273,9 +273,9 @@ describe('Torghut manifest scheduling', () => {
     expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh check')
     expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh create')
     expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh reconcile')
-    expect(readme).toContain('After `check` reports the 1Password item is present')
-    expect(readme).toContain('keep `externalsecret.yaml` in `kustomization.yaml`')
-    expect(readme).toContain('Keep `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false`')
+    expect(readme).toContain('Before enabling trading')
+    expect(readme).toContain('must be funded or authorized')
+    expect(readme).toContain('HYPERLIQUID_RUNTIME_TRADING_ENABLED=true')
     expect(bootstrapScript).toContain('$0 check')
     expect(bootstrapScript).toContain('check_item()')
   })


### PR DESCRIPTION
## Summary

- Enables `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true` for the isolated Hyperliquid runtime lane after the ExternalSecret and testnet funding gates were satisfied.
- Bumps the runtime Deployment config revision so Kubernetes rolls the pod after the ConfigMap change.
- Updates the runtime README and manifest scheduling test to document the funded testnet trading state.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-enable-render.yaml && rg -n 'HYPERLIQUID_RUNTIME_TRADING_ENABLED|hyperliquid-runtime-v1-20260618g|torghut-hyperliquid-testnet|execution_network' /tmp/torghut-hyperliquid-runtime-enable-render.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This only enables testnet execution for the isolated Hyperliquid runtime lane; mainnet execution remains blocked by config validation and code.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
