### PR TITLE
chore(symphony): promote image 7613d3da

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-20T06:33:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-20T21:12:56Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "69ba69c6"
-    digest: sha256:e4cd61203cc9a95ae06494c91737c16de0745bd8048a00178f698c91e1888451
+    newTag: "7613d3da"
+    digest: sha256:41ec3af5a425b7fbfe1f1dfb532399f2250ea517d680a3dd4f9c1d8fab73623d

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-20T06:33:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-20T21:12:56Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "69ba69c6"
-    digest: sha256:e4cd61203cc9a95ae06494c91737c16de0745bd8048a00178f698c91e1888451
+    newTag: "7613d3da"
+    digest: sha256:41ec3af5a425b7fbfe1f1dfb532399f2250ea517d680a3dd4f9c1d8fab73623d

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-20T06:33:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-20T21:12:56Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "69ba69c6"
-    digest: sha256:e4cd61203cc9a95ae06494c91737c16de0745bd8048a00178f698c91e1888451
+    newTag: "7613d3da"
+    digest: sha256:41ec3af5a425b7fbfe1f1dfb532399f2250ea517d680a3dd4f9c1d8fab73623d


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `7613d3da435a1b00e14806b8e359b9dcbce637cf`
- Image tag: `7613d3da`
- Image digest: `sha256:41ec3af5a425b7fbfe1f1dfb532399f2250ea517d680a3dd4f9c1d8fab73623d`