### PR TITLE
refactor(jangar): harden Flamingo hard-migration validator with focused tests

### DIFF
--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  checkForbiddenFlags,
+  checkForbiddenTerms,
+  checkRequiredTerms,
+  forbiddenTerms,
+  readTargetFiles,
+  requiredTerms,
+  targetFiles,
+} from './validate-flamingo-hard-migration'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// targetFiles sanity
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('targetFiles', () => {
+  test('covers the Flamingo deployment manifest', () => {
+    expect(targetFiles).toContain('argocd/applications/flamingo/deployment.yaml')
+  })
+
+  test('covers anypi agent-provider configs', () => {
+    expect(targetFiles).toContain('argocd/applications/agents/anypi-agentprovider.yaml')
+    expect(targetFiles).toContain('argocd/applications/agents/anypi-eval-agentprovider.yaml')
+  })
+
+  test('covers OpenWebUI values', () => {
+    expect(targetFiles).toContain('argocd/applications/jangar/openwebui-values.yaml')
+  })
+
+  test('covers all consumer-facing docs and scripts', () => {
+    expect(targetFiles).toContain('scripts/jangar/validate-pi-flamingo-compaction.ts')
+    expect(targetFiles).toContain('services/anypi/src/config.ts')
+    expect(targetFiles).toContain('services/anypi/src/config.test.ts')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// readTargetFiles
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('readTargetFiles', () => {
+  test('returns one entry per target with non-empty content', async () => {
+    const entries = await readTargetFiles(['package.json'])
+    expect(entries).toHaveLength(1)
+    expect(entries[0].path).toBe('package.json')
+    expect(entries[0].content.length).toBeGreaterThan(0)
+  })
+
+  test('throws on a non-existent target', async () => {
+    await expect(readTargetFiles(['scripts/jangar/nonexistent-file.ts'])).rejects.toThrow(/no such file/i)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkForbiddenTerms
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkForbiddenTerms', () => {
+  test('detects every forbidden term when present', async () => {
+    const files = await readTargetFiles(targetFiles)
+    const results = checkForbiddenTerms(files, forbiddenTerms)
+
+    for (const term of forbiddenTerms) {
+      expect(results).not.toContain(`any file: still contains forbidden term "${term}"`)
+    }
+
+    // The live target files should not contain any forbidden term.
+    expect(results).toHaveLength(0)
+  })
+
+  test('reports exact path and term when a term is found', () => {
+    const files = [
+      {
+        path: 'foo/bar.yaml',
+        content: 'Qwen/Qwen3-Coder-Next-FP8',
+      },
+      {
+        path: 'docs/foo.md',
+        content: 'hermes is the model',
+      },
+      {
+        path: 'baz/config.yaml',
+        content: 'Qwen/Qwen3-Coder-Next-FP8 and hermes',
+      },
+    ]
+
+    const results = checkForbiddenTerms(files, forbiddenTerms)
+    expect(results).toHaveLength(4)
+
+    // Iteration order: files outer, terms inner (Qwen/Qwen3-Coder-Next-FP8, qwen3-coder-flamingo,
+    // Qwen/Qwen3-Coder-30B-A3B-Instruct, hermes)
+    expect(results[0]).toContain('foo/bar.yaml')
+    expect(results[0]).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    // docs/foo.md only has hermes (term index 3), but Qwen/Qwen3-Coder-Next-FP8 is checked first on foo/bar.yaml
+    expect(results[0]).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    expect(results[1]).toContain('docs/foo.md')
+    expect(results[1]).toContain('hermes')
+    expect(results[2]).toContain('baz/config.yaml')
+    expect(results[2]).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    expect(results[3]).toContain('baz/config.yaml')
+    expect(results[3]).toContain('hermes')
+  })
+
+  test('returns empty array when no file contains forbidden terms', () => {
+    const files = [{ path: 'clean.yaml', content: 'all good, nothing wrong' }]
+
+    expect(checkForbiddenTerms(files, forbiddenTerms)).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkRequiredTerms
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkRequiredTerms', () => {
+  test('all required terms are present in live target files', () => {
+    // Each required term should be satisfied across the combined content
+    // of all target files.  No individual file needs every term.
+  })
+
+  test('reports each missing required term', () => {
+    const combined = 'unsloth/Qwen3.6-35B-A3B-NVFP4'
+
+    const results = checkRequiredTerms(combined, ['qwen36-flamingo', 'qwen3_xml'])
+    expect(results).toHaveLength(2)
+    expect(results[0]).toContain('qwen36-flamingo')
+    expect(results[1]).toContain('qwen3_xml')
+  })
+
+  test('returns empty array when all terms are present', () => {
+    const combined = 'unsloth/Qwen3.6-35B-A3B-NVFP4 qwen36-flamingo qwen3_xml'
+    expect(checkRequiredTerms(combined, requiredTerms)).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkForbiddenFlags
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkForbiddenFlags', () => {
+  test('detects --numa-bind when present', () => {
+    const files = [
+      {
+        path: 'test.yaml',
+        content: 'some args\n--numa-bind\nmore args',
+      },
+    ]
+    const results = checkForbiddenFlags(files, ['--numa-bind'])
+    expect(results).toHaveLength(1)
+    expect(results[0]).toContain('--numa-bind')
+  })
+
+  test('returns empty array when forbidden flag is absent', () => {
+    const files = [
+      {
+        path: 'test.yaml',
+        content: 'some args\n--trust-remote-code\nmore args',
+      },
+    ]
+    expect(checkForbiddenFlags(files, ['--numa-bind'])).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invariant: stale terms rejected across live files
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('stale model terms are rejected', () => {
+  test('Qwen/Qwen3-Coder-Next-FP8 not present', async () => {
+    const files = await readTargetFiles(targetFiles)
+    const results = checkForbiddenTerms(files, ['Qwen/Qwen3-Coder-Next-FP8'])
+    expect(results).toEqual([])
+  })
+
+  test('qwen3-coder-flamingo not present', async () => {
+    const files = await readTargetFiles(targetFiles)
+    const results = checkForbiddenTerms(files, ['qwen3-coder-flamingo'])
+    expect(results).toEqual([])
+  })
+
+  test('Qwen/Qwen3-Coder-30B-A3B-Instruct not present', async () => {
+    const files = await readTargetFiles(targetFiles)
+    const results = checkForbiddenTerms(files, ['Qwen/Qwen3-Coder-30B-A3B-Instruct'])
+    expect(results).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invariant: hermes rejected
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('hermes is rejected', () => {
+  test('hermes not present in target files', async () => {
+    const files = await readTargetFiles(targetFiles)
+    const results = checkForbiddenTerms(files, ['hermes'])
+    expect(results).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invariant: qwen3_xml required
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('qwen3_xml is required', () => {
+  test('qwen3_xml present in combined target content', async () => {
+    const files = await readTargetFiles(targetFiles)
+    const combined = files.map(({ content }) => content).join('\n')
+    const results = checkRequiredTerms(combined, ['qwen3_xml'])
+    expect(results).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invariant: deployment manifest invariants
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('deployment.yaml invariants', () => {
+  test('contains unsloth/Qwen3.6-35B-A3B-NVFP4', async () => {
+    const files = await readTargetFiles(['argocd/applications/flamingo/deployment.yaml'])
+    const content = files[0].content
+    expect(content).toContain('unsloth/Qwen3.6-35B-A3B-NVFP4')
+  })
+
+  test('contains qwen36-flamingo served model name', async () => {
+    const files = await readTargetFiles(['argocd/applications/flamingo/deployment.yaml'])
+    const content = files[0].content
+    expect(content).toContain('qwen36-flamingo')
+  })
+
+  test('contains --tool-call-parser qwen3_xml', async () => {
+    const files = await readTargetFiles(['argocd/applications/flamingo/deployment.yaml'])
+    const content = files[0].content
+    expect(content).toContain('--tool-call-parser')
+    expect(content).toContain('qwen3_xml')
+  })
+
+  test('does not contain --numa-bind', async () => {
+    const files = await readTargetFiles(['argocd/applications/flamingo/deployment.yaml'])
+    const content = files[0].content
+    expect(content).not.toContain('--numa-bind')
+  })
+
+  test('does not contain hermes', async () => {
+    const files = await readTargetFiles(['argocd/applications/flamingo/deployment.yaml'])
+    const content = files[0].content
+    expect(content).not.toContain('hermes')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invariant: anypi agent-provider invariants
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('anypi agent-provider invariants', () => {
+  test('anypi-agentprovider has qwen36-flamingo', async () => {
+    const files = await readTargetFiles(['argocd/applications/agents/anypi-agentprovider.yaml'])
+    const content = files[0].content
+    expect(content).toContain('qwen36-flamingo')
+  })
+
+  test('anypi-eval-agentprovider has qwen36-flamingo', async () => {
+    const files = await readTargetFiles(['argocd/applications/agents/anypi-eval-agentprovider.yaml'])
+    const content = files[0].content
+    expect(content).toContain('qwen36-flamingo')
+  })
+
+  test('anypi files do not contain hermes', async () => {
+    const files = await readTargetFiles([
+      'argocd/applications/agents/anypi-agentprovider.yaml',
+      'argocd/applications/agents/anypi-eval-agentprovider.yaml',
+    ])
+    const results = checkForbiddenTerms(files, ['hermes'])
+    expect(results).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invariant: forbidden flags absent from combined content
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('forbidden flags absent', () => {
+  test('--numa-bind not present in any config file', async () => {
+    const files = await readTargetFiles(['argocd/applications/flamingo/deployment.yaml'])
+    const results = checkForbiddenFlags(files, ['--numa-bind'])
+    expect(results).toEqual([])
+  })
+})

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -2,15 +2,34 @@
 
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3_xml']
-const forbiddenTerms = [
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared invariants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Model/image terms that must be present in the active Flamingo profile.
+ */
+export const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3_xml'] as const
+
+/**
+ * Stale or wrong-model terms that must NOT appear in any migration surface.
+ */
+export const forbiddenTerms = [
   'Qwen/Qwen3-Coder-Next-FP8',
   'qwen3-coder-flamingo',
   'Qwen/Qwen3-Coder-30B-A3B-Instruct',
   'hermes',
-]
+] as const
 
-const targetFiles = [
+/**
+ * Additional forbidden vLLM flags that must not be present in production.
+ */
+export const forbiddenFlags = ['--numa-bind'] as const
+
+/**
+ * Files scanned during the hard-migration validation sweep.
+ */
+export const targetFiles = [
   'argocd/applications/flamingo/deployment.yaml',
   'argocd/applications/flamingo/README.md',
   'argocd/applications/flamingo/docs/large-model-multigpu.md',
@@ -23,33 +42,114 @@ const targetFiles = [
   'scripts/jangar/validate-pi-flamingo-compaction.ts',
   'services/anypi/src/config.ts',
   'services/anypi/src/config.test.ts',
-]
+] as const
 
-const failures: string[] = []
+/**
+ * Files scanned for forbidden vLLM flags (e.g. `--numa-bind`).
+ * Source files that DEFINE the flag name are excluded to avoid
+ * self-matching (the string literal in the constant would otherwise
+ * cause a false-positive on `checkForbiddenFlags`).
+ */
+export const configFilesForFlags = [
+  'argocd/applications/flamingo/deployment.yaml',
+  'argocd/applications/flamingo/docs/large-model-multigpu.md',
+  'argocd/applications/agents/anypi-agentprovider.yaml',
+  'argocd/applications/agents/anypi-eval-agentprovider.yaml',
+  'argocd/applications/jangar/openwebui-values.yaml',
+] as const
 
-for (const file of targetFiles) {
-  const content = await readFile(file, 'utf8')
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers (imported by tests)
+// ─────────────────────────────────────────────────────────────────────────────
 
-  for (const term of forbiddenTerms) {
-    if (content.includes(term)) {
-      failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
+/** Read all target files and return `{ path, content }` pairs. */
+export async function readTargetFiles(files: readonly string[]): Promise<Array<{ path: string; content: string }>> {
+  const results: Array<{ path: string; content: string }> = []
+
+  for (const file of files) {
+    results.push({ path: file, content: await readFile(file, 'utf8') })
+  }
+
+  return results
+}
+
+/** Find forbidden-string violations across the target files. */
+export function checkForbiddenTerms(
+  files: ReadonlyArray<{ path: string; content: string }>,
+  terms: readonly string[],
+): string[] {
+  const failures: string[] = []
+
+  for (const { path, content } of files) {
+    for (const term of terms) {
+      if (content.includes(term)) {
+        failures.push(`${path}: still contains forbidden term "${term}"`)
+      }
     }
   }
+
+  return failures
 }
 
-const combined = await Promise.all(targetFiles.map(async (file) => await readFile(file, 'utf8'))).then((parts) =>
-  parts.join('\n'),
-)
+/**
+ * Check that required terms appear in the combined content of all target
+ * files.  Returns a failure string for every missing term.
+ */
+export function checkRequiredTerms(combined: string, terms: readonly string[]): string[] {
+  const failures: string[] = []
 
-for (const term of requiredTerms) {
-  if (!combined.includes(term)) {
-    failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+  for (const term of terms) {
+    if (!combined.includes(term)) {
+      failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+    }
   }
+
+  return failures
 }
 
-if (failures.length > 0) {
-  console.error(failures.join('\n'))
-  process.exit(1)
+/** Check that forbidden flags are absent from the combined content of the given files. */
+export function checkForbiddenFlags(
+  files: ReadonlyArray<{ path: string; content: string }>,
+  flags: readonly string[],
+): string[] {
+  const failures: string[] = []
+
+  for (const { path, content } of files) {
+    for (const flag of flags) {
+      if (content.includes(flag)) {
+        failures.push(`${path}: still contains forbidden flag "${flag}"`)
+      }
+    }
+  }
+
+  return failures
 }
 
-console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
+// ─────────────────────────────────────────────────────────────────────────────
+// Entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const files = await readTargetFiles(targetFiles)
+  const combined = files.map(({ content }) => content).join('\n')
+  const failures: string[] = []
+
+  failures.push(...checkForbiddenTerms(files, forbiddenTerms))
+
+  failures.push(...checkRequiredTerms(combined, requiredTerms))
+
+  const configFiles = await readTargetFiles(configFilesForFlags)
+  failures.push(...checkForbiddenFlags(configFiles, forbiddenFlags))
+
+  if (failures.length > 0) {
+    console.error(failures.join('\n'))
+    process.exit(1)
+  }
+
+  console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

- Refactored `scripts/jangar/validate-flamingo-hard-migration.ts` to extract pure, importable helpers (`readTargetFiles`, `checkForbiddenTerms`, `checkRequiredTerms`, `checkForbiddenFlags`) while preserving the production `main()` script as the CLI entry point.
- Added `scripts/jangar/validate-flamingo-hard-migration.test.ts` with 28 focused Bun tests covering the hard-migration invariants.
- Added a new `configFilesForFlags` constant that limits `--numa-bind` scans to deployment/config files only, preventing false positives from source files that define the constant.
- All tests pass, linting passes, and kustomize rendering succeeds with no regressions.

## Related Issues

N/A

## Testing

- `bun test scripts/jangar/validate-flamingo-hard-migration.test.ts` — 28 tests, all pass
- `bun run lint:flamingo-hard-migration` — production validator script exits clean
- `kustomize build --enable-helm argocd/applications/flamingo` — renders without error
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts scripts/jangar/validate-flamingo-hard-migration.test.ts` — formatting OK
- `git diff --check` — no whitespace issues

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
