### PR TITLE
fix(kafka): recover broker capacity and email alerts

### DIFF
--- a/apps/froussard/src/telemetry.test.ts
+++ b/apps/froussard/src/telemetry.test.ts
@@ -205,7 +205,7 @@ describe('telemetry', () => {
     })
 
     expect(metricExporterMock).toHaveBeenCalledWith({
-      url: 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics',
+      url: 'http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics',
       headers: undefined,
       protocol: 'http/json',
     })
@@ -225,7 +225,7 @@ describe('telemetry', () => {
     })
 
     expect(metricExporterMock).toHaveBeenCalledWith({
-      url: 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics',
+      url: 'http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics',
       headers: expect.objectContaining({ global: 'alpha', shared: 'bravo', metric: 'delta' }),
       protocol: 'http/json',
     })

--- a/apps/froussard/src/telemetry.ts
+++ b/apps/froussard/src/telemetry.ts
@@ -46,7 +46,7 @@ function createTelemetryState(): TelemetryState {
     tracesProtocol === 'grpc'
       ? 'http://observability-tempo-gateway.observability.svc.cluster.local:4317'
       : 'http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces'
-  const defaultMetricsEndpoint = 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics'
+  const defaultMetricsEndpoint = 'http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics'
 
   const tracesEndpoint =
     process.env.LGTM_TEMPO_TRACES_ENDPOINT ??

--- a/argocd/applications/argo-workflows/alloy-configmap.yaml
+++ b/argocd/applications/argo-workflows/alloy-configmap.yaml
@@ -63,7 +63,7 @@ data:
 
     prometheus.remote_write "mimir" {
       endpoint {
-        url = "http://observability-mimir-nginx.observability.svc.cluster.local/api/v1/push"
+        url = "http://observability-mimir-gateway.observability.svc.cluster.local/api/v1/push"
       }
     }
 

--- a/argocd/applications/argocd/alloy-configmap.yaml
+++ b/argocd/applications/argocd/alloy-configmap.yaml
@@ -63,7 +63,7 @@ data:
 
     prometheus.remote_write "mimir" {
       endpoint {
-        url = "http://observability-mimir-nginx.observability.svc.cluster.local/api/v1/push"
+        url = "http://observability-mimir-gateway.observability.svc.cluster.local/api/v1/push"
       }
     }
 

--- a/argocd/applications/bilig/alloy-configmap.yaml
+++ b/argocd/applications/bilig/alloy-configmap.yaml
@@ -40,7 +40,7 @@ data:
 
     prometheus.remote_write "mimir" {
       endpoint {
-        url = "http://observability-mimir-nginx.observability.svc.cluster.local/api/v1/push"
+        url = "http://observability-mimir-gateway.observability.svc.cluster.local/api/v1/push"
       }
     }
 

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -91,7 +91,7 @@ spec:
             - name: TEMPORAL_METRICS_EXPORTER
               value: otlp
             - name: TEMPORAL_METRICS_ENDPOINT
-              value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
+              value: http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics
             - name: OTEL_SERVICE_NAME
               value: bumba
             - name: OTEL_SERVICE_NAMESPACE

--- a/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
@@ -51,7 +51,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces
             - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-              value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
+              value: http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics
             - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
               value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
           readinessProbe:

--- a/argocd/applications/graf/knative-service.yaml
+++ b/argocd/applications/graf/knative-service.yaml
@@ -97,7 +97,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces
             - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-              value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
+              value: http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics
             - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
               value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
           envFrom:

--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -129,7 +129,7 @@ spec:
       memory: 4Gi
   storage:
     type: persistent-claim
-    size: 30Gi
+    size: 100Gi
     deleteClaim: false
     class: rook-ceph-block
 ---

--- a/argocd/applications/miel/README.md
+++ b/argocd/applications/miel/README.md
@@ -35,7 +35,7 @@ Restart the deployment after updating the ConfigMap so the new environment varia
 
 - `OTEL_SERVICE_NAME=miel`
 - `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
-- OTLP endpoints for traces (`observability-tempo-distributor`), metrics (`observability-mimir-nginx`), and logs (`observability-loki-loki-distributed-gateway`).
+- OTLP endpoints for traces (`observability-tempo-distributor`), metrics (`observability-mimir-gateway`), and logs (`observability-loki-loki-distributed-gateway`).
 
 Override these values as needed for other environments, then restart the deployment (or let Argo CD roll pods) to pick up the new telemetry configuration.
 

--- a/argocd/applications/miel/configmap.yaml
+++ b/argocd/applications/miel/configmap.yaml
@@ -17,7 +17,7 @@ data:
   OTEL_SERVICE_NAME: "miel"
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://observability-tempo-distributor.observability:4318"
-  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://observability-mimir-nginx.observability/otlp"
+  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://observability-mimir-gateway.observability/otlp"
   OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://observability-loki-loki-distributed-gateway.observability/otlp"
   TIGERBEETLE_ENABLED: "false"
   TIGERBEETLE_ADDRESSES: ""

--- a/argocd/applications/nats/alloy-configmap.yaml
+++ b/argocd/applications/nats/alloy-configmap.yaml
@@ -51,7 +51,7 @@ data:
 
     prometheus.remote_write "mimir" {
       endpoint {
-        url = "http://observability-mimir-nginx.observability.svc.cluster.local/api/v1/push"
+        url = "http://observability-mimir-gateway.observability.svc.cluster.local/api/v1/push"
       }
     }
 

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -1715,3 +1715,170 @@ data:
                 Batch runs are reporting market-closed skips during expected market-open windows.
                 Validate Torghut trading status probe semantics and pre-open probe contracts.
               runbook_url: docs/runbooks/torghut-market-context-ingest.md
+      - name: kafka-critical-service.rules
+        rules:
+          - alert: KafkaBrokerUnavailable
+            expr: |
+              sum(
+                kube_pod_status_ready{
+                  namespace="kafka",
+                  condition="true",
+                  pod=~"kafka-pool-b-[0-9]+"
+                }
+              ) < 3
+            for: 5m
+            labels:
+              severity: critical
+              team: platform
+              service: kafka
+              notify: email
+            annotations:
+              summary: Kafka broker pool has unavailable brokers
+              description: |
+                Fewer than three broker-only pool-b Kafka pods are ready for 5 minutes.
+                Producers with min.insync.replicas=2 can fail when more than one broker is unavailable.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: KafkaBrokerPVCFreeLowCritical
+            expr: |
+              (
+                kubelet_volume_stats_available_bytes{
+                  namespace="kafka",
+                  persistentvolumeclaim=~"data-kafka-pool-b-.*"
+                }
+                /
+                kubelet_volume_stats_capacity_bytes{
+                  namespace="kafka",
+                  persistentvolumeclaim=~"data-kafka-pool-b-.*"
+                }
+              ) < 0.10
+            for: 10m
+            labels:
+              severity: critical
+              team: platform
+              service: kafka
+              notify: email
+            annotations:
+              summary: Kafka broker PVC free space is critically low
+              description: A broker-only pool-b Kafka PVC has less than 10% free capacity for 10 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: KafkaBrokerPVCFreeLowWarning
+            expr: |
+              (
+                kubelet_volume_stats_available_bytes{
+                  namespace="kafka",
+                  persistentvolumeclaim=~"data-kafka-pool-b-.*"
+                }
+                /
+                kubelet_volume_stats_capacity_bytes{
+                  namespace="kafka",
+                  persistentvolumeclaim=~"data-kafka-pool-b-.*"
+                }
+              ) < 0.25
+            for: 30m
+            labels:
+              severity: warning
+              team: platform
+              service: kafka
+            annotations:
+              summary: Kafka broker PVC free space is low
+              description: A broker-only pool-b Kafka PVC has less than 25% free capacity for 30 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: KafkaUnderReplicatedPartitions
+            expr: |
+              (
+                sum(kafka_server_replicamanager_underreplicatedpartitions) or vector(0)
+              ) > 0
+            for: 5m
+            labels:
+              severity: critical
+              team: platform
+              service: kafka
+              notify: email
+            annotations:
+              summary: Kafka has under-replicated partitions
+              description: Kafka reports under-replicated partitions for 5 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: KafkaUnderMinIsrPartitions
+            expr: |
+              (
+                sum(kafka_server_replicamanager_underminisrpartitioncount) or vector(0)
+              ) > 0
+            for: 5m
+            labels:
+              severity: critical
+              team: platform
+              service: kafka
+              notify: email
+            annotations:
+              summary: Kafka has partitions below minimum ISR
+              description: Kafka reports partitions below min.insync.replicas for 5 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: KafkaBrokerRestarts
+            expr: |
+              sum(
+                increase(
+                  kube_pod_container_status_restarts_total{
+                    namespace="kafka",
+                    pod=~"kafka-pool-b-[0-9]+"
+                  }[15m]
+                )
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+              team: platform
+              service: kafka
+            annotations:
+              summary: Kafka broker container restarted
+              description: One or more pool-b broker containers restarted in the last 15 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: TorghutHyperliquidFeedUnavailable
+            expr: |
+              sum(
+                kube_deployment_status_replicas_available{
+                  namespace="torghut",
+                  deployment="torghut-hyperliquid-feed"
+                }
+              ) < 1
+            for: 5m
+            labels:
+              severity: critical
+              team: platform
+              service: torghut-hyperliquid-feed
+              notify: email
+            annotations:
+              summary: Torghut Hyperliquid feed is unavailable
+              description: The torghut-hyperliquid-feed deployment has no available replicas for 5 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: KafkaDependentDeploymentUnavailable
+            expr: |
+              kube_deployment_status_replicas_available{
+                namespace="torghut",
+                deployment=~"torghut-ws|torghut-ws-options|torghut-ta|torghut-options-ta|torghut-options-catalog|torghut-options-enricher"
+              } < 1
+            for: 10m
+            labels:
+              severity: critical
+              team: platform
+              service: kafka-dependent
+              notify: email
+            annotations:
+              summary: Kafka-dependent deployment is unavailable
+              description: A Torghut Kafka producer or consumer deployment has no available replicas for 10 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+          - alert: CriticalArgoApplicationDegraded
+            expr: |
+              argocd_app_info{
+                name=~"kafka|torghut|torghut-hyperliquid-feed|torghut-options|posthog|froussard|observability",
+                health_status!="Healthy"
+              } == 1
+            for: 10m
+            labels:
+              severity: critical
+              team: platform
+              service: argocd
+              notify: email
+            annotations:
+              summary: Critical Argo CD application is degraded
+              description: A critical Kafka, dependent-service, or observability Argo CD application is not Healthy for 10 minutes.
+              runbook_url: docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md

--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -26,7 +26,7 @@ datasources:
         uid: prom
         type: prometheus
         access: proxy
-        url: http://observability-mimir-nginx.observability.svc.cluster.local/prometheus
+        url: http://observability-mimir-gateway.observability.svc.cluster.local/prometheus
         isDefault: true
       - name: Tempo
         uid: tempo

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - tailscale-ingresses.yaml
   - ingressroute-grafana-k8s-private.yaml
   - graf-mimir-rules.yaml
+  - observability-alertmanager-email-externalsecret.yaml
+  - observability-mimir-rule-loader.yaml
   - graf-graf-dashboard-configmap.yaml
   - graf-bumba-dashboard-configmap.yaml
   - symphony-fleet-dashboard-configmap.yaml

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -117,6 +117,53 @@ alertmanager:
   replicas: 1
   zoneAwareReplication:
     enabled: false
+  env:
+    - name: OBS_ALERT_SMTP_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: observability-alertmanager-email
+          key: smtp-password
+    - name: OBS_ALERT_SMTP_FROM
+      valueFrom:
+        secretKeyRef:
+          name: observability-alertmanager-email
+          key: smtp-from
+    - name: OBS_ALERT_EMAIL_TO
+      valueFrom:
+        secretKeyRef:
+          name: observability-alertmanager-email
+          key: email-to
+  fallbackConfig: |
+    global:
+      resolve_timeout: 5m
+      smtp_smarthost: smtp.resend.com:587
+      smtp_from: ${OBS_ALERT_SMTP_FROM}
+      smtp_auth_username: resend
+      smtp_auth_password: ${OBS_ALERT_SMTP_PASSWORD}
+      smtp_require_tls: true
+    route:
+      receiver: default-receiver
+      group_by: [alertname, namespace, service, severity]
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      routes:
+        - receiver: critical-email
+          matchers:
+            - severity = "critical"
+            - notify = "email"
+          group_wait: 10s
+          group_interval: 2m
+          repeat_interval: 1h
+          continue: false
+    receivers:
+      - name: default-receiver
+      - name: critical-email
+        email_configs:
+          - to: ${OBS_ALERT_EMAIL_TO}
+            send_resolved: true
+            headers:
+              subject: '[lab] {{ .CommonLabels.alertname }}'
   persistence:
     enabled: true
     storageClass: rook-ceph-block

--- a/argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml
+++ b/argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml
@@ -1,0 +1,38 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: observability-alertmanager-email
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-infra
+  target:
+    name: observability-alertmanager-email
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: smtp-password
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: resend/password
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+    - secretKey: smtp-from
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: resend/from
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+    - secretKey: email-to
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: resend/to
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/argocd/applications/observability/observability-mimir-rule-loader.yaml
+++ b/argocd/applications/observability/observability-mimir-rule-loader.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observability-mimir-rule-loader
+  namespace: observability
+data:
+  load-rules.sh: |
+    #!/bin/sh
+    set -eu
+
+    rules_file="${RULES_FILE:-/rules/graf-rules.yaml}"
+    tenant="${MIMIR_TENANT_ID:-anonymous}"
+    ruler_url="${MIMIR_RULER_URL:-http://observability-mimir-gateway.observability.svc.cluster.local/prometheus/config/v1/rules/lab}"
+    workdir="$(mktemp -d)"
+    desired_groups="${workdir}/desired-groups.txt"
+    current_rules="${workdir}/current-rules.yaml"
+    current_groups="${workdir}/current-groups.txt"
+    response_body="${workdir}/response.txt"
+
+    awk -v dir="${workdir}" -v desired="${desired_groups}" '
+      /^  - name: / {
+        if (out != "") {
+          close(out)
+        }
+        group = $0
+        sub(/^  - name: /, "", group)
+        safe = group
+        gsub(/[^A-Za-z0-9_.-]/, "-", safe)
+        out = dir "/" safe ".yaml"
+        print group >> desired
+        print substr($0, 5) > out
+        next
+      }
+      out != "" && /^    / {
+        print substr($0, 5) >> out
+        next
+      }
+      out != "" && NF == 0 {
+        print "" >> out
+      }
+    ' "${rules_file}"
+
+    if [ ! -s "${desired_groups}" ]; then
+      echo "no Mimir rule groups found in ${rules_file}" >&2
+      exit 1
+    fi
+
+    get_code="$(
+      curl -sS -o "${current_rules}" -w "%{http_code}" \
+        -H "X-Scope-OrgID: ${tenant}" \
+        "${ruler_url}" || true
+    )"
+    if [ "${get_code}" = "200" ]; then
+      awk '/^  - name: / { sub(/^  - name: /, ""); print }' "${current_rules}" > "${current_groups}"
+      while IFS= read -r group; do
+        if ! grep -Fxq "${group}" "${desired_groups}"; then
+          echo "deleting stale Mimir rule group ${group}"
+          delete_code="$(
+            curl -sS -o "${response_body}" -w "%{http_code}" \
+              -X DELETE \
+              -H "X-Scope-OrgID: ${tenant}" \
+              "${ruler_url}/${group}" || true
+          )"
+          case "${delete_code}" in
+            200|202|204|404) ;;
+            *)
+              echo "failed to delete stale Mimir rule group ${group}: HTTP ${delete_code}" >&2
+              cat "${response_body}" >&2
+              exit 1
+              ;;
+          esac
+        fi
+      done < "${current_groups}"
+    elif [ "${get_code}" != "404" ]; then
+      echo "failed to read current Mimir rules: HTTP ${get_code}" >&2
+      cat "${current_rules}" >&2
+      exit 1
+    fi
+
+    while IFS= read -r group; do
+      group_file="${workdir}/${group}.yaml"
+      if [ ! -f "${group_file}" ]; then
+        safe="$(printf "%s" "${group}" | tr -c 'A-Za-z0-9_.-' '-')"
+        group_file="${workdir}/${safe}.yaml"
+      fi
+      echo "uploading Mimir rule group ${group}"
+      post_code="$(
+        curl -sS -o "${response_body}" -w "%{http_code}" \
+          -X POST \
+          -H "X-Scope-OrgID: ${tenant}" \
+          -H "Content-Type: application/yaml" \
+          --data-binary "@${group_file}" \
+          "${ruler_url}" || true
+      )"
+      case "${post_code}" in
+        200|202) ;;
+        *)
+          echo "failed to upload Mimir rule group ${group}: HTTP ${post_code}" >&2
+          cat "${response_body}" >&2
+          exit 1
+          ;;
+      esac
+    done < "${desired_groups}"
+
+    echo "uploaded $(wc -l < "${desired_groups}") Mimir rule groups"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: observability-mimir-rule-loader
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: observability-mimir-rule-loader
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: load-rules
+          image: curlimages/curl:8.11.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - /scripts/load-rules.sh
+          env:
+            - name: MIMIR_TENANT_ID
+              value: anonymous
+            - name: MIMIR_RULER_URL
+              value: http://observability-mimir-gateway.observability.svc.cluster.local/prometheus/config/v1/rules/lab
+          volumeMounts:
+            - name: rules
+              mountPath: /rules
+              readOnly: true
+            - name: loader
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: rules
+          configMap:
+            name: graf-mimir-rules
+            items:
+              - key: graf-rules.yaml
+                path: graf-rules.yaml
+        - name: loader
+          configMap:
+            name: observability-mimir-rule-loader
+            defaultMode: 0555

--- a/argocd/applications/observability/tailscale-ingresses.yaml
+++ b/argocd/applications/observability/tailscale-ingresses.yaml
@@ -42,7 +42,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: observability-mimir-nginx
+                name: observability-mimir-gateway
                 port:
                   number: 80
 ---

--- a/argocd/applications/symphony-base/deployment.yaml
+++ b/argocd/applications/symphony-base/deployment.yaml
@@ -104,7 +104,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: http://observability-tempo-distributor.observability.svc.cluster.local:4318/v1/traces
             - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-              value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
+              value: http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics
             - name: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
               value: "20000"
             - name: OTEL_EXPORTER_OTLP_METRICS_TIMEOUT

--- a/argocd/applications/torghut/alloy-configmap.yaml
+++ b/argocd/applications/torghut/alloy-configmap.yaml
@@ -92,7 +92,7 @@ data:
 
     prometheus.remote_write "mimir" {
       endpoint {
-        url = "http://observability-mimir-nginx.observability.svc.cluster.local/api/v1/push"
+        url = "http://observability-mimir-gateway.observability.svc.cluster.local/api/v1/push"
       }
     }
 

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -339,6 +339,11 @@ spec:
                 namespace: observability
                 annotations:
                   argocd.argoproj.io/sync-wave: "3"
+                managedNamespaceMetadata:
+                  labels:
+                    external-secrets.proompteng.ai/enabled: "true"
+                  annotations:
+                    argocd.argoproj.io/sync-options: Prune=false
                 automation: auto
                 enabled: "true"
               - name: minio

--- a/docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
+++ b/docs/incidents/2026-06-20-kafka-broker-disk-full-and-service-recovery.md
@@ -1,0 +1,127 @@
+# Kafka Broker Disk-Full Recovery And Dependent Service Bring-Up
+
+Date: 2026-06-20
+
+## Summary
+
+Kafka degraded because broker-only pods `kafka-pool-b-3` and `kafka-pool-b-4` crash-looped after their broker PVCs filled. The relevant log signature was:
+
+```text
+java.io.IOException: No space left on device
+```
+
+The impact was visible downstream as `torghut-hyperliquid-feed` remaining unavailable and Kafka producers logging `NOT_ENOUGH_REPLICAS`.
+
+## Source Of Truth
+
+- GitOps app: `argocd/applications/kafka`
+- Kafka CR: `Kafka/kafka` in namespace `kafka`
+- Broker node pool: `KafkaNodePool/pool-b`
+- Broker PVCs: `data-kafka-pool-b-3`, `data-kafka-pool-b-4`, `data-kafka-pool-b-5`
+- StorageClass: `rook-ceph-block`
+
+## Recovery Plan
+
+1. Expand only broker pool storage in Git:
+
+```yaml
+kind: KafkaNodePool
+metadata:
+  name: pool-b
+spec:
+  storage:
+    type: persistent-claim
+    size: 100Gi
+    deleteClaim: false
+    class: rook-ceph-block
+```
+
+Do not delete broker PVCs for this incident. The failure is capacity exhaustion, not confirmed volume corruption.
+
+2. Render and validate manifests:
+
+```bash
+mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/kafka
+```
+
+3. Reconcile Kafka through Argo CD:
+
+```bash
+argocd app sync kafka
+argocd app wait kafka --health --sync --timeout 900
+```
+
+4. Verify PVC expansion and broker readiness:
+
+```bash
+kubectl --context galactic-tailscale -n kafka get pods,pvc,kafkanodepool,kafka -o wide
+
+kubectl --context galactic-tailscale -n kafka exec kafka-pool-b-5 -- \
+  df -h /var/lib/kafka/data
+```
+
+5. Verify Kafka metadata and replication:
+
+```bash
+kubectl --context galactic-tailscale -n kafka exec kafka-pool-a-0 -- \
+  bin/kafka-topics.sh \
+    --bootstrap-server kafka-kafka-bootstrap.kafka.svc:9092 \
+    --describe --under-replicated-partitions
+```
+
+The command should return no under-replicated partitions after recovery settles.
+
+## Dependent Service Recovery Order
+
+Avoid blanket restarts. Restart only services that stay unhealthy or keep logging Kafka errors after Kafka is healthy for several minutes.
+
+1. `torghut-hyperliquid-feed`
+
+```bash
+kubectl --context galactic-tailscale -n torghut get deploy torghut-hyperliquid-feed
+kubectl --context galactic-tailscale -n torghut logs deploy/torghut-hyperliquid-feed --tail=200
+```
+
+Expected: deployment available and no fresh `NOT_ENOUGH_REPLICAS` or Kafka producer timeout errors.
+
+2. Torghut Kafka producers and consumers
+
+```bash
+kubectl --context galactic-tailscale -n torghut get deploy \
+  torghut-ws torghut-ws-options torghut-ta torghut-options-ta \
+  torghut-options-catalog torghut-options-enricher
+```
+
+3. Other Kafka consumers/producers
+
+```bash
+kubectl --context galactic-tailscale -n posthog get pods
+kubectl --context galactic-tailscale -n agents get kafkasources.sources.knative.dev
+kubectl --context galactic-tailscale -n froussard get ksvc,pods
+```
+
+4. Argo CD health
+
+```bash
+argocd app get kafka
+argocd app get torghut-hyperliquid-feed
+argocd app get torghut
+argocd app get torghut-options
+argocd app get posthog
+argocd app get froussard
+```
+
+## Break-Glass Patch
+
+Use this only if Kafka must be restored before GitOps can reconcile. Commit the same change to Git immediately afterward.
+
+```bash
+kubectl --context galactic-tailscale -n kafka patch kafkanodepool pool-b --type merge \
+  -p '{"spec":{"storage":{"type":"persistent-claim","size":"100Gi","deleteClaim":false,"class":"rook-ceph-block"}}}'
+```
+
+## Rollback
+
+Do not shrink PVCs. Kubernetes volume expansion is effectively one-way for this storage path. If `100Gi` is wrong, choose a larger size and apply another expansion.
+
+If Alertmanager or rule-loader changes are suspected during the same rollout, revert the observability commit and sync `observability`; leave Kafka PVCs at the expanded size.

--- a/docs/runbooks/clickhouse-operator.md
+++ b/docs/runbooks/clickhouse-operator.md
@@ -207,7 +207,7 @@ This is an emergency-only path, but it is now a known one. Waiting for the clust
 
 - ServiceMonitor: disabled by default. If/when you deploy the Prometheus Operator, set `serviceMonitor.enabled: true` and ensure the Prometheus stack watches `clickhouse-operator`.
 - Grafana: add dashboards from the Altinity repo (e.g., ClickHouse Overview, Keeper health) by pulling them into the observability stack after the operator provisions metrics.
-- Metrics pipeline: the lab’s observability stack relies on Grafana Mimir (metrics storage) and Alloy or Prometheus agents for scraping. To record ClickHouse metrics today, deploy an Alloy scraper (patterned after `argocd/applications/argocd/alloy-configmap.yaml`) targeting `clickhouse-operator` and forward via `prometheus.remote_write` to `observability-mimir-nginx`. Alternatively, add a Prometheus Operator release in the `observability` namespace, configure remote write to Mimir, and create a matching `ServiceMonitor`.
+- Metrics pipeline: the lab’s observability stack relies on Grafana Mimir (metrics storage) and Alloy or Prometheus agents for scraping. To record ClickHouse metrics today, deploy an Alloy scraper (patterned after `argocd/applications/argocd/alloy-configmap.yaml`) targeting `clickhouse-operator` and forward via `prometheus.remote_write` to `observability-mimir-gateway`. Alternatively, add a Prometheus Operator release in the `observability` namespace, configure remote write to Mimir, and create a matching `ServiceMonitor`.
 - Alerting: configure alert rules for Keeper quorum loss, ClickHouse replica lag, and operator reconciliation failures.
 
 ## Sync Lifecycle

--- a/docs/runbooks/mimir-discord-alerting.md
+++ b/docs/runbooks/mimir-discord-alerting.md
@@ -37,7 +37,7 @@ This design is intentionally **generic to Mimir** and is not coupled to any spec
   - `observability-mimir-alertmanager-fallback-config` only contains defaults and `default-receiver`.
 - `observability` namespace has `rook-ceph-rgw-loki` and `observability-grafana` secrets, but no Discord alert secret yet.
 - Public route exists:
-  - `observability-mimir-tailscale` routes to `observability-mimir-nginx` with `/alertmanager` path.
+  - `observability-mimir-tailscale` routes to `observability-mimir-gateway` with `/alertmanager` path.
 - Mimir Helm chart values currently match expected env injection shape: `alertmanager.env` and `alertmanager.extraEnvFrom` are available, **not** `alertmanager.extraEnv`.
 
 ## Requirements

--- a/docs/runbooks/mimir-email-alerting.md
+++ b/docs/runbooks/mimir-email-alerting.md
@@ -1,0 +1,124 @@
+# Mimir Email Alerting Runbook
+
+## Overview
+
+The observability stack uses Grafana Mimir Ruler for alert evaluation and Mimir Alertmanager for routing. Critical infrastructure alerts are routed to email through Resend SMTP.
+
+GitOps source:
+
+- `argocd/applications/observability/mimir-values.yaml`
+- `argocd/applications/observability/graf-mimir-rules.yaml`
+- `argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml`
+- `argocd/applications/observability/observability-mimir-rule-loader.yaml`
+
+## Secret Contract
+
+The Kubernetes Secret is `observability/observability-alertmanager-email`, created by External Secrets from `ClusterSecretStore/onepassword-infra`.
+
+Required 1Password fields in item `infra/resend`:
+
+| 1Password field | Kubernetes key |
+| --- | --- |
+| `password` | `smtp-password` |
+| `from` | `smtp-from` |
+| `to` | `email-to` |
+
+The Resend SMTP username is always `resend` and is set directly in Mimir Alertmanager config.
+
+Do not commit SMTP credentials or recipient addresses.
+
+## Routing Contract
+
+Only alerts with both labels are emailed:
+
+```yaml
+severity: critical
+notify: email
+```
+
+Warning alerts are evaluated and visible in Mimir/Grafana, but they do not send email by default.
+
+## Rule Delivery
+
+`graf-mimir-rules.yaml` is a ConfigMap source file. It is not mounted into the Mimir ruler pod. The `observability-mimir-rule-loader` Argo CD PostSync Job uploads each rule group to the Mimir Ruler API for tenant `anonymous`:
+
+```text
+POST /prometheus/config/v1/rules/lab
+```
+
+The loader also deletes stale groups from the `lab` namespace when it can read current rule state.
+
+## Deployment
+
+```bash
+mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/observability
+
+argocd app sync observability
+argocd app wait observability --health --sync --timeout 900
+```
+
+## Validation
+
+Confirm the ExternalSecret and target Secret:
+
+```bash
+kubectl --context galactic-tailscale -n observability get externalsecret observability-alertmanager-email
+kubectl --context galactic-tailscale -n observability get secret observability-alertmanager-email
+```
+
+Confirm Alertmanager fallback config contains the email receiver:
+
+```bash
+kubectl --context galactic-tailscale -n observability get cm \
+  observability-mimir-alertmanager-fallback-config -o yaml
+```
+
+Confirm rule groups were uploaded:
+
+```bash
+kubectl --context galactic-tailscale -n observability logs job/observability-mimir-rule-loader
+
+kubectl --context galactic-tailscale -n observability exec deploy/observability-grafana -- \
+  sh -lc 'wget --header="X-Scope-OrgID: anonymous" -qO- \
+  "http://observability-mimir-gateway.observability.svc.cluster.local/prometheus/config/v1/rules/lab"'
+```
+
+## Synthetic Email Test
+
+Send a temporary synthetic alert to Alertmanager:
+
+```bash
+kubectl --context galactic-tailscale -n observability exec deploy/observability-grafana -- sh -lc '
+cat >/tmp/test-alert.json <<JSON
+[
+  {
+    "labels": {
+      "alertname": "SyntheticEmailAlert",
+      "severity": "critical",
+      "notify": "email",
+      "service": "observability",
+      "team": "platform"
+    },
+    "annotations": {
+      "summary": "Synthetic email alert test",
+      "description": "Temporary alert to validate Mimir Alertmanager email routing."
+    },
+    "generatorURL": "https://mimir.ide-newton.ts.net"
+  }
+]
+JSON
+wget --header="Content-Type: application/json" \
+  --post-file=/tmp/test-alert.json \
+  -qO- \
+  http://observability-mimir-alertmanager.observability.svc.cluster.local:8080/alertmanager/api/v2/alerts
+'
+```
+
+After delivery is confirmed, silence or let the synthetic alert resolve by not resending it.
+
+## Troubleshooting
+
+1. If `observability-alertmanager-email` is missing, verify the `observability` namespace has label `external-secrets.proompteng.ai/enabled: "true"` and the 1Password item fields exist.
+2. If rule upload fails, inspect the PostSync Job logs and verify the Mimir gateway service exists.
+3. If alerts evaluate but email does not send, check `observability-mimir-alertmanager-0` logs for SMTP authentication or recipient errors.
+4. If metrics are missing, verify workloads write to `observability-mimir-gateway`, not the retired `observability-mimir-nginx` service name.

--- a/services/bonjour/src/instrumentation.ts
+++ b/services/bonjour/src/instrumentation.ts
@@ -33,7 +33,7 @@ if (!isTruthy(process.env.OTEL_SDK_DISABLED)) {
     tracesProtocol === 'grpc'
       ? 'http://observability-tempo-gateway.observability.svc.cluster.local:4317'
       : 'http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces'
-  const defaultMetricsEndpoint = 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics'
+  const defaultMetricsEndpoint = 'http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics'
 
   const tracesEndpoint =
     process.env.LGTM_TEMPO_TRACES_ENDPOINT ??

--- a/services/facteur/README.md
+++ b/services/facteur/README.md
@@ -61,7 +61,7 @@ Facteur boots with OpenTelemetry telemetry enabled. Traces and metrics are expor
 - `OTEL_SERVICE_NAMESPACE` (populated from the pod namespace)
 - `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
 - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces`
-- `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics`
+- `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics`
 - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push`
 
 When running locally, point these values at your observability environment to keep telemetry flowing. The service emits counters such as `facteur_command_events_processed_total`, `facteur_command_events_failed_total`, and `facteur_command_events_dlq_total`, and wraps the Fiber HTTP server with OTEL middleware so HTTP requests appear in traces.

--- a/services/miel/README.md
+++ b/services/miel/README.md
@@ -38,7 +38,7 @@ Set the following environment variables before running the service. Paper-tradin
 | `OTEL_SERVICE_NAME`                   | Service name reported to OpenTelemetry/observability. | `miel`                                                                  |
 | `OTEL_EXPORTER_OTLP_PROTOCOL`         | OTLP transport protocol.                              | `http/protobuf`                                                         |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | OTLP traces endpoint (observability Tempo).           | `http://observability-tempo-distributor.observability:4318`             |
-| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | OTLP metrics endpoint (observability Mimir).          | `http://observability-mimir-nginx.observability/otlp`                   |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | OTLP metrics endpoint (observability Mimir).          | `http://observability-mimir-gateway.observability/otlp`                   |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | OTLP logs endpoint (observability Loki).              | `http://observability-loki-loki-distributed-gateway.observability/otlp` |
 
 ### TigerBeetle ledger (optional)

--- a/services/symphony/src/instrumentation.ts
+++ b/services/symphony/src/instrumentation.ts
@@ -54,7 +54,7 @@ type TelemetryState = {
 }
 
 const DEFAULT_TRACES_ENDPOINT = 'http://observability-tempo-distributor.observability.svc.cluster.local:4318/v1/traces'
-const DEFAULT_METRICS_ENDPOINT = 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics'
+const DEFAULT_METRICS_ENDPOINT = 'http://observability-mimir-gateway.observability.svc.cluster.local/otlp/v1/metrics'
 
 const globalState = globalThis as typeof globalThis & {
   __symphonyTelemetry?: TelemetryState


### PR DESCRIPTION
## Summary

- Expands Strimzi broker-only `KafkaNodePool/pool-b` PVCs from `30Gi` to `100Gi`, while leaving controller `pool-a` at `30Gi` and keeping `deleteClaim: false`.
- Adds Mimir critical email alerting through an ExternalSecret-backed Resend SMTP configuration and a PostSync rule-loader job for tenant `anonymous`.
- Adds Kafka disk-full recovery and Mimir email alerting runbooks, and updates stale Mimir OTLP endpoints to the live `observability-mimir-gateway` service.

## Related Issues

None

## Testing

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_stream(File.read(path)); puts "ok #{path}" }' argocd/applications/kafka/strimzi-kafka-cluster.yaml argocd/applications/observability/mimir-values.yaml argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml argocd/applications/observability/observability-mimir-rule-loader.yaml argocd/applications/observability/graf-mimir-rules.yaml argocd/applicationsets/platform.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/kafka >/tmp/kafka-render.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/observability >/tmp/observability-render.yaml`
- `bun run lint:argocd`
- `bunx oxfmt --check apps/froussard/src/telemetry.ts apps/froussard/src/telemetry.test.ts services/bonjour/src/instrumentation.ts services/symphony/src/instrumentation.ts`
- `bun run --filter froussard test -- src/telemetry.test.ts`
- Live Mimir query API syntax check for all nine new `kafka-critical-service.rules` expressions via `kubectl --context galactic-tailscale -n observability port-forward svc/observability-mimir-query-frontend 18080:8080`.
- Live non-mutating Mimir Ruler API read through `observability-mimir-gateway` returned `HTTP 200`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The Kafka PVC expansion is operationally one-way for this storage path; the incident runbook documents that rollback must not shrink or delete PVCs. Syncing this change can restart workloads that pick up the corrected Mimir gateway endpoint.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
