### PR TITLE
fix(anypi): keep repo tooling guidance generic

### DIFF
--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:80d336a73@sha256:e2c13b1ab0860ec792d2e65fc2063a27eb57650866ec0e72abc80651b26300e3
+    image: registry.ide-newton.ts.net/lab/anypi:fa91d81ed@sha256:808b375b8acd9d3bd23fb6219fc57d9bcee1be3380a7021b060245a9530f700c
   adapter:
     type: exec
   envTemplate:

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:80d336a73@sha256:e2c13b1ab0860ec792d2e65fc2063a27eb57650866ec0e72abc80651b26300e3
+    image: registry.ide-newton.ts.net/lab/anypi:fa91d81ed@sha256:808b375b8acd9d3bd23fb6219fc57d9bcee1be3380a7021b060245a9530f700c
   adapter:
     type: exec
   envTemplate:

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -133,6 +133,8 @@ describe('Anypi prompt contract', () => {
       '/workspace/lab',
     )
     expect(prompt).toContain('Use repository instructions and existing patterns')
+    expect(prompt).toContain('Use existing repository scripts, package-manager commands, and test/build configs')
+    expect(prompt).toContain('Do not add package.json, tsconfig, test config, or local wrapper config solely')
     expect(prompt).toContain('Do not edit generated files or lockfiles')
     expect(prompt).toContain('Refactor code and add tests.')
     expect(prompt).toContain('Leave the final changes in the worktree')
@@ -142,6 +144,8 @@ describe('Anypi prompt contract', () => {
   test('keeps the default system prompt simple and repo-focused', () => {
     const prompt = buildSystemPrompt('minimal')
     expect(prompt).toContain('Act as a coding agent inside an existing repository')
+    expect(prompt).toContain('Use existing repository scripts, package-manager commands, and test/build configs')
+    expect(prompt).toContain('Do not add package.json, tsconfig, test config, or local wrapper config solely')
     expect(prompt).toContain('Run the checks required for touched files')
     expect(prompt).toContain('Do not edit generated files or lockfiles')
     expect(prompt).not.toMatch(/Anypi|YOLO|Kubernetes|Pi SDK|provider|Flamingo/)
@@ -153,6 +157,8 @@ describe('Anypi prompt contract', () => {
     expect(buildSystemPrompt('repair-loop')).toContain('fix the root cause')
     expect(buildSystemPrompt('strict-repo')).toContain('Follow AGENTS.md')
     for (const variant of ['minimal', 'finish-gated', 'repair-loop', 'strict-repo'] as const) {
+      expect(buildSystemPrompt(variant)).toContain('Use existing repository scripts')
+      expect(buildSystemPrompt(variant)).toContain('Do not add package.json, tsconfig')
       expect(buildSystemPrompt(variant)).not.toMatch(/Anypi|YOLO|Kubernetes|Pi SDK|provider|Flamingo/)
     }
   })

--- a/services/anypi/src/prompt.ts
+++ b/services/anypi/src/prompt.ts
@@ -132,6 +132,10 @@ export const resolveValidationPlan = (
 export const resolveValidationCommands = (runSpec: AgentRunSpecPayload, configuredCommands: string[]) =>
   resolveValidationPlan(runSpec, configuredCommands, 'override').commands
 
+const REPO_TOOLING_RULES = `- Use existing repository scripts, package-manager commands, and test/build configs before adding new tooling.
+- Do not add package.json, tsconfig, test config, or local wrapper config solely to make a validation command runnable.
+- Add or change tooling config only when the requested product change truly requires it.`
+
 export const buildAgentPrompt = (runSpec: AgentRunSpecPayload, worktree: string) => {
   const task = resolveTaskPrompt(runSpec)
   const parameters = runSpec.parameters ?? {}
@@ -143,6 +147,7 @@ Head branch: ${runSpec.vcs?.headBranch ?? runSpec.head ?? parameters.head ?? 'co
 ${goal ? `Goal: ${goal}\n` : ''}
 Task rules:
 - Use repository instructions and existing patterns.
+${REPO_TOOLING_RULES}
 - Implement the requested change directly.
 - Add or update tests when behavior changes.
 - Run the checks required for the files you touched.
@@ -186,7 +191,8 @@ Repair attempt: ${input.attempt} of ${input.maxAttempts}
 
 Fix the repository so every validation command passes. Preserve the requested feature work, do not remove or weaken
 tests to make the suite pass, and run the failing command(s) again before stopping. Leave the final code changes in the
-worktree.
+worktree. Use existing repository tooling first; do not add package or test/build config only to make the validation
+command runnable.
 
 Failures:
 ${failures.map(formatValidationResult).join('\n\n')}`
@@ -200,7 +206,8 @@ Repair attempt: ${input.attempt} of ${input.maxAttempts}
 
 The task requires a real implementation. Continue from the repository state now: inspect the requested files, edit
 source and tests, run relevant validation, and leave the final changes in the worktree. Do not stop with only analysis
-or a summary.`
+or a summary. Use existing repository tooling first; do not add package or test/build config only to create a place for
+the change.`
 
 export const buildCiRepairPrompt = (input: {
   attempt: number
@@ -225,6 +232,8 @@ const SYSTEM_PROMPTS: Record<PromptVariant, string> = {
 
 Rules:
 - Inspect repository instructions and relevant files before editing.
+- Use existing repository scripts, package-manager commands, and test/build configs before adding new tooling.
+- Do not add package.json, tsconfig, test config, or local wrapper config solely to make a validation command runnable.
 - Keep the solution focused, production-quality, and no broader than the task.
 - Add or update tests for changed behavior.
 - Run the checks required for touched files; fix failures and rerun them.
@@ -236,6 +245,8 @@ Rules:
 
 Rules:
 - Inspect repository instructions and relevant files before editing.
+- Use existing repository scripts, package-manager commands, and test/build configs before adding new tooling.
+- Do not add package.json, tsconfig, test config, or local wrapper config solely to make a validation command runnable.
 - Keep the solution focused, production-quality, and no broader than the task.
 - Add or update tests for changed behavior.
 - Run the checks required for touched files; fix failures and rerun them.
@@ -248,6 +259,8 @@ Rules:
 
 Rules:
 - Inspect repository instructions and relevant files before editing.
+- Use existing repository scripts, package-manager commands, and test/build configs before adding new tooling.
+- Do not add package.json, tsconfig, test config, or local wrapper config solely to make a validation command runnable.
 - Keep the solution focused, production-quality, and no broader than the task.
 - Add or update tests for changed behavior.
 - Run the checks required for touched files; fix failures and rerun them.
@@ -262,6 +275,8 @@ Rules:
 Rules:
 - Inspect repository instructions and relevant files before editing.
 - Follow AGENTS.md and existing code patterns for every file you touch.
+- Use existing repository scripts, package-manager commands, and test/build configs before adding new tooling.
+- Do not add package.json, tsconfig, test config, or local wrapper config solely to make a validation command runnable.
 - Keep the solution focused, production-quality, and no broader than the task.
 - Add or update tests for changed behavior.
 - Run the checks required for touched files; fix failures and rerun them.


### PR DESCRIPTION
## Summary

- Adds generic repo-tooling guidance to AnyPi system, task, and repair prompts.
- Keeps runtime/provider details out of the model-facing prompt.
- Publishes and pins a new multi-arch AnyPi runner image built from the prompt change.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi tsc`
- `bunx oxfmt --check services/anypi/src/prompt.ts services/anypi/src/config.test.ts`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/anypi:fa91d81ed`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render-generic-tooling.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
