### PR TITLE
chore(symphony): promote image 69ba69c6

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:35:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-20T06:33:01Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d5bbb059"
-    digest: sha256:a158075106ff584a2964f2ad61e90aadb3b9c782fb98749aaf4f8ba8837546da
+    newTag: "69ba69c6"
+    digest: sha256:e4cd61203cc9a95ae06494c91737c16de0745bd8048a00178f698c91e1888451

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:35:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-20T06:33:01Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d5bbb059"
-    digest: sha256:a158075106ff584a2964f2ad61e90aadb3b9c782fb98749aaf4f8ba8837546da
+    newTag: "69ba69c6"
+    digest: sha256:e4cd61203cc9a95ae06494c91737c16de0745bd8048a00178f698c91e1888451

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-17T02:35:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-20T06:33:01Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d5bbb059"
-    digest: sha256:a158075106ff584a2964f2ad61e90aadb3b9c782fb98749aaf4f8ba8837546da
+    newTag: "69ba69c6"
+    digest: sha256:e4cd61203cc9a95ae06494c91737c16de0745bd8048a00178f698c91e1888451


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `69ba69c6b9769d239ff76de8e2210532120f6618`
- Image tag: `69ba69c6`
- Image digest: `sha256:e4cd61203cc9a95ae06494c91737c16de0745bd8048a00178f698c91e1888451`