### PR TITLE
fix(torghut): reconcile hyperliquid open orders

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/exchange.py
+++ b/services/torghut/app/hyperliquid_runtime/exchange.py
@@ -39,6 +39,12 @@ class HyperliquidExchange(Protocol):
         """Read current account and position state from the dedicated testnet account."""
         ...
 
+    def reconcile_open_order_market_ids(
+        self, market_id_by_coin: dict[str, str]
+    ) -> frozenset[str]:
+        """Read market ids with currently open exchange orders."""
+        ...
+
     def filter_supported_markets(
         self,
         markets: tuple[HyperliquidMarket, ...],
@@ -88,6 +94,13 @@ class ShadowHyperliquidExchange:
             ),
             positions=(),
         )
+
+    def reconcile_open_order_market_ids(
+        self, market_id_by_coin: dict[str, str]
+    ) -> frozenset[str]:
+        _ = market_id_by_coin
+        self._observed_at = datetime.now(timezone.utc)
+        return frozenset()
 
     def filter_supported_markets(
         self,
@@ -145,6 +158,14 @@ class UnavailableHyperliquidExchange:
                 raw_payload={"unavailable": True, "reasons": list(self._reasons)},
             ),
             positions=(),
+        )
+
+    def reconcile_open_order_market_ids(
+        self, market_id_by_coin: dict[str, str]
+    ) -> frozenset[str]:
+        _ = market_id_by_coin
+        raise RuntimeError(
+            f"hyperliquid_exchange_unavailable:{','.join(self._reasons)}"
         )
 
     def filter_supported_markets(
@@ -238,6 +259,25 @@ class HyperliquidSdkExchange:
         raw_state = cast(dict[str, object], info.user_state(account))
         self._last_exchange_read_at = observed_at
         return _account_state_from_payload(raw_state, market_id_by_coin, observed_at)
+
+    def reconcile_open_order_market_ids(
+        self, market_id_by_coin: dict[str, str]
+    ) -> frozenset[str]:
+        info = self._info()
+        account = self._config.account_address
+        if account is None:
+            return frozenset()
+        open_market_ids: set[str] = set()
+        for dex in _open_order_dexes(market_id_by_coin):
+            raw_orders = cast(
+                list[dict[str, object]], info.open_orders(account, dex=dex)
+            )
+            for raw_order in raw_orders:
+                market_id = market_id_by_coin.get(_open_order_coin(raw_order))
+                if market_id:
+                    open_market_ids.add(market_id)
+        self._last_exchange_read_at = datetime.now(timezone.utc)
+        return frozenset(open_market_ids)
 
     def filter_supported_markets(
         self,
@@ -493,6 +533,10 @@ def _fill_coin(payload: dict[str, object]) -> str:
     return str(payload.get("coin") or "").strip()
 
 
+def _open_order_coin(payload: dict[str, object]) -> str:
+    return str(payload.get("coin") or "").strip()
+
+
 def _account_state_from_payload(
     payload: dict[str, object],
     market_id_by_coin: dict[str, str],
@@ -566,6 +610,19 @@ def _execution_metadata_dexes(
     dexes = {_sdk_dex(market.dex) for market in markets}
     _ = execution_network
     return tuple(sorted(dexes))
+
+
+def _open_order_dexes(market_id_by_coin: dict[str, str]) -> tuple[str, ...]:
+    dexes = {_coin_dex(coin) for coin in market_id_by_coin}
+    dexes.add("")
+    return tuple(sorted(dexes))
+
+
+def _coin_dex(coin: str) -> str:
+    prefix, separator, _suffix = coin.partition(":")
+    if not separator:
+        return ""
+    return prefix.strip()
 
 
 def _decimal(value: object) -> Decimal:

--- a/services/torghut/app/hyperliquid_runtime/repository.py
+++ b/services/torghut/app/hyperliquid_runtime/repository.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Iterable
+from typing import Iterable, Mapping, cast
 
 from sqlalchemy import text
 
@@ -17,6 +17,7 @@ from .models import (
     HyperliquidMarket,
     OrderIntent,
     OrderResult,
+    OrderSide,
     PerformanceSnapshot,
     RiskState,
     RuntimeDependencyStatus,
@@ -265,6 +266,93 @@ class HyperliquidRuntimeRepository:
             },
         )
         return order_id
+
+    def reconcile_closed_orders(
+        self, *, open_order_market_ids: frozenset[str]
+    ) -> list[tuple[OrderIntent, OrderResult]]:
+        release_orders: list[tuple[OrderIntent, OrderResult]] = []
+        rows = self._session.execute(
+            text(
+                """
+                    SELECT
+                      o.decision_id,
+                      o.network,
+                      o.market_id,
+                      o.coin,
+                      o.cloid,
+                      o.exchange_order_id,
+                      o.side,
+                      o.size,
+                      o.limit_price,
+                      o.notional_usd,
+                      o.reduce_only,
+                      EXISTS (
+                        SELECT 1
+                        FROM hyperliquid_runtime_fills f
+                        WHERE f.network = o.network
+                          AND f.exchange_order_id IS NOT NULL
+                          AND f.exchange_order_id = o.exchange_order_id
+                      ) AS has_fill
+                    FROM hyperliquid_runtime_orders o
+                    WHERE o.network = 'testnet'
+                      AND o.status IN ('accepted', 'submitted')
+                    """
+            )
+        ).mappings()
+        for row in rows:
+            row_map = cast(Mapping[str, object], row)
+            market_id = str(row_map["market_id"])
+            if market_id in open_order_market_ids:
+                continue
+            has_fill = bool(row_map["has_fill"])
+            reconciled_status = "filled" if has_fill else "cancelled"
+            rejection_reason = None
+            if not has_fill:
+                rejection_reason = "not_open_on_exchange_reconciliation"
+            reconciliation_payload: dict[str, object] = {
+                "source": "exchange_open_orders",
+                "open_on_exchange": False,
+                "filled_from_reconciled_fills": has_fill,
+            }
+            raw_response: dict[str, object] = {"reconciliation": reconciliation_payload}
+            self._session.execute(
+                text(
+                    """
+                    UPDATE hyperliquid_runtime_orders
+                    SET
+                      status = :status,
+                      rejection_reason = :rejection_reason,
+                      raw_response = raw_response || CAST(:raw_response AS jsonb),
+                      updated_at = now()
+                    WHERE network = :network
+                      AND cloid = :cloid
+                      AND status IN ('accepted', 'submitted')
+                    """
+                ),
+                {
+                    "network": str(row_map["network"]),
+                    "cloid": str(row_map["cloid"]),
+                    "status": reconciled_status,
+                    "rejection_reason": rejection_reason,
+                    "raw_response": json.dumps(raw_response, sort_keys=True),
+                },
+            )
+            if not has_fill:
+                intent = _order_intent_from_row(row_map)
+                release_orders.append(
+                    (
+                        intent,
+                        OrderResult(
+                            status="cancelled",
+                            exchange_order_id=_optional_text(
+                                row_map["exchange_order_id"]
+                            ),
+                            raw_response=raw_response,
+                            rejection_reason=rejection_reason,
+                        ),
+                    )
+                )
+        return release_orders
 
     def upsert_fills(self, fills: Iterable[Fill]) -> int:
         count = 0
@@ -534,6 +622,41 @@ def _decision_hash(
     return hashlib.sha256(
         f"{signal_id}\0{status}\0{reason}".encode("utf-8")
     ).hexdigest()
+
+
+def _order_intent_from_row(row: Mapping[str, object]) -> OrderIntent:
+    return OrderIntent(
+        market_id=str(row["market_id"]),
+        coin=str(row["coin"]),
+        dex=_coin_dex(str(row["coin"])),
+        side=_order_side(row["side"]),
+        size=Decimal(str(row["size"])),
+        limit_price=Decimal(str(row["limit_price"])),
+        notional_usd=Decimal(str(row["notional_usd"])),
+        cloid=str(row["cloid"]),
+        reduce_only=bool(row["reduce_only"]),
+        decision_id=str(row["decision_id"]),
+    )
+
+
+def _order_side(value: object) -> OrderSide:
+    side = str(value)
+    if side not in {"buy", "sell"}:
+        raise ValueError(f"invalid_order_side:{side}")
+    return cast(OrderSide, side)
+
+
+def _coin_dex(coin: str) -> str:
+    prefix, separator, _suffix = coin.partition(":")
+    if not separator:
+        return "default"
+    return prefix.strip()
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
 
 
 def _decimal_or_none(value: Decimal | None) -> str | None:

--- a/services/torghut/app/hyperliquid_runtime/service.py
+++ b/services/torghut/app/hyperliquid_runtime/service.py
@@ -183,10 +183,17 @@ class HyperliquidRuntimeService:
                 self._journal.persist_refs(session, self._journal.fill_events(fill))
         account_state = self._exchange.reconcile_account(market_id_by_coin)
         repository.upsert_account_state(account_state)
+        open_order_status = self._reconcile_closed_orders(
+            session=session,
+            repository=repository,
+            market_id_by_coin=market_id_by_coin,
+            journal_status=journal_status,
+        )
         exchange_status = self._exchange.dependency_status()
         dependencies = clickhouse_status.statuses + (
             execution_universe_status,
             feature_status,
+            open_order_status,
             journal_status,
             exchange_status,
         )
@@ -200,6 +207,48 @@ class HyperliquidRuntimeService:
             fill_count=fill_count,
             exchange_ready=exchange_status.ready,
             journal_ready=journal_status.ready,
+        )
+
+    def _reconcile_closed_orders(
+        self,
+        *,
+        session: RuntimeSession,
+        repository: HyperliquidRuntimeRepository,
+        market_id_by_coin: dict[str, str],
+        journal_status: RuntimeDependencyStatus,
+    ) -> RuntimeDependencyStatus:
+        status_name = "hyperliquid_open_order_reconciliation"
+        if not self._config.trading_enabled or not market_id_by_coin:
+            return RuntimeDependencyStatus(name=status_name, ready=True)
+        if not journal_status.ready:
+            return RuntimeDependencyStatus(
+                name=status_name,
+                ready=True,
+                reason="skipped_journal_not_ready",
+            )
+        try:
+            open_order_market_ids = self._exchange.reconcile_open_order_market_ids(
+                market_id_by_coin
+            )
+        except Exception as exc:
+            return RuntimeDependencyStatus(
+                name=status_name,
+                ready=False,
+                reason=f"open_order_reconciliation_failed:{type(exc).__name__}",
+            )
+        release_orders = repository.reconcile_closed_orders(
+            open_order_market_ids=open_order_market_ids
+        )
+        for intent, result in release_orders:
+            self._journal.persist_refs(
+                session,
+                self._journal.order_events(intent, result),
+            )
+        return RuntimeDependencyStatus(
+            name=status_name,
+            ready=True,
+            observed_at=datetime.now(timezone.utc),
+            lag_seconds=0,
         )
 
     def _process_feature(

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -273,6 +273,10 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
 ) -> None:
     shadow = ShadowHyperliquidExchange()
     assert shadow.reconcile_fills({"cash:AAPL": "hl:perp:cash:cash:AAPL"}) == []
+    assert (
+        shadow.reconcile_open_order_market_ids({"cash:AAPL": "hl:perp:cash:cash:AAPL"})
+        == frozenset()
+    )
     shadow_markets, shadow_status = shadow.filter_supported_markets((_market(),))
     assert shadow_markets == (_market(),)
     assert shadow_status.ready
@@ -288,6 +292,10 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     assert not unavailable_status.ready
     with pytest.raises(RuntimeError, match="hyperliquid_exchange_unavailable"):
         unavailable.submit_ioc_limit(_intent())
+    with pytest.raises(RuntimeError, match="hyperliquid_exchange_unavailable"):
+        unavailable.reconcile_open_order_market_ids(
+            {"cash:AAPL": "hl:perp:cash:cash:AAPL"}
+        )
     unavailable.schedule_dead_man_cancel(seconds_from_now=30)
 
     sdk_calls: dict[str, object] = {}
@@ -330,6 +338,15 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
                 },
                 {"coin": "BTC", "side": "A", "px": "1", "sz": "1", "time": 0},
             ]
+
+        def open_orders(self, account: str, dex: str = "") -> list[dict[str, object]]:
+            sdk_calls["open_orders_account"] = account
+            open_order_dexes = sdk_calls.setdefault("open_order_dexes", [])
+            assert isinstance(open_order_dexes, list)
+            open_order_dexes.append(dex)
+            if dex == "":
+                return [{"coin": "SPX"}, {"coin": "BTC"}]
+            return [{"coin": "cash:AAPL"}]
 
         def meta(self, dex: str = "") -> dict[str, object]:
             meta_dexes = sdk_calls.setdefault("meta_dexes", [])
@@ -405,6 +422,12 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
         )
     )
     fills = sdk_exchange.reconcile_fills({"cash:AAPL": "hl:perp:cash:cash:AAPL"})
+    open_market_ids = sdk_exchange.reconcile_open_order_market_ids(
+        {
+            "SPX": "hl:perp:default:SPX",
+            "cash:AAPL": "hl:perp:cash:cash:AAPL",
+        }
+    )
     sdk_exchange.schedule_dead_man_cancel(seconds_from_now=30)
 
     assert supported_markets == (
@@ -418,6 +441,8 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     assert empty_status.ready
     assert sdk_calls["meta_dexes"] == ["", "cash"]
     assert sdk_calls["exchange_init"][1]["perp_dexs"] == ["", "cash"]
+    assert sdk_calls["open_order_dexes"] == ["", "cash"]
+    assert sdk_calls["open_orders_account"] == "0xabc"
     assert result.status == "accepted"
     assert result.exchange_order_id == "42"
     assert non_default_result.status == "accepted"
@@ -426,6 +451,9 @@ def test_exchange_shadow_unavailable_and_sdk_paths(
     assert sdk_calls["orders"][1]["name"] == "cash:AAPL"
     assert fills[0].notional_usd == Decimal("20.0")
     assert fills[0].fee_usd == Decimal("0.02")
+    assert open_market_ids == frozenset(
+        {"hl:perp:default:SPX", "hl:perp:cash:cash:AAPL"}
+    )
     assert sdk_exchange.dependency_status().ready
     assert isinstance(exchange_from_config(config), HyperliquidSdkExchange)
 

--- a/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
@@ -157,6 +157,7 @@ class _FakeSession:
     def __init__(self) -> None:
         self.executed: list[tuple[str, dict[str, object] | None]] = []
         self.committed = False
+        self.closed_order_rows: list[dict[str, object]] = []
 
     def execute(
         self, statement: object, params: dict[str, object] | None = None
@@ -176,6 +177,8 @@ class _FakeSession:
             )
         if "SELECT DISTINCT market_id" in sql:
             return _MappingResult([{"market_id": "hl:perp:cash:cash:AAPL"}])
+        if "FROM hyperliquid_runtime_orders o" in sql:
+            return _MappingResult(self.closed_order_rows)
         if "fill_summary AS" in sql:
             return _MappingResult(
                 [
@@ -250,11 +253,82 @@ def test_repository_writes_runtime_tables_and_reads_risk_state() -> None:
     )
 
 
+def test_repository_reconciles_orders_not_open_on_exchange() -> None:
+    session = _FakeSession()
+    session.closed_order_rows = [
+        {
+            "decision_id": "decision-cancelled",
+            "network": "testnet",
+            "market_id": "hl:perp:cash:cash:AAPL",
+            "coin": "cash:AAPL",
+            "cloid": "0x11111111111111111111111111111111",
+            "exchange_order_id": "41",
+            "side": "buy",
+            "size": "0.1",
+            "limit_price": "200",
+            "notional_usd": "20",
+            "reduce_only": False,
+            "has_fill": False,
+        },
+        {
+            "decision_id": "decision-filled",
+            "network": "testnet",
+            "market_id": "hl:perp:cash:cash:MSFT",
+            "coin": "cash:MSFT",
+            "cloid": "0x22222222222222222222222222222222",
+            "exchange_order_id": "42",
+            "side": "sell",
+            "size": "0.2",
+            "limit_price": "300",
+            "notional_usd": "60",
+            "reduce_only": False,
+            "has_fill": True,
+        },
+        {
+            "decision_id": "decision-open",
+            "network": "testnet",
+            "market_id": "hl:perp:cash:cash:TSLA",
+            "coin": "cash:TSLA",
+            "cloid": "0x33333333333333333333333333333333",
+            "exchange_order_id": "43",
+            "side": "buy",
+            "size": "0.1",
+            "limit_price": "250",
+            "notional_usd": "25",
+            "reduce_only": False,
+            "has_fill": False,
+        },
+    ]
+    repository = HyperliquidRuntimeRepository(session)
+
+    release_orders = repository.reconcile_closed_orders(
+        open_order_market_ids=frozenset({"hl:perp:cash:cash:TSLA"})
+    )
+
+    assert len(release_orders) == 1
+    intent, result = release_orders[0]
+    assert intent.market_id == "hl:perp:cash:cash:AAPL"
+    assert intent.dex == "cash"
+    assert result.status == "cancelled"
+    assert result.rejection_reason == "not_open_on_exchange_reconciliation"
+    update_params = [
+        params
+        for sql, params in session.executed
+        if "UPDATE hyperliquid_runtime_orders" in sql
+    ]
+    assert [params["status"] for params in update_params if params] == [
+        "cancelled",
+        "filled",
+    ]
+
+
 class _FakeRepository:
     def __init__(self, _session: _FakeSession) -> None:
         self.orders: list[tuple[OrderIntent, OrderResult]] = []
         self.performance: list[PerformanceSnapshot] = []
         self.account_states: list[AccountState] = []
+        self.closed_order_releases: list[tuple[OrderIntent, OrderResult]] = []
+        self.reconciled_open_order_market_ids: list[frozenset[str]] = []
 
     def upsert_markets(self, markets: list[HyperliquidMarket]) -> None:
         self.markets = markets
@@ -265,6 +339,12 @@ class _FakeRepository:
 
     def upsert_account_state(self, account_state: AccountState) -> None:
         self.account_states.append(account_state)
+
+    def reconcile_closed_orders(
+        self, *, open_order_market_ids: frozenset[str]
+    ) -> list[tuple[OrderIntent, OrderResult]]:
+        self.reconciled_open_order_market_ids.append(open_order_market_ids)
+        return self.closed_order_releases
 
     def risk_state(
         self, *, dependencies: tuple[RuntimeDependencyStatus, ...]
@@ -332,11 +412,14 @@ class _FakeExchange:
         fills: bool = True,
         supports_markets: bool = True,
         fail_submit: bool = False,
+        open_order_market_ids: frozenset[str] | None = None,
     ) -> None:
         self.submitted: list[OrderIntent] = []
+        self.open_order_reconcile_inputs: list[dict[str, str]] = []
         self._fills = fills
         self._supports_markets = supports_markets
         self._fail_submit = fail_submit
+        self._open_order_market_ids = open_order_market_ids or frozenset()
 
     def filter_supported_markets(
         self,
@@ -363,6 +446,12 @@ class _FakeExchange:
 
     def reconcile_account(self, _market_id_by_coin: dict[str, str]) -> AccountState:
         return _account_state()
+
+    def reconcile_open_order_market_ids(
+        self, market_id_by_coin: dict[str, str]
+    ) -> frozenset[str]:
+        self.open_order_reconcile_inputs.append(market_id_by_coin)
+        return self._open_order_market_ids
 
     def dependency_status(self) -> RuntimeDependencyStatus:
         return RuntimeDependencyStatus("hyperliquid_exchange_shadow", True)
@@ -453,10 +542,60 @@ def test_runtime_service_orchestrates_signal_order_and_accounting(
     assert repository.account_states[0].positions[0].coin == "cash:AAPL"
     assert repository.performance[0].reconciliation_status == "pass"
     assert exchange.dead_man_seconds == 60
+    assert exchange.open_order_reconcile_inputs == [
+        {"cash:AAPL": "hl:perp:cash:cash:AAPL"}
+    ]
     assert [event.transfer_kind for event in journal.persisted] == [
         "fill",
         "order_submitted",
     ]
+
+
+def test_runtime_service_releases_reconciled_closed_orders(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    repository = _FakeRepository(_FakeSession())
+    repository.closed_order_releases = [
+        (
+            _intent(),
+            OrderResult(
+                status="cancelled",
+                exchange_order_id="42",
+                raw_response={
+                    "reconciliation": {
+                        "source": "exchange_open_orders",
+                        "open_on_exchange": False,
+                    }
+                },
+                rejection_reason="not_open_on_exchange_reconciliation",
+            ),
+        )
+    ]
+    exchange = _FakeExchange(fills=False)
+    journal = _FakeJournal()
+    monkeypatch.setattr(
+        service_module, "HyperliquidRuntimeRepository", lambda _session: repository
+    )
+    service = HyperliquidRuntimeService(
+        config=_config(
+            HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+            HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0x1111111111111111111111111111111111111111",
+            HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY=(
+                "0x2222222222222222222222222222222222222222222222222222222222222222"
+            ),
+        ),
+        clickhouse=_FakeClickHouse(features=[]),
+        exchange=exchange,
+        journal=journal,
+    )
+    session = _FakeSession()
+
+    result = service.run_once(session)
+
+    assert result.orders_submitted == 0
+    assert repository.reconciled_open_order_market_ids == [frozenset()]
+    assert [event.transfer_kind for event in journal.persisted] == ["order_cancelled"]
+    assert session.committed
 
 
 def test_runtime_service_persists_guarded_optimizer_run() -> None:


### PR DESCRIPTION
## Summary

- Adds live Hyperliquid open-order reconciliation to the isolated testnet runtime.
- Closes local submitted/accepted orders when they are no longer open on exchange, marking filled orders as `filled` when matching fills exist.
- Persists cancellation release accounting through the existing TigerBeetle journal before risk gating evaluates new orders.
- Keeps reconciliation failures as runtime dependency failures instead of guessing local order state.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py -q`
- `uv run --frozen ruff check app/hyperliquid_runtime/exchange.py app/hyperliquid_runtime/repository.py app/hyperliquid_runtime/service.py tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_service_repository.py`
- `uv run --frozen ruff format --check app/hyperliquid_runtime/exchange.py app/hyperliquid_runtime/repository.py app/hyperliquid_runtime/service.py tests/hyperliquid_runtime/test_adapters_api_metrics.py tests/hyperliquid_runtime/test_service_repository.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
