### PR TITLE
fix(torghut): restart kafka-dependent flink jobs

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
   imagePullPolicy: IfNotPresent
-  restartNonce: 15
+  restartNonce: 16
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
   imagePullPolicy: IfNotPresent
-  restartNonce: 12
+  restartNonce: 13
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:


### PR DESCRIPTION
## Summary

- Bumps `torghut-ta` Flink `spec.restartNonce` from `12` to `13`.
- Bumps `torghut-options-ta` Flink `spec.restartNonce` from `15` to `16`.
- Restarts the two Kafka-dependent Flink jobs that exhausted restart attempts after the Kafka broker-capacity incident.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/torghut`
- `mise exec helm@3 -- kustomize build --enable-helm /Users/gregkonush/github.com/lab/argocd/applications/torghut-options`
- Live recovery patch applied with the same restart nonce values while this PR reconciles through GitOps.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
