### PR TITLE
refactor(torghut): clean dependency tooling debt

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -854,3 +854,7 @@ jobs:
       - name: Security scan (ruff S, non-blocking)
         working-directory: services/torghut
         run: uv run --frozen ruff check app scripts migrations --select S --statistics --exit-zero
+
+      - name: Dead-code scan (vulture, non-blocking)
+        working-directory: services/torghut
+        run: uv run --frozen vulture --config pyproject.toml || true

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -76,7 +76,7 @@ Run Vulture from the Torghut service root so it picks up the checked-in `[tool.v
 
 ```bash
 cd services/torghut
-uvx --from vulture vulture --config pyproject.toml
+uv run --frozen vulture --config pyproject.toml
 ```
 
 The current config follows the upstream Vulture guidance for conservative cleanup:

--- a/services/torghut/pyproject.toml
+++ b/services/torghut/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "alpaca-py>=0.33.0,<1.0",
   "pandas>=2.2.3,<3.0",
   "numpy>=2.1.2,<3.0",
-  "openai>=1.55.3,<2.0",
   "dspy-ai>=2.6.27,<3.0",
   "kafka-python>=2.2.0,<3.0",
   "lz4>=4.3.3,<5.0",
@@ -44,6 +43,7 @@ dev = [
   "pytest-xdist>=3.8.0,<4.0",
   "ruff>=0.9.0,<1.0",
   "pandas-stubs>=2.2.3,<3.0",
+  "vulture>=2.14,<3.0",
 ]
 cuda-research = [
   "torch==2.11.0+cu128 ; sys_platform == 'win32' or sys_platform == 'linux'",

--- a/services/torghut/tests/test_dependency_manifest.py
+++ b/services/torghut/tests/test_dependency_manifest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+from typing import Any, cast
+
+from packaging.requirements import Requirement
+
+
+def _pyproject() -> dict[str, Any]:
+    pyproject_path = Path(__file__).parents[1] / "pyproject.toml"
+    return tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+
+def _requirement_names(requirements: list[str]) -> set[str]:
+    return {Requirement(requirement).name for requirement in requirements}
+
+
+def test_runtime_dependencies_do_not_directly_own_openai_sdk() -> None:
+    payload = _pyproject()
+    runtime_dependencies = cast(list[str], payload["project"]["dependencies"])
+
+    assert "openai" not in _requirement_names(runtime_dependencies)
+    assert "dspy-ai" in _requirement_names(runtime_dependencies)
+
+
+def test_dead_code_audit_tool_is_a_locked_dev_dependency() -> None:
+    payload = _pyproject()
+    optional_dependencies = cast(
+        dict[str, list[str]], payload["project"]["optional-dependencies"]
+    )
+
+    assert "vulture" in _requirement_names(optional_dependencies["dev"])
+    assert "vulture" in cast(dict[str, Any], payload["tool"])

--- a/services/torghut/uv.lock
+++ b/services/torghut/uv.lock
@@ -2684,7 +2684,6 @@ dependencies = [
     { name = "lz4" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "numpy" },
-    { name = "openai" },
     { name = "pandas" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
@@ -2712,6 +2711,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -2730,7 +2730,6 @@ requires-dist = [
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.29.2,<1.0" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.3.1,<4.0" },
     { name = "numpy", specifier = ">=2.1.2,<3.0" },
-    { name = "openai", specifier = ">=1.55.3,<2.0" },
     { name = "pandas", specifier = ">=2.2.3,<3.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.3,<3.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.1,<4.0" },
@@ -2748,6 +2747,7 @@ requires-dist = [
     { name = "tigerbeetle", specifier = "==0.17.4" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cuda-research') or (sys_platform == 'win32' and extra == 'cuda-research')", specifier = "==2.11.0+cu128", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "torghut", extra = "cuda-research" } },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0,<1.0" },
+    { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14,<3.0" },
 ]
 provides-extras = ["dev", "cuda-research"]
 
@@ -2914,6 +2914,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
     { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
     { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removed Torghut's direct `openai` runtime dependency; OpenAI SDK ownership now stays transitive through DSPy/LiteLLM.
- Added `vulture` to the locked Torghut `dev` extra and wired the checked-in Vulture config into the non-blocking quality-signals CI job.
- Updated the dead-code audit docs to use the frozen Torghut environment and added manifest contract tests for dependency ownership.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_dependency_manifest.py tests/test_cuda_research_runtime_contract.py`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen ruff format --check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python -m compileall -q app scripts tests`
- `cd services/torghut && uv run --frozen vulture --config pyproject.toml || true` reported the existing advisory findings in `app/alpaca_client.py` and `app/trading/scheduler/source_collection/collection_types.py`.
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/pylint_torghut_quality.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base $(git merge-base origin/main HEAD) tests/test_dependency_manifest.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
