### PR TITLE
feat: harden flamingo hard-migration validator coverage for qwen3.6 serving invariants

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,7 @@ on:
       - 'apps/**'
       - 'packages/**'
       - 'services/**'
+      - 'scripts/**'
 
 permissions:
   contents: read
@@ -29,6 +30,7 @@ jobs:
       bonjour: ${{ steps.filter.outputs.bonjour }}
       codex: ${{ steps.filter.outputs.codex }}
       discord: ${{ steps.filter.outputs.discord }}
+      scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - name: Check changed files
         id: filter
@@ -78,6 +80,7 @@ jobs:
           output_flag reviseur '^apps/reviseur/'
           output_flag codex '^packages/codex/'
           output_flag discord '^packages/discord/'
+          output_flag scripts '^scripts/'
 
   docs:
     needs: check_changed_files
@@ -465,3 +468,20 @@ jobs:
 
       - run: bun run build
         working-directory: apps/reviseur
+
+  scripts:
+    needs: check_changed_files
+    if: ${{ needs.check_changed_files.outputs.scripts == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Test scripts
+        run: bun test scripts/jangar

--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  checkForbiddenTerms,
+  checkRequiredTerms,
+  FORBIDDEN_TERMS,
+  readTargetFiles,
+  REQUIRED_TERMS,
+  TARGET_FILES,
+  validateFlamingoHardMigration,
+} from './validate-flamingo-hard-migration'
+
+// ── Forbidden-term rejection ─────────────────────────────────────────────────
+
+describe('forbidden terms', () => {
+  test('rejects old Qwen3-Coder model references', () => {
+    const surface = { path: 'test.yaml', content: 'Qwen/Qwen3-Coder-Next-FP8' }
+    const failures = checkForbiddenTerms(surface, FORBIDDEN_TERMS)
+    expect(failures.length).toBeGreaterThan(0)
+    expect(failures[0]).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    expect(failures[0]).toContain('test.yaml')
+  })
+
+  test('rejects the old served alias qwen3-coder-flamingo', () => {
+    const surface = { path: 'deployment.yaml', content: '--served-model-name qwen3-coder-flamingo' }
+    const failures = checkForbiddenTerms(surface, FORBIDDEN_TERMS)
+    expect(failures).toContain(
+      'deployment.yaml: still contains forbidden Flamingo migration term "qwen3-coder-flamingo"',
+    )
+  })
+
+  test('rejects old Qwen3-Coder 30B model', () => {
+    const surface = { path: 'config.yaml', content: 'Qwen/Qwen3-Coder-30B-A3B-Instruct' }
+    const failures = checkForbiddenTerms(surface, FORBIDDEN_TERMS)
+    expect(failures.length).toBeGreaterThan(0)
+  })
+
+  test('rejects hermes as a reasoning parser', () => {
+    const surface = { path: 'openwebui-values.yaml', content: '--reasoning-parser hermes' }
+    const failures = checkForbiddenTerms(surface, FORBIDDEN_TERMS)
+    expect(failures).toContain('openwebui-values.yaml: still contains forbidden Flamingo migration term "hermes"')
+  })
+})
+
+// ── Required-term enforcement ────────────────────────────────────────────────
+
+describe('required terms', () => {
+  test('requires unsloth/Qwen3.6-35B-A3B-NVFP4', () => {
+    const surfaces: { path: string; content: string }[] = [{ path: 'a.yaml', content: 'nothing here' }]
+    const failures = checkRequiredTerms(surfaces, REQUIRED_TERMS)
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "unsloth/Qwen3.6-35B-A3B-NVFP4"')
+  })
+
+  test('requires qwen36-flamingo served alias', () => {
+    const surfaces = [{ path: 'a.yaml', content: 'other model name' }]
+    const failures = checkRequiredTerms(surfaces, REQUIRED_TERMS)
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "qwen36-flamingo"')
+  })
+
+  test('requires qwen3 reasoning parser', () => {
+    const surfaces = [{ path: 'a.yaml', content: 'no reasoning parser' }]
+    const failures = checkRequiredTerms(surfaces, REQUIRED_TERMS)
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "qwen3"')
+  })
+
+  test('requires qwen3_coder tool-call parser', () => {
+    const surfaces = [{ path: 'a.yaml', content: 'tool call parser' }]
+    const failures = checkRequiredTerms(surfaces, REQUIRED_TERMS)
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "qwen3_coder"')
+  })
+})
+
+// ── Composite validation ─────────────────────────────────────────────────────
+
+describe('full validation', () => {
+  test('rejects stale terms and missing required terms together', () => {
+    const surfaces = [
+      { path: 'deploy.yaml', content: 'hermes qwen3-coder-flamingo' },
+      { path: 'other.yaml', content: 'no required terms at all' },
+    ]
+    const result = validateFlamingoHardMigration(surfaces)
+    expect(result.failures.length).toBeGreaterThan(0)
+    expect(result.failures.some((f) => f.includes('hermes'))).toBe(true)
+    expect(result.failures.some((f) => f.includes('qwen3-coder-flamingo'))).toBe(true)
+    expect(result.failures.some((f) => f.includes('unsloth/Qwen3.6-35B-A3B-NVFP4'))).toBe(true)
+  })
+
+  test('returns clean result when all invariants hold', () => {
+    const surfaces = [
+      {
+        path: 'deployment.yaml',
+        content: [
+          'unsloth/Qwen3.6-35B-A3B-NVFP4',
+          'qwen36-flamingo',
+          '--reasoning-parser qwen3',
+          '--tool-call-parser qwen3_coder',
+        ].join('\n'),
+      },
+    ]
+    const result = validateFlamingoHardMigration(surfaces)
+    expect(result.failures).toEqual([])
+  })
+
+  test('reports file path in forbidden-term failures', () => {
+    const surfaces = [{ path: 'argocd/applications/flamingo/deployment.yaml', content: 'qwen3-coder-flamingo' }]
+    const result = validateFlamingoHardMigration(surfaces)
+    // Forbidden term failures include file path and the term
+    const forbiddenFailures = result.failures.filter((f) => f.includes('forbidden Flamingo migration term'))
+    expect(forbiddenFailures.length).toBeGreaterThan(0)
+    for (const failure of forbiddenFailures) {
+      expect(failure).toContain('argocd/applications/flamingo/deployment.yaml')
+      expect(failure).toContain('qwen3-coder-flamingo')
+    }
+  })
+})
+
+// ── Current repository surfaces acceptance ───────────────────────────────────
+
+describe('current repository surfaces', () => {
+  test('all target files are resolved', async () => {
+    expect(TARGET_FILES.length).toBeGreaterThan(0)
+  })
+
+  test('reading target files from disk succeeds for every surface', async () => {
+    const surfaces = await readTargetFiles(TARGET_FILES)
+    expect(surfaces.length).toBe(TARGET_FILES.length)
+    for (const surface of surfaces) {
+      expect(surface.content.length).toBeGreaterThan(0)
+      expect(surface.path.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('all target files pass the full validation', async () => {
+    const surfaces = await readTargetFiles(TARGET_FILES)
+    const result = validateFlamingoHardMigration(surfaces)
+    expect(result.failures.length).toBe(0)
+  })
+})

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -2,15 +2,18 @@
 
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
-const forbiddenTerms = [
+// ── Data-driven validation configuration ─────────────────────────────────────
+
+export const REQUIRED_TERMS = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder'] as const
+
+export const FORBIDDEN_TERMS = [
   'Qwen/Qwen3-Coder-Next-FP8',
   'qwen3-coder-flamingo',
   'Qwen/Qwen3-Coder-30B-A3B-Instruct',
   'hermes',
-]
+] as const
 
-const targetFiles = [
+export const TARGET_FILES = [
   'argocd/applications/flamingo/deployment.yaml',
   'argocd/applications/flamingo/README.md',
   'argocd/applications/flamingo/docs/large-model-multigpu.md',
@@ -23,33 +26,87 @@ const targetFiles = [
   'scripts/jangar/validate-pi-flamingo-compaction.ts',
   'services/anypi/src/config.ts',
   'services/anypi/src/config.test.ts',
-]
+] as const
 
-const failures: string[] = []
+// ── Pure validation helpers ──────────────────────────────────────────────────
 
-for (const file of targetFiles) {
-  const content = await readFile(file, 'utf8')
+export interface SurfaceFile {
+  path: string
+  content: string
+}
 
-  for (const term of forbiddenTerms) {
-    if (content.includes(term)) {
-      failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
+export interface ValidationResult {
+  failures: string[]
+  surfaces: SurfaceFile[]
+}
+
+/**
+ * Read all target files and return their contents for inspection.
+ */
+export async function readTargetFiles(files: readonly string[]): Promise<SurfaceFile[]> {
+  const readOne = async (file: string): Promise<SurfaceFile> => ({
+    path: file,
+    content: await readFile(file, 'utf8'),
+  })
+  return Promise.all(files.map(readOne))
+}
+
+/**
+ * Check forbidden terms against a single file's content.
+ * Returns an array of failure strings; empty means clean.
+ */
+export function checkForbiddenTerms(file: SurfaceFile, forbiddenTerms: readonly string[]): string[] {
+  return forbiddenTerms.reduce<string[]>((acc, term) => {
+    if (file.content.includes(term)) {
+      acc.push(`${file.path}: still contains forbidden Flamingo migration term "${term}"`)
+    }
+    return acc
+  }, [])
+}
+
+/**
+ * Check that the combined content of all surfaces contains every required term.
+ * Returns an array of failure strings; empty means clean.
+ */
+export function checkRequiredTerms(surfaces: SurfaceFile[], requiredTerms: readonly string[]): string[] {
+  const combined = surfaces.map((s) => s.content).join('\n')
+  const missing: string[] = []
+  for (const term of requiredTerms) {
+    if (!combined.includes(term)) {
+      missing.push(`active Flamingo surfaces do not contain required term "${term}"`)
     }
   }
+  return missing
 }
 
-const combined = await Promise.all(targetFiles.map(async (file) => await readFile(file, 'utf8'))).then((parts) =>
-  parts.join('\n'),
-)
-
-for (const term of requiredTerms) {
-  if (!combined.includes(term)) {
-    failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+/**
+ * Run the full hard-migration validation over a set of surfaces.
+ * Returns `{ failures }` — empty means migration is clean.
+ */
+export function validateFlamingoHardMigration(surfaces: SurfaceFile[]): ValidationResult {
+  const forbiddenFailures: string[] = []
+  for (const surface of surfaces) {
+    forbiddenFailures.push(...checkForbiddenTerms(surface, FORBIDDEN_TERMS))
+  }
+  const requiredFailures = checkRequiredTerms(surfaces, REQUIRED_TERMS)
+  return {
+    failures: [...forbiddenFailures, ...requiredFailures],
+    surfaces,
   }
 }
 
-if (failures.length > 0) {
-  console.error(failures.join('\n'))
-  process.exit(1)
+// ── CLI entry point ──────────────────────────────────────────────────────────
+
+export async function main(): Promise<void> {
+  const surfaces = await readTargetFiles(TARGET_FILES)
+  const result = validateFlamingoHardMigration(surfaces)
+
+  if (result.failures.length > 0) {
+    console.error(result.failures.join('\n'))
+    process.exit(1)
+  }
+
+  console.log(`validated ${TARGET_FILES.length} Flamingo hard-migration surfaces`)
 }
 
-console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
+await main()


### PR DESCRIPTION
## Summary

- Harden Flamingo hard-migration validator coverage for Qwen3.6 serving invariants.
- Validation commands and CI status are listed below.

## Related Issues

None

## Testing

- `bash -lc bun test scripts/jangar/validate-flamingo-hard-migration.test.ts` exit 0
- `bash -lc bun run lint:flamingo-hard-migration` exit 0
- `bash -lc mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml` exit 0
- `bash -lc bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts scripts/jangar/validate-flamingo-hard-migration.test.ts package.json` exit 0
- `bash -lc git diff --check` exit 0
- CI: passed: 14 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
