### PR TITLE
fix(observability): split oversized mimir rule group

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -1557,6 +1557,8 @@ data:
                 LLM errors exceed 10% of trading review requests for 10 minutes. Consider forcing LLM shadow-only
                 to keep control-plane metrics stable while investigating.
               runbook_url: docs/runbooks/torghut-quant-control-plane.md
+      - name: torghut-quant-jangar.rules
+        rules:
           - alert: JangarQuantControlPlaneStreamErrors
             expr: |
               sum(rate(jangar_sse_errors_total{stream="torghut-quant"}[10m])) > 0.05


### PR DESCRIPTION
## Summary

- Splits the oversized `torghut-quant-control-plane.rules` Mimir rule group.
- Moves Jangar quant visibility alerts into `torghut-quant-jangar.rules`.
- Keeps all Mimir rule groups at or below the live per-group rule limit.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/observability >/tmp/observability-render.yaml`
- `bun run lint:argocd`
- Ruby YAML check confirmed every Mimir rule group in `graf-mimir-rules.yaml` has 20 or fewer rules.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
