### PR TITLE
fix(observability): render mimir alertmanager smtp password

### DIFF
--- a/argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml
+++ b/argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml
@@ -26,7 +26,7 @@ spec:
             smtp_smarthost: smtp.resend.com:587
             smtp_from: "{{ .smtp_from }}"
             smtp_auth_username: resend
-            smtp_auth_password_file: /configs/smtp-password
+            smtp_auth_password: "{{ .smtp_password }}"
             smtp_require_tls: true
           route:
             receiver: default-receiver

--- a/docs/runbooks/mimir-email-alerting.md
+++ b/docs/runbooks/mimir-email-alerting.md
@@ -68,12 +68,14 @@ kubectl --context galactic-tailscale -n observability get externalsecret observa
 kubectl --context galactic-tailscale -n observability get secret observability-alertmanager-email
 ```
 
-Confirm the Secret-rendered Alertmanager fallback config contains the email receiver and file-backed SMTP password path:
+Confirm the Secret-rendered Alertmanager fallback config contains the email receiver. Do not print the SMTP
+password value in normal operations.
 
 ```bash
 kubectl --context galactic-tailscale -n observability get secret \
   observability-alertmanager-email \
-  -o go-template='{{ index .data "alertmanager_fallback_config.yaml" | base64decode }}'
+  -o go-template='{{ index .data "alertmanager_fallback_config.yaml" | base64decode }}' | \
+  grep -E 'critical-email|smtp_smarthost|smtp_auth_username'
 ```
 
 Confirm rule groups were uploaded:
@@ -122,9 +124,10 @@ After delivery is confirmed, silence or let the synthetic alert resolve by not r
 ## Troubleshooting
 
 1. If `observability-alertmanager-email` is missing, verify the `observability` namespace has label `external-secrets.proompteng.ai/enabled: "true"` and the 1Password item fields exist.
-2. If rule upload fails, inspect the PostSync Job logs and verify the Mimir gateway service exists.
-3. If alerts evaluate but email does not send, check `observability-mimir-alertmanager-0` logs for SMTP authentication or recipient errors.
-4. If metrics are missing, verify workloads write to `observability-mimir-gateway`, not the retired `observability-mimir-nginx` service name.
+2. If Alertmanager returns `406 Not initializing the Alertmanager`, check `observability-mimir-alertmanager-0` logs for fallback config parse errors. Mimir tenant configs reject `smtp_auth_password_file`; the password must be rendered into the Secret-backed config file as `smtp_auth_password`.
+3. If rule upload fails, inspect the PostSync Job logs and verify the Mimir gateway service exists.
+4. If alerts evaluate but email does not send, check `observability-mimir-alertmanager-0` logs for SMTP authentication or recipient errors.
+5. If metrics are missing, verify workloads write to `observability-mimir-gateway`, not the retired `observability-mimir-nginx` service name.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Replace the disallowed `smtp_auth_password_file` tenant config field with a Secret-rendered `smtp_auth_password` value.
- Document the Mimir-specific `406 Not initializing the Alertmanager` failure mode.
- Keep credentials out of Git and ConfigMaps by rendering the fallback Alertmanager config through External Secrets.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/observability`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_stream(File.read(f)); puts "ok #{f}" }' argocd/applications/observability/observability-alertmanager-email-externalsecret.yaml argocd/applications/observability/kustomization.yaml argocd/applications/observability/mimir-values.yaml`
- `git diff --check`
- `bun run lint:argocd`
- Live Alertmanager logs showed Mimir rejects `smtp_auth_password_file` in tenant fallback configs with `406 Not initializing the Alertmanager`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
