### PR TITLE
fix(torghut): run deploy automerge on private runner

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -61,7 +61,9 @@ jobs:
         github.event.pull_request.base.ref == 'main' &&
         github.event.pull_request.draft == false
       }}
-    runs-on: ubuntu-latest
+    # The private registry is only reachable from the ARC runners on the lab network.
+    # This pull_request_target job does not check out pull request code.
+    runs-on: arc-arm64
     permissions:
       contents: write
       pull-requests: write

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -26,6 +26,13 @@ const hyperliquidFeedReleaseWorkflow = readFileSync(
 const countOccurrences = (haystack: string, needle: string): number => haystack.split(needle).length - 1
 
 describe('torghut-deploy-automerge workflow', () => {
+  test('runs registry digest validation where the private registry is reachable', () => {
+    expect(deployAutomergeWorkflow).toContain('runs-on: arc-arm64')
+    expect(deployAutomergeWorkflow).not.toContain('runs-on: ubuntu-latest')
+    expect(deployAutomergeWorkflow).toContain('This pull_request_target job does not check out pull request code.')
+    expect(deployAutomergeWorkflow).not.toContain('uses: actions/checkout')
+  })
+
   test('allowlists every hyperliquid runtime manifest promoted by torghut-release', () => {
     const promotedHyperliquidRuntimeManifests = [
       'argocd/applications/torghut-hyperliquid-runtime/deployment.yaml',


### PR DESCRIPTION
## Summary

- Move the Torghut release automerge digest verifier onto the ARC runner so it can reach `registry.ide-newton.ts.net`.
- Keep the `pull_request_target` job constrained: it verifies same-repo release PR metadata and does not check out PR code.
- Add a workflow regression test so the private-registry digest gate cannot drift back to `ubuntu-latest`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/torghut-deploy-automerge.yml .github/workflows/torghut-release.yml .github/workflows/torghut-build-push.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
