### PR TITLE
fix(torghut): roll hyperliquid edge config

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-execution-v2-activation-20260620
+        proompteng.ai/config-revision: hyperliquid-execution-v2-edge-20260620
       labels:
         app: torghut-hyperliquid-runtime
     spec:


### PR DESCRIPTION
## Summary

- Bump the Hyperliquid runtime Deployment `proompteng.ai/config-revision` annotation so the merged `MIN_EDGE_BPS=3` ConfigMap change actually rolls the pod.
- Keep image, command, resource, network, execution, and risk-cap settings unchanged.
- This is the GitOps rollout trigger for PR #11322.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
