### PR TITLE
fix(flamingo): use qwen36 reasoning and tool parsers

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -30,8 +30,9 @@ model as an active fallback in GitOps, Pi, AnyPi, or OpenWebUI config.
 --max-num-seqs 128
 --max-num-batched-tokens 16384
 --enable-prefix-caching
+--reasoning-parser qwen3
 --enable-auto-tool-choice
---tool-call-parser qwen3_xml
+--tool-call-parser qwen3_coder
 --optimization-level 2
 ```
 
@@ -43,8 +44,11 @@ autodetect the GPU-to-NUMA topology on this node and exits during startup when
 `--numa-bind` is used. Only re-enable CPU locality after validating explicit
 `--numa-bind-nodes` values live.
 
-The active tool parser is `qwen3_xml`. This model emits Qwen XML tool-call
-markup, and that parser converts it into OpenAI-compatible `tool_calls`.
+The active reasoning parser is `qwen3`, so reasoning text is returned through
+the OpenAI-compatible reasoning field instead of being mixed into normal
+assistant content. The active tool parser is `qwen3_coder`, which is the vLLM
+Qwen3.5/Qwen3.6 recipe recommendation for automatic tool calling.
+Reference: <https://docs.vllm.ai/projects/recipes/en/latest/Qwen/Qwen3.5.html>
 
 ## Rollout Gates
 
@@ -139,6 +143,8 @@ curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
 ```
 
 Expected: `tool_calls` is a non-empty array and arguments include `7` and `35`.
+If this returns only prose or raw XML, do not accept the rollout; fix the
+generic vLLM serving flags or image first.
 
 ## Pi And AnyPi Contract
 

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -59,9 +59,11 @@ spec:
             - --max-num-batched-tokens
             - "16384"
             - --enable-prefix-caching
+            - --reasoning-parser
+            - qwen3
             - --enable-auto-tool-choice
             - --tool-call-parser
-            - qwen3_xml
+            - qwen3_coder
             - --optimization-level
             - "2"
           env:

--- a/argocd/applications/flamingo/docs/large-model-multigpu.md
+++ b/argocd/applications/flamingo/docs/large-model-multigpu.md
@@ -78,9 +78,11 @@ args:
   - --max-num-batched-tokens
   - "32768"
   - --enable-prefix-caching
+  - --reasoning-parser
+  - qwen3
   - --enable-auto-tool-choice
   - --tool-call-parser
-  - qwen3_xml
+  - qwen3_coder
   - --optimization-level
   - "2"
 ```

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -2,7 +2,7 @@
 
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3_xml']
+const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
 const forbiddenTerms = [
   'Qwen/Qwen3-Coder-Next-FP8',
   'qwen3-coder-flamingo',


### PR DESCRIPTION
## Summary

- Add the vLLM Qwen reasoning parser to Flamingo so reasoning is separated from assistant content.
- Switch Flamingo automatic tool calling from qwen3_xml to the vLLM-recommended qwen3_coder parser for Qwen3.6.
- Update Flamingo docs, multi-GPU notes, and hard-migration validation to match the active parser contract.

## Related Issues

None

## Testing

- `bun run lint:flamingo-hard-migration`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml`
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts`
- `bun run lint:argocd`
- `GIT_CONFIG_COUNT=3 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=user.email GIT_CONFIG_VALUE_1=codex@example.invalid GIT_CONFIG_KEY_2=user.name GIT_CONFIG_VALUE_2=Codex bun run --filter @proompteng/anypi test`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
