### PR TITLE
chore(jangar): promote image 69ba69c6

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-17T02:37:22Z
+    deploy.knative.dev/rollout: 2026-06-20T06:42:53Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: d5bbb059e0f67c9d857f3c8b876d1db8682430a8
+              value: 69ba69c6b9769d239ff76de8e2210532120f6618
             - name: JANGAR_GITOPS_REVISION
-              value: d5bbb059e0f67c9d857f3c8b876d1db8682430a8
+              value: 69ba69c6b9769d239ff76de8e2210532120f6618
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "27661829557"
+              value: "27863191686"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:8ae1f32e6ce83ece7e4cf947b3c2b8b6f88fd247a1376c128c3f81755f14305b
+              value: sha256:2d36d4c6d80befb2c19bcc1f620c424d908b2baa8160ed01a27508088f4d7e3a
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: d5bbb059e0f67c9d857f3c8b876d1db8682430a8
+              value: 69ba69c6b9769d239ff76de8e2210532120f6618
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:8ae1f32e6ce83ece7e4cf947b3c2b8b6f88fd247a1376c128c3f81755f14305b
+              value: sha256:2d36d4c6d80befb2c19bcc1f620c424d908b2baa8160ed01a27508088f4d7e3a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: d5bbb059
-    digest: sha256:8ae1f32e6ce83ece7e4cf947b3c2b8b6f88fd247a1376c128c3f81755f14305b
+    newTag: 69ba69c6
+    digest: sha256:2d36d4c6d80befb2c19bcc1f620c424d908b2baa8160ed01a27508088f4d7e3a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `69ba69c6b9769d239ff76de8e2210532120f6618`
- Image tag: `69ba69c6`
- Image digest: `sha256:2d36d4c6d80befb2c19bcc1f620c424d908b2baa8160ed01a27508088f4d7e3a`
- Source CI run: `27863191686`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates