### PR TITLE
fix(flamingo): use qwen tool parser

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -31,7 +31,7 @@ model as an active fallback in GitOps, Pi, AnyPi, or OpenWebUI config.
 --max-num-batched-tokens 16384
 --enable-prefix-caching
 --enable-auto-tool-choice
---tool-call-parser hermes
+--tool-call-parser qwen3_xml
 --optimization-level 2
 ```
 
@@ -42,6 +42,9 @@ NUMA auto-binding is intentionally disabled on Turin. vLLM 0.23.0 cannot
 autodetect the GPU-to-NUMA topology on this node and exits during startup when
 `--numa-bind` is used. Only re-enable CPU locality after validating explicit
 `--numa-bind-nodes` values live.
+
+The active tool parser is `qwen3_xml`. This model emits Qwen XML tool-call
+markup, and that parser converts it into OpenAI-compatible `tool_calls`.
 
 ## Rollout Gates
 

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - --enable-prefix-caching
             - --enable-auto-tool-choice
             - --tool-call-parser
-            - hermes
+            - qwen3_xml
             - --optimization-level
             - "2"
           env:

--- a/argocd/applications/flamingo/docs/large-model-multigpu.md
+++ b/argocd/applications/flamingo/docs/large-model-multigpu.md
@@ -80,7 +80,7 @@ args:
   - --enable-prefix-caching
   - --enable-auto-tool-choice
   - --tool-call-parser
-  - hermes
+  - qwen3_xml
   - --optimization-level
   - "2"
 ```

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -2,8 +2,13 @@
 
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo']
-const forbiddenTerms = ['Qwen/Qwen3-Coder-Next-FP8', 'qwen3-coder-flamingo', 'Qwen/Qwen3-Coder-30B-A3B-Instruct']
+const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3_xml']
+const forbiddenTerms = [
+  'Qwen/Qwen3-Coder-Next-FP8',
+  'qwen3-coder-flamingo',
+  'Qwen/Qwen3-Coder-30B-A3B-Instruct',
+  'hermes',
+]
 
 const targetFiles = [
   'argocd/applications/flamingo/deployment.yaml',
@@ -27,7 +32,7 @@ for (const file of targetFiles) {
 
   for (const term of forbiddenTerms) {
     if (content.includes(term)) {
-      failures.push(`${file}: still contains forbidden old Flamingo model term "${term}"`)
+      failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Switches Flamingo's vLLM tool-call parser from `hermes` to `qwen3_xml` for the Qwen3.6 NVFP4 model.
- Documents that this model emits Qwen XML tool-call markup and needs the Qwen parser for OpenAI-compatible `tool_calls`.
- Extends the hard-migration guard so active Flamingo surfaces require `qwen3_xml` and reject stale parser/model terms.

## Related Issues

None

## Testing

- `bun run lint:flamingo-hard-migration`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml && yq e 'select(.kind == "Deployment" and .metadata.name == "flamingo") | .spec.template.spec.containers[0].args' /tmp/flamingo-render.yaml`
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts`
- `bun run lint:argocd`
- `git diff --check`
- Live smoke showed `hermes` left Qwen `<tool_call>` XML in message content instead of structured OpenAI `tool_calls`; the live Deployment has been patched to `--tool-call-parser qwen3_xml` for rollout validation.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
