### PR TITLE
refactor(torghut): type broker read surface

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import inspect
 import re
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, is_dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from dataclasses import asdict, is_dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol, cast
 from uuid import UUID
@@ -37,7 +37,7 @@ class OrderFirewallViolation(PermissionError):
     """Raised when broker mutation methods are called outside OrderFirewall."""
 
 
-class _TradingClientLike(Protocol):
+class _ReadOnlyTradingClientLike(Protocol):
     def get_account(self) -> Any: ...
 
     def get_all_positions(self) -> Iterable[Any]: ...
@@ -46,6 +46,20 @@ class _TradingClientLike(Protocol):
 
     def get_order_by_id(self, order_id: str) -> Any: ...
 
+
+class _AssetLookupTradingClientLike(Protocol):
+    def get_asset(self, symbol_or_asset_id: str) -> Any: ...
+
+
+class _ClientOrderLookupTradingClientLike(Protocol):
+    def get_order_by_client_order_id(self, client_order_id: str) -> Any: ...
+
+
+class _LegacyClientOrderLookupTradingClientLike(Protocol):
+    def get_order_by_client_id(self, client_order_id: str) -> Any: ...
+
+
+class _TradingClientLike(_ReadOnlyTradingClientLike, Protocol):
     def submit_order(self, _order_data: Any, /) -> Any: ...
 
     def cancel_order_by_id(self, order_id: str) -> Any: ...
@@ -57,21 +71,44 @@ class _StockDataClientLike(Protocol):
     def get_stock_bars(self, _request_params: StockBarsRequest, /) -> Any: ...
 
 
-class _TradingMutationGuardProxy:
-    """Expose non-mutating trading methods while blocking direct order mutations."""
+class _ReadOnlyTradingClient:
+    """Named Alpaca trading reads exposed outside the firewall boundary."""
 
-    _blocked_methods = frozenset(
-        {"submit_order", "cancel_order_by_id", "cancel_orders"}
-    )
-
-    def __init__(self, trading_client: _TradingClientLike) -> None:
+    def __init__(self, trading_client: _ReadOnlyTradingClientLike) -> None:
         self._trading_client = trading_client
 
-    def __getattr__(self, name: str) -> Any:
-        attr = getattr(self._trading_client, name)
-        if name in self._blocked_methods and callable(attr):
-            raise OrderFirewallViolation("order_firewall_boundary_violation")
-        return attr
+    def get_account(self) -> Any:
+        return self._trading_client.get_account()
+
+    def get_all_positions(self) -> Iterable[Any]:
+        return self._trading_client.get_all_positions()
+
+    def get_orders(self, filter: Any | None = None) -> Iterable[Any]:
+        return self._trading_client.get_orders(filter)
+
+    def get_order_by_id(self, order_id: str) -> Any:
+        return self._trading_client.get_order_by_id(order_id)
+
+    def get_asset(self, symbol_or_asset_id: str) -> Any | None:
+        if not hasattr(self._trading_client, "get_asset"):
+            return None
+        asset_client = cast(_AssetLookupTradingClientLike, self._trading_client)
+        return asset_client.get_asset(symbol_or_asset_id)
+
+    def get_order_by_client_order_id(self, client_order_id: str) -> Any | None:
+        if hasattr(self._trading_client, "get_order_by_client_order_id"):
+            order_client = cast(
+                _ClientOrderLookupTradingClientLike,
+                self._trading_client,
+            )
+            return order_client.get_order_by_client_order_id(client_order_id)
+        if hasattr(self._trading_client, "get_order_by_client_id"):
+            legacy_order_client = cast(
+                _LegacyClientOrderLookupTradingClientLike,
+                self._trading_client,
+            )
+            return legacy_order_client.get_order_by_client_id(client_order_id)
+        return None
 
 
 class TorghutAlpacaClient:
@@ -102,7 +139,9 @@ class TorghutAlpacaClient:
             url_override=base,
         )
         self._trading = raw_trading_client
-        self.trading = _TradingMutationGuardProxy(raw_trading_client)
+        self.trading: _ReadOnlyTradingClient = _ReadOnlyTradingClient(
+            raw_trading_client
+        )
 
         # Market Data v2 (stocks).
         self.data: _StockDataClientLike = data_client or StockHistoricalDataClient(
@@ -114,17 +153,12 @@ class TorghutAlpacaClient:
 
     # ------------------- Trading helpers -------------------
     def get_account(self) -> Dict[str, Any]:
-        account = self._trading.get_account()
+        account = self.trading.get_account()
         return self._model_to_dict(account)
 
     def get_asset(self, symbol_or_asset_id: str) -> Dict[str, Any] | None:
-        getter = cast(
-            Callable[[str], Any] | None, getattr(self._trading, "get_asset", None)
-        )
-        if getter is None:
-            return None
         try:
-            asset = getter(symbol_or_asset_id)
+            asset = self.trading.get_asset(symbol_or_asset_id)
         except APIError as exc:
             status_code = getattr(exc, "status_code", None)
             if isinstance(status_code, int) and status_code == 404:
@@ -135,47 +169,36 @@ class TorghutAlpacaClient:
         return self._model_to_dict(asset)
 
     def list_positions(self) -> List[Dict[str, Any]]:
-        positions = self._trading.get_all_positions()
+        positions = self.trading.get_all_positions()
         return [self._model_to_dict(pos) for pos in positions]
 
     def list_open_orders(self) -> List[Dict[str, Any]]:
         request = GetOrdersRequest(status=QueryOrderStatus.OPEN)
-        orders = self._trading.get_orders(request)
+        orders = self.trading.get_orders(request)
         return [self._model_to_dict(order) for order in orders]
 
     def list_orders(self, status: str = "all") -> List[Dict[str, Any]]:
         status_value = QueryOrderStatus(status.lower())
         request = GetOrdersRequest(status=status_value)
-        orders = self._trading.get_orders(request)
+        orders = self.trading.get_orders(request)
         return [self._model_to_dict(order) for order in orders]
 
     def get_order(self, alpaca_order_id: str) -> Dict[str, Any]:
-        order = self._trading.get_order_by_id(alpaca_order_id)
+        order = self.trading.get_order_by_id(alpaca_order_id)
         return self._model_to_dict(order)
 
     def get_order_by_client_order_id(
         self, client_order_id: str
     ) -> Dict[str, Any] | None:
-        # alpaca-py renamed this helper across versions.
-        getter = cast(
-            Callable[[str], Any] | None,
-            getattr(self._trading, "get_order_by_client_order_id", None),
-        )
-        if getter is None:
-            getter = cast(
-                Callable[[str], Any] | None,
-                getattr(self._trading, "get_order_by_client_id", None),
-            )
-        if getter is None:
-            return None
-
         try:
-            order = getter(client_order_id)
+            order = self.trading.get_order_by_client_order_id(client_order_id)
         except APIError as exc:
             status_code = getattr(exc, "status_code", None)
             if isinstance(status_code, int) and status_code == 404:
                 return None
             raise
+        if order is None:
+            return None
 
         return self._model_to_dict(order)
 

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -106,6 +106,12 @@ class TestAlpacaClient(TestCase):
         self.assertEqual(orders[0]["id"], "order-1")
         self.assertIsInstance(orders[0]["uuid_id"], str)
 
+        all_orders = client.list_orders()
+        self.assertEqual(all_orders[0]["symbol"], "AAPL")
+
+        order = client.get_order("order-abc")
+        self.assertEqual(order["id"], "order-abc")
+
         firewall = OrderFirewall(client)
         submitted = firewall.submit_order(
             symbol="AAPL",
@@ -178,6 +184,24 @@ class TestAlpacaClient(TestCase):
         self.assertEqual(order["id"], "order-xyz")
         self.assertEqual(order["client_order_id"], "client-123")
 
+    def test_get_order_by_client_order_id_prefers_named_lookup(self) -> None:
+        class TradingClientWithClientOrderId(DummyTradingClient):
+            def get_order_by_client_order_id(self, client_id: str) -> DummyModel:
+                return DummyModel(id="order-named", client_order_id=client_id)
+
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=TradingClientWithClientOrderId(),
+            data_client=DummyDataClient(),
+        )
+
+        order = client.get_order_by_client_order_id("client-456")
+        assert order is not None
+        self.assertEqual(order["id"], "order-named")
+        self.assertEqual(order["client_order_id"], "client-456")
+
     def test_get_order_by_client_order_id_returns_none_when_unavailable(self) -> None:
         client = TorghutAlpacaClient(
             api_key="k",
@@ -188,6 +212,35 @@ class TestAlpacaClient(TestCase):
         )
 
         self.assertIsNone(client.get_order_by_client_order_id("client-123"))
+
+    def test_get_asset_returns_model_when_read_surface_supports_lookup(self) -> None:
+        class TradingClientWithAssetLookup(DummyTradingClient):
+            def get_asset(self, symbol_or_asset_id: str) -> DummyModel:
+                return DummyModel(symbol=symbol_or_asset_id, tradable=True)
+
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=TradingClientWithAssetLookup(),
+            data_client=DummyDataClient(),
+        )
+
+        asset = client.get_asset("AAPL")
+        assert asset is not None
+        self.assertEqual(asset["symbol"], "AAPL")
+        self.assertTrue(asset["tradable"])
+
+    def test_get_asset_returns_none_when_lookup_unavailable(self) -> None:
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=DummyTradingClient(),
+            data_client=DummyDataClient(),
+        )
+
+        self.assertIsNone(client.get_asset("AAPL"))
 
     def test_mutating_methods_require_firewall_boundary(self) -> None:
         client = TorghutAlpacaClient(
@@ -207,7 +260,7 @@ class TestAlpacaClient(TestCase):
                 firewall_token=cast(OrderFirewallToken, object()),
             )
 
-    def test_raw_trading_client_proxy_blocks_mutations(self) -> None:
+    def test_read_only_trading_client_does_not_expose_mutations(self) -> None:
         client = TorghutAlpacaClient(
             api_key="k",
             secret_key="s",
@@ -219,14 +272,18 @@ class TestAlpacaClient(TestCase):
         account = client.trading.get_account()
         self.assertEqual(account.model_dump()["equity"], "10000")
 
-        with self.assertRaises(OrderFirewallViolation):
-            client.trading.submit_order(object())
+        self.assertFalse(hasattr(client.trading, "submit_order"))
+        self.assertFalse(hasattr(client.trading, "cancel_order_by_id"))
+        self.assertFalse(hasattr(client.trading, "cancel_orders"))
 
-        with self.assertRaises(OrderFirewallViolation):
-            client.trading.cancel_order_by_id("order-1")
+        with self.assertRaises(AttributeError):
+            getattr(client.trading, "submit_order")
 
-        with self.assertRaises(OrderFirewallViolation):
-            client.trading.cancel_orders()
+        with self.assertRaises(AttributeError):
+            getattr(client.trading, "cancel_order_by_id")
+
+        with self.assertRaises(AttributeError):
+            getattr(client.trading, "cancel_orders")
 
     def test_market_data_uses_data_endpoint_by_default(self) -> None:
         with patch("app.alpaca_client.StockHistoricalDataClient") as mock_data_client:


### PR DESCRIPTION
## Summary

- Replaces the dynamic Alpaca trading mutation guard with an explicit read-only trading adapter.
- Routes TorghutAlpacaClient read helpers through the named read-only surface while keeping submit/cancel methods on the private raw client behind OrderFirewallToken.
- Adds regression coverage proving client.trading exposes account reads but does not expose submit/cancel mutation attributes.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app scripts tests migrations`
- `uv run --frozen pytest tests/test_alpaca_client.py tests/test_order_firewall.py`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
