### PR TITLE
fix(torghut): normalize hyperliquid order precision

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/exchange.py
+++ b/services/torghut/app/hyperliquid_runtime/exchange.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import importlib
+from dataclasses import replace
 from datetime import datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, ROUND_DOWN, ROUND_UP
 from typing import Any, Mapping, Protocol, cast
 
 from .config import HyperliquidRuntimeConfig
@@ -26,6 +27,10 @@ _EXECUTION_UNIVERSE_REFRESH_SECONDS = 300
 
 class HyperliquidExchange(Protocol):
     """Minimal exchange surface used by the runtime service."""
+
+    def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
+        """Return an exchange-compliant order intent."""
+        ...
 
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
         """Submit an IOC limit order."""
@@ -66,6 +71,9 @@ class ShadowHyperliquidExchange:
 
     def __init__(self) -> None:
         self._observed_at = datetime.now(timezone.utc)
+
+    def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
+        return intent
 
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
         _ = intent
@@ -135,6 +143,9 @@ class UnavailableHyperliquidExchange:
 
     def __init__(self, reasons: list[str]) -> None:
         self._reasons = tuple(reasons)
+
+    def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
+        return intent
 
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
         _ = intent
@@ -209,8 +220,34 @@ class HyperliquidSdkExchange:
         self._last_exchange_read_at: datetime | None = None
         self._last_execution_universe_at: datetime | None = None
         self._execution_universe_by_dex: dict[str, frozenset[str]] = {}
+        self._sz_decimals_by_dex_coin: dict[str, dict[str, int]] = {}
+
+    def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
+        sz_decimals = self._sz_decimals_by_dex_coin.get(_sdk_dex(intent.dex), {}).get(
+            intent.coin
+        )
+        if sz_decimals is None:
+            return intent
+        price = _normalize_hyperliquid_perp_price(
+            intent.limit_price,
+            sz_decimals=sz_decimals,
+            side=intent.side,
+        )
+        size = _normalize_hyperliquid_size(
+            intent.size,
+            sz_decimals=sz_decimals,
+        )
+        if size <= Decimal("0"):
+            raise ValueError("order_size_below_exchange_precision")
+        return replace(
+            intent,
+            size=size,
+            limit_price=price,
+            notional_usd=(price * size).quantize(Decimal("0.000001")),
+        )
 
     def submit_ioc_limit(self, intent: OrderIntent) -> OrderResult:
+        intent = self.normalize_order_intent(intent)
         exchange = self._exchange()
         cloid = self._cloid(intent.cloid)
         response = cast(
@@ -403,6 +440,7 @@ class HyperliquidSdkExchange:
         if self._execution_universe_cache_is_fresh():
             return
         by_dex: dict[str, frozenset[str]] = {}
+        sz_decimals_by_dex_coin: dict[str, dict[str, int]] = {}
         loaded_any_metadata = False
         for dex in _execution_metadata_dexes(
             markets,
@@ -421,6 +459,7 @@ class HyperliquidSdkExchange:
                 else None
             )
             coins: set[str] = set()
+            sz_decimals_by_coin: dict[str, int] = {}
             if isinstance(universe, list):
                 for asset in cast(list[object], universe):
                     if not isinstance(asset, dict):
@@ -429,13 +468,19 @@ class HyperliquidSdkExchange:
                     name = str(asset_map.get("name") or "").strip()
                     if name:
                         coins.add(name)
+                        sz_decimals = _optional_int(asset_map.get("szDecimals"))
+                        if sz_decimals is not None and sz_decimals >= 0:
+                            sz_decimals_by_coin[name] = sz_decimals
             by_dex[dex] = frozenset(coins)
+            sz_decimals_by_dex_coin[dex] = sz_decimals_by_coin
             loaded_any_metadata = True
         if not loaded_any_metadata:
             self._execution_universe_by_dex = by_dex
+            self._sz_decimals_by_dex_coin = sz_decimals_by_dex_coin
             return
         observed_at = datetime.now(timezone.utc)
         self._execution_universe_by_dex = by_dex
+        self._sz_decimals_by_dex_coin = sz_decimals_by_dex_coin
         self._last_execution_universe_at = observed_at
         self._last_exchange_read_at = observed_at
 
@@ -625,6 +670,45 @@ def _coin_dex(coin: str) -> str:
     return prefix.strip()
 
 
+def _normalize_hyperliquid_perp_price(
+    price: Decimal,
+    *,
+    sz_decimals: int,
+    side: str,
+) -> Decimal:
+    if price <= Decimal("0"):
+        raise ValueError("order_price_must_be_positive")
+    # Hyperliquid perp prices are capped at 5 significant figures and
+    # at most 6 - szDecimals fractional digits.
+    decimal_places = min(
+        max(0, 6 - sz_decimals),
+        _decimal_places_for_significant_figures(price, significant_figures=5),
+    )
+    quantum = Decimal("1").scaleb(-decimal_places)
+    rounding = ROUND_DOWN if side == "buy" else ROUND_UP
+    normalized = price.quantize(quantum, rounding=rounding)
+    if normalized <= Decimal("0"):
+        return price.quantize(quantum, rounding=ROUND_UP)
+    return normalized
+
+
+def _normalize_hyperliquid_size(
+    size: Decimal,
+    *,
+    sz_decimals: int,
+) -> Decimal:
+    quantum = Decimal("1").scaleb(-max(0, sz_decimals))
+    return size.quantize(quantum, rounding=ROUND_DOWN)
+
+
+def _decimal_places_for_significant_figures(
+    value: Decimal,
+    *,
+    significant_figures: int,
+) -> int:
+    return max(0, significant_figures - value.copy_abs().adjusted() - 1)
+
+
 def _decimal(value: object) -> Decimal:
     if value is None:
         return Decimal("0")
@@ -635,6 +719,15 @@ def _optional_decimal(value: object) -> Decimal | None:
     if value in (None, ""):
         return None
     return Decimal(str(value))
+
+
+def _optional_int(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(str(value))
+    except ValueError:
+        return None
 
 
 def _position_notional(

--- a/services/torghut/app/hyperliquid_runtime/service.py
+++ b/services/torghut/app/hyperliquid_runtime/service.py
@@ -288,6 +288,20 @@ class HyperliquidRuntimeService:
             config=self._config,
             decision_id=decision_id,
         )
+        try:
+            intent = self._exchange.normalize_order_intent(intent)
+        except ValueError as exc:
+            result = OrderResult(
+                status="rejected",
+                exchange_order_id=None,
+                raw_response={"error": type(exc).__name__},
+                rejection_reason=f"order_intent_invalid:{exc}",
+            )
+            context.repository.insert_order(intent, result)
+            self._journal.persist_refs(
+                context.session, self._journal.order_events(intent, result)
+            )
+            return
         self._journal.persist_refs(
             context.session,
             self._journal.order_events(

--- a/services/torghut/tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.hyperliquid_runtime.config import HyperliquidRuntimeConfig
 from app.hyperliquid_runtime.exchange import (
+    HyperliquidSdkExchange,
     ShadowHyperliquidExchange,
     _account_state_from_payload,
     exchange_from_config,
@@ -74,6 +75,41 @@ def test_shadow_exchange_never_requires_private_keys() -> None:
         "shadow": True,
         "reason": "trading_disabled_shadow",
     }
+
+
+def test_sdk_exchange_normalizes_perp_price_and_size_precision() -> None:
+    config = HyperliquidRuntimeConfig.from_env(
+        {
+            "HYPERLIQUID_RUNTIME_TRADING_ENABLED": "true",
+            "HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS": "0x1111111111111111111111111111111111111111",
+            "HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY": (
+                "0x2222222222222222222222222222222222222222222222222222222222222222"
+            ),
+            "TORGHUT_TIGERBEETLE_ENABLED": "true",
+            "TORGHUT_TIGERBEETLE_REQUIRED": "true",
+            "TORGHUT_TIGERBEETLE_JOURNAL_ENABLED": "true",
+        }
+    )
+    exchange = HyperliquidSdkExchange(config)
+    exchange._sz_decimals_by_dex_coin = {"xyz": {"xyz:SMSN": 1}}
+    intent = OrderIntent(
+        market_id="hl:perp:xyz:xyz:SMSN",
+        coin="xyz:SMSN",
+        dex="xyz",
+        side="sell",
+        size=Decimal("0.141976"),
+        limit_price=Decimal("176.080123"),
+        notional_usd=Decimal("24.992235"),
+        cloid="0x1234567890abcdef1234567890abcdef",
+        reduce_only=False,
+        decision_id="decision",
+    )
+
+    normalized = exchange.normalize_order_intent(intent)
+
+    assert normalized.limit_price == Decimal("176.09")
+    assert normalized.size == Decimal("0.1")
+    assert normalized.notional_usd == Decimal("17.609000")
 
 
 def test_user_state_payload_materializes_account_and_positions() -> None:

--- a/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
@@ -432,13 +432,16 @@ class _FakeExchange:
         fills: bool = True,
         supports_markets: bool = True,
         fail_submit: bool = False,
+        normalized_intent: OrderIntent | None = None,
         open_order_market_ids: frozenset[str] | None = None,
     ) -> None:
         self.submitted: list[OrderIntent] = []
+        self.normalized_inputs: list[OrderIntent] = []
         self.open_order_reconcile_inputs: list[dict[str, str]] = []
         self._fills = fills
         self._supports_markets = supports_markets
         self._fail_submit = fail_submit
+        self._normalized_intent = normalized_intent
         self._open_order_market_ids = open_order_market_ids or frozenset()
 
     def filter_supported_markets(
@@ -457,6 +460,17 @@ class _FakeExchange:
                 False,
                 reason="no_execution_supported_markets",
             ),
+        )
+
+    def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
+        self.normalized_inputs.append(intent)
+        if self._normalized_intent is None:
+            return intent
+        return replace(
+            intent,
+            size=self._normalized_intent.size,
+            limit_price=self._normalized_intent.limit_price,
+            notional_usd=self._normalized_intent.notional_usd,
         )
 
     def reconcile_fills(self, _market_id_by_coin: dict[str, str]) -> list[Fill]:
@@ -555,7 +569,14 @@ def test_runtime_service_orchestrates_signal_order_and_accounting(
     monkeypatch: MonkeyPatch,
 ) -> None:
     repository = _FakeRepository(_FakeSession())
-    exchange = _FakeExchange()
+    normalized_intent = replace(
+        _intent(),
+        decision_id="decision-id",
+        limit_price=Decimal("200.3"),
+        size=Decimal("0.04"),
+        notional_usd=Decimal("8.012000"),
+    )
+    exchange = _FakeExchange(normalized_intent=normalized_intent)
     journal = _FakeJournal()
     monkeypatch.setattr(
         service_module, "HyperliquidRuntimeRepository", lambda _session: repository
@@ -582,8 +603,11 @@ def test_runtime_service_orchestrates_signal_order_and_accounting(
     assert result.decisions_written == 1
     assert result.orders_submitted == 1
     assert result.blocked_decisions == 0
+    assert exchange.normalized_inputs
     assert exchange.submitted[0].side == "buy"
-    assert repository.orders[0][0].decision_id == "decision-id"
+    assert exchange.submitted[0].limit_price == Decimal("200.3")
+    assert exchange.submitted[0].size == Decimal("0.04")
+    assert repository.orders[0][0] == exchange.submitted[0]
     assert repository.account_states[0].positions[0].coin == "cash:AAPL"
     assert repository.performance[0].reconciliation_status == "pass"
     assert exchange.dead_man_seconds == 60


### PR DESCRIPTION
## Summary

- Normalize Hyperliquid testnet IOC price and size precision from SDK metadata before order submission.
- Persist and journal the normalized order intent so Postgres, TigerBeetle refs, and exchange payloads agree.
- Add focused tests for Hyperliquid price/size precision and service-level normalized order handling.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_risk_strategy.py`
- `uv run --frozen ruff check app/hyperliquid_runtime/exchange.py app/hyperliquid_runtime/service.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_risk_strategy.py`
- `uv run --frozen ruff format --check app/hyperliquid_runtime/exchange.py app/hyperliquid_runtime/service.py tests/hyperliquid_runtime/test_exchange_ledger_optimizer.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_risk_strategy.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
