### PR TITLE
fix(torghut): stabilize hyperliquid feed readiness

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/configmap.yaml
@@ -63,5 +63,6 @@ data:
   CLICKHOUSE_REQUEST_TIMEOUT_MS: "30000"
   CLICKHOUSE_ENABLED_TABLES: "hyperliquid_market_catalog,hyperliquid_bbo,hyperliquid_candles,hyperliquid_asset_contexts,hyperliquid_funding,hyperliquid_status"
   CLICKHOUSE_READY_TABLES: "hyperliquid_bbo,hyperliquid_candles"
-  CLICKHOUSE_READY_MAX_AGE_MS: "120000"
+  CLICKHOUSE_READY_MAX_AGE_MS: "300000"
+  CLICKHOUSE_TABLE_READY_MAX_AGE_MS: "300000"
   CLICKHOUSE_FAILURE_HOLD_MS: "60000"

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-feed-nonblocking-publish-20260619a
+        proompteng.ai/config-revision: hyperliquid-feed-clickhouse-catchup-window-20260620a
       labels:
         app: torghut-hyperliquid-feed
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -170,6 +170,8 @@ describe('Torghut manifest scheduling', () => {
     expect(data.CLICKHOUSE_ENABLED).toBe('true')
     expect(data.CLICKHOUSE_REQUIRED_FOR_READINESS).toBe('true')
     expect(data.KAFKA_READY_MAX_AGE_MS).toBe('120000')
+    expect(data.CLICKHOUSE_READY_MAX_AGE_MS).toBe('300000')
+    expect(data.CLICKHOUSE_TABLE_READY_MAX_AGE_MS).toBe('300000')
 
     const deployment = parseManifest('argocd/applications/torghut-hyperliquid-feed/deployment.yaml')
     const feedContainer = getAtPath(deployment, ['spec', 'template', 'spec', 'containers', 0])
@@ -192,7 +194,7 @@ describe('Torghut manifest scheduling', () => {
     )
     expect(
       getAtPath(deployment, ['spec', 'template', 'metadata', 'annotations'])['proompteng.ai/config-revision'],
-    ).toBe('hyperliquid-feed-nonblocking-publish-20260619a')
+    ).toBe('hyperliquid-feed-clickhouse-catchup-window-20260620a')
   })
 
   it('bounds Hyperliquid runtime ClickHouse schema hooks so Argo syncs cannot hang on distributed DDL', () => {

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSink.kt
@@ -164,13 +164,13 @@ class ClickHouseSink(
         freshness.ingestLagMs.forEach { (table, lagMs) -> metrics.setClickHouseTableIngestLagMs(table, lagMs) }
         freshness.eventLagMs.forEach { (table, lagMs) -> metrics.setClickHouseTableEventLagMs(table, lagMs) }
         freshness.eventFutureSkewMs.forEach { (table, skewMs) -> metrics.setClickHouseTableEventFutureSkewMs(table, skewMs) }
-        val fresh = freshness.ingestLagMs.values.all { lagMs -> lagMs != null && lagMs <= config.readyMaxAgeMs }
+        val fresh = freshness.ingestLagMs.values.all { lagMs -> lagMs != null && lagMs <= config.tableReadyMaxAgeMs }
         tableFreshnessReady.set(fresh)
         lastFreshnessCheckMs.set(observedAt)
         if (!fresh) {
           clickHouseLogger.warn {
             "clickhouse table ingest freshness stale ingest_lags_ms=${freshness.ingestLagMs} " +
-              "event_lags_ms=${freshness.eventLagMs}"
+              "event_lags_ms=${freshness.eventLagMs} table_ready_max_age_ms=${config.tableReadyMaxAgeMs}"
           }
         }
         fresh

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HealthServer.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HealthServer.kt
@@ -38,6 +38,7 @@ data class HyperliquidReadinessInfo(
   val clickhouseLastSuccessLagMs: Long?,
   val clickhouseLastFailureAgeMs: Long?,
   val clickhouseReadyMaxAgeMs: Long,
+  val clickhouseTableReadyMaxAgeMs: Long,
   val clickhouseFailureHoldMs: Long,
   val clickhouseTableIngestLagMs: Map<String, Long?>,
   val clickhouseTableEventLagMs: Map<String, Long?>,

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfig.kt
@@ -29,6 +29,7 @@ data class ClickHouseConfig(
   val flushMs: Long,
   val requestTimeoutMs: Long,
   val readyMaxAgeMs: Long,
+  val tableReadyMaxAgeMs: Long = readyMaxAgeMs,
   val failureHoldMs: Long,
   val enabledTables: Set<String>,
   val readyTables: Set<String> = setOf("hyperliquid_raw", "hyperliquid_candles"),
@@ -159,6 +160,9 @@ data class HyperliquidConfig(
         error("HYPERLIQUID_REST_WEIGHT_BUDGET_PER_MINUTE must be within 1..1200")
       }
 
+      val clickHouseReadyMaxAgeMs = longEnv(mergedEnv, "CLICKHOUSE_READY_MAX_AGE_MS", 120_000).coerceAtLeast(1_000)
+      val clickHouseTableReadyMaxAgeMs =
+        longEnv(mergedEnv, "CLICKHOUSE_TABLE_READY_MAX_AGE_MS", 300_000).coerceAtLeast(clickHouseReadyMaxAgeMs)
       val clickHouse =
         ClickHouseConfig(
           enabled = mergedEnv["CLICKHOUSE_ENABLED"]?.toBooleanStrictOrNull() ?: true,
@@ -170,7 +174,8 @@ data class HyperliquidConfig(
           batchSize = intEnv(mergedEnv, "CLICKHOUSE_BATCH_SIZE", 250).coerceIn(1, 5000),
           flushMs = longEnv(mergedEnv, "CLICKHOUSE_FLUSH_MS", 1000).coerceAtLeast(250),
           requestTimeoutMs = longEnv(mergedEnv, "CLICKHOUSE_REQUEST_TIMEOUT_MS", 10_000).coerceAtLeast(1_000),
-          readyMaxAgeMs = longEnv(mergedEnv, "CLICKHOUSE_READY_MAX_AGE_MS", 120_000).coerceAtLeast(1_000),
+          readyMaxAgeMs = clickHouseReadyMaxAgeMs,
+          tableReadyMaxAgeMs = clickHouseTableReadyMaxAgeMs,
           failureHoldMs = longEnv(mergedEnv, "CLICKHOUSE_FAILURE_HOLD_MS", 60_000).coerceAtLeast(1_000),
           enabledTables =
             csv(mergedEnv["CLICKHOUSE_ENABLED_TABLES"] ?: supportedClickHouseTables.joinToString(","))

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
@@ -184,6 +184,7 @@ class HyperliquidFeedApp(
       clickhouseLastSuccessLagMs = clickHouseLastSuccessLagMs(),
       clickhouseLastFailureAgeMs = clickHouseLastFailureAgeMs(),
       clickhouseReadyMaxAgeMs = config.clickHouse.readyMaxAgeMs,
+      clickhouseTableReadyMaxAgeMs = config.clickHouse.tableReadyMaxAgeMs,
       clickhouseFailureHoldMs = config.clickHouse.failureHoldMs,
       clickhouseTableIngestLagMs = clickHouseTableIngestLagMs,
       clickhouseTableEventLagMs = clickHouseTableEventLagMs,

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/ClickHouseSinkTest.kt
@@ -278,6 +278,53 @@ class ClickHouseSinkTest {
     }
 
   @Test
+  fun `keeps clickhouse ready when table ingest lag is within the table catchup window`() =
+    runBlocking {
+      val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
+      val client =
+        HttpClient(
+          MockEngine { request ->
+            if (queryParam(request.url).startsWith("INSERT")) {
+              respond(content = "", status = HttpStatusCode.OK)
+            } else {
+              respond(
+                content =
+                  """
+                  {"table":"hyperliquid_candles","latest_ingest_ms":7000,"latest_event_ms":9900}
+                  {"table":"hyperliquid_raw","latest_ingest_ms":7000,"latest_event_ms":9900}
+                  """.trimIndent(),
+                status = HttpStatusCode.OK,
+              )
+            }
+          },
+        )
+      val sink =
+        ClickHouseSink(
+          config = clickHouseConfig(readyMaxAgeMs = 1_000, tableReadyMaxAgeMs = 5_000),
+          httpClient = client,
+          metrics = HyperliquidMetrics(SimpleMeterRegistry()),
+          json = Json,
+          nowMs = { 10_000 },
+          onReady = { readySignals += it },
+        )
+      val job = sink.start(this)
+
+      sink.enqueue(candleRecord())
+
+      withTimeout(1_000) {
+        while (readySignals.lastOrNull()?.ready != true) {
+          delay(10)
+        }
+      }
+
+      assertEquals(true, readySignals.last().ready)
+      assertEquals(true, readySignals.last().tableFreshnessReady)
+      assertEquals(3_000, readySignals.last().tableIngestLagMs["hyperliquid_candles"])
+      job.cancelAndJoin()
+      client.close()
+    }
+
+  @Test
   fun `marks clickhouse ready when ingest is fresh even if candle event time is older`() =
     runBlocking {
       val readySignals = mutableListOf<ClickHouseReadinessUpdate>()
@@ -469,6 +516,7 @@ class ClickHouseSinkTest {
 
   private fun clickHouseConfig(
     readyMaxAgeMs: Long,
+    tableReadyMaxAgeMs: Long = readyMaxAgeMs,
     batchSize: Int = 1,
     flushMs: Long = 1,
     requestTimeoutMs: Long = 1_000,
@@ -486,6 +534,7 @@ class ClickHouseSinkTest {
       flushMs = flushMs,
       requestTimeoutMs = requestTimeoutMs,
       readyMaxAgeMs = readyMaxAgeMs,
+      tableReadyMaxAgeMs = tableReadyMaxAgeMs,
       failureHoldMs = 1_000,
       enabledTables = enabledTables,
       readyTables = readyTables,

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidConfigTest.kt
@@ -48,6 +48,7 @@ class HyperliquidConfigTest {
         mapOf(
           "KAFKA_SASL_PASSWORD" to "secret",
           "CLICKHOUSE_READY_MAX_AGE_MS" to "90000",
+          "CLICKHOUSE_TABLE_READY_MAX_AGE_MS" to "300000",
           "CLICKHOUSE_FAILURE_HOLD_MS" to "45000",
           "CLICKHOUSE_REQUEST_TIMEOUT_MS" to "7000",
           "CLICKHOUSE_REQUIRED_FOR_READINESS" to "false",
@@ -61,6 +62,7 @@ class HyperliquidConfigTest {
       )
 
     assertEquals(90_000, config.clickHouse.readyMaxAgeMs)
+    assertEquals(300_000, config.clickHouse.tableReadyMaxAgeMs)
     assertEquals(45_000, config.clickHouse.failureHoldMs)
     assertEquals(7_000, config.clickHouse.requestTimeoutMs)
     assertFalse(config.clickHouse.requiredForReadiness)
@@ -70,6 +72,20 @@ class HyperliquidConfigTest {
     assertEquals(setOf("raw", "candle"), config.readyRequiredChannels)
     assertEquals(120_000, config.readyEventMaxAgeMs)
     assertEquals(180_000, config.kafkaReadyMaxAgeMs)
+  }
+
+  @Test
+  fun `defaults clickhouse table freshness to a wider catchup window`() {
+    val config =
+      HyperliquidConfig.fromEnv(
+        mapOf(
+          "KAFKA_SASL_PASSWORD" to "secret",
+          "CLICKHOUSE_PASSWORD" to "secret",
+        ),
+      )
+
+    assertEquals(120_000, config.clickHouse.readyMaxAgeMs)
+    assertEquals(300_000, config.clickHouse.tableReadyMaxAgeMs)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Split Hyperliquid feed ClickHouse table catch-up freshness from the generic ClickHouse readiness age so normal two-minute table lag no longer flips the pod unready.
- Expose `clickhouseTableReadyMaxAgeMs` in `/readyz` and include the table freshness bound in stale-table warnings.
- Raise the live GitOps ClickHouse readiness window to five minutes and bump the feed deployment config revision so Argo restarts with the safer config.

## Related Issues

None

## Testing

- `./gradlew :hyperliquid-feed:test --tests 'ai.proompteng.dorvud.hyperliquid.ClickHouseSinkTest' --tests 'ai.proompteng.dorvud.hyperliquid.HyperliquidConfigTest' --tests 'ai.proompteng.dorvud.hyperliquid.HyperliquidFeedAppHealthTest'`
- `./gradlew :hyperliquid-feed:build`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
