### PR TITLE
feat(anypi): harden anypi completion-loop and timeout handling

### DIFF
--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -39,7 +39,10 @@ import {
   hasWorktreeProgress,
   normalizeConventionalSummary,
   renderPullRequestBody,
+  detectCompletionLoop,
+  createCompletionLoopState,
 } from './run'
+import type { CompletionLoopEvidence, CompletionLoopState } from './types'
 
 describe('Anypi config', () => {
   test('defaults to Flamingo and all Pi coding tools', () => {
@@ -483,5 +486,138 @@ describe('Anypi prompt contract', () => {
         { status: ' M foo.ts', commitsAhead: 1, contentHash: 'same' },
       ),
     ).toBe(false)
+  })
+
+  test('detects completion loop from repeated finish calls and no worktree progress', () => {
+    const state = createCompletionLoopState()
+    // First attempt: finish called with some commands, no worktree change
+    const result1 = {
+      text: 'done',
+      tools: ['read', 'edit'],
+      sessionFile: '/tmp/session1',
+      finishCalled: true,
+      commandCount: 3,
+      worktreeChanges: 0,
+    }
+    const loop1 = detectCompletionLoop(state, result1, '')
+    expect(loop1.loopDetected).toBe(false)
+    expect(state.finishCalledCount).toBe(1)
+    expect(state.consecutiveNoOpCount).toBe(0)
+
+    // Second attempt: finish called again with no worktree change
+    const result2 = {
+      text: 'finalized',
+      tools: ['finish'],
+      sessionFile: '/tmp/session2',
+      finishCalled: true,
+      commandCount: 0,
+      worktreeChanges: 0,
+    }
+    const loop2 = detectCompletionLoop(state, result2, '')
+    expect(loop2.loopDetected).toBe(true)
+    expect(loop2.evidence?.finishCalledCount).toBe(2)
+    expect(loop2.evidence?.commandCount).toBe(0)
+    expect(state.consecutiveNoOpCount).toBe(1)
+  })
+
+  test('detects completion loop from repeated no-op cycles', () => {
+    const state = createCompletionLoopState()
+    // First attempt: no finish, no worktree change
+    const result1 = {
+      text: 'analysis',
+      tools: ['read'],
+      sessionFile: '/tmp/session1',
+      finishCalled: false,
+      commandCount: 0,
+      worktreeChanges: 0,
+    }
+    const loop1 = detectCompletionLoop(state, result1, '')
+    expect(loop1.loopDetected).toBe(false) // First check is skipped
+
+    // Second attempt: still no worktree change
+    const result2 = {
+      text: 'more analysis',
+      tools: ['read'],
+      sessionFile: '/tmp/session2',
+      finishCalled: false,
+      commandCount: 0,
+      worktreeChanges: 0,
+    }
+    const loop2 = detectCompletionLoop(state, result2, '')
+    // After two consecutive no-op checks (first skipped, second counted = 1),
+    // we need one more to reach count >= 2 for loop detection
+    expect(loop2.loopDetected).toBe(false)
+    expect(state.consecutiveNoOpCount).toBe(1)
+
+    // Third attempt: still no worktree change
+    const result3 = {
+      text: 'still analysis',
+      tools: ['read'],
+      sessionFile: '/tmp/session3',
+      finishCalled: false,
+      commandCount: 0,
+      worktreeChanges: 0,
+    }
+    const loop3 = detectCompletionLoop(state, result3, '')
+    expect(loop3.loopDetected).toBe(true) // Now count = 2 >= 2
+    expect(loop3.evidence?.finishCalledCount).toBe(0)
+    expect(state.consecutiveNoOpCount).toBe(2)
+  })
+
+  test('detects completion loop when finish tool and no-op worktree alternate', () => {
+    const state = createCompletionLoopState()
+    // First attempt: finish called, no worktree change
+    const result1 = {
+      text: 'done',
+      tools: ['finish'],
+      sessionFile: '/tmp/session1',
+      finishCalled: true,
+      commandCount: 0,
+      worktreeChanges: 0,
+    }
+    const loop1 = detectCompletionLoop(state, result1, ' M file.ts')
+    expect(loop1.loopDetected).toBe(false)
+
+    // Second attempt: finish called again, still no worktree change
+    const result2 = {
+      text: 'finalized',
+      tools: ['finish'],
+      sessionFile: '/tmp/session2',
+      finishCalled: true,
+      commandCount: 0,
+      worktreeChanges: 0,
+    }
+    const loop2 = detectCompletionLoop(state, result2, ' M file.ts')
+    expect(loop2.loopDetected).toBe(true)
+    expect(state.consecutiveNoOpCount).toBe(1)
+  })
+
+  test('resets no-op count when worktree changes', () => {
+    const state = createCompletionLoopState()
+    // First attempt: no worktree change
+    const result1 = {
+      text: 'analysis',
+      tools: ['read'],
+      sessionFile: '/tmp/session1',
+      finishCalled: false,
+      commandCount: 0,
+      worktreeChanges: 0,
+    }
+    const loop1 = detectCompletionLoop(state, result1, '')
+    expect(loop1.loopDetected).toBe(false) // First check is skipped
+    expect(state.consecutiveNoOpCount).toBe(0)
+
+    // Second attempt: worktree changes
+    const result2 = {
+      text: 'done',
+      tools: ['edit'],
+      sessionFile: '/tmp/session2',
+      finishCalled: false,
+      commandCount: 1,
+      worktreeChanges: 1,
+    }
+    const loop2 = detectCompletionLoop(state, result2, ' M new.ts')
+    expect(loop2.loopDetected).toBe(false)
+    expect(state.consecutiveNoOpCount).toBe(0) // Reset because worktree changed
   })
 })

--- a/services/anypi/src/logger.ts
+++ b/services/anypi/src/logger.ts
@@ -3,6 +3,7 @@ import { dirname } from 'node:path'
 
 export type Logger = {
   info: (message: string) => Promise<void>
+  warn: (message: string) => Promise<void>
   error: (message: string) => Promise<void>
 }
 
@@ -10,7 +11,7 @@ const timestampUtc = () => new Date().toISOString()
 
 export const createLogger = async (logPath: string): Promise<Logger> => {
   await mkdir(dirname(logPath), { recursive: true })
-  const write = async (level: 'info' | 'error', message: string) => {
+  const write = async (level: 'info' | 'warn' | 'error', message: string) => {
     const line = `${timestampUtc()} ${level.toUpperCase()} ${message}\n`
     if (level === 'error') {
       process.stderr.write(line)
@@ -21,6 +22,7 @@ export const createLogger = async (logPath: string): Promise<Logger> => {
   }
   return {
     info: (message) => write('info', message),
+    warn: (message) => write('warn', message),
     error: (message) => write('error', message),
   }
 }

--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -21,6 +21,9 @@ export type PiRunResult = {
   text: string
   tools: string[]
   sessionFile?: string
+  finishCalled: boolean
+  commandCount: number
+  worktreeChanges: number
 }
 
 export type PiRunOptions = {
@@ -30,6 +33,35 @@ export type PiRunOptions = {
 
 export const isBenignAssistantContinuationError = (error: unknown) =>
   error instanceof Error && error.message.includes('Cannot continue from message role: assistant')
+
+export type CompletionLoopState = {
+  finishCalledCount: number
+  lastCommand: string | null
+  commandSequence: string[]
+  worktreeSnapshot: string
+}
+
+export const isCompletionLoopTool = (toolName: string): boolean => {
+  const finishTools = ['finish', 'finalization', 'finalize', 'complete']
+  return finishTools.some((t) => toolName.toLowerCase().includes(t))
+}
+
+export const isBenignCommand = (command: string): boolean => {
+  const benignPatterns = [
+    /^git (status|diff|log|rev-list|rev-parse)/i,
+    /^ls( -la)?$/i,
+    /^cat\s+/i,
+    /^head\s+/i,
+    /^tail\s+/i,
+    /^echo\s+/i,
+    /^pwd$/i,
+    /^date$/i,
+    /^whoami$/i,
+    /^uname( -a)?$/i,
+    /^ls\s/,
+  ]
+  return benignPatterns.some((pattern) => pattern.test(command.trim()))
+}
 
 export const resolveAttemptSessionDir = (sessionDir: string, sessionLabel = 'attempt') => {
   const safeLabel = sessionLabel
@@ -137,6 +169,9 @@ export const runPiAgent = async (
   await log(`pi active tools: ${session.getActiveToolNames().join(', ')}`)
 
   let text = ''
+  let finishCalled = false
+  let commandCount = 0
+  let lastCommand: string | null = null
   const unsubscribe = session.subscribe((event) => {
     if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
       const delta = event.assistantMessageEvent.delta
@@ -145,9 +180,22 @@ export const runPiAgent = async (
     }
     if (event.type === 'tool_execution_start') {
       void log(`tool start: ${event.toolName}`)
+      const toolName = event.toolName
+      if (isCompletionLoopTool(toolName)) {
+        finishCalled = true
+        void log(`finish tool detected: ${toolName}`)
+      } else if (toolName === 'bash') {
+        commandCount += 1
+      }
     }
     if (event.type === 'tool_execution_end') {
       void log(`tool end: ${event.toolName}`)
+      if (event.toolName === 'bash' && event.result && typeof event.result === 'object') {
+        const result = event.result as { stdout?: string; stderr?: string }
+        if (result.stdout) {
+          lastCommand = (result.stdout as string).trim()
+        }
+      }
     }
   })
 
@@ -162,6 +210,9 @@ export const runPiAgent = async (
       text,
       tools: session.getActiveToolNames(),
       sessionFile: session.sessionFile,
+      finishCalled,
+      commandCount,
+      worktreeChanges: 0,
     }
   } finally {
     unsubscribe()

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'node:path'
 
 import { applyRunnerArtifacts, loadRunnerSpec, loadRunSpec, resolveConfig, type AnypiConfig } from './config'
 import { createLogger } from './logger'
-import { runPiAgent } from './pi-session'
+import { runPiAgent, type PiRunResult, isCompletionLoopTool } from './pi-session'
 import {
   buildAgentPrompt,
   buildCiRepairPrompt,
@@ -30,6 +30,8 @@ import type {
   AgentRunSpecPayload,
   AnypiStatus,
   CiWaitResult,
+  CompletionLoopEvidence,
+  CompletionLoopState,
   PullRequestResult,
   ValidationPlan,
   ValidationResult,
@@ -198,6 +200,62 @@ const getWorktreeProgress = async (git: GitContext | null, worktree: string): Pr
   contentHash: git ? await gitWorktreeContentHash(worktree, git.env) : '',
 })
 
+// Completion loop detection state and helpers
+export const createCompletionLoopState = (): CompletionLoopState => ({
+  finishCalledCount: 0,
+  commandSequence: [],
+  lastWorktreeStatus: '',
+  consecutiveNoOpCount: 0,
+  isFirstCheck: true,
+})
+
+export const detectCompletionLoop = (
+  state: CompletionLoopState,
+  result: PiRunResult,
+  currentWorktreeStatus: string,
+): { loopDetected: boolean; evidence?: CompletionLoopEvidence } => {
+  // Track finish/finalization tool calls
+  if (result.finishCalled) {
+    state.finishCalledCount += 1
+  }
+
+  // Track command sequence (last 3 commands)
+  const commands = state.commandSequence.slice(-2)
+  if (result.commandCount > 0) {
+    commands.push(`executed ${result.commandCount} commands`)
+  }
+  state.commandSequence = commands
+
+  // Detect worktree no-op (no changes since last check)
+  // Skip the first check since we haven't had a chance to make progress yet
+  if (!state.isFirstCheck && state.lastWorktreeStatus === currentWorktreeStatus) {
+    state.consecutiveNoOpCount += 1
+  } else {
+    state.consecutiveNoOpCount = 0
+  }
+  state.isFirstCheck = false
+  state.lastWorktreeStatus = currentWorktreeStatus
+
+  // Loop detected if:
+  // - Multiple finish calls AND consecutive no-op worktree, OR
+  // - Repeated no-op cycles without progress
+  const loopDetected =
+    (state.finishCalledCount >= 2 && state.consecutiveNoOpCount >= 1) || state.consecutiveNoOpCount >= 2
+
+  if (loopDetected) {
+    return {
+      loopDetected: true,
+      evidence: {
+        finishCalledCount: state.finishCalledCount,
+        commandCount: result.commandCount,
+        lastCommands: state.commandSequence,
+      },
+    }
+  }
+
+  return { loopDetected: false }
+}
+
 const formatValidationError = (result: ValidationResult) =>
   `validation failed (${result.exitCode}): ${[result.command, ...result.args].join(' ')}`
 
@@ -295,6 +353,9 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       }
     }
 
+    // Completion loop detection state
+    let completionLoopState = createCompletionLoopState()
+
     for (let attempt = 0; attempt <= config.noChangeRepairAttempts; attempt += 1) {
       const nextPrompt =
         attempt === 0
@@ -304,18 +365,42 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
               maxAttempts: config.noChangeRepairAttempts,
               worktree: config.worktree,
             })
-      await recordPiResult(
-        await runPiAgent(config, nextPrompt, logger.info, {
-          sessionLabel: attempt === 0 ? 'initial' : `no-change-repair-${attempt}`,
-          systemPrompt,
-        }),
-        attempt === 0 ? undefined : `No-change repair ${attempt}`,
-      )
+      const piResult = await runPiAgent(config, nextPrompt, logger.info, {
+        sessionLabel: attempt === 0 ? 'initial' : `no-change-repair-${attempt}`,
+        systemPrompt,
+      })
+      await recordPiResult(piResult, attempt === 0 ? undefined : `No-change repair ${attempt}`)
       status.agentAttempts = attempt + 1
       await writeStatus(config.statusPath, status)
 
       const changed = await gitStatusShort(config.worktree, git?.env)
       const commitsAhead = git ? await countCommitsAhead(git) : 0
+
+      // Detect completion loop
+      const loopResult = detectCompletionLoop(completionLoopState, piResult, changed)
+      if (loopResult.loopDetected) {
+        status.completionLoopDetected = true
+        status.loopEvidence = {
+          finishCalledCount: loopResult.evidence?.finishCalledCount ?? 0,
+          commandCount: loopResult.evidence?.commandCount ?? 0,
+          lastCommands: loopResult.evidence?.lastCommands ?? [],
+          worktreeStatus: changed,
+          elapsedSeconds: Math.round((Date.now() - Date.parse(status.startedAt)) / 1000),
+        }
+        await logger.warn(`completion loop detected after ${status.agentAttempts} attempts`)
+        await logger.warn(`loop evidence: ${JSON.stringify(status.loopEvidence)}`)
+        // If worktree has changes despite loop, proceed to validation
+        if (changed || (git && commitsAhead > 0)) {
+          await logger.info(`completion loop detected but worktree has changes; proceeding to validation`)
+          break
+        }
+        // No changes, exit with loop detection
+        throw new Error(
+          `completion loop detected: model repeatedly signaled completion without making worktree changes ` +
+            `(finishCalled=${loopResult.evidence?.finishCalledCount}, consecutiveNoOp=${completionLoopState.consecutiveNoOpCount})`,
+        )
+      }
+
       if (changed || !git || commitsAhead > 0) break
       if (attempt >= config.noChangeRepairAttempts) {
         throw new Error('Anypi completed without leaving code changes in the worktree')
@@ -327,6 +412,8 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
 
     const validationCommands = status.validationPlan.commands
     let validationResults: ValidationResult[] = []
+    // Completion loop detection for validation repair
+    let validationLoopState = createCompletionLoopState()
     for (let attempt = 0; attempt <= config.validationRepairAttempts; attempt += 1) {
       validationResults = await runValidationPass(validationCommands, git, runSpec, config.worktree, logger.info)
       status.validationAttempts = attempt + 1
@@ -361,6 +448,29 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       }
       const afterRepair = await getWorktreeProgress(git, config.worktree)
       if (!hasWorktreeProgress(beforeRepair, afterRepair)) {
+        // Check for completion loop
+        const loopResult = detectCompletionLoop(validationLoopState, repairResult, afterRepair.status)
+        if (loopResult.loopDetected) {
+          status.completionLoopDetected = true
+          status.loopEvidence = {
+            finishCalledCount: loopResult.evidence?.finishCalledCount ?? 0,
+            commandCount: loopResult.evidence?.commandCount ?? 0,
+            lastCommands: loopResult.evidence?.lastCommands ?? [],
+            worktreeStatus: afterRepair.status,
+            elapsedSeconds: Math.round((Date.now() - Date.parse(status.startedAt)) / 1000),
+          }
+          await logger.warn(`validation repair completion loop detected after ${status.agentAttempts} attempts`)
+          await logger.warn(`loop evidence: ${JSON.stringify(status.loopEvidence)}`)
+          // If worktree has changes despite loop, proceed to validation
+          if (afterRepair.status || (git && afterRepair.commitsAhead > 0)) {
+            await logger.info(`validation loop detected but worktree has changes; proceeding to validation`)
+            break
+          }
+          throw new Error(
+            `validation repair completion loop detected: model repeatedly made no meaningful progress ` +
+              `(finishCalled=${loopResult.evidence?.finishCalledCount}, consecutiveNoOp=${validationLoopState.consecutiveNoOpCount})`,
+          )
+        }
         throw new Error(
           `${formatValidationError(failed)}; validation repair ${attempt + 1} produced no worktree changes`,
         )
@@ -381,6 +491,8 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
       await writeStatus(config.statusPath, status)
 
       if (pullRequest.enabled) {
+        // Completion loop detection for CI repair
+        let ciLoopState = createCompletionLoopState()
         for (let attempt = 0; attempt <= config.ciRepairAttempts; attempt += 1) {
           const ci = await waitForPullRequestChecks(
             git,
@@ -424,7 +536,34 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
 
           const previousCommit: string | undefined = status.commit
           const repairedCommit = await commitIfNeeded(git, buildCommitMessage(runSpec))
-          if (!repairedCommit || repairedCommit === previousCommit) throw new Error('CI repair produced no new commit')
+
+          // Check for completion loop - no new commit after repair
+          if (!repairedCommit || repairedCommit === previousCommit) {
+            const currentWorktreeStatus = await gitStatusShort(config.worktree, git?.env)
+            const loopResult = detectCompletionLoop(ciLoopState, repairResult, currentWorktreeStatus)
+            if (loopResult.loopDetected) {
+              status.completionLoopDetected = true
+              status.loopEvidence = {
+                finishCalledCount: loopResult.evidence?.finishCalledCount ?? 0,
+                commandCount: loopResult.evidence?.commandCount ?? 0,
+                lastCommands: loopResult.evidence?.lastCommands ?? [],
+                worktreeStatus: currentWorktreeStatus,
+                elapsedSeconds: Math.round((Date.now() - Date.parse(status.startedAt)) / 1000),
+              }
+              await logger.warn(`CI repair completion loop detected after ${status.agentAttempts} attempts`)
+              await logger.warn(`loop evidence: ${JSON.stringify(status.loopEvidence)}`)
+              // If worktree has changes despite loop, proceed
+              if (currentWorktreeStatus || (git && (await countCommitsAhead(git)) > 0)) {
+                await logger.info(`CI loop detected but worktree has changes; proceeding`)
+              } else {
+                throw new Error(
+                  `CI repair completion loop detected: model repeatedly made no meaningful progress ` +
+                    `(finishCalled=${loopResult.evidence?.finishCalledCount}, consecutiveNoOp=${ciLoopState.consecutiveNoOpCount})`,
+                )
+              }
+            }
+            throw new Error('CI repair produced no new commit')
+          }
           status.commit = repairedCommit
           await pushBranch(git)
           pullRequest = await createOrUpdatePullRequest(git, {

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -104,6 +104,20 @@ export type CiWaitResult = {
   summary: string
 }
 
+export type CompletionLoopState = {
+  finishCalledCount: number
+  commandSequence: string[]
+  lastWorktreeStatus: string
+  consecutiveNoOpCount: number
+  isFirstCheck?: boolean
+}
+
+export type CompletionLoopEvidence = {
+  finishCalledCount: number
+  commandCount: number
+  lastCommands: string[]
+}
+
 export type AnypiStatus = {
   provider: string
   status: 'running' | 'succeeded' | 'failed'
@@ -133,4 +147,12 @@ export type AnypiStatus = {
   validationAttempts: number
   promptChars: number
   error?: string
+  completionLoopDetected?: boolean
+  loopEvidence?: {
+    finishCalledCount: number
+    commandCount: number
+    lastCommands: string[]
+    worktreeStatus: string
+    elapsedSeconds: number
+  }
 }


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-agent-94wrg.
- Prompt variant: `repair-loop` (`b77c133ef91aab25`).
- Session artifact: `/workspace/.anypi/sessions/initial-f96d1797/2026-06-18T21-22-22-244Z_019edc9d-13a4-7aa8-8876-74dc2e2b6463.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc bun run --filter @proompteng/anypi tsc` exit 0
- `bash -lc bun run --filter @proompteng/anypi test` exit 0
- `bash -lc bun run --filter @proompteng/anypi lint` exit 0
- `bash -lc kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml` exit 0
- `bash -lc bunx oxfmt --check services/anypi argocd/applications/agents` exit 0
- `bash -lc bun run lint:argocd` exit 0
- CI: passed: 13 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
