### PR TITLE
fix(torghut): run release manifest check on private runner

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -141,7 +141,9 @@ jobs:
 
   release-manifests:
     name: Release manifest changes
-    runs-on: ubuntu-latest
+    # The digest contract check inspects registry.ide-newton.ts.net, which is only
+    # reachable from ARC runners on the lab network.
+    runs-on: arc-arm64
     needs:
       - changes
     if: ${{ needs.changes.outputs.service != 'true' && needs.changes.outputs.manifests == 'true' }}

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -229,6 +229,8 @@ describe('torghut build-push workflow', () => {
     )
 
     expect(buildContractStep).toBeGreaterThan(releaseManifestJob)
+    expect(releaseManifestJobBody).toContain('runs-on: arc-arm64')
+    expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net, which is only')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/knative-service.yaml')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ta/flinkdeployment.yaml')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ws/deployment.yaml')


### PR DESCRIPTION
## Summary

- Move Torghut manifest-only release CI onto the ARC runner so the private registry digest check can resolve `registry.ide-newton.ts.net`.
- Keep the existing digest-pinned multi-arch image verification intact.
- Add a workflow regression assertion covering the private-runner requirement.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/torghut-ci.yml .github/workflows/torghut-deploy-automerge.yml .github/workflows/torghut-release.yml .github/workflows/torghut-build-push.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
