### PR TITLE
fix(anypi): pin current qwen36 runner image

### DIFF
--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:9cd6ed580@sha256:b6f90e286832458ee228472a066ba1249536bef2d53618014164f70b85e01990
+    image: registry.ide-newton.ts.net/lab/anypi:80d336a73@sha256:e2c13b1ab0860ec792d2e65fc2063a27eb57650866ec0e72abc80651b26300e3
   adapter:
     type: exec
   envTemplate:

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -4,6 +4,8 @@ metadata:
   name: anypi-eval
 spec:
   binary: /usr/local/bin/anypi-runner
+  workload:
+    image: registry.ide-newton.ts.net/lab/anypi:80d336a73@sha256:e2c13b1ab0860ec792d2e65fc2063a27eb57650866ec0e72abc80651b26300e3
   adapter:
     type: exec
   envTemplate:


### PR DESCRIPTION
## Summary

- Pins the AnyPi provider to the current `80d336a73` multi-arch runner image digest.
- Adds the same explicit workload image to `anypi-eval` so prompt eval runs use the same runner.
- Keeps the Qwen3.6 Flamingo environment unchanged.

## Related Issues

None

## Testing

- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/anypi:80d336a73`
- `bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi tsc`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render-imagepin.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
