### PR TITLE
chore(agents): promote images d26e313e

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 0337065f
-  digest: sha256:8f149b515141d8c8af82d0833eb7ac6924e5ceef948392334749af497eb4d4b6
+  tag: d26e313e
+  digest: sha256:5289d38be26fc94d90b2cb61f5dc5671457e2630642f0ca3fe8f2d7a9d99b3df
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,26 +14,26 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 0337065f
-    digest: sha256:04268492447cc1c0cb36383c8822a9a341deded7f6ced28f838ff28e1950018f
+    tag: d26e313e
+    digest: sha256:795bdf0506ef3fe6dc90df4af97533e777b31a5a378df38c8311c4b104df5511
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 0337065f0441e98fa52ef99c5dcaea8b84e9b27a
-      AGENTS_GITOPS_REVISION: 0337065f0441e98fa52ef99c5dcaea8b84e9b27a
-      AGENTS_SOURCE_CI_RUN_ID: "27865306860"
+      AGENTS_SOURCE_HEAD_SHA: d26e313e22fc2fa387b16b8ae1a1d2713b51449d
+      AGENTS_GITOPS_REVISION: d26e313e22fc2fa387b16b8ae1a1d2713b51449d
+      AGENTS_SOURCE_CI_RUN_ID: "27865562004"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:04268492447cc1c0cb36383c8822a9a341deded7f6ced28f838ff28e1950018f
-      AGENTS_SERVING_BUILD_COMMIT: 0337065f0441e98fa52ef99c5dcaea8b84e9b27a
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:04268492447cc1c0cb36383c8822a9a341deded7f6ced28f838ff28e1950018f
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:795bdf0506ef3fe6dc90df4af97533e777b31a5a378df38c8311c4b104df5511
+      AGENTS_SERVING_BUILD_COMMIT: d26e313e22fc2fa387b16b8ae1a1d2713b51449d
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:795bdf0506ef3fe6dc90df4af97533e777b31a5a378df38c8311c4b104df5511
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 0337065f
-    digest: sha256:0ca62d84c7f766e2e259d5fd33470ac9cadcd866338b10bbf8e4cbe448b43086
+    tag: d26e313e
+    digest: sha256:cbca5f4a2f8dd453b7dd1e36b28028661b23094b7624bb7b939f969a43df777c
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -88,8 +88,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 0337065f
-    digest: sha256:8f149b515141d8c8af82d0833eb7ac6924e5ceef948392334749af497eb4d4b6
+    tag: d26e313e
+    digest: sha256:5289d38be26fc94d90b2cb61f5dc5671457e2630642f0ca3fe8f2d7a9d99b3df
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `d26e313e22fc2fa387b16b8ae1a1d2713b51449d`
- Image tag: `d26e313e`
- Agents build run: `27865562004`
- Promotion source: `workflow_run`