### PR TITLE
chore(torghut): promote image 2af65187

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -51,9 +51,9 @@ spec:
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+              value: 2af651874371ba81f2eac8116558bd6c6a27f094
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              value: sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -45,9 +45,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+              value: 2af651874371ba81f2eac8116558bd6c6a27f094
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              value: sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-861-ga7d3caca5
+              value: v0.596.0-867-g2af651874
             - name: TORGHUT_OPTIONS_COMMIT
-              value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+              value: 2af651874371ba81f2eac8116558bd6c6a27f094
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-861-ga7d3caca5
+              value: v0.596.0-867-g2af651874
             - name: TORGHUT_OPTIONS_COMMIT
-              value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+              value: 2af651874371ba81f2eac8116558bd6c6a27f094
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -164,9 +164,9 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+                  value: sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
                 - name: TORGHUT_COMMIT
-                  value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+                  value: 2af651874371ba81f2eac8116558bd6c6a27f094
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-19T00:20:25Z"
+        client.knative.dev/updateTimestamp: "2026-06-19T08:10:02Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           ports:
             - name: http1
               containerPort: 8181
@@ -541,11 +541,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-861-ga7d3caca5
+              value: v0.596.0-867-g2af651874
             - name: TORGHUT_COMMIT
-              value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+              value: 2af651874371ba81f2eac8116558bd6c6a27f094
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              value: sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-19T00:20:25Z"
+        client.knative.dev/updateTimestamp: "2026-06-19T08:10:02Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           ports:
             - name: http1
               containerPort: 8181
@@ -415,11 +415,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-861-ga7d3caca5
+              value: v0.596.0-867-g2af651874
             - name: TORGHUT_COMMIT
-              value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+              value: 2af651874371ba81f2eac8116558bd6c6a27f094
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              value: sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: a7d3caca5a87410321f3b9b2ae8a606fca336b32
+            value: 2af651874371ba81f2eac8116558bd6c6a27f094
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+            value: sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:769144ce6f6fda7c356bcf8b717711d4943eb02a07458eb18dc3b15f73f72738
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2af651874371ba81f2eac8116558bd6c6a27f094`
- Image tag: `2af65187`
- Image digest: `sha256:02fff677259d73201b8c06f43f18169ba82b17f5a6eef3b2f75ae91a07584c7f`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher