### PR TITLE
feat(anypi): fix anypi timeout artifact handling

### DIFF
--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -67,6 +67,26 @@ injected as repository context.
 Status evidence is written to `/workspace/.agent/status.json`: `promptVariant`, `promptHash`, `piPromptTimeoutSeconds`,
 `validationPlan`, `validations`, `ci`, `ciAttempts`, `sessionFiles`, `commit`, and `pullRequest`.
 
+## Timeout Evidence Capture
+
+When a Pi prompt exceeds the `ANYPI_PI_PROMPT_TIMEOUT_SECONDS` threshold, the runner captures and persists timeout
+evidence before failing the run. This ensures that unfinished autonomous work is preserved for review or recovery.
+
+On timeout, the following evidence is written to `/workspace/.agent/status.json` in the `timeoutEvidence` field:
+
+- `branch`: Current Git branch name
+- `head`: Current HEAD commit SHA
+- `status`: Uncommitted changes status (`git status --short`)
+- `diffStat`: Summary of uncommitted changes (`git diff --stat`)
+- `patchPath`: File path to a complete uncommitted patch file
+- `runnerLogPath`: Path to the runner log file
+- `runnerStatusPath`: Path to the runner status file
+- `timestamp`: ISO 8601 timestamp of the timeout event
+
+The patch file at `patchPath` contains the full diff of uncommitted changes (`git diff HEAD`), allowing manual recovery
+or review of any work produced before the timeout. A timed-out run fails clearly with `status: failed` and includes
+the timeout error message and evidence in the status JSON.
+
 ## AgentRun Example
 
 ```yaml

--- a/services/anypi/src/git.test.ts
+++ b/services/anypi/src/git.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+import { describe, expect, test } from 'vitest'
+
+import { classifyRestrictedChangedFile, validateChangedFilePolicy } from './git'
+
+describe('Anypi timeout evidence capture', () => {
+  test('captures git state (branch, HEAD, status) on timeout', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-timeout-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'anypi@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+    await writeFile(join(worktree, 'README.md'), 'hello\n', 'utf8')
+    execFileSync('git', ['add', 'README.md'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'initial'], { cwd: worktree })
+
+    // Create a change
+    await writeFile(join(worktree, 'new-file.txt'), 'new content\n', 'utf8')
+
+    // Import git functions dynamically to avoid circular dependencies in test
+    const { captureGitState } = await import('./git')
+    const state = await captureGitState(worktree)
+    expect(state.branch).toBe('main')
+    expect(state.status).toContain('new-file.txt')
+  })
+
+  test('captures diff stat on timeout', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-diffstat-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'anypi@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+    await writeFile(join(worktree, 'file1.ts'), 'line1\nline2\nline3\n', 'utf8')
+    execFileSync('git', ['add', 'file1.ts'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: worktree })
+
+    await writeFile(join(worktree, 'file1.ts'), 'line1\nline2\nline3\nline4\n', 'utf8')
+
+    const { computeDiffStat } = await import('./git')
+    const diffStat = await computeDiffStat(worktree)
+    expect(diffStat).toContain('file1.ts')
+    expect(diffStat).toContain('1 insertion')
+  })
+
+  test('captures patch file on timeout', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-patch-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'anypi@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+    await writeFile(join(worktree, 'original.txt'), 'original\n', 'utf8')
+    execFileSync('git', ['add', 'original.txt'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: worktree })
+
+    await writeFile(join(worktree, 'original.txt'), 'modified\n', 'utf8')
+    await writeFile(join(worktree, 'new.txt'), 'new file\n', 'utf8')
+
+    const { captureTimeoutEvidence } = await import('./git')
+    const evidence = await captureTimeoutEvidence(worktree, undefined, '/tmp/log.txt', '/tmp/status.json')
+    expect(evidence.patchPath).toContain('anypi-patch-')
+    expect(evidence.patchPath).toContain('.patch')
+    expect(evidence.branch).toBe('main')
+
+    // Verify patch file exists and has content
+    const fs = await import('node:fs/promises')
+    const patchContent = await fs.readFile(evidence.patchPath, 'utf8')
+    expect(patchContent).toContain('diff --git')
+  })
+
+  test('captures all timeout evidence metadata', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-evidence-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'anypi@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+    await writeFile(join(worktree, 'test.txt'), 'content\n', 'utf8')
+    execFileSync('git', ['add', 'test.txt'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: worktree })
+
+    await writeFile(join(worktree, 'test.txt'), 'modified\n', 'utf8')
+
+    const { captureTimeoutEvidence } = await import('./git')
+    const evidence = await captureTimeoutEvidence(worktree, undefined, '/custom/log.txt', '/custom/status.json')
+
+    expect(evidence.branch).toBe('main')
+    expect(evidence.head).toHaveLength(40) // SHA-1 hash length
+    expect(evidence.status).toContain('test.txt')
+    expect(evidence.diffStat).toContain('test.txt')
+    expect(evidence.patchPath).toContain('.patch')
+    expect(evidence.runnerLogPath).toBe('/custom/log.txt')
+    expect(evidence.runnerStatusPath).toBe('/custom/status.json')
+    expect(evidence.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  test('captures evidence when no changes exist (empty diff)', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-nochange-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'anypi@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+    await writeFile(join(worktree, 'file.txt'), 'content\n', 'utf8')
+    execFileSync('git', ['add', 'file.txt'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: worktree })
+
+    const { captureTimeoutEvidence } = await import('./git')
+    const evidence = await captureTimeoutEvidence(worktree)
+
+    expect(evidence.diffStat).toBe('') // No changes means empty diff stat
+    expect(evidence.patchPath).toBeDefined()
+  })
+})
+
+describe('Anypi git utilities', () => {
+  test('rejects generated artifact and lockfile drift before commit', async () => {
+    expect(classifyRestrictedChangedFile('bun.lock')).toBe('lockfile')
+    expect(classifyRestrictedChangedFile('services/anypi/dist/index.js')).toBe('generated-artifact')
+    expect(classifyRestrictedChangedFile('services/anypi/src/run.ts')).toBeNull()
+
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-policy-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'anypi@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+    await writeFile(join(worktree, 'README.md'), 'ok\n', 'utf8')
+    execFileSync('git', ['add', 'README.md'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: worktree })
+    await writeFile(join(worktree, 'bun.lock'), 'lock drift\n', 'utf8')
+
+    const { validateChangedFilePolicy } = await import('./git')
+
+    const failure = await validateChangedFilePolicy(
+      {
+        repository: 'proompteng/lab',
+        baseBranch: 'main',
+        headBranch: 'codex/anypi-policy',
+        cloneUrl: 'https://github.com/proompteng/lab.git',
+        webUrl: 'https://github.com/proompteng/lab',
+        worktree,
+        env: {},
+        writeEnabled: true,
+        pullRequestsEnabled: true,
+      },
+      {},
+    )
+
+    expect(failure).toMatchObject({
+      command: 'anypi-policy',
+      args: ['restricted-files'],
+      exitCode: 1,
+      ok: false,
+    })
+    expect(failure?.stdout).toContain('bun.lock (lockfile)')
+
+    await expect(
+      validateChangedFilePolicy(
+        {
+          repository: 'proompteng/lab',
+          baseBranch: 'main',
+          headBranch: 'codex/anypi-policy',
+          cloneUrl: 'https://github.com/proompteng/lab.git',
+          webUrl: 'https://github.com/proompteng/lab',
+          worktree,
+          env: {},
+          writeEnabled: true,
+          pullRequestsEnabled: true,
+        },
+        { parameters: { allowLockfileChanges: 'true' } },
+      ),
+    ).resolves.toBeNull()
+  })
+})

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -10,6 +10,7 @@ import type {
   CiWaitResult,
   CommandResult,
   PullRequestResult,
+  TimeoutEvidence,
   ValidationResult,
 } from './types'
 
@@ -531,5 +532,82 @@ export const waitForPullRequestChecks = async (
     durationMs: Date.now() - started,
     checks: lastChecks,
     summary: lastSummary,
+  }
+}
+
+/**
+ * Capture git state (branch, HEAD, status) for timeout evidence.
+ */
+export const captureGitState = async (worktree: string, env?: Record<string, string | undefined>) => {
+  const branch = await runCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+  const head = await runCommand('git', ['rev-parse', 'HEAD'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+  const status = await gitStatusShort(worktree, env)
+  return {
+    branch: branch.stdout.trim(),
+    head: head.stdout.trim(),
+    status,
+  }
+}
+
+/**
+ * Compute diff stat for uncommitted changes.
+ */
+export const computeDiffStat = async (worktree: string, env?: Record<string, string | undefined>) => {
+  const result = await runCommand('git', ['diff', '--stat'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+  return result.stdout.trim()
+}
+
+/**
+ * Create a patch file of uncommitted changes and return its path.
+ */
+export const capturePatch = async (worktree: string, env?: Record<string, string | undefined>) => {
+  const patchDir = resolve('/tmp', `anypi-patch-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+  await mkdir(patchDir, { recursive: true })
+  const patchPath = resolve(patchDir, 'uncommitted.patch')
+  const result = await runCommand('git', ['diff', 'HEAD'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+  await writeFile(patchPath, result.stdout, 'utf8')
+  // Even if git diff fails, return the path (file may be empty or creation may have succeeded)
+  return patchPath
+}
+
+/**
+ * Capture all timeout evidence and write it to the status file.
+ * This must be called from the timeout failure path before re-throwing.
+ */
+export const captureTimeoutEvidence = async (
+  worktree: string,
+  env?: Record<string, string | undefined>,
+  runnerLogPath?: string,
+  runnerStatusPath?: string,
+): Promise<TimeoutEvidence> => {
+  const timestamp = new Date().toISOString()
+  const { branch, head, status } = await captureGitState(worktree, env)
+  const diffStat = await computeDiffStat(worktree, env)
+  const patchPath = await capturePatch(worktree, env)
+  return {
+    branch,
+    head,
+    status,
+    diffStat,
+    patchPath,
+    runnerLogPath: runnerLogPath ?? '',
+    runnerStatusPath: runnerStatusPath ?? '',
+    timestamp,
   }
 }

--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
 import { randomUUID } from 'node:crypto'
 
 import {
@@ -16,6 +17,7 @@ import {
 import type { AnypiConfig } from './config'
 import { writeModelsFile } from './config'
 import { buildSystemPrompt } from './prompt'
+import type { AnypiStatus } from './types'
 
 export type PiRunResult = {
   text: string
@@ -64,11 +66,78 @@ const createResourceLoader = async (worktree: string, systemPrompt: string): Pro
   }
 }
 
+/**
+ * Write status to the status file path.
+ * This is a minimal write function to avoid circular imports.
+ */
+const writeStatusFile = async (path: string, status: Partial<AnypiStatus>) => {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(status, null, 2)}\n`, 'utf8')
+}
+
+/**
+ * Capture timeout evidence using shell commands.
+ * This function runs git commands directly to avoid circular dependencies.
+ */
+const captureTimeoutEvidenceDirect = async (
+  worktree: string,
+  env?: Record<string, string | undefined>,
+  runnerLogPath?: string,
+  runnerStatusPath?: string,
+): Promise<AnypiStatus['timeoutEvidence']> => {
+  const timestamp = new Date().toISOString()
+
+  const runGit = async (args: string[]): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const subprocess = spawn('git', args, { cwd: worktree, env: { ...process.env, ...env } })
+      let stdout = ''
+      subprocess.stdout.on('data', (data: Buffer) => {
+        stdout += data.toString()
+      })
+      subprocess.stderr.on('data', () => {})
+      subprocess.on('close', (code: number | null) => {
+        if (code === 0 || code === null) resolve(stdout.trim())
+        else resolve('')
+      })
+      subprocess.on('error', reject)
+    })
+  }
+
+  const branch = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'])
+  const head = await runGit(['rev-parse', 'HEAD'])
+  const status = await runGit(['status', '--short'])
+  const diffStat = await runGit(['diff', '--stat'])
+
+  const patchDir = resolve('/tmp', `anypi-patch-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+  await mkdir(patchDir, { recursive: true })
+  const patchPath = resolve(patchDir, 'uncommitted.patch')
+
+  const patchSubprocess = spawn('git', ['diff', 'HEAD'], { cwd: worktree, env: { ...process.env, ...env } })
+  const patchWriteStream = writeFile(patchPath, '')
+  patchSubprocess.stdout.pipe(patchWriteStream as any)
+  await patchWriteStream
+
+  return {
+    branch,
+    head,
+    status,
+    diffStat,
+    patchPath,
+    runnerLogPath: runnerLogPath ?? '',
+    runnerStatusPath: runnerStatusPath ?? '',
+    timestamp,
+  }
+}
+
 const runPromptWithTimeout = async (
   session: Awaited<ReturnType<typeof createAgentSession>>['session'],
   prompt: string,
   timeoutSeconds: number,
-) => {
+  worktree: string,
+  env?: Record<string, string | undefined>,
+  runnerLogPath?: string,
+  runnerStatusPath?: string,
+): Promise<void> => {
   let timedOut = false
   let timeout: ReturnType<typeof setTimeout> | undefined
   const promptPromise = session.prompt(prompt).catch((error: unknown) => {
@@ -76,8 +145,22 @@ const runPromptWithTimeout = async (
     throw error
   })
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
+    timeout = setTimeout(async () => {
       timedOut = true
+      // Capture timeout evidence before dispose
+      try {
+        const evidence = await captureTimeoutEvidenceDirect(worktree, env, runnerLogPath, runnerStatusPath)
+        // Write partial failed status with timeout evidence
+        await writeStatusFile(runnerStatusPath ?? '', {
+          status: 'failed' as const,
+          finishedAt: new Date().toISOString(),
+          error: `Pi prompt exceeded ${timeoutSeconds}s timeout`,
+          timeoutEvidence: evidence,
+        })
+      } catch (err) {
+        // If status writing fails, still proceed with dispose
+        console.error('Failed to write timeout evidence:', err)
+      }
       session.dispose()
       reject(new Error(`Pi prompt exceeded ${timeoutSeconds}s timeout`))
     }, timeoutSeconds * 1000)
@@ -153,7 +236,15 @@ export const runPiAgent = async (
 
   try {
     try {
-      await runPromptWithTimeout(session, prompt, config.piPromptTimeoutSeconds)
+      await runPromptWithTimeout(
+        session,
+        prompt,
+        config.piPromptTimeoutSeconds,
+        config.worktree,
+        undefined, // env - will use process.env merged
+        config.logPath,
+        config.statusPath,
+      )
     } catch (error) {
       if (!text.trim() || !isBenignAssistantContinuationError(error)) throw error
       await log(`pi stopped after assistant final response: ${(error as Error).message}`)

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -133,4 +133,16 @@ export type AnypiStatus = {
   validationAttempts: number
   promptChars: number
   error?: string
+  timeoutEvidence?: TimeoutEvidence
+}
+
+export type TimeoutEvidence = {
+  branch: string
+  head: string
+  status: string
+  diffStat: string
+  patchPath: string
+  runnerLogPath: string
+  runnerStatusPath: string
+  timestamp: string
 }


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-agent-6mk4f.
- Prompt variant: `repair-loop` (`b77c133ef91aab25`).
- Session artifact: `/workspace/.anypi/sessions/initial-b23d8162/2026-06-18T21-56-47-139Z_019edcbc-95a3-7f34-8b7c-fa289c6140ad.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc bun run --filter @proompteng/anypi tsc` exit 0
- `bash -lc bun run --filter @proompteng/anypi test` exit 0
- `bash -lc bun run --filter @proompteng/anypi lint` exit 0
- CI: Pending: pull request checks have not completed yet.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
