### PR TITLE
chore(torghut): promote hyperliquid feed image 0f64c90a

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -31,18 +31,18 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-feed
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:cfa40b4dee647a778f3625911019f5ab275b392381cf364b40ea563d2d4db16a
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:918cdcab49a12b7f468b0110fdee289f53d7509480ee891ea920e0277cbce0ac
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-d38835f1
+              value: main-0f64c90a
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: d38835f175ea99bea2fcf7d7bbda39dd5cdc3c4e
+              value: 0f64c90aa4e9501ed7fdd6fcf834042e778eda06
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:cfa40b4dee647a778f3625911019f5ab275b392381cf364b40ea563d2d4db16a
+              value: sha256:918cdcab49a12b7f468b0110fdee289f53d7509480ee891ea920e0277cbce0ac
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD


### PR DESCRIPTION
## Summary
Promote the Torghut Hyperliquid feed image into GitOps manifests.

- Source commit: `0f64c90aa4e9501ed7fdd6fcf834042e778eda06`
- Image tag: `0f64c90a`
- Image digest: `sha256:918cdcab49a12b7f468b0110fdee289f53d7509480ee891ea920e0277cbce0ac`
- Manifest: Hyperliquid feed Deployment