### PR TITLE
fix(torghut): persist hyperliquid execution cycle before signals

### DIFF
--- a/services/torghut/app/hyperliquid_execution/repository.py
+++ b/services/torghut/app/hyperliquid_execution/repository.py
@@ -628,6 +628,16 @@ class HyperliquidExecutionRepository:
                   CAST(:universe_details AS jsonb),
                   :error
                 )
+                ON CONFLICT (id) DO UPDATE SET
+                  finished_at = EXCLUDED.finished_at,
+                  trading_enabled = EXCLUDED.trading_enabled,
+                  selected_coins = EXCLUDED.selected_coins,
+                  signals_written = EXCLUDED.signals_written,
+                  orders_submitted = EXCLUDED.orders_submitted,
+                  orders_cancelled = EXCLUDED.orders_cancelled,
+                  dependency_statuses = EXCLUDED.dependency_statuses,
+                  universe_details = EXCLUDED.universe_details,
+                  error = EXCLUDED.error
                 """
             ),
             {

--- a/services/torghut/app/hyperliquid_execution/service.py
+++ b/services/torghut/app/hyperliquid_execution/service.py
@@ -68,6 +68,22 @@ class HyperliquidExecutionService:
         repository = HyperliquidExecutionRepository(session)
         context = self._load_context(repository, started_at)
         counts = _CycleCounts()
+        repository.insert_cycle(
+            self._cycle_record(
+                cycle_id,
+                started_at,
+                CycleResult(
+                    observed_at=started_at,
+                    markets_seen=len(context.markets),
+                    selected_coins=tuple(market.coin for market in context.markets),
+                    signals_written=0,
+                    orders_submitted=0,
+                    orders_cancelled=0,
+                    dependencies=context.dependencies,
+                    universe_details=context.universe_details,
+                ),
+            )
+        )
 
         counts.orders_cancelled = self._cancel_expired_orders(repository, started_at)
 

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
@@ -267,6 +267,17 @@ def test_service_cycle_cancels_reconciles_submits_and_records_cycle() -> None:
     assert result.orders_submitted == 1
     assert result.orders_cancelled == 1
     assert session.committed
+    cycle_calls = [
+        index
+        for index, (sql, _) in enumerate(session.calls)
+        if "INSERT INTO hyperliquid_execution_cycles" in sql
+    ]
+    signal_call = next(
+        index
+        for index, (sql, _) in enumerate(session.calls)
+        if "INSERT INTO hyperliquid_execution_signals" in sql
+    )
+    assert cycle_calls[0] < signal_call < cycle_calls[-1]
 
 
 def test_runtime_readiness_reports_config_errors_and_dependency_blockers() -> None:


### PR DESCRIPTION
## Summary

- Persist the Hyperliquid v2 cycle parent row before writing FK-bound signals and orders.
- Make cycle persistence idempotent so the final cycle result updates the same row with completed counts.
- Add regression coverage that asserts cycle persistence happens before signal persistence in a runtime cycle.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_execution`
- `uv run --frozen ruff format --check app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen ruff check app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen python -m compileall -q app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/hyperliquid_execution --cov=app --cov=scripts --cov-branch --cov-report=xml:coverage.xml --cov-report=term --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --base-ref origin/main --threshold 90 --format json`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/hyperliquid_execution/service.py app/hyperliquid_execution/repository.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/hyperliquid_execution/service.py app/hyperliquid_execution/repository.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
