### PR TITLE
fix(flamingo): hard-migration validator hardening with import-safe helpers and scripts CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,7 @@ on:
       - 'apps/**'
       - 'packages/**'
       - 'services/**'
+      - 'scripts/**'
 
 permissions:
   contents: read
@@ -29,6 +30,7 @@ jobs:
       bonjour: ${{ steps.filter.outputs.bonjour }}
       codex: ${{ steps.filter.outputs.codex }}
       discord: ${{ steps.filter.outputs.discord }}
+      scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - name: Check changed files
         id: filter
@@ -78,6 +80,7 @@ jobs:
           output_flag reviseur '^apps/reviseur/'
           output_flag codex '^packages/codex/'
           output_flag discord '^packages/discord/'
+          output_flag scripts '^scripts/'
 
   docs:
     needs: check_changed_files
@@ -348,6 +351,35 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       # codex CI handled by dedicated workflow (.github/workflows/codex-ci.yml)
+
+  scripts:
+    needs: check_changed_files
+    if: ${{ needs.check_changed_files.outputs.scripts == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.14-
+
+      - run: bun install --frozen-lockfile
+
+      - name: Run Bun format check
+        run: bunx oxfmt --check scripts/
+
+      - name: Validate flamingo hard-migration
+        run: bun run lint:flamingo-hard-migration
+
+      - name: Test flamingo hard-migration validator
+        run: bun test scripts/jangar/validate-flamingo-hard-migration.test.ts
 
   discord:
     needs: check_changed_files

--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  validateForbiddenTerms,
+  validateFlamingoHardMigration,
+  validateRequiredTerms,
+} from './validate-flamingo-hard-migration'
+
+const FORBIDDEN_TERMS = [
+  'Qwen/Qwen3-Coder-Next-FP8',
+  'qwen3-coder-flamingo',
+  'Qwen/Qwen3-Coder-30B-A3B-Instruct',
+  'hermes',
+  'qwen3_xml',
+]
+
+const REQUIRED_TERMS = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
+
+describe('validateFlamingoHardMigration', () => {
+  test('passes when all target files are clean', async () => {
+    const result = await validateFlamingoHardMigration()
+    expect(result.success).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+})
+
+describe('validateRequiredTerms', () => {
+  test('returns empty array when all terms are present', () => {
+    const combined = REQUIRED_TERMS.join('\n')
+    const results = validateRequiredTerms(combined, REQUIRED_TERMS)
+    expect(results).toEqual([])
+  })
+
+  test('reports all terms as missing when none present', () => {
+    const results = validateRequiredTerms('no match', REQUIRED_TERMS)
+    expect(results.length).toBe(REQUIRED_TERMS.length)
+    for (const r of results) {
+      expect(r.type).toBe('missing')
+    }
+  })
+
+  test('reports only missing terms', () => {
+    const combined = REQUIRED_TERMS[0] + '\n' + REQUIRED_TERMS[2]
+    const results = validateRequiredTerms(combined, REQUIRED_TERMS)
+    expect(results.length).toBe(2)
+    const missingTerms = results.map((r) => r.term)
+    expect(missingTerms).toContain(REQUIRED_TERMS[1])
+    expect(missingTerms).toContain(REQUIRED_TERMS[3])
+  })
+})
+
+describe('validateForbiddenTerms', () => {
+  test('returns empty array when no forbidden terms found in file contents', () => {
+    const contents = new Map<string, string>([
+      ['file1.txt', 'clean content here'],
+      ['file2.txt', 'more clean text'],
+    ])
+    const results = validateForbiddenTerms(contents, FORBIDDEN_TERMS)
+    expect(results).toEqual([])
+  })
+
+  test('reports each forbidden term found with file path', () => {
+    const contents = new Map<string, string>([
+      ['myfile.txt', 'contains hermes and qwen3-coder-flamingo terms'],
+      ['other.txt', 'clean'],
+    ])
+    const results = validateForbiddenTerms(contents, ['hermes', 'qwen3-coder-flamingo'])
+    expect(results.length).toBe(2)
+    const terms = results.map((r) => r.term)
+    expect(terms).toContain('hermes')
+    expect(terms).toContain('qwen3-coder-flamingo')
+    // Verify file path is attached
+    for (const r of results) {
+      expect(r.file).toBe('myfile.txt')
+    }
+  })
+
+  test('handles empty file map', () => {
+    const contents = new Map<string, string>()
+    const results = validateForbiddenTerms(contents, FORBIDDEN_TERMS)
+    expect(results).toEqual([])
+  })
+})
+
+describe('stale term rejection', () => {
+  test('rejects stale Qwen3-Coder model references', () => {
+    expect(FORBIDDEN_TERMS).toContain('Qwen/Qwen3-Coder-Next-FP8')
+    expect(FORBIDDEN_TERMS).toContain('Qwen/Qwen3-Coder-30B-A3B-Instruct')
+  })
+
+  test('rejects old qwen3-coder-flamingo served alias', () => {
+    expect(FORBIDDEN_TERMS).toContain('qwen3-coder-flamingo')
+  })
+
+  test('rejects hermes as active desired state', () => {
+    expect(FORBIDDEN_TERMS).toContain('hermes')
+  })
+
+  test('rejects stale qwen3_xml', () => {
+    expect(FORBIDDEN_TERMS).toContain('qwen3_xml')
+  })
+})
+
+describe('active state requirements', () => {
+  test('requires qwen36-flamingo served alias', () => {
+    expect(REQUIRED_TERMS).toContain('qwen36-flamingo')
+  })
+
+  test('requires qwen3 reasoning parser', () => {
+    expect(REQUIRED_TERMS).toContain('qwen3')
+  })
+
+  test('requires qwen3_coder tool-call parser', () => {
+    expect(REQUIRED_TERMS).toContain('qwen3_coder')
+  })
+
+  test('requires unsloth model', () => {
+    expect(REQUIRED_TERMS).toContain('unsloth/Qwen3.6-35B-A3B-NVFP4')
+  })
+})

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -2,15 +2,17 @@
 
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
-const forbiddenTerms = [
+const REQUIRED_TERMS = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
+
+const FORBIDDEN_TERMS = [
   'Qwen/Qwen3-Coder-Next-FP8',
   'qwen3-coder-flamingo',
   'Qwen/Qwen3-Coder-30B-A3B-Instruct',
   'hermes',
+  'qwen3_xml',
 ]
 
-const targetFiles = [
+const TARGET_FILES = [
   'argocd/applications/flamingo/deployment.yaml',
   'argocd/applications/flamingo/README.md',
   'argocd/applications/flamingo/docs/large-model-multigpu.md',
@@ -25,31 +27,82 @@ const targetFiles = [
   'services/anypi/src/config.test.ts',
 ]
 
-const failures: string[] = []
+type CheckResult = {
+  file?: string
+  term: string
+  type: 'missing' | 'found'
+}
 
-for (const file of targetFiles) {
-  const content = await readFile(file, 'utf8')
-
-  for (const term of forbiddenTerms) {
-    if (content.includes(term)) {
-      failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
+/**
+ * Check which required terms are absent from the combined content.
+ * Pure function: no I/O.
+ */
+export function validateRequiredTerms(combined: string, terms: readonly string[]): CheckResult[] {
+  const results: CheckResult[] = []
+  for (const term of terms) {
+    if (!combined.includes(term)) {
+      results.push({ term, type: 'missing' })
     }
   }
+  return results
 }
 
-const combined = await Promise.all(targetFiles.map(async (file) => await readFile(file, 'utf8'))).then((parts) =>
-  parts.join('\n'),
-)
+/**
+ * Check which forbidden terms appear in file contents.
+ * Pure function: takes a map of file paths to content strings. No I/O.
+ */
+export function validateForbiddenTerms(fileContents: Map<string, string>, terms: readonly string[]): CheckResult[] {
+  const results: CheckResult[] = []
+  for (const [file, content] of fileContents) {
+    for (const term of terms) {
+      if (content.includes(term)) {
+        results.push({ file, term, type: 'found' })
+      }
+    }
+  }
+  return results
+}
 
-for (const term of requiredTerms) {
-  if (!combined.includes(term)) {
-    failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+/**
+ * Read all target files once, then run required and forbidden term checks.
+ * Pure async I/O with no side effects beyond file reads.
+ */
+export async function validateFlamingoHardMigration(
+  files: readonly string[] = TARGET_FILES,
+  required: readonly string[] = REQUIRED_TERMS,
+  forbidden: readonly string[] = FORBIDDEN_TERMS,
+): Promise<{ success: boolean; errors: string[] }> {
+  const fileContents = new Map<string, string>()
+  for (const file of files) {
+    fileContents.set(file, await readFile(file, 'utf8'))
+  }
+  const forbiddenResults = validateForbiddenTerms(fileContents, forbidden)
+  const combined = [...fileContents.values()].join('\n')
+  const requiredResults = validateRequiredTerms(combined, required)
+
+  const errors: string[] = []
+  for (const r of forbiddenResults) {
+    errors.push(`${r.file}: still contains forbidden Flamingo migration term "${r.term}"`)
+  }
+  for (const r of requiredResults) {
+    errors.push(`active Flamingo surfaces do not contain required term "${r.term}"`)
+  }
+
+  return {
+    success: errors.length === 0,
+    errors,
   }
 }
 
-if (failures.length > 0) {
-  console.error(failures.join('\n'))
-  process.exit(1)
+if (import.meta.main) {
+  await main()
 }
 
-console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
+async function main() {
+  const result = await validateFlamingoHardMigration()
+  if (!result.success) {
+    console.error(result.errors.join('\n'))
+    process.exit(1)
+  }
+  console.log(`validated ${TARGET_FILES.length} Flamingo hard-migration surfaces`)
+}


### PR DESCRIPTION
## Summary

- Refactor `validate-flamingo-hard-migration.ts` into reusable pure validation helpers (`validateRequiredTerms`, `validateForbiddenTerms`) plus a CLI entry point guarded by `import.meta.main`.
- Add `qwen3_xml` to forbidden terms.
- Add focused Bun regression tests for the validator.
- Add `scripts/**` to CI path filter and create a `scripts` job with format check, validation, and test coverage.
- Importing the module has no side effects; CLI only runs when the file is the main module.

## Related Issues

## Testing

- `bun test scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `bash -lc 'out="$(bun -e "await import(\"./scripts/jangar/validate-flamingo-hard-migration.ts\")" 2>&1)"; test -z "$out"'`
- `bun run lint:flamingo-hard-migration`
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts scripts/jangar/validate-flamingo-hard-migration.test.ts .github/workflows/pull-request.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
