### PR TITLE
fix(torghut): skip unsupported hyperliquid testnet dex metadata

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/exchange.py
+++ b/services/torghut/app/hyperliquid_runtime/exchange.py
@@ -296,8 +296,16 @@ class HyperliquidSdkExchange:
         if self._execution_universe_cache_is_fresh():
             return
         by_dex: dict[str, frozenset[str]] = {}
+        loaded_any_metadata = False
         for dex in sorted({_sdk_dex(market.dex) for market in markets}):
-            meta: object = self._info().meta(dex=dex)
+            try:
+                meta: object = self._info().meta(dex=dex)
+            except Exception:
+                # Testnet can omit non-default dex metadata; treat those markets as unsupported.
+                if dex:
+                    by_dex[dex] = frozenset()
+                    continue
+                raise
             universe: object = (
                 cast(Mapping[str, object], meta).get("universe")
                 if isinstance(meta, dict)
@@ -313,6 +321,10 @@ class HyperliquidSdkExchange:
                     if name:
                         coins.add(name)
             by_dex[dex] = frozenset(coins)
+            loaded_any_metadata = True
+        if not loaded_any_metadata:
+            self._execution_universe_by_dex = by_dex
+            return
         observed_at = datetime.now(timezone.utc)
         self._execution_universe_by_dex = by_dex
         self._last_execution_universe_at = observed_at

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -393,11 +393,110 @@ def test_sdk_execution_universe_reports_metadata_failure(
         )
     )
 
-    supported_markets, status = sdk_exchange.filter_supported_markets((_market(),))
+    supported_markets, status = sdk_exchange.filter_supported_markets(
+        (
+            _market(
+                coin="SPX",
+                dex="default",
+                market_id="hl:perp:default:SPX",
+            ),
+        )
+    )
 
     assert supported_markets == ()
     assert not status.ready
     assert status.reason == "execution_market_metadata_unavailable:TimeoutError"
+
+
+def test_sdk_execution_universe_skips_unsupported_non_default_testnet_dexes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk_calls: dict[str, object] = {}
+
+    class FakeInfo:
+        def __init__(self, _url: str, *, skip_ws: bool) -> None:
+            assert skip_ws
+
+        def meta(self, dex: str = "") -> dict[str, object]:
+            meta_dexes = sdk_calls.setdefault("meta_dexes", [])
+            assert isinstance(meta_dexes, list)
+            meta_dexes.append(dex)
+            if dex:
+                raise RuntimeError(f"unsupported dex {dex}")
+            return {"universe": [{"name": "SPX"}]}
+
+    def fake_import(name: str) -> object:
+        if name == "hyperliquid.info":
+            return SimpleNamespace(Info=FakeInfo)
+        raise AssertionError(f"unexpected import {name}")
+
+    monkeypatch.setattr(exchange_module.importlib, "import_module", fake_import)
+    sdk_exchange = HyperliquidSdkExchange(
+        _config(
+            HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+            HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0xabc",
+            HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY="0xdef",
+        )
+    )
+
+    supported_markets, status = sdk_exchange.filter_supported_markets(
+        (
+            _market(),
+            _market(coin="xyz:NVDA", dex="xyz", market_id="hl:perp:xyz:xyz:NVDA"),
+            _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
+        )
+    )
+
+    assert supported_markets == (
+        _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
+    )
+    assert status.ready
+    assert sdk_calls["meta_dexes"] == ["", "cash", "xyz"]
+    assert sdk_exchange.dependency_status().ready
+
+
+def test_sdk_execution_universe_reports_no_markets_when_only_non_default_dexes_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk_calls: dict[str, object] = {}
+
+    class FakeInfo:
+        def __init__(self, _url: str, *, skip_ws: bool) -> None:
+            assert skip_ws
+
+        def meta(self, dex: str = "") -> dict[str, object]:
+            meta_dexes = sdk_calls.setdefault("meta_dexes", [])
+            assert isinstance(meta_dexes, list)
+            meta_dexes.append(dex)
+            raise RuntimeError(f"unsupported dex {dex}")
+
+    def fake_import(name: str) -> object:
+        if name == "hyperliquid.info":
+            return SimpleNamespace(Info=FakeInfo)
+        raise AssertionError(f"unexpected import {name}")
+
+    monkeypatch.setattr(exchange_module.importlib, "import_module", fake_import)
+    sdk_exchange = HyperliquidSdkExchange(
+        _config(
+            HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+            HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0xabc",
+            HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY="0xdef",
+        )
+    )
+
+    supported_markets, status = sdk_exchange.filter_supported_markets(
+        (
+            _market(),
+            _market(coin="xyz:NVDA", dex="xyz", market_id="hl:perp:xyz:xyz:NVDA"),
+        )
+    )
+
+    assert supported_markets == ()
+    assert not status.ready
+    assert status.reason == "no_execution_supported_markets"
+    assert sdk_calls["meta_dexes"] == ["cash", "xyz"]
+    assert not sdk_exchange.dependency_status().ready
+    assert sdk_exchange.dependency_status().reason == "exchange_not_read"
 
 
 def test_order_result_status_variants() -> None:


### PR DESCRIPTION
## Summary

- Skips unsupported non-default Hyperliquid testnet dex metadata while preserving default-dex metadata as a hard readiness dependency.
- Keeps unsupported `xyz` and `cash` execution markets out of the testnet order universe instead of degrading the whole runtime.
- Adds regression coverage for the live testnet behavior that returned errors for non-default dex metadata.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/hyperliquid_runtime -q`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Unsupported testnet dexes remain excluded from execution; mainnet execution remains blocked by config validation and code.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
