### PR TITLE
chore(external-secrets): add media vault store

### DIFF
--- a/argocd/applications/external-secrets/kustomization.yaml
+++ b/argocd/applications/external-secrets/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: external-secrets
 resources:
   - onepassword-sdk-token-sealedsecret.yaml
   - onepassword-infra-clustersecretstore.yaml
+  - onepassword-media-clustersecretstore.yaml
   - external-secrets-canary.yaml
 
 helmCharts:

--- a/argocd/applications/external-secrets/onepassword-media-clustersecretstore.yaml
+++ b/argocd/applications/external-secrets/onepassword-media-clustersecretstore.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-media
+spec:
+  conditions:
+    - namespaceSelector:
+        matchLabels:
+          external-secrets.proompteng.ai/enabled: "true"
+  provider:
+    onepasswordSDK:
+      vault: media
+      auth:
+        serviceAccountSecretRef:
+          name: onepassword-sdk-token
+          namespace: external-secrets
+          key: token
+      integrationInfo:
+        name: proompteng-lab-external-secrets
+        version: v1


### PR DESCRIPTION
## Summary

- Add `ClusterSecretStore/onepassword-media` for the dedicated media 1Password vault.
- Wire the new store into the external-secrets Kustomization.
- Reuse the existing external-secrets SDK service account token and namespace selector policy.

## Related Issues

None

## Testing

- `kubectl --context galactic-tailscale apply --dry-run=server -f argocd/applications/external-secrets/onepassword-media-clustersecretstore.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/external-secrets >/tmp/external-secrets-render.yaml && rg -n 'name: onepassword-(infra|media)|vault: (infra|media)' /tmp/external-secrets-render.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
