### PR TITLE
fix(observability): roll alertmanager after secret config update

### DIFF
--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -126,6 +126,9 @@ patches:
       kind: StatefulSet
       name: observability-mimir-alertmanager
     patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations/observability.proompteng.ai~1alertmanager-fallback-config-revision
+        value: "2026-06-20-1"
       - op: replace
         path: /spec/template/spec/volumes/4
         value:


### PR DESCRIPTION
## Summary

- Add a pod-template rollout annotation for Mimir Alertmanager after the fallback config moved from ConfigMap to Secret.
- Keep the Secret-mounted fallback config behavior unchanged.
- Force the running pod to remount the corrected Secret-backed config through GitOps.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/observability`
- `git diff --check`
- `bun run lint:argocd`
- Render inspection confirmed the Alertmanager StatefulSet has `observability.proompteng.ai/alertmanager-fallback-config-revision` and mounts `observability-alertmanager-email`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
