### PR TITLE
fix(torghut): ignore created-once external secret health

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -14,44 +14,6 @@ data:
     hs.status = "Healthy"
     hs.message = "SealedSecret health is ignored; decryption is handled by the sealed-secrets controller."
     return hs
-  resource.customizations.health.external-secrets.io_ExternalSecret: |
-    hs = {}
-    local spec = obj.spec or {}
-    local status = obj.status or {}
-    local binding = status.binding or {}
-    local bindingName = binding.name or ""
-    local syncedResourceVersion = status.syncedResourceVersion or ""
-
-    if spec.refreshPolicy == "CreatedOnce" and bindingName ~= "" and syncedResourceVersion ~= "" then
-      hs.status = "Healthy"
-      hs.message = "Created-once ExternalSecret has already created its target Secret."
-      return hs
-    end
-
-    local conditions = status.conditions or {}
-    for _, condition in ipairs(conditions) do
-      if condition.type == "Ready" then
-        if condition.status == "True" then
-          hs.status = "Healthy"
-          hs.message = condition.message or "ExternalSecret is ready."
-          return hs
-        end
-
-        if condition.status == "False" then
-          hs.status = "Degraded"
-          hs.message = condition.message or "ExternalSecret is not ready."
-          return hs
-        end
-
-        hs.status = "Progressing"
-        hs.message = condition.message or "ExternalSecret is reconciling."
-        return hs
-      end
-    end
-
-    hs.status = "Progressing"
-    hs.message = "ExternalSecret has not reported readiness."
-    return hs
   resource.customizations.health.batch_CronJob: |
     hs = {}
     local metadata = obj.metadata or {}

--- a/argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: torghut
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/ignore-healthcheck: "true"
 spec:
   refreshPolicy: CreatedOnce
   refreshInterval: 0s

--- a/packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts
+++ b/packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts
@@ -15,8 +15,6 @@ const argoConfigMap = YAML.parse(
 ) as ArgoConfigMap
 
 const cronJobHealth = argoConfigMap.data?.['resource.customizations.health.batch_CronJob'] ?? ''
-const externalSecretHealth =
-  argoConfigMap.data?.['resource.customizations.health.external-secrets.io_ExternalSecret'] ?? ''
 
 describe('Argo CD CronJob health customization', () => {
   it('keeps stale Torghut scheduled-job history from blocking app promotion sync', () => {
@@ -30,20 +28,5 @@ describe('Argo CD CronJob health customization', () => {
     expect(cronJobHealth).toContain('status.lastScheduleTime ~= nil and status.lastSuccessfulTime == nil')
     expect(cronJobHealth).toContain('status.lastScheduleTime > status.lastSuccessfulTime')
     expect(cronJobHealth).toContain('CronJob has not completed its last execution successfully.')
-  })
-})
-
-describe('Argo CD ExternalSecret health customization', () => {
-  it('keeps created-once synced secrets healthy without periodic provider reads', () => {
-    expect(externalSecretHealth).toContain('spec.refreshPolicy == "CreatedOnce"')
-    expect(externalSecretHealth).toContain('bindingName ~= ""')
-    expect(externalSecretHealth).toContain('syncedResourceVersion ~= ""')
-    expect(externalSecretHealth).toContain('Created-once ExternalSecret has already created its target Secret.')
-  })
-
-  it('keeps provider failures degraded for normal ExternalSecrets', () => {
-    expect(externalSecretHealth).toContain('condition.type == "Ready"')
-    expect(externalSecretHealth).toContain('condition.status == "False"')
-    expect(externalSecretHealth).toContain('hs.status = "Degraded"')
   })
 })

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -268,6 +268,9 @@ describe('Torghut manifest scheduling', () => {
     const externalSecret = parseManifest('argocd/applications/torghut-hyperliquid-runtime/externalsecret.yaml')
     expect(externalSecret.kind).toBe('ExternalSecret')
     expect(getAtPath(externalSecret, ['metadata']).name).toBe('torghut-hyperliquid-testnet')
+    expect(getAtPath(externalSecret, ['metadata', 'annotations'])).toMatchObject({
+      'argocd.argoproj.io/ignore-healthcheck': 'true',
+    })
     expect(getAtPath(externalSecret, ['spec'])).toMatchObject({
       refreshPolicy: 'CreatedOnce',
       refreshInterval: '0s',


### PR DESCRIPTION
## Summary

- Adds the supported Argo CD health-ignore annotation to the created-once Torghut Hyperliquid ExternalSecret.
- Keeps the runtime secret created once with no periodic 1Password polling.
- Removes the ineffective ExternalSecret custom health override and its stale tests.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argocd >/tmp/argocd-render.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hyperliquid-runtime-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
