### PR TITLE
fix(torghut): reconcile hyperliquid perpdex account state

### DIFF
--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -236,9 +236,22 @@ class HyperliquidSdkExecutionExchange:
                 ),
                 positions=(),
             )
-        raw_state = cast(dict[str, object], self._info().user_state(account))
+        info = self._info()
+        raw_states = {
+            dex: cast(dict[str, object], info.user_state(account, dex=dex))
+            for dex in self._known_dexes()
+        }
+        try:
+            spot_state = cast(dict[str, object], info.spot_user_state(account))
+        except Exception:
+            spot_state = {}
         self._last_read_at = observed_at
-        return _account_state_from_payload(raw_state, market_id_by_coin, observed_at)
+        return _account_state_from_payloads(
+            raw_states,
+            spot_state,
+            market_id_by_coin,
+            observed_at,
+        )
 
     def reconcile_open_order_coins(self, coins: frozenset[str]) -> frozenset[str]:
         account = self._config.account_address
@@ -528,6 +541,52 @@ def _account_state_from_payload(
     )
 
 
+def _account_state_from_payloads(
+    dex_payloads: Mapping[str, Mapping[str, object]],
+    spot_payload: Mapping[str, object],
+    market_id_by_coin: dict[str, str],
+    observed_at: datetime,
+) -> AccountState:
+    account_value_usd = Decimal("0")
+    withdrawable_usd = Decimal("0")
+    gross_exposure_usd = Decimal("0")
+    positions: list[PositionSnapshot] = []
+    raw_dex_payloads: dict[str, object] = {}
+
+    for dex, payload in dex_payloads.items():
+        dex_state = _account_state_from_payload(
+            payload,
+            market_id_by_coin,
+            observed_at,
+        )
+        account_value_usd += dex_state.account.account_value_usd
+        withdrawable_usd += dex_state.account.withdrawable_usd
+        gross_exposure_usd += dex_state.account.gross_exposure_usd
+        positions.extend(dex_state.positions)
+        raw_dex_payloads[dex or "default"] = dex_state.account.raw_payload
+
+    spot_usdc_total = _spot_usdc_total(spot_payload)
+    spot_usdc_available = _spot_usdc_available_after_maintenance(spot_payload)
+    account_value_usd = max(account_value_usd, spot_usdc_total)
+    withdrawable_usd = max(withdrawable_usd, spot_usdc_available)
+
+    return AccountState(
+        account=AccountSnapshot(
+            observed_at=observed_at,
+            account_value_usd=account_value_usd.quantize(Decimal("0.000001")),
+            withdrawable_usd=withdrawable_usd.quantize(Decimal("0.000001")),
+            gross_exposure_usd=gross_exposure_usd.quantize(Decimal("0.000001")),
+            raw_payload={
+                "dexStates": raw_dex_payloads,
+                "spotUserState": {
+                    str(key): value for key, value in spot_payload.items()
+                },
+            },
+        ),
+        positions=tuple(positions),
+    )
+
+
 def _raw_account_exposure_usd(
     payload: Mapping[str, object],
     selected_positions: list[PositionSnapshot],
@@ -571,6 +630,46 @@ def _position_exposure_usd(position: Mapping[str, object]) -> Decimal:
     size = _decimal(position.get("szi"))
     entry_price = _optional_decimal(position.get("entryPx")) or Decimal("0")
     return abs(size * entry_price).quantize(Decimal("0.000001"))
+
+
+def _spot_usdc_total(payload: Mapping[str, object]) -> Decimal:
+    for balance in _spot_usdc_balances(payload):
+        return _decimal(balance.get("total"))
+    return Decimal("0")
+
+
+def _spot_usdc_available_after_maintenance(payload: Mapping[str, object]) -> Decimal:
+    raw_available = payload.get("tokenToAvailableAfterMaintenance")
+    if isinstance(raw_available, list):
+        for item in cast(list[object], raw_available):
+            if not isinstance(item, list):
+                continue
+            parts = cast(list[object], item)
+            if len(parts) < 2:
+                continue
+            token, available = parts[0], parts[1]
+            if str(token) == "0":
+                return _decimal(available)
+    for balance in _spot_usdc_balances(payload):
+        return max(
+            Decimal("0"),
+            _decimal(balance.get("total")) - _decimal(balance.get("hold")),
+        )
+    return Decimal("0")
+
+
+def _spot_usdc_balances(payload: Mapping[str, object]) -> list[Mapping[str, object]]:
+    balances = payload.get("balances")
+    if not isinstance(balances, list):
+        return []
+    usdc_balances: list[Mapping[str, object]] = []
+    for balance in cast(list[object], balances):
+        if not isinstance(balance, dict):
+            continue
+        balance_map = cast(Mapping[str, object], balance)
+        if str(balance_map.get("coin") or "").strip().upper() == "USDC":
+            usdc_balances.append(balance_map)
+    return usdc_balances
 
 
 def _normalize_price(price: Decimal, *, side: str) -> Decimal:

--- a/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
+++ b/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
@@ -143,11 +143,34 @@ def test_exchange_filters_metadata_reconciles_account_and_tracks_halts() -> None
     dependency = exchange.dependency_status()
 
     assert fills[0].notional_usd == Decimal("10.000000")
-    assert account.account.gross_exposure_usd == Decimal("20.000000")
+    assert account.account.gross_exposure_usd == Decimal("30.000000")
     assert [position.coin for position in account.positions] == ["NVDA"]
     assert open_coins == frozenset({"NVDA"})
     assert dependency.ready is True
     assert exchange.execution_metadata_details()
+
+
+def test_exchange_reconciles_unified_account_spot_and_perp_dex_state() -> None:
+    exchange = _FakeExchange(
+        HyperliquidExecutionConfig.from_env(
+            {
+                "HYPERLIQUID_EXECUTION_API_WALLET_PRIVATE_KEY": "0x1",
+                "HYPERLIQUID_EXECUTION_ACCOUNT_ADDRESS": "0xabc",
+            }
+        ),
+        sdk=_FakeSdk(),
+        info=_UnifiedAccountInfo(),
+    )
+    exchange.filter_supported_markets((_market("AMD", "xyz"),))
+
+    account = exchange.reconcile_account({"AMD": "hl:perp:xyz:AMD"})
+
+    assert account.account.account_value_usd == Decimal("997.945380")
+    assert account.account.withdrawable_usd == Decimal("987.602738")
+    assert account.account.gross_exposure_usd == Decimal("10.024656")
+    assert [position.coin for position in account.positions] == ["AMD"]
+    assert "spotUserState" in account.account.raw_payload
+    assert "xyz" in account.account.raw_payload["dexStates"]
 
 
 def test_exchange_rejects_non_alo_missing_key_and_local_cancel() -> None:
@@ -249,25 +272,87 @@ class _FakeInfo:
             {"coin": "BTC", "px": "100", "sz": "1"},
         ]
 
-    def user_state(self, _account: str) -> dict[str, object]:
-        return {
-            "marginSummary": {"accountValue": "1000"},
-            "withdrawable": "900",
-            "assetPositions": [
-                {
-                    "position": {
-                        "coin": "NVDA",
-                        "szi": "0.1",
-                        "entryPx": "100",
-                        "unrealizedPnl": "0.25",
-                    }
+    def user_state(self, _account: str, dex: str = "") -> dict[str, object]:
+        if dex == "xyz":
+            return {
+                "marginSummary": {
+                    "accountValue": "1000",
+                    "totalNtlPos": "20",
                 },
-                {"position": {"coin": "BTC", "szi": "1", "entryPx": "10"}},
-            ],
+                "withdrawable": "900",
+                "assetPositions": [
+                    {
+                        "position": {
+                            "coin": "NVDA",
+                            "szi": "0.1",
+                            "entryPx": "100",
+                            "positionValue": "20",
+                            "unrealizedPnl": "0.25",
+                        }
+                    },
+                    {"position": {"coin": "BTC", "szi": "1", "entryPx": "10"}},
+                ],
+            }
+        return {
+            "marginSummary": {"accountValue": "0", "totalNtlPos": "0"},
+            "withdrawable": "0",
+            "assetPositions": [],
         }
+
+    def spot_user_state(self, _account: str) -> dict[str, object]:
+        return {"balances": [], "tokenToAvailableAfterMaintenance": []}
 
     def open_orders(self, _account: str, *, dex: str = "") -> list[dict[str, object]]:
         return [{"coin": "NVDA"}] if dex == "xyz" else [{"coin": "BTC"}]
+
+
+class _UnifiedAccountInfo(_FakeInfo):
+    def meta(self, *, dex: str = "") -> dict[str, object]:
+        if dex == "xyz":
+            return {"universe": [{"name": "AMD", "szDecimals": 3}]}
+        return {"universe": []}
+
+    def user_state(self, _account: str, dex: str = "") -> dict[str, object]:
+        if dex == "xyz":
+            return {
+                "marginSummary": {
+                    "accountValue": "10.342642",
+                    "totalNtlPos": "10.024656",
+                },
+                "withdrawable": "0.102402",
+                "assetPositions": [
+                    {
+                        "position": {
+                            "coin": "AMD",
+                            "szi": "0.0186",
+                            "entryPx": "538.96",
+                            "positionValue": "10.024656",
+                            "unrealizedPnl": "0",
+                        }
+                    }
+                ],
+            }
+        return {
+            "marginSummary": {
+                "accountValue": "0",
+                "totalNtlPos": "0",
+            },
+            "withdrawable": "0",
+            "assetPositions": [],
+        }
+
+    def spot_user_state(self, _account: str) -> dict[str, object]:
+        return {
+            "balances": [
+                {
+                    "coin": "USDC",
+                    "token": 0,
+                    "total": "997.94538",
+                    "hold": "10.342642",
+                }
+            ],
+            "tokenToAvailableAfterMaintenance": [[0, "987.602738"]],
+        }
 
 
 class _FakeExchange(HyperliquidSdkExecutionExchange):


### PR DESCRIPTION
## Summary

- Aggregate Hyperliquid v2 account snapshots across every known perpdex instead of reading only the default user state.
- Include spot USDC state for unified-account balances and available collateral while preserving gross exposure from perpdex positions.
- Add regression coverage for the unified-account `xyz` perpdex state shape observed during live testnet execution.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_execution`
- `uv run --frozen ruff format --check app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen ruff check app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
