### PR TITLE
fix(flamingo): disable unsafe numa auto bind

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -33,11 +33,15 @@ model as an active fallback in GitOps, Pi, AnyPi, or OpenWebUI config.
 --enable-auto-tool-choice
 --tool-call-parser hermes
 --optimization-level 2
---numa-bind
 ```
 
 The production floor is 128K context. If this profile fails, reduce concurrency
 first. Do not restore the old model as the desired state.
+
+NUMA auto-binding is intentionally disabled on Turin. vLLM 0.23.0 cannot
+autodetect the GPU-to-NUMA topology on this node and exits during startup when
+`--numa-bind` is used. Only re-enable CPU locality after validating explicit
+`--numa-bind-nodes` values live.
 
 ## Rollout Gates
 

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -64,7 +64,6 @@ spec:
             - hermes
             - --optimization-level
             - "2"
-            - --numa-bind
           env:
             - name: HF_HOME
               value: /models/huggingface

--- a/argocd/applications/flamingo/docs/large-model-multigpu.md
+++ b/argocd/applications/flamingo/docs/large-model-multigpu.md
@@ -83,7 +83,6 @@ args:
   - hermes
   - --optimization-level
   - "2"
-  - --numa-bind
 ```
 
 Add the parallelism flags for the shape under test.


### PR DESCRIPTION
## Summary

- Removes the unsafe `--numa-bind` vLLM flag from Flamingo's active Qwen3.6 launch profile.
- Documents why NUMA auto-binding is disabled on Turin and what must be validated before re-enabling it.
- Keeps the hard migration on `unsloth/Qwen3.6-35B-A3B-NVFP4` with the rest of the optimized serving flags unchanged.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml && yq e 'select(.kind == "Deployment" and .metadata.name == "flamingo") | .spec.template.spec.containers[0].args' /tmp/flamingo-render.yaml`
- `bun run lint:flamingo-hard-migration`
- `bun run lint:argocd`
- Live rollout evidence: vLLM crashed with `RuntimeError: NUMA binding was requested, but vLLM could not detect the GPU-to-NUMA topology automatically`; after removing only `--numa-bind`, vLLM proceeded to model load with `FlashInferCutlassNvFp4LinearKernel` and `FLASHINFER_CUTLASS` NVFP4 MoE backend.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
