### PR TITLE
fix(torghut): unblock bounded paper trading readiness

### DIFF
--- a/services/torghut/app/api/trading_status.py
+++ b/services/torghut/app/api/trading_status.py
@@ -184,6 +184,30 @@ def _skip_expensive_status_reads_after_closed_gate(
     )
 
 
+def _deferred_clickhouse_ta_status(reason: str) -> dict[str, object]:
+    return {
+        "state": "deferred",
+        "source_ref": "trading_status",
+        "read_model_unavailable": True,
+        "read_model_status": "deferred",
+        "reason": reason,
+        "reason_codes": [reason],
+    }
+
+
+def _load_clickhouse_ta_status_for_trading_status(
+    status_read_budget: TradingStatusReadBudget,
+    scheduler: TradingScheduler,
+) -> dict[str, object]:
+    skip_reason = status_read_budget.skip_reason_if_unavailable(
+        "clickhouse_ta_status",
+        min_remaining_seconds=0.75,
+    )
+    if skip_reason is not None:
+        return _deferred_clickhouse_ta_status(skip_reason)
+    return _load_clickhouse_ta_status(scheduler)
+
+
 @router.get("/trading/status")
 def trading_status() -> dict[str, object]:
     """Return trading loop status and metrics."""
@@ -204,7 +228,9 @@ def trading_status() -> dict[str, object]:
     )
     forecast_service_status = _forecast_service_status(empirical_jobs)
     lean_authority_status = _lean_authority_status()
-    clickhouse_ta_status = _load_clickhouse_ta_status(scheduler)
+    clickhouse_ta_status = _deferred_clickhouse_ta_status(
+        "clickhouse_ta_status_deferred_until_after_live_submission_gate"
+    )
     status_observed_at = datetime.now(timezone.utc)
     status_stage_scope = "live" if settings.trading_mode == "live" else "paper"
     market_context_status = scheduler.market_context_status()
@@ -252,6 +278,10 @@ def trading_status() -> dict[str, object]:
             reason=fast_status_gate_reason,
         )
     else:
+        clickhouse_ta_status = _load_clickhouse_ta_status_for_trading_status(
+            status_read_budget,
+            scheduler,
+        )
         llm_evaluation = _load_trading_status_llm_evaluation(status_read_budget)
         tca_summary = _load_trading_status_tca_summary(
             status_read_budget,

--- a/services/torghut/app/trading/submission_council/__init__.py
+++ b/services/torghut/app/trading/submission_council/__init__.py
@@ -50,6 +50,9 @@ from .gate_payloads import (
     bounded_live_paper_collection_gate_payload as _bounded_live_paper_collection_gate_payload,
     common_submission_payload as _common_submission_payload,
 )
+from .configured_collection import (
+    with_configured_paper_collection_targets as _with_configured_paper_collection_targets,
+)
 from .runtime_summary import (
     runtime_ledger_aggregate_candidate_payloads as _runtime_ledger_aggregate_candidate_payloads,
     runtime_ledger_latest_payloads_per_symbol as _runtime_ledger_latest_payloads_per_symbol,
@@ -485,15 +488,20 @@ def _submission_runtime_ledger_context(
     import_plan = _runtime_ledger_paper_probation_import_plan(
         [*paper_probation_candidates, *source_collection_candidates]
     )
+    merged_import_plan = _with_bounded_paper_route_manifest_collection_targets(
+        import_plan,
+        registry_items=registry_item_payloads,
+    )
+    merged_import_plan = _with_configured_paper_collection_targets(
+        merged_import_plan,
+        session=session,
+    )
     return _SubmissionRuntimeLedgerContext(
         repair_candidates=repair_candidates,
         paper_probation_candidates=paper_probation_candidates,
         source_collection_candidates=source_collection_candidates,
         source_collection_profit_target_candidates=source_collection_profit_target_candidates,
-        paper_probation_import_plan=_with_bounded_paper_route_manifest_collection_targets(
-            import_plan,
-            registry_items=registry_item_payloads,
-        ),
+        paper_probation_import_plan=merged_import_plan,
     )
 
 

--- a/services/torghut/app/trading/submission_council/configured_collection.py
+++ b/services/torghut/app/trading/submission_council/configured_collection.py
@@ -1,0 +1,311 @@
+"""Configured bounded paper collection fallback targets."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ...models import Strategy
+from ..promotion_authority import capital_blocked_authority, source_collection_authority
+
+from .common import (
+    bounded_paper_route_probe_collection_payload,
+    decimal_text,
+    safe_decimal,
+    settings,
+)
+from .paper_probation import (
+    BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS,
+    RUNTIME_LEDGER_PAPER_PROBATION_IMPORT_SCHEMA_VERSION,
+)
+
+_CONFIGURED_COLLECTION_SOURCE = "configured_simple_lane_paper_data_collection"
+_CONFIGURED_COLLECTION_ACCOUNT_LABEL = "TORGHUT_SIM"
+_CONFIGURED_COLLECTION_LIMIT = 8
+
+
+def with_configured_paper_collection_targets(
+    plan: Mapping[str, object],
+    *,
+    session: Session | None,
+) -> dict[str, object]:
+    merged_plan = dict(plan)
+    max_notional = safe_decimal(settings.trading_simple_paper_route_probe_max_notional)
+    configured_collection_enabled = (
+        session is not None
+        and settings.trading_mode == "live"
+        and settings.trading_simple_paper_route_probe_enabled
+        and settings.trading_simple_paper_route_probe_allow_live_mode
+        and max_notional is not None
+        and max_notional > 0
+    )
+    if not configured_collection_enabled:
+        return merged_plan
+
+    symbols = _configured_static_symbols()
+    if not symbols:
+        return merged_plan
+
+    assert session is not None
+    assert max_notional is not None
+    max_notional_text = decimal_text(max_notional)
+    targets = _configured_strategy_targets(
+        session,
+        static_symbols=symbols,
+        max_notional=max_notional_text,
+        existing_targets=_mapping_items(merged_plan.get("targets")),
+    )
+    if not targets:
+        return merged_plan
+
+    existing_targets = _mapping_items(merged_plan.get("targets"))
+    merged_targets = [*existing_targets, *targets]
+    existing_source_count = _int_value(
+        merged_plan.get("source_collection_target_count")
+    )
+    source = str(merged_plan.get("source") or "").strip()
+    merged_plan.update(
+        {
+            "schema_version": RUNTIME_LEDGER_PAPER_PROBATION_IMPORT_SCHEMA_VERSION,
+            "target_count": len(merged_targets),
+            "source_collection_target_count": existing_source_count + len(targets),
+            "configured_bounded_collection_target_count": len(targets),
+            "bounded_collection_account_label": _CONFIGURED_COLLECTION_ACCOUNT_LABEL,
+            "observed_stage": "paper",
+            "paper_data_collection_authorized": True,
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "bounded_evidence_collection_max_notional": max_notional_text,
+            "promotion_allowed": False,
+            "capital_promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "paper_route_target_plan_fallback": True,
+            "paper_route_target_plan_fallback_reason": (
+                "configured_static_universe_paper_collection"
+            ),
+            "targets": merged_targets,
+        }
+    )
+    if not source or _target_count(plan) <= 0:
+        merged_plan["source"] = _CONFIGURED_COLLECTION_SOURCE
+        merged_plan["source_ref"] = "configured-static-universe-paper-data-collection"
+        merged_plan["account_label"] = _CONFIGURED_COLLECTION_ACCOUNT_LABEL
+        merged_plan["source_account_label"] = _CONFIGURED_COLLECTION_ACCOUNT_LABEL
+    else:
+        merged_plan["configured_collection_source"] = _CONFIGURED_COLLECTION_SOURCE
+        merged_plan["configured_collection_source_ref"] = (
+            "configured-static-universe-paper-data-collection"
+        )
+    return merged_plan
+
+
+def _mapping_items(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [
+        dict(cast(Mapping[str, object], item))
+        for item in cast(Sequence[object], value)
+        if isinstance(item, Mapping)
+    ]
+
+
+def _int_value(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return 0
+
+
+def _target_count(plan: Mapping[str, object]) -> int:
+    targets = _mapping_items(plan.get("targets"))
+    if targets:
+        return len(targets)
+    return _int_value(plan.get("target_count"))
+
+
+def _configured_static_symbols() -> list[str]:
+    symbols: list[str] = []
+    for raw_symbol in settings.trading_static_symbols:
+        symbol = str(raw_symbol).strip().upper()
+        if symbol and symbol not in symbols:
+            symbols.append(symbol)
+    return symbols
+
+
+def _configured_strategy_targets(
+    session: Session,
+    *,
+    static_symbols: Sequence[str],
+    max_notional: str,
+    existing_targets: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    rows = session.execute(
+        select(Strategy).where(Strategy.enabled.is_(True)).order_by(Strategy.name)
+    ).scalars()
+    targets: list[dict[str, object]] = []
+    for strategy in rows:
+        symbols = _strategy_collection_symbols(strategy, static_symbols=static_symbols)
+        if not symbols:
+            continue
+        strategy_name = str(strategy.name or "").strip()
+        if not strategy_name:
+            continue
+        hypothesis_id = f"configured-paper-collection:{strategy_name}"
+        candidate_id = f"configured:{strategy_name}"
+        if _has_target(
+            existing_targets,
+            hypothesis_id=hypothesis_id,
+            candidate_id=candidate_id,
+        ):
+            continue
+        targets.append(
+            _configured_strategy_target(
+                strategy=strategy,
+                symbols=symbols,
+                max_notional=max_notional,
+            )
+        )
+        if len(targets) >= _CONFIGURED_COLLECTION_LIMIT:
+            break
+    return targets
+
+
+def _has_target(
+    targets: Sequence[Mapping[str, object]],
+    *,
+    hypothesis_id: str,
+    candidate_id: str,
+) -> bool:
+    for target in targets:
+        if (
+            str(target.get("hypothesis_id") or "").strip() == hypothesis_id
+            and str(target.get("candidate_id") or "").strip() == candidate_id
+        ):
+            return True
+    return False
+
+
+def _strategy_collection_symbols(
+    strategy: Strategy,
+    *,
+    static_symbols: Sequence[str],
+) -> list[str]:
+    strategy_symbols = _strategy_symbol_values(strategy.universe_symbols)
+    if strategy_symbols:
+        return [symbol for symbol in strategy_symbols if symbol in static_symbols]
+    return list(static_symbols)
+
+
+def _strategy_symbol_values(raw_symbols: object) -> list[str]:
+    if isinstance(raw_symbols, str):
+        values: Sequence[object] = raw_symbols.split(",")
+    elif isinstance(raw_symbols, Sequence) and not isinstance(
+        raw_symbols,
+        (bytes, bytearray),
+    ):
+        values = cast(Sequence[object], raw_symbols)
+    else:
+        values = ()
+
+    symbols: list[str] = []
+    for raw_symbol in values:
+        symbol = str(raw_symbol).strip().upper()
+        if symbol and symbol not in symbols:
+            symbols.append(symbol)
+    return symbols
+
+
+def _configured_strategy_target(
+    *,
+    strategy: Strategy,
+    symbols: Sequence[str],
+    max_notional: str,
+) -> dict[str, object]:
+    strategy_name = str(strategy.name or "").strip()
+    hypothesis_id = f"configured-paper-collection:{strategy_name}"
+    candidate_id = f"configured:{strategy_name}"
+    symbol_actions = {symbol: "buy" for symbol in symbols}
+    strategy_family = str(strategy.universe_type or "").strip() or "static"
+    target = {
+        "hypothesis_id": hypothesis_id,
+        "candidate_id": candidate_id,
+        "strategy_id": str(strategy.id or ""),
+        "strategy_name": strategy_name,
+        "runtime_strategy_name": strategy_name,
+        "strategy_lookup_names": [strategy_name],
+        "strategy_family": strategy_family,
+        "strategy_type": strategy_family,
+        "account_label": _CONFIGURED_COLLECTION_ACCOUNT_LABEL,
+        "source_account_label": _CONFIGURED_COLLECTION_ACCOUNT_LABEL,
+        "execution_account_label": settings.trading_account_label,
+        "paper_account_label": settings.trading_account_label,
+        "paper_route_runtime_account_label": settings.trading_account_label,
+        "bounded_collection_account_label": _CONFIGURED_COLLECTION_ACCOUNT_LABEL,
+        "account_stage_runtime_identity": {
+            "account_label": _CONFIGURED_COLLECTION_ACCOUNT_LABEL,
+            "source_account_label": _CONFIGURED_COLLECTION_ACCOUNT_LABEL,
+            "execution_account_label": settings.trading_account_label,
+            "runtime_account_label": settings.trading_account_label,
+            "paper_account_label": settings.trading_account_label,
+            "paper_route_runtime_account_label": settings.trading_account_label,
+            "observed_stage": "paper",
+            "source_kind": _CONFIGURED_COLLECTION_SOURCE,
+        },
+        "observed_stage": "paper",
+        "source_kind": _CONFIGURED_COLLECTION_SOURCE,
+        "source_plan_ref": "configured-static-universe-paper-data-collection",
+        "source_manifest_ref": (
+            f"configured-static-universe-paper-data-collection:{strategy_name}"
+        ),
+        "source_decision_mode": "bounded_paper_route_collection",
+        "paper_probation_authorized": True,
+        "paper_data_collection_authorized": True,
+        "bounded_evidence_collection_authorized": True,
+        "bounded_live_paper_collection_authorized": True,
+        "source_collection_authorized": True,
+        "source_collection_authorization_scope": (
+            "configured_strategy_catalog_evidence_collection_only"
+        ),
+        "paper_route_probe_scope_authority": "configured_static_universe",
+        "paper_route_probe_symbols": list(symbols),
+        "paper_route_probe_raw_target_symbols": list(symbols),
+        "paper_route_probe_symbol_actions": symbol_actions,
+        "target_symbol_actions": symbol_actions,
+        "symbol_actions": symbol_actions,
+        "paper_route_probe_symbol_quantities": {},
+        "target_symbol_quantities": {},
+        "paper_route_probe_strategy_universe_fallback": not bool(
+            _strategy_symbol_values(strategy.universe_symbols)
+        ),
+        "paper_route_probe_next_session_max_notional": max_notional,
+        "paper_route_probe_effective_max_notional": max_notional,
+        "bounded_evidence_collection_max_notional": max_notional,
+        "target_notional": max_notional,
+        "max_notional": max_notional,
+        "promotion_allowed": False,
+        "capital_promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "evidence_collection_ok": True,
+        **capital_blocked_authority(
+            blockers=["configured_collection_not_capital_promotion_authority"],
+        ).as_target_fields(),
+        **source_collection_authority(
+            blockers=list(BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS),
+            bounded_live_paper_collection_authorized=True,
+        ).as_target_fields(),
+        **bounded_paper_route_probe_collection_payload(authorized=True),
+    }
+    return target
+
+
+__all__ = [
+    "with_configured_paper_collection_targets",
+]

--- a/services/torghut/app/trading/submission_council/gate_payloads.py
+++ b/services/torghut/app/trading/submission_council/gate_payloads.py
@@ -70,6 +70,7 @@ def bounded_live_paper_collection_gate_payload(
         len(runtime_ledger.source_collection_candidates),
         safe_int(import_plan.get("source_collection_target_count")),
         safe_int(import_plan.get("manifest_bounded_collection_target_count")),
+        safe_int(import_plan.get("configured_bounded_collection_target_count")),
     )
     profit_target_count = max(
         len(runtime_ledger.source_collection_profit_target_candidates),

--- a/services/torghut/tests/api/test_trading_api_status_read_budget.py
+++ b/services/torghut/tests/api/test_trading_api_status_read_budget.py
@@ -79,6 +79,76 @@ class TestTradingApiStatusReadBudget(TradingApiTestCaseBase):
         payload = response.json()
         self.assertIn("status_read_budget", payload)
 
+    def test_trading_status_builds_live_gate_before_clickhouse_ta_read(
+        self,
+    ) -> None:
+        class ManualBudget(TradingStatusReadBudget):
+            def __init__(self) -> None:
+                super().__init__(max_seconds=10.0)
+                self.current_elapsed = 1.0
+
+            def elapsed_seconds(self) -> float:
+                return self.current_elapsed
+
+        budget = ManualBudget()
+        call_order: list[str] = []
+        live_submission_gate_payload = {
+            "allowed": False,
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "blocked_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "read_model_unavailable": False,
+            "promotion_authority": False,
+            "final_authority_ok": False,
+            "final_promotion_allowed": False,
+        }
+
+        def _load_clickhouse_ta_status(*_args: object) -> dict[str, object]:
+            call_order.append("clickhouse_ta_status")
+            budget.current_elapsed = 9.8
+            return {
+                "state": "current",
+                "latest_signal_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+                "source_ref": "clickhouse:ta_signals",
+            }
+
+        def _build_live_submission_gate(
+            *args: object,
+            **kwargs: object,
+        ) -> dict[str, object]:
+            call_order.append("live_submission_gate")
+            clickhouse_ta_status = kwargs["clickhouse_ta_status"]
+            self.assertEqual(clickhouse_ta_status["state"], "deferred")
+            self.assertIn(
+                "clickhouse_ta_status_deferred_until_after_live_submission_gate",
+                clickhouse_ta_status["reason_codes"],
+            )
+            return live_submission_gate_payload
+
+        with (
+            patch(
+                "app.api.trading_status._TradingStatusReadBudget", return_value=budget
+            ),
+            patch(
+                "app.api.trading_status._load_clickhouse_ta_status",
+                side_effect=_load_clickhouse_ta_status,
+            ),
+            patch(
+                "app.api.trading_status._build_live_submission_gate_payload",
+                side_effect=_build_live_submission_gate,
+            ) as live_gate,
+        ):
+            response = self.client.get("/trading/status")
+
+        self.assertEqual(response.status_code, 200)
+        live_gate.assert_called_once()
+        self.assertEqual(call_order, ["live_submission_gate", "clickhouse_ta_status"])
+        payload = response.json()
+        self.assertNotIn(
+            "live_submission_gate",
+            payload["status_read_budget"]["skipped_reads"],
+        )
+        self.assertFalse(payload["live_submission_gate"]["read_model_unavailable"])
+
     def test_trading_status_fails_closed_late_reads_after_budget_exhausted(
         self,
     ) -> None:

--- a/services/torghut/tests/submission_council/test_configured_collection_targets.py
+++ b/services/torghut/tests/submission_council/test_configured_collection_targets.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from app.trading.submission_council.configured_collection import (
+    with_configured_paper_collection_targets,
+)
+
+from tests.submission_council.support import (
+    Base,
+    StaticPool,
+    Strategy,
+    SubmissionCouncilTestCase,
+    create_engine,
+    sessionmaker,
+    settings,
+)
+
+
+class TestConfiguredCollectionTargets(SubmissionCouncilTestCase):
+    def test_configured_collection_replaces_empty_plan_source(self) -> None:
+        account_label_before = settings.trading_account_label
+        static_symbols_before = settings.trading_static_symbols_raw
+        try:
+            settings.trading_simple_paper_route_probe_enabled = True
+            settings.trading_simple_paper_route_probe_allow_live_mode = True
+            settings.trading_simple_paper_route_probe_max_notional = 100
+            settings.trading_account_label = "PA3SX7FYNUTF"
+            settings.trading_static_symbols_raw = "NVDA,AMD,MU"
+
+            engine = create_engine(
+                "sqlite+pysqlite:///:memory:",
+                future=True,
+                connect_args={"check_same_thread": False},
+                poolclass=StaticPool,
+            )
+            Base.metadata.create_all(engine)
+            session_local = sessionmaker(
+                bind=engine,
+                expire_on_commit=False,
+                future=True,
+            )
+
+            with session_local() as session:
+                session.add(
+                    Strategy(
+                        name="string-universe",
+                        description="configured paper collection",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols="nvda, mu, NVDA",
+                    )
+                )
+                session.commit()
+
+                result = with_configured_paper_collection_targets(
+                    {
+                        "targets": "not-a-target-list",
+                        "target_count": "0",
+                        "source_collection_target_count": True,
+                    },
+                    session=session,
+                )
+        finally:
+            settings.trading_account_label = account_label_before
+            settings.trading_static_symbols_raw = static_symbols_before
+
+        self.assertEqual(
+            result["source"], "configured_simple_lane_paper_data_collection"
+        )
+        self.assertEqual(
+            result["source_ref"],
+            "configured-static-universe-paper-data-collection",
+        )
+        self.assertEqual(result["account_label"], "TORGHUT_SIM")
+        self.assertEqual(result["source_collection_target_count"], 2)
+        self.assertEqual(result["configured_bounded_collection_target_count"], 1)
+        targets = result["targets"]
+        self.assertEqual(targets[0]["paper_route_probe_symbols"], ["NVDA", "MU"])
+
+    def test_configured_collection_skips_unusable_and_duplicate_strategies(
+        self,
+    ) -> None:
+        static_symbols_before = settings.trading_static_symbols_raw
+        try:
+            settings.trading_simple_paper_route_probe_enabled = True
+            settings.trading_simple_paper_route_probe_allow_live_mode = True
+            settings.trading_simple_paper_route_probe_max_notional = 100
+            settings.trading_static_symbols_raw = "NVDA,AMD"
+
+            engine = create_engine(
+                "sqlite+pysqlite:///:memory:",
+                future=True,
+                connect_args={"check_same_thread": False},
+                poolclass=StaticPool,
+            )
+            Base.metadata.create_all(engine)
+            session_local = sessionmaker(
+                bind=engine,
+                expire_on_commit=False,
+                future=True,
+            )
+            plan = {
+                "source": "external_paper_route_target_plan",
+                "target_count": 1,
+                "targets": [
+                    {
+                        "hypothesis_id": "configured-paper-collection:duplicate",
+                        "candidate_id": "configured:duplicate",
+                    }
+                ],
+            }
+
+            with session_local() as session:
+                session.add_all(
+                    [
+                        Strategy(
+                            name="duplicate",
+                            description="duplicate target",
+                            enabled=True,
+                            base_timeframe="1Min",
+                            universe_type="static",
+                            universe_symbols=["NVDA"],
+                        ),
+                        Strategy(
+                            name="no-match",
+                            description="no static universe overlap",
+                            enabled=True,
+                            base_timeframe="1Min",
+                            universe_type="static",
+                            universe_symbols=["MSFT"],
+                        ),
+                        Strategy(
+                            name="",
+                            description="empty strategy name",
+                            enabled=True,
+                            base_timeframe="1Min",
+                            universe_type="static",
+                            universe_symbols=["AMD"],
+                        ),
+                    ]
+                )
+                session.commit()
+
+                result = with_configured_paper_collection_targets(
+                    plan,
+                    session=session,
+                )
+        finally:
+            settings.trading_static_symbols_raw = static_symbols_before
+
+        self.assertEqual(result, plan)
+
+    def test_configured_collection_limits_static_universe_targets(self) -> None:
+        static_symbols_before = settings.trading_static_symbols_raw
+        try:
+            settings.trading_simple_paper_route_probe_enabled = True
+            settings.trading_simple_paper_route_probe_allow_live_mode = True
+            settings.trading_simple_paper_route_probe_max_notional = 100
+            settings.trading_static_symbols_raw = "NVDA,AMD"
+
+            engine = create_engine(
+                "sqlite+pysqlite:///:memory:",
+                future=True,
+                connect_args={"check_same_thread": False},
+                poolclass=StaticPool,
+            )
+            Base.metadata.create_all(engine)
+            session_local = sessionmaker(
+                bind=engine,
+                expire_on_commit=False,
+                future=True,
+            )
+
+            with session_local() as session:
+                session.add_all(
+                    Strategy(
+                        name=f"collector-{index}",
+                        description="static fallback collector",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=None,
+                    )
+                    for index in range(9)
+                )
+                session.commit()
+
+                result = with_configured_paper_collection_targets(
+                    {
+                        "source": "external_paper_route_target_plan",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "external",
+                                "candidate_id": "external",
+                            }
+                        ],
+                    },
+                    session=session,
+                )
+        finally:
+            settings.trading_static_symbols_raw = static_symbols_before
+
+        self.assertEqual(result["source"], "external_paper_route_target_plan")
+        self.assertEqual(
+            result["configured_collection_source"],
+            "configured_simple_lane_paper_data_collection",
+        )
+        self.assertEqual(result["configured_bounded_collection_target_count"], 8)
+        self.assertEqual(result["target_count"], 9)
+        configured_targets = [
+            target
+            for target in result["targets"]
+            if target.get("source_kind")
+            == "configured_simple_lane_paper_data_collection"
+        ]
+        self.assertEqual(len(configured_targets), 8)
+        self.assertTrue(
+            configured_targets[0]["paper_route_probe_strategy_universe_fallback"]
+        )

--- a/services/torghut/tests/submission_council/test_live_submission_gate.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 
 from tests.submission_council.support import (
+    Base,
     SimpleNamespace,
+    StaticPool,
+    Strategy,
     SubmissionCouncilTestCase,
     build_live_submission_gate_payload,
+    create_engine,
     datetime,
+    sessionmaker,
+    settings,
     timezone,
 )
 
@@ -165,6 +171,106 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
         self.assertIn(
             "live_submit_activation_expiry_invalid",
             collection_gate["blocked_reasons"],
+        )
+
+    def test_bounded_live_paper_collection_gate_uses_configured_strategy_universe(
+        self,
+    ) -> None:
+        account_label_before = settings.trading_account_label
+        static_symbols_before = settings.trading_static_symbols_raw
+        try:
+            settings.trading_simple_paper_route_probe_enabled = True
+            settings.trading_simple_paper_route_probe_allow_live_mode = True
+            settings.trading_simple_submit_enabled = True
+            settings.trading_simple_paper_route_probe_max_notional = 100
+            settings.trading_live_submit_activation_expires_at = "2026-06-22T20:05:00Z"
+            settings.trading_account_label = "PA3SX7FYNUTF"
+            settings.trading_static_symbols_raw = "NVDA,AMD,MU,WDC"
+
+            engine = create_engine(
+                "sqlite+pysqlite:///:memory:",
+                future=True,
+                connect_args={"check_same_thread": False},
+                poolclass=StaticPool,
+            )
+            Base.metadata.create_all(engine)
+            session_local = sessionmaker(
+                bind=engine,
+                expire_on_commit=False,
+                future=True,
+            )
+
+            with session_local() as session:
+                session.add_all(
+                    [
+                        Strategy(
+                            name="ai-chip-momentum",
+                            description="configured paper collection",
+                            enabled=True,
+                            base_timeframe="1Min",
+                            universe_type="static",
+                            universe_symbols=["NVDA", "TSLA", "AMD"],
+                        ),
+                        Strategy(
+                            name="disabled-collector",
+                            description="disabled collector",
+                            enabled=False,
+                            base_timeframe="1Min",
+                            universe_type="static",
+                            universe_symbols=["MU"],
+                        ),
+                    ]
+                )
+                session.commit()
+
+                result = build_live_submission_gate_payload(
+                    SimpleNamespace(
+                        market_session_open=True,
+                        last_autonomy_promotion_eligible=False,
+                        last_autonomy_promotion_action=None,
+                        drift_live_promotion_eligible=False,
+                        last_market_context_freshness_seconds=45,
+                    ),
+                    hypothesis_summary={
+                        "promotion_eligible_total": 0,
+                        "capital_stage_totals": {"shadow": 1},
+                        "dependency_quorum": {
+                            "decision": "allow",
+                            "reasons": [],
+                            "message": "ready",
+                        },
+                    },
+                    empirical_jobs_status={"ready": True, "status": "healthy"},
+                    quant_health_status=self._healthy_quant_status(),
+                    session=session,
+                )
+        finally:
+            settings.trading_account_label = account_label_before
+            settings.trading_static_symbols_raw = static_symbols_before
+
+        self.assertFalse(result["allowed"])
+        self.assertIn(
+            "runtime_ledger_source_collection_pending",
+            result["blocked_reasons"],
+        )
+        import_plan = result["runtime_ledger_paper_probation_import_plan"]
+        self.assertEqual(import_plan["configured_bounded_collection_target_count"], 1)
+        self.assertGreaterEqual(import_plan["target_count"], 1)
+        self.assertGreaterEqual(import_plan["source_collection_target_count"], 1)
+        targets = {target["strategy_name"]: target for target in import_plan["targets"]}
+        target = targets["ai-chip-momentum"]
+        self.assertEqual(target["strategy_name"], "ai-chip-momentum")
+        self.assertEqual(target["paper_route_probe_symbols"], ["NVDA", "AMD"])
+        self.assertEqual(target["account_label"], "TORGHUT_SIM")
+        self.assertEqual(target["execution_account_label"], "PA3SX7FYNUTF")
+        self.assertTrue(target["bounded_live_paper_collection_authorized"])
+        self.assertFalse(target["final_promotion_allowed"])
+        collection_gate = result["bounded_live_paper_collection_gate"]
+        self.assertTrue(collection_gate["allowed"])
+        self.assertTrue(collection_gate["active"])
+        self.assertEqual(
+            collection_gate["reason"],
+            "bounded_live_paper_collection_ready",
         )
 
     def test_build_live_submission_gate_payload_exports_runtime_window_health_inputs(


### PR DESCRIPTION
## Summary

- Prioritizes the live submission gate before expensive ClickHouse TA status reads so `/trading/status` does not report a skipped gate when diagnostics consume the read budget.
- Adds a configured bounded paper-collection target fallback that merges enabled strategies with the static AI/semi universe and preserves capped collection-only authority.
- Counts configured collection targets in the bounded live paper gate and adds regression tests for status read ordering and configured target generation.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_status_read_budget.py tests/submission_council/test_live_submission_gate.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/simple_pipeline/test_local_target_plan_enriches_probe_contract_before_bounded_gate.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py`
- `cd services/torghut && uv run --frozen ruff check app/api/trading_status.py app/trading/submission_council/configured_collection.py app/trading/submission_council/__init__.py app/trading/submission_council/gate_payloads.py tests/api/test_trading_api_status_read_budget.py tests/submission_council/test_live_submission_gate.py`
- `cd services/torghut && uv run --frozen ruff format --check app/api/trading_status.py app/trading/submission_council/configured_collection.py app/trading/submission_council/__init__.py app/trading/submission_council/gate_payloads.py tests/api/test_trading_api_status_read_budget.py tests/submission_council/test_live_submission_gate.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
