### PR TITLE
fix(torghut): accept future candle freshness

### DIFF
--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
@@ -157,7 +157,7 @@ class ClickHouseSink(
         latestTableEventLagMs = freshness.eventLagMs
         freshness.ingestLagMs.forEach { (table, lagMs) -> metrics.setClickHouseTableIngestLagMs(table, lagMs) }
         freshness.eventLagMs.forEach { (table, lagMs) -> metrics.setClickHouseTableEventLagMs(table, lagMs) }
-        val fresh = freshness.eventLagMs.values.all { lagMs -> lagMs != null && lagMs in 0L..config.readyMaxAgeMs }
+        val fresh = freshness.eventLagMs.values.all { lagMs -> lagMs != null && lagMs <= config.readyMaxAgeMs }
         tableFreshnessReady.set(fresh)
         lastFreshnessCheckMs.set(observedAt)
         if (!fresh) clickHouseLogger.warn { "clickhouse table event freshness stale lags_ms=${freshness.eventLagMs}" }

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
@@ -326,6 +326,53 @@ class ClickHouseSinkTest {
     }
 
   @Test
+  fun `marks clickhouse ready when candle event time is ahead of observed clock`() =
+    runBlocking {
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            if (queryParam(request.url).startsWith("INSERT")) {
+              respond(content = "", status = HttpStatusCode.OK)
+            } else {
+              respond(
+                content =
+                  """
+                  {"table":"hyperliquid_candles","latest_ingest_ms":9900,"latest_event_ms":12000}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":9900,"latest_event_ms":9900}
+                  """.trimIndent(),
+                status = HttpStatusCode.OK,
+              )
+            }
+          },
+        )
+      val sink =
+        ClickHouseSink(
+          config = clickHouseConfig(readyMaxAgeMs = 1_000),
+          httpClient = client,
+          metrics = HyperliquidMetrics(SimpleMeterRegistry()),
+          json = Json,
+          nowMs = { 10_000 },
+          onReady = { readySignals += it },
+        )
+      val job = sink.start(this)
+
+      sink.enqueue(candleRecord())
+
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != true) {
+          delay(10)
+        }
+      }
+
+      assertEquals(true, readySignals.last().ready)
+      assertEquals(true, readySignals.last().tableFreshnessReady)
+      assertEquals(-2_000, readySignals.last().tableEventLagMs["hyperliquid_candles"])
+      job.cancelAndJoin()
+      client.close()
+    }
+
+  @Test
   fun `skips clickhouse writes for disabled tables`() =
     runBlocking {
       val observedQueries = mutableListOf<String>()


### PR DESCRIPTION
## Summary

- Allows ClickHouse table event freshness to pass when the latest candle event timestamp is ahead of the observed wall clock.
- Keeps stale past event timestamps failing readiness so real feed lag still blocks `/readyz`.
- Adds a regression test for future-dated candle event freshness.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :hyperliquid-feed:test`
- `cd services/dorvud && ./gradlew :hyperliquid-feed:ktlintCheck`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-feed >/tmp/hyperliquid-feed-render.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
