### PR TITLE
fix(torghut): restrict hyperliquid testnet execution dex

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/exchange.py
+++ b/services/torghut/app/hyperliquid_runtime/exchange.py
@@ -154,6 +154,17 @@ class HyperliquidSdkExchange:
         self._execution_universe_by_dex: dict[str, frozenset[str]] = {}
 
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
+        if self._config.execution_network == "testnet" and _sdk_dex(intent.dex):
+            return OrderResult(
+                status="rejected",
+                exchange_order_id=None,
+                raw_response={
+                    "reason": "unsupported_testnet_dex",
+                    "dex": intent.dex,
+                    "coin": intent.coin,
+                },
+                rejection_reason="unsupported_testnet_dex",
+            )
         exchange = self._exchange()
         cloid = self._cloid(intent.cloid)
         response = cast(
@@ -297,11 +308,13 @@ class HyperliquidSdkExchange:
             return
         by_dex: dict[str, frozenset[str]] = {}
         loaded_any_metadata = False
-        for dex in sorted({_sdk_dex(market.dex) for market in markets}):
+        for dex in _execution_metadata_dexes(
+            markets,
+            execution_network=self._config.execution_network,
+        ):
             try:
                 meta: object = self._info().meta(dex=dex)
             except Exception:
-                # Testnet can omit non-default dex metadata; treat those markets as unsupported.
                 if dex:
                     by_dex[dex] = frozenset()
                     continue
@@ -429,6 +442,17 @@ def _sdk_dex(dex: str) -> str:
     if cleaned in {"", "default"}:
         return ""
     return cleaned
+
+
+def _execution_metadata_dexes(
+    markets: tuple[HyperliquidMarket, ...],
+    *,
+    execution_network: str,
+) -> tuple[str, ...]:
+    dexes = {_sdk_dex(market.dex) for market in markets}
+    if execution_network == "testnet":
+        return ("",) if "" in dexes else ()
+    return tuple(sorted(dexes))
 
 
 def _decimal(value: object) -> Decimal:

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -39,14 +39,20 @@ def _config(**overrides: str) -> HyperliquidRuntimeConfig:
     return HyperliquidRuntimeConfig.from_env(env)
 
 
-def _intent() -> OrderIntent:
+def _intent(
+    *,
+    coin: str = "SPX",
+    dex: str = "default",
+    market_id: str = "hl:perp:default:SPX",
+    limit_price: Decimal = Decimal("5000"),
+) -> OrderIntent:
     return OrderIntent(
-        market_id="hl:perp:cash:cash:AAPL",
-        coin="cash:AAPL",
-        dex="cash",
+        market_id=market_id,
+        coin=coin,
+        dex=dex,
         side="buy",
         size=Decimal("0.1"),
-        limit_price=Decimal("200"),
+        limit_price=limit_price,
         notional_usd=Decimal("20"),
         cloid="0x1234567890abcdef1234567890abcdef",
         reduce_only=False,
@@ -86,6 +92,22 @@ def _cycle() -> CycleResult:
         dependency_statuses=(
             RuntimeDependencyStatus("clickhouse", True, lag_seconds=1),
         ),
+    )
+
+
+def test_execution_metadata_dexes_keeps_all_mainnet_dexes() -> None:
+    markets = (
+        _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
+        _market(),
+        _market(coin="xyz:NVDA", dex="xyz", market_id="hl:perp:xyz:xyz:NVDA"),
+    )
+
+    assert exchange_module._execution_metadata_dexes(
+        markets, execution_network="mainnet"
+    ) == (
+        "",
+        "cash",
+        "xyz",
     )
 
 
@@ -343,24 +365,40 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
             ),
         )
     )
-    cached_markets, cached_status = sdk_exchange.filter_supported_markets((_market(),))
+    default_market = _market(
+        coin="SPX",
+        dex="default",
+        market_id="hl:perp:default:SPX",
+    )
+    cached_markets, cached_status = sdk_exchange.filter_supported_markets(
+        (default_market,)
+    )
     empty_markets, empty_status = sdk_exchange.filter_supported_markets(())
     result = sdk_exchange.submit_ioc_limit(_intent())
+    rejected_non_default = sdk_exchange.submit_ioc_limit(
+        _intent(
+            coin="cash:AAPL",
+            dex="cash",
+            market_id="hl:perp:cash:cash:AAPL",
+            limit_price=Decimal("200"),
+        )
+    )
     fills = sdk_exchange.reconcile_fills({"cash:AAPL": "hl:perp:cash:cash:AAPL"})
     sdk_exchange.schedule_dead_man_cancel(seconds_from_now=30)
 
     assert supported_markets == (
-        _market(),
         _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
     )
     assert universe_status.ready
-    assert cached_markets == (_market(),)
+    assert cached_markets == (default_market,)
     assert cached_status.ready
     assert empty_markets == ()
     assert empty_status.ready
-    assert sdk_calls["meta_dexes"] == ["", "cash"]
+    assert sdk_calls["meta_dexes"] == [""]
     assert result.status == "accepted"
     assert result.exchange_order_id == "42"
+    assert rejected_non_default.status == "rejected"
+    assert rejected_non_default.rejection_reason == "unsupported_testnet_dex"
     assert sdk_calls["order"]  # SDK received a real order payload.
     assert fills[0].notional_usd == Decimal("20.0")
     assert fills[0].fee_usd == Decimal("0.02")
@@ -421,8 +459,7 @@ def test_sdk_execution_universe_skips_unsupported_non_default_testnet_dexes(
             meta_dexes = sdk_calls.setdefault("meta_dexes", [])
             assert isinstance(meta_dexes, list)
             meta_dexes.append(dex)
-            if dex:
-                raise RuntimeError(f"unsupported dex {dex}")
+            assert dex == ""
             return {"universe": [{"name": "SPX"}]}
 
     def fake_import(name: str) -> object:
@@ -451,7 +488,7 @@ def test_sdk_execution_universe_skips_unsupported_non_default_testnet_dexes(
         _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
     )
     assert status.ready
-    assert sdk_calls["meta_dexes"] == ["", "cash", "xyz"]
+    assert sdk_calls["meta_dexes"] == [""]
     assert sdk_exchange.dependency_status().ready
 
 
@@ -494,7 +531,7 @@ def test_sdk_execution_universe_reports_no_markets_when_only_non_default_dexes_f
     assert supported_markets == ()
     assert not status.ready
     assert status.reason == "no_execution_supported_markets"
-    assert sdk_calls["meta_dexes"] == ["cash", "xyz"]
+    assert sdk_calls.get("meta_dexes", []) == []
     assert not sdk_exchange.dependency_status().ready
     assert sdk_exchange.dependency_status().reason == "exchange_not_read"
 


### PR DESCRIPTION
## Summary

- Restricts Hyperliquid testnet execution metadata to the SDK default dex, preventing non-default equity DEX symbols from entering the testnet order path.
- Adds a defensive `unsupported_testnet_dex` rejection if a non-default testnet order intent reaches the exchange adapter.
- Updates adapter tests to cover default-dex-only testnet execution and non-default intent rejection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py -q`
- `uv run --frozen pytest tests/hyperliquid_runtime -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app/hyperliquid_runtime/exchange.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `uv run --frozen ruff format --check app/hyperliquid_runtime/exchange.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
