### PR TITLE
feat: repair flamingo hard-migration validator proof quality issues

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,6 +79,7 @@ jobs:
           output_flag reviseur '^apps/reviseur/'
           output_flag codex '^packages/codex/'
           output_flag discord '^packages/discord/'
+          output_flag scripts '^scripts/'
 
   docs:
     needs: check_changed_files
@@ -466,3 +467,27 @@ jobs:
 
       - run: bun run build
         working-directory: apps/reviseur
+
+  scripts:
+    needs: check_changed_files
+    if: ${{ needs.check_changed_files.outputs.scripts == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.11.1
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Format check
+        run: bunx oxfmt --check scripts/**
+
+      - name: Oxlint
+        run: bun run lint:oxlint
+
+      - name: Run scripts tests
+        run: bun test scripts/

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,7 @@ on:
       - 'apps/**'
       - 'packages/**'
       - 'services/**'
+      - 'scripts/**'
 
 permissions:
   contents: read

--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test'
+
+import { checkForbiddenTerms, checkRequiredTerms, validateMigration } from './validate-flamingo-hard-migration'
+
+describe('validate-flamingo-hard-migration', () => {
+  test('importing the module produces no stdout or stderr output', async () => {
+    let capturedStdout = ''
+    let capturedStderr = ''
+    let exitCode: number | undefined
+
+    const originalExit = process.exit
+    const originalWrite = process.stdout.write
+    const originalWriteErr = process.stderr.write
+
+    process.stdout.write = (chunk: string | Uint8Array | Buffer) => {
+      capturedStdout += String(chunk)
+      return true
+    }
+    process.stderr.write = (chunk: string | Uint8Array | Buffer) => {
+      capturedStderr += String(chunk)
+      return true
+    }
+    const _originalExit = process.exit
+    process.exit = ((_code?: number) => {
+      exitCode = _code
+    }) as never
+
+    await import('./validate-flamingo-hard-migration')
+
+    process.stdout.write = originalWrite
+    process.stderr.write = originalWriteErr
+    process.exit = originalExit
+
+    expect(capturedStdout).toBe('')
+    expect(capturedStderr).toBe('')
+    expect(exitCode).toBeUndefined()
+  })
+
+  test('checkForbiddenTerms catches stale Qwen3-Coder model reference', () => {
+    const result = checkForbiddenTerms('Qwen/Qwen3-Coder-Next-FP8', 'test.yaml')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    expect(result[0]).toContain('test.yaml')
+  })
+
+  test('checkForbiddenTerms catches old served alias qwen3-coder-flamingo', () => {
+    const result = checkForbiddenTerms('qwen3-coder-flamingo', 'test.yaml')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('qwen3-coder-flamingo')
+  })
+
+  test('checkForbiddenTerms catches stale hermes reference', () => {
+    const result = checkForbiddenTerms('hermes', 'test.yaml')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('hermes')
+  })
+
+  test('checkForbiddenTerms catches stale qwen3_xml reference', () => {
+    const result = checkForbiddenTerms('qwen3_xml', 'test.yaml')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('qwen3_xml')
+  })
+
+  test('checkForbiddenTerms catches Qwen/Qwen3-Coder-30B-A3B-Instruct', () => {
+    const result = checkForbiddenTerms('Qwen/Qwen3-Coder-30B-A3B-Instruct', 'test.yaml')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('Qwen/Qwen3-Coder-30B-A3B-Instruct')
+  })
+
+  test('checkForbiddenTerms returns empty for clean content', () => {
+    const result = checkForbiddenTerms(
+      'unsloth/Qwen3.6-35B-A3B-NVFP4\nqwen36-flamingo\nqwen3\nqwen3_coder',
+      'test.yaml',
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  test('checkForbiddenTerms catches all forbidden terms in one file', () => {
+    const content = 'qwen3-coder-flamingo\nhermes\nqwen3_xml'
+    const result = checkForbiddenTerms(content, 'test.yaml')
+    expect(result.length).toBeGreaterThanOrEqual(3)
+    expect(result).toEqual(
+      expect.arrayContaining([expect.stringContaining('qwen3-coder-flamingo'), expect.stringContaining('hermes')]),
+    )
+  })
+
+  test('checkRequiredTerms catches missing required terms', () => {
+    // 'qwen36-flamingo' contains 'qwen3' as substring, so only 2 are truly missing
+    const result = checkRequiredTerms([{ path: 'a', content: 'qwen36-flamingo' }])
+    expect(result.length).toBe(2)
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('unsloth/Qwen3.6-35B-A3B-NVFP4'),
+        expect.stringContaining('qwen3_coder'),
+      ]),
+    )
+  })
+
+  test('checkRequiredTerms passes when all required terms present', () => {
+    const combined = 'unsloth/Qwen3.6-35B-A3B-NVFP4\nqwen36-flamingo\nqwen3\nqwen3_coder'
+    const result = checkRequiredTerms([{ path: 'a', content: combined }])
+    expect(result).toHaveLength(0)
+  })
+
+  test('validateMigration detects forbidden terms', async () => {
+    const files = [
+      { path: 'a.yaml', read: () => Promise.resolve('qwen3-coder-flamingo') },
+      { path: 'b.yaml', read: () => Promise.resolve('unsloth/Qwen3.6-35B-A3B-NVFP4') },
+    ]
+    const errors = await validateMigration(files)
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+    expect(errors.some((e) => e.includes('qwen3-coder-flamingo'))).toBe(true)
+  })
+
+  test('validateMigration detects missing required terms', async () => {
+    const files = [
+      { path: 'a.yaml', read: () => Promise.resolve('hermes') },
+      { path: 'b.yaml', read: () => Promise.resolve('qwen36-flamingo') },
+    ]
+    const errors = await validateMigration(files)
+    expect(errors.length).toBeGreaterThanOrEqual(3)
+    expect(errors.some((e) => e.includes('unsloth/Qwen3.6-35B-A3B-NVFP4'))).toBe(true)
+  })
+
+  test('validateMigration passes for fully compliant files', async () => {
+    const model = 'unsloth/Qwen3.6-35B-A3B-NVFP4'
+    const served = 'qwen36-flamingo'
+    const reasoning = 'qwen3'
+    const toolParser = 'qwen3_coder'
+    const allContent = `${model}\n${served}\n${reasoning}\n${toolParser}`
+
+    const files = [
+      { path: 'a.yaml', read: () => Promise.resolve(allContent) },
+      { path: 'b.yaml', read: () => Promise.resolve(allContent) },
+      { path: 'c.yaml', read: () => Promise.resolve(allContent) },
+    ]
+    const errors = await validateMigration(files)
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -2,15 +2,17 @@
 
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
-const forbiddenTerms = [
+const REQUIRED_TERMS = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
+
+const FORBIDDEN_TERMS = [
   'Qwen/Qwen3-Coder-Next-FP8',
   'qwen3-coder-flamingo',
   'Qwen/Qwen3-Coder-30B-A3B-Instruct',
   'hermes',
+  'qwen3_xml',
 ]
 
-const targetFiles = [
+const TARGET_FILES = [
   'argocd/applications/flamingo/deployment.yaml',
   'argocd/applications/flamingo/README.md',
   'argocd/applications/flamingo/docs/large-model-multigpu.md',
@@ -25,31 +27,66 @@ const targetFiles = [
   'services/anypi/src/config.test.ts',
 ]
 
-const failures: string[] = []
-
-for (const file of targetFiles) {
-  const content = await readFile(file, 'utf8')
-
-  for (const term of forbiddenTerms) {
+export function checkForbiddenTerms(content: string, filePath: string): string[] {
+  const errors: string[] = []
+  for (const term of FORBIDDEN_TERMS) {
     if (content.includes(term)) {
-      failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
+      errors.push(`${filePath}: still contains forbidden Flamingo migration term "${term}"`)
     }
   }
+  return errors
 }
 
-const combined = await Promise.all(targetFiles.map(async (file) => await readFile(file, 'utf8'))).then((parts) =>
-  parts.join('\n'),
-)
-
-for (const term of requiredTerms) {
-  if (!combined.includes(term)) {
-    failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+export function checkRequiredTerms(filePaths: { path: string; content: string }[]): string[] {
+  const combined = filePaths.map((f) => f.content).join('\n')
+  const errors: string[] = []
+  for (const term of REQUIRED_TERMS) {
+    if (!combined.includes(term)) {
+      errors.push(`active Flamingo surfaces do not contain required term "${term}"`)
+    }
   }
+  return errors
 }
 
-if (failures.length > 0) {
-  console.error(failures.join('\n'))
-  process.exit(1)
+export async function validateMigration(files: { path: string; read: () => Promise<string> }[]): Promise<string[]> {
+  const failures: string[] = []
+
+  for (const file of files) {
+    const content = await file.read()
+    failures.push(...checkForbiddenTerms(content, file.path))
+  }
+
+  const filesWithContent = files.map((f) => ({
+    path: f.path,
+    content: null as string | null,
+  }))
+
+  // Read all content first
+  for (const file of files) {
+    const entry = filesWithContent.find((f) => f.path === file.path)
+    if (entry) entry.content = await file.read()
+  }
+
+  const validEntries = filesWithContent.filter((f) => f.content !== null) as { path: string; content: string }[]
+  failures.push(...checkRequiredTerms(validEntries))
+
+  return failures
 }
 
-console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
+export async function main(): Promise<void> {
+  const files = TARGET_FILES.map((path) => ({
+    path,
+    read: () => readFile(path, 'utf8'),
+  }))
+
+  const failures = await validateMigration(files)
+
+  if (failures.length > 0) {
+    console.error(failures.join('\n'))
+    process.exit(1)
+  }
+
+  console.log(`validated ${TARGET_FILES.length} Flamingo hard-migration surfaces`)
+}
+
+if (import.meta.main) await main()


### PR DESCRIPTION
## Summary

- Repair Flamingo hard-migration validator proof quality issues.
- Validation commands and CI status are listed below.

## Related Issues

None

## Testing

- `bash -lc bun test scripts/jangar/validate-flamingo-hard-migration.test.ts` exit 0
- `bash -lc bash -lc 'out="$(bun -e "await import(\"./scripts/jangar/validate-flamingo-hard-migration.ts\")" 2>&1)"; test -z "$out"'` exit 0
- `bash -lc bun run lint:flamingo-hard-migration` exit 0
- `bash -lc mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml` exit 0
- `bash -lc python3 -c "from pathlib import Path; paths=[Path('scripts/jangar/validate-flamingo-hard-migration.ts'), Path('scripts/jangar/validate-flamingo-hard-migration.test.ts')]; bad=[str(p) for p in paths if any(ord(ch)>127 for ch in p.read_text())]; assert not bad, bad"` exit 0
- `bash -lc bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts scripts/jangar/validate-flamingo-hard-migration.test.ts .github/workflows/pull-request.yml package.json` exit 0
- `bash -lc git diff --check` exit 0
- CI: passed: 14 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
