### PR TITLE
test(torghut): align hyperliquid feed scheduling contract

### DIFF
--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -155,12 +155,13 @@ describe('Torghut manifest scheduling', () => {
 
     expect(enabledTables).toEqual([
       'hyperliquid_market_catalog',
+      'hyperliquid_bbo',
       'hyperliquid_candles',
       'hyperliquid_asset_contexts',
       'hyperliquid_funding',
       'hyperliquid_status',
     ])
-    expect(readyTables).toEqual(['hyperliquid_candles'])
+    expect(readyTables).toEqual(['hyperliquid_bbo', 'hyperliquid_candles'])
     expect(readyTables.every((table) => enabledTables.includes(table))).toBe(true)
     expect(data.CLICKHOUSE_REQUEST_TIMEOUT_MS).toBe('30000')
     expect(data.CLICKHOUSE_ENABLED).toBe('true')
@@ -187,7 +188,7 @@ describe('Torghut manifest scheduling', () => {
     )
     expect(
       getAtPath(deployment, ['spec', 'template', 'metadata', 'annotations'])['proompteng.ai/config-revision'],
-    ).toBe('hyperliquid-feed-pinned-spx-20260618a')
+    ).toBe('hyperliquid-feed-bbo-clickhouse-20260619a')
   })
 
   it('bounds Hyperliquid runtime ClickHouse schema hooks so Argo syncs cannot hang on distributed DDL', () => {


### PR DESCRIPTION
## Summary

- Update the Torghut manifest scheduling contract for the current Hyperliquid feed manifest.
- Treat `hyperliquid_bbo` as an enabled and readiness-critical ClickHouse table.
- Align the expected feed rollout annotation with `hyperliquid-feed-bbo-clickhouse-20260619a`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
