### PR TITLE
ci(torghut): sync argo during post deploy verify

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -109,10 +109,6 @@ jobs:
             git fetch --no-tags --depth=200 origin main
           fi
 
-          for app in torghut torghut-options; do
-            kubectl annotate application "${app}" -n argocd argocd.argoproj.io/refresh=hard --overwrite
-          done
-
           ensure_revision_known() {
             local revision="$1"
             if [ -z "${revision}" ]; then
@@ -125,8 +121,50 @@ jobs:
             git cat-file -e "${revision}^{commit}" >/dev/null 2>&1
           }
 
+          request_argocd_sync() {
+            local app="$1"
+            local revision="$2"
+            local active_operation
+            local payload
+
+            kubectl annotate application "${app}" -n argocd argocd.argoproj.io/refresh=hard --overwrite
+
+            active_operation="$(kubectl get application "${app}" -n argocd -o jsonpath='{.operation.sync.revision}' 2>/dev/null || true)"
+            if [ -n "${active_operation}" ]; then
+              echo "Argo application ${app} already has a sync operation for revision ${active_operation}"
+              return
+            fi
+
+            payload="$(
+              SYNC_REVISION="${revision}" python3 - <<'PY'
+import json
+import os
+
+sync = {"prune": True}
+revision = os.environ.get("SYNC_REVISION", "")
+if revision:
+    sync["revision"] = revision
+print(json.dumps({"operation": {"sync": sync}}))
+PY
+            )"
+            kubectl patch application "${app}" -n argocd --type merge -p "${payload}"
+          }
+
+          dump_argocd_app_diagnostics() {
+            local app="$1"
+
+            echo "Argo application ${app} status:"
+            kubectl get application "${app}" -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision} {.status.operationState.phase} {.status.operationState.message}{"\n"}' || true
+            echo "Argo application ${app} OutOfSync resources:"
+            kubectl get application "${app}" -n argocd -o jsonpath='{range .status.resources[?(@.status=="OutOfSync")]}{.kind}{"/"}{.namespace}{"/"}{.name}{"\t"}{.status}{"\t"}{.health.status}{"\n"}{end}' || true
+          }
+
           for app in torghut torghut-options; do
-            for attempt in $(seq 1 90); do
+            request_argocd_sync "${app}" "${EXPECTED_REVISION}"
+          done
+
+          for app in torghut torghut-options; do
+            for attempt in $(seq 1 60); do
               STATUS="$(kubectl get application "${app}" -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision} {.status.operationState.phase} {.status.operationState.syncResult.revision} {.status.history[-1].revision}')"
               SYNC_STATUS="$(echo "${STATUS}" | awk '{print $1}')"
               HEALTH_STATUS="$(echo "${STATUS}" | awk '{print $2}')"
@@ -178,12 +216,13 @@ jobs:
                 fi
               fi
 
-              if [ "${attempt}" -eq 90 ]; then
+              if [ "${attempt}" -eq 60 ]; then
                 echo "Argo application ${app} did not become Synced/Healthy with expected revision"
+                dump_argocd_app_diagnostics "${app}"
                 exit 1
               fi
               echo "Attempt ${attempt}: ${app} sync=${SYNC_STATUS} health=${HEALTH_STATUS} revision=${REVISION} desired=${DESIRED_REVISION} operation=${OPERATION_PHASE} syncResult=${SYNC_RESULT_REVISION} history=${HISTORY_REVISION}"
-              sleep 10
+              sleep 5
             done
           done
 

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -91,9 +91,19 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('Torghut sim paper-route target mirror did not materialize after bounded retry window')
   })
 
-  it('requests Argo refresh before polling deployed revisions', () => {
+  it('requests explicit Argo sync before polling deployed revisions', () => {
     expect(workflow).toContain('argocd.argoproj.io/refresh=hard --overwrite')
+    expect(workflow).toContain('request_argocd_sync()')
+    expect(workflow).toContain('{"prune": True}')
+    expect(workflow).toContain('kubectl patch application "${app}" -n argocd --type merge -p "${payload}"')
     expect(workflow).toContain('for app in torghut torghut-options; do')
+  })
+
+  it('bounds Argo convergence waits and prints resource diagnostics on timeout', () => {
+    expect(workflow).toContain('for attempt in $(seq 1 60); do')
+    expect(workflow).toContain('sleep 5')
+    expect(workflow).toContain('dump_argocd_app_diagnostics "${app}"')
+    expect(workflow).toContain('Argo application ${app} OutOfSync resources:')
   })
 
   it('fails when Torghut-managed images still have pull errors', () => {


### PR DESCRIPTION
## Summary

- Requests an explicit Argo sync for `torghut` and `torghut-options` before post-deploy polling instead of only hard-refreshing applications.
- Enables prune on that sync operation so GitOps removals converge during release verification.
- Bounds Argo convergence polling to a 5-minute window per app and prints OutOfSync resource diagnostics on timeout.
- Adds workflow tests covering explicit sync, prune, shorter waits, and diagnostics.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- YAML parse for `.github/workflows/torghut-post-deploy-verify.yml`
- `git diff --check`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- Server-side dry-run: `kubectl patch application torghut -n argocd --type merge --dry-run=server -p '{"operation":{"sync":{"prune":true,"revision":"24d12598151bf1dd7406fa85218672e6d703b4b9"}}}'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
