### PR TITLE
fix(torghut): allow hyperliquid runtime tigerbeetle io

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -97,6 +97,8 @@ spec:
             - name: tmp
               mountPath: /tmp
           securityContext:
+            seccompProfile:
+              type: Unconfined
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -227,6 +227,11 @@ describe('Torghut manifest scheduling', () => {
     const runtimeContainer = getAtPath(runtimeDeployment, ['spec', 'template', 'spec', 'containers', 0])
     expect(String(runtimeContainer.image)).toMatch(/^registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:[0-9a-f]{64}$/)
     expect(String(runtimeContainer.image)).not.toContain(':latest')
+    expect(getAtPath(runtimeContainer, ['securityContext'])).toMatchObject({
+      allowPrivilegeEscalation: false,
+      readOnlyRootFilesystem: true,
+      seccompProfile: { type: 'Unconfined' },
+    })
     const runtimeEnv = runtimeContainer.env
     expect(runtimeEnv).toContainEqual(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- Allow the Hyperliquid runtime container to use an Unconfined seccomp profile for TigerBeetle client IO.
- Keep the rest of the container hardening intact: no privilege escalation, read-only root filesystem, and dropped capabilities.
- Add manifest coverage so future runtime changes preserve the TigerBeetle seccomp requirement.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
