### PR TITLE
fix(anypi): include ripgrep in runner preflight

### DIFF
--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:6a8639415@sha256:7ba681e01392f0691903f2f02d37dfc3aadc7da3c968fb644af6a71c581b301c
+    image: registry.ide-newton.ts.net/lab/anypi:85953dd7a@sha256:362b1416b62d6e5461b1ea4214d156edef7e425066c3f886c268650863c7a764
   adapter:
     type: exec
   envTemplate:
@@ -21,7 +21,7 @@ spec:
     ANYPI_CONTEXT_WINDOW: "98304"
     ANYPI_MAX_TOKENS: "32768"
     ANYPI_TOOLS: all
-    ANYPI_REQUIRED_TOOLS: bash,bun,git,gh,jq,node,python3,uv,mise,helm,kustomize
+    ANYPI_REQUIRED_TOOLS: bash,bun,git,gh,jq,node,python3,rg,uv,mise,helm,kustomize
     ANYPI_WORKSPACE: /workspace
     ANYPI_WORKTREE: /workspace/lab
     ANYPI_AGENT_DIR: /workspace/.anypi

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:6a8639415@sha256:7ba681e01392f0691903f2f02d37dfc3aadc7da3c968fb644af6a71c581b301c
+    image: registry.ide-newton.ts.net/lab/anypi:85953dd7a@sha256:362b1416b62d6e5461b1ea4214d156edef7e425066c3f886c268650863c7a764
   adapter:
     type: exec
   envTemplate:
@@ -21,7 +21,7 @@ spec:
     ANYPI_CONTEXT_WINDOW: "98304"
     ANYPI_MAX_TOKENS: "32768"
     ANYPI_TOOLS: all
-    ANYPI_REQUIRED_TOOLS: bash,bun,git,gh,jq,node,python3,uv,mise,helm,kustomize
+    ANYPI_REQUIRED_TOOLS: bash,bun,git,gh,jq,node,python3,rg,uv,mise,helm,kustomize
     ANYPI_WORKSPACE: /workspace
     ANYPI_WORKTREE: /workspace/lab
     ANYPI_AGENT_DIR: /workspace/.anypi

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ harness against the self-hosted Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:6a8639415@sha256:7ba681e01392f0691903f2f02d37dfc3aadc7da3c968fb644af6a71c581b301c`
+- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:85953dd7a@sha256:362b1416b62d6e5461b1ea4214d156edef7e425066c3f886c268650863c7a764`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen36-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`
@@ -30,8 +30,8 @@ Anypi embeds `@earendil-works/pi-coding-agent` with `createAgentSession()`.
 - `ANYPI_TOOLS=all` enables the full built-in coding tool set: `read`, `bash`,
   `edit`, `write`, `grep`, `find`, `ls`.
 - `ANYPI_REQUIRED_TOOLS` is checked before clone/model work. The default image
-  contract includes `bash`, `bun`, `git`, `gh`, `jq`, `node`, `python3`, `uv`,
-  `mise`, `helm`, and `kustomize`.
+  contract includes `bash`, `bun`, `git`, `gh`, `jq`, `node`, `python3`, `rg`,
+  `uv`, `mise`, `helm`, and `kustomize`.
 - `ANYPI_MODEL=qwen36-flamingo` targets the Qwen3.6 NVFP4 Flamingo endpoint.
 - `ANYPI_CONTEXT_WINDOW=98304` and `ANYPI_MAX_TOKENS=32768` fit inside the
   current 128K production serving profile.

--- a/services/anypi/Dockerfile
+++ b/services/anypi/Dockerfile
@@ -62,7 +62,8 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     jq \
     openssh-client \
     python3 \
-    python3-pip; \
+    python3-pip \
+    ripgrep; \
   rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --break-system-packages --no-cache-dir "uv==${UV_VERSION}"
@@ -90,6 +91,7 @@ RUN set -eux; \
   mise --version; \
   gh --version; \
   gh pr checks --help | grep -- '--json'; \
+  rg --version; \
   helm version --short; \
   kustomize version; \
   mise exec helm@3 -- helm version --short

--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -35,6 +35,7 @@ import {
   resolveValidationPlan,
 } from './prompt'
 import {
+  formatToolExecutionSummary,
   isBenignAssistantContinuationError,
   resolveAttemptSessionDir,
   resolveEffectiveSystemPrompt,
@@ -136,6 +137,28 @@ describe('Anypi config', () => {
   test('recognizes the narrow assistant continuation terminal error', () => {
     expect(isBenignAssistantContinuationError(new Error('Cannot continue from message role: assistant'))).toBe(true)
     expect(isBenignAssistantContinuationError(new Error('rate limit'))).toBe(false)
+  })
+
+  test('summarizes tool calls with useful redacted context for runner logs', () => {
+    expect(
+      formatToolExecutionSummary('bash', {
+        command: 'GH_TOKEN=ghp_1234567890123456789012345678901234567890 gh pr checks 123 --watch',
+        timeout: 120,
+      }),
+    ).toBe('command="GH_TOKEN=<redacted> gh pr checks 123 --watch" timeout=120')
+
+    expect(formatToolExecutionSummary('write', { path: 'tmp/result.txt', content: 'secret body' })).toBe(
+      'path="tmp/result.txt" contentChars=11',
+    )
+    expect(formatToolExecutionSummary('edit', { path: 'src/file.ts', edits: [{ oldText: 'a', newText: 'b' }] })).toBe(
+      'path="src/file.ts" edits=1',
+    )
+    expect(formatToolExecutionSummary('grep', { pattern: 'ANYPI_REQUIRED_TOOLS', path: 'argocd' })).toBe(
+      'pattern="ANYPI_REQUIRED_TOOLS" path="argocd"',
+    )
+    expect(formatToolExecutionSummary('custom_tool', { token: 'abc123', action: 'inspect' })).toBe(
+      'token=<redacted> action="inspect"',
+    )
   })
 })
 

--- a/services/anypi/src/config.ts
+++ b/services/anypi/src/config.ts
@@ -14,6 +14,7 @@ export const DEFAULT_REQUIRED_RUNTIME_TOOLS = [
   'jq',
   'node',
   'python3',
+  'rg',
   'uv',
   'mise',
   'helm',

--- a/services/anypi/src/pi-session.ts
+++ b/services/anypi/src/pi-session.ts
@@ -40,6 +40,85 @@ export const resolveAttemptSessionDir = (sessionDir: string, sessionLabel = 'att
   return join(sessionDir, `${safeLabel || 'attempt'}-${randomUUID().slice(0, 8)}`)
 }
 
+const MAX_TOOL_LOG_VALUE_LENGTH = 240
+
+const SENSITIVE_KEY_PATTERN =
+  /(auth|credential|password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key)/i
+
+const redactSensitiveText = (value: string) =>
+  value
+    .replace(
+      /\b([A-Z0-9_]*(?:AUTH|CREDENTIAL|PASSWORD|PASSWD|SECRET|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*)=("[^"]*"|'[^']*'|[^\s]+)/gi,
+      '$1=<redacted>',
+    )
+    .replace(/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/g, '<redacted-github-token>')
+    .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, '<redacted-github-token>')
+    .replace(/\bhf_[A-Za-z0-9_]{20,}\b/g, '<redacted-huggingface-token>')
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, '<redacted-api-key>')
+
+const truncateToolLogValue = (value: string) =>
+  value.length > MAX_TOOL_LOG_VALUE_LENGTH ? `${value.slice(0, MAX_TOOL_LOG_VALUE_LENGTH - 3)}...` : value
+
+const stringifyToolValue = (value: unknown, key?: string): string | undefined => {
+  if (value === undefined || value === null) return undefined
+  if (key && SENSITIVE_KEY_PATTERN.test(key)) return '<redacted>'
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (typeof value === 'string') return JSON.stringify(truncateToolLogValue(redactSensitiveText(value)))
+  if (Array.isArray(value)) return `array(${value.length})`
+  return `object(${Object.keys(value as Record<string, unknown>).length})`
+}
+
+const toolArg = (args: unknown, name: string): unknown =>
+  args && typeof args === 'object' ? (args as Record<string, unknown>)[name] : undefined
+
+const joinToolParts = (parts: (string | undefined)[]) => parts.filter(Boolean).join(' ')
+
+const formatKeyValue = (args: unknown, key: string) => {
+  const value = stringifyToolValue(toolArg(args, key), key)
+  return value ? `${key}=${value}` : undefined
+}
+
+export const formatToolExecutionSummary = (toolName: string, args: unknown) => {
+  if (!args || typeof args !== 'object') return ''
+
+  if (toolName === 'bash') {
+    return joinToolParts([formatKeyValue(args, 'command'), formatKeyValue(args, 'timeout')])
+  }
+  if (toolName === 'read') {
+    return joinToolParts([formatKeyValue(args, 'path'), formatKeyValue(args, 'offset'), formatKeyValue(args, 'limit')])
+  }
+  if (toolName === 'write') {
+    const content = toolArg(args, 'content')
+    const contentSummary = typeof content === 'string' ? `contentChars=${content.length}` : undefined
+    return joinToolParts([formatKeyValue(args, 'path'), contentSummary])
+  }
+  if (toolName === 'edit') {
+    const edits = toolArg(args, 'edits')
+    const editSummary = Array.isArray(edits) ? `edits=${edits.length}` : undefined
+    return joinToolParts([formatKeyValue(args, 'path'), editSummary])
+  }
+  if (toolName === 'grep') {
+    return joinToolParts([
+      formatKeyValue(args, 'pattern'),
+      formatKeyValue(args, 'path'),
+      formatKeyValue(args, 'glob'),
+      formatKeyValue(args, 'limit'),
+    ])
+  }
+  if (toolName === 'find') {
+    return joinToolParts([formatKeyValue(args, 'pattern'), formatKeyValue(args, 'path'), formatKeyValue(args, 'limit')])
+  }
+  if (toolName === 'ls') {
+    return joinToolParts([formatKeyValue(args, 'path'), formatKeyValue(args, 'limit')])
+  }
+
+  return Object.keys(args as Record<string, unknown>)
+    .slice(0, 6)
+    .map((key) => formatKeyValue(args, key))
+    .filter(Boolean)
+    .join(' ')
+}
+
 const collectAgentsFiles = async (worktree: string) => {
   const rootAgents = join(worktree, 'AGENTS.md')
   if (!existsSync(rootAgents)) return []
@@ -144,10 +223,11 @@ export const runPiAgent = async (
       void log(delta)
     }
     if (event.type === 'tool_execution_start') {
-      void log(`tool start: ${event.toolName}`)
+      const summary = formatToolExecutionSummary(event.toolName, event.args)
+      void log(`tool start: ${event.toolName}${summary ? ` ${summary}` : ''}`)
     }
     if (event.type === 'tool_execution_end') {
-      void log(`tool end: ${event.toolName}`)
+      void log(`tool end: ${event.toolName} ${event.isError ? 'error' : 'ok'}`)
     }
   })
 


### PR DESCRIPTION
## Summary

- Add `rg`/ripgrep to the AnyPi runner image, runtime preflight defaults, provider required-tool contracts, and operator documentation.
- Pin both AnyPi AgentProviders to the verified multi-arch image `registry.ide-newton.ts.net/lab/anypi:85953dd7a@sha256:362b1416b62d6e5461b1ea4214d156edef7e425066c3f886c268650863c7a764`.
- Improve AnyPi runner logs by recording sanitized tool-call context for bash/read/write/edit/search tool executions.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi tsc`
- `bunx oxfmt --check services/anypi/src/config.ts services/anypi/src/config.test.ts services/anypi/src/pi-session.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml && rg -n 'ANYPI_REQUIRED_TOOLS|image: registry.ide-newton.ts.net/lab/anypi' /tmp/agents-render.yaml`
- `bun run lint:argocd`
- `git diff --check`
- `crane digest registry.ide-newton.ts.net/lab/anypi:85953dd7a`
- `crane manifest registry.ide-newton.ts.net/lab/anypi:85953dd7a | jq -r '.manifests[] | [.platform.os, .platform.architecture, .digest] | @tsv'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
