### PR TITLE
ci(torghut): remove release build polling

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -167,22 +167,17 @@ jobs:
           fi
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-      - name: Verify source image build contract
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Verify source image digest contract
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
-
-          required_build_jobs=(
-            'build-platform (linux/amd64, amd64, arc-amd64)'
-            'build-platform (linux/arm64, arm64, arc-arm64)'
-            'publish-index'
-          )
 
           changed_files="$(mktemp)"
           if [ "${EVENT_NAME}" = "pull_request" ]; then
@@ -217,124 +212,92 @@ jobs:
             ' "${manifest_path}"
           }
 
-          assert_required_build_jobs() {
-            local run_id="$1"
-            local job_lines
-            job_lines="$(
-              gh run view "${run_id}" \
-                -R "${GH_REPO}" \
-                --json jobs \
-                --jq '.jobs[] | [.name, (.conclusion // ""), (.status // "")] | @tsv'
-            )"
+          resolve_image_ref() {
+            local manifest_path="$1"
+            local image_name="$2"
+            awk -v expected="${image_name}" '
+              /^[[:space:]]*image:[[:space:]]*/ {
+                sub(/^[[:space:]]*image:[[:space:]]*/, "")
+                gsub(/"/, "")
+                if (index($0, expected "@sha256:") == 1) {
+                  print
+                  exit
+                }
+              }
+            ' "${manifest_path}"
+          }
 
-            for required_job in "${required_build_jobs[@]}"; do
-              state="$(
-                printf '%s\n' "${job_lines}" |
-                  awk -F '\t' \
-                    -v name="${required_job}" \
-                    '$1 == name { print ($2 == "" ? "PENDING" : $2) "\t" $3; found = 1; exit } END { if (!found) print "MISSING\t" }'
+          assert_multi_arch_image() {
+            local image_ref="$1"
+            local image_digest manifest_json platform platform_digest
+
+            image_digest="${image_ref#*@}"
+            if [ "${image_digest}" = "${image_ref}" ] || ! printf '%s' "${image_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Release manifest image is not digest pinned: ${image_ref}"
+              exit 1
+            fi
+
+            manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image_ref}")"
+            for platform in linux/amd64 linux/arm64; do
+              platform_digest="$(
+                jq -r --arg platform "${platform}" \
+                  '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                  <<< "${manifest_json}" | head -n 1
               )"
-              IFS=$'\t' read -r conclusion status <<< "${state}"
-              case "${conclusion}" in
-                success)
-                  ;;
-                MISSING)
-                  echo "Required build-push job is missing from run ${run_id}: ${required_job}"
-                  exit 1
-                  ;;
-                PENDING)
-                  echo "Required build-push job did not complete in successful run ${run_id}: ${required_job} (${status:-unknown})"
-                  exit 1
-                  ;;
-                failure | cancelled | skipped | timed_out | action_required | startup_failure)
-                  echo "Required build-push job failed in run ${run_id}: ${required_job} -> ${conclusion}"
-                  exit 1
-                  ;;
-                *)
-                  echo "Required build-push job has unexpected conclusion in run ${run_id}: ${required_job} -> ${conclusion}"
-                  exit 1
-                  ;;
-              esac
+              if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+                echo "Release manifest image ${image_ref} is missing required platform ${platform}"
+                docker buildx imagetools inspect "${image_ref}"
+                exit 1
+              fi
             done
           }
 
-          verify_build_contract() {
+          verify_image_contract() {
             local label="$1"
             local manifest_path="$2"
             local env_name="$3"
-            local workflow_name="$4"
-            local source_sha
+            local image_name="$4"
+            local source_sha image_ref
+
             source_sha="$(resolve_source_sha "${manifest_path}" "${env_name}")"
             if ! printf '%s' "${source_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
               echo "Unable to resolve ${env_name} from ${manifest_path}"
               exit 1
             fi
-            echo "${label} release manifest-only change; requiring successful multi-arch build for ${source_sha}."
 
-            deadline=$((SECONDS + 900))
-            while true; do
-              run_line="$(
-                gh run list \
-                  -R "${GH_REPO}" \
-                  --workflow "${workflow_name}" \
-                  --commit "${source_sha}" \
-                  --json databaseId,status,conclusion,url,createdAt \
-                  --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
-              )"
-              IFS=$'\t' read -r run_id run_status run_conclusion run_url <<< "${run_line}"
+            image_ref="$(resolve_image_ref "${manifest_path}" "${image_name}")"
+            if [ -z "${image_ref}" ]; then
+              echo "Unable to resolve digest-pinned ${image_name} image from ${manifest_path}"
+              exit 1
+            fi
 
-              if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
-                assert_required_build_jobs "${run_id}"
-                echo "${label} build-push passed required image contract jobs for ${source_sha}: ${run_url}"
-                break
-              fi
-
-              if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
-                echo "${label} build-push did not pass for ${source_sha}: ${run_conclusion}"
-                echo "${run_url}"
-                exit 1
-              fi
-
-              if [ "${SECONDS}" -ge "${deadline}" ]; then
-                echo "Timed out waiting for ${label} build-push for ${source_sha}"
-                if [ -n "${run_url}" ]; then
-                  echo "${run_url}"
-                fi
-                exit 1
-              fi
-
-              if [ -z "${run_id}" ]; then
-                echo "Waiting for ${label} build-push to appear for ${source_sha}"
-              else
-                echo "Waiting for ${label} build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
-              fi
-              sleep 10
-            done
+            assert_multi_arch_image "${image_ref}"
+            echo "${label} release manifest pins a multi-arch image digest for ${source_sha}: ${image_ref}"
           }
 
           verified_any=false
           if matches_changed '^argocd/applications/(torghut/(knative-service(-sim)?|db-migrations-job|historical-simulation-workflowtemplate|empirical-promotion-workflowtemplate|empirical-promotion-renewal-cronjob|whitepaper-autoresearch-workflowtemplate|analysis-template-(runtime-ready|activity|teardown-clean|artifact-bundle)|empirical-jobs-backfill-job|execution-tca-refresh-cronjob|order-feed-source-window-repair-cronjob|zero-notional-drift-repair-cronjob|paper-account-flatten-cronjob|whitepaper-semantic-backfill-job|tigerbeetle-smoke-job)\.yaml|torghut-options/(catalog|enricher)/deployment\.yaml|torghut-hyperliquid-runtime/(deployment|db-migrations-job)\.yaml)$'; then
-            verify_build_contract \
+            verify_image_contract \
               "Torghut" \
               argocd/applications/torghut/knative-service.yaml \
               TORGHUT_COMMIT \
-              torghut-build-push.yaml
+              registry.ide-newton.ts.net/lab/torghut
             verified_any=true
           fi
           if matches_changed '^argocd/applications/(torghut/(ta|ta-sim)/flinkdeployment\.yaml|torghut-options/ta/flinkdeployment\.yaml)$'; then
-            verify_build_contract \
+            verify_image_contract \
               "Torghut TA" \
               argocd/applications/torghut/ta/flinkdeployment.yaml \
               TORGHUT_TA_COMMIT \
-              torghut-ta-build-push.yaml
+              registry.ide-newton.ts.net/lab/torghut-ta
             verified_any=true
           fi
           if matches_changed '^argocd/applications/(torghut/ws/deployment\.yaml|torghut-options/ws/deployment\.yaml)$'; then
-            verify_build_contract \
+            verify_image_contract \
               "Torghut WS" \
               argocd/applications/torghut/ws/deployment.yaml \
               TORGHUT_WS_COMMIT \
-              torghut-ws-build-push.yaml
+              registry.ide-newton.ts.net/lab/torghut-ws
             verified_any=true
           fi
 

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -190,7 +190,11 @@ jobs:
           printf 'eligible=%s\n' "${ELIGIBLE}"
           printf 'reason=%s\n' "${REASON}"
 
-      - name: Verify source image build contract
+      - name: Set up Docker Buildx
+        if: steps.gates.outputs.eligible == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Verify source image digest contract
         if: steps.gates.outputs.eligible == 'true' && steps.gates.outputs.release_lane != 'hyperliquid-feed'
         shell: bash
         env:
@@ -205,19 +209,19 @@ jobs:
             codex/torghut-release-*)
               source_manifest='argocd/applications/torghut/knative-service.yaml'
               source_env_name='TORGHUT_COMMIT'
-              build_workflow='torghut-build-push.yaml'
+              expected_image='registry.ide-newton.ts.net/lab/torghut'
               build_label='Torghut'
               ;;
             codex/torghut-ta-release-*)
               source_manifest='argocd/applications/torghut/ta/flinkdeployment.yaml'
               source_env_name='TORGHUT_TA_COMMIT'
-              build_workflow='torghut-ta-build-push.yaml'
+              expected_image='registry.ide-newton.ts.net/lab/torghut-ta'
               build_label='Torghut TA'
               ;;
             codex/torghut-ws-release-*)
               source_manifest='argocd/applications/torghut/ws/deployment.yaml'
               source_env_name='TORGHUT_WS_COMMIT'
-              build_workflow='torghut-ws-build-push.yaml'
+              expected_image='registry.ide-newton.ts.net/lab/torghut-ws'
               build_label='Torghut WS'
               ;;
             *)
@@ -231,9 +235,11 @@ jobs:
               -H 'Accept: application/vnd.github.raw' \
               "repos/${GH_REPO}/contents/${source_manifest}?ref=${PR_HEAD_SHA}"
           )"
-          source_sha="$(
+
+          resolve_env_value() {
+            local env_name="$1"
             printf '%s\n' "${manifest}" |
-              awk -v env_name="${source_env_name}" '
+              awk -v env_name="${env_name}" '
                 $0 ~ "^[[:space:]]*- name:[[:space:]]*" env_name "[[:space:]]*$" { found = 1; next }
                 found && /^[[:space:]]*value:/ {
                   sub(/^[[:space:]]*value:[[:space:]]*/, "")
@@ -242,100 +248,64 @@ jobs:
                   exit
                 }
               '
-          )"
+          }
+
+          resolve_image_ref() {
+            local image_name="$1"
+            printf '%s\n' "${manifest}" |
+              awk -v expected="${image_name}" '
+                /^[[:space:]]*image:[[:space:]]*/ {
+                  sub(/^[[:space:]]*image:[[:space:]]*/, "")
+                  gsub(/"/, "")
+                  if (index($0, expected "@sha256:") == 1) {
+                    print
+                    exit
+                  }
+                }
+              '
+          }
+
+          assert_multi_arch_image() {
+            local image_ref="$1"
+            local image_digest manifest_json platform platform_digest
+
+            image_digest="${image_ref#*@}"
+            if [ "${image_digest}" = "${image_ref}" ] || ! printf '%s' "${image_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Release manifest image is not digest pinned: ${image_ref}"
+              exit 1
+            fi
+
+            manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image_ref}")"
+            for platform in linux/amd64 linux/arm64; do
+              platform_digest="$(
+                jq -r --arg platform "${platform}" \
+                  '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                  <<< "${manifest_json}" | head -n 1
+              )"
+              if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+                echo "Release manifest image ${image_ref} is missing required platform ${platform}"
+                docker buildx imagetools inspect "${image_ref}"
+                exit 1
+              fi
+            done
+          }
+
+          source_sha="$(resolve_env_value "${source_env_name}")"
           if ! printf '%s' "${source_sha}" | grep -Eq '^[0-9a-f]{40}$'; then
             echo "Unable to resolve ${source_env_name} from ${source_manifest}"
             exit 1
           fi
 
-          required_build_jobs=(
-            'build-platform (linux/amd64, amd64, arc-amd64)'
-            'build-platform (linux/arm64, arm64, arc-arm64)'
-            'publish-index'
-          )
+          image_ref="$(resolve_image_ref "${expected_image}")"
+          if [ -z "${image_ref}" ]; then
+            echo "Unable to resolve digest-pinned ${expected_image} image from ${source_manifest}"
+            exit 1
+          fi
 
-          assert_required_build_jobs() {
-            local run_id="$1"
-            local job_lines
-            job_lines="$(
-              gh run view "${run_id}" \
-                -R "${GH_REPO}" \
-                --json jobs \
-                --jq '.jobs[] | [.name, (.conclusion // ""), (.status // "")] | @tsv'
-            )"
+          assert_multi_arch_image "${image_ref}"
+          echo "${build_label} release manifest pins a multi-arch image digest for ${source_sha}: ${image_ref}"
 
-            for required_job in "${required_build_jobs[@]}"; do
-              state="$(
-                printf '%s\n' "${job_lines}" |
-                  awk -F '\t' \
-                    -v name="${required_job}" \
-                    '$1 == name { print ($2 == "" ? "PENDING" : $2) "\t" $3; found = 1; exit } END { if (!found) print "MISSING\t" }'
-              )"
-              IFS=$'\t' read -r conclusion status <<< "${state}"
-              case "${conclusion}" in
-                success)
-                  ;;
-                MISSING)
-                  echo "Required build-push job is missing from run ${run_id}: ${required_job}"
-                  exit 1
-                  ;;
-                PENDING)
-                  echo "Required build-push job did not complete in successful run ${run_id}: ${required_job} (${status:-unknown})"
-                  exit 1
-                  ;;
-                failure | cancelled | skipped | timed_out | action_required | startup_failure)
-                  echo "Required build-push job failed in run ${run_id}: ${required_job} -> ${conclusion}"
-                  exit 1
-                  ;;
-                *)
-                  echo "Required build-push job has unexpected conclusion in run ${run_id}: ${required_job} -> ${conclusion}"
-                  exit 1
-                  ;;
-              esac
-            done
-          }
-
-          deadline=$((SECONDS + 900))
-          while true; do
-            run_line="$(
-              gh run list \
-                -R "${GH_REPO}" \
-                --workflow "${build_workflow}" \
-                --commit "${source_sha}" \
-                --json databaseId,status,conclusion,url,createdAt \
-                --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
-            )"
-            IFS=$'\t' read -r run_id run_status run_conclusion run_url <<< "${run_line}"
-
-            if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
-              assert_required_build_jobs "${run_id}"
-              echo "${build_label} build-push passed required image contract jobs for ${source_sha}: ${run_url}"
-              break
-            fi
-
-            if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
-              echo "${build_label} build-push did not pass for ${source_sha}: ${run_conclusion}"
-              echo "${run_url}"
-              exit 1
-            fi
-
-            if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "Timed out waiting for ${build_label} build-push for ${source_sha}"
-              if [ -n "${run_url}" ]; then
-                echo "${run_url}"
-              fi
-              exit 1
-            fi
-
-            if [ -z "${run_id}" ]; then
-              echo "Waiting for ${build_label} build-push to appear for ${source_sha}"
-            else
-              echo "Waiting for ${build_label} build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
-            fi
-            sleep 10
-          done
-
-      - name: Verify source Hyperliquid feed image build contract
+      - name: Verify source Hyperliquid feed image digest contract
         if: steps.gates.outputs.eligible == 'true' && steps.gates.outputs.release_lane == 'hyperliquid-feed'
         shell: bash
         env:
@@ -350,6 +320,7 @@ jobs:
               -H 'Accept: application/vnd.github.raw' \
               "repos/${GH_REPO}/contents/argocd/applications/torghut-hyperliquid-feed/deployment.yaml?ref=${PR_HEAD_SHA}"
           )"
+
           source_sha="$(
             printf '%s\n' "${manifest}" |
               awk '
@@ -367,92 +338,40 @@ jobs:
             exit 1
           fi
 
-          required_build_jobs=(
-            'build-platform (linux/amd64, amd64, arc-amd64)'
-            'build-platform (linux/arm64, arm64, arc-arm64)'
-            'publish-index'
-          )
+          image_ref="$(
+            printf '%s\n' "${manifest}" |
+              awk '
+                /^[[:space:]]*image:[[:space:]]*/ {
+                  sub(/^[[:space:]]*image:[[:space:]]*/, "")
+                  gsub(/"/, "")
+                  if (index($0, "registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:") == 1) {
+                    print
+                    exit
+                  }
+                }
+              '
+          )"
+          image_digest="${image_ref#*@}"
+          if [ -z "${image_ref}" ] || [ "${image_digest}" = "${image_ref}" ] || ! printf '%s' "${image_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+            echo "Unable to resolve digest-pinned Hyperliquid feed image from release manifest"
+            exit 1
+          fi
 
-          assert_required_build_jobs() {
-            local run_id="$1"
-            local job_lines
-            job_lines="$(
-              gh run view "${run_id}" \
-                -R "${GH_REPO}" \
-                --json jobs \
-                --jq '.jobs[] | [.name, (.conclusion // ""), (.status // "")] | @tsv'
+          manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image_ref}")"
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${manifest_json}" | head -n 1
             )"
-
-            for required_job in "${required_build_jobs[@]}"; do
-              state="$(
-                printf '%s\n' "${job_lines}" |
-                  awk -F '\t' \
-                    -v name="${required_job}" \
-                    '$1 == name { print ($2 == "" ? "PENDING" : $2) "\t" $3; found = 1; exit } END { if (!found) print "MISSING\t" }'
-              )"
-              IFS=$'\t' read -r conclusion status <<< "${state}"
-              case "${conclusion}" in
-                success)
-                  ;;
-                MISSING)
-                  echo "Required Hyperliquid feed build-push job is missing from run ${run_id}: ${required_job}"
-                  exit 1
-                  ;;
-                PENDING)
-                  echo "Required Hyperliquid feed build-push job did not complete in successful run ${run_id}: ${required_job} (${status:-unknown})"
-                  exit 1
-                  ;;
-                failure | cancelled | skipped | timed_out | action_required | startup_failure)
-                  echo "Required Hyperliquid feed build-push job failed in run ${run_id}: ${required_job} -> ${conclusion}"
-                  exit 1
-                  ;;
-                *)
-                  echo "Required Hyperliquid feed build-push job has unexpected conclusion in run ${run_id}: ${required_job} -> ${conclusion}"
-                  exit 1
-                  ;;
-              esac
-            done
-          }
-
-          deadline=$((SECONDS + 900))
-          while true; do
-            run_line="$(
-              gh run list \
-                -R "${GH_REPO}" \
-                --workflow torghut-hyperliquid-feed-build-push.yaml \
-                --commit "${source_sha}" \
-                --json databaseId,status,conclusion,url,createdAt \
-                --jq 'sort_by(.createdAt) | reverse | .[0] // {} | [.databaseId // "", .status // "", .conclusion // "", .url // ""] | @tsv'
-            )"
-            IFS=$'\t' read -r run_id run_status run_conclusion run_url <<< "${run_line}"
-
-            if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ] && [ "${run_conclusion}" = 'success' ]; then
-              assert_required_build_jobs "${run_id}"
-              echo "Hyperliquid feed build-push passed required image contract jobs for ${source_sha}: ${run_url}"
-              break
-            fi
-
-            if [ -n "${run_id}" ] && [ "${run_status}" = 'completed' ]; then
-              echo "Source commit Hyperliquid feed build did not pass for ${source_sha}: ${run_conclusion}"
-              echo "${run_url}"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Hyperliquid feed release manifest image ${image_ref} is missing required platform ${platform}"
+              docker buildx imagetools inspect "${image_ref}"
               exit 1
             fi
-
-            if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "Timed out waiting for source commit Hyperliquid feed build for ${source_sha}"
-              if [ -n "${run_url}" ]; then
-                echo "${run_url}"
-              fi
-              exit 1
-            fi
-
-            if [ -z "${run_id}" ]; then
-              echo "Waiting for Hyperliquid feed build-push to appear for ${source_sha}"
-            else
-              echo "Waiting for Hyperliquid feed build-push: status=${run_status} conclusion=${run_conclusion:-pending}"
-            fi
-            sleep 10
           done
+
+          echo "Hyperliquid feed release manifest pins a multi-arch image digest for ${source_sha}: ${image_ref}"
 
       - name: Wait for required release checks
         if: steps.gates.outputs.eligible == 'true'

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -183,7 +183,7 @@ describe('torghut build-push workflow', () => {
     const releaseManifestJobBody = ciWorkflow.slice(releaseManifestJob, nextJob)
 
     expect(releaseManifestJob).toBeGreaterThan(-1)
-    expect(releaseManifestJobBody).toContain('name: Verify source image build contract')
+    expect(releaseManifestJobBody).toContain('name: Verify source image digest contract')
     expect(releaseManifestJobBody).toContain('TORGHUT_COMMIT')
     expect(releaseManifestJobBody).toContain('TORGHUT_TA_COMMIT')
     expect(releaseManifestJobBody).toContain('TORGHUT_WS_COMMIT')
@@ -220,21 +220,26 @@ describe('torghut build-push workflow', () => {
     expect(prFilesCall).toBeGreaterThan(authHeader)
   })
 
-  it('gates release manifest-only CI on the completed build-push image contract', () => {
+  it('gates release manifest-only CI on digest-pinned multi-arch image contracts', () => {
     const releaseManifestJob = ciWorkflow.indexOf('release-manifests:')
-    const buildContractStep = ciWorkflow.indexOf('name: Verify source image build contract', releaseManifestJob)
+    const buildContractStep = ciWorkflow.indexOf('name: Verify source image digest contract', releaseManifestJob)
+    const releaseManifestJobBody = ciWorkflow.slice(
+      releaseManifestJob,
+      ciWorkflow.indexOf('\n  pyright:', releaseManifestJob),
+    )
 
     expect(buildContractStep).toBeGreaterThan(releaseManifestJob)
-    expect(ciWorkflow).toContain('torghut-build-push.yaml')
-    expect(ciWorkflow).toContain('torghut-ta-build-push.yaml')
-    expect(ciWorkflow).toContain('torghut-ws-build-push.yaml')
-    expect(ciWorkflow).toContain('argocd/applications/torghut/knative-service.yaml')
-    expect(ciWorkflow).toContain('argocd/applications/torghut/ta/flinkdeployment.yaml')
-    expect(ciWorkflow).toContain('argocd/applications/torghut/ws/deployment.yaml')
-    expect(ciWorkflow).toContain('build-platform (linux/amd64, amd64, arc-amd64)')
-    expect(ciWorkflow).toContain('build-platform (linux/arm64, arm64, arc-arm64)')
-    expect(ciWorkflow).toContain('publish-index')
-    expect(ciWorkflow).toContain('build-push passed required image contract jobs')
+    expect(releaseManifestJobBody).toContain('argocd/applications/torghut/knative-service.yaml')
+    expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ta/flinkdeployment.yaml')
+    expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ws/deployment.yaml')
+    expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net/lab/torghut')
+    expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net/lab/torghut-ta')
+    expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net/lab/torghut-ws')
+    expect(releaseManifestJobBody).toContain('docker buildx imagetools inspect')
+    expect(releaseManifestJobBody).toContain('for platform in linux/amd64 linux/arm64; do')
+    expect(releaseManifestJobBody).toContain('release manifest pins a multi-arch image digest')
+    expect(releaseManifestJobBody).not.toContain('gh run list')
+    expect(releaseManifestJobBody).not.toContain('gh run view')
     expect(ciWorkflow).not.toContain('name: Require source commit Torghut CI')
     expect(ciWorkflow).not.toContain('--workflow torghut-ci.yml')
   })

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -59,8 +59,8 @@ describe('torghut-deploy-automerge workflow', () => {
     }
   })
 
-  test('verifies the matching source build-push image contract instead of waiting for full source CI', () => {
-    expect(deployAutomergeWorkflow).toContain('name: Verify source image build contract')
+  test('verifies the promoted digest contract without rediscovering source build runs', () => {
+    expect(deployAutomergeWorkflow).toContain('name: Verify source image digest contract')
     expect(deployAutomergeWorkflow).toContain(
       "startsWith(github.event.pull_request.head.ref, 'codex/torghut-release-')",
     )
@@ -70,21 +70,22 @@ describe('torghut-deploy-automerge workflow', () => {
     expect(deployAutomergeWorkflow).toContain(
       "startsWith(github.event.pull_request.head.ref, 'codex/torghut-ws-release-')",
     )
-    expect(deployAutomergeWorkflow).toContain("build_workflow='torghut-build-push.yaml'")
-    expect(deployAutomergeWorkflow).toContain("build_workflow='torghut-ta-build-push.yaml'")
-    expect(deployAutomergeWorkflow).toContain("build_workflow='torghut-ws-build-push.yaml'")
+    expect(deployAutomergeWorkflow).toContain("expected_image='registry.ide-newton.ts.net/lab/torghut'")
+    expect(deployAutomergeWorkflow).toContain("expected_image='registry.ide-newton.ts.net/lab/torghut-ta'")
+    expect(deployAutomergeWorkflow).toContain("expected_image='registry.ide-newton.ts.net/lab/torghut-ws'")
     expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_COMMIT'")
     expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_TA_COMMIT'")
     expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_WS_COMMIT'")
-    expect(deployAutomergeWorkflow).toContain('build-platform (linux/amd64, amd64, arc-amd64)')
-    expect(deployAutomergeWorkflow).toContain('build-platform (linux/arm64, arm64, arc-arm64)')
-    expect(deployAutomergeWorkflow).toContain('publish-index')
-    expect(deployAutomergeWorkflow).toContain('build-push passed required image contract jobs')
+    expect(deployAutomergeWorkflow).toContain('docker buildx imagetools inspect')
+    expect(deployAutomergeWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')
+    expect(deployAutomergeWorkflow).toContain('release manifest pins a multi-arch image digest')
+    expect(deployAutomergeWorkflow).not.toContain('gh run list')
+    expect(deployAutomergeWorkflow).not.toContain('gh run view')
     expect(deployAutomergeWorkflow).not.toContain('name: Wait for source commit Torghut CI')
     expect(deployAutomergeWorkflow).not.toContain('--workflow torghut-ci.yml')
   })
 
-  test('allowlists hyperliquid feed image promotion PRs with a feed build gate', () => {
+  test('allowlists hyperliquid feed image promotion PRs with a feed digest gate', () => {
     const manifestPath = 'argocd/applications/torghut-hyperliquid-feed/deployment.yaml'
 
     expect(hyperliquidFeedReleaseWorkflow).toContain(manifestPath)
@@ -96,9 +97,8 @@ describe('torghut-deploy-automerge workflow', () => {
       "startsWith(github.event.pull_request.head.ref, 'codex/torghut-hyperliquid-feed-release-')",
     )
     expect(deployAutomergeWorkflow).toContain("steps.gates.outputs.release_lane == 'hyperliquid-feed'")
-    expect(deployAutomergeWorkflow).toContain('torghut-hyperliquid-feed-build-push.yaml')
-    expect(deployAutomergeWorkflow).toContain('name: Verify source Hyperliquid feed image build contract')
-    expect(deployAutomergeWorkflow).toContain('Hyperliquid feed build-push passed required image contract jobs')
+    expect(deployAutomergeWorkflow).toContain('name: Verify source Hyperliquid feed image digest contract')
+    expect(deployAutomergeWorkflow).toContain('Hyperliquid feed release manifest pins a multi-arch image digest')
     expect(deployAutomergeWorkflow).toContain('TORGHUT_HYPERLIQUID_FEED_COMMIT')
   })
 })


### PR DESCRIPTION
## Summary

- Replace Torghut deploy-automerge build-run polling with direct validation of the digest-pinned image in the release manifest.
- Replace Torghut CI manifest-only release polling with the same registry multi-arch digest contract for core, TA, and WS promotions.
- Keep the release safety contract: source commit envs must resolve, images must be digest-pinned, and each digest must expose `linux/amd64` and `linux/arm64`.
- Update workflow tests so the slow `gh run list` / `gh run view` path cannot be reintroduced.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/torghut-ci.yml .github/workflows/torghut-deploy-automerge.yml`
- `git diff --check`
- `docker buildx imagetools inspect --format '{{json .}}'` against the currently pinned `lab/torghut`, `lab/torghut-ta`, and `lab/torghut-ws` GitOps digests, confirming both `linux/amd64` and `linux/arm64` manifests.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
