### PR TITLE
feat: harden the flamingo hard-migration validator and add scripts ci coverage

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,7 @@ on:
       - 'apps/**'
       - 'packages/**'
       - 'services/**'
+      - 'scripts/**'
 
 permissions:
   contents: read
@@ -29,6 +30,7 @@ jobs:
       bonjour: ${{ steps.filter.outputs.bonjour }}
       codex: ${{ steps.filter.outputs.codex }}
       discord: ${{ steps.filter.outputs.discord }}
+      scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - name: Check changed files
         id: filter
@@ -78,6 +80,7 @@ jobs:
           output_flag reviseur '^apps/reviseur/'
           output_flag codex '^packages/codex/'
           output_flag discord '^packages/discord/'
+          output_flag scripts '^scripts/'
 
   docs:
     needs: check_changed_files
@@ -465,3 +468,15 @@ jobs:
 
       - run: bun run build
         working-directory: apps/reviseur
+
+  scripts:
+    needs: check_changed_files
+    if: ${{ needs.check_changed_files.outputs.scripts == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - run: bun run lint:flamingo-hard-migration

--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -1,0 +1,64 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { validateFiles, requiredTerms, forbiddenTerms } from './validate-flamingo-hard-migration'
+
+async function mkfile(content: string): Promise<string> {
+  const id = Math.random().toString(36).slice(2)
+  const dir = join('/tmp', 'flamingo-test-' + id)
+  await mkdir(dir, { recursive: true })
+  const path = join(dir, 'file.txt')
+  await writeFile(path, content)
+  return path
+}
+
+describe('validateFiles', () => {
+  it('import safety: exports are defined without side effects', () => {
+    expect(typeof validateFiles).toBe('function')
+    expect(Array.isArray(requiredTerms)).toBe(true)
+    expect(Array.isArray(forbiddenTerms)).toBe(true)
+    expect(requiredTerms.length).toBeGreaterThan(0)
+    expect(forbiddenTerms.length).toBeGreaterThan(0)
+  })
+
+  it('detects missing required term', async () => {
+    const path = await mkfile('some content without any terms')
+    const failures = await validateFiles([path], requiredTerms, forbiddenTerms)
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "unsloth/Qwen3.6-35B-A3B-NVFP4"')
+    expect(failures.length).toBeGreaterThan(0)
+  })
+
+  it('detects stale forbidden term', async () => {
+    const path = await mkfile('contains Qwen/Qwen3-Coder-Next-FP8 here')
+    const failures = await validateFiles([path], requiredTerms, forbiddenTerms)
+    expect(failures).toContain(`${path}: still contains forbidden Flamingo migration term "Qwen/Qwen3-Coder-Next-FP8"`)
+  })
+
+  it('passes when all terms are satisfied', async () => {
+    const path = await mkfile(requiredTerms.join('\n'))
+    const failures = await validateFiles([path], requiredTerms, forbiddenTerms)
+    expect(failures).toEqual([])
+  })
+
+  it('detects multiple forbidden terms in one file', async () => {
+    const path = await mkfile([forbiddenTerms[0], forbiddenTerms[1], forbiddenTerms[2]].join('\n'))
+    const failures = await validateFiles([path], requiredTerms, forbiddenTerms)
+    // 3 forbidden + 3 missing required (qwen3 is substring of qwen3-coder-flamingo)
+    expect(failures.length).toBe(6)
+    expect(failures).toContain(`${path}: still contains forbidden Flamingo migration term "${forbiddenTerms[0]}"`)
+    expect(failures).toContain(`${path}: still contains forbidden Flamingo migration term "${forbiddenTerms[1]}"`)
+    expect(failures).toContain(`${path}: still contains forbidden Flamingo migration term "${forbiddenTerms[2]}"`)
+  })
+
+  it('reports all missing required terms', async () => {
+    const path = await mkfile(requiredTerms[0] + '\n' + forbiddenTerms[0])
+    const failures = await validateFiles([path], requiredTerms, forbiddenTerms)
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "qwen36-flamingo"')
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "qwen3"')
+    expect(failures).toContain('active Flamingo surfaces do not contain required term "qwen3_coder"')
+    expect(failures).toContain(`${path}: still contains forbidden Flamingo migration term "Qwen/Qwen3-Coder-Next-FP8"`)
+    expect(failures.length).toBe(4)
+  })
+})

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -1,16 +1,16 @@
-#!/usr/bin/env bun
-
 import { readFile } from 'node:fs/promises'
 
-const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
-const forbiddenTerms = [
+export const requiredTerms = ['unsloth/Qwen3.6-35B-A3B-NVFP4', 'qwen36-flamingo', 'qwen3', 'qwen3_coder']
+
+export const forbiddenTerms = [
   'Qwen/Qwen3-Coder-Next-FP8',
-  'qwen3-coder-flamingo',
   'Qwen/Qwen3-Coder-30B-A3B-Instruct',
+  'qwen3-coder-flamingo',
   'hermes',
+  'qwen3_xml',
 ]
 
-const targetFiles = [
+export const targetFiles = [
   'argocd/applications/flamingo/deployment.yaml',
   'argocd/applications/flamingo/README.md',
   'argocd/applications/flamingo/docs/large-model-multigpu.md',
@@ -25,31 +25,39 @@ const targetFiles = [
   'services/anypi/src/config.test.ts',
 ]
 
-const failures: string[] = []
+export async function validateFiles(paths: string[], required: string[], forbidden: string[]): Promise<string[]> {
+  const contents = await Promise.all(paths.map((f) => readFile(f, 'utf8')))
+  const combined = contents.join('\n')
+  const failures: string[] = []
 
-for (const file of targetFiles) {
-  const content = await readFile(file, 'utf8')
-
-  for (const term of forbiddenTerms) {
-    if (content.includes(term)) {
-      failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
+  for (let i = 0; i < paths.length; i++) {
+    const file = paths[i]
+    const content = contents[i]
+    for (const term of forbidden) {
+      if (content.includes(term)) {
+        failures.push(`${file}: still contains forbidden Flamingo migration term "${term}"`)
+      }
     }
   }
-}
 
-const combined = await Promise.all(targetFiles.map(async (file) => await readFile(file, 'utf8'))).then((parts) =>
-  parts.join('\n'),
-)
-
-for (const term of requiredTerms) {
-  if (!combined.includes(term)) {
-    failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+  for (const term of required) {
+    if (!combined.includes(term)) {
+      failures.push(`active Flamingo surfaces do not contain required term "${term}"`)
+    }
   }
+
+  return failures
 }
 
-if (failures.length > 0) {
-  console.error(failures.join('\n'))
-  process.exit(1)
+async function main(): Promise<void> {
+  const failures = await validateFiles(targetFiles, requiredTerms, forbiddenTerms)
+  if (failures.length > 0) {
+    console.error(failures.join('\n'))
+    process.exit(1)
+  }
+  console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
 }
 
-console.log(`validated ${targetFiles.length} Flamingo hard-migration surfaces`)
+if (import.meta.main) {
+  await main()
+}


### PR DESCRIPTION
## Summary

- Harden the Flamingo hard-migration validator and add scripts CI coverage.
- Validation commands and CI status are listed below.

## Related Issues

None

## Testing

- `bash -lc bun test scripts/jangar/validate-flamingo-hard-migration.test.ts` exit 0
- `bash -lc bash -lc 'out="$(bun -e "await import(\"./scripts/jangar/validate-flamingo-hard-migration.ts\")" 2>&1)"; test -z "$out"'` exit 0
- `bash -lc bun run lint:flamingo-hard-migration` exit 0
- `bash -lc mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml` exit 0
- `bash -lc python3 -c "from pathlib import Path; paths=[Path('scripts/jangar/validate-flamingo-hard-migration.ts'), Path('scripts/jangar/validate-flamingo-hard-migration.test.ts')]; bad=[str(p) for p in paths if any(ord(ch)>127 for ch in p.read_text())]; assert not bad, bad"` exit 0
- `bash -lc rg -n 'scripts: \$\{\{ steps\.filter\.outputs\.scripts \}\}' .github/workflows/pull-request.yml` exit 0
- `bash -lc rg -n "output_flag scripts '\^scripts/'" .github/workflows/pull-request.yml` exit 0
- `bash -lc rg -n '^  scripts:' .github/workflows/pull-request.yml` exit 0
- `bash -lc bash -lc 'git diff --name-only | sort | comm -23 - <(printf "%s\n" ".github/workflows/pull-request.yml" "scripts/jangar/validate-flamingo-hard-migration.test.ts" "scripts/jangar/validate-flamingo-hard-migration.ts" | sort) | tee /tmp/unexpected-anypi-files && test ! -s /tmp/unexpected-anypi-files'` exit 0
- `bash -lc bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts scripts/jangar/validate-flamingo-hard-migration.test.ts .github/workflows/pull-request.yml` exit 0
- `bash -lc git diff --check` exit 0
- CI: passed: 14 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
