### PR TITLE
feat(anypi): fix anypi timeout handling through the real prompt path

### DIFF
--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -16,16 +16,12 @@ import {
 import type { AnypiConfig } from './config'
 import { writeModelsFile } from './config'
 import { buildSystemPrompt } from './prompt'
+import { captureTimeoutEvidence, TimeoutErrorWithEvidence, TIMEOUT_ERROR_PREFIX } from './timeout-evidence'
 
 export type PiRunResult = {
   text: string
   tools: string[]
   sessionFile?: string
-}
-
-export type PiRunOptions = {
-  sessionLabel?: string
-  systemPrompt?: string
 }
 
 export const isBenignAssistantContinuationError = (error: unknown) =>
@@ -68,18 +64,30 @@ const runPromptWithTimeout = async (
   session: Awaited<ReturnType<typeof createAgentSession>>['session'],
   prompt: string,
   timeoutSeconds: number,
-) => {
+  config: AnypiConfig,
+): Promise<void> => {
   let timedOut = false
   let timeout: ReturnType<typeof setTimeout> | undefined
   const promptPromise = session.prompt(prompt).catch((error: unknown) => {
     if (timedOut) return
     throw error
   })
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
+  const timeoutPromise = new Promise<never>(async (_, reject) => {
+    timeout = setTimeout(async () => {
       timedOut = true
+      let evidence: TimeoutErrorWithEvidence['evidence'] | null = null
+      try {
+        // Capture timeout evidence before disposing the session
+        evidence = await captureTimeoutEvidence(config.worktree, process.env)
+      } catch {
+        // Evidence capture failed, but we still need to fail clearly
+      }
       session.dispose()
-      reject(new Error(`Pi prompt exceeded ${timeoutSeconds}s timeout`))
+      if (evidence) {
+        reject(new TimeoutErrorWithEvidence(`Pi prompt exceeded ${timeoutSeconds}s timeout`, evidence))
+      } else {
+        reject(new Error(`Pi prompt exceeded ${timeoutSeconds}s timeout`))
+      }
     }, timeoutSeconds * 1000)
   })
 
@@ -94,14 +102,17 @@ export const runPiAgent = async (
   config: AnypiConfig,
   prompt: string,
   log: (message: string) => Promise<void>,
-  options: PiRunOptions = {},
+  options?: {
+    sessionLabel?: string
+    systemPrompt?: string
+  },
 ): Promise<PiRunResult> => {
   await mkdir(config.agentDir, { recursive: true })
   await mkdir(config.sessionDir, { recursive: true })
   await mkdir(dirname(config.authPath), { recursive: true })
   if (!existsSync(config.authPath)) await writeFile(config.authPath, '{}\n', 'utf8')
   await writeModelsFile(config)
-  const attemptSessionDir = resolveAttemptSessionDir(config.sessionDir, options.sessionLabel)
+  const attemptSessionDir = resolveAttemptSessionDir(config.sessionDir, options?.sessionLabel)
   await mkdir(attemptSessionDir, { recursive: true })
 
   const authStorage = AuthStorage.create(config.authPath)
@@ -109,7 +120,7 @@ export const runPiAgent = async (
   const model = modelRegistry.find(config.provider, config.model)
   if (!model) throw new Error(`Pi model not found: ${config.provider}/${config.model}`)
 
-  const systemPrompt = resolveEffectiveSystemPrompt(config, options.systemPrompt)
+  const systemPrompt = resolveEffectiveSystemPrompt(config, options?.systemPrompt)
   const resourceLoader = await createResourceLoader(config.worktree, systemPrompt)
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: true },
@@ -153,7 +164,7 @@ export const runPiAgent = async (
 
   try {
     try {
-      await runPromptWithTimeout(session, prompt, config.piPromptTimeoutSeconds)
+      await runPromptWithTimeout(session, prompt, config.piPromptTimeoutSeconds, config)
     } catch (error) {
       if (!text.trim() || !isBenignAssistantContinuationError(error)) throw error
       await log(`pi stopped after assistant final response: ${(error as Error).message}`)

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { applyRunnerArtifacts, loadRunnerSpec, loadRunSpec, resolveConfig, type AnypiConfig } from './config'
 import { createLogger } from './logger'
 import { runPiAgent } from './pi-session'
+import { TimeoutErrorWithEvidence } from './timeout-evidence'
 import {
   buildAgentPrompt,
   buildCiRepairPrompt,
@@ -453,6 +454,33 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
     status.status = 'failed'
     status.finishedAt = timestampUtc()
     status.error = toErrorMessage(error)
+
+    // Check if this is a timeout error with evidence and merge it into status
+    if (error instanceof TimeoutErrorWithEvidence) {
+      const evidence = error.evidence
+      status.gitBranch = evidence.git.branch
+      status.gitHead = evidence.git.head
+      status.gitStatusShort = evidence.git.statusShort
+      status.gitDiffStat = evidence.git.diffStat
+      status.timeoutPatchFile = evidence.patchFile
+    } else if (error instanceof Error && (error as any).evidence?.git) {
+      // Fallback for errors with evidence property
+      const evidence = (error as any).evidence as {
+        git: {
+          branch: string
+          head: string
+          statusShort: string
+          diffStat?: string
+        }
+        patchFile?: string
+      }
+      status.gitBranch = evidence.git.branch
+      status.gitHead = evidence.git.head
+      status.gitStatusShort = evidence.git.statusShort
+      status.gitDiffStat = evidence.git.diffStat
+      status.timeoutPatchFile = evidence.patchFile
+    }
+
     await writeStatus(config.statusPath, status)
     await logger.error(status.error)
     throw error

--- a/services/anypi/src/timeout-evidence.test.ts
+++ b/services/anypi/src/timeout-evidence.test.ts
@@ -1,0 +1,149 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { execFileSync } from 'node:child_process'
+import { describe, expect, test } from 'vitest'
+
+import { captureTimeoutEvidence, mergeTimeoutEvidence, TimeoutErrorWithEvidence } from './timeout-evidence'
+
+describe('Anypi timeout evidence', () => {
+  test('captures git branch, HEAD, status, and diff files on timeout', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-timeout-'))
+
+    // Initialize a git repo
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'test@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+
+    // Create an initial commit
+    await writeFile(join(worktree, 'README.md'), '# Test\n', 'utf8')
+    execFileSync('git', ['add', 'README.md'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: worktree })
+
+    // Make some changes (uncommitted)
+    await writeFile(join(worktree, 'README.md'), '# Test Updated\n', 'utf8')
+    await writeFile(join(worktree, 'newfile.ts'), 'console.log("hello");\n', 'utf8')
+
+    const evidence = await captureTimeoutEvidence(worktree, process.env)
+
+    expect(evidence).toMatchObject({
+      git: {
+        branch: 'main',
+        statusShort: expect.stringContaining('M'),
+      },
+    })
+    expect(evidence.git.head).toMatch(/^[a-f0-9]{40}$/)
+    expect(evidence.patchFile).toBeDefined()
+    expect(evidence.patchFile).toMatch(/\.agent\/timeout-patch-\d+\.patch$/)
+
+    // Verify the patch file exists and contains diff
+    const patchContent = await import('node:fs/promises').then(({ readFile }) => readFile(evidence.patchFile!, 'utf8'))
+    expect(patchContent).toContain('diff --git')
+    expect(patchContent).toContain('README.md')
+    expect(patchContent).toContain('+# Test Updated')
+
+    await rm(worktree, { recursive: true, force: true })
+  })
+
+  test('captures empty patch when no changes', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'anypi-timeout-clean-'))
+
+    execFileSync('git', ['init', '-b', 'main'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.email', 'test@example.invalid'], { cwd: worktree })
+    execFileSync('git', ['config', 'user.name', 'Anypi Test'], { cwd: worktree })
+
+    await writeFile(join(worktree, 'README.md'), '# Clean\n', 'utf8')
+    execFileSync('git', ['add', 'README.md'], { cwd: worktree })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: worktree })
+
+    const evidence = await captureTimeoutEvidence(worktree, process.env)
+
+    expect(evidence.git.branch).toBe('main')
+    expect(evidence.git.statusShort).toBe('')
+    expect(evidence.patchFile).toBeDefined()
+
+    // Empty diff should produce an empty patch file
+    const patchContent = await import('node:fs/promises').then(({ readFile }) => readFile(evidence.patchFile!, 'utf8'))
+    // The patch file exists but may be empty or just have headers
+    expect(patchContent).toBeDefined()
+
+    await rm(worktree, { recursive: true, force: true })
+  })
+
+  test('mergeTimeoutEvidence preserves existing status fields', () => {
+    const existingStatus = {
+      provider: 'anypi',
+      status: 'running',
+      startedAt: '2026-06-18T00:00:00.000Z',
+      runName: 'test-run',
+      namespace: 'agents',
+      repository: 'proompteng/lab',
+      baseBranch: 'main',
+      headBranch: 'codex/test',
+      worktree: '/workspace/lab',
+      model: 'qwen3-coder-flamingo',
+      providerModel: 'flamingo/qwen3-coder-flamingo',
+      piPromptTimeoutSeconds: 1800,
+      promptVariant: 'minimal',
+      promptHash: 'abc123def456',
+      tools: ['bash', 'edit', 'read'],
+      sessionFile: '/path/to/session.json',
+      sessionFiles: ['/path/to/session.json'],
+      commit: 'abc123',
+      validations: [{ command: 'bash', args: [], exitCode: 0, stdout: '', stderr: '', durationMs: 100, ok: true }],
+      validationPlan: { policy: 'append', sources: [], commands: [] },
+      agentAttempts: 1,
+      validationAttempts: 1,
+      ciAttempts: 0,
+      promptChars: 1000,
+    }
+
+    const evidence = {
+      git: {
+        branch: 'codex/test',
+        head: 'def456abc123',
+        statusShort: ' M services/anypi/src/run.ts',
+        diffStat: '1 file changed, 1 insertion(+)',
+      },
+      patchFile: '/workspace/lab/.agent/timeout-patch-123.patch',
+    }
+
+    const merged = mergeTimeoutEvidence(existingStatus as any, evidence)
+
+    // Verify existing fields are preserved
+    expect(merged.provider).toBe('anypi')
+    expect(merged.runName).toBe('test-run')
+    expect(merged.tools).toEqual(['bash', 'edit', 'read'])
+    expect(merged.sessionFile).toBe('/path/to/session.json')
+    expect(merged.validations.length).toBe(1)
+    expect(merged.promptChars).toBe(1000)
+
+    // Verify timeout evidence fields are added
+    expect(merged.gitBranch).toBe('codex/test')
+    expect(merged.gitHead).toBe('def456abc123')
+    expect(merged.gitStatusShort).toBe(' M services/anypi/src/run.ts')
+    expect(merged.gitDiffStat).toBe('1 file changed, 1 insertion(+)')
+    expect(merged.timeoutPatchFile).toBe('/workspace/lab/.agent/timeout-patch-123.patch')
+
+    // Verify the original is not mutated
+    expect(existingStatus.provider).toBe('anypi')
+  })
+
+  test('TimeoutErrorWithEvidence error class captures evidence', () => {
+    const evidence = {
+      git: {
+        branch: 'test-branch',
+        head: 'abc123',
+        statusShort: 'M test.txt',
+        diffStat: '1 file changed',
+      },
+      patchFile: '/tmp/test.patch',
+    }
+    const error = new TimeoutErrorWithEvidence('test timeout', evidence)
+    expect(error.message).toBe('test timeout')
+    expect(error.name).toBe('TimeoutErrorWithEvidence')
+    expect(error.evidence).toBe(evidence)
+    expect(error.evidence.git.branch).toBe('test-branch')
+  })
+})

--- a/services/anypi/src/timeout-evidence.ts
+++ b/services/anypi/src/timeout-evidence.ts
@@ -1,0 +1,113 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import { runCommand } from './command'
+import type { AnypiStatus } from './types'
+
+export type TimeoutEvidence = {
+  git: {
+    branch: string
+    head: string
+    statusShort: string
+    diffStat?: string
+  }
+  patchFile?: string
+}
+
+export const TIMEOUT_ERROR_PREFIX = 'Pi prompt exceeded'
+
+export class TimeoutErrorWithEvidence extends Error {
+  constructor(
+    message: string,
+    public evidence: TimeoutEvidence,
+  ) {
+    super(message)
+    this.name = 'TimeoutErrorWithEvidence'
+  }
+}
+
+const captureGitState = async (
+  worktree: string,
+  env?: Record<string, string | undefined>,
+): Promise<TimeoutEvidence['git']> => {
+  const branchResult = await runCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+  const branch = branchResult.stdout.trim() || 'unknown'
+
+  const headResult = await runCommand('git', ['rev-parse', 'HEAD'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+  const head = headResult.stdout.trim() || 'unknown'
+
+  const statusResult = await runCommand('git', ['status', '--short'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+  const statusShort = statusResult.stdout.trim()
+
+  const diffStatResult = await runCommand('git', ['diff', '--stat', 'HEAD'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+
+  return {
+    branch,
+    head,
+    statusShort,
+    diffStat: diffStatResult.exitCode === 0 ? diffStatResult.stdout.trim() : undefined,
+  }
+}
+
+export const captureTimeoutEvidence = async (
+  worktree: string,
+  env?: Record<string, string | undefined>,
+): Promise<TimeoutEvidence> => {
+  const git = await captureGitState(worktree, env)
+
+  // Create a patch file with the full diff
+  const patchFileName = `timeout-patch-${Date.now()}.patch`
+  const patchFilePath = join(worktree, '.agent', patchFileName)
+
+  try {
+    await mkdir(dirname(patchFilePath), { recursive: true })
+  } catch {
+    // Directory may already exist, ignore
+  }
+
+  const diffResult = await runCommand('git', ['diff', 'HEAD'], {
+    cwd: worktree,
+    env,
+    allowFailure: true,
+  })
+
+  if (diffResult.exitCode === 0 && diffResult.stdout) {
+    await writeFile(patchFilePath, diffResult.stdout, 'utf8')
+  } else {
+    // Write an empty patch file even if diff failed
+    await writeFile(patchFilePath, '', 'utf8')
+  }
+
+  return {
+    git,
+    patchFile: patchFilePath,
+  }
+}
+
+export const mergeTimeoutEvidence = (status: AnypiStatus, evidence: TimeoutEvidence): AnypiStatus => {
+  // Preserve all existing fields and add timeout evidence
+  return {
+    ...status,
+    gitBranch: evidence.git.branch,
+    gitHead: evidence.git.head,
+    gitStatusShort: evidence.git.statusShort,
+    gitDiffStat: evidence.git.diffStat,
+    timeoutPatchFile: evidence.patchFile,
+  }
+}

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -133,4 +133,10 @@ export type AnypiStatus = {
   validationAttempts: number
   promptChars: number
   error?: string
+  // Timeout evidence fields (populated when prompt times out)
+  gitBranch?: string
+  gitHead?: string
+  gitStatusShort?: string
+  gitDiffStat?: string
+  timeoutPatchFile?: string
 }


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-agent-wpjs4.
- Prompt variant: `repair-loop` (`b77c133ef91aab25`).
- Session artifact: `/workspace/.anypi/sessions/initial-7f7a1301/2026-06-18T22-14-02-696Z_019edccc-62c8-777c-b5a9-b912e18551c8.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc bun run --filter @proompteng/anypi tsc` exit 0
- `bash -lc bun run --filter @proompteng/anypi test` exit 0
- `bash -lc bun run --filter @proompteng/anypi lint` exit 0
- CI: passed: 13 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
