### PR TITLE
revert(torghut): rollback failed promotion 5c346181bc570b7c5ceabf4c1a5d3b985eab529b

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -164,9 +164,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+                  value: sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
                 - name: TORGHUT_COMMIT
-                  value: 7eccd4a4af650429ea3356890a4ae95ff5e72f44
+                  value: 27f4342a7d43703f9f5461ae21ca5b4575bf837f
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-18T21:46:34Z"
+        client.knative.dev/updateTimestamp: "2026-06-18T21:23:10Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
           ports:
             - name: http1
               containerPort: 8181
@@ -541,11 +541,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-829-g7eccd4a4a
+              value: v0.596.0-827-g27f4342a7
             - name: TORGHUT_COMMIT
-              value: 7eccd4a4af650429ea3356890a4ae95ff5e72f44
+              value: 27f4342a7d43703f9f5461ae21ca5b4575bf837f
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+              value: sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-18T21:46:34Z"
+        client.knative.dev/updateTimestamp: "2026-06-18T21:23:10Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
           ports:
             - name: http1
               containerPort: 8181
@@ -415,11 +415,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-829-g7eccd4a4a
+              value: v0.596.0-827-g27f4342a7
             - name: TORGHUT_COMMIT
-              value: 7eccd4a4af650429ea3356890a4ae95ff5e72f44
+              value: 27f4342a7d43703f9f5461ae21ca5b4575bf837f
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+              value: sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 7eccd4a4af650429ea3356890a4ae95ff5e72f44
+            value: 27f4342a7d43703f9f5461ae21ca5b4575bf837f
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+            value: sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:11a1529b2ea52f50fbe59cbc3fcc34f41d46be4c61cda113578466141e816417
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:472fd30ea2d5027e614eccc33398a6e11bc75330030e4c648ae6e68c29096c2a
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `5c346181bc570b7c5ceabf4c1a5d3b985eab529b`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/27791480042`
- Rollback source: `HEAD^` manifests from the failed run checkout