### PR TITLE
fix(anypi): honor explicit validation commands

### DIFF
--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -290,7 +290,7 @@ describe('Anypi prompt contract', () => {
     )
   })
 
-  test('records validation sources and appends run commands', () => {
+  test('records validation sources and appends run commands (env appended, no inferred)', () => {
     const plan = resolveValidationPlan(
       {
         implementation: { text: 'Improve services/anypi prompt handling.' },
@@ -299,9 +299,11 @@ describe('Anypi prompt contract', () => {
       ['bun run --filter @proompteng/anypi lint'],
       'append',
     )
-    expect(plan.sources).toEqual(['inferred', 'run-spec', 'env'])
-    expect(plan.commands).toContain('bun run --filter @proompteng/anypi tsc')
+    // Run-spec commands are authoritative; env commands appended; inferred commands NOT included
+    expect(plan.sources).toEqual(['run-spec', 'env'])
+    expect(plan.commands).toContain('bun run --filter @proompteng/anypi test')
     expect(plan.commands).toContain('bun run --filter @proompteng/anypi lint')
+    expect(plan.commands).not.toContain('bun run --filter @proompteng/anypi tsc')
   })
 
   test('parses and summarizes GitHub check buckets', () => {
@@ -483,5 +485,152 @@ describe('Anypi prompt contract', () => {
         { status: ' M foo.ts', commitsAhead: 1, contentHash: 'same' },
       ),
     ).toBe(false)
+  })
+
+  describe('validation planning - regression tests', () => {
+    test('explicit run-spec validation commands are authoritative (append policy)', () => {
+      // Run with explicit validation commands and task text mentioning multiple unrelated areas
+      // Should only run the explicit commands, NOT inferred commands for those areas
+      const plan = resolveValidationPlan(
+        {
+          implementation: {
+            text: 'Improve services/torghut validation and services/anypi prompt handling and argocd/applications/agents manifests.',
+          },
+          parameters: {
+            validationCommands: 'echo specific validation command\ngit diff --check',
+          },
+        },
+        [],
+        'append',
+      )
+
+      // Should only have the explicit commands, NOT inferred commands
+      expect(plan.sources).toEqual(['run-spec'])
+      expect(plan.commands).toEqual(['echo specific validation command', 'git diff --check'])
+      expect(plan.commands).not.toContain('cd services/torghut && uv sync --frozen --extra dev')
+      expect(plan.commands).not.toContain('bun run --filter @proompteng/anypi tsc')
+      expect(plan.commands).not.toContain(
+        'kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml',
+      )
+    })
+
+    test('inferred commands work as fallback when no explicit commands are provided', () => {
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Improve services/anypi prompt handling.' },
+        },
+        [],
+        'append',
+      )
+
+      expect(plan.sources).toEqual(['inferred'])
+      expect(plan.commands).toContain('bun run --filter @proompteng/anypi tsc')
+      expect(plan.commands).toContain('bun run --filter @proompteng/anypi test')
+      expect(plan.commands).toContain('bun run --filter @proompteng/anypi lint')
+    })
+
+    test('env override still wins in override mode', () => {
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Change something.' },
+          parameters: { validationCommands: 'run-spec command' },
+        },
+        ['env override command'],
+        'override',
+      )
+
+      expect(plan.sources).toEqual(['env'])
+      expect(plan.commands).toEqual(['env override command'])
+    })
+
+    test('validation source metadata is accurate for append policy with run-spec only', () => {
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Improve services/anypi prompt handling.' },
+          parameters: { validationCommands: 'custom validation' },
+        },
+        [],
+        'append',
+      )
+
+      expect(plan.sources).toEqual(['run-spec'])
+      expect(plan.commands).toEqual(['custom validation'])
+    })
+
+    test('validation source metadata is accurate for append policy with run-spec and env', () => {
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Improve services/anypi prompt handling.' },
+          parameters: { validationCommands: 'run-spec command' },
+        },
+        ['env command'],
+        'append',
+      )
+
+      // Env commands should be appended, but inferred should NOT be included
+      expect(plan.sources).toEqual(['run-spec', 'env'])
+      expect(plan.commands).toEqual(['run-spec command', 'env command'])
+    })
+
+    test('validation source metadata is accurate for append policy with env only', () => {
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Change generic docs.' },
+        },
+        ['env only command'],
+        'append',
+      )
+
+      // Only env commands, no inferred
+      expect(plan.sources).toEqual(['env'])
+      expect(plan.commands).toEqual(['env only command'])
+    })
+
+    test('append policy with env does not add inferred commands', () => {
+      // Even though the task mentions torghut, inferred commands should NOT be added
+      // because env commands are provided
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Improve services/torghut validation.' },
+        },
+        ['env command 1', 'env command 2'],
+        'append',
+      )
+
+      expect(plan.sources).toEqual(['env'])
+      expect(plan.commands).toEqual(['env command 1', 'env command 2'])
+      expect(plan.commands).not.toContain('cd services/torghut && uv sync --frozen --extra dev')
+    })
+
+    test('override policy still works correctly with env override', () => {
+      // When env commands are provided with override policy, they should be used exclusively
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Improve services/torghut validation.' },
+          parameters: { validationCommands: 'run-spec command' },
+        },
+        ['env override command 1', 'env override command 2'],
+        'override',
+      )
+
+      expect(plan.sources).toEqual(['env'])
+      expect(plan.commands).toEqual(['env override command 1', 'env override command 2'])
+      expect(plan.commands).not.toContain('run-spec command')
+      expect(plan.commands).not.toContain('cd services/torghut && uv sync --frozen --extra dev')
+    })
+
+    test('override policy falls back to run-spec when no env commands', () => {
+      const plan = resolveValidationPlan(
+        {
+          implementation: { text: 'Improve services/anypi prompt handling.' },
+          parameters: { validationCommands: 'run-spec command 1\nrun-spec command 2' },
+        },
+        [],
+        'override',
+      )
+
+      expect(plan.sources).toEqual(['run-spec'])
+      expect(plan.commands).toEqual(['run-spec command 1', 'run-spec command 2'])
+    })
   })
 })

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -100,10 +100,22 @@ export const resolveValidationPlan = (
       sources.push('inferred')
     }
   } else {
-    commands = dedupeCommands([...inferredCommands, ...runCommands, ...configuredCommands])
-    if (inferredCommands.length > 0) sources.push('inferred')
-    if (runCommands.length > 0) sources.push('run-spec')
-    if (configuredCommands.length > 0) sources.push('env')
+    // Append policy: explicit run-spec commands are authoritative
+    // inferred commands are only used as fallback when both run-spec and env commands are absent
+    if (runCommands.length > 0) {
+      // Run-spec commands are provided; append env commands without inferred
+      commands = dedupeCommands([...runCommands, ...configuredCommands])
+      sources.push('run-spec')
+      if (configuredCommands.length > 0) sources.push('env')
+    } else if (configuredCommands.length > 0) {
+      // Only env commands are provided; use those without inferred
+      commands = configuredCommands
+      sources.push('env')
+    } else {
+      // No run-spec and no env commands; fall back to inferred
+      commands = inferredCommands
+      sources.push('inferred')
+    }
   }
 
   if (commands.length <= 1 && commands[0] === 'git diff --check') {

--- a/services/anypi/vitest.config.ts
+++ b/services/anypi/vitest.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, resolveRoot } from 'vitest/config'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = join(__dirname, '../..')
 
 export default defineConfig({
+  root,
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['services/anypi/src/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Summary

- Generated for agents/anypi-agent-hbncx.
- Prompt variant: `repair-loop` (`b77c133ef91aab25`).
- Session artifact: `/workspace/.anypi/sessions/validation-repair-1-747696db/2026-06-18T23-15-06-995Z_019edd04-4c73-748b-93ae-6880f2ae0c74.jsonl`.

## Related Issues

None

## Testing

- `bash -lc git diff --check` exit 0
- `bash -lc bun run --filter @proompteng/anypi tsc` exit 0
- `bash -lc bun run --filter @proompteng/anypi test` exit 0
- `bash -lc bun run --filter @proompteng/anypi lint` exit 0
- `bash -lc kustomize build --enable-helm argocd/applications/agents >/tmp/anypi-agents.yaml` exit 0
- `bash -lc bun run --filter @proompteng/anypi test -- services/anypi/src/config.test.ts` exit 0
- `bash -lc bunx oxfmt --check services/anypi/src/prompt.ts services/anypi/src/config.test.ts` exit 0
- CI: passed: 13 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
