### PR TITLE
revert(torghut): rollback failed promotion d117379b4384e12005d3a092d3f1f24966bd17ab

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: empirical-promotion-renewal
 spec:
-  suspend: true
   schedule: "23 8,21 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `d117379b4384e12005d3a092d3f1f24966bd17ab`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28148141711`
- Rollback source: `HEAD^` manifests from the failed run checkout