### PR TITLE
fix(torghut): cap hyperliquid collection universe exposure

### DIFF
--- a/services/torghut/app/hyperliquid_runtime/models.py
+++ b/services/torghut/app/hyperliquid_runtime/models.py
@@ -129,6 +129,7 @@ class RiskState:
     symbol_exposure_usd_by_coin: dict[str, Decimal] = field(
         default_factory=_empty_decimal_by_coin
     )
+    collection_gross_exposure_usd: Decimal | None = None
     reject_cooldown_coins: frozenset[str] = field(default_factory=_empty_frozenset)
     halted_coins: frozenset[str] = field(default_factory=_empty_frozenset)
 

--- a/services/torghut/app/hyperliquid_runtime/repository.py
+++ b/services/torghut/app/hyperliquid_runtime/repository.py
@@ -534,6 +534,8 @@ class HyperliquidRuntimeRepository:
         self,
         *,
         dependencies: Iterable[RuntimeDependencyStatus],
+        trade_coins: Iterable[str] = (),
+        excluded_coins: Iterable[str] = (),
         reject_cooldown_threshold: int = 3,
         reject_cooldown_window_seconds: int = 1800,
         reject_cooldown_seconds: int = 900,
@@ -638,8 +640,19 @@ class HyperliquidRuntimeRepository:
             ),
             {"cooldown_seconds": halted_cooldown_seconds},
         ).mappings()
+        symbol_exposure_usd_by_coin = {
+            str(exposure_row["coin"]): Decimal(str(exposure_row["exposure_usd"]))
+            for exposure_row in symbol_exposure_rows
+        }
+        account_gross_exposure_usd = Decimal(str(row["gross_exposure_usd"]))
+        collection_gross_exposure_usd = _collection_gross_exposure_usd(
+            account_gross_exposure_usd=account_gross_exposure_usd,
+            symbol_exposure_usd_by_coin=symbol_exposure_usd_by_coin,
+            trade_coins=trade_coins,
+            excluded_coins=excluded_coins,
+        )
         return RiskState(
-            gross_exposure_usd=Decimal(str(row["gross_exposure_usd"])),
+            gross_exposure_usd=account_gross_exposure_usd,
             daily_realized_pnl_usd=Decimal(str(row["daily_realized_pnl_usd"])),
             unrealized_pnl_usd=Decimal(str(row["unrealized_pnl_usd"])),
             daily_fees_usd=Decimal(str(row["daily_fees_usd"])),
@@ -647,10 +660,8 @@ class HyperliquidRuntimeRepository:
                 str(open_row["market_id"]) for open_row in open_rows
             ),
             dependencies=tuple(dependencies),
-            symbol_exposure_usd_by_coin={
-                str(exposure_row["coin"]): Decimal(str(exposure_row["exposure_usd"]))
-                for exposure_row in symbol_exposure_rows
-            },
+            symbol_exposure_usd_by_coin=symbol_exposure_usd_by_coin,
+            collection_gross_exposure_usd=collection_gross_exposure_usd,
             reject_cooldown_coins=frozenset(
                 str(cooldown_row["coin"]) for cooldown_row in reject_cooldown_rows
             ),
@@ -669,6 +680,20 @@ class HyperliquidRuntimeRepository:
         return {
             "schema_version": "torghut.hyperliquid-runtime-report.v1",
             "config": dict(config_payload),
+            "account": self._query_report_rows(
+                """
+                SELECT
+                  observed_at::text,
+                  account_value_usd::text,
+                  withdrawable_usd::text,
+                  gross_exposure_usd::text,
+                  raw_payload
+                FROM hyperliquid_runtime_account_snapshots
+                WHERE network = 'testnet'
+                ORDER BY observed_at DESC
+                LIMIT 1
+                """
+            ),
             "positions": self._query_report_rows(
                 """
                 SELECT
@@ -804,6 +829,32 @@ class HyperliquidRuntimeRepository:
     ) -> list[dict[str, object]]:
         rows = self._session.execute(text(sql), dict(params or {})).mappings()
         return [dict(row) for row in rows]
+
+
+def _collection_gross_exposure_usd(
+    *,
+    account_gross_exposure_usd: Decimal,
+    symbol_exposure_usd_by_coin: Mapping[str, Decimal],
+    trade_coins: Iterable[str],
+    excluded_coins: Iterable[str],
+) -> Decimal:
+    trade_coin_set = _normalized_coin_set(trade_coins)
+    excluded_coin_set = _normalized_coin_set(excluded_coins)
+    if not trade_coin_set and not excluded_coin_set:
+        return account_gross_exposure_usd
+    total = Decimal("0")
+    for coin, exposure_usd in symbol_exposure_usd_by_coin.items():
+        normalized = coin.casefold()
+        if normalized in excluded_coin_set:
+            continue
+        if trade_coin_set and normalized not in trade_coin_set:
+            continue
+        total += exposure_usd.copy_abs()
+    return total
+
+
+def _normalized_coin_set(coins: Iterable[str]) -> frozenset[str]:
+    return frozenset(coin.strip().casefold() for coin in coins if coin.strip())
 
 
 def _feature_payload(signal: Signal) -> dict[str, str | int]:

--- a/services/torghut/app/hyperliquid_runtime/risk.py
+++ b/services/torghut/app/hyperliquid_runtime/risk.py
@@ -22,7 +22,12 @@ def evaluate_signal_risk(
     blocked_reason = _blocked_reason(signal, state, config, now=now)
     if blocked_reason is not None:
         return _blocked(blocked_reason)
-    remaining_exposure = config.max_gross_exposure_usd - state.gross_exposure_usd
+    cap_exposure = (
+        state.collection_gross_exposure_usd
+        if state.collection_gross_exposure_usd is not None
+        else state.gross_exposure_usd
+    )
+    remaining_exposure = config.max_gross_exposure_usd - cap_exposure
     if remaining_exposure <= Decimal("0"):
         return _blocked("gross_exposure_cap")
     if remaining_exposure < config.min_order_notional_usd:

--- a/services/torghut/app/hyperliquid_runtime/service.py
+++ b/services/torghut/app/hyperliquid_runtime/service.py
@@ -210,6 +210,8 @@ class HyperliquidRuntimeService:
             dependencies=dependencies,
             risk_state=repository.risk_state(
                 dependencies=dependencies,
+                trade_coins=self._config.trade_coins,
+                excluded_coins=self._config.excluded_coins,
                 reject_cooldown_threshold=self._config.reject_cooldown_threshold,
                 reject_cooldown_window_seconds=(
                     self._config.reject_cooldown_window_seconds

--- a/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_adapters_api_metrics.py
@@ -679,6 +679,7 @@ def test_api_report_returns_configured_runtime_evidence(
             return {
                 "schema_version": "torghut.hyperliquid-runtime-report.v1",
                 "config": config_payload,
+                "account": [{"gross_exposure_usd": "100.59"}],
                 "positions": [],
                 "fills_by_coin": [],
                 "rejects_by_coin_reason": [],
@@ -712,6 +713,7 @@ def test_api_report_returns_configured_runtime_evidence(
     assert payload["config"]["max_order_notional_usd"] == "10"
     assert payload["config"]["max_symbol_exposure_usd"] == "25"
     assert payload["config"]["halted_cooldown_seconds"] == 120
+    assert payload["account"] == [{"gross_exposure_usd": "100.59"}]
 
 
 def test_api_run_one_cycle_success_and_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/torghut/tests/hyperliquid_runtime/test_risk_strategy.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_risk_strategy.py
@@ -212,6 +212,40 @@ def test_risk_blocks_remaining_exposure_below_min_order_notional() -> None:
     assert verdict.reason == "remaining_exposure_below_min_order_notional"
 
 
+def test_risk_uses_collection_exposure_for_order_cap() -> None:
+    config = _config(
+        HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",
+        HYPERLIQUID_RUNTIME_ACCOUNT_ADDRESS="0x1111111111111111111111111111111111111111",
+        HYPERLIQUID_RUNTIME_API_WALLET_PRIVATE_KEY=(
+            "0x2222222222222222222222222222222222222222222222222222222222222222"
+        ),
+        HYPERLIQUID_RUNTIME_MAX_ORDER_NOTIONAL_USD="10",
+        HYPERLIQUID_RUNTIME_MIN_ORDER_NOTIONAL_USD="10",
+    )
+    signal = generate_signal(
+        _feature(coin="xyz:NVDA", dex="xyz"), parameter_version="test-v1"
+    )
+    state = RiskState(
+        gross_exposure_usd=Decimal("100.59"),
+        collection_gross_exposure_usd=Decimal("0"),
+        daily_realized_pnl_usd=Decimal("0"),
+        unrealized_pnl_usd=Decimal("0"),
+        daily_fees_usd=Decimal("0"),
+        open_order_markets=frozenset(),
+        dependencies=(RuntimeDependencyStatus("clickhouse", True),),
+    )
+
+    verdict = evaluate_signal_risk(
+        signal,
+        state,
+        config,
+        now=datetime(2026, 6, 18, 15, tzinfo=timezone.utc),
+    )
+
+    assert verdict.allowed
+    assert verdict.order_notional_usd == Decimal("10")
+
+
 def test_risk_caps_symbol_exposure_before_global_cap() -> None:
     config = _config(
         HYPERLIQUID_RUNTIME_TRADING_ENABLED="true",

--- a/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
+++ b/services/torghut/tests/hyperliquid_runtime/test_service_repository.py
@@ -311,12 +311,20 @@ def test_repository_writes_runtime_tables_and_reads_risk_state() -> None:
     risk_state = repository.risk_state(
         dependencies=(RuntimeDependencyStatus("clickhouse", True),)
     )
+    filtered_risk_state = repository.risk_state(
+        dependencies=(RuntimeDependencyStatus("clickhouse", True),),
+        trade_coins=("cash:AAPL",),
+        excluded_coins=("SPX",),
+    )
 
     assert signal_id
     assert decision_id
     assert order_id
     assert fill_count == 1
     assert risk_state.gross_exposure_usd == Decimal("25.5")
+    assert risk_state.collection_gross_exposure_usd == Decimal("25.5")
+    assert filtered_risk_state.gross_exposure_usd == Decimal("25.5")
+    assert filtered_risk_state.collection_gross_exposure_usd == Decimal("20")
     assert risk_state.daily_realized_pnl_usd == Decimal("-1.25")
     assert risk_state.unrealized_pnl_usd == Decimal("0.75")
     assert risk_state.daily_fees_usd == Decimal("0.01")


### PR DESCRIPTION
## Summary

- Separates real account gross exposure from configured-universe collection exposure for Hyperliquid runtime order caps.
- Keeps excluded/out-of-universe exposure visible by adding the latest account snapshot to `/report`.
- Adds regressions for the live SPX blocker: excluded SPX exposure no longer consumes the collection cap for configured equity coins.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_runtime/test_risk_strategy.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_service_gates.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `uv run --frozen ruff format --check app/hyperliquid_runtime tests/hyperliquid_runtime`
- `uv run --frozen ruff check app/hyperliquid_runtime tests/hyperliquid_runtime`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base "$(git -C ../.. merge-base origin/main HEAD)" app/hyperliquid_runtime/models.py app/hyperliquid_runtime/risk.py app/hyperliquid_runtime/repository.py app/hyperliquid_runtime/service.py tests/hyperliquid_runtime/test_risk_strategy.py tests/hyperliquid_runtime/test_service_repository.py tests/hyperliquid_runtime/test_adapters_api_metrics.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
