### PR TITLE
fix(anypi): remove runtime details from PR bodies

### DIFF
--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:62cf896ec@sha256:d318d97629e8a1b39e05935b706dfefa8a912fb28e585a564c21c6f2da175af9
+    image: registry.ide-newton.ts.net/lab/anypi:6a8639415@sha256:7ba681e01392f0691903f2f02d37dfc3aadc7da3c968fb644af6a71c581b301c
   adapter:
     type: exec
   envTemplate:

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:62cf896ec@sha256:d318d97629e8a1b39e05935b706dfefa8a912fb28e585a564c21c6f2da175af9
+    image: registry.ide-newton.ts.net/lab/anypi:6a8639415@sha256:7ba681e01392f0691903f2f02d37dfc3aadc7da3c968fb644af6a71c581b301c
   adapter:
     type: exec
   envTemplate:

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ harness against the self-hosted Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:62cf896ec@sha256:d318d97629e8a1b39e05935b706dfefa8a912fb28e585a564c21c6f2da175af9`
+- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:6a8639415@sha256:7ba681e01392f0691903f2f02d37dfc3aadc7da3c968fb644af6a71c581b301c`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen36-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -200,14 +200,14 @@ describe('Anypi prompt contract', () => {
       'improve torghut diff coverage',
     )
     expect(buildCommitMessage({ implementation: { summary: 'Improve Torghut Diff Coverage' } })).toBe(
-      'feat(anypi): improve torghut diff coverage',
+      'feat: improve torghut diff coverage',
     )
     expect(buildPullRequestTitle({ implementation: { summary: 'Improve Torghut Diff Coverage' } })).toBe(
-      'feat(anypi): improve torghut diff coverage',
+      'feat: improve torghut diff coverage',
     )
   })
 
-  test('renders PR bodies from the repository template without placeholders', () => {
+  test('renders PR bodies from the repository template without runtime leakage or placeholders', () => {
     const body = renderPullRequestBody({
       runSpec: { implementation: { summary: 'Improve Anypi PR body rendering' } },
       status: {
@@ -291,10 +291,17 @@ describe('Anypi prompt contract', () => {
 
     expect(body).toContain('## Summary')
     expect(body).toContain('## Testing')
-    expect(body).toContain('Prompt variant: `repair-loop` (`0123456789abcdef`)')
+    expect(body).toContain('- Improve Anypi PR body rendering.')
+    expect(body).toContain('- Validation commands and CI status are listed below.')
     expect(body).toContain('bun run --filter @proompteng/anypi test')
     expect(body).toContain('- CI: passed: 2 passed/skipped, 0 pending, 0 failed/cancelled')
     expect(body).toContain('- [x] Testing section documents the exact validation performed.')
+    expect(body).not.toContain('Generated for')
+    expect(body).not.toContain('Prompt variant')
+    expect(body).not.toContain('Session artifact')
+    expect(body).not.toContain('anypi-eval-runner-repair-20260616')
+    expect(body).not.toContain('0123456789abcdef')
+    expect(body).not.toContain('/workspace/.anypi/sessions')
     expect(body).not.toContain('<!--')
     expect(body).not.toContain('[ ]')
     expect(body).not.toMatch(/TODO|TBD|<\.\.\.>/)

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -57,13 +57,13 @@ const writeStatus = async (path: string, status: AnypiStatus) => {
 
 export const buildCommitMessage = (runSpec: AgentRunSpecPayload) => {
   const summary = runSpec.implementation?.summary?.trim() || runSpec.issueTitle?.trim() || runSpec.agentRun?.name
-  return `feat(anypi): ${normalizeConventionalSummary(summary, 'implement agent task')}`
+  return `feat: ${normalizeConventionalSummary(summary, 'implement agent task')}`
 }
 
 export const buildPullRequestTitle = (runSpec: AgentRunSpecPayload) => {
   const title =
     process.env.VCS_PR_TITLE_TEMPLATE?.trim() || runSpec.issueTitle?.trim() || runSpec.implementation?.summary?.trim()
-  return `feat(anypi): ${normalizeConventionalSummary(title, 'apply autonomous agent changes')}`
+  return `feat: ${normalizeConventionalSummary(title, 'apply autonomous agent changes')}`
 }
 
 const DEFAULT_PULL_REQUEST_HEADINGS = [
@@ -94,6 +94,14 @@ const validationSummary = (status: AnypiStatus) => {
   return `${validations || '- N/A'}\n- CI: ${ci}`
 }
 
+const pullRequestSummary = (runSpec: AgentRunSpecPayload) => {
+  const rawSummary = runSpec.implementation?.summary?.trim() || runSpec.issueTitle?.trim()
+  const summary = rawSummary
+    ? rawSummary.replace(/\s+/g, ' ').replace(/[.。]+$/g, '')
+    : 'Implemented the requested repository changes'
+  return [`- ${summary}.`, '- Validation commands and CI status are listed below.'].join('\n')
+}
+
 export const renderPullRequestBody = (input: {
   runSpec: AgentRunSpecPayload
   status: AnypiStatus
@@ -102,14 +110,7 @@ export const renderPullRequestBody = (input: {
   template?: string
 }) => {
   const sections = new Map([
-    [
-      'summary',
-      [
-        `- Generated for ${input.status.namespace ?? 'agents'}/${input.status.runName ?? 'unknown'}.`,
-        `- Prompt variant: \`${input.status.promptVariant}\` (\`${input.status.promptHash}\`).`,
-        `- Session artifact: \`${input.status.sessionFile ?? 'N/A'}\`.`,
-      ].join('\n'),
-    ],
+    ['summary', pullRequestSummary(input.runSpec)],
     ['related issues', 'None'],
     ['testing', validationSummary(input.status)],
     ['screenshots (if applicable)', 'N/A'],


### PR DESCRIPTION
## Summary

- Removes Anypi runtime metadata from generated PR bodies.
- Stops default generated commit/PR titles from hardcoding the `anypi` scope for unrelated repositories or services.
- Pins both Anypi providers to the verified multi-arch image containing the PR-body fix.

## Related Issues

None

## Testing

- `GIT_CONFIG_COUNT=3 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=tag.gpgSign GIT_CONFIG_VALUE_1=false GIT_CONFIG_KEY_2=gpg.format GIT_CONFIG_VALUE_2=openpgp bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi tsc`
- `bunx oxfmt --check services/anypi/src/run.ts services/anypi/src/config.test.ts argocd/applications/agents/anypi-agentprovider.yaml argocd/applications/agents/anypi-eval-agentprovider.yaml docs/agents/anypi.md`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `bun run lint:argocd`
- `git diff --check`
- `crane manifest registry.ide-newton.ts.net/lab/anypi:6a8639415 | jq -e '[.manifests[] | select(.platform.os=="linux") | .platform.architecture] | sort == ["amd64","arm64"]'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
