### PR TITLE
fix(torghut): use ingest freshness for hyperliquid quotes

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/clickhouse-schema-configmap.yaml
@@ -118,7 +118,7 @@ data:
       b.bid_price,
       b.ask_price,
       b.quote_event_ts,
-      greatest(0, dateDiff('second', b.quote_event_ts, now64(3))) AS quote_lag_seconds
+      greatest(0, dateDiff('second', b.quote_ingest_ts, now64(3))) AS quote_lag_seconds
     FROM
     (
       SELECT
@@ -157,18 +157,22 @@ data:
         market_id,
         argMax(
           toFloat64OrZero(JSONExtractString(payload, 'bbo', 1, 'px')),
-          parseDateTimeBestEffort(event_ts)
+          parseDateTimeBestEffort(ingest_ts)
         ) AS bid_price,
         argMax(
           toFloat64OrZero(JSONExtractString(payload, 'bbo', 2, 'px')),
-          parseDateTimeBestEffort(event_ts)
+          parseDateTimeBestEffort(ingest_ts)
         ) AS ask_price,
-        max(toDateTime64(parseDateTimeBestEffort(event_ts), 3, 'UTC')) AS quote_event_ts
+        argMax(
+          toDateTime64(parseDateTimeBestEffort(event_ts), 3, 'UTC'),
+          parseDateTimeBestEffort(ingest_ts)
+        ) AS quote_event_ts,
+        max(toDateTime64(parseDateTimeBestEffort(ingest_ts), 3, 'UTC')) AS quote_ingest_ts
       FROM torghut.hyperliquid_bbo
       WHERE channel = 'bbo'
         AND market_type = 'perp'
         AND market_id IS NOT NULL
-        AND parseDateTimeBestEffort(event_ts) >= now() - INTERVAL 2 HOUR
+        AND parseDateTimeBestEffort(ingest_ts) >= now() - INTERVAL 2 HOUR
       GROUP BY network, market_id
     ) AS b
       ON f.network = b.network

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -165,7 +165,7 @@ describe('Torghut manifest scheduling', () => {
     expect(readyTables.every((table) => enabledTables.includes(table))).toBe(true)
     expect(data.CLICKHOUSE_REQUEST_TIMEOUT_MS).toBe('30000')
     expect(data.CLICKHOUSE_ENABLED).toBe('true')
-    expect(data.CLICKHOUSE_REQUIRED_FOR_READINESS).toBe('false')
+    expect(data.CLICKHOUSE_REQUIRED_FOR_READINESS).toBe('true')
 
     const deployment = parseManifest('argocd/applications/torghut-hyperliquid-feed/deployment.yaml')
     const feedContainer = getAtPath(deployment, ['spec', 'template', 'spec', 'containers', 0])
@@ -188,7 +188,7 @@ describe('Torghut manifest scheduling', () => {
     )
     expect(
       getAtPath(deployment, ['spec', 'template', 'metadata', 'annotations'])['proompteng.ai/config-revision'],
-    ).toBe('hyperliquid-feed-bbo-clickhouse-20260619a')
+    ).toBe('hyperliquid-feed-nonblocking-publish-20260619a')
   })
 
   it('bounds Hyperliquid runtime ClickHouse schema hooks so Argo syncs cannot hang on distributed DDL', () => {
@@ -216,6 +216,12 @@ describe('Torghut manifest scheduling', () => {
     const data = getAtPath(schema, ['data'])
     expect(data['schema.sql']).toContain('SET distributed_ddl_task_timeout = 10;')
     expect(data['schema.sql']).toContain("SET distributed_ddl_output_mode = 'null_status_on_timeout';")
+    expect(data['schema.sql']).toContain(
+      "greatest(0, dateDiff('second', b.quote_ingest_ts, now64(3))) AS quote_lag_seconds",
+    )
+    expect(data['schema.sql']).toContain('parseDateTimeBestEffort(ingest_ts)')
+    expect(data['schema.sql']).toContain('AS quote_ingest_ts')
+    expect(data['schema.sql']).toContain('AND parseDateTimeBestEffort(ingest_ts) >= now() - INTERVAL 2 HOUR')
     expect(data['schema.sql']).not.toContain('INSERT INTO torghut.hyperliquid_ta_features')
   })
 


### PR DESCRIPTION
## Summary

- Change the Hyperliquid runtime latest-feature view to choose bid/ask from the freshest ingested BBO row instead of the freshest exchange event timestamp.
- Compute `quote_lag_seconds` from BBO `ingest_ts` so live quote messages with unchanged exchange timestamps do not block executable signals as stale.
- Update manifest coverage for runtime quote freshness and align stale feed-readiness expectations with current manifests.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
