### PR TITLE
ci(torghut): fix post deploy workflow syntax

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -137,15 +137,15 @@ jobs:
 
             payload="$(
               SYNC_REVISION="${revision}" python3 - <<'PY'
-import json
-import os
+          import json
+          import os
 
-sync = {"prune": True}
-revision = os.environ.get("SYNC_REVISION", "")
-if revision:
-    sync["revision"] = revision
-print(json.dumps({"operation": {"sync": sync}}))
-PY
+          sync = {"prune": True}
+          revision = os.environ.get("SYNC_REVISION", "")
+          if revision:
+              sync["revision"] = revision
+          print(json.dumps({"operation": {"sync": sync}}))
+          PY
             )"
             kubectl patch application "${app}" -n argocd --type merge -p "${payload}"
           }


### PR DESCRIPTION
## Summary

- Fixes the post-deploy workflow heredoc indentation so GitHub can parse the workflow after the explicit Argo sync change.
- Keeps the Python payload builder inside the YAML block scalar while preserving valid shell heredoc delimiters.
- Verifies the workflow with targeted tests and actionlint.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- YAML parse for `.github/workflows/torghut-post-deploy-verify.yml`
- `git diff --check`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-post-deploy-verify.yml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
