### PR TITLE
ci(torghut): enforce structural cleanup gate

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -454,6 +454,10 @@ jobs:
         working-directory: services/torghut
         run: uv run --frozen ruff check app tests scripts migrations
 
+      - name: Pylint structural hardening gate
+        working-directory: services/torghut
+        run: uv run --frozen python scripts/run_pylint_torghut_structural_gate.py
+
       - name: Pylint refactor quality gate
         working-directory: services/torghut
         shell: bash

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -62,12 +62,15 @@ Current rollout commands:
 
 ```bash
 cd services/torghut
+uv run --frozen python scripts/run_pylint_torghut_structural_gate.py
 uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n
 uv run --frozen pylint app scripts --disable=all --enable=too-many-branches,too-many-locals,too-many-return-statements,too-many-statements --score=n
 ```
 
-The file-length command is blocking in CI. The design-complexity command is intentionally non-blocking inventory until
-the remaining findings are refactored without broad suppressions.
+The structural and file-length commands are blocking in CI. The structural gate rejects regenerated split filenames,
+dynamic module facades, wildcard imports, source-string execution, and broad Ruff/Pyright/type suppressions across the
+full Torghut Python surface. The design-complexity command is intentionally non-blocking inventory until the remaining
+findings are refactored without broad suppressions.
 
 ## Dead-code audit (Vulture)
 

--- a/services/torghut/scripts/pylint_torghut_quality.py
+++ b/services/torghut/scripts/pylint_torghut_quality.py
@@ -16,7 +16,7 @@ from pylint.lint import PyLinter
 PLUGIN_PATH = Path(__file__).resolve()
 
 GENERATED_SPLIT_NAME_RE = re.compile(
-    r"^(?:part_\d+|source_part_\d+|test_part_\d+).*\.(?:py|pyi)$"
+    r"^(?:part_\d+|source_part_\d+|source_segment_\d+|test_part_\d+).*\.(?:py|pyi)$"
 )
 PYRIGHT_PRIVATE_USAGE_SETTING = "reportPrivateUsage"
 
@@ -150,6 +150,11 @@ class TorghutQualityChecker(BaseChecker):
             "%s: %s",
             "torghut-wildcard-ruff-noqa",
             "Used when a file-level Ruff suppression keeps wildcard-import checks disabled.",
+        ),
+        "C9018": (
+            "Dynamic exec call %s; move generated source into normal modules",
+            "torghut-source-string-execution",
+            "Used when code executes source strings instead of importing normal modules.",
         ),
     }
 
@@ -288,14 +293,20 @@ class TorghutQualityChecker(BaseChecker):
         )
 
     def _check_call(self, module_node: nodes.Module, node: ast.Call) -> None:
-        if not _is_globals_update_call(node):
-            return
-        self.add_message(
-            "torghut-dynamic-globals-reexport",
-            node=module_node,
-            line=node.lineno,
-            args=("dynamic globals re-export", ast.unparse(node)),
-        )
+        if _is_globals_update_call(node):
+            self.add_message(
+                "torghut-dynamic-globals-reexport",
+                node=module_node,
+                line=node.lineno,
+                args=("dynamic globals re-export", ast.unparse(node)),
+            )
+        if _is_exec_call(node):
+            self.add_message(
+                "torghut-source-string-execution",
+                node=module_node,
+                line=node.lineno,
+                args=(ast.unparse(node),),
+            )
 
     def _check_test_wrapper(
         self, module_node: nodes.Module, path: Path, text: str
@@ -378,6 +389,10 @@ def _is_globals_update_call(node: ast.Call) -> bool:
         and isinstance(node.func.value.func, ast.Name)
         and node.func.value.func.id == "globals"
     )
+
+
+def _is_exec_call(node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Name) and node.func.id == "exec"
 
 
 def _is_dead_test_compat_wrapper(path: Path, text: str) -> bool:

--- a/services/torghut/scripts/run_pylint_torghut_quality_diff_gate.py
+++ b/services/torghut/scripts/run_pylint_torghut_quality_diff_gate.py
@@ -26,6 +26,7 @@ CUSTOM_RULES = (
     "torghut-wildcard-import",
     "torghut-custom-module-class",
     "torghut-test-compat-wrapper",
+    "torghut-source-string-execution",
 )
 
 _DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")

--- a/services/torghut/scripts/run_pylint_torghut_structural_gate.py
+++ b/services/torghut/scripts/run_pylint_torghut_structural_gate.py
@@ -1,0 +1,93 @@
+"""Run the repo-wide Torghut structural Pylint gate."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+DEFAULT_PATHS = ("app", "scripts", "tests", "migrations")
+STRICT_STRUCTURAL_RULES = (
+    "torghut-generated-split-filename",
+    "torghut-dynamic-globals-reexport",
+    "torghut-compat-module-wrapper",
+    "torghut-compat-module-registry",
+    "torghut-module-class-mutation",
+    "torghut-module-replacement",
+    "torghut-private-pyright-suppression",
+    "torghut-file-pyright-suppression",
+    "torghut-type-ignore",
+    "torghut-file-ruff-noqa",
+    "torghut-wildcard-ruff-noqa",
+    "torghut-blanket-pylint-disable",
+    "torghut-dynamic-attribute-hook",
+    "torghut-dynamic-all",
+    "torghut-wildcard-import",
+    "torghut-custom-module-class",
+    "torghut-test-compat-wrapper",
+    "torghut-source-string-execution",
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=DEFAULT_PATHS,
+        help="Torghut-relative files or directories to scan.",
+    )
+    parser.add_argument(
+        "--enable",
+        default=",".join(STRICT_STRUCTURAL_RULES),
+        help="Comma-separated Pylint structural rules to enable.",
+    )
+    parser.add_argument(
+        "--load-plugins",
+        default="scripts.pylint_torghut_quality",
+        help="Comma-separated Pylint plugins to load, or an empty string.",
+    )
+    args = parser.parse_args(argv)
+
+    scan_paths = _existing_paths(args.paths)
+    if not scan_paths:
+        print("No Torghut Python paths exist for structural gate.")
+        return 0
+
+    result = _run(build_pylint_command(args.enable, args.load_plugins, scan_paths))
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.returncode != 0:
+        return result.returncode
+    print("No Torghut structural Pylint violations.")
+    return 0
+
+
+def build_pylint_command(
+    enable: str, load_plugins: str, paths: Sequence[str]
+) -> list[str]:
+    command = [sys.executable, "-m", "pylint"]
+    if load_plugins:
+        command.append(f"--load-plugins={load_plugins}")
+    command.extend(("--disable=all", f"--enable={enable}", "--score=n", *paths))
+    return command
+
+
+def _existing_paths(paths: Sequence[str]) -> list[str]:
+    return [path for path in paths if Path(path).exists()]
+
+
+def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/torghut/tests/test_pylint_torghut_quality.py
+++ b/services/torghut/tests/test_pylint_torghut_quality.py
@@ -28,6 +28,7 @@ PLUGIN_ENABLES = ",".join(
         "torghut-wildcard-import",
         "torghut-custom-module-class",
         "torghut-test-compat-wrapper",
+        "torghut-source-string-execution",
     )
 )
 
@@ -118,6 +119,7 @@ def test_torghut_pylint_quality_plugin_rejects_refactor_slop(
                 "",
                 "__all__ = [name for name in globals() if name]",
                 "globals().update(other.__dict__)",
+                "exec(compile('__compat_source__ = 1', '<compat>', 'exec'))",
                 "_sys.modules[__name__] = other",
                 "_sys.modules[__name__].__class__ = Facade",
                 "",
@@ -146,10 +148,23 @@ def test_torghut_pylint_quality_plugin_rejects_refactor_slop(
         "torghut-dynamic-all",
         "torghut-wildcard-import",
         "torghut-custom-module-class",
+        "torghut-source-string-execution",
     }
     output = result.output
     missing = sorted(symbol for symbol in expected_symbols if symbol not in output)
     assert not missing, output
+
+
+def test_torghut_pylint_quality_plugin_rejects_source_segment_names(
+    tmp_path: Path,
+) -> None:
+    module_path = tmp_path / "source_segment_001.py"
+    module_path.write_text("VALUE = 1\n", encoding="utf-8")
+
+    result = _run_quality_pylint(module_path)
+
+    assert result.returncode != 0
+    assert "torghut-generated-split-filename" in result.output
 
 
 def test_torghut_pylint_quality_plugin_rejects_test_compat_wrappers(

--- a/services/torghut/tests/test_pylint_torghut_quality_diff_gate.py
+++ b/services/torghut/tests/test_pylint_torghut_quality_diff_gate.py
@@ -35,6 +35,7 @@ def test_default_diff_gate_rules_include_cleanup_guard_rules() -> None:
     assert "torghut-test-compat-wrapper" in CUSTOM_RULES
     assert "torghut-private-pyright-suppression" in CUSTOM_RULES
     assert "torghut-wildcard-ruff-noqa" in CUSTOM_RULES
+    assert "torghut-source-string-execution" in CUSTOM_RULES
 
 
 def test_filter_messages_keeps_only_changed_line_violations() -> None:

--- a/services/torghut/tests/test_pylint_torghut_structural_gate.py
+++ b/services/torghut/tests/test_pylint_torghut_structural_gate.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import subprocess
 import sys
+from collections.abc import Sequence
 
+import pytest
+
+from scripts import run_pylint_torghut_structural_gate
 from scripts.run_pylint_torghut_structural_gate import (
     DEFAULT_PATHS,
     STRICT_STRUCTURAL_RULES,
     build_pylint_command,
+    main,
 )
 
 
@@ -56,3 +62,82 @@ def test_structural_gate_builds_plugin_pylint_command() -> None:
         "app",
         "scripts",
     ]
+
+
+def test_structural_gate_skips_when_no_paths_exist(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        run_pylint_torghut_structural_gate, "_existing_paths", lambda paths: []
+    )
+
+    assert main(["--paths", "missing"]) == 0
+    assert (
+        capsys.readouterr().out
+        == "No Torghut Python paths exist for structural gate.\n"
+    )
+
+
+def test_structural_gate_prints_success_output(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    observed_commands: list[list[str]] = []
+    monkeypatch.setattr(
+        run_pylint_torghut_structural_gate, "_existing_paths", lambda paths: ["app"]
+    )
+
+    def fake_run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        observed_commands.append(list(command))
+        return subprocess.CompletedProcess(
+            args=list(command), returncode=0, stdout="pylint clean\n"
+        )
+
+    monkeypatch.setattr(run_pylint_torghut_structural_gate, "_run", fake_run)
+
+    assert (
+        main(
+            [
+                "--paths",
+                "app",
+                "--enable",
+                "torghut-wildcard-import",
+                "--load-plugins",
+                "",
+            ]
+        )
+        == 0
+    )
+
+    assert observed_commands == [
+        [
+            sys.executable,
+            "-m",
+            "pylint",
+            "--disable=all",
+            "--enable=torghut-wildcard-import",
+            "--score=n",
+            "app",
+        ]
+    ]
+    assert (
+        capsys.readouterr().out
+        == "pylint clean\nNo Torghut structural Pylint violations.\n"
+    )
+
+
+def test_structural_gate_returns_pylint_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        run_pylint_torghut_structural_gate, "_existing_paths", lambda paths: ["scripts"]
+    )
+
+    def fake_run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=list(command), returncode=12, stdout="structural violation\n"
+        )
+
+    monkeypatch.setattr(run_pylint_torghut_structural_gate, "_run", fake_run)
+
+    assert main(["--paths", "scripts"]) == 12
+    assert capsys.readouterr().out == "structural violation\n"

--- a/services/torghut/tests/test_pylint_torghut_structural_gate.py
+++ b/services/torghut/tests/test_pylint_torghut_structural_gate.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+
+from scripts.run_pylint_torghut_structural_gate import (
+    DEFAULT_PATHS,
+    STRICT_STRUCTURAL_RULES,
+    build_pylint_command,
+)
+
+
+def test_structural_gate_scans_full_torghut_surface_by_default() -> None:
+    assert DEFAULT_PATHS == ("app", "scripts", "tests", "migrations")
+
+
+def test_structural_gate_includes_final_hardening_rules() -> None:
+    expected_rules = {
+        "torghut-generated-split-filename",
+        "torghut-dynamic-globals-reexport",
+        "torghut-compat-module-wrapper",
+        "torghut-compat-module-registry",
+        "torghut-module-class-mutation",
+        "torghut-module-replacement",
+        "torghut-private-pyright-suppression",
+        "torghut-file-pyright-suppression",
+        "torghut-type-ignore",
+        "torghut-file-ruff-noqa",
+        "torghut-wildcard-ruff-noqa",
+        "torghut-blanket-pylint-disable",
+        "torghut-dynamic-attribute-hook",
+        "torghut-dynamic-all",
+        "torghut-wildcard-import",
+        "torghut-custom-module-class",
+        "torghut-test-compat-wrapper",
+        "torghut-source-string-execution",
+    }
+
+    assert expected_rules <= set(STRICT_STRUCTURAL_RULES)
+
+
+def test_structural_gate_builds_plugin_pylint_command() -> None:
+    command = build_pylint_command(
+        "torghut-wildcard-import,torghut-source-string-execution",
+        "scripts.pylint_torghut_quality",
+        ["app", "scripts"],
+    )
+
+    assert command == [
+        sys.executable,
+        "-m",
+        "pylint",
+        "--load-plugins=scripts.pylint_torghut_quality",
+        "--disable=all",
+        "--enable=torghut-wildcard-import,torghut-source-string-execution",
+        "--score=n",
+        "app",
+        "scripts",
+    ]


### PR DESCRIPTION
## Summary

- Added a repo-wide Torghut structural Pylint gate and wired it into `torghut-ci` before changed-line checks.
- Extended the custom Torghut quality checker to reject regenerated `source_segment_*` files and dynamic `exec(...)` source loaders.
- Documented the local structural gate command and added tests for the strict rule inventory, command wrapper, source-segment filenames, and exec-loader rejection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_pylint_torghut_gate_helpers.py tests/test_pylint_torghut_quality.py tests/test_pylint_torghut_quality_diff_gate.py tests/test_pylint_torghut_structural_gate.py tests/test_explicit_module_facade_exports.py -q`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen vulture --config pyproject.toml`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main scripts/pylint_torghut_quality.py scripts/run_pylint_torghut_quality_diff_gate.py scripts/run_pylint_torghut_structural_gate.py tests/test_pylint_torghut_quality.py tests/test_pylint_torghut_quality_diff_gate.py tests/test_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main scripts/pylint_torghut_quality.py scripts/run_pylint_torghut_quality_diff_gate.py scripts/run_pylint_torghut_structural_gate.py tests/test_pylint_torghut_quality.py tests/test_pylint_torghut_quality_diff_gate.py tests/test_pylint_torghut_structural_gate.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked. The README now documents the structural gate; release notes are not needed for this CI hardening change.
