### PR TITLE
ci(torghut): accelerate release promotion gates

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -168,31 +168,50 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
-
-          source_sha="$(
-            awk '
-              /^[[:space:]]*- name:[[:space:]]*TORGHUT_COMMIT[[:space:]]*$/ { found = 1; next }
-              found && /^[[:space:]]*value:/ {
-                sub(/^[[:space:]]*value:[[:space:]]*/, "")
-                gsub(/"/, "")
-                print
-                exit
-              }
-            ' argocd/applications/torghut/knative-service.yaml
-          )"
-          if ! printf '%s' "${source_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "Unable to resolve TORGHUT_COMMIT from release manifest"
-            exit 1
-          fi
-          echo "Torghut release manifest-only change; requiring successful multi-arch build for ${source_sha}."
 
           required_build_jobs=(
             'build-platform (linux/amd64, amd64, arc-amd64)'
             'build-platform (linux/arm64, arm64, arc-arm64)'
             'publish-index'
           )
+
+          changed_files="$(mktemp)"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            if [ -z "${BASE_REF}" ]; then
+              echo "BASE_REF is required for pull_request release manifest verification" >&2
+              exit 1
+            fi
+            diff_base="$(git merge-base "origin/${BASE_REF}" HEAD)"
+          elif [ -n "${BEFORE_SHA}" ] && ! [[ "${BEFORE_SHA}" =~ ^0+$ ]] && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            diff_base="${BEFORE_SHA}"
+          else
+            diff_base="$(git rev-parse HEAD^)"
+          fi
+          git diff --name-only "${diff_base}...HEAD" > "${changed_files}"
+
+          matches_changed() {
+            local regex="$1"
+            grep -Eq "${regex}" "${changed_files}"
+          }
+
+          resolve_source_sha() {
+            local manifest_path="$1"
+            local env_name="$2"
+            awk -v env_name="${env_name}" '
+              $0 ~ "^[[:space:]]*- name:[[:space:]]*" env_name "[[:space:]]*$" { found = 1; next }
+              found && /^[[:space:]]*value:/ {
+                sub(/^[[:space:]]*value:[[:space:]]*/, "")
+                gsub(/"/, "")
+                print
+                exit
+              }
+            ' "${manifest_path}"
+          }
 
           assert_required_build_jobs() {
             local run_id="$1"
@@ -235,45 +254,89 @@ jobs:
             done
           }
 
-          deadline=$((SECONDS + 900))
-          while true; do
-            run_line="$(
-              gh run list \
-                -R "${GH_REPO}" \
-                --workflow torghut-build-push.yaml \
-                --commit "${source_sha}" \
-                --json databaseId,status,conclusion,url,createdAt \
-                --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
-            )"
-            IFS=$'\t' read -r run_id run_status run_conclusion run_url <<< "${run_line}"
-
-            if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
-              assert_required_build_jobs "${run_id}"
-              echo "Torghut build-push passed required image contract jobs for ${source_sha}: ${run_url}"
-              break
-            fi
-
-            if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
-              echo "Torghut build-push did not pass for ${source_sha}: ${run_conclusion}"
-              echo "${run_url}"
+          verify_build_contract() {
+            local label="$1"
+            local manifest_path="$2"
+            local env_name="$3"
+            local workflow_name="$4"
+            local source_sha
+            source_sha="$(resolve_source_sha "${manifest_path}" "${env_name}")"
+            if ! printf '%s' "${source_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "Unable to resolve ${env_name} from ${manifest_path}"
               exit 1
             fi
+            echo "${label} release manifest-only change; requiring successful multi-arch build for ${source_sha}."
 
-            if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "Timed out waiting for Torghut build-push for ${source_sha}"
-              if [ -n "${run_url}" ]; then
-                echo "${run_url}"
+            deadline=$((SECONDS + 900))
+            while true; do
+              run_line="$(
+                gh run list \
+                  -R "${GH_REPO}" \
+                  --workflow "${workflow_name}" \
+                  --commit "${source_sha}" \
+                  --json databaseId,status,conclusion,url,createdAt \
+                  --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
+              )"
+              IFS=$'\t' read -r run_id run_status run_conclusion run_url <<< "${run_line}"
+
+              if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
+                assert_required_build_jobs "${run_id}"
+                echo "${label} build-push passed required image contract jobs for ${source_sha}: ${run_url}"
+                break
               fi
-              exit 1
-            fi
 
-            if [ -z "${run_id}" ]; then
-              echo "Waiting for Torghut build-push to appear for ${source_sha}"
-            else
-              echo "Waiting for Torghut build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
-            fi
-            sleep 10
-          done
+              if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
+                echo "${label} build-push did not pass for ${source_sha}: ${run_conclusion}"
+                echo "${run_url}"
+                exit 1
+              fi
+
+              if [ "${SECONDS}" -ge "${deadline}" ]; then
+                echo "Timed out waiting for ${label} build-push for ${source_sha}"
+                if [ -n "${run_url}" ]; then
+                  echo "${run_url}"
+                fi
+                exit 1
+              fi
+
+              if [ -z "${run_id}" ]; then
+                echo "Waiting for ${label} build-push to appear for ${source_sha}"
+              else
+                echo "Waiting for ${label} build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
+              fi
+              sleep 10
+            done
+          }
+
+          verified_any=false
+          if matches_changed '^argocd/applications/(torghut/(knative-service(-sim)?|db-migrations-job|historical-simulation-workflowtemplate|empirical-promotion-workflowtemplate|empirical-promotion-renewal-cronjob|whitepaper-autoresearch-workflowtemplate|analysis-template-(runtime-ready|activity|teardown-clean|artifact-bundle)|empirical-jobs-backfill-job|execution-tca-refresh-cronjob|order-feed-source-window-repair-cronjob|zero-notional-drift-repair-cronjob|paper-account-flatten-cronjob|whitepaper-semantic-backfill-job|tigerbeetle-smoke-job)\.yaml|torghut-options/(catalog|enricher)/deployment\.yaml|torghut-hyperliquid-runtime/(deployment|db-migrations-job)\.yaml)$'; then
+            verify_build_contract \
+              "Torghut" \
+              argocd/applications/torghut/knative-service.yaml \
+              TORGHUT_COMMIT \
+              torghut-build-push.yaml
+            verified_any=true
+          fi
+          if matches_changed '^argocd/applications/(torghut/(ta|ta-sim)/flinkdeployment\.yaml|torghut-options/ta/flinkdeployment\.yaml)$'; then
+            verify_build_contract \
+              "Torghut TA" \
+              argocd/applications/torghut/ta/flinkdeployment.yaml \
+              TORGHUT_TA_COMMIT \
+              torghut-ta-build-push.yaml
+            verified_any=true
+          fi
+          if matches_changed '^argocd/applications/(torghut/ws/deployment\.yaml|torghut-options/ws/deployment\.yaml)$'; then
+            verify_build_contract \
+              "Torghut WS" \
+              argocd/applications/torghut/ws/deployment.yaml \
+              TORGHUT_WS_COMMIT \
+              torghut-ws-build-push.yaml
+            verified_any=true
+          fi
+
+          if [ "${verified_any}" != 'true' ]; then
+            echo "No Torghut image promotion manifests changed; release manifest check passed."
+          fi
 
   pyright:
     name: Pyright

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -28,10 +28,15 @@ on:
       - 'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
       - 'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
       - 'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+      - 'argocd/applications/torghut/ta/flinkdeployment.yaml'
+      - 'argocd/applications/torghut/ta-sim/flinkdeployment.yaml'
+      - 'argocd/applications/torghut/ws/deployment.yaml'
       - 'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml'
       - 'argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml'
       - 'argocd/applications/torghut-options/catalog/deployment.yaml'
       - 'argocd/applications/torghut-options/enricher/deployment.yaml'
+      - 'argocd/applications/torghut-options/ta/flinkdeployment.yaml'
+      - 'argocd/applications/torghut-options/ws/deployment.yaml'
       - '.github/workflows/torghut-deploy-automerge.yml'
 
 permissions:
@@ -46,7 +51,11 @@ jobs:
   enable:
     if: >-
       ${{
-        startsWith(github.event.pull_request.head.ref, 'codex/torghut-release-') &&
+        (
+          startsWith(github.event.pull_request.head.ref, 'codex/torghut-release-') ||
+          startsWith(github.event.pull_request.head.ref, 'codex/torghut-ta-release-') ||
+          startsWith(github.event.pull_request.head.ref, 'codex/torghut-ws-release-')
+        ) &&
         github.event.pull_request.base.ref == 'main' &&
         github.event.pull_request.draft == false
       }}
@@ -88,10 +97,15 @@ jobs:
             'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+            'argocd/applications/torghut/ta/flinkdeployment.yaml'
+            'argocd/applications/torghut/ta-sim/flinkdeployment.yaml'
+            'argocd/applications/torghut/ws/deployment.yaml'
             'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml'
             'argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml'
             'argocd/applications/torghut-options/catalog/deployment.yaml'
             'argocd/applications/torghut-options/enricher/deployment.yaml'
+            'argocd/applications/torghut-options/ta/flinkdeployment.yaml'
+            'argocd/applications/torghut-options/ws/deployment.yaml'
           )
 
           contains() {
@@ -165,19 +179,45 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
+          case "${PR_HEAD_REF}" in
+            codex/torghut-release-*)
+              source_manifest='argocd/applications/torghut/knative-service.yaml'
+              source_env_name='TORGHUT_COMMIT'
+              build_workflow='torghut-build-push.yaml'
+              build_label='Torghut'
+              ;;
+            codex/torghut-ta-release-*)
+              source_manifest='argocd/applications/torghut/ta/flinkdeployment.yaml'
+              source_env_name='TORGHUT_TA_COMMIT'
+              build_workflow='torghut-ta-build-push.yaml'
+              build_label='Torghut TA'
+              ;;
+            codex/torghut-ws-release-*)
+              source_manifest='argocd/applications/torghut/ws/deployment.yaml'
+              source_env_name='TORGHUT_WS_COMMIT'
+              build_workflow='torghut-ws-build-push.yaml'
+              build_label='Torghut WS'
+              ;;
+            *)
+              echo "Unsupported Torghut release branch: ${PR_HEAD_REF}"
+              exit 1
+              ;;
+          esac
+
           manifest="$(
             gh api \
               -H 'Accept: application/vnd.github.raw' \
-              "repos/${GH_REPO}/contents/argocd/applications/torghut/knative-service.yaml?ref=${PR_HEAD_SHA}"
+              "repos/${GH_REPO}/contents/${source_manifest}?ref=${PR_HEAD_SHA}"
           )"
           source_sha="$(
             printf '%s\n' "${manifest}" |
-              awk '
-                /^[[:space:]]*- name:[[:space:]]*TORGHUT_COMMIT[[:space:]]*$/ { found = 1; next }
+              awk -v env_name="${source_env_name}" '
+                $0 ~ "^[[:space:]]*- name:[[:space:]]*" env_name "[[:space:]]*$" { found = 1; next }
                 found && /^[[:space:]]*value:/ {
                   sub(/^[[:space:]]*value:[[:space:]]*/, "")
                   gsub(/"/, "")
@@ -187,7 +227,7 @@ jobs:
               '
           )"
           if ! printf '%s' "${source_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "Unable to resolve TORGHUT_COMMIT from release manifest"
+            echo "Unable to resolve ${source_env_name} from ${source_manifest}"
             exit 1
           fi
 
@@ -243,7 +283,7 @@ jobs:
             run_line="$(
               gh run list \
                 -R "${GH_REPO}" \
-                --workflow torghut-build-push.yaml \
+                --workflow "${build_workflow}" \
                 --commit "${source_sha}" \
                 --json databaseId,status,conclusion,url,createdAt \
                 --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
@@ -252,18 +292,18 @@ jobs:
 
             if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
               assert_required_build_jobs "${run_id}"
-              echo "Torghut build-push passed required image contract jobs for ${source_sha}: ${run_url}"
+              echo "${build_label} build-push passed required image contract jobs for ${source_sha}: ${run_url}"
               break
             fi
 
             if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
-              echo "Torghut build-push did not pass for ${source_sha}: ${run_conclusion}"
+              echo "${build_label} build-push did not pass for ${source_sha}: ${run_conclusion}"
               echo "${run_url}"
               exit 1
             fi
 
             if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "Timed out waiting for Torghut build-push for ${source_sha}"
+              echo "Timed out waiting for ${build_label} build-push for ${source_sha}"
               if [ -n "${run_url}" ]; then
                 echo "${run_url}"
               fi
@@ -271,9 +311,9 @@ jobs:
             fi
 
             if [ -z "${run_id}" ]; then
-              echo "Waiting for Torghut build-push to appear for ${source_sha}"
+              echo "Waiting for ${build_label} build-push to appear for ${source_sha}"
             else
-              echo "Waiting for Torghut build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
+              echo "Waiting for ${build_label} build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
             fi
             sleep 10
           done

--- a/.github/workflows/torghut-ta-release.yml
+++ b/.github/workflows/torghut-ta-release.yml
@@ -102,8 +102,35 @@ jobs:
             fi
 
             if [ "${SOURCE_SHA}" != "${MAIN_HEAD}" ]; then
-              echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main is ${MAIN_HEAD}"
-              PROMOTE='false'
+              if ! git merge-base --is-ancestor "${SOURCE_SHA}" "${MAIN_HEAD}"; then
+                echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main ${MAIN_HEAD} is not a descendant."
+                PROMOTE='false'
+              else
+                TA_CHANGES="$(
+                  git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" -- \
+                    services/dorvud/gradle \
+                    services/dorvud/gradlew \
+                    services/dorvud/gradle.properties \
+                    services/dorvud/settings.gradle.kts \
+                    services/dorvud/build.gradle.kts \
+                    services/dorvud/platform \
+                    services/dorvud/flink-integration \
+                    services/dorvud/technical-analysis \
+                    services/dorvud/technical-analysis-flink \
+                    packages/scripts/src/torghut/release-contract.ts \
+                    packages/scripts/src/torghut/update-ta-manifest.ts \
+                    packages/scripts/src/shared/docker.ts \
+                    .github/workflows/torghut-ta-build-push.yaml \
+                    .github/workflows/torghut-ta-release.yml
+                )"
+                if [ -n "${TA_CHANGES}" ]; then
+                  echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; newer Torghut TA build inputs changed:"
+                  printf '%s\n' "${TA_CHANGES}"
+                  PROMOTE='false'
+                else
+                  echo "Promoting ${SOURCE_SHA}; newer main ${MAIN_HEAD} contains only unrelated changes."
+                fi
+              fi
             fi
           else
             if [ -n "${COMMIT_SHA_INPUT}" ]; then

--- a/.github/workflows/torghut-ws-release.yml
+++ b/.github/workflows/torghut-ws-release.yml
@@ -102,8 +102,33 @@ jobs:
             fi
 
             if [ "${SOURCE_SHA}" != "${MAIN_HEAD}" ]; then
-              echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main is ${MAIN_HEAD}"
-              PROMOTE='false'
+              if ! git merge-base --is-ancestor "${SOURCE_SHA}" "${MAIN_HEAD}"; then
+                echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main ${MAIN_HEAD} is not a descendant."
+                PROMOTE='false'
+              else
+                WS_CHANGES="$(
+                  git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" -- \
+                    services/dorvud/gradle \
+                    services/dorvud/gradlew \
+                    services/dorvud/gradle.properties \
+                    services/dorvud/settings.gradle.kts \
+                    services/dorvud/build.gradle.kts \
+                    services/dorvud/platform \
+                    services/dorvud/websockets \
+                    packages/scripts/src/torghut/release-contract.ts \
+                    packages/scripts/src/torghut/update-ws-manifest.ts \
+                    packages/scripts/src/shared/docker.ts \
+                    .github/workflows/torghut-ws-build-push.yaml \
+                    .github/workflows/torghut-ws-release.yml
+                )"
+                if [ -n "${WS_CHANGES}" ]; then
+                  echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; newer Torghut WS build inputs changed:"
+                  printf '%s\n' "${WS_CHANGES}"
+                  PROMOTE='false'
+                else
+                  echo "Promoting ${SOURCE_SHA}; newer main ${MAIN_HEAD} contains only unrelated changes."
+                fi
+              fi
             fi
           else
             if [ -n "${COMMIT_SHA_INPUT}" ]; then

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -18,6 +18,14 @@ const hyperliquidFeedWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-hyperliquid-feed-build-push.yaml', import.meta.url),
   'utf8',
 )
+const taReleaseWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-ta-release.yml', import.meta.url),
+  'utf8',
+)
+const wsReleaseWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-ws-release.yml', import.meta.url),
+  'utf8',
+)
 const ciWorkflow = readFileSync(new URL('../../../../../.github/workflows/torghut-ci.yml', import.meta.url), 'utf8')
 const pullRequestWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/pull-request.yml', import.meta.url),
@@ -154,6 +162,8 @@ describe('torghut build-push workflow', () => {
     expect(releaseManifestJob).toBeGreaterThan(-1)
     expect(releaseManifestJobBody).toContain('name: Verify source image build contract')
     expect(releaseManifestJobBody).toContain('TORGHUT_COMMIT')
+    expect(releaseManifestJobBody).toContain('TORGHUT_TA_COMMIT')
+    expect(releaseManifestJobBody).toContain('TORGHUT_WS_COMMIT')
     expect(releaseManifestJobBody).not.toContain('oven-sh/setup-bun')
     expect(releaseManifestJobBody).not.toContain('actions/cache@v4')
     expect(releaseManifestJobBody).not.toContain('bun install')
@@ -192,13 +202,52 @@ describe('torghut build-push workflow', () => {
     const buildContractStep = ciWorkflow.indexOf('name: Verify source image build contract', releaseManifestJob)
 
     expect(buildContractStep).toBeGreaterThan(releaseManifestJob)
-    expect(ciWorkflow).toContain('--workflow torghut-build-push.yaml')
+    expect(ciWorkflow).toContain('torghut-build-push.yaml')
+    expect(ciWorkflow).toContain('torghut-ta-build-push.yaml')
+    expect(ciWorkflow).toContain('torghut-ws-build-push.yaml')
+    expect(ciWorkflow).toContain('argocd/applications/torghut/knative-service.yaml')
+    expect(ciWorkflow).toContain('argocd/applications/torghut/ta/flinkdeployment.yaml')
+    expect(ciWorkflow).toContain('argocd/applications/torghut/ws/deployment.yaml')
     expect(ciWorkflow).toContain('build-platform (linux/amd64, amd64, arc-amd64)')
     expect(ciWorkflow).toContain('build-platform (linux/arm64, arm64, arc-arm64)')
     expect(ciWorkflow).toContain('publish-index')
-    expect(ciWorkflow).toContain('Torghut build-push passed required image contract jobs')
+    expect(ciWorkflow).toContain('build-push passed required image contract jobs')
     expect(ciWorkflow).not.toContain('name: Require source commit Torghut CI')
     expect(ciWorkflow).not.toContain('--workflow torghut-ci.yml')
+  })
+
+  it('keeps TA and WS stale workflow promotions path-aware so unrelated main commits do not force rebuilds', () => {
+    const releaseWorkflows = [
+      {
+        workflow: taReleaseWorkflow,
+        workflowPath: '.github/workflows/torghut-ta-release.yml',
+        buildPath: '.github/workflows/torghut-ta-build-push.yaml',
+        updateScript: 'packages/scripts/src/torghut/update-ta-manifest.ts',
+        servicePath: 'services/dorvud/technical-analysis-flink',
+        message: 'newer Torghut TA build inputs changed',
+      },
+      {
+        workflow: wsReleaseWorkflow,
+        workflowPath: '.github/workflows/torghut-ws-release.yml',
+        buildPath: '.github/workflows/torghut-ws-build-push.yaml',
+        updateScript: 'packages/scripts/src/torghut/update-ws-manifest.ts',
+        servicePath: 'services/dorvud/websockets',
+        message: 'newer Torghut WS build inputs changed',
+      },
+    ]
+
+    for (const { workflow, workflowPath, buildPath, updateScript, servicePath, message } of releaseWorkflows) {
+      expect(workflow).toContain('git merge-base --is-ancestor "${SOURCE_SHA}" "${MAIN_HEAD}"')
+      expect(workflow).toContain('git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" --')
+      expect(workflow).toContain(servicePath)
+      expect(workflow).toContain('services/dorvud/platform')
+      expect(workflow).toContain('packages/scripts/src/torghut/release-contract.ts')
+      expect(workflow).toContain(updateScript)
+      expect(workflow).toContain(buildPath)
+      expect(workflow).toContain(workflowPath)
+      expect(workflow).toContain(message)
+      expect(workflow).toContain('newer main ${MAIN_HEAD} contains only unrelated changes')
+    }
   })
 
   it('does not cancel main source CI while release promotion verifies the image contract', () => {

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -6,6 +6,14 @@ const releaseWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-release.yml', import.meta.url),
   'utf8',
 )
+const taReleaseWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-ta-release.yml', import.meta.url),
+  'utf8',
+)
+const wsReleaseWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-ws-release.yml', import.meta.url),
+  'utf8',
+)
 const deployAutomergeWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-deploy-automerge.yml', import.meta.url),
   'utf8',
@@ -26,13 +34,48 @@ describe('torghut-deploy-automerge workflow', () => {
     }
   })
 
-  test('verifies the source build-push image contract instead of waiting for full source CI', () => {
+  test('allowlists TA and WS promotion manifests for automatic release PR merges', () => {
+    const promotedTaManifests = [
+      'argocd/applications/torghut/ta/flinkdeployment.yaml',
+      'argocd/applications/torghut/ta-sim/flinkdeployment.yaml',
+      'argocd/applications/torghut-options/ta/flinkdeployment.yaml',
+    ]
+    const promotedWsManifests = [
+      'argocd/applications/torghut/ws/deployment.yaml',
+      'argocd/applications/torghut-options/ws/deployment.yaml',
+    ]
+
+    for (const manifestPath of promotedTaManifests) {
+      expect(taReleaseWorkflow).toContain(manifestPath)
+      expect(countOccurrences(deployAutomergeWorkflow, `'${manifestPath}'`)).toBeGreaterThanOrEqual(2)
+    }
+    for (const manifestPath of promotedWsManifests) {
+      expect(wsReleaseWorkflow).toContain(manifestPath)
+      expect(countOccurrences(deployAutomergeWorkflow, `'${manifestPath}'`)).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  test('verifies the matching source build-push image contract instead of waiting for full source CI', () => {
     expect(deployAutomergeWorkflow).toContain('name: Verify source image build contract')
-    expect(deployAutomergeWorkflow).toContain('--workflow torghut-build-push.yaml')
+    expect(deployAutomergeWorkflow).toContain(
+      "startsWith(github.event.pull_request.head.ref, 'codex/torghut-release-')",
+    )
+    expect(deployAutomergeWorkflow).toContain(
+      "startsWith(github.event.pull_request.head.ref, 'codex/torghut-ta-release-')",
+    )
+    expect(deployAutomergeWorkflow).toContain(
+      "startsWith(github.event.pull_request.head.ref, 'codex/torghut-ws-release-')",
+    )
+    expect(deployAutomergeWorkflow).toContain("build_workflow='torghut-build-push.yaml'")
+    expect(deployAutomergeWorkflow).toContain("build_workflow='torghut-ta-build-push.yaml'")
+    expect(deployAutomergeWorkflow).toContain("build_workflow='torghut-ws-build-push.yaml'")
+    expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_COMMIT'")
+    expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_TA_COMMIT'")
+    expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_WS_COMMIT'")
     expect(deployAutomergeWorkflow).toContain('build-platform (linux/amd64, amd64, arc-amd64)')
     expect(deployAutomergeWorkflow).toContain('build-platform (linux/arm64, arm64, arc-arm64)')
     expect(deployAutomergeWorkflow).toContain('publish-index')
-    expect(deployAutomergeWorkflow).toContain('Torghut build-push passed required image contract jobs')
+    expect(deployAutomergeWorkflow).toContain('build-push passed required image contract jobs')
     expect(deployAutomergeWorkflow).not.toContain('name: Wait for source commit Torghut CI')
     expect(deployAutomergeWorkflow).not.toContain('--workflow torghut-ci.yml')
   })


### PR DESCRIPTION
## Summary

- Make Torghut TA and WS release workflows path-aware for stale `workflow_run` promotions, so unrelated `main` commits no longer force rebuilds.
- Extend Torghut deploy automerge to `codex/torghut-ta-release-*` and `codex/torghut-ws-release-*` promotion PRs.
- Make manifest-only CI validate the matching image build contract for core, TA, and WS promotions instead of checking only the core Torghut image.

## Related Issues

None

## Testing

- `python - <<'PY'` YAML parse for `.github/workflows/torghut-ci.yml`, `.github/workflows/torghut-deploy-automerge.yml`, `.github/workflows/torghut-ta-release.yml`, and `.github/workflows/torghut-ws-release.yml`
- `bun test packages/scripts/src/torghut/__tests__`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
