### PR TITLE
refactor(torghut): split hyperliquid repository reporting

### DIFF
--- a/services/torghut/app/hyperliquid_execution/reporting.py
+++ b/services/torghut/app/hyperliquid_execution/reporting.py
@@ -1,0 +1,363 @@
+"""Operational reporting queries for Hyperliquid execution v2."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Mapping, Protocol, cast
+
+from sqlalchemy import text
+
+
+class QuerySession(Protocol):
+    """Minimal SQLAlchemy session surface used by reporting queries."""
+
+    def execute(
+        self,
+        statement: object,
+        parameters: Mapping[str, object] | None = None,
+    ) -> Any:
+        """Execute a SQL statement and return a SQLAlchemy result."""
+
+
+def build_operational_report(
+    session: QuerySession,
+    *,
+    runtime_payload: Mapping[str, object],
+    config_payload: Mapping[str, object],
+) -> dict[str, object]:
+    """Return a compact operator report from v2 evidence only."""
+
+    return {
+        "schema_version": "torghut.hyperliquid-execution-report.v2",
+        "runtime": dict(runtime_payload),
+        "config": dict(config_payload),
+        "account": _query_rows(
+            session,
+            """
+            SELECT
+              observed_at::text,
+              account_value_usd::text,
+              withdrawable_usd::text,
+              gross_exposure_usd::text,
+              raw_payload
+            FROM hyperliquid_execution_account_snapshots
+            WHERE execution_network = 'testnet'
+            ORDER BY observed_at DESC
+            LIMIT 1
+            """,
+        ),
+        "positions": _query_rows(
+            session,
+            """
+            SELECT
+              observed_at::text,
+              coin,
+              size::text,
+              entry_price::text,
+              notional_usd::text,
+              unrealized_pnl_usd::text
+            FROM hyperliquid_execution_positions
+            WHERE execution_network = 'testnet'
+            ORDER BY coin
+            LIMIT 100
+            """,
+        ),
+        "external_account_positions": _raw_account_positions(session),
+        "open_orders": _query_rows(
+            session,
+            """
+            SELECT
+              created_at::text,
+              coin,
+              side,
+              status,
+              exchange_order_id,
+              limit_price::text,
+              size::text,
+              notional_usd::text,
+              expires_at::text
+            FROM hyperliquid_execution_orders
+            WHERE execution_network = 'testnet'
+              AND status IN ('accepted', 'submitted')
+            ORDER BY created_at DESC
+            LIMIT 100
+            """,
+        ),
+        "fills_by_coin": _query_rows(
+            session,
+            """
+            SELECT
+              coin,
+              side,
+              count(*)::int AS fills,
+              COALESCE(sum(notional_usd), 0)::text AS notional_usd,
+              COALESCE(sum(fee_usd), 0)::text AS fees_usd,
+              COALESCE(sum(closed_pnl_usd - fee_usd), 0)::text AS net_pnl_after_fees_usd
+            FROM hyperliquid_execution_fills
+            WHERE execution_network = 'testnet'
+            GROUP BY coin, side
+            ORDER BY coin, side
+            """,
+        ),
+        "rejects_by_coin_reason": _query_rows(
+            session,
+            """
+            SELECT
+              coin,
+              COALESCE(rejection_reason, '') AS reason,
+              count(*)::int AS rejects,
+              max(created_at)::text AS latest_at
+            FROM hyperliquid_execution_orders
+            WHERE execution_network = 'testnet'
+              AND status = 'rejected'
+            GROUP BY coin, COALESCE(rejection_reason, '')
+            ORDER BY latest_at DESC
+            LIMIT 100
+            """,
+        ),
+        "cooldowns": _query_rows(
+            session,
+            """
+            SELECT
+              coin,
+              cooldown_reason,
+              cooldown_until::text,
+              updated_at::text
+            FROM hyperliquid_execution_symbol_state
+            WHERE cooldown_until IS NOT NULL
+              AND cooldown_until > now()
+            ORDER BY cooldown_until DESC
+            """,
+        ),
+        "performance": _query_rows(
+            session,
+            """
+            SELECT
+              observed_at::text,
+              fill_count_24h,
+              notional_usd_24h::text,
+              fees_usd_24h::text,
+              net_pnl_after_fees_usd_24h::text,
+              max_drawdown_usd_24h::text,
+              fill_count_7d,
+              notional_usd_7d::text,
+              fees_usd_7d::text,
+              net_pnl_after_fees_usd_7d::text,
+              max_drawdown_usd_7d::text,
+              maker_fill_rate_24h::text,
+              cancel_rate_24h::text,
+              reject_rate_24h::text,
+              sample_ready,
+              symbol_pnl
+            FROM hyperliquid_execution_performance_snapshots
+            WHERE execution_network = 'testnet'
+            ORDER BY observed_at DESC
+            LIMIT 1
+            """,
+        ),
+    }
+
+
+def build_performance_metrics(session: QuerySession) -> dict[str, object]:
+    summary = (
+        session.execute(
+            text(
+                """
+                WITH
+                fills_24h AS (
+                  SELECT
+                    count(*) AS fills,
+                    COALESCE(sum(notional_usd), 0) AS notional,
+                    COALESCE(sum(fee_usd), 0) AS fees,
+                    COALESCE(sum(closed_pnl_usd - fee_usd), 0) AS net_pnl
+                  FROM hyperliquid_execution_fills
+                  WHERE execution_network = 'testnet'
+                    AND event_ts >= now() - interval '24 hours'
+                ),
+                fills_7d AS (
+                  SELECT
+                    count(*) AS fills,
+                    COALESCE(sum(notional_usd), 0) AS notional,
+                    COALESCE(sum(fee_usd), 0) AS fees,
+                    COALESCE(sum(closed_pnl_usd - fee_usd), 0) AS net_pnl
+                  FROM hyperliquid_execution_fills
+                  WHERE execution_network = 'testnet'
+                    AND event_ts >= now() - interval '7 days'
+                ),
+                orders_24h AS (
+                  SELECT
+                    count(*) AS orders,
+                    count(*) FILTER (WHERE status = 'filled') AS filled,
+                    count(*) FILTER (WHERE status = 'cancelled') AS cancelled,
+                    count(*) FILTER (WHERE status = 'rejected') AS rejected
+                  FROM hyperliquid_execution_orders
+                  WHERE execution_network = 'testnet'
+                    AND created_at >= now() - interval '24 hours'
+                ),
+                all_fills AS (
+                  SELECT count(*) AS fills
+                  FROM hyperliquid_execution_fills
+                  WHERE execution_network = 'testnet'
+                )
+                SELECT
+                  fills_24h.fills AS fills_24h,
+                  fills_24h.notional AS notional_24h,
+                  fills_24h.fees AS fees_24h,
+                  fills_24h.net_pnl AS net_pnl_24h,
+                  fills_7d.fills AS fills_7d,
+                  fills_7d.notional AS notional_7d,
+                  fills_7d.fees AS fees_7d,
+                  fills_7d.net_pnl AS net_pnl_7d,
+                  orders_24h.orders AS orders_24h,
+                  orders_24h.filled AS filled_orders_24h,
+                  orders_24h.cancelled AS cancelled_orders_24h,
+                  orders_24h.rejected AS rejected_orders_24h,
+                  all_fills.fills AS all_fills
+                FROM fills_24h, fills_7d, orders_24h, all_fills
+                """
+            )
+        )
+        .mappings()
+        .one()
+    )
+    symbol_pnl = _query_rows(
+        session,
+        """
+        SELECT
+          coin,
+          count(*)::int AS fills,
+          COALESCE(sum(notional_usd), 0)::text AS notional_usd,
+          COALESCE(sum(fee_usd), 0)::text AS fees_usd,
+          COALESCE(sum(closed_pnl_usd - fee_usd), 0)::text AS net_pnl_after_fees_usd
+        FROM hyperliquid_execution_fills
+        WHERE execution_network = 'testnet'
+        GROUP BY coin
+        ORDER BY coin
+        """,
+    )
+    orders_24h = Decimal(str(summary["orders_24h"]))
+    filled = Decimal(str(summary["filled_orders_24h"]))
+    cancelled = Decimal(str(summary["cancelled_orders_24h"]))
+    rejected = Decimal(str(summary["rejected_orders_24h"]))
+    net_24h = Decimal(str(summary["net_pnl_24h"]))
+    net_7d = Decimal(str(summary["net_pnl_7d"]))
+    return {
+        "fill_count_24h": int(summary["fills_24h"]),
+        "notional_usd_24h": str(summary["notional_24h"]),
+        "fees_usd_24h": str(summary["fees_24h"]),
+        "net_pnl_after_fees_usd_24h": str(net_24h),
+        "max_drawdown_usd_24h": str(min(net_24h, Decimal("0"))),
+        "fill_count_7d": int(summary["fills_7d"]),
+        "notional_usd_7d": str(summary["notional_7d"]),
+        "fees_usd_7d": str(summary["fees_7d"]),
+        "net_pnl_after_fees_usd_7d": str(net_7d),
+        "max_drawdown_usd_7d": str(min(net_7d, Decimal("0"))),
+        "maker_fill_rate_24h": str(_ratio(filled, orders_24h)),
+        "cancel_rate_24h": str(_ratio(cancelled, orders_24h)),
+        "reject_rate_24h": str(_ratio(rejected, orders_24h)),
+        "sample_ready": int(summary["all_fills"]) >= 40,
+        "symbol_pnl": json.dumps(symbol_pnl, sort_keys=True),
+    }
+
+
+def _query_rows(session: QuerySession, query: str) -> list[dict[str, object]]:
+    rows = session.execute(text(query)).mappings().all()
+    return [
+        {
+            str(key): _json_safe(value)
+            for key, value in cast(Mapping[str, object], row).items()
+        }
+        for row in rows
+    ]
+
+
+def _raw_account_positions(session: QuerySession) -> list[dict[str, object]]:
+    rows = _query_rows(session, _latest_account_snapshot_query())
+    if not rows:
+        return []
+    observed_at = rows[0].get("observed_at")
+    payload = _mapping_payload(rows[0].get("raw_payload"))
+    raw_positions = payload.get("assetPositions")
+    if not isinstance(raw_positions, list):
+        return []
+    positions: list[dict[str, object]] = []
+    for item in cast(list[object], raw_positions):
+        if not isinstance(item, dict):
+            continue
+        position = _mapping_payload(cast(Mapping[str, object], item).get("position"))
+        coin = _optional_text(position.get("coin"))
+        if coin is None:
+            continue
+        positions.append(
+            {
+                "observed_at": observed_at,
+                "coin": coin,
+                "size": str(position.get("szi") or "0"),
+                "entry_price": _optional_text(position.get("entryPx")),
+                "notional_usd": str(_position_exposure_usd(position)),
+                "unrealized_pnl_usd": str(position.get("unrealizedPnl") or "0"),
+                "source": "exchange_raw_account",
+            }
+        )
+    return sorted(positions, key=lambda row: str(row["coin"]))
+
+
+def _latest_account_snapshot_query() -> str:
+    return """
+    SELECT
+      observed_at::text,
+      raw_payload
+    FROM hyperliquid_execution_account_snapshots
+    WHERE execution_network = 'testnet'
+    ORDER BY observed_at DESC
+    LIMIT 1
+    """
+
+
+def _mapping_payload(value: object) -> Mapping[str, object]:
+    if isinstance(value, dict):
+        return cast(Mapping[str, object], value)
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(loaded, dict):
+            return cast(Mapping[str, object], loaded)
+    return {}
+
+
+def _position_exposure_usd(position: Mapping[str, object]) -> Decimal:
+    position_value = _optional_decimal(position.get("positionValue"))
+    if position_value is not None:
+        return abs(position_value)
+    size = _optional_decimal(position.get("szi")) or Decimal("0")
+    entry_price = _optional_decimal(position.get("entryPx")) or Decimal("0")
+    return abs(size * entry_price)
+
+
+def _optional_decimal(value: object) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    return Decimal(str(value))
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text_value = str(value)
+    return text_value if text_value else None
+
+
+def _json_safe(value: object) -> object:
+    if isinstance(value, (datetime, Decimal)):
+        return str(value)
+    return value
+
+
+def _ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
+    if denominator <= Decimal("0"):
+        return Decimal("0")
+    return (numerator / denominator).quantize(Decimal("0.0001"))

--- a/services/torghut/app/hyperliquid_execution/repository.py
+++ b/services/torghut/app/hyperliquid_execution/repository.py
@@ -23,6 +23,7 @@ from .models import (
     RuntimeDependencyStatus,
     Signal,
 )
+from .reporting import build_operational_report, build_performance_metrics
 
 
 class HyperliquidExecutionRepository:
@@ -555,7 +556,7 @@ class HyperliquidExecutionRepository:
         )
 
     def insert_performance_snapshot(self, *, observed_at: datetime) -> None:
-        metrics = self._performance_metrics()
+        metrics = build_performance_metrics(self._session)
         self._session.execute(
             text(
                 """
@@ -675,130 +676,11 @@ class HyperliquidExecutionRepository:
         runtime_payload: Mapping[str, object],
         config_payload: Mapping[str, object],
     ) -> dict[str, object]:
-        """Return a compact operator report from v2 evidence only."""
-
-        return {
-            "schema_version": "torghut.hyperliquid-execution-report.v2",
-            "runtime": dict(runtime_payload),
-            "config": dict(config_payload),
-            "account": self._query_rows(
-                """
-                SELECT
-                  observed_at::text,
-                  account_value_usd::text,
-                  withdrawable_usd::text,
-                  gross_exposure_usd::text,
-                  raw_payload
-                FROM hyperliquid_execution_account_snapshots
-                WHERE execution_network = 'testnet'
-                ORDER BY observed_at DESC
-                LIMIT 1
-                """
-            ),
-            "positions": self._query_rows(
-                """
-                SELECT
-                  observed_at::text,
-                  coin,
-                  size::text,
-                  entry_price::text,
-                  notional_usd::text,
-                  unrealized_pnl_usd::text
-                FROM hyperliquid_execution_positions
-                WHERE execution_network = 'testnet'
-                ORDER BY coin
-                LIMIT 100
-                """
-            ),
-            "external_account_positions": self._raw_account_positions(),
-            "open_orders": self._query_rows(
-                """
-                SELECT
-                  created_at::text,
-                  coin,
-                  side,
-                  status,
-                  exchange_order_id,
-                  limit_price::text,
-                  size::text,
-                  notional_usd::text,
-                  expires_at::text
-                FROM hyperliquid_execution_orders
-                WHERE execution_network = 'testnet'
-                  AND status IN ('accepted', 'submitted')
-                ORDER BY created_at DESC
-                LIMIT 100
-                """
-            ),
-            "fills_by_coin": self._query_rows(
-                """
-                SELECT
-                  coin,
-                  side,
-                  count(*)::int AS fills,
-                  COALESCE(sum(notional_usd), 0)::text AS notional_usd,
-                  COALESCE(sum(fee_usd), 0)::text AS fees_usd,
-                  COALESCE(sum(closed_pnl_usd - fee_usd), 0)::text AS net_pnl_after_fees_usd
-                FROM hyperliquid_execution_fills
-                WHERE execution_network = 'testnet'
-                GROUP BY coin, side
-                ORDER BY coin, side
-                """
-            ),
-            "rejects_by_coin_reason": self._query_rows(
-                """
-                SELECT
-                  coin,
-                  COALESCE(rejection_reason, '') AS reason,
-                  count(*)::int AS rejects,
-                  max(created_at)::text AS latest_at
-                FROM hyperliquid_execution_orders
-                WHERE execution_network = 'testnet'
-                  AND status = 'rejected'
-                GROUP BY coin, COALESCE(rejection_reason, '')
-                ORDER BY latest_at DESC
-                LIMIT 100
-                """
-            ),
-            "cooldowns": self._query_rows(
-                """
-                SELECT
-                  coin,
-                  cooldown_reason,
-                  cooldown_until::text,
-                  updated_at::text
-                FROM hyperliquid_execution_symbol_state
-                WHERE cooldown_until IS NOT NULL
-                  AND cooldown_until > now()
-                ORDER BY cooldown_until DESC
-                """
-            ),
-            "performance": self._query_rows(
-                """
-                SELECT
-                  observed_at::text,
-                  fill_count_24h,
-                  notional_usd_24h::text,
-                  fees_usd_24h::text,
-                  net_pnl_after_fees_usd_24h::text,
-                  max_drawdown_usd_24h::text,
-                  fill_count_7d,
-                  notional_usd_7d::text,
-                  fees_usd_7d::text,
-                  net_pnl_after_fees_usd_7d::text,
-                  max_drawdown_usd_7d::text,
-                  maker_fill_rate_24h::text,
-                  cancel_rate_24h::text,
-                  reject_rate_24h::text,
-                  sample_ready,
-                  symbol_pnl
-                FROM hyperliquid_execution_performance_snapshots
-                WHERE execution_network = 'testnet'
-                ORDER BY observed_at DESC
-                LIMIT 1
-                """
-            ),
-        }
+        return build_operational_report(
+            self._session,
+            runtime_payload=runtime_payload,
+            config_payload=config_payload,
+        )
 
     def _set_cooldown(self, *, coin: str, reason: str, seconds: int) -> None:
         self._session.execute(
@@ -827,148 +709,6 @@ class HyperliquidExecutionRepository:
             {"coin": coin, "reason": reason, "seconds": seconds},
         )
 
-    def _performance_metrics(self) -> dict[str, object]:
-        summary = (
-            self._session.execute(
-                text(
-                    """
-                    WITH
-                    fills_24h AS (
-                      SELECT
-                        count(*) AS fills,
-                        COALESCE(sum(notional_usd), 0) AS notional,
-                        COALESCE(sum(fee_usd), 0) AS fees,
-                        COALESCE(sum(closed_pnl_usd - fee_usd), 0) AS net_pnl
-                      FROM hyperliquid_execution_fills
-                      WHERE execution_network = 'testnet'
-                        AND event_ts >= now() - interval '24 hours'
-                    ),
-                    fills_7d AS (
-                      SELECT
-                        count(*) AS fills,
-                        COALESCE(sum(notional_usd), 0) AS notional,
-                        COALESCE(sum(fee_usd), 0) AS fees,
-                        COALESCE(sum(closed_pnl_usd - fee_usd), 0) AS net_pnl
-                      FROM hyperliquid_execution_fills
-                      WHERE execution_network = 'testnet'
-                        AND event_ts >= now() - interval '7 days'
-                    ),
-                    orders_24h AS (
-                      SELECT
-                        count(*) AS orders,
-                        count(*) FILTER (WHERE status = 'filled') AS filled,
-                        count(*) FILTER (WHERE status = 'cancelled') AS cancelled,
-                        count(*) FILTER (WHERE status = 'rejected') AS rejected
-                      FROM hyperliquid_execution_orders
-                      WHERE execution_network = 'testnet'
-                        AND created_at >= now() - interval '24 hours'
-                    ),
-                    all_fills AS (
-                      SELECT count(*) AS fills
-                      FROM hyperliquid_execution_fills
-                      WHERE execution_network = 'testnet'
-                    )
-                    SELECT
-                      fills_24h.fills AS fills_24h,
-                      fills_24h.notional AS notional_24h,
-                      fills_24h.fees AS fees_24h,
-                      fills_24h.net_pnl AS net_pnl_24h,
-                      fills_7d.fills AS fills_7d,
-                      fills_7d.notional AS notional_7d,
-                      fills_7d.fees AS fees_7d,
-                      fills_7d.net_pnl AS net_pnl_7d,
-                      orders_24h.orders AS orders_24h,
-                      orders_24h.filled AS filled_orders_24h,
-                      orders_24h.cancelled AS cancelled_orders_24h,
-                      orders_24h.rejected AS rejected_orders_24h,
-                      all_fills.fills AS all_fills
-                    FROM fills_24h, fills_7d, orders_24h, all_fills
-                    """
-                )
-            )
-            .mappings()
-            .one()
-        )
-        symbol_pnl = self._query_rows(
-            """
-            SELECT
-              coin,
-              count(*)::int AS fills,
-              COALESCE(sum(notional_usd), 0)::text AS notional_usd,
-              COALESCE(sum(fee_usd), 0)::text AS fees_usd,
-              COALESCE(sum(closed_pnl_usd - fee_usd), 0)::text AS net_pnl_after_fees_usd
-            FROM hyperliquid_execution_fills
-            WHERE execution_network = 'testnet'
-            GROUP BY coin
-            ORDER BY coin
-            """
-        )
-        orders_24h = Decimal(str(summary["orders_24h"]))
-        filled = Decimal(str(summary["filled_orders_24h"]))
-        cancelled = Decimal(str(summary["cancelled_orders_24h"]))
-        rejected = Decimal(str(summary["rejected_orders_24h"]))
-        net_24h = Decimal(str(summary["net_pnl_24h"]))
-        net_7d = Decimal(str(summary["net_pnl_7d"]))
-        return {
-            "fill_count_24h": int(summary["fills_24h"]),
-            "notional_usd_24h": str(summary["notional_24h"]),
-            "fees_usd_24h": str(summary["fees_24h"]),
-            "net_pnl_after_fees_usd_24h": str(net_24h),
-            "max_drawdown_usd_24h": str(min(net_24h, Decimal("0"))),
-            "fill_count_7d": int(summary["fills_7d"]),
-            "notional_usd_7d": str(summary["notional_7d"]),
-            "fees_usd_7d": str(summary["fees_7d"]),
-            "net_pnl_after_fees_usd_7d": str(net_7d),
-            "max_drawdown_usd_7d": str(min(net_7d, Decimal("0"))),
-            "maker_fill_rate_24h": str(_ratio(filled, orders_24h)),
-            "cancel_rate_24h": str(_ratio(cancelled, orders_24h)),
-            "reject_rate_24h": str(_ratio(rejected, orders_24h)),
-            "sample_ready": int(summary["all_fills"]) >= 40,
-            "symbol_pnl": json.dumps(symbol_pnl, sort_keys=True),
-        }
-
-    def _query_rows(self, query: str) -> list[dict[str, object]]:
-        rows = self._session.execute(text(query)).mappings().all()
-        return [
-            {
-                str(key): _json_safe(value)
-                for key, value in cast(Mapping[str, object], row).items()
-            }
-            for row in rows
-        ]
-
-    def _raw_account_positions(self) -> list[dict[str, object]]:
-        rows = self._query_rows(_latest_account_snapshot_query())
-        if not rows:
-            return []
-        observed_at = rows[0].get("observed_at")
-        payload = _mapping_payload(rows[0].get("raw_payload"))
-        raw_positions = payload.get("assetPositions")
-        if not isinstance(raw_positions, list):
-            return []
-        positions: list[dict[str, object]] = []
-        for item in cast(list[object], raw_positions):
-            if not isinstance(item, dict):
-                continue
-            position = _mapping_payload(
-                cast(Mapping[str, object], item).get("position")
-            )
-            coin = _optional_text(position.get("coin"))
-            if coin is None:
-                continue
-            positions.append(
-                {
-                    "observed_at": observed_at,
-                    "coin": coin,
-                    "size": str(position.get("szi") or "0"),
-                    "entry_price": _optional_text(position.get("entryPx")),
-                    "notional_usd": str(_position_exposure_usd(position)),
-                    "unrealized_pnl_usd": str(position.get("unrealizedPnl") or "0"),
-                    "source": "exchange_raw_account",
-                }
-            )
-        return sorted(positions, key=lambda row: str(row["coin"]))
-
 
 def _dependency_payload(dependency: RuntimeDependencyStatus) -> dict[str, object]:
     return {
@@ -983,12 +723,6 @@ def _dependency_payload(dependency: RuntimeDependencyStatus) -> dict[str, object
     }
 
 
-def _ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
-    if denominator <= Decimal("0"):
-        return Decimal("0")
-    return (numerator / denominator).quantize(Decimal("0.0001"))
-
-
 def _decimal_or_none(value: Decimal | None) -> str | None:
     return None if value is None else str(value)
 
@@ -998,49 +732,3 @@ def _optional_text(value: object) -> str | None:
         return None
     text_value = str(value)
     return text_value if text_value else None
-
-
-def _json_safe(value: object) -> object:
-    if isinstance(value, (datetime, Decimal)):
-        return str(value)
-    return value
-
-
-def _latest_account_snapshot_query() -> str:
-    return """
-    SELECT
-      observed_at::text,
-      raw_payload
-    FROM hyperliquid_execution_account_snapshots
-    WHERE execution_network = 'testnet'
-    ORDER BY observed_at DESC
-    LIMIT 1
-    """
-
-
-def _mapping_payload(value: object) -> Mapping[str, object]:
-    if isinstance(value, dict):
-        return cast(Mapping[str, object], value)
-    if isinstance(value, str):
-        try:
-            loaded = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        if isinstance(loaded, dict):
-            return cast(Mapping[str, object], loaded)
-    return {}
-
-
-def _position_exposure_usd(position: Mapping[str, object]) -> Decimal:
-    position_value = _optional_decimal(position.get("positionValue"))
-    if position_value is not None:
-        return abs(position_value)
-    size = _optional_decimal(position.get("szi")) or Decimal("0")
-    entry_price = _optional_decimal(position.get("entryPx")) or Decimal("0")
-    return abs(size * entry_price)
-
-
-def _optional_decimal(value: object) -> Decimal | None:
-    if value is None or value == "":
-        return None
-    return Decimal(str(value))

--- a/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
+++ b/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
@@ -173,6 +173,39 @@ def test_exchange_reconciles_unified_account_spot_and_perp_dex_state() -> None:
     assert "xyz" in account.account.raw_payload["dexStates"]
 
 
+def test_exchange_reconciles_spot_state_fallback_paths() -> None:
+    config = HyperliquidExecutionConfig.from_env(
+        {
+            "HYPERLIQUID_EXECUTION_API_WALLET_PRIVATE_KEY": "0x1",
+            "HYPERLIQUID_EXECUTION_ACCOUNT_ADDRESS": "0xabc",
+        }
+    )
+
+    failing_spot = _FakeExchange(config, sdk=_FakeSdk(), info=_FailingSpotInfo())
+    failing_spot.filter_supported_markets((_market("AMD", "xyz"),))
+    failing_account = failing_spot.reconcile_account({"AMD": "hl:perp:xyz:AMD"})
+
+    malformed_spot = _FakeExchange(config, sdk=_FakeSdk(), info=_MalformedSpotInfo())
+    malformed_spot.filter_supported_markets((_market("AMD", "xyz"),))
+    malformed_account = malformed_spot.reconcile_account({"AMD": "hl:perp:xyz:AMD"})
+
+    missing_balances = _FakeExchange(
+        config, sdk=_FakeSdk(), info=_MissingSpotBalancesInfo()
+    )
+    missing_balances.filter_supported_markets((_market("AMD", "xyz"),))
+    missing_balance_account = missing_balances.reconcile_account(
+        {"AMD": "hl:perp:xyz:AMD"}
+    )
+
+    assert failing_account.account.account_value_usd == Decimal("10.342642")
+    assert failing_account.account.withdrawable_usd == Decimal("0.102402")
+    assert failing_account.account.raw_payload["spotUserState"] == {}
+    assert malformed_account.account.account_value_usd == Decimal("13.500000")
+    assert malformed_account.account.withdrawable_usd == Decimal("10.250000")
+    assert missing_balance_account.account.account_value_usd == Decimal("10.342642")
+    assert missing_balance_account.account.withdrawable_usd == Decimal("0.102402")
+
+
 def test_exchange_rejects_non_alo_missing_key_and_local_cancel() -> None:
     exchange = _FakeExchange(HyperliquidExecutionConfig.from_env({}), sdk=_FakeSdk())
 
@@ -353,6 +386,32 @@ class _UnifiedAccountInfo(_FakeInfo):
             ],
             "tokenToAvailableAfterMaintenance": [[0, "987.602738"]],
         }
+
+
+class _FailingSpotInfo(_UnifiedAccountInfo):
+    def spot_user_state(self, _account: str) -> dict[str, object]:
+        raise RuntimeError("spot_down")
+
+
+class _MalformedSpotInfo(_UnifiedAccountInfo):
+    def spot_user_state(self, _account: str) -> dict[str, object]:
+        return {
+            "balances": [
+                "bad-balance-row",
+                {"coin": "BTC", "total": "100", "hold": "0"},
+                {"coin": "USDC", "total": "13.5", "hold": "3.25"},
+            ],
+            "tokenToAvailableAfterMaintenance": [
+                "bad-available-row",
+                [0],
+                [1, "99"],
+            ],
+        }
+
+
+class _MissingSpotBalancesInfo(_UnifiedAccountInfo):
+    def spot_user_state(self, _account: str) -> dict[str, object]:
+        return {"balances": "not-a-list", "tokenToAvailableAfterMaintenance": []}
 
 
 class _FakeExchange(HyperliquidSdkExecutionExchange):

--- a/services/torghut/tests/hyperliquid_execution/test_reporting.py
+++ b/services/torghut/tests/hyperliquid_execution/test_reporting.py
@@ -1,0 +1,166 @@
+"""Tests for Hyperliquid execution reporting query assembly."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Iterable, Mapping
+
+from app.hyperliquid_execution.reporting import (
+    build_operational_report,
+    build_performance_metrics,
+)
+
+
+def test_operational_report_external_account_position_defensive_parsing() -> None:
+    assert _external_positions([]) == []
+    assert _external_positions([_account_row({"assetPositions": "not-a-list"})]) == []
+    assert _external_positions([_account_row("{not-json")]) == []
+
+    positions = _external_positions(
+        [
+            _account_row(
+                json.dumps(
+                    {
+                        "assetPositions": [
+                            "bad-position-row",
+                            {"position": {"szi": "1"}},
+                            {
+                                "position": {
+                                    "coin": "NOENTRY",
+                                    "szi": "2",
+                                    "unrealizedPnl": "0",
+                                }
+                            },
+                            {
+                                "position": {
+                                    "coin": "FALLBACK",
+                                    "szi": "2",
+                                    "entryPx": "3.5",
+                                    "unrealizedPnl": "1.2",
+                                }
+                            },
+                        ]
+                    },
+                    sort_keys=True,
+                )
+            )
+        ]
+    )
+
+    assert [position["coin"] for position in positions] == ["FALLBACK", "NOENTRY"]
+    assert positions[0]["notional_usd"] == "7.0"
+    assert positions[1]["notional_usd"] == "0"
+
+
+def test_performance_metrics_zero_order_ratios() -> None:
+    metrics = build_performance_metrics(
+        _ReportingSession(
+            performance_summary={
+                "fills_24h": 0,
+                "notional_24h": "0",
+                "fees_24h": "0",
+                "net_pnl_24h": "0",
+                "fills_7d": 0,
+                "notional_7d": "0",
+                "fees_7d": "0",
+                "net_pnl_7d": "0",
+                "orders_24h": 0,
+                "filled_orders_24h": 0,
+                "cancelled_orders_24h": 0,
+                "rejected_orders_24h": 0,
+                "all_fills": 0,
+            },
+        )
+    )
+
+    assert metrics["maker_fill_rate_24h"] == "0"
+    assert metrics["cancel_rate_24h"] == "0"
+    assert metrics["reject_rate_24h"] == "0"
+    assert metrics["sample_ready"] is False
+
+
+def _external_positions(
+    account_rows: Iterable[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    report = build_operational_report(
+        _ReportingSession(account_rows=account_rows),
+        runtime_payload={},
+        config_payload={},
+    )
+    external_positions = report["external_account_positions"]
+    assert isinstance(external_positions, list)
+    return external_positions
+
+
+def _account_row(raw_payload: object) -> dict[str, object]:
+    return {
+        "observed_at": datetime.now(timezone.utc),
+        "account_value_usd": "0",
+        "withdrawable_usd": "0",
+        "gross_exposure_usd": "0",
+        "raw_payload": raw_payload,
+    }
+
+
+class _ReportingSession:
+    def __init__(
+        self,
+        *,
+        account_rows: Iterable[Mapping[str, object]] = (),
+        performance_summary: Mapping[str, object] | None = None,
+    ) -> None:
+        self.account_rows = [dict(row) for row in account_rows]
+        self.performance_summary = dict(performance_summary or _performance_summary())
+
+    def execute(
+        self,
+        statement: object,
+        parameters: Mapping[str, object] | None = None,
+    ) -> "_ReportingResult":
+        query = str(statement)
+        if "WITH" in query and "fills_24h" in query:
+            return _ReportingResult([self.performance_summary])
+        if (
+            "FROM hyperliquid_execution_account_snapshots" in query
+            and "raw_payload" in query
+        ):
+            return _ReportingResult(self.account_rows)
+        return _ReportingResult([])
+
+
+class _ReportingResult:
+    def __init__(self, rows: Iterable[Mapping[str, object]]) -> None:
+        self._rows = [dict(row) for row in rows]
+
+    def mappings(self) -> "_ReportingRows":
+        return _ReportingRows(self._rows)
+
+
+class _ReportingRows:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def one(self) -> dict[str, object]:
+        return self._rows[0]
+
+    def all(self) -> list[dict[str, object]]:
+        return self._rows
+
+
+def _performance_summary() -> dict[str, object]:
+    return {
+        "fills_24h": 1,
+        "notional_24h": "10",
+        "fees_24h": "0.01",
+        "net_pnl_24h": "0.50",
+        "fills_7d": 1,
+        "notional_7d": "10",
+        "fees_7d": "0.01",
+        "net_pnl_7d": "0.50",
+        "orders_24h": 1,
+        "filled_orders_24h": 1,
+        "cancelled_orders_24h": 0,
+        "rejected_orders_24h": 0,
+        "all_fills": 41,
+    }


### PR DESCRIPTION
## Summary

- Split Hyperliquid execution repository reporting and performance query construction into `reporting.py` while keeping `HyperliquidExecutionRepository` as the stable public import.
- Reduced `app/hyperliquid_execution/repository.py` from 1,046 lines to 734 lines so the full Torghut file-length gate passes.
- Added focused spot-account fallback coverage for SDK spot failures, malformed availability rows, USDC balance fallback, and missing spot balances.
- Added reporting-query regression coverage so changed-line coverage stays above the Torghut CI threshold after the repository split.

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/hyperliquid_execution/test_reporting.py tests/hyperliquid_execution/test_exchange_policy.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `uv run --frozen coverage run -m pytest -q tests/hyperliquid_execution/test_reporting.py tests/hyperliquid_execution/test_exchange_policy.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff check app/hyperliquid_execution/repository.py app/hyperliquid_execution/reporting.py tests/hyperliquid_execution/test_exchange_policy.py tests/hyperliquid_execution/test_reporting.py`
- `uv run --frozen ruff format --check app scripts tests migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main $(rg --files app scripts | rg '\.py$')`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen python -m compileall app/hyperliquid_execution tests/hyperliquid_execution`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. N/A: internal code refactor and regression coverage only.
