### PR TITLE
fix(observability): mount alertmanager fallback config from secret

### DIFF
--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -122,3 +122,13 @@ patches:
         name: observability-loki-loki-distributed-querier
         annotations:
           argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
+      name: observability-mimir-alertmanager
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/4
+        value:
+          name: alertmanager-fallback-config
+          secret:
+            secretName: observability-alertmanager-email

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -117,53 +117,13 @@ alertmanager:
   replicas: 1
   zoneAwareReplication:
     enabled: false
-  env:
-    - name: OBS_ALERT_SMTP_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: observability-alertmanager-email
-          key: smtp-password
-    - name: OBS_ALERT_SMTP_FROM
-      valueFrom:
-        secretKeyRef:
-          name: observability-alertmanager-email
-          key: smtp-from
-    - name: OBS_ALERT_EMAIL_TO
-      valueFrom:
-        secretKeyRef:
-          name: observability-alertmanager-email
-          key: email-to
   fallbackConfig: |
-    global:
-      resolve_timeout: 5m
-      smtp_smarthost: smtp.resend.com:587
-      smtp_from: ${OBS_ALERT_SMTP_FROM}
-      smtp_auth_username: resend
-      smtp_auth_password: ${OBS_ALERT_SMTP_PASSWORD}
-      smtp_require_tls: true
+    # Real fallback config is rendered by External Secrets into the
+    # observability-alertmanager-email Secret and mounted over this file.
     route:
       receiver: default-receiver
-      group_by: [alertname, namespace, service, severity]
-      group_wait: 30s
-      group_interval: 5m
-      repeat_interval: 4h
-      routes:
-        - receiver: critical-email
-          matchers:
-            - severity = "critical"
-            - notify = "email"
-          group_wait: 10s
-          group_interval: 2m
-          repeat_interval: 1h
-          continue: false
     receivers:
       - name: default-receiver
-      - name: critical-email
-        email_configs:
-          - to: ${OBS_ALERT_EMAIL_TO}
-            send_resolved: true
-            headers:
-              subject: '[lab] {{ .CommonLabels.alertname }}'
   persistence:
     enabled: true
     storageClass: rook-ceph-block

--- a/argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml
+++ b/argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml
@@ -14,22 +14,59 @@ spec:
     name: observability-alertmanager-email
     creationPolicy: Owner
     deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        smtp-password: '{{ .smtp_password }}'
+        smtp-from: '{{ .smtp_from }}'
+        email-to: '{{ .email_to }}'
+        alertmanager_fallback_config.yaml: |
+          global:
+            resolve_timeout: 5m
+            smtp_smarthost: smtp.resend.com:587
+            smtp_from: "{{ .smtp_from }}"
+            smtp_auth_username: resend
+            smtp_auth_password_file: /configs/smtp-password
+            smtp_require_tls: true
+          route:
+            receiver: default-receiver
+            group_by: [alertname, namespace, service, severity]
+            group_wait: 30s
+            group_interval: 5m
+            repeat_interval: 4h
+            routes:
+              - receiver: critical-email
+                matchers:
+                  - severity = "critical"
+                  - notify = "email"
+                group_wait: 10s
+                group_interval: 2m
+                repeat_interval: 1h
+                continue: false
+          receivers:
+            - name: default-receiver
+            - name: critical-email
+              email_configs:
+                - to: "{{ .email_to }}"
+                  send_resolved: true
+                  headers:
+                    subject: '[lab] {{ "{{" }} .CommonLabels.alertname {{ "}}" }}'
   data:
-    - secretKey: smtp-password
+    - secretKey: smtp_password
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
         key: resend/password
         metadataPolicy: None
         nullBytePolicy: Ignore
-    - secretKey: smtp-from
+    - secretKey: smtp_from
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
         key: resend/from
         metadataPolicy: None
         nullBytePolicy: Ignore
-    - secretKey: email-to
+    - secretKey: email_to
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None

--- a/docs/runbooks/mimir-email-alerting.md
+++ b/docs/runbooks/mimir-email-alerting.md
@@ -14,6 +14,8 @@ GitOps source:
 ## Secret Contract
 
 The Kubernetes Secret is `observability/observability-alertmanager-email`, created by External Secrets from `ClusterSecretStore/onepassword-infra`.
+The same ExternalSecret renders `alertmanager_fallback_config.yaml`, which is mounted into Mimir Alertmanager at `/configs/alertmanager_fallback_config.yaml`.
+Do not put `${...}` placeholders in `alertmanager.fallbackConfig`; Mimir expands environment variables in its main config, not in the mounted fallback Alertmanager config file.
 
 Required 1Password fields in item `infra/resend`:
 
@@ -66,11 +68,12 @@ kubectl --context galactic-tailscale -n observability get externalsecret observa
 kubectl --context galactic-tailscale -n observability get secret observability-alertmanager-email
 ```
 
-Confirm Alertmanager fallback config contains the email receiver:
+Confirm the Secret-rendered Alertmanager fallback config contains the email receiver and file-backed SMTP password path:
 
 ```bash
-kubectl --context galactic-tailscale -n observability get cm \
-  observability-mimir-alertmanager-fallback-config -o yaml
+kubectl --context galactic-tailscale -n observability get secret \
+  observability-alertmanager-email \
+  -o go-template='{{ index .data "alertmanager_fallback_config.yaml" | base64decode }}'
 ```
 
 Confirm rule groups were uploaded:
@@ -85,7 +88,7 @@ kubectl --context galactic-tailscale -n observability exec deploy/observability-
 
 ## Synthetic Email Test
 
-Send a temporary synthetic alert to Alertmanager:
+Send a temporary synthetic alert to Alertmanager. Keep it active for longer than the critical route `group_wait` before resolving it.
 
 ```bash
 kubectl --context galactic-tailscale -n observability exec deploy/observability-grafana -- sh -lc '
@@ -110,7 +113,7 @@ JSON
 wget --header="Content-Type: application/json" \
   --post-file=/tmp/test-alert.json \
   -qO- \
-  http://observability-mimir-alertmanager.observability.svc.cluster.local:8080/alertmanager/api/v2/alerts
+  http://observability-mimir-gateway.observability.svc.cluster.local/alertmanager/api/v2/alerts
 '
 ```
 
@@ -122,3 +125,11 @@ After delivery is confirmed, silence or let the synthetic alert resolve by not r
 2. If rule upload fails, inspect the PostSync Job logs and verify the Mimir gateway service exists.
 3. If alerts evaluate but email does not send, check `observability-mimir-alertmanager-0` logs for SMTP authentication or recipient errors.
 4. If metrics are missing, verify workloads write to `observability-mimir-gateway`, not the retired `observability-mimir-nginx` service name.
+
+## References
+
+- [Grafana Mimir configuration parameters](https://grafana.com/docs/mimir/latest/configure/configuration-parameters/)
+- [Grafana Mimir distributed Helm chart configuration](https://grafana.com/docs/helm-charts/mimir-distributed/latest/run-production-environment-with-helm/configuration-with-helm/)
+- [Prometheus Alertmanager configuration](https://prometheus.io/docs/alerting/latest/configuration/)
+- [External Secrets templating](https://external-secrets.io/latest/guides/templating/)
+- [Resend SMTP integration](https://resend.com/docs/send-with-smtp)


### PR DESCRIPTION
## Summary

- Render the Mimir Alertmanager fallback config through External Secrets so SMTP credentials and recipients stay in the generated Secret.
- Mount the generated Secret over the chart fallback config file instead of relying on unexpanded `${...}` placeholders.
- Keep the chart fallback config as a safe no-op placeholder and document the supported integration path.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_stream(File.read(f)); puts "ok #{f}" }' argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml argocd/applications/observability/kustomization.yaml argocd/applications/observability/mimir-values.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/observability`
- `git diff --check`
- `bun run lint:argocd`
- Render inspection confirmed `observability-mimir-alertmanager` mounts `observability-alertmanager-email` for `alertmanager-fallback-config`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
