### PR TITLE
fix(torghut): restart hyperliquid runtime for equity config

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260618g
+        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260619-equity-recovery
       labels:
         app: torghut-hyperliquid-runtime
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -232,8 +232,19 @@ describe('Torghut manifest scheduling', () => {
     const runtimeConfig = parseManifest('argocd/applications/torghut-hyperliquid-runtime/configmap.yaml')
     const runtimeData = getAtPath(runtimeConfig, ['data'])
     expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('true')
+    expect(runtimeData.HYPERLIQUID_RUNTIME_MARKET_DATA_NETWORK).toBe('mainnet')
+    expect(runtimeData.HYPERLIQUID_RUNTIME_EXECUTION_NETWORK).toBe('testnet')
+    expect(runtimeData.HYPERLIQUID_RUNTIME_TRADE_COINS).toBe(
+      'xyz:NVDA,xyz:AMD,xyz:AVGO,xyz:MRVL,xyz:INTC,xyz:MU,xyz:WDC,xyz:SNDK,xyz:ARM,xyz:LITE',
+    )
+    expect(runtimeData.HYPERLIQUID_RUNTIME_EXCLUDED_COINS).toBe('SPX')
+    expect(runtimeData.HYPERLIQUID_RUNTIME_MAX_ORDER_NOTIONAL_USD).toBe('10')
+    expect(runtimeData.HYPERLIQUID_RUNTIME_MAX_SYMBOL_EXPOSURE_USD).toBe('25')
 
     const runtimeDeployment = parseManifest('argocd/applications/torghut-hyperliquid-runtime/deployment.yaml')
+    expect(getAtPath(runtimeDeployment, ['spec', 'template', 'metadata', 'annotations'])).toMatchObject({
+      'proompteng.ai/config-revision': 'hyperliquid-runtime-v1-20260619-equity-recovery',
+    })
     const runtimeContainer = getAtPath(runtimeDeployment, ['spec', 'template', 'spec', 'containers', 0])
     expect(String(runtimeContainer.image)).toMatch(/^registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:[0-9a-f]{64}$/)
     expect(String(runtimeContainer.image)).not.toContain(':latest')


### PR DESCRIPTION
## Summary

- Bumps the Hyperliquid runtime pod-template config revision so the merged equity execution ConfigMap takes effect through a real rollout.
- Adds manifest regression coverage for the mainnet-data/testnet-execution split, configured AI equity universe, SPX exclusion, order caps, and restart annotation.
- Keeps the change scoped to GitOps restart mechanics; no runtime strategy behavior is changed in this PR.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
