### PR TITLE
fix(torghut): remove hyperliquid feed publish backpressure

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -53,7 +53,7 @@ data:
   TOPIC_FUNDING: "torghut.hyperliquid.funding.v1"
   TOPIC_STATUS: "torghut.hyperliquid.status.v1"
   CLICKHOUSE_ENABLED: "true"
-  CLICKHOUSE_REQUIRED_FOR_READINESS: "false"
+  CLICKHOUSE_REQUIRED_FOR_READINESS: "true"
   CLICKHOUSE_HTTP_URL: "http://torghut-clickhouse.torghut.svc.cluster.local:8123"
   CLICKHOUSE_DATABASE: "torghut"
   CLICKHOUSE_USERNAME: "torghut"

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-feed-bbo-clickhouse-20260619a
+        proompteng.ai/config-revision: hyperliquid-feed-nonblocking-publish-20260619a
       labels:
         app: torghut-hyperliquid-feed
     spec:

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
@@ -35,6 +35,12 @@ data class ClickHouseReadinessUpdate(
   val ready: Boolean,
   val tableFreshnessReady: Boolean = ready,
   val tableIngestLagMs: Map<String, Long?>,
+  val tableEventLagMs: Map<String, Long?>,
+)
+
+private data class ClickHouseTableFreshness(
+  val ingestLagMs: Map<String, Long?>,
+  val eventLagMs: Map<String, Long?>,
 )
 
 class ClickHouseSink(
@@ -52,6 +58,9 @@ class ClickHouseSink(
 
   @Volatile
   private var latestTableIngestLagMs: Map<String, Long?> = config.readyTables.associateWith { null }
+
+  @Volatile
+  private var latestTableEventLagMs: Map<String, Long?> = config.readyTables.associateWith { null }
 
   suspend fun enqueue(record: RoutedEnvelope) {
     if (!config.enabled) return
@@ -143,13 +152,15 @@ class ClickHouseSink(
     return runCatching {
       queryTableFreshness(observedAt)
     }.fold(
-      onSuccess = { lags ->
-        latestTableIngestLagMs = lags
-        lags.forEach { (table, lagMs) -> metrics.setClickHouseTableIngestLagMs(table, lagMs) }
-        val fresh = lags.values.all { lagMs -> lagMs != null && lagMs in 0L..config.readyMaxAgeMs }
+      onSuccess = { freshness ->
+        latestTableIngestLagMs = freshness.ingestLagMs
+        latestTableEventLagMs = freshness.eventLagMs
+        freshness.ingestLagMs.forEach { (table, lagMs) -> metrics.setClickHouseTableIngestLagMs(table, lagMs) }
+        freshness.eventLagMs.forEach { (table, lagMs) -> metrics.setClickHouseTableEventLagMs(table, lagMs) }
+        val fresh = freshness.eventLagMs.values.all { lagMs -> lagMs != null && lagMs in 0L..config.readyMaxAgeMs }
         tableFreshnessReady.set(fresh)
         lastFreshnessCheckMs.set(observedAt)
-        if (!fresh) clickHouseLogger.warn { "clickhouse table freshness stale lags_ms=$lags" }
+        if (!fresh) clickHouseLogger.warn { "clickhouse table event freshness stale lags_ms=${freshness.eventLagMs}" }
         fresh
       },
       onFailure = { error ->
@@ -161,23 +172,29 @@ class ClickHouseSink(
     )
   }
 
-  private suspend fun queryTableFreshness(observedAt: Long): Map<String, Long?> {
+  private suspend fun queryTableFreshness(observedAt: Long): ClickHouseTableFreshness {
     val database = clickHouseIdentifier(config.database)
     val tables = config.readyTables.sorted().map(::clickHouseIdentifier)
     val union =
       tables.joinToString("\nUNION ALL\n") { table ->
-        "SELECT '$table' AS table, max(parseDateTimeBestEffort(ingest_ts)) AS latest_ingest " +
+        "SELECT '$table' AS table, " +
+          "max(parseDateTimeBestEffort(ingest_ts)) AS latest_ingest, " +
+          "max(parseDateTimeBestEffort(event_ts)) AS latest_event " +
           "FROM $database.$table WHERE network = ${sqlString(network)}"
       }
     val query =
       """
-      SELECT table, if(isNull(latest_ingest), NULL, toUnixTimestamp64Milli(toDateTime64(latest_ingest, 3))) AS latest_ingest_ms
+      SELECT
+        table,
+        if(isNull(latest_ingest), NULL, toUnixTimestamp64Milli(toDateTime64(latest_ingest, 3))) AS latest_ingest_ms,
+        if(isNull(latest_event), NULL, toUnixTimestamp64Milli(toDateTime64(latest_event, 3))) AS latest_event_ms
       FROM (
       $union
       )
       FORMAT JSONEachRow
       """.trimIndent()
-    val observedRows = mutableMapOf<String, Long?>()
+    val ingestRows = mutableMapOf<String, Long?>()
+    val eventRows = mutableMapOf<String, Long?>()
     executeClickHouse(query)
       .lineSequence()
       .map { it.trim() }
@@ -186,9 +203,16 @@ class ClickHouseSink(
         val row = json.decodeFromString<JsonObject>(line)
         val table = row["table"]?.jsonPrimitive?.contentOrNull
         val latestIngestMs = row["latest_ingest_ms"]?.jsonPrimitive?.longOrNull
-        if (table != null) observedRows[table] = latestIngestMs?.takeIf { it > 0 }?.let { observedAt - it }
+        val latestEventMs = row["latest_event_ms"]?.jsonPrimitive?.longOrNull
+        if (table != null) {
+          ingestRows[table] = latestIngestMs?.takeIf { it > 0 }?.let { observedAt - it }
+          eventRows[table] = latestEventMs?.takeIf { it > 0 }?.let { observedAt - it }
+        }
       }
-    return tables.associateWith { observedRows[it] }
+    return ClickHouseTableFreshness(
+      ingestLagMs = tables.associateWith { ingestRows[it] },
+      eventLagMs = tables.associateWith { eventRows[it] },
+    )
   }
 
   private fun rowFor(record: RoutedEnvelope): JsonObject =
@@ -235,6 +259,7 @@ class ClickHouseSink(
         ready = ready,
         tableFreshnessReady = tableFreshnessReady,
         tableIngestLagMs = latestTableIngestLagMs,
+        tableEventLagMs = latestTableEventLagMs,
       ),
     )
   }

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HealthServer.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HealthServer.kt
@@ -33,6 +33,7 @@ data class HyperliquidReadinessInfo(
   val clickhouseLastSuccessLagMs: Long?,
   val clickhouseLastFailureAgeMs: Long?,
   val clickhouseTableIngestLagMs: Map<String, Long?>,
+  val clickhouseTableEventLagMs: Map<String, Long?>,
   val marketDataFresh: Boolean,
   val marketDataLastSeenLagMs: Map<String, Long?>,
   val marketDataMaxAgeMs: Long,

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
@@ -69,6 +69,9 @@ class HyperliquidFeedApp(
   @Volatile
   private var clickHouseTableIngestLagMs: Map<String, Long?> = config.clickHouse.readyTables.associateWith { null }
 
+  @Volatile
+  private var clickHouseTableEventLagMs: Map<String, Long?> = config.clickHouse.readyTables.associateWith { null }
+
   private val httpClient =
     HttpClient(CIO) {
       install(WebSockets)
@@ -96,6 +99,7 @@ class HyperliquidFeedApp(
         ClickHouseSink(config.clickHouse, httpClient, metrics, json, network = config.network) { update ->
           val observedAt = nowMs()
           clickHouseTableIngestLagMs = update.tableIngestLagMs
+          clickHouseTableEventLagMs = update.tableEventLagMs
           clickHouseTableFresh.set(update.tableFreshnessReady)
           if (update.ready) {
             clickHouseLastSuccessMs.set(observedAt)
@@ -161,6 +165,7 @@ class HyperliquidFeedApp(
       clickhouseLastSuccessLagMs = clickHouseLastSuccessLagMs(),
       clickhouseLastFailureAgeMs = clickHouseLastFailureAgeMs(),
       clickhouseTableIngestLagMs = clickHouseTableIngestLagMs,
+      clickhouseTableEventLagMs = clickHouseTableEventLagMs,
       marketDataFresh = freshness.fresh,
       marketDataLastSeenLagMs = freshness.lastSeenLagMs,
       marketDataMaxAgeMs = config.readyEventMaxAgeMs,
@@ -267,19 +272,26 @@ class HyperliquidFeedApp(
       }
       val payload = json.encodeToString(record.envelope)
       runCatching {
-        producer.send(ProducerRecord(record.topic, record.key, payload)).get()
-      }.onSuccess {
-        kafkaReady.set(true)
-        metrics.kafkaProduceSuccess.increment()
-        metrics.recordEvent(record.envelope.channel)
-        recordMarketDataFreshness(record.envelope.channel)
+        producer.send(ProducerRecord(record.topic, record.key, payload)) { _, error ->
+          if (error == null) {
+            kafkaReady.set(true)
+            metrics.kafkaProduceSuccess.increment()
+            metrics.recordEvent(record.envelope.channel)
+            recordMarketDataFreshness(record.envelope.channel)
+          } else {
+            kafkaReady.set(false)
+            metrics.recordKafkaError(record.topic)
+            appLogger.warn(error) { "Kafka produce failed topic=${record.topic}" }
+          }
+          updateReady()
+        }
         clickHouseSink.enqueue(record)
       }.onFailure { error ->
         kafkaReady.set(false)
         metrics.recordKafkaError(record.topic)
         appLogger.warn(error) { "Kafka produce failed topic=${record.topic}" }
+        updateReady()
       }
-      updateReady()
     }
   }
 

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidMetrics.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidMetrics.kt
@@ -25,6 +25,7 @@ class HyperliquidMetrics(
   private val dedupDrops = ConcurrentHashMap<String, Counter>()
   private val eventLastSeenEpochMs = ConcurrentHashMap<String, AtomicLong>()
   private val clickHouseTableIngestLagMs = ConcurrentHashMap<String, AtomicLong>()
+  private val clickHouseTableEventLagMs = ConcurrentHashMap<String, AtomicLong>()
 
   val reconnects: Counter = registry.counter("torghut_hyperliquid_ws_reconnects_total")
   val wsConnectSuccess: Counter = registry.counter("torghut_hyperliquid_ws_connect_success_total")
@@ -107,6 +108,23 @@ class HyperliquidMetrics(
         val value = AtomicLong(-1)
         Gauge
           .builder("torghut_hyperliquid_clickhouse_table_ingest_lag_seconds", value) {
+            val observed = it.get()
+            if (observed < 0) -1.0 else observed.toDouble() / 1_000.0
+          }.tag("table", table)
+          .register(registry)
+        value
+      }.set(lagMs ?: -1)
+  }
+
+  fun setClickHouseTableEventLagMs(
+    table: String,
+    lagMs: Long?,
+  ) {
+    clickHouseTableEventLagMs
+      .computeIfAbsent(table) {
+        val value = AtomicLong(-1)
+        Gauge
+          .builder("torghut_hyperliquid_clickhouse_table_event_lag_seconds", value) {
             val observed = it.get()
             if (observed < 0) -1.0 else observed.toDouble() / 1_000.0
           }.tag("table", table)

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
@@ -82,8 +82,8 @@ class ClickHouseSinkTest {
               respond(
                 content =
                   """
-                  {"table":"hyperliquid_candles","latest_ingest_ms":9900}
-                  {"table":"hyperliquid_raw","latest_ingest_ms":9900}
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900,"latest_event_ms":9900}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900,"latest_event_ms":9900}
                   """.trimIndent(),
                 status = HttpStatusCode.OK,
               )
@@ -140,8 +140,8 @@ class ClickHouseSinkTest {
               respond(
                 content =
                   """
-                  {"table":"hyperliquid_candles","latest_ingest_ms":9900}
-                  {"table":"hyperliquid_raw","latest_ingest_ms":9900}
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900,"latest_event_ms":9900}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900,"latest_event_ms":9900}
                   """.trimIndent(),
                 status = HttpStatusCode.OK,
               )
@@ -191,8 +191,8 @@ class ClickHouseSinkTest {
               respond(
                 content =
                   """
-                  {"table":"hyperliquid_candles","latest_ingest_ms":9900}
-                  {"table":"hyperliquid_raw","latest_ingest_ms":9900}
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900,"latest_event_ms":9900}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900,"latest_event_ms":9900}
                   """.trimIndent(),
                 status = HttpStatusCode.OK,
               )
@@ -242,8 +242,8 @@ class ClickHouseSinkTest {
               respond(
                 content =
                   """
-                  {"table":"hyperliquid_candles","latest_ingest_ms":7000}
-                  {"table":"hyperliquid_raw","latest_ingest_ms":7000}
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900,"latest_event_ms":7000}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900,"latest_event_ms":7000}
                   """.trimIndent(),
                 status = HttpStatusCode.OK,
               )
@@ -271,13 +271,14 @@ class ClickHouseSinkTest {
 
       assertEquals(false, readySignals.last().ready)
       assertEquals(false, readySignals.last().tableFreshnessReady)
-      assertEquals(3_000, readySignals.last().tableIngestLagMs["hyperliquid_candles"])
+      assertEquals(100, readySignals.last().tableIngestLagMs["hyperliquid_candles"])
+      assertEquals(3_000, readySignals.last().tableEventLagMs["hyperliquid_candles"])
       job.cancelAndJoin()
       client.close()
     }
 
   @Test
-  fun `marks clickhouse ready when insert succeeds and table ingest is fresh`() =
+  fun `marks clickhouse ready when insert succeeds and table event time is fresh`() =
     runBlocking {
       val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
       val client =
@@ -289,8 +290,8 @@ class ClickHouseSinkTest {
               respond(
                 content =
                   """
-                  {"table":"hyperliquid_candles","latest_ingest_ms":9500}
-                  {"table":"hyperliquid_raw","latest_ingest_ms":9400}
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9500,"latest_event_ms":9500}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9400,"latest_event_ms":9400}
                   """.trimIndent(),
                 status = HttpStatusCode.OK,
               )
@@ -319,6 +320,7 @@ class ClickHouseSinkTest {
       assertEquals(true, readySignals.last().ready)
       assertEquals(true, readySignals.last().tableFreshnessReady)
       assertEquals(500, readySignals.last().tableIngestLagMs["hyperliquid_candles"])
+      assertEquals(500, readySignals.last().tableEventLagMs["hyperliquid_candles"])
       job.cancelAndJoin()
       client.close()
     }


### PR DESCRIPTION
## Summary

- Removes blocking Kafka ack waits from the Hyperliquid feed websocket publish path so high-volume subscriptions do not stall frame handling.
- Makes ClickHouse readiness validate BBO/candle table event-time freshness separately from ingest-time freshness.
- Exposes ClickHouse table event lag in `/readyz` and metrics, and requires ClickHouse freshness for feed readiness.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :hyperliquid-feed:test`
- `cd services/dorvud && ./gradlew :hyperliquid-feed:ktlintCheck`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
