### PR TITLE
fix(torghut): freeze hyperliquid runtime before hard reset

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/README.md
+++ b/argocd/applications/torghut-hyperliquid-runtime/README.md
@@ -34,8 +34,9 @@ and target Kubernetes Secret exist; it does not print credential values.
 
 This app includes the ExternalSecret because `op://infra/hyperliquid-testnet` exists with the required fields.
 Before enabling trading, `reconcile` must report the Kubernetes Secret as ready and the exchange-side testnet account
-must be funded or authorized. Trading is now enabled with `HYPERLIQUID_RUNTIME_TRADING_ENABLED=true`; the runtime must
-continue to report `execution_network=testnet`, and mainnet execution is rejected by config validation.
+must be funded or authorized. Trading is intentionally frozen with `HYPERLIQUID_RUNTIME_TRADING_ENABLED=false` and
+`replicas=0` while the hard-reset migration replaces the v1 runtime. The runtime must continue to report
+`execution_network=testnet` when it is restored, and mainnet execution is rejected by config validation.
 
 Acceptance checks:
 

--- a/argocd/applications/torghut-hyperliquid-runtime/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/configmap.yaml
@@ -11,7 +11,7 @@ data:
   LOG_FORMAT: json
   HYPERLIQUID_RUNTIME_ENABLED: "true"
   # Testnet-only execution is enabled after the ExternalSecret is ready and the dedicated account is funded.
-  HYPERLIQUID_RUNTIME_TRADING_ENABLED: "true"
+  HYPERLIQUID_RUNTIME_TRADING_ENABLED: "false"
   HYPERLIQUID_RUNTIME_EXECUTION_NETWORK: testnet
   HYPERLIQUID_RUNTIME_MARKET_DATA_NETWORK: mainnet
   HYPERLIQUID_RUNTIME_EXCHANGE_API_URL: https://api.hyperliquid-testnet.xyz

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: torghut-hyperliquid-runtime
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-runtime-v1-20260619-equity-recovery-min-notional
+        proompteng.ai/config-revision: hyperliquid-hard-reset-freeze-20260619
       labels:
         app: torghut-hyperliquid-runtime
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -228,10 +228,10 @@ describe('Torghut manifest scheduling', () => {
     expect(data['schema.sql']).not.toContain('INSERT INTO torghut.hyperliquid_ta_features')
   })
 
-  it('keeps Hyperliquid runtime testnet trading wired to a gated execution secret', () => {
+  it('freezes the v1 Hyperliquid runtime before hard-reset migration', () => {
     const runtimeConfig = parseManifest('argocd/applications/torghut-hyperliquid-runtime/configmap.yaml')
     const runtimeData = getAtPath(runtimeConfig, ['data'])
-    expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('true')
+    expect(runtimeData.HYPERLIQUID_RUNTIME_TRADING_ENABLED).toBe('false')
     expect(runtimeData.HYPERLIQUID_RUNTIME_MARKET_DATA_NETWORK).toBe('mainnet')
     expect(runtimeData.HYPERLIQUID_RUNTIME_EXECUTION_NETWORK).toBe('testnet')
     expect(runtimeData.HYPERLIQUID_RUNTIME_TRADE_COINS).toBe(
@@ -243,8 +243,9 @@ describe('Torghut manifest scheduling', () => {
     expect(runtimeData.HYPERLIQUID_RUNTIME_MAX_SYMBOL_EXPOSURE_USD).toBe('25')
 
     const runtimeDeployment = parseManifest('argocd/applications/torghut-hyperliquid-runtime/deployment.yaml')
+    expect(getAtPath(runtimeDeployment, ['spec']).replicas).toBe(0)
     expect(getAtPath(runtimeDeployment, ['spec', 'template', 'metadata', 'annotations'])).toMatchObject({
-      'proompteng.ai/config-revision': 'hyperliquid-runtime-v1-20260619-equity-recovery-min-notional',
+      'proompteng.ai/config-revision': 'hyperliquid-hard-reset-freeze-20260619',
     })
     const runtimeContainer = getAtPath(runtimeDeployment, ['spec', 'template', 'spec', 'containers', 0])
     expect(String(runtimeContainer.image)).toMatch(/^registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:[0-9a-f]{64}$/)
@@ -327,7 +328,7 @@ describe('Torghut manifest scheduling', () => {
     expect(readme).toContain('bootstrap-hyperliquid-testnet-1password.sh reconcile')
     expect(readme).toContain('Before enabling trading')
     expect(readme).toContain('must be funded or authorized')
-    expect(readme).toContain('HYPERLIQUID_RUNTIME_TRADING_ENABLED=true')
+    expect(readme).toContain('HYPERLIQUID_RUNTIME_TRADING_ENABLED=false')
     expect(bootstrapScript).toContain('$0 check')
     expect(bootstrapScript).toContain('check_item()')
   })


### PR DESCRIPTION
## Summary

- Scales `torghut-hyperliquid-runtime` to `replicas=0` before the destructive hard-reset migration.
- Disables the v1 runtime trading flag while preserving mainnet market data and testnet execution config.
- Updates manifest coverage and runbook text to document the freeze state.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Temporarily freezes the Hyperliquid runtime by scaling it to zero. This is intentional so the next hard-reset migration cannot drop v1 tables while the old pod is still writing.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
