### PR TITLE
refactor(jangar): hard-migration validator into pure helpers + CLI entry point

### DIFF
--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -1,0 +1,273 @@
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdir, writeFile, rm } from 'node:fs/promises'
+import { describe, expect, test, afterAll, beforeEach } from 'vitest'
+
+import {
+  FORBIDDEN_TERMS,
+  REQUIRED_TERMS,
+  REQUIRED_MODEL,
+  REQUIRED_SERVED_NAME,
+  REQUIRED_REASONING_PARSER,
+  REQUIRED_TOOL_CALL_PARSER,
+  scanForForbidden,
+  scanForMissingFromCombined,
+  validateFile,
+  validateAll,
+  TARGET_FILES,
+} from './validate-flamingo-hard-migration'
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/** Temporary workspace used by tests. */
+let tmpRoot = ''
+
+afterAll(async () => {
+  if (tmpRoot) {
+    await rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+    tmpRoot = ''
+  }
+})
+
+beforeEach(() => {
+  tmpRoot = join(tmpdir(), `flamingo-validator-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+})
+
+// ── Pure helpers: scanForForbidden ──────────────────────────────────────────
+
+describe('scanForForbidden', () => {
+  test('rejects stale Qwen3-Coder model references', () => {
+    const result = scanForForbidden('Qwen/Qwen3-Coder-Next-FP8')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('Qwen/Qwen3-Coder-Next-FP8')
+  })
+
+  test('rejects old served alias qwen3-coder-flamingo', () => {
+    const result = scanForForbidden('qwen3-coder-flamingo')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('qwen3-coder-flamingo')
+  })
+
+  test('rejects the hermes parser', () => {
+    const result = scanForForbidden('hermes')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('hermes')
+  })
+
+  test('rejects the stale qwen3_xml parser', () => {
+    const result = scanForForbidden('qwen3_xml')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('qwen3_xml')
+  })
+
+  test('reports multiple forbidden terms in a single pass', () => {
+    const result = scanForForbidden('hermes qwen3-coder-flamingo')
+    expect(result).toHaveLength(2)
+    expect(result).toContain('still contains forbidden term "hermes"')
+    expect(result).toContain('still contains forbidden term "qwen3-coder-flamingo"')
+  })
+
+  test('returns empty array when content is clean', () => {
+    expect(scanForForbidden('unsloth/Qwen3.6-35B-A3B-NVFP4 qwen36-flamingo')).toEqual([])
+  })
+
+  test('is case-sensitive', () => {
+    // "Hermes" with capital H is NOT the forbidden term "hermes"
+    expect(scanForForbidden('Hermes')).toEqual([])
+    expect(scanForForbidden('QWEN3_XML')).toEqual([])
+  })
+})
+
+// ── Pure helpers: scanForMissingFromCombined ─────────────────────────────────
+
+describe('scanForMissingFromCombined', () => {
+  test('reports when the model image is absent from combined content', () => {
+    const result = scanForMissingFromCombined('some unrelated text')
+    expect(result).toContain('active Flamingo surfaces do not contain required term "unsloth/Qwen3.6-35B-A3B-NVFP4"')
+  })
+
+  test('reports when the served name is absent from combined content', () => {
+    const result = scanForMissingFromCombined('just plain text without the model name')
+    expect(result).toContain('active Flamingo surfaces do not contain required term "qwen36-flamingo"')
+  })
+
+  test('reports when both parsers are missing from combined content', () => {
+    const result = scanForMissingFromCombined('just plain text')
+    expect(result).toContain('active Flamingo surfaces do not contain required term "qwen3"')
+    expect(result).toContain('active Flamingo surfaces do not contain required term "qwen3_coder"')
+  })
+
+  test('passes when all required terms are present in combined content', () => {
+    const combined = 'unsloth/Qwen3.6-35B-A3B-NVFP4 qwen36-flamingo qwen3 qwen3_coder'
+    expect(scanForMissingFromCombined(combined)).toEqual([])
+  })
+})
+
+// ── Pure helper: validateFile ──────────────────────────────────────────────
+
+describe('validateFile', () => {
+  test('includes file path in every diagnostic', () => {
+    const results = validateFile('some/file.yaml', 'hermes')
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatch(/^some\/file\.yaml:/)
+    expect(results[0]).toContain('hermes')
+  })
+
+  test('reports multiple forbidden terms with path prefix', () => {
+    const results = validateFile('path.yaml', 'Qwen/Qwen3-Coder-Next-FP8 hermes')
+    expect(results.length).toBe(2)
+    expect(results[0]).toContain('path.yaml')
+    expect(results[0]).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    expect(results[1]).toContain('path.yaml')
+    expect(results[1]).toContain('hermes')
+  })
+
+  test('empty array when a file is fully compliant', () => {
+    const content = [
+      'unsloth/Qwen3.6-35B-A3B-NVFP4',
+      'qwen36-flamingo',
+      'reasoning-parser qwen3',
+      'tool-call-parser qwen3_coder',
+    ].join('\n')
+    expect(validateFile('compliant.yaml', content)).toEqual([])
+  })
+})
+
+// ── Data-driven invariants ─────────────────────────────────────────────────
+
+describe('exported invariants', () => {
+  test('REQUIRED_TERMS includes all four contract tokens', () => {
+    expect(REQUIRED_TERMS).toContain(REQUIRED_MODEL)
+    expect(REQUIRED_TERMS).toContain(REQUIRED_SERVED_NAME)
+    expect(REQUIRED_TERMS).toContain(REQUIRED_REASONING_PARSER)
+    expect(REQUIRED_TERMS).toContain(REQUIRED_TOOL_CALL_PARSER)
+  })
+
+  test('REQUIRED_TERMS matches the model name and served name constants', () => {
+    expect(REQUIRED_MODEL).toBe('unsloth/Qwen3.6-35B-A3B-NVFP4')
+    expect(REQUIRED_SERVED_NAME).toBe('qwen36-flamingo')
+    expect(REQUIRED_REASONING_PARSER).toBe('qwen3')
+    expect(REQUIRED_TOOL_CALL_PARSER).toBe('qwen3_coder')
+  })
+
+  test('FORBIDDEN_TERMS rejects the specified stale terms', () => {
+    expect(FORBIDDEN_TERMS).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    expect(FORBIDDEN_TERMS).toContain('qwen3-coder-flamingo')
+    expect(FORBIDDEN_TERMS).toContain('hermes')
+    expect(FORBIDDEN_TERMS).toContain('qwen3_xml')
+    // old model variant
+    expect(FORBIDDEN_TERMS).toContain('Qwen/Qwen3-Coder-30B-A3B-Instruct')
+  })
+})
+
+// ── Integration: validateAll ────────────────────────────────────────────────
+
+describe('validateAll', () => {
+  test('rejects a temp file with forbidden terms', async () => {
+    const stagingDir = join(tmpRoot, 'staging')
+    await mkdir(stagingDir, { recursive: true })
+
+    await writeFile(
+      join(stagingDir, 'bad.yaml'),
+      'model: Qwen/Qwen3-Coder-Next-FP8\nserved: qwen3-coder-flamingo',
+      'utf8',
+    )
+    await writeFile(
+      join(stagingDir, 'good.yaml'),
+      ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder'].join('\n'),
+      'utf8',
+    )
+
+    const results = await validateAll([join(stagingDir, 'bad.yaml'), join(stagingDir, 'good.yaml')])
+
+    // 2 forbidden terms in bad.yaml, no combined missing terms
+    expect(results).toHaveLength(2)
+    expect(results[0]).toContain('bad.yaml')
+    expect(results[0]).toContain('forbidden term')
+    expect(results[1]).toContain('bad.yaml')
+    expect(results[1]).toContain('forbidden term')
+  })
+
+  test('rejects when combined content is missing required terms', async () => {
+    const stagingDir = join(tmpRoot, 'staging-missing')
+    await mkdir(stagingDir, { recursive: true })
+
+    await writeFile(
+      join(stagingDir, 'empty.yaml'),
+      'no required terms here\njust stale\nQwen/Qwen3-Coder-Next-FP8',
+      'utf8',
+    )
+
+    const results = await validateAll([join(stagingDir, 'empty.yaml')])
+    expect(results.length).toBeGreaterThan(0)
+    // Forbidden term + 4 missing required terms
+    expect(results[0]).toContain('empty.yaml')
+    expect(results[0]).toContain('forbidden term')
+  })
+
+  test('passes when all temp files are fully compliant', async () => {
+    const stagingDir = join(tmpRoot, 'staging-ok')
+    await mkdir(stagingDir, { recursive: true })
+
+    const compliant = [
+      'unsloth/Qwen3.6-35B-A3B-NVFP4',
+      'qwen36-flamingo',
+      'reasoning-parser qwen3',
+      'tool-call-parser qwen3_coder',
+    ].join('\n')
+
+    await writeFile(join(stagingDir, 'a.yaml'), compliant, 'utf8')
+    await writeFile(join(stagingDir, 'b.yaml'), compliant, 'utf8')
+
+    const results = await validateAll([join(stagingDir, 'a.yaml'), join(stagingDir, 'b.yaml')])
+    expect(results).toEqual([])
+  })
+
+  test('passes when the combined content has all required terms across files', async () => {
+    const stagingDir = join(tmpRoot, 'staging-split')
+    await mkdir(stagingDir, { recursive: true })
+
+    // Term 1 and 2 in file a, term 3 and 4 in file b — combined, all present.
+    await writeFile(join(stagingDir, 'a.yaml'), 'unsloth/Qwen3.6-35B-A3B-NVFP4\nqwen36-flamingo', 'utf8')
+    await writeFile(join(stagingDir, 'b.yaml'), 'qwen3\nqwen3_coder', 'utf8')
+
+    const results = await validateAll([join(stagingDir, 'a.yaml'), join(stagingDir, 'b.yaml')])
+    expect(results).toEqual([])
+  })
+
+  test('fails with combined-required-term check when all files are individually clean but collectively missing one term', async () => {
+    const stagingDir = join(tmpRoot, 'staging-collective')
+    await mkdir(stagingDir, { recursive: true })
+
+    // No file individually has qwen3_coder, so the combined check fails.
+    await writeFile(join(stagingDir, 'a.yaml'), 'unsloth/Qwen3.6-35B-A3B-NVFP4\nqwen36-flamingo\nqwen3', 'utf8')
+    await writeFile(join(stagingDir, 'b.yaml'), 'unsloth/Qwen3.6-35B-A3B-NVFP4\nqwen36-flamingo\nqwen3', 'utf8')
+
+    const results = await validateAll([join(stagingDir, 'a.yaml'), join(stagingDir, 'b.yaml')])
+    expect(results).toHaveLength(1)
+    expect(results[0]).toContain('required term "qwen3_coder"')
+    // Combined check does NOT include a file path
+    expect(results[0]).not.toContain(':')
+  })
+})
+
+// ── End-to-end: current repository surfaces pass ───────────────────────────
+
+describe('repository surfaces', () => {
+  test('TARGET_FILES is a non-empty array', () => {
+    expect(TARGET_FILES.length).toBeGreaterThan(0)
+  })
+
+  test('all TARGET_FILES exist in the repository', async () => {
+    for (const filePath of TARGET_FILES) {
+      const content = await readFile(filePath, 'utf8')
+      expect(content.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('current repository surfaces pass validation', async () => {
+    const results = await validateAll()
+    expect(results).toEqual([])
+  })
+})

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -1,16 +1,67 @@
 #!/usr/bin/env bun
 
+/**
+ * Hard-migration validator for the Flamingo Qwen3.6 service contract.
+ *
+ * Validates that all Git-referenced surfaces carry the correct model name,
+ * served alias, reasoning parser, and tool-call parser while rejecting stale
+ * Qwen3-Coder references, the old `hermes` parser, and the deprecated
+ * `qwen3_xml` parser.
+ *
+ * Usage:
+ *   bun run scripts/jangar/validate-flamingo-hard-migration.ts
+ *
+ * Exit code 0 when all surfaces satisfy the invariants.
+ * Exit code 1 with actionable error messages when any invariant fails.
+ */
+
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
-const forbiddenTerms = [
-  'Qwen/Qwen3-Coder-Next-FP8',
-  'qwen3-coder-flamingo',
-  'Qwen/Qwen3-Coder-30B-A3B-Instruct',
-  'hermes',
+// ── Data-driven invariants ──────────────────────────────────────────────────
+
+/** The model image tag that must appear in every deployment surface. */
+export const REQUIRED_MODEL = 'unsloth/Qwen3.6-35B-A3B-NVFP4'
+
+/** The served model name the vLLM endpoint must advertise. */
+export const REQUIRED_SERVED_NAME = 'qwen36-flamingo'
+
+/** The reasoning parser argument value the vLLM container must use. */
+export const REQUIRED_REASONING_PARSER = 'qwen3'
+
+/** The tool-call parser argument value the vLLM container must use. */
+export const REQUIRED_TOOL_CALL_PARSER = 'qwen3_coder'
+
+/**
+ * Terms that must appear across all target files combined.
+ * Each entry is checked via `String.includes` so the test is fully data-driven
+ * over actual file contents, not against any runtime or cluster state.
+ */
+export const REQUIRED_TERMS = [
+  REQUIRED_MODEL,
+  REQUIRED_SERVED_NAME,
+  REQUIRED_REASONING_PARSER,
+  REQUIRED_TOOL_CALL_PARSER,
 ]
 
-const targetFiles = [
+/**
+ * Forbidden model references, served aliases, and parsers that must NOT
+ * appear in any target file. These block the hard migration when present.
+ */
+export const FORBIDDEN_TERMS = [
+  'Qwen/Qwen3-Coder-Next-FP8',
+  'Qwen/Qwen3-Coder-30B-A3B-Instruct',
+  'qwen3-coder-flamingo',
+  'hermes',
+  'qwen3_xml',
+]
+
+// ── Target file surfaces ────────────────────────────────────────────────────
+
+/**
+ * File paths that participate in the Flamingo hard-migration contract.
+ * Add or remove files here when the surface area changes.
+ */
+export const TARGET_FILES = [
   'argocd/applications/flamingo/deployment.yaml',
   'argocd/applications/flamingo/README.md',
   'argocd/applications/flamingo/docs/large-model-multigpu.md',
@@ -25,31 +76,102 @@ const targetFiles = [
   'services/anypi/src/config.test.ts',
 ]
 
-const failures: string[] = []
+// ── Validation helpers ──────────────────────────────────────────────────────
 
-for (const file of targetFiles) {
-  const content = await readFile(file, 'utf8')
-
-  for (const term of forbiddenTerms) {
+/**
+ * Scan a single file's content for forbidden terms.
+ * Returns a list of diagnostic messages.
+ */
+export function scanForForbidden(content: string): string[] {
+  const messages: string[] = []
+  for (const term of FORBIDDEN_TERMS) {
     if (content.includes(term)) {
-      failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
+      messages.push(`still contains forbidden term "${term}"`)
     }
   }
+  return messages
 }
 
-const combined = await Promise.all(targetFiles.map(async (file) => await readFile(file, 'utf8'))).then((parts) =>
-  parts.join('\n'),
-)
-
-for (const term of requiredTerms) {
-  if (!combined.includes(term)) {
-    failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+/**
+ * Scan combined content for missing required terms.
+ * Returns a list of diagnostic messages.
+ */
+export function scanForMissingFromCombined(combined: string): string[] {
+  const messages: string[] = []
+  for (const term of REQUIRED_TERMS) {
+    if (!combined.includes(term)) {
+      messages.push(`active Flamingo surfaces do not contain required term "${term}"`)
+    }
   }
+  return messages
 }
 
-if (failures.length > 0) {
-  console.error(failures.join('\n'))
-  process.exit(1)
+/**
+ * Validate a single file against forbidden terms.
+ * Returns an array of human-readable failure messages. Each message includes
+ * the file path so the operator can locate the problem immediately.
+ *
+ * @param filePath - Path relative to repository root.
+ * @returns Diagnostic messages (empty when the file passes).
+ */
+export function validateFile(filePath: string, content: string): string[] {
+  const diagnostics: string[] = []
+  const forbidden = scanForForbidden(content)
+  for (const msg of forbidden) {
+    diagnostics.push(`${filePath}: ${msg}`)
+  }
+  return diagnostics
 }
 
-console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
+/**
+ * Validate all target files. Reads each file from disk, applies the checks,
+ * and returns a flat list of diagnostic strings.
+ *
+ * Forbidden terms are checked per-file (with path prefix).
+ * Required terms are checked across all combined content.
+ *
+ * @param files - Override list of target file paths. Defaults to `TARGET_FILES`.
+ * @returns Array of diagnostic messages (empty when everything passes).
+ */
+export async function validateAll(files?: string[]): Promise<string[]> {
+  const targets = files ?? TARGET_FILES
+  const results: string[] = []
+
+  // Phase 1 — per-file: forbidden terms.
+  for (const filePath of targets) {
+    const content = await readFile(filePath, 'utf8')
+    results.push(...validateFile(filePath, content))
+  }
+
+  // Phase 2 — combined: every required term must appear somewhere.
+  const combined = await Promise.all(targets.map(async (filePath) => await readFile(filePath, 'utf8'))).then((parts) =>
+    parts.join('\n'),
+  )
+
+  results.push(...scanForMissingFromCombined(combined))
+
+  return results
+}
+
+// ── CLI entry point ─────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const diagnostics = await validateAll()
+
+  if (diagnostics.length > 0) {
+    console.error(diagnostics.join('\n'))
+    process.exitCode = 1
+    return
+  }
+
+  const targets = TARGET_FILES
+  console.log(`validated ${targets.length} Flamingo hard-migration surfaces`)
+}
+
+// Allow importing for test-driven usage.
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

- Refactor `scripts/jangar/validate-flamingo-hard-migration.ts` into reusable pure validation helpers (`scanForForbidden`, `scanForMissingFromCombined`, `validateFile`, `validateAll`) plus a CLI entry point that preserves existing behavior (nonzero exit with actionable failures, zero with the success summary).
- Export constants for `REQUIRED_MODEL`, `REQUIRED_SERVED_NAME`, `REQUIRED_REASONING_PARSER`, `REQUIRED_TOOL_CALL_PARSER`, `REQUIRED_TERMS`, `FORBIDDEN_TERMS`, and `TARGET_FILES` so tests can import them directly.
- Add focused Bun regression tests covering rejection of stale Qwen3-Coder model references, the old `qwen3-coder-flamingo` alias, `hermes` and `qwen3_xml` parsers; requirement of `unsloth/Qwen3.6-35B-A3B-NVFP4`, `qwen36-flamingo`, `qwen3`, and `qwen3_coder`; file-path inclusion in diagnostics; combined-required-term checks; and acceptance of current repository surfaces.
- Checks are fully data-driven over file contents with no hardcoded AgentRun name, branch, PR number, pod name, or live cluster state.

## Related Issues

None

## Testing

- `bun test scripts/jangar/validate-flamingo-hard-migration.test.ts` — 25 tests, all pass (forbidden-term rejection, missing-term detection, file-path diagnostics, combined-term checks, current-surface pass).
- `bun run lint:flamingo-hard-migration` — exits zero, prints `validated 12 Flamingo hard-migration surfaces`.
- `kustomize build --enable-helm argocd/applications/flamingo > /tmp/flamingo-render.yaml` — render succeeds (exit 0).
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts scripts/jangar/validate-flamingo-hard-migration.test.ts package.json` — all files formatted correctly.
- `git diff --check` — no whitespace errors.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This is a refactor of a CI-only validation script; the CLI interface and behavior are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
