### PR TITLE
fix(torghut): avoid polling static hyperliquid secret

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml
@@ -6,7 +6,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  refreshInterval: 5m
+  refreshPolicy: CreatedOnce
+  refreshInterval: 0s
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-infra

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -268,6 +268,10 @@ describe('Torghut manifest scheduling', () => {
     const externalSecret = parseManifest('argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml')
     expect(externalSecret.kind).toBe('ExternalSecret')
     expect(getAtPath(externalSecret, ['metadata']).name).toBe('torghut-hyperliquid-testnet')
+    expect(getAtPath(externalSecret, ['spec'])).toMatchObject({
+      refreshPolicy: 'CreatedOnce',
+      refreshInterval: '0s',
+    })
     expect(getAtPath(externalSecret, ['spec', 'secretStoreRef'])).toMatchObject({
       kind: 'ClusterSecretStore',
       name: 'onepassword-infra',


### PR DESCRIPTION
## Summary

- Changes `torghut-hyperliquid-testnet` from 5-minute periodic 1Password polling to created-once sync.
- Keeps the existing runtime secret owned by External Secrets while avoiding unnecessary provider reads for static testnet credentials.
- Adds a manifest regression assertion so the runtime secret does not regress to high-frequency refresh.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
