### PR TITLE
fix(torghut): select fresh hyperliquid execution markets

### DIFF
--- a/services/torghut/app/hyperliquid_execution/service.py
+++ b/services/torghut/app/hyperliquid_execution/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Protocol
+from typing import Protocol, cast
 
 from .config import HyperliquidExecutionConfig
 from .exchange import HyperliquidExecutionExchange
@@ -212,17 +212,25 @@ class HyperliquidExecutionService:
             feed_markets
         )
         fresh_features = self._fresh_features(execution_markets)
+        selected_markets, selected_features = _select_markets_with_fresh_features(
+            execution_markets, fresh_features
+        )
         feature_status = _feature_status(execution_markets, fresh_features)
         open_order_status = self._reconcile_exchange_state(
-            repository, execution_markets, observed_at
+            repository, selected_markets, observed_at
         )
         exchange_status = self._exchange.dependency_status()
         return _CycleContext(
-            markets=execution_markets,
-            features=fresh_features,
+            markets=selected_markets,
+            features=selected_features,
             dependencies=feed_status.statuses
             + (execution_status, feature_status, open_order_status, exchange_status),
-            universe_details=self._universe_details(feed_details, execution_status),
+            universe_details=self._universe_details(
+                feed_details,
+                execution_status,
+                feature_status,
+                selected_markets,
+            ),
         )
 
     def _fresh_features(
@@ -264,10 +272,22 @@ class HyperliquidExecutionService:
         self,
         feed_details: dict[str, object],
         execution_status: RuntimeDependencyStatus,
+        feature_status: RuntimeDependencyStatus,
+        selected_markets: tuple[ExecutionMarket, ...],
     ) -> dict[str, object]:
         details = dict(feed_details)
         details.update(execution_status.details)
         details.update(self._exchange.execution_metadata_details())
+        details["selected_execution_metadata"] = _string_list_detail(
+            details.get("selected")
+        )
+        details["selected"] = [market.coin for market in selected_markets]
+        details["fresh_features"] = _string_list_detail(
+            feature_status.details.get("features")
+        )
+        details["missing_fresh_features"] = _string_list_detail(
+            feature_status.details.get("missing")
+        )
         return details
 
 
@@ -317,6 +337,28 @@ class _CycleCounts:
     orders_cancelled: int = 0
 
 
+def _select_markets_with_fresh_features(
+    markets: tuple[ExecutionMarket, ...],
+    features: tuple[FeatureSnapshot, ...],
+) -> tuple[tuple[ExecutionMarket, ...], tuple[FeatureSnapshot, ...]]:
+    feature_by_market_id = {
+        feature.market_id: feature for feature in reversed(features)
+    }
+    selected_markets = tuple(
+        market for market in markets if market.market_id in feature_by_market_id
+    )
+    selected_features = tuple(
+        feature_by_market_id[market.market_id] for market in selected_markets
+    )
+    return selected_markets, selected_features
+
+
+def _string_list_detail(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in cast(list[object], value)]
+
+
 def _feature_status(
     markets: tuple[ExecutionMarket, ...],
     features: tuple[FeatureSnapshot, ...],
@@ -325,11 +367,14 @@ def _feature_status(
     missing = [
         market.coin for market in markets if market.market_id not in feature_market_ids
     ]
-    ready = bool(markets) and not missing
+    ready = bool(features)
+    reason: str | None = None
+    if not ready:
+        reason = "no_fresh_features" if markets else "no_execution_markets"
     return RuntimeDependencyStatus(
         name="hyperliquid_mainnet_features",
         ready=ready,
-        reason=None if ready else "missing_fresh_features",
+        reason=reason,
         details={
             "missing": missing,
             "features": [feature.coin for feature in features],

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -178,6 +178,7 @@ from .lane_common import (
 from .lane_profitability_manifest import (
     build_profitability_stage_manifest as _build_profitability_stage_manifest,
 )
+from . import lane_gate_inputs as lane_gate_inputs_module
 from .lane_phase_payloads import (
     build_actuation_intent_payload as _build_actuation_intent_payload,
     build_phase_manifest as _build_phase_manifest,
@@ -279,7 +280,7 @@ from .lane_gate_inputs import (
     coerce_fragility_measurement as _coerce_fragility_measurement,
     is_more_worse_fragility as _is_more_worse_fragility,
     resolve_gate_fragility_inputs as _resolve_gate_fragility_inputs,
-    resolve_gate_forecast_metrics as _resolve_gate_forecast_metrics,
+    resolve_gate_forecast_metrics as _base_resolve_gate_forecast_metrics,
     resolve_gate_staleness_ms_p95 as _resolve_gate_staleness_ms_p95,
     to_finite_float as _to_finite_float,
     resolve_gate_llm_metrics as _resolve_gate_llm_metrics,
@@ -296,6 +297,17 @@ from .lane_run_summary import (
     evaluate_drift_promotion_gate as _evaluate_drift_promotion_gate,
     write_paper_candidate_patch as _write_paper_candidate_patch,
 )
+
+
+def _resolve_gate_forecast_metrics(*, signals: list[SignalEnvelope]) -> dict[str, str]:
+    original_router_builder = lane_gate_inputs_module.build_default_forecast_router
+    lane_gate_inputs_module.build_default_forecast_router = (
+        build_default_forecast_router
+    )
+    try:
+        return _base_resolve_gate_forecast_metrics(signals=signals)
+    finally:
+        lane_gate_inputs_module.build_default_forecast_router = original_router_builder
 
 
 def run_autonomous_lane(

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -49,6 +49,8 @@ from app.trading.runtime_window_import import (
     resolve_hypothesis_manifest,
 )
 
+import scripts.hypothesis_runtime_window_import.cli_parsing as runtime_window_cli_parsing_module
+
 from scripts.hypothesis_runtime_window_import.common import (
     _runtime_source_row_symbol as _runtime_source_row_symbol,
     _execution_signed_qty as _execution_signed_qty,
@@ -284,7 +286,6 @@ from scripts.hypothesis_runtime_window_import.cli_parsing import (
     _parse_args,
     _sqlalchemy_dsn,
     _target_persistence_dsn,
-    _persistence_session,
     _flag,
     _load_json_artifact,
 )
@@ -341,6 +342,17 @@ _SOURCE_RUNTIME_LEDGER_COLUMNS = (
     "pnl_basis",
     "payload_json",
 )
+
+
+@contextmanager
+def _persistence_session(args: argparse.Namespace) -> Iterator[Session]:
+    original_session_local = runtime_window_cli_parsing_module.SessionLocal
+    runtime_window_cli_parsing_module.SessionLocal = SessionLocal
+    try:
+        with runtime_window_cli_parsing_module._persistence_session(args) as session:
+            yield session
+    finally:
+        runtime_window_cli_parsing_module.SessionLocal = original_session_local
 
 
 def _query_timestamps(

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -13,12 +13,13 @@ import signal
 import socket
 import subprocess
 import time as monotonic_time
+from contextlib import contextmanager
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Mapping, Sequence, cast
+from typing import Any, Iterator, Mapping, Sequence, cast
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
 
@@ -121,6 +122,13 @@ from app.whitepapers.claim_compiler import (
 import scripts.local_intraday_tsmom_replay as replay_mod
 import scripts.materialize_replay_tape as replay_materializer
 import scripts.run_strategy_factory_v2 as strategy_factory_runner
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io_module
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources_module
+import scripts.whitepaper_autoresearch_runner.preview_narrowing as preview_narrowing_module
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building_module
+import scripts.whitepaper_autoresearch_runner.proposal_training as proposal_training_module
+import scripts.whitepaper_autoresearch_runner.replay_execution as replay_execution_module
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards_module
 
 from scripts.whitepaper_autoresearch_runner.candidate_board_fields import (
     _candidate_board_score_rows as _candidate_board_score_rows,
@@ -248,7 +256,6 @@ from scripts.whitepaper_autoresearch_runner.artifact_io import (
     _write_json,
     _write_jsonl,
     _write_failure_summary,
-    _current_code_commit,
     _resolved_clickhouse_password,
     _clickhouse_host_requires_dns_preflight,
     _clickhouse_endpoint_preflight_failure,
@@ -275,15 +282,10 @@ from scripts.whitepaper_autoresearch_runner.rejected_signal_feedback import (
 )
 
 from scripts.whitepaper_autoresearch_runner.persisted_feedback_sources import (
-    _load_recent_persisted_feedback_evidence_bundles,
-    _load_autoresearch_feedback_evidence_bundles,
     _program_claim_type,
     _program_research_source_to_whitepaper_source,
     _program_whitepaper_sources,
     _dedupe_whitepaper_sources,
-    _load_sources_from_db,
-    _persist_vnext_specs,
-    _persist_epoch_ledgers,
 )
 
 from scripts.whitepaper_autoresearch_runner.oracle_policy import (
@@ -297,7 +299,6 @@ from scripts.whitepaper_autoresearch_runner.oracle_policy import (
 )
 
 from scripts.whitepaper_autoresearch_runner.proposal_training import (
-    _proposal_model_and_rows,
     _candidate_quality_gate_failures,
     _false_positive_table,
     _replay_diagnostic_proposal_rows,
@@ -382,7 +383,6 @@ from scripts.whitepaper_autoresearch_runner.feedback_bundle_builders import (
 )
 
 from scripts.whitepaper_autoresearch_runner.proposal_building import (
-    _pre_replay_proposal_model_and_rows,
     _proposal_score_confidence,
     _selection_reason_blocks_replay,
 )
@@ -392,7 +392,6 @@ from scripts.whitepaper_autoresearch_runner.candidate_identity import (
 
 from scripts.whitepaper_autoresearch_runner.preview_narrowing import (
     _candidate_selection_for_direct_replay,
-    _apply_fast_replay_preview_narrowing,
     _resolved_fast_replay_preview_top_k,
     _resolved_fast_replay_exact_candidate_cap,
 )
@@ -424,29 +423,17 @@ from scripts.whitepaper_autoresearch_runner.replay_execution import (
     _synthetic_net_for_spec,
     _synthetic_symbol_contribution_shares,
     _synthetic_candidate_payload,
-    _run_synthetic_replay,
-    _run_real_replay,
-    _real_replay_result_from_factory_payload,
     _dedupe_replay_evidence,
     _candidate_spec_id_from_experiment_result_path,
-    _collect_partial_real_replay,
-    _run_real_replay_once_with_optional_timeout,
-    _real_replay_worker,
-    _terminate_process,
-    _run_real_replay_once_in_child_process,
 )
 
 from scripts.whitepaper_autoresearch_runner.replay_shards import (
-    _run_replay_with_optional_timeout,
     _build_real_replay_shards,
-    _execute_real_replay_shard,
     _failed_shard_spec_ids,
     _evidenced_spec_ids,
-    _retry_real_replay_failed_shard_specs,
     _replay_shard_frontier_candidate_budget,
     _bounded_real_replay_shard_workers,
     _bounded_real_replay_shard_timeout_seconds,
-    _run_real_replay_shards,
     _load_epoch_program,
     _resolved_staged_train_screen_multiplier,
     _resolved_program_family_int_arg,
@@ -640,6 +627,245 @@ _EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS = frozenset(
 )
 
 _EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE = "exact_replay_runtime_ledger"
+
+_BASE_CURRENT_CODE_COMMIT = artifact_io_module._current_code_commit
+_BASE_RUN_SYNTHETIC_REPLAY = replay_execution_module._run_synthetic_replay
+_BASE_RUN_REAL_REPLAY = replay_execution_module._run_real_replay
+_BASE_REAL_REPLAY_RESULT_FROM_FACTORY_PAYLOAD = (
+    replay_execution_module._real_replay_result_from_factory_payload
+)
+_BASE_COLLECT_PARTIAL_REAL_REPLAY = replay_execution_module._collect_partial_real_replay
+_BASE_REAL_REPLAY_WORKER = replay_execution_module._real_replay_worker
+_BASE_TERMINATE_PROCESS = replay_execution_module._terminate_process
+_BASE_RUN_REAL_REPLAY_ONCE_WITH_OPTIONAL_TIMEOUT = (
+    replay_execution_module._run_real_replay_once_with_optional_timeout
+)
+_BASE_RUN_REAL_REPLAY_ONCE_IN_CHILD_PROCESS = (
+    replay_execution_module._run_real_replay_once_in_child_process
+)
+_BASE_APPLY_FAST_REPLAY_PREVIEW_NARROWING = (
+    preview_narrowing_module._apply_fast_replay_preview_narrowing
+)
+_BASE_EXECUTE_REAL_REPLAY_SHARD = replay_shards_module._execute_real_replay_shard
+_BASE_RETRY_REAL_REPLAY_FAILED_SHARD_SPECS = (
+    replay_shards_module._retry_real_replay_failed_shard_specs
+)
+_BASE_RUN_REAL_REPLAY_SHARDS = replay_shards_module._run_real_replay_shards
+_BASE_RUN_REPLAY_WITH_OPTIONAL_TIMEOUT = (
+    replay_shards_module._run_replay_with_optional_timeout
+)
+
+
+@contextmanager
+def _temporary_module_attr(module: Any, name: str, value: Any) -> Iterator[None]:
+    original = getattr(module, name)
+    setattr(module, name, value)
+    try:
+        yield
+    finally:
+        setattr(module, name, original)
+
+
+def _current_code_commit() -> str:
+    with _temporary_module_attr(artifact_io_module, "__file__", __file__):
+        return _BASE_CURRENT_CODE_COMMIT()
+
+
+def _load_recent_persisted_feedback_evidence_bundles(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        persisted_feedback_sources_module, "SessionLocal", SessionLocal
+    ):
+        return persisted_feedback_sources_module._load_recent_persisted_feedback_evidence_bundles(
+            *args, **kwargs
+        )
+
+
+def _load_autoresearch_feedback_evidence_bundles(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        persisted_feedback_sources_module, "SessionLocal", SessionLocal
+    ):
+        return persisted_feedback_sources_module._load_autoresearch_feedback_evidence_bundles(
+            *args, **kwargs
+        )
+
+
+def _load_sources_from_db(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        persisted_feedback_sources_module, "SessionLocal", SessionLocal
+    ):
+        return persisted_feedback_sources_module._load_sources_from_db(*args, **kwargs)
+
+
+def _persist_vnext_specs(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        persisted_feedback_sources_module, "SessionLocal", SessionLocal
+    ):
+        return persisted_feedback_sources_module._persist_vnext_specs(*args, **kwargs)
+
+
+def _persist_epoch_ledgers(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        persisted_feedback_sources_module, "SessionLocal", SessionLocal
+    ):
+        return persisted_feedback_sources_module._persist_epoch_ledgers(*args, **kwargs)
+
+
+def _pre_replay_proposal_model_and_rows(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        proposal_building_module, "train_mlx_ranker", train_mlx_ranker
+    ):
+        return proposal_building_module._pre_replay_proposal_model_and_rows(
+            *args, **kwargs
+        )
+
+
+def _proposal_model_and_rows(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        proposal_training_module, "train_mlx_ranker", train_mlx_ranker
+    ):
+        return proposal_training_module._proposal_model_and_rows(*args, **kwargs)
+
+
+def _run_synthetic_replay(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        replay_execution_module, "_current_code_commit", _current_code_commit
+    ):
+        return _BASE_RUN_SYNTHETIC_REPLAY(*args, **kwargs)
+
+
+def _run_real_replay(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        replay_execution_module, "_current_code_commit", _current_code_commit
+    ):
+        return _BASE_RUN_REAL_REPLAY(*args, **kwargs)
+
+
+def _real_replay_result_from_factory_payload(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        replay_execution_module, "_current_code_commit", _current_code_commit
+    ):
+        return _BASE_REAL_REPLAY_RESULT_FROM_FACTORY_PAYLOAD(*args, **kwargs)
+
+
+def _collect_partial_real_replay(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        replay_execution_module,
+        "_real_replay_result_from_factory_payload",
+        _real_replay_result_from_factory_payload,
+    ):
+        return _BASE_COLLECT_PARTIAL_REAL_REPLAY(*args, **kwargs)
+
+
+def _run_real_replay_once_with_optional_timeout(*args: Any, **kwargs: Any) -> Any:
+    with (
+        _temporary_module_attr(replay_execution_module, "signal", signal),
+        _temporary_module_attr(
+            replay_execution_module, "_run_real_replay", _run_real_replay
+        ),
+        _temporary_module_attr(
+            replay_execution_module,
+            "_run_real_replay_once_in_child_process",
+            _run_real_replay_once_in_child_process,
+        ),
+    ):
+        return _BASE_RUN_REAL_REPLAY_ONCE_WITH_OPTIONAL_TIMEOUT(*args, **kwargs)
+
+
+def _real_replay_worker(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        replay_execution_module, "_run_real_replay", _run_real_replay
+    ):
+        return _BASE_REAL_REPLAY_WORKER(*args, **kwargs)
+
+
+def _terminate_process(*args: Any, **kwargs: Any) -> Any:
+    return _BASE_TERMINATE_PROCESS(*args, **kwargs)
+
+
+def _run_real_replay_once_in_child_process(*args: Any, **kwargs: Any) -> Any:
+    with (
+        _temporary_module_attr(
+            replay_execution_module, "_real_replay_worker", _real_replay_worker
+        ),
+        _temporary_module_attr(
+            replay_execution_module, "_terminate_process", _terminate_process
+        ),
+        _temporary_module_attr(
+            replay_execution_module, "multiprocessing", multiprocessing
+        ),
+        _temporary_module_attr(replay_execution_module, "queue", queue),
+        _temporary_module_attr(
+            replay_execution_module, "monotonic_time", monotonic_time
+        ),
+    ):
+        return _BASE_RUN_REAL_REPLAY_ONCE_IN_CHILD_PROCESS(*args, **kwargs)
+
+
+def _execute_real_replay_shard(*args: Any, **kwargs: Any) -> Any:
+    with (
+        _temporary_module_attr(
+            replay_shards_module,
+            "_run_real_replay_once_with_optional_timeout",
+            _run_real_replay_once_with_optional_timeout,
+        ),
+        _temporary_module_attr(
+            replay_shards_module,
+            "_collect_partial_real_replay",
+            _collect_partial_real_replay,
+        ),
+    ):
+        return _BASE_EXECUTE_REAL_REPLAY_SHARD(*args, **kwargs)
+
+
+def _retry_real_replay_failed_shard_specs(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        replay_shards_module, "_execute_real_replay_shard", _execute_real_replay_shard
+    ):
+        return _BASE_RETRY_REAL_REPLAY_FAILED_SHARD_SPECS(*args, **kwargs)
+
+
+def _run_real_replay_shards(*args: Any, **kwargs: Any) -> Any:
+    with (
+        _temporary_module_attr(
+            replay_shards_module,
+            "_execute_real_replay_shard",
+            _execute_real_replay_shard,
+        ),
+        _temporary_module_attr(
+            replay_shards_module,
+            "_retry_real_replay_failed_shard_specs",
+            _retry_real_replay_failed_shard_specs,
+        ),
+        _temporary_module_attr(
+            replay_shards_module, "ProcessPoolExecutor", ProcessPoolExecutor
+        ),
+        _temporary_module_attr(replay_shards_module, "as_completed", as_completed),
+    ):
+        return _BASE_RUN_REAL_REPLAY_SHARDS(*args, **kwargs)
+
+
+def _run_replay_with_optional_timeout(*args: Any, **kwargs: Any) -> Any:
+    with (
+        _temporary_module_attr(
+            replay_shards_module, "_run_synthetic_replay", _run_synthetic_replay
+        ),
+        _temporary_module_attr(
+            replay_shards_module,
+            "_run_real_replay_once_with_optional_timeout",
+            _run_real_replay_once_with_optional_timeout,
+        ),
+        _temporary_module_attr(
+            replay_shards_module, "_run_real_replay_shards", _run_real_replay_shards
+        ),
+    ):
+        return _BASE_RUN_REPLAY_WITH_OPTIONAL_TIMEOUT(*args, **kwargs)
+
+
+def _apply_fast_replay_preview_narrowing(*args: Any, **kwargs: Any) -> Any:
+    with _temporary_module_attr(
+        preview_narrowing_module, "build_fast_replay_preview", build_fast_replay_preview
+    ):
+        return _BASE_APPLY_FAST_REPLAY_PREVIEW_NARROWING(*args, **kwargs)
 
 
 def _select_candidate_specs_for_replay(

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -69,6 +69,7 @@ from app.trading.reporting import (
     summarize_replay_profitability,
 )
 import scripts.local_intraday_tsmom_replay as replay_mod
+import scripts.consistent_profitability_frontier.replay_data as replay_data_module
 from scripts.local_intraday_tsmom_replay import run_replay
 from scripts.search_profitability_frontier import (
     _SWEEP_SCHEMA_VERSION,
@@ -232,7 +233,7 @@ from scripts.consistent_profitability_frontier.replay_data import (
     _replay_tape_trading_days,
     _build_replay_tape_snapshot_receipt,
     _replay_tape_row_days,
-    apply_candidate_to_configmap_with_overrides,
+    apply_candidate_to_configmap_with_overrides as _base_apply_candidate_to_configmap_with_overrides,
 )
 
 from scripts.consistent_profitability_frontier.scoring_ranking import (
@@ -273,6 +274,29 @@ from scripts.consistent_profitability_frontier.candidate_repairs import (
     _generate_consistency_repair_children,
     _selected_normalization_regime,
 )
+
+
+def apply_candidate_to_configmap_with_overrides(
+    *,
+    configmap_payload: Mapping[str, Any],
+    strategy_name: str,
+    candidate_params: Mapping[str, Any],
+    strategy_overrides: Mapping[str, Any],
+    disable_other_strategies: bool,
+) -> dict[str, Any]:
+    original_apply_candidate = replay_data_module.apply_candidate_to_configmap
+    replay_data_module.apply_candidate_to_configmap = apply_candidate_to_configmap
+    try:
+        return _base_apply_candidate_to_configmap_with_overrides(
+            configmap_payload=configmap_payload,
+            strategy_name=strategy_name,
+            candidate_params=candidate_params,
+            strategy_overrides=strategy_overrides,
+            disable_other_strategies=disable_other_strategies,
+        )
+    finally:
+        replay_data_module.apply_candidate_to_configmap = original_apply_candidate
+
 
 _LOCAL_ONLY_OVERRIDE_KEYS = frozenset({"normalization_regime"})
 

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
@@ -31,6 +31,8 @@ from app.hyperliquid_execution.models import (
 from app.hyperliquid_execution.repository import HyperliquidExecutionRepository
 from app.hyperliquid_execution.service import (
     HyperliquidExecutionService,
+    _feature_status,
+    _string_list_detail,
     runtime_readiness,
 )
 
@@ -280,6 +282,52 @@ def test_service_cycle_cancels_reconciles_submits_and_records_cycle() -> None:
     assert cycle_calls[0] < signal_call < cycle_calls[-1]
 
 
+def test_service_selects_only_fresh_execution_markets() -> None:
+    now = _now()
+    config = HyperliquidExecutionConfig.from_env(
+        {
+            "HYPERLIQUID_EXECUTION_TRADING_ENABLED": "true",
+            "HYPERLIQUID_EXECUTION_API_WALLET_PRIVATE_KEY": "0x1",
+            "HYPERLIQUID_EXECUTION_ACCOUNT_ADDRESS": "0xabc",
+            "HYPERLIQUID_EXECUTION_TRADE_COINS": "xyz:NVDA,xyz:MU",
+        }
+    )
+    session = _FakeSession()
+    exchange = _ServiceExchange(now)
+    service = HyperliquidExecutionService(
+        config=config,
+        feed=_PartialFeatureServiceFeed(now),
+        exchange=exchange,
+    )
+
+    result = service.run_once(session)
+
+    dependencies = {dependency.name: dependency for dependency in result.dependencies}
+    feature_dependency = dependencies["hyperliquid_mainnet_features"]
+    assert result.selected_coins == ("NVDA",)
+    assert result.signals_written == 1
+    assert result.orders_submitted == 1
+    assert feature_dependency.ready is True
+    assert feature_dependency.reason is None
+    assert feature_dependency.details["features"] == ["NVDA"]
+    assert feature_dependency.details["missing"] == ["MU"]
+    assert result.universe_details["selected"] == ["NVDA"]
+    assert result.universe_details["selected_execution_metadata"] == ["NVDA", "MU"]
+    assert result.universe_details["missing_fresh_features"] == ["MU"]
+    assert exchange.reconciled_coins == {"NVDA"}
+
+
+def test_feature_status_and_detail_helpers_report_empty_paths() -> None:
+    no_features = _feature_status((_market(),), ())
+    no_markets = _feature_status((), ())
+
+    assert no_features.ready is False
+    assert no_features.reason == "no_fresh_features"
+    assert no_markets.ready is False
+    assert no_markets.reason == "no_execution_markets"
+    assert _string_list_detail("NVDA") == []
+
+
 def test_runtime_readiness_reports_config_errors_and_dependency_blockers() -> None:
     config = HyperliquidExecutionConfig.from_env(
         {
@@ -423,9 +471,36 @@ class _ServiceFeed:
         return [_feature(event_ts=self.now)]
 
 
+class _PartialFeatureServiceFeed(_ServiceFeed):
+    def load_catalog_rows(self) -> list[dict[str, object]]:
+        return [
+            {
+                "market_id": "hl:perp:xyz:NVDA",
+                "coin": "NVDA",
+                "dex": "xyz",
+                "network": "mainnet",
+                "market_type": "perp",
+                "dayNtlVlm": "1000",
+            },
+            {
+                "market_id": "hl:perp:xyz:MU",
+                "coin": "MU",
+                "dex": "xyz",
+                "network": "mainnet",
+                "market_type": "perp",
+                "dayNtlVlm": "900",
+            },
+        ]
+
+    def load_feature_rows(self, market_ids: list[str]) -> list[FeatureSnapshot]:
+        assert market_ids == ["hl:perp:xyz:NVDA", "hl:perp:xyz:MU"]
+        return [_feature(event_ts=self.now)]
+
+
 class _ServiceExchange:
     def __init__(self, now: datetime) -> None:
         self.now = now
+        self.reconciled_coins: set[str] = set()
 
     def filter_supported_markets(
         self,
@@ -434,7 +509,10 @@ class _ServiceExchange:
         return markets, RuntimeDependencyStatus(
             "hyperliquid_execution_metadata",
             True,
-            details={"active_execution_metadata": ["NVDA"]},
+            details={
+                "active_execution_metadata": [market.coin for market in markets],
+                "selected": [market.coin for market in markets],
+            },
         )
 
     def submit_maker_order(self, intent: OrderIntent) -> OrderResult:
@@ -445,12 +523,15 @@ class _ServiceExchange:
         return OrderResult("cancelled", "123", {"ok": True})
 
     def reconcile_fills(self, _market_id_by_coin: dict[str, str]) -> list[Fill]:
+        self.reconciled_coins.update(_market_id_by_coin)
         return [_fill(self.now)]
 
     def reconcile_account(self, _market_id_by_coin: dict[str, str]) -> AccountState:
+        self.reconciled_coins.update(_market_id_by_coin)
         return _account_state(self.now)
 
-    def reconcile_open_order_coins(self, _coins: frozenset[str]) -> frozenset[str]:
+    def reconcile_open_order_coins(self, coins: frozenset[str]) -> frozenset[str]:
+        self.reconciled_coins.update(coins)
         return frozenset()
 
     def dependency_status(self) -> RuntimeDependencyStatus:
@@ -459,7 +540,7 @@ class _ServiceExchange:
         )
 
     def execution_metadata_details(self) -> dict[str, object]:
-        return {"selected_execution_metadata": ["NVDA"]}
+        return {}
 
 
 class _FakeSession:


### PR DESCRIPTION
## Summary

- Select Hyperliquid execution markets only when the coin has active testnet execution metadata and a fresh mainnet feature row.
- Preserve missing/stale feature evidence in runtime reports through `selected_execution_metadata`, `fresh_features`, and `missing_fresh_features`.
- Restore root runner patch surfaces after the autoresearch split so tests patch the facade instead of reaching real Postgres or ClickHouse.
- Keep runtime-window import persistence session patching aligned with the root CLI facade.
- Preserve public facade patch hooks for autonomy forecast routing and consistent-frontier configmap application after the split.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/hyperliquid_execution`
- `uv run --frozen pytest tests/autonomous_lane/test_autonomous_lane_evidence.py::TestAutonomousLaneEvidence::test_gate_forecast_metrics_accept_authoritative_router_outputs tests/profitability_frontier/test_search_frontier_replay_inputs.py::TestSearchFrontierReplayInputs::test_apply_candidate_to_configmap_with_overrides_validates_returned_catalog`
- `uv run --frozen pytest tests/autonomous_lane/test_autonomous_lane_evidence.py::TestAutonomousLaneEvidence::test_gate_forecast_metrics_accept_authoritative_router_outputs tests/profitability_frontier/test_search_frontier_replay_inputs.py::TestSearchFrontierReplayInputs::test_apply_candidate_to_configmap_with_overrides_validates_returned_catalog tests/hyperliquid_execution -q`
- `uv run --frozen pytest tests/runtime_window_import/test_runtime_window_main_a.py tests/runtime_window_import/test_runtime_window_main_b.py`
- `uv run --frozen pytest tests/whitepaper_autoresearch/test_autoresearch_runner_feedback_loading.py tests/whitepaper_autoresearch/test_autoresearch_runner_persistence_remediation.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py`
- `uv run --frozen pytest tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py`
- `uv run --frozen pytest tests/autoresearch_runner`
- `uv run --frozen pytest tests/hyperliquid_execution tests/runtime_window_import/test_runtime_window_main_a.py tests/runtime_window_import/test_runtime_window_main_b.py tests/whitepaper_autoresearch/test_autoresearch_runner_feedback_loading.py tests/whitepaper_autoresearch/test_autoresearch_runner_persistence_remediation.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py`
- `uv run --frozen ruff format --check app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen python -m compileall -q scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/hyperliquid_execution tests/autoresearch_runner tests/runtime_window_import/test_runtime_window_main_a.py tests/runtime_window_import/test_runtime_window_main_b.py tests/whitepaper_autoresearch/test_autoresearch_runner_feedback_loading.py tests/whitepaper_autoresearch/test_autoresearch_runner_persistence_remediation.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py --cov=app --cov=scripts --cov-branch --cov-report=xml:coverage.xml --cov-report=term --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --base-ref origin/main --threshold 90 --format json`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/hyperliquid_execution/service.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/hyperliquid_execution/service.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
