### PR TITLE
fix(anypi): preflight runner toolchain

### DIFF
--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -21,6 +21,7 @@ spec:
     ANYPI_CONTEXT_WINDOW: "98304"
     ANYPI_MAX_TOKENS: "32768"
     ANYPI_TOOLS: all
+    ANYPI_REQUIRED_TOOLS: bash,bun,git,gh,jq,node,python3,uv,mise,helm,kustomize
     ANYPI_WORKSPACE: /workspace
     ANYPI_WORKTREE: /workspace/lab
     ANYPI_AGENT_DIR: /workspace/.anypi

--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:fa91d81ed@sha256:808b375b8acd9d3bd23fb6219fc57d9bcee1be3380a7021b060245a9530f700c
+    image: registry.ide-newton.ts.net/lab/anypi:62cf896ec@sha256:d318d97629e8a1b39e05935b706dfefa8a912fb28e585a564c21c6f2da175af9
   adapter:
     type: exec
   envTemplate:

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -21,6 +21,7 @@ spec:
     ANYPI_CONTEXT_WINDOW: "98304"
     ANYPI_MAX_TOKENS: "32768"
     ANYPI_TOOLS: all
+    ANYPI_REQUIRED_TOOLS: bash,bun,git,gh,jq,node,python3,uv,mise,helm,kustomize
     ANYPI_WORKSPACE: /workspace
     ANYPI_WORKTREE: /workspace/lab
     ANYPI_AGENT_DIR: /workspace/.anypi

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:fa91d81ed@sha256:808b375b8acd9d3bd23fb6219fc57d9bcee1be3380a7021b060245a9530f700c
+    image: registry.ide-newton.ts.net/lab/anypi:62cf896ec@sha256:d318d97629e8a1b39e05935b706dfefa8a912fb28e585a564c21c6f2da175af9
   adapter:
     type: exec
   envTemplate:

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -29,6 +29,9 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 
 - `ANYPI_TOOLS=all` enables the full built-in coding tool set: `read`, `bash`,
   `edit`, `write`, `grep`, `find`, `ls`.
+- `ANYPI_REQUIRED_TOOLS` is checked before clone/model work. The default image
+  contract includes `bash`, `bun`, `git`, `gh`, `jq`, `node`, `python3`, `uv`,
+  `mise`, `helm`, and `kustomize`.
 - `ANYPI_MODEL=qwen36-flamingo` targets the Qwen3.6 NVFP4 Flamingo endpoint.
 - `ANYPI_CONTEXT_WINDOW=98304` and `ANYPI_MAX_TOKENS=32768` fit inside the
   current 128K production serving profile.
@@ -69,7 +72,8 @@ runner config and logs, not in the model-facing behavioral contract.
 
 Status evidence is written to `/workspace/.agent/status.json`: model,
 providerModel, thinkingLevel, contextWindow, maxTokens, promptVariant,
-promptHash, validations, CI result, session files, commit, and pull request.
+promptHash, requiredTools, validations, CI result, session files, commit, and
+pull request.
 
 ## AgentRun Example
 

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ harness against the self-hosted Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:9cd6ed580@sha256:b6f90e286832458ee228472a066ba1249536bef2d53618014164f70b85e01990`
+- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:62cf896ec@sha256:d318d97629e8a1b39e05935b706dfefa8a912fb28e585a564c21c6f2da175af9`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen36-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`

--- a/services/anypi/Dockerfile
+++ b/services/anypi/Dockerfile
@@ -8,6 +8,7 @@ ARG UV_VERSION=0.11.14
 ARG GH_VERSION=2.94.0
 ARG HELM_VERSION=3.18.6
 ARG KUSTOMIZE_VERSION=5.8.1
+ARG MISE_VERSION=2026.6.11
 ARG LAB_GIT_SHA=dev
 
 FROM node:${NODE_VERSION}-bookworm-slim AS node-runtime
@@ -29,11 +30,16 @@ ARG UV_VERSION
 ARG GH_VERSION
 ARG HELM_VERSION
 ARG KUSTOMIZE_VERSION
+ARG MISE_VERSION
 ENV NODE_ENV=production \
   WORKSPACE=/workspace \
   WORKTREE=/workspace/lab \
   GIT_TERMINAL_PROMPT=0 \
   BUN_INSTALL=/usr/local \
+  MISE_DATA_DIR=/usr/local/share/mise \
+  MISE_CACHE_DIR=/usr/local/share/mise/cache \
+  MISE_CONFIG_DIR=/usr/local/etc/mise \
+  MISE_YES=1 \
   ANYPI_WORKSPACE=/workspace \
   ANYPI_WORKTREE=/workspace/lab \
   ANYPI_AGENT_DIR=/workspace/.anypi
@@ -64,10 +70,12 @@ RUN python3 -m pip install --break-system-packages --no-cache-dir "uv==${UV_VERS
 RUN set -eux; \
   arch="$(dpkg --print-architecture)"; \
   case "${arch}" in \
-    amd64) tool_arch=amd64 ;; \
-    arm64) tool_arch=arm64 ;; \
+    amd64) tool_arch=amd64; mise_arch=x64 ;; \
+    arm64) tool_arch=arm64; mise_arch=arm64 ;; \
     *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
   esac; \
+  curl -fsSL "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-${mise_arch}" -o /usr/local/bin/mise; \
+  chmod +x /usr/local/bin/mise; \
   curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${tool_arch}.tar.gz" -o /tmp/helm.tar.gz; \
   tar -xzf /tmp/helm.tar.gz -C /tmp; \
   mv "/tmp/linux-${tool_arch}/helm" /usr/local/bin/helm; \
@@ -79,10 +87,12 @@ RUN set -eux; \
     -o /tmp/kustomize.tar.gz; \
   tar -xzf /tmp/kustomize.tar.gz -C /usr/local/bin kustomize; \
   rm -rf /tmp/gh.tar.gz /tmp/helm.tar.gz /tmp/kustomize.tar.gz "/tmp/gh_${GH_VERSION}_linux_${tool_arch}" "/tmp/linux-${tool_arch}"; \
+  mise --version; \
   gh --version; \
   gh pr checks --help | grep -- '--json'; \
   helm version --short; \
-  kustomize version
+  kustomize version; \
+  mise exec helm@3 -- helm version --short
 
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -5,7 +5,13 @@ import { execFileSync } from 'node:child_process'
 
 import { describe, expect, test } from 'vitest'
 
-import { ALL_PI_TOOL_NAMES, buildModelsJson, parseCommandList, resolveConfig } from './config'
+import {
+  ALL_PI_TOOL_NAMES,
+  DEFAULT_REQUIRED_RUNTIME_TOOLS,
+  buildModelsJson,
+  parseCommandList,
+  resolveConfig,
+} from './config'
 import {
   isNoChecksReportedResult,
   isNoRequiredChecksResult,
@@ -33,6 +39,7 @@ import {
   resolveAttemptSessionDir,
   resolveEffectiveSystemPrompt,
 } from './pi-session'
+import { checkRuntimeTool, verifyRequiredRuntimeTools } from './runtime-preflight'
 import {
   buildCommitMessage,
   buildPullRequestTitle,
@@ -55,6 +62,7 @@ describe('Anypi config', () => {
     expect(config.contextWindow).toBe(98304)
     expect(config.maxTokens).toBe(32768)
     expect(config.tools).toEqual([...ALL_PI_TOOL_NAMES])
+    expect(config.requiredTools).toEqual([...DEFAULT_REQUIRED_RUNTIME_TOOLS])
     expect(config.validationPolicy).toBe('append')
     expect(config.noChangeRepairAttempts).toBe(2)
     expect(config.validationRepairAttempts).toBe(2)
@@ -85,6 +93,23 @@ describe('Anypi config', () => {
   test('parses validation commands from newline text or JSON', () => {
     expect(parseCommandList('git diff --check\nbun test')).toEqual(['git diff --check', 'bun test'])
     expect(parseCommandList('["git diff --check","bun test"]')).toEqual(['git diff --check', 'bun test'])
+  })
+
+  test('allows provider config to override required runtime tools', () => {
+    expect(resolveConfig({ ANYPI_REQUIRED_TOOLS: 'git,gh bun' }).requiredTools).toEqual(['git', 'gh', 'bun'])
+  })
+
+  test('checks required runtime tools before model work', async () => {
+    await expect(checkRuntimeTool('sh', process.cwd())).resolves.toMatchObject({ tool: 'sh', ok: true })
+
+    const logs: string[] = []
+    await expect(
+      verifyRequiredRuntimeTools(['sh', 'definitely-missing-anypi-tool'], process.cwd(), async (message) => {
+        logs.push(message)
+      }),
+    ).rejects.toThrow(/runtime preflight failed: missing required tools: definitely-missing-anypi-tool/)
+    expect(logs.some((line) => line.startsWith('runtime tool ready: sh'))).toBe(true)
+    expect(logs.some((line) => line.startsWith('runtime tool missing: definitely-missing-anypi-tool'))).toBe(true)
   })
 
   test('normalizes prompt variants and validation policy from env', () => {
@@ -200,6 +225,7 @@ describe('Anypi prompt contract', () => {
         promptVariant: 'repair-loop',
         promptHash: '0123456789abcdef',
         tools: ['bash', 'edit'],
+        requiredTools: ['bash', 'bun', 'git'],
         sessionFile: '/workspace/.anypi/sessions/initial/session.json',
         validations: [
           {

--- a/services/anypi/src/config.ts
+++ b/services/anypi/src/config.ts
@@ -6,6 +6,19 @@ import { resolvePromptVariant, resolveValidationPolicy } from './prompt'
 import type { AgentRunnerSpecPayload, AgentRunSpecPayload, PromptVariant, ValidationPolicy } from './types'
 
 export const ALL_PI_TOOL_NAMES = ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'] as const
+export const DEFAULT_REQUIRED_RUNTIME_TOOLS = [
+  'bash',
+  'bun',
+  'git',
+  'gh',
+  'jq',
+  'node',
+  'python3',
+  'uv',
+  'mise',
+  'helm',
+  'kustomize',
+] as const
 
 export type AnypiConfig = {
   workspace: string
@@ -30,6 +43,7 @@ export type AnypiConfig = {
   contextWindow: number
   maxTokens: number
   tools: string[]
+  requiredTools: string[]
   allowNoVcs: boolean
   validationCommands: string[]
   validationPolicy: ValidationPolicy
@@ -68,6 +82,15 @@ const parseTools = (raw: string | undefined): string[] => {
     .map((tool) => tool.trim())
     .filter(Boolean)
   return tools.length > 0 ? [...new Set(tools)] : [...ALL_PI_TOOL_NAMES]
+}
+
+const parseRequiredTools = (raw: string | undefined): string[] => {
+  if (!raw?.trim()) return [...DEFAULT_REQUIRED_RUNTIME_TOOLS]
+  const tools = raw
+    .split(/[\s,]+/)
+    .map((tool) => tool.trim())
+    .filter(Boolean)
+  return tools.length > 0 ? [...new Set(tools)] : [...DEFAULT_REQUIRED_RUNTIME_TOOLS]
 }
 
 export const parseCommandList = (raw: string | undefined): string[] => {
@@ -120,6 +143,7 @@ export const resolveConfig = (env: NodeJS.ProcessEnv = process.env): AnypiConfig
     contextWindow: readNumber(env, 'ANYPI_CONTEXT_WINDOW', 98304),
     maxTokens: readNumber(env, 'ANYPI_MAX_TOKENS', 32768),
     tools: parseTools(env.ANYPI_TOOLS),
+    requiredTools: parseRequiredTools(env.ANYPI_REQUIRED_TOOLS),
     allowNoVcs: readBoolean(env, 'ANYPI_ALLOW_NO_VCS', false),
     validationCommands: parseCommandList(env.ANYPI_VALIDATION_COMMANDS),
     validationPolicy: resolveValidationPolicy(env.ANYPI_VALIDATION_POLICY),

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { applyRunnerArtifacts, loadRunnerSpec, loadRunSpec, resolveConfig, type AnypiConfig } from './config'
 import { createLogger } from './logger'
 import { runPiAgent } from './pi-session'
+import { verifyRequiredRuntimeTools } from './runtime-preflight'
 import {
   buildAgentPrompt,
   buildCiRepairPrompt,
@@ -172,6 +173,7 @@ const baseStatus = (
   promptVariant: config.promptVariant,
   promptHash: hashSystemPrompt(config.promptVariant),
   tools: [],
+  requiredTools: config.requiredTools,
   validations: [],
   validationPlan,
   agentAttempts: 0,
@@ -280,6 +282,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
     if (runSpec.systemPrompt && !config.allowSystemPromptOverride) {
       await logger.info('run systemPrompt ignored because ANYPI_ALLOW_SYSTEM_PROMPT_OVERRIDE is false')
     }
+    await verifyRequiredRuntimeTools(config.requiredTools, config.workspace, logger.info)
     await prepareRepository(config, git, logger.info)
     await waitForModelEndpoint(config, logger.info)
     const prompt = buildAgentPrompt(runSpec, config.worktree)

--- a/services/anypi/src/runtime-preflight.ts
+++ b/services/anypi/src/runtime-preflight.ts
@@ -1,0 +1,60 @@
+import { runCommand } from './command'
+
+export type RuntimeToolCheck = {
+  tool: string
+  ok: boolean
+  path?: string
+  error?: string
+}
+
+const TOOL_NAME_PATTERN = /^[A-Za-z0-9._+-]+$/
+
+const assertToolName = (tool: string) => {
+  if (!TOOL_NAME_PATTERN.test(tool)) {
+    throw new Error(`invalid runtime tool name: ${tool}`)
+  }
+}
+
+export const checkRuntimeTool = async (
+  tool: string,
+  cwd: string,
+  env?: Record<string, string | undefined>,
+): Promise<RuntimeToolCheck> => {
+  assertToolName(tool)
+  const result = await runCommand('sh', ['-lc', `command -v ${tool}`], {
+    cwd,
+    env,
+    allowFailure: true,
+  })
+  const path = result.stdout.trim()
+  return result.exitCode === 0 && path
+    ? { tool, ok: true, path }
+    : { tool, ok: false, error: (result.stderr || result.stdout || `missing ${tool}`).trim() }
+}
+
+export const verifyRequiredRuntimeTools = async (
+  tools: string[],
+  cwd: string,
+  log: (message: string) => Promise<void>,
+  env?: Record<string, string | undefined>,
+) => {
+  const checks: RuntimeToolCheck[] = []
+  for (const tool of tools) {
+    const check = await checkRuntimeTool(tool, cwd, env)
+    checks.push(check)
+    await log(
+      check.ok
+        ? `runtime tool ready: ${check.tool} (${check.path})`
+        : `runtime tool missing: ${check.tool}${check.error ? ` (${check.error})` : ''}`,
+    )
+  }
+
+  const missing = checks.filter((check) => !check.ok)
+  if (missing.length > 0) {
+    throw new Error(
+      `runtime preflight failed: missing required tools: ${missing.map((check) => check.tool).join(', ')}`,
+    )
+  }
+
+  return checks
+}

--- a/services/anypi/src/types.ts
+++ b/services/anypi/src/types.ts
@@ -124,6 +124,7 @@ export type AnypiStatus = {
   promptVariant: PromptVariant
   promptHash: string
   tools: string[]
+  requiredTools: string[]
   sessionFile?: string
   sessionFiles?: string[]
   commit?: string


### PR DESCRIPTION
## Summary

- Adds an Anypi startup preflight that verifies required runtime tools before clone/model work.
- Installs pinned mise in the multi-arch Anypi image and prewarms Helm 3 through mise during image build.
- Pins both Anypi providers to the verified linux/amd64,linux/arm64 preflight image digest and updates operator docs.

## Related Issues

None

## Testing

- `GIT_CONFIG_COUNT=3 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=tag.gpgSign GIT_CONFIG_VALUE_1=false GIT_CONFIG_KEY_2=gpg.format GIT_CONFIG_VALUE_2=openpgp bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi tsc`
- `bunx oxfmt --check services/anypi/src services/anypi/Dockerfile argocd/applications/agents/anypi-agentprovider.yaml argocd/applications/agents/anypi-eval-agentprovider.yaml docs/agents/anypi.md`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `bun run lint:argocd`
- `git diff --check`
- `crane manifest registry.ide-newton.ts.net/lab/anypi:62cf896ec | jq -e '[.manifests[] | select(.platform.os=="linux") | .platform.architecture] | sort == ["amd64","arm64"]'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
