### PR TITLE
fix(torghut): keep hyperliquid feed release path aware

### DIFF
--- a/.github/workflows/torghut-hyperliquid-feed-release.yml
+++ b/.github/workflows/torghut-hyperliquid-feed-release.yml
@@ -102,8 +102,35 @@ jobs:
             fi
 
             if [ "${SOURCE_SHA}" != "${MAIN_HEAD}" ]; then
-              echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main is ${MAIN_HEAD}"
-              PROMOTE='false'
+              if ! git merge-base --is-ancestor "${SOURCE_SHA}" "${MAIN_HEAD}"; then
+                echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main ${MAIN_HEAD} is not a descendant."
+                PROMOTE='false'
+              else
+                FEED_CHANGES="$(
+                  git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" -- \
+                    services/dorvud/gradle \
+                    services/dorvud/gradlew \
+                    services/dorvud/gradle.properties \
+                    services/dorvud/settings.gradle.kts \
+                    services/dorvud/build.gradle.kts \
+                    services/dorvud/platform \
+                    services/dorvud/hyperliquid-feed \
+                    packages/scripts/src/torghut/release-contract.ts \
+                    packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts \
+                    packages/scripts/src/shared/cli.ts \
+                    packages/scripts/src/shared/docker.ts \
+                    packages/scripts/src/shared/git.ts \
+                    .github/workflows/torghut-hyperliquid-feed-build-push.yaml \
+                    .github/workflows/torghut-hyperliquid-feed-release.yml
+                )"
+                if [ -n "${FEED_CHANGES}" ]; then
+                  echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; newer Hyperliquid feed build inputs changed:"
+                  printf '%s\n' "${FEED_CHANGES}"
+                  PROMOTE='false'
+                else
+                  echo "Promoting ${SOURCE_SHA}; newer main ${MAIN_HEAD} contains only unrelated changes."
+                fi
+              fi
             fi
           else
             if [ -n "${COMMIT_SHA_INPUT}" ]; then

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -273,6 +273,22 @@ describe('torghut build-push workflow', () => {
     }
   })
 
+  it('keeps Hyperliquid feed stale workflow promotions path-aware so unrelated main commits do not block release', () => {
+    expect(hyperliquidFeedReleaseWorkflow).toContain('git merge-base --is-ancestor "${SOURCE_SHA}" "${MAIN_HEAD}"')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" --')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('services/dorvud/hyperliquid-feed')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('services/dorvud/platform')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/torghut/release-contract.ts')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/shared/cli.ts')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/shared/docker.ts')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/shared/git.ts')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('.github/workflows/torghut-hyperliquid-feed-build-push.yaml')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('.github/workflows/torghut-hyperliquid-feed-release.yml')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('newer Hyperliquid feed build inputs changed')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('newer main ${MAIN_HEAD} contains only unrelated changes')
+  })
+
   it('does not cancel main source CI while release promotion verifies the image contract', () => {
     expect(ciWorkflow).toContain(
       "group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}",


### PR DESCRIPTION
## Summary

- Make Hyperliquid feed release promotion path-aware when a completed build is no longer the exact main HEAD.
- Allow promotion when newer main commits are descendants and only unrelated files changed.
- Add workflow coverage so unrelated main commits do not block Hyperliquid feed image release PRs.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/torghut-hyperliquid-feed-release.yml"); puts "ok"'`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/torghut-hyperliquid-feed-release.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
