### PR TITLE
fix(observability): repair mimir llm token spike rule

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -585,7 +585,7 @@ data:
                           service="torghut-llm-guardrails-exporter"
                         }[5m]
                       )
-                    )[1h]
+                    )[1h:5m]
                   ),
                   1
                 )


### PR DESCRIPTION
## Summary

- Fixes the `TorghutLLMTokensSpike` PromQL expression so Mimir accepts the rule group.
- Uses PromQL subquery syntax for the 1h baseline instead of an invalid range over a binary expression.
- Keeps the new Mimir rule-loader behavior intact so invalid rules fail visibly.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/observability >/tmp/observability-render.yaml`
- `bun run lint:argocd`
- Queried the corrected `TorghutLLMTokensSpike` expression against live Mimir with tenant `anonymous`; response status was `success`.
- Queried every expression in `argocd/applications/observability/graf-mimir-rules.yaml` against live Mimir; no parse failures returned.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
