### PR TITLE
ci(torghut): accelerate release verification

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -643,12 +643,16 @@ jobs:
           include-hidden-files: true
 
   pytest-autoresearch-runner:
-    name: Pytest autoresearch runner
+    name: Pytest autoresearch runner ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
     needs:
       - changes
     if: ${{ needs.changes.outputs.service == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - name: Checkout
         shell: bash
@@ -695,16 +699,38 @@ jobs:
         working-directory: services/torghut
         shell: bash
         env:
-          COVERAGE_FILE: .coverage.autoresearch-runner
+          COVERAGE_FILE: .coverage.autoresearch-runner-${{ matrix.shard }}
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_TOTAL: 4
         run: |
           set -euo pipefail
-          collected_count="$(
+          mapfile -t TEST_NODES < <(
             uv run --frozen pytest --collect-only -q tests/autoresearch_runner |
-              awk '/^tests\/.*::/ {count += 1} END {print count + 0}'
-          )"
-          printf 'Collected %s autoresearch runner tests\n' "${collected_count}"
-          if [ "${collected_count}" -ne 185 ]; then
+              awk -v shard="${SHARD_INDEX}" -v total="${SHARD_TOTAL}" '
+                /^tests\/.*::/ {
+                  collected += 1
+                  if (((collected - 1) % total) == shard) {
+                    print
+                  }
+                }
+                END {
+                  if (collected != 185) {
+                    printf "EXPECTED_COUNT_MISMATCH:%d\n", collected
+                  }
+                }
+              '
+          )
+          last_index=$((${#TEST_NODES[@]} - 1))
+          if [ "${#TEST_NODES[@]}" -gt 0 ] && [[ "${TEST_NODES[${last_index}]}" == EXPECTED_COUNT_MISMATCH:* ]]; then
+            collected_count="${TEST_NODES[${last_index}]#EXPECTED_COUNT_MISMATCH:}"
+            unset 'TEST_NODES[${last_index}]'
             echo "Expected 185 autoresearch runner tests after split, got ${collected_count}"
+            exit 1
+          fi
+          printf 'Running %s autoresearch runner test nodes in shard %s/%s\n' \
+            "${#TEST_NODES[@]}" "${SHARD_INDEX}" "${SHARD_TOTAL}"
+          if [ "${#TEST_NODES[@]}" -eq 0 ]; then
+            echo "No autoresearch runner test nodes selected for shard ${SHARD_INDEX}"
             exit 1
           fi
 
@@ -715,14 +741,14 @@ jobs:
             --cov-branch \
             --cov-fail-under=0 \
             --cov-report= \
-            tests/autoresearch_runner
+            "${TEST_NODES[@]}"
 
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: torghut-coverage-autoresearch-runner
-          path: services/torghut/.coverage.autoresearch-runner*
+          name: torghut-coverage-autoresearch-runner-${{ matrix.shard }}
+          path: services/torghut/.coverage.autoresearch-runner-${{ matrix.shard }}*
           if-no-files-found: error
           include-hidden-files: true
 

--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -163,8 +163,11 @@ jobs:
             request_argocd_sync "${app}" "${EXPECTED_REVISION}"
           done
 
+          ARGO_SYNC_POLL_ATTEMPTS=150
+          ARGO_SYNC_POLL_INTERVAL_SECONDS=2
+
           for app in torghut torghut-options; do
-            for attempt in $(seq 1 60); do
+            for attempt in $(seq 1 "${ARGO_SYNC_POLL_ATTEMPTS}"); do
               STATUS="$(kubectl get application "${app}" -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision} {.status.operationState.phase} {.status.operationState.syncResult.revision} {.status.history[-1].revision}')"
               SYNC_STATUS="$(echo "${STATUS}" | awk '{print $1}')"
               HEALTH_STATUS="$(echo "${STATUS}" | awk '{print $2}')"
@@ -210,19 +213,23 @@ jobs:
                 if [ "${HEALTH_STATUS}" = 'Healthy' ]; then
                   break
                 fi
+                if [ "${HEALTH_STATUS}" = 'Progressing' ] && [ "${OPERATION_PHASE}" = 'Succeeded' ]; then
+                  echo "Argo application ${app} sync operation succeeded while health is Progressing; runtime checks will verify readiness"
+                  break
+                fi
                 if [ "${app}" = 'torghut' ] && [ "${HEALTH_STATUS}" = 'Degraded' ] && [ "${OPERATION_PHASE}" = 'Succeeded' ]; then
                   echo "Torghut Argo health is Degraded after sync; continuing to runtime safety checks"
                   break
                 fi
               fi
 
-              if [ "${attempt}" -eq 60 ]; then
+              if [ "${attempt}" -eq "${ARGO_SYNC_POLL_ATTEMPTS}" ]; then
                 echo "Argo application ${app} did not become Synced/Healthy with expected revision"
                 dump_argocd_app_diagnostics "${app}"
                 exit 1
               fi
               echo "Attempt ${attempt}: ${app} sync=${SYNC_STATUS} health=${HEALTH_STATUS} revision=${REVISION} desired=${DESIRED_REVISION} operation=${OPERATION_PHASE} syncResult=${SYNC_RESULT_REVISION} history=${HISTORY_REVISION}"
-              sleep 5
+              sleep "${ARGO_SYNC_POLL_INTERVAL_SECONDS}"
             done
           done
 
@@ -292,6 +299,13 @@ jobs:
 
           EVIDENCE_DIR="${RUNNER_TEMP}/torghut-post-deploy"
           mkdir -p "${EVIDENCE_DIR}"
+          HTTP_CONNECT_TIMEOUT_SECONDS=5
+          HTTP_MAX_TIME_SECONDS=15
+          JSON_EVIDENCE_ATTEMPTS=3
+          READYZ_EVIDENCE_ATTEMPTS=12
+          EVIDENCE_RETRY_INTERVAL_SECONDS=2
+          SIM_MIRROR_ATTEMPTS=12
+          SIM_MIRROR_RETRY_INTERVAL_SECONDS=5
 
           fetch_json() {
             local url="$1"
@@ -299,9 +313,9 @@ jobs:
             local label="$3"
             local status
 
-            for attempt in $(seq 1 18); do
+            for attempt in $(seq 1 "${JSON_EVIDENCE_ATTEMPTS}"); do
               status="$(
-                curl -sS --connect-timeout 10 --max-time 90 \
+                curl -sS --connect-timeout "${HTTP_CONNECT_TIMEOUT_SECONDS}" --max-time "${HTTP_MAX_TIME_SECONDS}" \
                   -o "${output_path}" -w '%{http_code}' "${url}" || true
               )"
               if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
@@ -311,7 +325,7 @@ jobs:
                 return 0
               fi
 
-              if [ "${attempt}" -eq 18 ]; then
+              if [ "${attempt}" -eq "${JSON_EVIDENCE_ATTEMPTS}" ]; then
                 echo "${label} did not return a parseable JSON HTTP response; status=${status:-empty}" >&2
                 head -c 1000 "${output_path}" >&2 || true
                 echo >&2
@@ -319,7 +333,7 @@ jobs:
               fi
 
               echo "Attempt ${attempt}: ${label} status=${status:-empty} not usable JSON yet; retrying" >&2
-              sleep 5
+              sleep "${EVIDENCE_RETRY_INTERVAL_SECONDS}"
             done
           }
 
@@ -330,9 +344,9 @@ jobs:
             local status
             local decision
 
-            for attempt in $(seq 1 48); do
+            for attempt in $(seq 1 "${READYZ_EVIDENCE_ATTEMPTS}"); do
               status="$(
-                curl -sS --connect-timeout 10 --max-time 90 \
+                curl -sS --connect-timeout "${HTTP_CONNECT_TIMEOUT_SECONDS}" --max-time "${HTTP_MAX_TIME_SECONDS}" \
                   -o "${output_path}" -w '%{http_code}' "${url}" || true
               )"
               if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
@@ -349,13 +363,13 @@ jobs:
                     return 0
                     ;;
                   retryable_database_timeout)
-                    if [ "${attempt}" -eq 48 ]; then
+                    if [ "${attempt}" -eq "${READYZ_EVIDENCE_ATTEMPTS}" ]; then
                       echo "${label} still reports a retryable database-readiness timeout after ${attempt} attempts" >&2
                       printf '%s' "${status}"
                       return 0
                     fi
                     echo "Attempt ${attempt}: ${label} database readiness timed out; retrying until readyz contract is acceptable" >&2
-                    sleep 5
+                    sleep "${EVIDENCE_RETRY_INTERVAL_SECONDS}"
                     continue
                     ;;
                   *)
@@ -365,7 +379,7 @@ jobs:
                 esac
               fi
 
-              if [ "${attempt}" -eq 18 ]; then
+              if [ "${attempt}" -eq "${READYZ_EVIDENCE_ATTEMPTS}" ]; then
                 if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
                   [ "${status}" != '000' ] &&
                   python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
@@ -385,7 +399,7 @@ jobs:
               else
                 echo "Attempt ${attempt}: ${label} status=${status:-empty} not usable JSON yet; retrying" >&2
               fi
-              sleep 5
+              sleep "${EVIDENCE_RETRY_INTERVAL_SECONDS}"
             done
           }
 
@@ -395,9 +409,9 @@ jobs:
             local label="$3"
             local status
 
-            for attempt in $(seq 1 18); do
+            for attempt in $(seq 1 "${JSON_EVIDENCE_ATTEMPTS}"); do
               status="$(
-                curl -sS --connect-timeout 10 --max-time 90 \
+                curl -sS --connect-timeout "${HTTP_CONNECT_TIMEOUT_SECONDS}" --max-time "${HTTP_MAX_TIME_SECONDS}" \
                   -o "${output_path}" -w '%{http_code}' "${url}" || true
               )"
               if [[ "${status}" =~ ^2[0-9][0-9]$ ]] &&
@@ -405,7 +419,7 @@ jobs:
                 return 0
               fi
 
-              if [ "${attempt}" -eq 18 ]; then
+              if [ "${attempt}" -eq "${JSON_EVIDENCE_ATTEMPTS}" ]; then
                 if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
                   [ "${status}" != '000' ] &&
                   python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
@@ -425,7 +439,7 @@ jobs:
               else
                 echo "Attempt ${attempt}: ${label} status=${status:-empty} not usable JSON 2xx yet; retrying" >&2
               fi
-              sleep 5
+              sleep "${EVIDENCE_RETRY_INTERVAL_SECONDS}"
             done
           }
 
@@ -473,7 +487,7 @@ jobs:
             local status
             local output_path="${EVIDENCE_DIR}/post-deploy-evidence-validator.out"
 
-            for attempt in $(seq 1 48); do
+            for attempt in $(seq 1 "${SIM_MIRROR_ATTEMPTS}"); do
               set +e
               bun run packages/scripts/src/torghut/post-deploy-evidence.ts > "${output_path}" 2>&1
               status=$?
@@ -489,7 +503,7 @@ jobs:
                 return "${status}"
               fi
 
-              if [ "${attempt}" -eq 48 ]; then
+              if [ "${attempt}" -eq "${SIM_MIRROR_ATTEMPTS}" ]; then
                 echo "Torghut sim paper-route target mirror did not materialize after bounded retry window" >&2
                 cat "${output_path}" >&2
                 return "${status}"
@@ -504,7 +518,7 @@ jobs:
                 'http://torghut-sim.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=next&limit=20' \
                 "${EVIDENCE_DIR}/torghut-sim-proofs.json" \
                 "Torghut sim /trading/proofs"
-              sleep 10
+              sleep "${SIM_MIRROR_RETRY_INTERVAL_SECONDS}"
             done
           }
 

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -246,6 +246,21 @@ describe('torghut build-push workflow', () => {
     expect(ciWorkflow).not.toContain('--workflow torghut-ci.yml')
   })
 
+  it('shards the expensive autoresearch runner tests in Torghut CI', () => {
+    const autoresearchJob = ciWorkflow.indexOf('pytest-autoresearch-runner:')
+    const nextJob = ciWorkflow.indexOf('\n  lint-and-tests:', autoresearchJob)
+    const autoresearchJobBody = ciWorkflow.slice(autoresearchJob, nextJob)
+
+    expect(autoresearchJob).toBeGreaterThan(-1)
+    expect(autoresearchJobBody).toContain('name: Pytest autoresearch runner ${{ matrix.shard }}')
+    expect(autoresearchJobBody).toContain('shard: [0, 1, 2, 3]')
+    expect(autoresearchJobBody).toContain('SHARD_TOTAL: 4')
+    expect(autoresearchJobBody).toContain('uv run --frozen pytest --collect-only -q tests/autoresearch_runner')
+    expect(autoresearchJobBody).toContain('EXPECTED_COUNT_MISMATCH:%d')
+    expect(autoresearchJobBody).toContain('name: torghut-coverage-autoresearch-runner-${{ matrix.shard }}')
+    expect(autoresearchJobBody).not.toContain('name: torghut-coverage-autoresearch-runner\n')
+  })
+
   it('keeps TA and WS stale workflow promotions path-aware so unrelated main commits do not force rebuilds', () => {
     const releaseWorkflows = [
       {

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -54,6 +54,7 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('retryable_database_timeout')
     expect(workflow).toContain('database readiness timed out; retrying')
     expect(workflow).toContain('without an acceptable readyz contract')
+    expect(workflow).toContain('READYZ_EVIDENCE_ATTEMPTS=12')
     expect(workflow).toContain('fetch_readyz_json \\')
   })
 
@@ -69,7 +70,11 @@ describe('torghut post-deploy verifier workflow', () => {
   it('retries parseable non-2xx deploy evidence before failing', () => {
     expect(workflow).toContain('Attempt ${attempt}: ${label} returned HTTP ${status}; expected 2xx; retrying')
     expect(workflow).toContain('did not return a parseable JSON HTTP 2xx response')
+    expect(workflow).toContain('HTTP_MAX_TIME_SECONDS=15')
+    expect(workflow).toContain('JSON_EVIDENCE_ATTEMPTS=3')
+    expect(workflow).toContain('--max-time "${HTTP_MAX_TIME_SECONDS}"')
     expect(workflow).not.toContain('status="$(fetch_json "${url}" "${output_path}" "${label}")"')
+    expect(workflow).not.toContain('--max-time 90')
   })
 
   it('verifies torghut-sim paper-route target mirroring after deploy', () => {
@@ -89,6 +94,9 @@ describe('torghut post-deploy verifier workflow', () => {
       'Torghut sim paper-route target mirror not materialized yet; refreshing evidence payloads',
     )
     expect(workflow).toContain('Torghut sim paper-route target mirror did not materialize after bounded retry window')
+    expect(workflow).toContain('SIM_MIRROR_ATTEMPTS=12')
+    expect(workflow).toContain('SIM_MIRROR_RETRY_INTERVAL_SECONDS=5')
+    expect(workflow).not.toContain('sleep 10')
   })
 
   it('requests explicit Argo sync before polling deployed revisions', () => {
@@ -100,8 +108,13 @@ describe('torghut post-deploy verifier workflow', () => {
   })
 
   it('bounds Argo convergence waits and prints resource diagnostics on timeout', () => {
-    expect(workflow).toContain('for attempt in $(seq 1 60); do')
-    expect(workflow).toContain('sleep 5')
+    expect(workflow).toContain('ARGO_SYNC_POLL_ATTEMPTS=150')
+    expect(workflow).toContain('ARGO_SYNC_POLL_INTERVAL_SECONDS=2')
+    expect(workflow).toContain('for attempt in $(seq 1 "${ARGO_SYNC_POLL_ATTEMPTS}"); do')
+    expect(workflow).toContain('sleep "${ARGO_SYNC_POLL_INTERVAL_SECONDS}"')
+    expect(workflow).toContain(
+      'Argo application ${app} sync operation succeeded while health is Progressing; runtime checks will verify readiness',
+    )
     expect(workflow).toContain('dump_argocd_app_diagnostics "${app}"')
     expect(workflow).toContain('Argo application ${app} OutOfSync resources:')
   })


### PR DESCRIPTION
## Summary

- Shard the expensive Torghut autoresearch runner tests across four CI jobs using collected pytest node IDs.
- Tighten Torghut post-deploy Argo polling from fixed 5-second sleeps to 2-second polling while preserving the same sync/revision checks.
- Bound post-deploy HTTP evidence capture to short retry windows so slow `/trading/status` and related endpoints fail fast instead of burning minutes.
- Reduce transient sim proof-mirror retries from an eight-minute ceiling to a bounded one-minute window.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/torghut-ci.yml .github/workflows/torghut-post-deploy-verify.yml`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `uv run --frozen pytest --collect-only -q tests/autoresearch_runner` from `services/torghut`, plus shard-count readback for shards 0-3: 47/46/46/46 selected, 185 collected.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
