### PR TITLE
ci(torghut): speed release promotion verification

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -163,24 +163,7 @@ jobs:
           fi
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Cache Bun downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.14-torghut-ci-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.14-torghut-ci-
-            ${{ runner.os }}-bun-1.3.14-
-
-      - name: Install script dependencies
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
-
-      - name: Require source commit Torghut CI
+      - name: Verify source image build contract
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -189,22 +172,29 @@ jobs:
           set -euo pipefail
 
           source_sha="$(
-            bun run packages/scripts/src/torghut/source-ci.ts source-sha \
-              --manifest argocd/applications/torghut/knative-service.yaml
+            awk '
+              /^[[:space:]]*- name:[[:space:]]*TORGHUT_COMMIT[[:space:]]*$/ { found = 1; next }
+              found && /^[[:space:]]*value:/ {
+                sub(/^[[:space:]]*value:[[:space:]]*/, "")
+                gsub(/"/, "")
+                print
+                exit
+              }
+            ' argocd/applications/torghut/knative-service.yaml
           )"
-          echo "Torghut release manifest-only change; requiring full source CI for ${source_sha}."
+          if ! printf '%s' "${source_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Unable to resolve TORGHUT_COMMIT from release manifest"
+            exit 1
+          fi
+          echo "Torghut release manifest-only change; requiring successful multi-arch build for ${source_sha}."
 
-          required_source_jobs=(
-            'Pyright'
-            'Bytecode + lint + migration guard'
-            'Pytest shard 0'
-            'Pytest shard 1'
-            'Pytest shard 2'
-            'Pytest shard 3'
-            'Bytecode + pytest + coverage'
+          required_build_jobs=(
+            'build-platform (linux/amd64, amd64, arc-amd64)'
+            'build-platform (linux/arm64, arm64, arc-arm64)'
+            'publish-index'
           )
 
-          assert_required_source_jobs() {
+          assert_required_build_jobs() {
             local run_id="$1"
             local job_lines
             job_lines="$(
@@ -214,7 +204,7 @@ jobs:
                 --jq '.jobs[] | [.name, (.conclusion // ""), (.status // "")] | @tsv'
             )"
 
-            for required_job in "${required_source_jobs[@]}"; do
+            for required_job in "${required_build_jobs[@]}"; do
               state="$(
                 printf '%s\n' "${job_lines}" |
                   awk -F '\t' \
@@ -226,31 +216,31 @@ jobs:
                 success)
                   ;;
                 MISSING)
-                  echo "Required source CI job is missing from run ${run_id}: ${required_job}"
+                  echo "Required build-push job is missing from run ${run_id}: ${required_job}"
                   exit 1
                   ;;
                 PENDING)
-                  echo "Required source CI job did not complete in successful run ${run_id}: ${required_job} (${status:-unknown})"
+                  echo "Required build-push job did not complete in successful run ${run_id}: ${required_job} (${status:-unknown})"
                   exit 1
                   ;;
                 failure | cancelled | skipped | timed_out | action_required | startup_failure)
-                  echo "Required source CI job failed in run ${run_id}: ${required_job} -> ${conclusion}"
+                  echo "Required build-push job failed in run ${run_id}: ${required_job} -> ${conclusion}"
                   exit 1
                   ;;
                 *)
-                  echo "Required source CI job has unexpected conclusion in run ${run_id}: ${required_job} -> ${conclusion}"
+                  echo "Required build-push job has unexpected conclusion in run ${run_id}: ${required_job} -> ${conclusion}"
                   exit 1
                   ;;
               esac
             done
           }
 
-          deadline=$((SECONDS + 2700))
+          deadline=$((SECONDS + 900))
           while true; do
             run_line="$(
               gh run list \
                 -R "${GH_REPO}" \
-                --workflow torghut-ci.yml \
+                --workflow torghut-build-push.yaml \
                 --commit "${source_sha}" \
                 --json databaseId,status,conclusion,url,createdAt \
                 --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
@@ -258,19 +248,19 @@ jobs:
             IFS=$'\t' read -r run_id run_status run_conclusion run_url <<< "${run_line}"
 
             if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
-              assert_required_source_jobs "${run_id}"
-              echo "Source commit Torghut CI passed required jobs for ${source_sha}: ${run_url}"
+              assert_required_build_jobs "${run_id}"
+              echo "Torghut build-push passed required image contract jobs for ${source_sha}: ${run_url}"
               break
             fi
 
             if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
-              echo "Source commit Torghut CI did not pass for ${source_sha}: ${run_conclusion}"
+              echo "Torghut build-push did not pass for ${source_sha}: ${run_conclusion}"
               echo "${run_url}"
               exit 1
             fi
 
             if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "Timed out waiting for source commit Torghut CI for ${source_sha}"
+              echo "Timed out waiting for Torghut build-push for ${source_sha}"
               if [ -n "${run_url}" ]; then
                 echo "${run_url}"
               fi
@@ -278,11 +268,11 @@ jobs:
             fi
 
             if [ -z "${run_id}" ]; then
-              echo "Waiting for source commit Torghut CI to appear for ${source_sha}"
+              echo "Waiting for Torghut build-push to appear for ${source_sha}"
             else
-              echo "Waiting for source commit Torghut CI: status=${run_status} conclusion=${run_conclusion:-pending}"
+              echo "Waiting for Torghut build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
             fi
-            sleep 15
+            sleep 10
           done
 
   pyright:

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -159,7 +159,7 @@ jobs:
           printf 'eligible=%s\n' "${ELIGIBLE}"
           printf 'reason=%s\n' "${REASON}"
 
-      - name: Wait for source commit Torghut CI
+      - name: Verify source image build contract
         if: steps.gates.outputs.eligible == 'true'
         shell: bash
         env:
@@ -191,17 +191,13 @@ jobs:
             exit 1
           fi
 
-          required_source_jobs=(
-            'Pyright'
-            'Bytecode + lint + migration guard'
-            'Pytest shard 0'
-            'Pytest shard 1'
-            'Pytest shard 2'
-            'Pytest shard 3'
-            'Bytecode + pytest + coverage'
+          required_build_jobs=(
+            'build-platform (linux/amd64, amd64, arc-amd64)'
+            'build-platform (linux/arm64, arm64, arc-arm64)'
+            'publish-index'
           )
 
-          assert_required_source_jobs() {
+          assert_required_build_jobs() {
             local run_id="$1"
             local job_lines
             job_lines="$(
@@ -211,7 +207,7 @@ jobs:
                 --jq '.jobs[] | [.name, (.conclusion // ""), (.status // "")] | @tsv'
             )"
 
-            for required_job in "${required_source_jobs[@]}"; do
+            for required_job in "${required_build_jobs[@]}"; do
               state="$(
                 printf '%s\n' "${job_lines}" |
                   awk -F '\t' \
@@ -223,31 +219,31 @@ jobs:
                 success)
                   ;;
                 MISSING)
-                  echo "Required source CI job is missing from run ${run_id}: ${required_job}"
+                  echo "Required build-push job is missing from run ${run_id}: ${required_job}"
                   exit 1
                   ;;
                 PENDING)
-                  echo "Required source CI job did not complete in successful run ${run_id}: ${required_job} (${status:-unknown})"
+                  echo "Required build-push job did not complete in successful run ${run_id}: ${required_job} (${status:-unknown})"
                   exit 1
                   ;;
                 failure | cancelled | skipped | timed_out | action_required | startup_failure)
-                  echo "Required source CI job failed in run ${run_id}: ${required_job} -> ${conclusion}"
+                  echo "Required build-push job failed in run ${run_id}: ${required_job} -> ${conclusion}"
                   exit 1
                   ;;
                 *)
-                  echo "Required source CI job has unexpected conclusion in run ${run_id}: ${required_job} -> ${conclusion}"
+                  echo "Required build-push job has unexpected conclusion in run ${run_id}: ${required_job} -> ${conclusion}"
                   exit 1
                   ;;
               esac
             done
           }
 
-          deadline=$((SECONDS + 2700))
+          deadline=$((SECONDS + 900))
           while true; do
             run_line="$(
               gh run list \
                 -R "${GH_REPO}" \
-                --workflow torghut-ci.yml \
+                --workflow torghut-build-push.yaml \
                 --commit "${source_sha}" \
                 --json databaseId,status,conclusion,url,createdAt \
                 --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
@@ -255,19 +251,19 @@ jobs:
             IFS=$'\t' read -r run_id run_status run_conclusion run_url <<< "${run_line}"
 
             if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
-              assert_required_source_jobs "${run_id}"
-              echo "Source commit Torghut CI passed for ${source_sha}: ${run_url}"
+              assert_required_build_jobs "${run_id}"
+              echo "Torghut build-push passed required image contract jobs for ${source_sha}: ${run_url}"
               break
             fi
 
             if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
-              echo "Source commit Torghut CI did not pass for ${source_sha}: ${run_conclusion}"
+              echo "Torghut build-push did not pass for ${source_sha}: ${run_conclusion}"
               echo "${run_url}"
               exit 1
             fi
 
             if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "Timed out waiting for source commit Torghut CI for ${source_sha}"
+              echo "Timed out waiting for Torghut build-push for ${source_sha}"
               if [ -n "${run_url}" ]; then
                 echo "${run_url}"
               fi
@@ -275,11 +271,11 @@ jobs:
             fi
 
             if [ -z "${run_id}" ]; then
-              echo "Waiting for source commit Torghut CI to appear for ${source_sha}"
+              echo "Waiting for Torghut build-push to appear for ${source_sha}"
             else
-              echo "Waiting for source commit Torghut CI: status=${run_status} conclusion=${run_conclusion:-pending}"
+              echo "Waiting for Torghut build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
             fi
-            sleep 15
+            sleep 10
           done
 
       - name: Wait for required release checks

--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -315,7 +315,7 @@ jobs:
                       printf '%s' "${status}"
                       return 0
                     fi
-                    echo "Attempt ${attempt}: ${label} database readiness timed out; retrying until repair-only readyz contract is acceptable" >&2
+                    echo "Attempt ${attempt}: ${label} database readiness timed out; retrying until readyz contract is acceptable" >&2
                     sleep 5
                     continue
                     ;;

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -146,16 +146,17 @@ describe('torghut build-push workflow', () => {
     expect(arcApplication).toContain('kubernetes.io/arch: arm64')
   })
 
-  it('caches Bun downloads before manifest-only CI installs script dependencies', () => {
+  it('keeps manifest-only release CI free of package install overhead', () => {
     const releaseManifestJob = ciWorkflow.indexOf('release-manifests:')
-    const cacheStep = ciWorkflow.indexOf('name: Cache Bun downloads', releaseManifestJob)
-    const cachePath = ciWorkflow.indexOf('path: ~/.bun/install/cache', cacheStep)
-    const installStep = ciWorkflow.indexOf('name: Install script dependencies', cachePath)
+    const nextJob = ciWorkflow.indexOf('\n  pyright:', releaseManifestJob)
+    const releaseManifestJobBody = ciWorkflow.slice(releaseManifestJob, nextJob)
 
     expect(releaseManifestJob).toBeGreaterThan(-1)
-    expect(cacheStep).toBeGreaterThan(releaseManifestJob)
-    expect(cachePath).toBeGreaterThan(cacheStep)
-    expect(installStep).toBeGreaterThan(cachePath)
+    expect(releaseManifestJobBody).toContain('name: Verify source image build contract')
+    expect(releaseManifestJobBody).toContain('TORGHUT_COMMIT')
+    expect(releaseManifestJobBody).not.toContain('oven-sh/setup-bun')
+    expect(releaseManifestJobBody).not.toContain('actions/cache@v4')
+    expect(releaseManifestJobBody).not.toContain('bun install')
   })
 
   it('authenticates changed-file planner GitHub API calls', () => {
@@ -186,7 +187,21 @@ describe('torghut build-push workflow', () => {
     expect(prFilesCall).toBeGreaterThan(authHeader)
   })
 
-  it('does not cancel main source CI that release promotion must verify', () => {
+  it('gates release manifest-only CI on the completed build-push image contract', () => {
+    const releaseManifestJob = ciWorkflow.indexOf('release-manifests:')
+    const buildContractStep = ciWorkflow.indexOf('name: Verify source image build contract', releaseManifestJob)
+
+    expect(buildContractStep).toBeGreaterThan(releaseManifestJob)
+    expect(ciWorkflow).toContain('--workflow torghut-build-push.yaml')
+    expect(ciWorkflow).toContain('build-platform (linux/amd64, amd64, arc-amd64)')
+    expect(ciWorkflow).toContain('build-platform (linux/arm64, arm64, arc-arm64)')
+    expect(ciWorkflow).toContain('publish-index')
+    expect(ciWorkflow).toContain('Torghut build-push passed required image contract jobs')
+    expect(ciWorkflow).not.toContain('name: Require source commit Torghut CI')
+    expect(ciWorkflow).not.toContain('--workflow torghut-ci.yml')
+  })
+
+  it('does not cancel main source CI while release promotion verifies the image contract', () => {
     expect(ciWorkflow).toContain(
       "group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}",
     )

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -25,4 +25,15 @@ describe('torghut-deploy-automerge workflow', () => {
       expect(countOccurrences(deployAutomergeWorkflow, `'${manifestPath}'`)).toBeGreaterThanOrEqual(2)
     }
   })
+
+  test('verifies the source build-push image contract instead of waiting for full source CI', () => {
+    expect(deployAutomergeWorkflow).toContain('name: Verify source image build contract')
+    expect(deployAutomergeWorkflow).toContain('--workflow torghut-build-push.yaml')
+    expect(deployAutomergeWorkflow).toContain('build-platform (linux/amd64, amd64, arc-amd64)')
+    expect(deployAutomergeWorkflow).toContain('build-platform (linux/arm64, arm64, arc-arm64)')
+    expect(deployAutomergeWorkflow).toContain('publish-index')
+    expect(deployAutomergeWorkflow).toContain('Torghut build-push passed required image contract jobs')
+    expect(deployAutomergeWorkflow).not.toContain('name: Wait for source commit Torghut CI')
+    expect(deployAutomergeWorkflow).not.toContain('--workflow torghut-ci.yml')
+  })
 })

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -161,6 +161,38 @@ const baseReadyz = {
   },
 }
 
+const coreDependenciesOnlyReadyz = {
+  status: 'degraded',
+  reason_codes: ['alpaca_degraded'],
+  scheduler: { ok: true, running: true },
+  readiness_surface: 'core_dependencies_only',
+  dependencies: {
+    postgres: { ok: true },
+    clickhouse: { ok: true },
+    database: { ok: true },
+    alpaca: {
+      ok: false,
+      detail: 'alpaca account probe timed out after 2.00s',
+    },
+  },
+  live_submission_gate: {
+    allowed: false,
+    promotion_authority: false,
+    promotion_authority_ok: false,
+    final_authority_ok: false,
+    final_promotion_allowed: false,
+    final_promotion_authorized: false,
+    reason: 'readyz_core_dependencies_only',
+    reason_codes: ['readyz_core_dependencies_only'],
+    blocked_reasons: ['readyz_core_dependencies_only'],
+    capital_stage: 'shadow',
+    capital_state: 'observe',
+    read_model_evaluated: false,
+    readiness_surface: 'core_dependencies_only',
+    live_submit_activation: baseLiveSubmitActivation,
+  },
+}
+
 describe('validatePostDeployEvidence', () => {
   it('accepts normal 2xx readyz with route board evidence', () => {
     const result = validatePostDeployEvidence({
@@ -291,6 +323,53 @@ describe('validatePostDeployEvidence', () => {
 
     expect(result.readyzAcceptedReason).toBe('repair_only_zero_notional')
     expect(result.summaryLines.join('\n')).toContain('Readyz acceptance: `repair_only_zero_notional`')
+  })
+
+  it('accepts core-dependencies-only readyz 503 when the deploy surface is healthy and the gate is closed', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '503',
+      readyz: coreDependenciesOnlyReadyz,
+      revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+      tradingStatus: baseTradingStatus,
+    })
+
+    expect(result.readyzAcceptedReason).toBe('core_dependencies_only_gate_closed')
+    expect(result.liveSubmitContract).toBe('bounded_live_submit_active')
+    expect(result.summaryLines.join('\n')).toContain('Readyz acceptance: `core_dependencies_only_gate_closed`')
+  })
+
+  it('rejects core-dependencies-only readyz 503 when a core runtime dependency is down', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '503',
+        readyz: {
+          ...coreDependenciesOnlyReadyz,
+          dependencies: {
+            ...coreDependenciesOnlyReadyz.dependencies,
+            database: { ok: false, detail: 'schema drift' },
+          },
+        },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+      }),
+    ).toThrow('readyz dependencies.database.ok must be true')
+  })
+
+  it('rejects core-dependencies-only readyz 503 if it carries live submission authority', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '503',
+        readyz: {
+          ...coreDependenciesOnlyReadyz,
+          live_submission_gate: {
+            ...coreDependenciesOnlyReadyz.live_submission_gate,
+            allowed: true,
+          },
+        },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+      }),
+    ).toThrow('live_submission_gate.allowed=false')
   })
 
   it('rejects repair-only 503 when runtime dependencies are down', () => {

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -48,7 +48,7 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).not.toContain('Torghut /readyz returned HTTP')
   })
 
-  it('retries database-timeout readyz 503 payloads until they match the repair-only contract', () => {
+  it('retries database-timeout readyz 503 payloads until they match an accepted readyz contract', () => {
     expect(workflow).toContain('fetch_readyz_json()')
     expect(workflow).toContain('packages/scripts/src/torghut/readyz-contract.ts')
     expect(workflow).toContain('retryable_database_timeout')

--- a/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
+++ b/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
@@ -14,6 +14,37 @@ const repairOnlyReadyz = {
   },
 }
 
+const coreDependenciesOnlyReadyz = {
+  status: 'degraded',
+  scheduler: { ok: true, running: true },
+  readiness_surface: 'core_dependencies_only',
+  dependencies: {
+    postgres: { ok: true, detail: 'ok' },
+    clickhouse: { ok: true, detail: 'ok' },
+    database: { ok: true, detail: 'ok' },
+    alpaca: { ok: false, detail: 'alpaca account probe timed out after 2.00s' },
+  },
+  live_submission_gate: {
+    allowed: false,
+    promotion_authority: false,
+    promotion_authority_ok: false,
+    final_authority_ok: false,
+    final_promotion_allowed: false,
+    final_promotion_authorized: false,
+    reason: 'readyz_core_dependencies_only',
+    reason_codes: ['readyz_core_dependencies_only'],
+    blocked_reasons: ['readyz_core_dependencies_only'],
+    read_model_evaluated: false,
+    readiness_surface: 'core_dependencies_only',
+    live_submit_activation: {
+      configured: true,
+      valid: true,
+      expired: false,
+      expires_at: '2030-06-17T20:05:00+00:00',
+    },
+  },
+}
+
 describe('classifyReadyzForPostDeployRetry', () => {
   it('accepts healthy 2xx readyz payloads immediately', () => {
     expect(
@@ -31,6 +62,30 @@ describe('classifyReadyzForPostDeployRetry', () => {
         readyz: repairOnlyReadyz,
       }),
     ).toBe('acceptable')
+  })
+
+  it('accepts core-dependencies-only 503 when runtime dependencies are healthy and the top-level gate is closed', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: coreDependenciesOnlyReadyz,
+      }),
+    ).toBe('acceptable')
+  })
+
+  it('rejects core-dependencies-only 503 when the readiness gate carries authority', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: {
+          ...coreDependenciesOnlyReadyz,
+          live_submission_gate: {
+            ...coreDependenciesOnlyReadyz.live_submission_gate,
+            final_promotion_allowed: true,
+          },
+        },
+      }),
+    ).toBe('unacceptable')
   })
 
   it('retries a degraded 503 when the database contract only shows a statement timeout', () => {

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -30,7 +30,7 @@ type PostDeployEvidenceInput = {
 type LiveSubmitContract = 'bounded_live_submit_active' | 'expired_activation_blocked'
 
 export type PostDeployEvidenceResult = {
-  readyzAcceptedReason: 'healthy_2xx' | 'repair_only_zero_notional'
+  readyzAcceptedReason: 'healthy_2xx' | 'repair_only_zero_notional' | 'core_dependencies_only_gate_closed'
   readyzStatusCode: number
   summaryLines: string[]
   liveSubmitContract?: LiveSubmitContract
@@ -204,6 +204,63 @@ const assertLiveSubmitActivationContract = (activation: JsonObject): LiveSubmitC
     throw new Error('torghut live_submit_activation.reason must be empty before expiry')
   }
   return 'bounded_live_submit_active'
+}
+
+const assertCoreDependenciesOnlyReadyz = (readyz: JsonObject) => {
+  if (readyz.status !== 'degraded') {
+    throw new Error('non-2xx core-dependencies-only /readyz is only accepted when payload.status is degraded')
+  }
+  requireScalarValue(readyz.readiness_surface, 'core_dependencies_only', 'readyz readiness_surface')
+
+  const dependencies = requireObject(readyz.dependencies, 'readyz dependencies')
+  requireDependencyOk(dependencies, 'postgres')
+  requireDependencyOk(dependencies, 'clickhouse')
+  requireDependencyOk(dependencies, 'database')
+
+  const scheduler = requireObject(readyz.scheduler, 'readyz scheduler')
+  if (scheduler.ok !== true || scheduler.running !== true) {
+    throw new Error('readyz scheduler must be ok and running for core-dependencies-only rollout acceptance')
+  }
+
+  const liveSubmissionGate = requireObject(readyz.live_submission_gate, 'readyz live_submission_gate')
+  if (requireBoolean(liveSubmissionGate.allowed, 'readyz live_submission_gate.allowed') !== false) {
+    throw new Error('core-dependencies-only rollout acceptance requires live_submission_gate.allowed=false')
+  }
+  requireScalarValue(liveSubmissionGate.reason, 'readyz_core_dependencies_only', 'readyz live_submission_gate.reason')
+  requireArrayIncludes(
+    liveSubmissionGate.reason_codes,
+    'readyz_core_dependencies_only',
+    'readyz live_submission_gate.reason_codes',
+  )
+  requireArrayIncludes(
+    liveSubmissionGate.blocked_reasons,
+    'readyz_core_dependencies_only',
+    'readyz live_submission_gate.blocked_reasons',
+  )
+  requireScalarValue(
+    liveSubmissionGate.readiness_surface,
+    'core_dependencies_only',
+    'readyz live_submission_gate.readiness_surface',
+  )
+  if (requireBoolean(liveSubmissionGate.read_model_evaluated, 'readyz live_submission_gate.read_model_evaluated')) {
+    throw new Error(
+      'core-dependencies-only rollout acceptance requires live_submission_gate.read_model_evaluated=false',
+    )
+  }
+  for (const authorityKey of [
+    'promotion_authority',
+    'promotion_authority_ok',
+    'final_authority_ok',
+    'final_promotion_allowed',
+    'final_promotion_authorized',
+  ]) {
+    if (requireBoolean(liveSubmissionGate[authorityKey], `readyz live_submission_gate.${authorityKey}`) !== false) {
+      throw new Error(`core-dependencies-only rollout acceptance requires live_submission_gate.${authorityKey}=false`)
+    }
+  }
+  assertLiveSubmitActivationContract(
+    requireObject(liveSubmissionGate.live_submit_activation, 'readyz live_submission_gate.live_submit_activation'),
+  )
 }
 
 const assertBoundedLiveSubmitContract = (status: JsonObject): LiveSubmitContract => {
@@ -586,10 +643,19 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
   let liveSubmitContract: LiveSubmitContract | undefined
   if (readyzStatusCode < 200 || readyzStatusCode >= 300) {
     if (readyzStatusCode !== 503) {
-      throw new Error(`Torghut /readyz returned HTTP ${readyzStatusCode}; expected 2xx or repair-only 503`)
+      throw new Error(
+        `Torghut /readyz returned HTTP ${readyzStatusCode}; expected 2xx, repair-only 503, or core-dependencies-only 503`,
+      )
     }
-    assertRepairOnlyZeroNotionalReadyz(readyz, digest)
-    readyzAcceptedReason = 'repair_only_zero_notional'
+    const dependencies = requireObject(readyz.dependencies, 'readyz dependencies')
+    if (dependencies.live_submission_gate !== undefined || dependencies.profitability_proof_floor !== undefined) {
+      assertRepairOnlyZeroNotionalReadyz(readyz, digest)
+      readyzAcceptedReason = 'repair_only_zero_notional'
+    } else {
+      assertCoreDependenciesOnlyReadyz(readyz)
+      liveSubmitContract = assertBoundedLiveSubmitContract(status)
+      readyzAcceptedReason = 'core_dependencies_only_gate_closed'
+    }
   } else {
     liveSubmitContract = assertBoundedLiveSubmitContract(status)
   }

--- a/packages/scripts/src/torghut/readyz-contract.ts
+++ b/packages/scripts/src/torghut/readyz-contract.ts
@@ -29,6 +29,19 @@ const stringAt = (value: unknown, key: string): string => {
   return ''
 }
 
+const booleanAt = (value: unknown, key: string): boolean | undefined => {
+  if (!isObject(value)) return undefined
+  const nested = value[key]
+  if (nested === true || nested === 'true') return true
+  if (nested === false || nested === 'false') return false
+  return undefined
+}
+
+const arrayIncludes = (value: unknown, expected: string): boolean => {
+  if (!Array.isArray(value)) return false
+  return value.some((item) => stringAt({ item }, 'item') === expected)
+}
+
 const parseHttpStatus = (value: string): number | undefined => {
   if (!/^[0-9]{3}$/.test(value)) return undefined
   return Number(value)
@@ -78,6 +91,46 @@ const hasRepairOnlyReadyzContract = (readyz: JsonObject): boolean => {
   return true
 }
 
+const hasCoreDependenciesOnlyReadyzContract = (readyz: JsonObject): boolean => {
+  if (readyz.status !== 'degraded') return false
+  if (stringAt(readyz, 'readiness_surface') !== 'core_dependencies_only') return false
+
+  const dependencies = objectAt(readyz, 'dependencies')
+  if (!dependencies) return false
+  if (!dependencyOk(dependencies, 'postgres')) return false
+  if (!dependencyOk(dependencies, 'clickhouse')) return false
+  if (!dependencyOk(dependencies, 'database')) return false
+
+  const scheduler = objectAt(readyz, 'scheduler')
+  if (!scheduler || scheduler.ok !== true || scheduler.running !== true) return false
+
+  const liveSubmissionGate = objectAt(readyz, 'live_submission_gate')
+  if (!liveSubmissionGate) return false
+  if (booleanAt(liveSubmissionGate, 'allowed') !== false) return false
+  if (stringAt(liveSubmissionGate, 'reason') !== 'readyz_core_dependencies_only') return false
+  if (!arrayIncludes(liveSubmissionGate.reason_codes, 'readyz_core_dependencies_only')) return false
+  if (!arrayIncludes(liveSubmissionGate.blocked_reasons, 'readyz_core_dependencies_only')) return false
+  if (stringAt(liveSubmissionGate, 'readiness_surface') !== 'core_dependencies_only') return false
+  if (booleanAt(liveSubmissionGate, 'read_model_evaluated') !== false) return false
+  for (const authorityKey of [
+    'promotion_authority',
+    'promotion_authority_ok',
+    'final_authority_ok',
+    'final_promotion_allowed',
+    'final_promotion_authorized',
+  ]) {
+    if (booleanAt(liveSubmissionGate, authorityKey) !== false) return false
+  }
+
+  const activation = objectAt(liveSubmissionGate, 'live_submit_activation')
+  if (!activation) return false
+  if (booleanAt(activation, 'configured') !== true) return false
+  if (booleanAt(activation, 'valid') !== true) return false
+  if (!stringAt(activation, 'expires_at')) return false
+
+  return true
+}
+
 export const classifyReadyzForPostDeployRetry = ({
   httpStatus,
   readyz,
@@ -87,6 +140,7 @@ export const classifyReadyzForPostDeployRetry = ({
   if (statusCode >= 200 && statusCode < 300) return 'acceptable'
   if (statusCode !== 503 || readyz.status !== 'degraded') return 'unacceptable'
   if (hasRepairOnlyReadyzContract(readyz)) return 'acceptable'
+  if (hasCoreDependenciesOnlyReadyzContract(readyz)) return 'acceptable'
 
   const database = objectAt(objectAt(readyz, 'dependencies'), 'database')
   if (database && database.ok !== true && containsDatabaseTimeoutSignal(database)) {


### PR DESCRIPTION
## Summary

- Replaces the Torghut release-manifest source-CI wait with a direct `torghut-build-push` image contract check for amd64, arm64, and OCI index publish jobs.
- Removes Bun setup/install/cache overhead from manifest-only release CI and reduces the promotion wait window from 45 minutes to 15 minutes.
- Accepts the current `/readyz` `core_dependencies_only` 503 contract when core runtime dependencies and scheduler are healthy, while rejecting readiness gates that carry live submission authority.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint` (passes; reports four pre-existing warnings in unrelated script files)
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/torghut-ci.yml .github/workflows/torghut-deploy-automerge.yml .github/workflows/torghut-post-deploy-verify.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
