### PR TITLE
fix(metallb): update galactic LAN address pools

### DIFF
--- a/argocd/applications/forgejo/values.yaml
+++ b/argocd/applications/forgejo/values.yaml
@@ -29,6 +29,7 @@ service:
     annotations:
       metallb.io/address-pool: metallb-ip-pool
       metallb.io/allow-shared-ip: ingress-edge
+      metallb.io/loadBalancerIPs: 100.100.244.181
 
 gitea:
   admin:

--- a/argocd/applications/istio-ingress/kustomization.yaml
+++ b/argocd/applications/istio-ingress/kustomization.yaml
@@ -11,4 +11,4 @@ helmCharts:
     namespace: istio-ingress
     valuesInline:
       service:
-        loadBalancerIP: "192.168.1.105"
+        loadBalancerIP: "100.100.244.182"

--- a/argocd/applications/metallb-system/ipaddresspool.yaml
+++ b/argocd/applications/metallb-system/ipaddresspool.yaml
@@ -5,4 +5,14 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-    - 192.168.1.100-192.168.1.149
+    - 100.100.244.181-100.100.244.190
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: metallb-plex-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - 100.100.244.180/32
+  autoAssign: false

--- a/argocd/applications/metallb-system/l2advertisement.yaml
+++ b/argocd/applications/metallb-system/l2advertisement.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   ipAddressPools:
     - metallb-ip-pool
+    - metallb-plex-pool

--- a/argocd/applications/traefik/values.yaml
+++ b/argocd/applications/traefik/values.yaml
@@ -6,6 +6,7 @@ service:
   annotations:
     metallb.io/address-pool: metallb-ip-pool
     metallb.io/allow-shared-ip: ingress-edge
+    metallb.io/loadBalancerIPs: 100.100.244.181
 
 ingressClass:
   enabled: true

--- a/docs/runbooks/galactic-kubernetes-access.md
+++ b/docs/runbooks/galactic-kubernetes-access.md
@@ -12,17 +12,22 @@ Keep exactly two local `kubectl` contexts for normal operator use:
 | `galactic-lan`       | `https://100.100.244.141:6443` | Provider-managed LAN path. Use this when on the local network. |
 | `galactic-tailscale` | `https://100.94.129.1:6443`    | Tailnet path. Use this when off-LAN with Tailscale connected.  |
 
-The live node layer currently has two Ready Kubernetes nodes:
+The live node layer currently has three Ready Kubernetes nodes:
 
 | Kubernetes node name  | Current internal IP | Role          |
 | --------------------- | ------------------- | ------------- |
 | `talos-192-168-1-194` | `100.100.244.141`   | control plane |
 | `talos-192-168-1-85`  | `100.100.244.142`   | control plane |
+| `turin`               | `100.100.244.171`   | control plane |
 
 The node names still contain the original `192.168.1.*` addresses, but those
 names are not the current LAN reachability source. Do not use old
 `192.168.1.*` addresses for current kube API access unless a separate live
 reachability check proves that path has returned.
+
+MetalLB is on the same provider-managed LAN. The current reserved addresses are
+`100.100.244.180` for Plex, `100.100.244.181` for the shared Traefik/Forgejo
+edge, and `100.100.244.182` for Istio ingress.
 
 ## Rebuild local kubeconfig contexts
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -62,8 +62,10 @@ kubectl -n metallb-system rollout status ds/speaker --timeout=300s
 
 Notes:
 
-- Edit `argocd/applications/metallb-system/ipaddresspool.yaml` to match your LAN range and avoid static IPs. Current pool: `192.168.1.100-192.168.1.149`.
-- The K3s Traefik Service (`kube-system/traefik`) is type LoadBalancer and will be Pending until MetalLB assigns an External IP. After this step it should have an IP, e.g., `192.168.1.100`.
+- Edit `argocd/applications/metallb-system/ipaddresspool.yaml` to match your LAN range and avoid static IPs. Current pools:
+  - `metallb-plex-pool`: `100.100.244.180/32`, reserved for Plex LAN access.
+  - `metallb-ip-pool`: `100.100.244.181-100.100.244.190`, shared platform services.
+- Traefik and Forgejo SSH share `100.100.244.181`; Istio ingress uses `100.100.244.182`.
 
 4. Apply the root Application (ApplicationSet) to sync the rest of the stack:
 


### PR DESCRIPTION
## Summary

- Move the galactic MetalLB platform pool from stale `192.168.1.*` addresses to the current `100.100.244.*` LAN.
- Reserve `100.100.244.180` for Plex LAN access and pin the shared Traefik/Forgejo edge to `100.100.244.181`.
- Move Istio ingress to `100.100.244.182` and document the current node/IP allocation.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/metallb-system`
- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/traefik`
- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/forgejo`
- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/istio-ingress`
- `kubectl --context galactic-tailscale apply --dry-run=server -f /tmp/metallb-render.yaml`
- `kubectl --context galactic-tailscale apply --dry-run=server -f /tmp/traefik-render.yaml`
- `kubectl --context galactic-tailscale apply --dry-run=server -f /tmp/forgejo-render.yaml`
- `kubectl --context galactic-tailscale apply --dry-run=server -f /tmp/istio-render.yaml`

## Breaking Changes

MetalLB local service IPs intentionally move from the old `192.168.1.*` network to the current provider-managed `100.100.244.*` LAN. Traefik/Forgejo SSH and Istio clients must use the new IPs after rollout.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
