### PR TITLE
fix(torghut): label proof cronjobs for health checks

### DIFF
--- a/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
@@ -3,6 +3,9 @@ kind: CronJob
 metadata:
   name: torghut-empirical-artifacts-retention
   namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: empirical-artifacts-retention
 spec:
   schedule: "17 4 * * *"
   concurrencyPolicy: Forbid

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -3,6 +3,9 @@ kind: CronJob
 metadata:
   name: torghut-empirical-promotion-renewal
   namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: empirical-promotion-renewal
 spec:
   schedule: "23 8,21 * * *"
   concurrencyPolicy: Forbid

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -106,6 +106,9 @@ describe('Torghut manifest scheduling', () => {
     for (const path of cronJobPaths) {
       for (const manifest of parseManifestDocuments(path)) {
         expect(manifest.kind, path).toBe('CronJob')
+        expect(getAtPath(manifest, ['metadata', 'labels']), path).toMatchObject({
+          'app.kubernetes.io/name': 'torghut',
+        })
         const spec = getAtPath(manifest, ['spec'])
         const jobSpec = getAtPath(manifest, ['spec', 'jobTemplate', 'spec'])
         expect(spec.failedJobsHistoryLimit, path).toBe(2)


### PR DESCRIPTION
## Summary

- Adds Torghut app labels to the empirical artifacts retention and empirical promotion renewal CronJobs.
- Ensures all Torghut CronJobs use the existing non-blocking Argo health rule for scheduled proof jobs.
- Adds a manifest regression assertion so future CronJobs do not miss the label.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts packages/scripts/src/torghut/__tests__/argocd-cronjob-health.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
