### PR TITLE
fix(torghut): enable hyperliquid testnet dex execution

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/exchange.py
+++ b/services/torghut/app/hyperliquid_runtime/exchange.py
@@ -183,23 +183,13 @@ class HyperliquidSdkExchange:
             raise ValueError("hyperliquid_testnet_account_secret_required")
         self._config = config
         self._sdk_exchange: Any | None = None
+        self._sdk_exchange_perp_dexs: tuple[str, ...] | None = None
         self._sdk_info: Any | None = None
         self._last_exchange_read_at: datetime | None = None
         self._last_execution_universe_at: datetime | None = None
         self._execution_universe_by_dex: dict[str, frozenset[str]] = {}
 
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
-        if self._config.execution_network == "testnet" and _sdk_dex(intent.dex):
-            return OrderResult(
-                status="rejected",
-                exchange_order_id=None,
-                raw_response={
-                    "reason": "unsupported_testnet_dex",
-                    "dex": intent.dex,
-                    "coin": intent.coin,
-                },
-                rejection_reason="unsupported_testnet_dex",
-            )
         exchange = self._exchange()
         cloid = self._cloid(intent.cloid)
         response = cast(
@@ -324,7 +314,8 @@ class HyperliquidSdkExchange:
         self._last_exchange_read_at = datetime.now(timezone.utc)
 
     def _exchange(self) -> Any:
-        if self._sdk_exchange is None:
+        perp_dexs = self._supported_perp_dexs()
+        if self._sdk_exchange is None or self._sdk_exchange_perp_dexs != perp_dexs:
             eth_account = importlib.import_module("eth_account")
             exchange_module = importlib.import_module("hyperliquid.exchange")
             wallet = eth_account.Account.from_key(self._config.api_wallet_private_key)
@@ -333,9 +324,20 @@ class HyperliquidSdkExchange:
                 wallet,
                 base_url=self._config.exchange_api_url,
                 account_address=self._config.account_address,
+                perp_dexs=list(perp_dexs),
                 timeout=float(self._config.exchange_staleness_seconds),
             )
+            self._sdk_exchange_perp_dexs = perp_dexs
         return self._sdk_exchange
+
+    def _supported_perp_dexs(self) -> tuple[str, ...]:
+        dexes = {
+            dex
+            for dex, coins in self._execution_universe_by_dex.items()
+            if dex == "" or coins
+        }
+        dexes.add("")
+        return tuple(sorted(dexes))
 
     def _info(self) -> Any:
         if self._sdk_info is None:
@@ -562,8 +564,7 @@ def _execution_metadata_dexes(
     execution_network: str,
 ) -> tuple[str, ...]:
     dexes = {_sdk_dex(market.dex) for market in markets}
-    if execution_network == "testnet":
-        return ("",) if "" in dexes else ()
+    _ = execution_network
     return tuple(sorted(dexes))
 
 

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -99,7 +99,7 @@ def _cycle() -> CycleResult:
     )
 
 
-def test_execution_metadata_dexes_keeps_all_mainnet_dexes() -> None:
+def test_execution_metadata_dexes_keeps_all_dexes() -> None:
     markets = (
         _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
         _market(),
@@ -108,6 +108,13 @@ def test_execution_metadata_dexes_keeps_all_mainnet_dexes() -> None:
 
     assert exchange_module._execution_metadata_dexes(
         markets, execution_network="mainnet"
+    ) == (
+        "",
+        "cash",
+        "xyz",
+    )
+    assert exchange_module._execution_metadata_dexes(
+        markets, execution_network="testnet"
     ) == (
         "",
         "cash",
@@ -295,7 +302,9 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
             sdk_calls["exchange_init"] = (wallet, kwargs)
 
         def order(self, **kwargs: object) -> dict[str, object]:
-            sdk_calls["order"] = kwargs
+            orders = sdk_calls.setdefault("orders", [])
+            assert isinstance(orders, list)
+            orders.append(kwargs)
             return {"response": {"data": {"statuses": [{"resting": {"oid": 42}}]}}}
 
         def schedule_cancel(self, cancel_at_ms: int) -> None:
@@ -387,7 +396,7 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     )
     empty_markets, empty_status = sdk_exchange.filter_supported_markets(())
     result = sdk_exchange.submit_ioc_limit(_intent())
-    rejected_non_default = sdk_exchange.submit_ioc_limit(
+    non_default_result = sdk_exchange.submit_ioc_limit(
         _intent(
             coin="cash:AAPL",
             dex="cash",
@@ -399,6 +408,7 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     sdk_exchange.schedule_dead_man_cancel(seconds_from_now=30)
 
     assert supported_markets == (
+        _market(),
         _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
     )
     assert universe_status.ready
@@ -406,12 +416,14 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     assert cached_status.ready
     assert empty_markets == ()
     assert empty_status.ready
-    assert sdk_calls["meta_dexes"] == [""]
+    assert sdk_calls["meta_dexes"] == ["", "cash"]
+    assert sdk_calls["exchange_init"][1]["perp_dexs"] == ["", "cash"]
     assert result.status == "accepted"
     assert result.exchange_order_id == "42"
-    assert rejected_non_default.status == "rejected"
-    assert rejected_non_default.rejection_reason == "unsupported_testnet_dex"
-    assert sdk_calls["order"]  # SDK received a real order payload.
+    assert non_default_result.status == "accepted"
+    assert non_default_result.exchange_order_id == "42"
+    assert len(sdk_calls["orders"]) == 2
+    assert sdk_calls["orders"][1]["name"] == "cash:AAPL"
     assert fills[0].notional_usd == Decimal("20.0")
     assert fills[0].fee_usd == Decimal("0.02")
     assert sdk_exchange.dependency_status().ready
@@ -458,7 +470,7 @@ def test_sdk_execution_universe_reports_metadata_failure(
     assert status.reason == "execution_market_metadata_unavailable:TimeoutError"
 
 
-def test_sdk_execution_universe_skips_unsupported_non_default_testnet_dexes(
+def test_sdk_execution_universe_loads_supported_non_default_testnet_dexes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sdk_calls: dict[str, object] = {}
@@ -471,7 +483,8 @@ def test_sdk_execution_universe_skips_unsupported_non_default_testnet_dexes(
             meta_dexes = sdk_calls.setdefault("meta_dexes", [])
             assert isinstance(meta_dexes, list)
             meta_dexes.append(dex)
-            assert dex == ""
+            if dex == "xyz":
+                return {"universe": [{"name": "xyz:NVDA"}]}
             return {"universe": [{"name": "SPX"}]}
 
     def fake_import(name: str) -> object:
@@ -490,17 +503,17 @@ def test_sdk_execution_universe_skips_unsupported_non_default_testnet_dexes(
 
     supported_markets, status = sdk_exchange.filter_supported_markets(
         (
-            _market(),
             _market(coin="xyz:NVDA", dex="xyz", market_id="hl:perp:xyz:xyz:NVDA"),
             _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
         )
     )
 
     assert supported_markets == (
+        _market(coin="xyz:NVDA", dex="xyz", market_id="hl:perp:xyz:xyz:NVDA"),
         _market(coin="SPX", dex="default", market_id="hl:perp:default:SPX"),
     )
     assert status.ready
-    assert sdk_calls["meta_dexes"] == [""]
+    assert sdk_calls["meta_dexes"] == ["", "xyz"]
     assert sdk_exchange.dependency_status().ready
 
 
@@ -543,7 +556,7 @@ def test_sdk_execution_universe_reports_no_markets_when_only_non_default_dexes_f
     assert supported_markets == ()
     assert not status.ready
     assert status.reason == "no_execution_supported_markets"
-    assert sdk_calls.get("meta_dexes", []) == []
+    assert sdk_calls.get("meta_dexes", []) == ["cash", "xyz"]
     assert not sdk_exchange.dependency_status().ready
     assert sdk_exchange.dependency_status().reason == "exchange_not_read"
 


### PR DESCRIPTION
## Summary

- Enable the Hyperliquid runtime to load non-default perp DEX metadata on testnet instead of limiting execution discovery to default perps.
- Build the SDK `Exchange` with the supported DEX list so symbols such as `xyz:NVDA` can resolve to Hyperliquid asset ids.
- Update focused runtime adapter tests for testnet DEX metadata, SDK initialization, and unsupported DEX handling.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py -q`
- `uv run --frozen ruff check app/hyperliquid_runtime/exchange.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `uv run --frozen ruff format --check app/hyperliquid_runtime/exchange.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
