### PR TITLE
refactor(torghut): move router assembly out of app main

### DIFF
--- a/services/torghut/app/api/application.py
+++ b/services/torghut/app/api/application.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from collections.abc import Callable
+
+from fastapi import APIRouter, FastAPI
 
 _current_app: FastAPI | None = None
+
+WhitepaperRouteRegistrar = Callable[[FastAPI], object | None]
 
 
 def register_app(app: FastAPI) -> FastAPI:
@@ -16,6 +20,51 @@ def register_app(app: FastAPI) -> FastAPI:
     return app
 
 
+def api_routers() -> tuple[APIRouter, ...]:
+    """Return the concrete Torghut API routers mounted on the FastAPI app."""
+
+    from .maintenance import router as maintenance_router
+    from .proofs import router as proofs_router
+    from .readiness import router as readiness_router
+    from .runtime_profitability import router as runtime_profitability_router
+    from .trading_health import router as trading_health_router
+    from .trading_misc import router as trading_misc_router
+    from .trading_status import router as trading_status_router
+    from .whitepaper import router as whitepaper_router
+
+    return (
+        readiness_router,
+        whitepaper_router,
+        trading_status_router,
+        maintenance_router,
+        trading_misc_router,
+        runtime_profitability_router,
+        proofs_router,
+        trading_health_router,
+    )
+
+
+def mount_api_routes(app: FastAPI) -> FastAPI:
+    """Mount Torghut API routers on the registered FastAPI app."""
+
+    for router in api_routers():
+        app.include_router(router)
+    return app
+
+
+def build_registered_app(
+    app: FastAPI,
+    *,
+    register_whitepaper_inngest_routes: WhitepaperRouteRegistrar,
+) -> FastAPI:
+    """Register the process app, mount API routes, and attach workflow routes."""
+
+    register_app(app)
+    mount_api_routes(app)
+    register_whitepaper_inngest_routes(app)
+    return app
+
+
 def get_app() -> FastAPI:
     """Return the registered FastAPI app."""
 
@@ -24,4 +73,10 @@ def get_app() -> FastAPI:
     return _current_app
 
 
-__all__ = ("get_app", "register_app")
+__all__ = (
+    "api_routers",
+    "build_registered_app",
+    "get_app",
+    "mount_api_routes",
+    "register_app",
+)

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3,50 +3,13 @@
 from __future__ import annotations
 
 from . import bootstrap as app_bootstrap
-from .api import common as common_api
-from .api import health_checks as health_checks_api
-from .api import maintenance as maintenance_api
-from .api import proof_floor_payloads as proof_floor_payloads_api
-from .api import proofs as proofs_api
-from .api import readiness as readiness_api
-from .api import readiness_helpers as readiness_helpers_api
-from .api import runtime_profitability as runtime_profitability_api
-from .api import runtime_profitability_helpers as runtime_profitability_helpers_api
-from .api import status_helpers as status_helpers_api
-from .api import trading_health as trading_health_api
-from .api import trading_misc as trading_misc_api
-from .api import trading_status as trading_status_api
-from .api import vnext_helpers as vnext_helpers_api
-from .api import whitepaper as whitepaper_api
-from .api.application import register_app
+from .api.application import build_registered_app
 
 create_app = app_bootstrap.create_app
 
-app = register_app(create_app())
-
-ROUTER_PROVIDERS = (
-    common_api,
-    status_helpers_api,
-    readiness_helpers_api,
-    readiness_api,
-    whitepaper_api,
-    trading_status_api,
-    maintenance_api,
-    trading_misc_api,
-    runtime_profitability_api,
-    proofs_api,
-    trading_health_api,
-    health_checks_api,
-    proof_floor_payloads_api,
-    runtime_profitability_helpers_api,
-    vnext_helpers_api,
+app = build_registered_app(
+    create_app(),
+    register_whitepaper_inngest_routes=app_bootstrap.register_whitepaper_inngest_routes,
 )
-
-for api_module in ROUTER_PROVIDERS:
-    router = getattr(api_module, "router", None)
-    if router is not None:
-        app.include_router(router)
-
-app_bootstrap.register_whitepaper_inngest_routes(app)
 
 __all__ = ("app", "create_app")

--- a/services/torghut/tests/test_main_api_refactor.py
+++ b/services/torghut/tests/test_main_api_refactor.py
@@ -7,7 +7,7 @@ from fastapi.routing import APIRoute
 from app import main as main_module
 from app.api import common as api_common
 from app.api import proofs as proofs_api
-from app.api.application import get_app
+from app.api.application import api_routers, get_app
 from app.trading.scheduler import TradingScheduler
 
 
@@ -52,6 +52,7 @@ def test_main_public_contract_is_entrypoint_only() -> None:
     assert get_app() is main_module.app
 
     removed_private_attrs = (
+        "ROUTER_PROVIDERS",
         "SessionLocal",
         "_TradingStatusReadBudget",
         "_build_live_submission_gate_payload",
@@ -64,6 +65,25 @@ def test_main_public_contract_is_entrypoint_only() -> None:
         name for name in removed_private_attrs if hasattr(main_module, name)
     ]
     assert leaked_attrs == []
+
+
+def test_api_application_mounts_concrete_routers() -> None:
+    route_paths = {
+        route.path
+        for router in api_routers()
+        for route in router.routes
+        if isinstance(route, APIRoute)
+    }
+
+    assert {
+        "/readyz",
+        "/trading/status",
+        "/trading/health",
+        "/trading/proofs",
+        "/trading/consumer-evidence",
+        "/trading/profitability/runtime",
+        "/whitepapers/status",
+    }.issubset(route_paths)
 
 
 def test_main_runtime_value_falls_back_to_common_default() -> None:


### PR DESCRIPTION
## Summary

- Moved Torghut API router assembly from `app.main` into `app.api.application`, leaving `app.main` as the thin runtime entrypoint for `app` and `create_app`.
- Replaced the broad mixed module provider loop with a concrete typed router tuple that mounts only modules with real FastAPI routers.
- Added regression coverage that `app.main` does not expose the old route registry and that the API application layer owns the expected routers.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_main_api_refactor.py`
- `uv run --frozen pytest tests/test_main_api_refactor.py tests/test_whitepaper_api.py tests/test_trading_proofs_api.py tests/test_evidence_epochs.py tests/api`
- `uv run --frozen ruff check app scripts tests`
- `uv run --frozen ruff format --check app scripts tests`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/pylint_torghut_quality.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base $(git merge-base origin/main HEAD) app/api/application.py app/main.py tests/test_main_api_refactor.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
