### PR TITLE
ci(torghut): balance primary pytest shards

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -565,7 +565,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - name: Checkout
         shell: bash
@@ -614,17 +614,36 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.${{ matrix.shard }}
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_TOTAL: 4
+          SHARD_TOTAL: 8
         run: |
           set -euo pipefail
-          mapfile -t TEST_FILES < <(
-            find tests -name 'test_*.py' ! -path 'tests/autoresearch_runner/*' -print |
-              sort |
-              awk -v shard="${SHARD_INDEX}" -v total="${SHARD_TOTAL}" '((NR - 1) % total) == shard'
+          collected_tests="$(mktemp)"
+          uv run --frozen pytest --collect-only -q tests --ignore=tests/autoresearch_runner > "${collected_tests}"
+          mapfile -t TEST_NODES < <(
+            awk -v shard="${SHARD_INDEX}" -v total="${SHARD_TOTAL}" '
+              /^tests\/.*::/ {
+                collected += 1
+                if (((collected - 1) % total) == shard) {
+                  print
+                }
+              }
+              END {
+                if (collected < 5000) {
+                  printf "EXPECTED_MIN_COUNT_MISMATCH:%d\n", collected
+                }
+              }
+            ' "${collected_tests}"
           )
-          printf 'Running %s test files in shard %s/%s\n' "${#TEST_FILES[@]}" "${SHARD_INDEX}" "${SHARD_TOTAL}"
-          if [ "${#TEST_FILES[@]}" -eq 0 ]; then
-            echo "No test files selected for shard ${SHARD_INDEX}"
+          last_index=$((${#TEST_NODES[@]} - 1))
+          if [ "${#TEST_NODES[@]}" -gt 0 ] && [[ "${TEST_NODES[${last_index}]}" == EXPECTED_MIN_COUNT_MISMATCH:* ]]; then
+            collected_count="${TEST_NODES[${last_index}]#EXPECTED_MIN_COUNT_MISMATCH:}"
+            unset 'TEST_NODES[${last_index}]'
+            echo "Expected at least 5000 non-autoresearch tests after split, got ${collected_count}"
+            exit 1
+          fi
+          printf 'Running %s test nodes in shard %s/%s\n' "${#TEST_NODES[@]}" "${SHARD_INDEX}" "${SHARD_TOTAL}"
+          if [ "${#TEST_NODES[@]}" -eq 0 ]; then
+            echo "No test nodes selected for shard ${SHARD_INDEX}"
             exit 1
           fi
 
@@ -635,7 +654,7 @@ jobs:
             --cov-branch \
             --cov-fail-under=0 \
             --cov-report= \
-            "${TEST_FILES[@]}"
+            "${TEST_NODES[@]}"
 
       - name: Upload coverage data
         if: always()
@@ -708,21 +727,22 @@ jobs:
           SHARD_TOTAL: 4
         run: |
           set -euo pipefail
+          collected_tests="$(mktemp)"
+          uv run --frozen pytest --collect-only -q tests/autoresearch_runner > "${collected_tests}"
           mapfile -t TEST_NODES < <(
-            uv run --frozen pytest --collect-only -q tests/autoresearch_runner |
-              awk -v shard="${SHARD_INDEX}" -v total="${SHARD_TOTAL}" '
-                /^tests\/.*::/ {
-                  collected += 1
-                  if (((collected - 1) % total) == shard) {
-                    print
-                  }
+            awk -v shard="${SHARD_INDEX}" -v total="${SHARD_TOTAL}" '
+              /^tests\/.*::/ {
+                collected += 1
+                if (((collected - 1) % total) == shard) {
+                  print
                 }
-                END {
-                  if (collected != 185) {
-                    printf "EXPECTED_COUNT_MISMATCH:%d\n", collected
-                  }
+              }
+              END {
+                if (collected != 185) {
+                  printf "EXPECTED_COUNT_MISMATCH:%d\n", collected
                 }
-              '
+              }
+            ' "${collected_tests}"
           )
           last_index=$((${#TEST_NODES[@]} - 1))
           if [ "${#TEST_NODES[@]}" -gt 0 ] && [[ "${TEST_NODES[${last_index}]}" == EXPECTED_COUNT_MISMATCH:* ]]; then

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -261,6 +261,24 @@ describe('torghut build-push workflow', () => {
     expect(autoresearchJobBody).not.toContain('name: torghut-coverage-autoresearch-runner\n')
   })
 
+  it('shards primary Torghut pytest by collected test node instead of file list', () => {
+    const pytestShardJob = ciWorkflow.indexOf('pytest-shards:')
+    const nextJob = ciWorkflow.indexOf('\n  pytest-autoresearch-runner:', pytestShardJob)
+    const pytestShardJobBody = ciWorkflow.slice(pytestShardJob, nextJob)
+
+    expect(pytestShardJob).toBeGreaterThan(-1)
+    expect(pytestShardJobBody).toContain('name: Pytest shard ${{ matrix.shard }}')
+    expect(pytestShardJobBody).toContain('shard: [0, 1, 2, 3, 4, 5, 6, 7]')
+    expect(pytestShardJobBody).toContain('SHARD_TOTAL: 8')
+    expect(pytestShardJobBody).toContain(
+      'uv run --frozen pytest --collect-only -q tests --ignore=tests/autoresearch_runner',
+    )
+    expect(pytestShardJobBody).toContain('EXPECTED_MIN_COUNT_MISMATCH:%d')
+    expect(pytestShardJobBody).toContain('"${TEST_NODES[@]}"')
+    expect(pytestShardJobBody).not.toContain("find tests -name 'test_*.py'")
+    expect(pytestShardJobBody).not.toContain('"${TEST_FILES[@]}"')
+  })
+
   it('keeps TA and WS stale workflow promotions path-aware so unrelated main commits do not force rebuilds', () => {
     const releaseWorkflows = [
       {


### PR DESCRIPTION
## Summary

- Split primary Torghut pytest from 4 file-list shards into 8 collected test-node shards so one large file bucket no longer dominates CI wall clock.
- Keep autoresearch runner collection failure-visible by collecting into a temp file before sharding.
- Add workflow contract coverage to prevent Torghut CI from drifting back to file-list sharding.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/torghut-ci.yml`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`
- `uv run --frozen pytest --collect-only -q tests --ignore=tests/autoresearch_runner` split readback: 5,254 nodes across 8 shards, 657/657/657/657/657/657/656/656.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
