### PR TITLE
fix(agents): terminalize runs with missing runtime jobs

### DIFF
--- a/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
@@ -362,4 +362,118 @@ describe('agents controller agent-run reconciler', () => {
       expect.objectContaining({ runName: 'old-workflow-run' }),
     )
   })
+
+  it('terminalizes a job AgentRun when the Job is missing without stored runner status', async () => {
+    const setStatus = vi.fn(async () => undefined)
+    const kube = {
+      patch: vi.fn(async () => ({})),
+      get: vi.fn(async () => null),
+    }
+    const reconciler = createAgentRunReconciler(createBaseDependencies({ setStatus }))
+
+    await reconciler.reconcileAgentRun(
+      kube as never,
+      {
+        metadata: {
+          name: 'run-1',
+          namespace: 'agents',
+          generation: 1,
+          finalizers: ['agents.proompteng.ai/runtime-cleanup'],
+        },
+        spec: {
+          agentRef: { name: 'codex-agent' },
+          runtime: { type: 'job' },
+          parameters: {},
+          workload: {},
+        },
+        status: {
+          phase: 'Running',
+          startedAt: '2026-05-18T13:00:00.000Z',
+          runtimeRef: {
+            type: 'job',
+            name: 'run-1-job',
+            namespace: 'agents',
+            jobObservedAt: '2026-05-18T13:00:01.000Z',
+          },
+        },
+      },
+      'agents',
+      [],
+      [],
+      {
+        perNamespace: 10,
+        perAgent: 10,
+        cluster: 10,
+        repoConcurrency: { enabled: false, defaultLimit: 0, overrides: new Map() },
+      },
+      { total: 0, perAgent: new Map(), perRepository: new Map() },
+      0,
+    )
+
+    expect(kube.get).toHaveBeenCalledWith('job', 'run-1-job', 'agents')
+    expect(setStatus).toHaveBeenCalledWith(
+      kube,
+      expect.any(Object),
+      expect.objectContaining({
+        phase: 'Failed',
+        reason: 'JobMissing',
+        finishedAt: '2026-05-18T14:00:00.000Z',
+        runtimeRef: expect.objectContaining({ type: 'job', name: 'run-1-job' }),
+        conditions: expect.arrayContaining([
+          expect.objectContaining({ type: 'Warning', status: 'True', reason: 'JobMissing' }),
+          expect.objectContaining({ type: 'Failed', status: 'True', reason: 'JobMissing' }),
+        ]),
+      }),
+    )
+  })
+
+  it('returns without updating when Job is missing and jobObservedAt is not set', async () => {
+    const setStatus = vi.fn(async () => undefined)
+    const kube = {
+      patch: vi.fn(async () => ({})),
+      get: vi.fn(async () => null),
+    }
+    const reconciler = createAgentRunReconciler(createBaseDependencies({ setStatus }))
+
+    await reconciler.reconcileAgentRun(
+      kube as never,
+      {
+        metadata: {
+          name: 'run-1',
+          namespace: 'agents',
+          generation: 1,
+          finalizers: ['agents.proompteng.ai/runtime-cleanup'],
+        },
+        spec: {
+          agentRef: { name: 'codex-agent' },
+          runtime: { type: 'job' },
+          parameters: {},
+          workload: {},
+        },
+        status: {
+          phase: 'Running',
+          startedAt: '2026-05-18T13:00:00.000Z',
+          runtimeRef: {
+            type: 'job',
+            name: 'run-1-job',
+            namespace: 'agents',
+          },
+        },
+      },
+      'agents',
+      [],
+      [],
+      {
+        perNamespace: 10,
+        perAgent: 10,
+        cluster: 10,
+        repoConcurrency: { enabled: false, defaultLimit: 0, overrides: new Map() },
+      },
+      { total: 0, perAgent: new Map(), perRepository: new Map() },
+      0,
+    )
+
+    expect(kube.get).toHaveBeenCalledWith('job', 'run-1-job', 'agents')
+    expect(setStatus).not.toHaveBeenCalled()
+  })
 })

--- a/services/agents/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.ts
@@ -1241,14 +1241,24 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
             message,
             durationMs: Date.now() - reconcileStartedAt,
           })
+          const terminalMessage = `${message}; runner status not preserved in AgentRun status`
+          const terminalConditions = upsertCondition(warningConditions, {
+            type: 'Failed',
+            status: 'True',
+            reason: 'JobMissing',
+            message: terminalMessage,
+          })
           await setStatus(kube, agentRun, {
             observedGeneration,
-            phase: 'Running',
-            startedAt: asString(status.startedAt) ?? nowIso(),
+            phase: 'Failed',
+            reason: 'JobMissing',
+            message: terminalMessage,
+            finishedAt: nowIso(),
             runtimeRef,
-            conditions: warningConditions,
+            conditions: terminalConditions,
             vcs: asRecord(status.vcs) ?? undefined,
           })
+          return
         }
         return
       }

--- a/services/agents/src/server/v1/agent-run-projection-authority.test.ts
+++ b/services/agents/src/server/v1/agent-run-projection-authority.test.ts
@@ -128,4 +128,36 @@ describe('AgentRun projection authority API', () => {
       }),
     ])
   })
+
+  it('classifies Failed terminal AgentRuns as terminal_audit for missing Job without runner status', async () => {
+    const failedRun = {
+      id: 'failed-missing-job',
+      agentName: 'codex-worker',
+      deliveryId: 'delivery-failed',
+      provider: 'job',
+      status: 'Failed',
+      externalRunId: 'agentrun-failed',
+      payload: {},
+      createdAt: '2026-05-20T09:00:00.000Z',
+      updatedAt: '2026-05-20T10:00:00.000Z',
+    }
+    const store = createStore([failedRun])
+
+    const response = await getAgentRunProjectionAuthorityHandler(
+      new Request('http://agents.test/v1/agent-runs/projection-authority?includeTerminalAudit=true'),
+      depsFor(store),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(store.listAgentRuns).toHaveBeenCalledWith({ agentName: null, statuses: null, limit: 100 })
+    expect(body.claims).toEqual([
+      expect.objectContaining({
+        source_ref: 'agent_runs:failed-missing-job',
+        authority_state: 'terminal_audit',
+        status: 'failed',
+        reason_codes: expect.arrayContaining(['agents_service_agentrun_projection_terminal_audit']),
+      }),
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

- Terminalize job-backed AgentRuns as `Failed` with `JobMissing` when their previously observed Kubernetes Job disappears and no terminal runner status was preserved.
- Preserve the existing non-terminal path when a Job is missing before it was ever observed, avoiding false failures during startup races.
- Add focused controller and projection-authority regression coverage for missing-runtime-job terminal handling.

## Related Issues

None

## Testing

- `git diff --check`
- `cd services/agents && bun run test -- src/server/agents-controller/agent-run-reconciler.test.ts src/server/v1/agent-run-projection-authority.test.ts`
- `cd services/agents && bunx oxfmt --check src/server/agents-controller/agent-run-reconciler.ts src/server/agents-controller/agent-run-reconciler.test.ts src/server/v1/agent-run-projection-authority.ts src/server/v1/agent-run-projection-authority.test.ts`
- GitHub Actions `agents-ci / validate`
- GitHub Actions `agents-ci / integration`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
