### PR TITLE
feat(torghut): add generic multifactor restore lane

### DIFF
--- a/services/torghut/app/hyperliquid_execution/models.py
+++ b/services/torghut/app/hyperliquid_execution/models.py
@@ -7,6 +7,13 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Literal
 
+from app.trading.multifactor.contracts import (
+    AlphaForecast,
+    FactorVector,
+    PortfolioTarget,
+    RiskForecast,
+)
+
 
 Action = Literal["buy", "sell", "hold"]
 OrderSide = Literal["buy", "sell"]
@@ -93,6 +100,8 @@ class Signal:
     edge_bps: Decimal
     reason: str
     feature: FeatureSnapshot
+    factor_vector: FactorVector | None = None
+    alpha_forecast: AlphaForecast | None = None
 
 
 @dataclass(frozen=True)
@@ -115,6 +124,8 @@ class RiskVerdict:
     status: RiskStatus
     reason: str
     order_notional_usd: Decimal
+    risk_forecast: RiskForecast | None = None
+    portfolio_target: PortfolioTarget | None = None
 
     @property
     def allowed(self) -> bool:

--- a/services/torghut/app/hyperliquid_execution/multifactor_repository.py
+++ b/services/torghut/app/hyperliquid_execution/multifactor_repository.py
@@ -1,0 +1,510 @@
+"""Persistence helpers for generic multifactor proof tables."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Mapping
+
+from sqlalchemy import text
+
+from .models import CycleRecord, OrderIntent, OrderResult, Signal
+from .reporting import build_performance_metrics
+
+
+class MultifactorExecutionRepository:
+    """Writes generic multifactor proof rows for the Hyperliquid runtime."""
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    def insert_signal(
+        self,
+        *,
+        run_id: str,
+        signal_id: str,
+        signal: Signal,
+    ) -> None:
+        vector = signal.factor_vector
+        forecast = signal.alpha_forecast
+        if vector is None or forecast is None:
+            return
+        asset_key = vector.asset.key
+        self._session.execute(
+            text(
+                """
+                INSERT INTO multifactor_factor_snapshots (
+                  run_id,
+                  asset_key,
+                  venue,
+                  symbol,
+                  market_id,
+                  source_event_at,
+                  observed_at,
+                  raw_factors,
+                  normalized_factors,
+                  source_lag_seconds,
+                  quote_lag_seconds,
+                  freshness_blocker
+                )
+                VALUES (
+                  :run_id,
+                  :asset_key,
+                  :venue,
+                  :symbol,
+                  :market_id,
+                  :source_event_at,
+                  :observed_at,
+                  CAST(:raw_factors AS jsonb),
+                  CAST(:normalized_factors AS jsonb),
+                  :source_lag_seconds,
+                  :quote_lag_seconds,
+                  :freshness_blocker
+                )
+                ON CONFLICT (run_id, asset_key) DO UPDATE SET
+                  source_event_at = EXCLUDED.source_event_at,
+                  observed_at = EXCLUDED.observed_at,
+                  raw_factors = EXCLUDED.raw_factors,
+                  normalized_factors = EXCLUDED.normalized_factors,
+                  source_lag_seconds = EXCLUDED.source_lag_seconds,
+                  quote_lag_seconds = EXCLUDED.quote_lag_seconds,
+                  freshness_blocker = EXCLUDED.freshness_blocker,
+                  updated_at = now()
+                """
+            ),
+            {
+                "run_id": run_id,
+                "asset_key": asset_key,
+                "venue": vector.asset.venue,
+                "symbol": vector.asset.symbol,
+                "market_id": vector.asset.market_id,
+                "source_event_at": vector.source_event_at,
+                "observed_at": vector.observed_at,
+                "raw_factors": json.dumps(
+                    _decimal_map_payload(vector.raw_factors), sort_keys=True
+                ),
+                "normalized_factors": json.dumps(
+                    _decimal_map_payload(vector.normalized_factors), sort_keys=True
+                ),
+                "source_lag_seconds": vector.source_lag_seconds,
+                "quote_lag_seconds": vector.quote_lag_seconds,
+                "freshness_blocker": vector.freshness_blocker,
+            },
+        )
+        self._insert_forecast(
+            run_id=run_id,
+            signal_id=signal_id,
+            signal=signal,
+            asset_key=asset_key,
+        )
+
+    def insert_execution_intent(
+        self,
+        *,
+        run_id: str,
+        intent: OrderIntent,
+        result: OrderResult,
+        verdict: Any,
+    ) -> None:
+        target = getattr(verdict, "portfolio_target", None)
+        if target is None:
+            return
+        self._session.execute(
+            text(
+                """
+                INSERT INTO multifactor_execution_intents (
+                  run_id,
+                  asset_key,
+                  venue,
+                  side,
+                  notional_usd,
+                  idempotency_key,
+                  status,
+                  blocker,
+                  venue_order_id,
+                  raw_payload
+                )
+                VALUES (
+                  :run_id,
+                  :asset_key,
+                  'hyperliquid',
+                  :side,
+                  :notional_usd,
+                  :idempotency_key,
+                  :status,
+                  :blocker,
+                  :venue_order_id,
+                  CAST(:raw_payload AS jsonb)
+                )
+                ON CONFLICT (run_id, asset_key) DO UPDATE SET
+                  side = EXCLUDED.side,
+                  notional_usd = EXCLUDED.notional_usd,
+                  idempotency_key = EXCLUDED.idempotency_key,
+                  status = EXCLUDED.status,
+                  blocker = EXCLUDED.blocker,
+                  venue_order_id = EXCLUDED.venue_order_id,
+                  raw_payload = EXCLUDED.raw_payload,
+                  updated_at = now()
+                """
+            ),
+            {
+                "run_id": run_id,
+                "asset_key": target.asset.key,
+                "side": intent.side,
+                "notional_usd": str(intent.notional_usd),
+                "idempotency_key": intent.cloid,
+                "status": result.status,
+                "blocker": result.rejection_reason,
+                "venue_order_id": result.exchange_order_id,
+                "raw_payload": json.dumps(result.raw_response, sort_keys=True),
+            },
+        )
+
+    def insert_risk_and_target(self, *, run_id: str, verdict: Any) -> None:
+        risk = getattr(verdict, "risk_forecast", None)
+        target = getattr(verdict, "portfolio_target", None)
+        if risk is None or target is None:
+            return
+        asset_key = target.asset.key
+        self._insert_risk(run_id=run_id, asset_key=asset_key, risk=risk)
+        self._insert_target(run_id=run_id, asset_key=asset_key, target=target)
+
+    def insert_attribution_snapshot(
+        self,
+        *,
+        run_id: str,
+        observed_at: datetime,
+    ) -> None:
+        metrics = build_performance_metrics(self._session)
+        self._session.execute(
+            text(
+                """
+                INSERT INTO multifactor_attribution_snapshots (
+                  run_id,
+                  observed_at,
+                  fill_count,
+                  realized_pnl_usd,
+                  turnover_usd,
+                  realized_cost_usd,
+                  hit_rate,
+                  raw_payload
+                )
+                VALUES (
+                  :run_id,
+                  :observed_at,
+                  :fill_count,
+                  :realized_pnl_usd,
+                  :turnover_usd,
+                  :realized_cost_usd,
+                  :hit_rate,
+                  CAST(:raw_payload AS jsonb)
+                )
+                ON CONFLICT (run_id) DO UPDATE SET
+                  observed_at = EXCLUDED.observed_at,
+                  fill_count = EXCLUDED.fill_count,
+                  realized_pnl_usd = EXCLUDED.realized_pnl_usd,
+                  turnover_usd = EXCLUDED.turnover_usd,
+                  realized_cost_usd = EXCLUDED.realized_cost_usd,
+                  hit_rate = EXCLUDED.hit_rate,
+                  raw_payload = EXCLUDED.raw_payload,
+                  updated_at = now()
+                """
+            ),
+            {
+                "run_id": run_id,
+                "observed_at": observed_at,
+                "fill_count": metrics["fill_count_24h"],
+                "realized_pnl_usd": metrics["net_pnl_after_fees_usd_24h"],
+                "turnover_usd": metrics["notional_usd_24h"],
+                "realized_cost_usd": metrics["fees_usd_24h"],
+                "hit_rate": "1" if int(str(metrics["fill_count_24h"])) > 0 else "0",
+                "raw_payload": json.dumps(metrics, sort_keys=True),
+            },
+        )
+
+    def insert_cycle(self, record: CycleRecord) -> None:
+        self._session.execute(
+            text(
+                """
+                INSERT INTO multifactor_runs (
+                  id,
+                  lane,
+                  model_version,
+                  started_at,
+                  finished_at,
+                  status,
+                  blockers,
+                  selected_assets,
+                  raw_payload
+                )
+                VALUES (
+                  :id,
+                  'hyperliquid_testnet',
+                  'active-portfolio-management-v1',
+                  :started_at,
+                  :finished_at,
+                  :status,
+                  CAST(:blockers AS jsonb),
+                  CAST(:selected_assets AS jsonb),
+                  CAST(:raw_payload AS jsonb)
+                )
+                ON CONFLICT (id) DO UPDATE SET
+                  finished_at = EXCLUDED.finished_at,
+                  status = EXCLUDED.status,
+                  blockers = EXCLUDED.blockers,
+                  selected_assets = EXCLUDED.selected_assets,
+                  raw_payload = EXCLUDED.raw_payload,
+                  updated_at = now()
+                """
+            ),
+            {
+                "id": record.cycle_id,
+                "started_at": record.started_at,
+                "finished_at": record.finished_at,
+                "status": "failed" if record.error else "completed",
+                "blockers": json.dumps(
+                    [
+                        dependency.name
+                        for dependency in record.dependency_statuses
+                        if not dependency.ready
+                    ],
+                    sort_keys=True,
+                ),
+                "selected_assets": json.dumps(list(record.selected_coins)),
+                "raw_payload": json.dumps(
+                    {
+                        "signals_written": record.signals_written,
+                        "orders_submitted": record.orders_submitted,
+                        "orders_cancelled": record.orders_cancelled,
+                        "universe_details": record.universe_details,
+                    },
+                    sort_keys=True,
+                ),
+            },
+        )
+
+    def _insert_forecast(
+        self,
+        *,
+        run_id: str,
+        signal_id: str,
+        signal: Signal,
+        asset_key: str,
+    ) -> None:
+        vector = signal.factor_vector
+        forecast = signal.alpha_forecast
+        if vector is None or forecast is None:
+            return
+        self._session.execute(
+            text(
+                """
+                INSERT INTO multifactor_forecasts (
+                  run_id,
+                  asset_key,
+                  model_id,
+                  signal_id,
+                  horizon_seconds,
+                  score,
+                  residual_volatility_bps,
+                  information_coefficient,
+                  expected_return_bps,
+                  direction,
+                  blocker
+                )
+                VALUES (
+                  :run_id,
+                  :asset_key,
+                  :model_id,
+                  :signal_id,
+                  :horizon_seconds,
+                  :score,
+                  :residual_volatility_bps,
+                  :information_coefficient,
+                  :expected_return_bps,
+                  :direction,
+                  :blocker
+                )
+                ON CONFLICT (run_id, asset_key) DO UPDATE SET
+                  model_id = EXCLUDED.model_id,
+                  signal_id = EXCLUDED.signal_id,
+                  horizon_seconds = EXCLUDED.horizon_seconds,
+                  score = EXCLUDED.score,
+                  residual_volatility_bps = EXCLUDED.residual_volatility_bps,
+                  information_coefficient = EXCLUDED.information_coefficient,
+                  expected_return_bps = EXCLUDED.expected_return_bps,
+                  direction = EXCLUDED.direction,
+                  blocker = EXCLUDED.blocker,
+                  updated_at = now()
+                """
+            ),
+            {
+                "run_id": run_id,
+                "asset_key": asset_key,
+                "model_id": forecast.model_id,
+                "signal_id": signal_id,
+                "horizon_seconds": forecast.horizon_seconds,
+                "score": str(forecast.score),
+                "residual_volatility_bps": str(forecast.residual_volatility_bps),
+                "information_coefficient": str(forecast.information_coefficient),
+                "expected_return_bps": str(forecast.expected_return_bps),
+                "direction": forecast.direction,
+                "blocker": forecast.blocker,
+            },
+        )
+        self._update_signal_features(
+            run_id=run_id,
+            signal_id=signal_id,
+            signal=signal,
+            asset_key=asset_key,
+        )
+
+    def _insert_risk(self, *, run_id: str, asset_key: str, risk: Any) -> None:
+        self._session.execute(
+            text(
+                """
+                INSERT INTO multifactor_risk_forecasts (
+                  run_id,
+                  asset_key,
+                  active_risk_bps,
+                  gross_exposure_usd,
+                  symbol_exposure_usd,
+                  liquidity_capacity_usd,
+                  concentration_bps,
+                  blocker
+                )
+                VALUES (
+                  :run_id,
+                  :asset_key,
+                  :active_risk_bps,
+                  :gross_exposure_usd,
+                  :symbol_exposure_usd,
+                  :liquidity_capacity_usd,
+                  :concentration_bps,
+                  :blocker
+                )
+                ON CONFLICT (run_id, asset_key) DO UPDATE SET
+                  active_risk_bps = EXCLUDED.active_risk_bps,
+                  gross_exposure_usd = EXCLUDED.gross_exposure_usd,
+                  symbol_exposure_usd = EXCLUDED.symbol_exposure_usd,
+                  liquidity_capacity_usd = EXCLUDED.liquidity_capacity_usd,
+                  concentration_bps = EXCLUDED.concentration_bps,
+                  blocker = EXCLUDED.blocker,
+                  updated_at = now()
+                """
+            ),
+            {
+                "run_id": run_id,
+                "asset_key": asset_key,
+                "active_risk_bps": str(risk.active_risk_bps),
+                "gross_exposure_usd": str(risk.gross_exposure_usd),
+                "symbol_exposure_usd": str(risk.symbol_exposure_usd),
+                "liquidity_capacity_usd": str(risk.liquidity_capacity_usd),
+                "concentration_bps": str(risk.concentration_bps),
+                "blocker": risk.blocker,
+            },
+        )
+
+    def _insert_target(self, *, run_id: str, asset_key: str, target: Any) -> None:
+        self._session.execute(
+            text(
+                """
+                INSERT INTO multifactor_portfolio_targets (
+                  run_id,
+                  asset_key,
+                  direction,
+                  current_notional_usd,
+                  target_notional_usd,
+                  delta_notional_usd,
+                  expected_return_bps,
+                  expected_cost_bps,
+                  active_risk_bps,
+                  risk_buffer_bps,
+                  clip_reason
+                )
+                VALUES (
+                  :run_id,
+                  :asset_key,
+                  :direction,
+                  :current_notional_usd,
+                  :target_notional_usd,
+                  :delta_notional_usd,
+                  :expected_return_bps,
+                  :expected_cost_bps,
+                  :active_risk_bps,
+                  :risk_buffer_bps,
+                  :clip_reason
+                )
+                ON CONFLICT (run_id, asset_key) DO UPDATE SET
+                  direction = EXCLUDED.direction,
+                  current_notional_usd = EXCLUDED.current_notional_usd,
+                  target_notional_usd = EXCLUDED.target_notional_usd,
+                  delta_notional_usd = EXCLUDED.delta_notional_usd,
+                  expected_return_bps = EXCLUDED.expected_return_bps,
+                  expected_cost_bps = EXCLUDED.expected_cost_bps,
+                  active_risk_bps = EXCLUDED.active_risk_bps,
+                  risk_buffer_bps = EXCLUDED.risk_buffer_bps,
+                  clip_reason = EXCLUDED.clip_reason,
+                  updated_at = now()
+                """
+            ),
+            {
+                "run_id": run_id,
+                "asset_key": asset_key,
+                "direction": target.direction,
+                "current_notional_usd": str(target.current_notional_usd),
+                "target_notional_usd": str(target.target_notional_usd),
+                "delta_notional_usd": str(target.delta_notional_usd),
+                "expected_return_bps": str(target.expected_return_bps),
+                "expected_cost_bps": str(target.expected_cost_bps),
+                "active_risk_bps": str(target.active_risk_bps),
+                "risk_buffer_bps": str(target.risk_buffer_bps),
+                "clip_reason": target.clip_reason,
+            },
+        )
+
+    def _update_signal_features(
+        self,
+        *,
+        run_id: str,
+        signal_id: str,
+        signal: Signal,
+        asset_key: str,
+    ) -> None:
+        vector = signal.factor_vector
+        forecast = signal.alpha_forecast
+        if vector is None or forecast is None:
+            return
+        raw_features = dict(signal.feature.raw_features)
+        raw_features.setdefault("source_lag_seconds", signal.feature.source_lag_seconds)
+        if signal.feature.quote_lag_seconds is not None:
+            raw_features.setdefault(
+                "quote_lag_seconds", signal.feature.quote_lag_seconds
+            )
+        raw_features["multifactor"] = {
+            "schema_version": "torghut.multifactor.signal.v1",
+            "run_id": run_id,
+            "asset_key": asset_key,
+            "model_id": forecast.model_id,
+            "expected_return_bps": str(forecast.expected_return_bps),
+            "score": str(forecast.score),
+            "direction": forecast.direction,
+            "freshness_blocker": vector.freshness_blocker,
+        }
+        self._session.execute(
+            text(
+                """
+                UPDATE hyperliquid_execution_signals
+                SET features = CAST(:features AS jsonb)
+                WHERE id = :signal_id
+                """
+            ),
+            {
+                "signal_id": signal_id,
+                "features": json.dumps(raw_features, sort_keys=True),
+            },
+        )
+
+
+def _decimal_map_payload(values: Mapping[str, Decimal]) -> dict[str, str]:
+    return {key: str(value) for key, value in values.items()}

--- a/services/torghut/app/hyperliquid_execution/repository.py
+++ b/services/torghut/app/hyperliquid_execution/repository.py
@@ -23,6 +23,7 @@ from .models import (
     RuntimeDependencyStatus,
     Signal,
 )
+from .multifactor_repository import MultifactorExecutionRepository
 from .reporting import build_operational_report, build_performance_metrics
 
 
@@ -31,6 +32,7 @@ class HyperliquidExecutionRepository:
 
     def __init__(self, session: Any) -> None:
         self._session = session
+        self._multifactor = MultifactorExecutionRepository(session)
 
     def upsert_markets(self, markets: Iterable[ExecutionMarket]) -> None:
         for market in markets:
@@ -117,6 +119,11 @@ class HyperliquidExecutionRepository:
                 "features": json.dumps(signal.feature.raw_features, sort_keys=True),
             },
         )
+        self._multifactor.insert_signal(
+            run_id=cycle_id,
+            signal_id=signal_id,
+            signal=signal,
+        )
         return signal_id
 
     def insert_order(self, intent: OrderIntent, result: OrderResult) -> str:
@@ -193,6 +200,24 @@ class HyperliquidExecutionRepository:
             },
         )
         return order_id
+
+    def insert_multifactor_execution_intent(
+        self,
+        *,
+        run_id: str,
+        intent: OrderIntent,
+        result: OrderResult,
+        verdict: Any,
+    ) -> None:
+        self._multifactor.insert_execution_intent(
+            run_id=run_id,
+            intent=intent,
+            result=result,
+            verdict=verdict,
+        )
+
+    def insert_multifactor_risk_and_target(self, *, run_id: str, verdict: Any) -> None:
+        self._multifactor.insert_risk_and_target(run_id=run_id, verdict=verdict)
 
     def update_reject_cooldown(
         self,
@@ -605,6 +630,17 @@ class HyperliquidExecutionRepository:
             {"id": str(uuid.uuid4()), "observed_at": observed_at, **metrics},
         )
 
+    def insert_multifactor_attribution_snapshot(
+        self,
+        *,
+        run_id: str,
+        observed_at: datetime,
+    ) -> None:
+        self._multifactor.insert_attribution_snapshot(
+            run_id=run_id,
+            observed_at=observed_at,
+        )
+
     def insert_cycle(self, record: CycleRecord) -> None:
         self._session.execute(
             text(
@@ -669,6 +705,7 @@ class HyperliquidExecutionRepository:
                 "error": record.error,
             },
         )
+        self._multifactor.insert_cycle(record)
 
     def operational_report(
         self,

--- a/services/torghut/app/hyperliquid_execution/risk.py
+++ b/services/torghut/app/hyperliquid_execution/risk.py
@@ -4,6 +4,18 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from app.trading.multifactor.cost_model import estimate_transaction_cost
+from app.trading.multifactor.portfolio_construction import (
+    PortfolioCostInput,
+    PortfolioLimits,
+    build_portfolio_target,
+)
+from app.trading.multifactor.risk_model import (
+    RiskExposureState,
+    RiskLimits,
+    build_risk_forecast,
+)
+
 from .config import HyperliquidExecutionConfig
 from .models import RiskState, RiskVerdict, Signal, symbol_key
 
@@ -25,6 +37,69 @@ def evaluate_signal_risk(
     remaining_symbol = config.max_symbol_exposure_usd - symbol_exposure
     if remaining_symbol < config.min_order_notional_usd:
         return RiskVerdict("blocked", "symbol_exposure_cap", Decimal("0"))
+    if signal.factor_vector is not None and signal.alpha_forecast is not None:
+        risk_forecast = build_risk_forecast(
+            vector=signal.factor_vector,
+            forecast=signal.alpha_forecast,
+            exposure=RiskExposureState(
+                gross_exposure_usd=state.gross_exposure_usd,
+                symbol_exposure_usd=symbol_exposure,
+                daily_realized_pnl_usd=state.daily_realized_pnl_usd,
+            ),
+            limits=RiskLimits(
+                max_gross_exposure_usd=config.max_gross_exposure_usd,
+                max_symbol_exposure_usd=config.max_symbol_exposure_usd,
+                max_daily_loss_usd=config.max_daily_loss_usd,
+            ),
+        )
+        expected_cost_bps = estimate_transaction_cost(
+            signal.factor_vector,
+            cost_buffer_bps=config.cost_buffer_bps,
+            participation_rate=Decimal("0.001"),
+        )
+        portfolio_target = build_portfolio_target(
+            forecast=signal.alpha_forecast,
+            risk=risk_forecast,
+            costs=PortfolioCostInput(
+                expected_cost_bps=expected_cost_bps,
+                min_edge_bps=config.min_edge_bps,
+            ),
+            limits=PortfolioLimits(
+                min_order_notional_usd=config.min_order_notional_usd,
+                max_order_notional_usd=config.max_order_notional_usd,
+                max_gross_exposure_usd=config.max_gross_exposure_usd,
+                max_symbol_exposure_usd=config.max_symbol_exposure_usd,
+            ),
+        )
+        if not portfolio_target.executable:
+            return RiskVerdict(
+                "blocked",
+                portfolio_target.clip_reason or "portfolio_target_blocked",
+                Decimal("0"),
+                risk_forecast,
+                portfolio_target,
+            )
+        order_notional = min(
+            portfolio_target.delta_notional_usd,
+            config.max_order_notional_usd,
+            remaining_gross,
+            remaining_symbol,
+        )
+        if order_notional < config.min_order_notional_usd:
+            return RiskVerdict(
+                "blocked",
+                "target_notional_below_min_order",
+                Decimal("0"),
+                risk_forecast,
+                portfolio_target,
+            )
+        return RiskVerdict(
+            "allowed",
+            "allowed",
+            order_notional,
+            risk_forecast,
+            portfolio_target,
+        )
     order_notional = min(
         config.max_order_notional_usd, remaining_gross, remaining_symbol
     )
@@ -44,7 +119,10 @@ def _blocked_reason(
     checks = (
         (bool(config_errors), ",".join(config_errors)),
         (not state.trading_enabled, "trading_disabled"),
-        (signal.action == "hold", f"hold:{signal.reason}"),
+        (
+            signal.action == "hold" and signal.alpha_forecast is None,
+            f"hold:{signal.reason}",
+        ),
         (
             signal.action == "sell" and not config.allow_short_entries,
             "short_entries_disabled",

--- a/services/torghut/app/hyperliquid_execution/service.py
+++ b/services/torghut/app/hyperliquid_execution/service.py
@@ -103,6 +103,10 @@ class HyperliquidExecutionService:
         )
 
         repository.insert_performance_snapshot(observed_at=started_at)
+        repository.insert_multifactor_attribution_snapshot(
+            run_id=cycle_id,
+            observed_at=started_at,
+        )
         finished_at = datetime.now(timezone.utc)
         universe_details = _cycle_universe_details(context.universe_details, counts)
         result = CycleResult(
@@ -146,12 +150,21 @@ class HyperliquidExecutionService:
         counts: "_CycleCounts",
     ) -> None:
         for feature in context.features:
-            signal = generate_signal(feature, self._config, now=context.started_at)
+            signal = generate_signal(
+                feature,
+                self._config,
+                now=context.started_at,
+                run_id=context.cycle_id,
+            )
             signal_id = repository.insert_signal(
                 cycle_id=context.cycle_id, signal=signal
             )
             counts.signals_written += 1
             verdict = evaluate_signal_risk(signal, context.risk_state, self._config)
+            repository.insert_multifactor_risk_and_target(
+                run_id=context.cycle_id,
+                verdict=verdict,
+            )
             if not verdict.allowed:
                 counts.record_risk_block(signal.coin, verdict.reason)
                 continue
@@ -168,6 +181,12 @@ class HyperliquidExecutionService:
                 counts.record_order_error(type(exc).__name__)
                 continue
             repository.insert_order(intent, result)
+            repository.insert_multifactor_execution_intent(
+                run_id=context.cycle_id,
+                intent=intent,
+                result=result,
+                verdict=verdict,
+            )
             repository.update_reject_cooldown(
                 coin=intent.coin,
                 rejection_reason=result.rejection_reason,

--- a/services/torghut/app/hyperliquid_execution/strategy.py
+++ b/services/torghut/app/hyperliquid_execution/strategy.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 
+from app.trading.multifactor.adapters.hyperliquid import factor_vector_from_feature
+from app.trading.multifactor.alpha_model import build_alpha_forecast
+from app.trading.multifactor.cost_model import estimate_transaction_cost
+from app.trading.multifactor.factor_registry import DEFAULT_RISK_BUFFER_BPS
+
 from .config import HyperliquidExecutionConfig
 from .models import FeatureSnapshot, Signal
 
@@ -19,10 +24,22 @@ def generate_signal(
     config: HyperliquidExecutionConfig,
     *,
     now: datetime | None = None,
+    run_id: str = "runtime-pending",
 ) -> Signal:
     """Emit buy/sell only when edge exceeds spread plus cost buffer."""
 
     generated_at = now or datetime.now(timezone.utc)
+    factor_vector = factor_vector_from_feature(
+        run_id=run_id,
+        feature=feature,
+        max_staleness_seconds=config.signal_staleness_seconds,
+    )
+    alpha_forecast = build_alpha_forecast(
+        factor_vector,
+        residual_volatility_bps=max(
+            feature.volatility_bps, abs(feature.momentum_5m_bps) * Decimal("3")
+        ),
+    )
     hold_reason = _hold_reason(feature, config)
     if hold_reason is not None:
         return Signal(
@@ -33,10 +50,17 @@ def generate_signal(
             Decimal("0"),
             hold_reason,
             feature,
+            factor_vector,
+            alpha_forecast,
         )
-    edge_bps = feature.momentum_5m_bps
+    edge_bps = alpha_forecast.expected_return_bps
+    expected_cost_bps = estimate_transaction_cost(
+        factor_vector,
+        cost_buffer_bps=config.cost_buffer_bps,
+        participation_rate=Decimal("0.001"),
+    )
     required_edge_bps = max(
-        config.min_edge_bps, feature.spread_bps + config.cost_buffer_bps
+        config.min_edge_bps, expected_cost_bps + DEFAULT_RISK_BUFFER_BPS
     )
     if abs(edge_bps) <= required_edge_bps:
         return Signal(
@@ -47,6 +71,8 @@ def generate_signal(
             edge_bps,
             "no_edge",
             feature,
+            factor_vector,
+            alpha_forecast,
         )
     action = "buy" if edge_bps > Decimal("0") else "sell"
     return Signal(
@@ -57,6 +83,8 @@ def generate_signal(
         edge_bps,
         "edge_exceeds_cost",
         feature,
+        factor_vector,
+        alpha_forecast,
     )
 
 

--- a/services/torghut/app/trading/loop_status.py
+++ b/services/torghut/app/trading/loop_status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Protocol, cast
@@ -12,10 +12,29 @@ from typing import Any, Protocol, cast
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
+from app.trading.multifactor.status_payloads import (
+    LATEST_ATTRIBUTION_SQL,
+    LATEST_EXECUTION_INTENT_SQL,
+    LATEST_FACTOR_SNAPSHOT_SQL,
+    LATEST_FORECAST_SQL,
+    LATEST_MULTIFACTOR_RUN_SQL,
+    LATEST_PORTFOLIO_TARGET_SQL,
+    LATEST_RISK_FORECAST_SQL,
+    alpha_model_payload,
+    attribution_payload,
+    execution_intent_payload,
+    portfolio_target_payload,
+    risk_forecast_payload,
+)
+
 SCHEMA_VERSION = "torghut.trading-loop-status.v1"
 DEFAULT_FRESHNESS_THRESHOLD_SECONDS = 180
 DEFAULT_ACCOUNT_FRESHNESS_SECONDS = 300
 DEFAULT_MIN_RECENT_FILLS = 3
+
+
+def _empty_mapping() -> Mapping[str, object]:
+    return {}
 
 
 class QuerySession(Protocol):
@@ -45,6 +64,17 @@ class LoopStatusRows:
     stale_open_orders: Sequence[Mapping[str, object]]
     unexpected_live_alpaca: Mapping[str, object]
     query_errors: Sequence[str]
+    latest_multifactor_run: Mapping[str, object] = field(default_factory=_empty_mapping)
+    latest_factor_snapshot: Mapping[str, object] = field(default_factory=_empty_mapping)
+    latest_forecast: Mapping[str, object] = field(default_factory=_empty_mapping)
+    latest_risk_forecast: Mapping[str, object] = field(default_factory=_empty_mapping)
+    latest_portfolio_target: Mapping[str, object] = field(
+        default_factory=_empty_mapping
+    )
+    latest_execution_intent: Mapping[str, object] = field(
+        default_factory=_empty_mapping
+    )
+    latest_attribution: Mapping[str, object] = field(default_factory=_empty_mapping)
 
 
 @dataclass(frozen=True)
@@ -79,6 +109,14 @@ class LoopProofSummary:
     stale_open_order_count: int
     unexpected_live_orders: int
     unexpected_live_events: int
+    multifactor_run_present: bool
+    factor_snapshot_present: bool
+    alpha_forecast_present: bool
+    risk_forecast_present: bool
+    portfolio_target_present: bool
+    execution_intent_present: bool
+    alpha_edge_above_cost: bool
+    target_notional_positive: bool
 
     @property
     def unexpected_live_total(self) -> int:
@@ -131,6 +169,27 @@ def load_trading_loop_status_rows(session: QuerySession) -> LoopStatusRows:
             errors,
         ),
         query_errors=tuple(errors),
+        latest_multifactor_run=_safe_one(
+            session, "latest_multifactor_run", LATEST_MULTIFACTOR_RUN_SQL, errors
+        ),
+        latest_factor_snapshot=_safe_one(
+            session, "latest_factor_snapshot", LATEST_FACTOR_SNAPSHOT_SQL, errors
+        ),
+        latest_forecast=_safe_one(
+            session, "latest_forecast", LATEST_FORECAST_SQL, errors
+        ),
+        latest_risk_forecast=_safe_one(
+            session, "latest_risk_forecast", LATEST_RISK_FORECAST_SQL, errors
+        ),
+        latest_portfolio_target=_safe_one(
+            session, "latest_portfolio_target", LATEST_PORTFOLIO_TARGET_SQL, errors
+        ),
+        latest_execution_intent=_safe_one(
+            session, "latest_execution_intent", LATEST_EXECUTION_INTENT_SQL, errors
+        ),
+        latest_attribution=_safe_one(
+            session, "latest_attribution", LATEST_ATTRIBUTION_SQL, errors
+        ),
     )
 
 
@@ -154,12 +213,17 @@ def assemble_trading_loop_status(
         "blocker_reasons": blockers,
         "runtime": _runtime_payload(rows, options, summary),
         "market_data": _market_data_payload(rows, options, summary),
+        "alpha_model": alpha_model_payload(rows, summary),
+        "risk_forecast": risk_forecast_payload(rows, summary),
+        "portfolio_target": portfolio_target_payload(rows, summary),
+        "execution_intent": execution_intent_payload(rows, summary),
         "decision": _decision_payload(rows),
         "submitted_order": _submitted_order_payload(rows, summary),
         "exchange_order_state": _exchange_order_state_payload(rows, summary),
         "fills": _fills_payload(rows, options, summary),
         "position": _position_payload(rows, options, summary),
         "pnl_snapshot": dict(rows.performance),
+        "attribution": attribution_payload(rows),
         "database": _database_payload(rows, summary),
         "stale_open_orders": _stale_open_orders_payload(rows, summary),
         "alpaca_guard": _alpaca_guard_payload(summary),
@@ -188,6 +252,18 @@ def _proof_summary(
     raw_exchange_positions = _raw_account_positions(rows.latest_account)
     unexpected_live_orders = _int(rows.unexpected_live_alpaca.get("orders_24h"))
     unexpected_live_events = _int(rows.unexpected_live_alpaca.get("events_24h"))
+    expected_return_bps = _optional_decimal(
+        rows.latest_forecast.get("expected_return_bps")
+    )
+    expected_cost_bps = _optional_decimal(
+        rows.latest_portfolio_target.get("expected_cost_bps")
+    )
+    risk_buffer_bps = _optional_decimal(
+        rows.latest_portfolio_target.get("risk_buffer_bps")
+    )
+    target_notional_usd = _optional_decimal(
+        rows.latest_portfolio_target.get("target_notional_usd")
+    )
     market_data_fresh = (
         _fresh_enough(
             market_lag_seconds,
@@ -227,6 +303,21 @@ def _proof_summary(
         stale_open_order_count=len(rows.stale_open_orders),
         unexpected_live_orders=unexpected_live_orders,
         unexpected_live_events=unexpected_live_events,
+        multifactor_run_present=bool(rows.latest_multifactor_run),
+        factor_snapshot_present=bool(rows.latest_factor_snapshot),
+        alpha_forecast_present=bool(rows.latest_forecast),
+        risk_forecast_present=bool(rows.latest_risk_forecast),
+        portfolio_target_present=bool(rows.latest_portfolio_target),
+        execution_intent_present=bool(rows.latest_execution_intent),
+        alpha_edge_above_cost=(
+            expected_return_bps is not None
+            and expected_cost_bps is not None
+            and risk_buffer_bps is not None
+            and abs(expected_return_bps) > expected_cost_bps + risk_buffer_bps
+        ),
+        target_notional_positive=(
+            target_notional_usd is not None and target_notional_usd > Decimal("0")
+        ),
     )
 
 
@@ -350,6 +441,12 @@ def _database_payload(
         "fills_24h": summary.recent_fill_count,
         "account_snapshots_24h": _int(rows.counts_24h.get("account_snapshots_24h")),
         "positions_current": summary.position_count,
+        "multifactor_run_present": summary.multifactor_run_present,
+        "multifactor_factor_snapshot_present": summary.factor_snapshot_present,
+        "multifactor_forecast_present": summary.alpha_forecast_present,
+        "multifactor_risk_forecast_present": summary.risk_forecast_present,
+        "multifactor_portfolio_target_present": summary.portfolio_target_present,
+        "multifactor_execution_intent_present": summary.execution_intent_present,
     }
 
 
@@ -412,6 +509,22 @@ def _blockers(
     blockers = list(summary.query_errors)
     if not summary.market_data_fresh:
         blockers.append("hyperliquid_market_data_not_fresh")
+    if not summary.multifactor_run_present:
+        blockers.append("multifactor_run_missing")
+    if not summary.factor_snapshot_present:
+        blockers.append("multifactor_factor_snapshot_missing")
+    if not summary.alpha_forecast_present:
+        blockers.append("multifactor_alpha_forecast_missing")
+    if not summary.risk_forecast_present:
+        blockers.append("multifactor_risk_forecast_missing")
+    if not summary.portfolio_target_present:
+        blockers.append("multifactor_portfolio_target_missing")
+    if not summary.execution_intent_present:
+        blockers.append("multifactor_execution_intent_missing")
+    if not summary.alpha_edge_above_cost:
+        blockers.append("multifactor_expected_edge_not_above_cost")
+    if not summary.target_notional_positive:
+        blockers.append("multifactor_target_notional_not_positive")
     if not summary.latest_order_present:
         blockers.append("hyperliquid_order_submission_missing")
     if not summary.exchange_ack_seen:
@@ -563,6 +676,15 @@ def _optional_int(value: object) -> int | None:
         return None
     try:
         return int(Decimal(str(value)))
+    except Exception:
+        return None
+
+
+def _optional_decimal(value: object) -> Decimal | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return Decimal(str(value))
     except Exception:
         return None
 
@@ -763,7 +885,6 @@ SELECT
    WHERE COALESCE(event_ts, created_at) >= now() - interval '24 hours'
      AND alpaca_account_label ILIKE '%live%')::int AS events_24h
 """
-
 
 __all__ = (
     "DEFAULT_ACCOUNT_FRESHNESS_SECONDS",

--- a/services/torghut/app/trading/multifactor/__init__.py
+++ b/services/torghut/app/trading/multifactor/__init__.py
@@ -1,0 +1,42 @@
+"""Generic multifactor trading machine contracts and runtime helpers."""
+
+from .alpha_model import build_alpha_forecast
+from .attribution import AttributionInputs, build_attribution_snapshot
+from .contracts import (
+    AlphaForecast,
+    AssetKey,
+    AttributionSnapshot,
+    ExecutionIntent,
+    FactorVector,
+    PortfolioTarget,
+    RiskForecast,
+    UniverseSnapshot,
+)
+from .cost_model import estimate_transaction_cost
+from .portfolio_construction import (
+    PortfolioCostInput,
+    PortfolioLimits,
+    build_portfolio_target,
+)
+from .risk_model import RiskExposureState, RiskLimits, build_risk_forecast
+
+__all__ = [
+    "AlphaForecast",
+    "AssetKey",
+    "AttributionSnapshot",
+    "AttributionInputs",
+    "ExecutionIntent",
+    "FactorVector",
+    "PortfolioCostInput",
+    "PortfolioLimits",
+    "PortfolioTarget",
+    "RiskExposureState",
+    "RiskForecast",
+    "RiskLimits",
+    "UniverseSnapshot",
+    "build_alpha_forecast",
+    "build_attribution_snapshot",
+    "build_portfolio_target",
+    "build_risk_forecast",
+    "estimate_transaction_cost",
+]

--- a/services/torghut/app/trading/multifactor/adapters/__init__.py
+++ b/services/torghut/app/trading/multifactor/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Venue adapters for the generic multifactor machine."""

--- a/services/torghut/app/trading/multifactor/adapters/hyperliquid.py
+++ b/services/torghut/app/trading/multifactor/adapters/hyperliquid.py
@@ -1,0 +1,103 @@
+"""Hyperliquid adapter for the generic multifactor machine."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.hyperliquid_execution.models import FeatureSnapshot
+
+from ..contracts import AssetKey, ExecutionIntent, FactorVector, PortfolioTarget
+from ..normalization import (
+    bounded_score,
+    negative_quality_score,
+    positive_quality_score,
+)
+
+
+def asset_from_feature(feature: FeatureSnapshot) -> AssetKey:
+    """Build a venue-neutral asset key from a Hyperliquid feature row."""
+
+    return AssetKey(
+        venue="hyperliquid",
+        symbol=feature.coin,
+        market_id=feature.market_id,
+        asset_class="perp",
+    )
+
+
+def factor_vector_from_feature(
+    *,
+    run_id: str,
+    feature: FeatureSnapshot,
+    max_staleness_seconds: int,
+) -> FactorVector:
+    """Map Hyperliquid runtime features into generic raw and normalized factors."""
+
+    raw = {
+        "momentum_5m": feature.momentum_5m_bps,
+        "book_imbalance": feature.book_imbalance,
+        "liquidity_usd": feature.liquidity_usd,
+        "spread_bps": feature.spread_bps,
+        "volatility_bps": feature.volatility_bps,
+        "source_lag_seconds": Decimal(feature.source_lag_seconds),
+    }
+    if feature.quote_lag_seconds is not None:
+        raw["quote_lag_seconds"] = Decimal(feature.quote_lag_seconds)
+    freshness_blocker = _freshness_blocker(feature, max_staleness_seconds)
+    normalized = {
+        "momentum_5m": bounded_score(feature.momentum_5m_bps, Decimal("2")),
+        "book_imbalance": bounded_score(feature.book_imbalance, Decimal("0.5")),
+        "liquidity_usd": positive_quality_score(
+            feature.liquidity_usd, Decimal("1000"), Decimal("100000")
+        ),
+        "spread_bps": negative_quality_score(
+            feature.spread_bps, Decimal("25"), Decimal("10")
+        ),
+        "volatility_bps": negative_quality_score(
+            feature.volatility_bps, Decimal("350"), Decimal("100")
+        ),
+    }
+    return FactorVector(
+        run_id=run_id,
+        asset=asset_from_feature(feature),
+        observed_at=feature.event_ts,
+        source_event_at=feature.event_ts,
+        raw_factors=raw,
+        normalized_factors=normalized,
+        source_lag_seconds=feature.source_lag_seconds,
+        quote_lag_seconds=feature.quote_lag_seconds,
+        freshness_blocker=freshness_blocker,
+    )
+
+
+def execution_intent_from_target(
+    *,
+    target: PortfolioTarget,
+    idempotency_key: str,
+) -> ExecutionIntent:
+    """Create a generic execution intent for an executable Hyperliquid target."""
+
+    side = "buy" if target.direction == "buy" else "sell"
+    return ExecutionIntent(
+        run_id=target.run_id,
+        asset=target.asset,
+        venue="hyperliquid",
+        side=side,
+        notional_usd=target.delta_notional_usd,
+        idempotency_key=idempotency_key,
+        status="planned" if target.executable else "blocked",
+        blocker=target.clip_reason,
+    )
+
+
+def _freshness_blocker(
+    feature: FeatureSnapshot,
+    max_staleness_seconds: int,
+) -> str | None:
+    if feature.source_lag_seconds > max_staleness_seconds:
+        return "stale_features"
+    if feature.quote_lag_seconds is None:
+        return "missing_quote_timestamp"
+    if feature.quote_lag_seconds > max_staleness_seconds:
+        return "stale_quote"
+    return None

--- a/services/torghut/app/trading/multifactor/alpha_model.py
+++ b/services/torghut/app/trading/multifactor/alpha_model.py
@@ -1,0 +1,68 @@
+"""Active Portfolio Management style alpha refinement."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .contracts import AlphaForecast, FactorVector
+from .factor_registry import (
+    DEFAULT_FACTOR_DEFINITIONS,
+    DEFAULT_HORIZON_SECONDS,
+    DEFAULT_INFORMATION_COEFFICIENT,
+    DEFAULT_MODEL_ID,
+)
+from .normalization import quantize_bps
+
+
+def build_alpha_forecast(
+    vector: FactorVector,
+    *,
+    residual_volatility_bps: Decimal,
+    information_coefficient: Decimal = DEFAULT_INFORMATION_COEFFICIENT,
+    horizon_seconds: int = DEFAULT_HORIZON_SECONDS,
+    model_id: str = DEFAULT_MODEL_ID,
+) -> AlphaForecast:
+    """Transform normalized factors into a refined return forecast."""
+
+    if not vector.fresh:
+        return AlphaForecast(
+            run_id=vector.run_id,
+            asset=vector.asset,
+            model_id=model_id,
+            horizon_seconds=horizon_seconds,
+            score=Decimal("0"),
+            residual_volatility_bps=residual_volatility_bps,
+            information_coefficient=information_coefficient,
+            expected_return_bps=Decimal("0"),
+            direction="hold",
+            blocker=vector.freshness_blocker,
+        )
+    score = sum(
+        (
+            definition.weight
+            * vector.normalized_factors.get(definition.name, Decimal("0"))
+            for definition in DEFAULT_FACTOR_DEFINITIONS
+        ),
+        Decimal("0"),
+    )
+    expected_return_bps = quantize_bps(
+        residual_volatility_bps * information_coefficient * score
+    )
+    if expected_return_bps > Decimal("0"):
+        direction = "buy"
+    elif expected_return_bps < Decimal("0"):
+        direction = "sell"
+    else:
+        direction = "hold"
+    return AlphaForecast(
+        run_id=vector.run_id,
+        asset=vector.asset,
+        model_id=model_id,
+        horizon_seconds=horizon_seconds,
+        score=score,
+        residual_volatility_bps=residual_volatility_bps,
+        information_coefficient=information_coefficient,
+        expected_return_bps=expected_return_bps,
+        direction=direction,
+        blocker=None if direction != "hold" else "zero_expected_return",
+    )

--- a/services/torghut/app/trading/multifactor/attribution.py
+++ b/services/torghut/app/trading/multifactor/attribution.py
@@ -1,0 +1,40 @@
+"""Small attribution helpers for multifactor proof snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from .contracts import AttributionSnapshot
+
+
+@dataclass(frozen=True)
+class AttributionInputs:
+    """Reduced realized performance inputs for one runtime proof snapshot."""
+
+    run_id: str
+    observed_at: datetime
+    fill_count: int
+    realized_pnl_usd: Decimal
+    turnover_usd: Decimal
+    realized_cost_usd: Decimal
+
+
+def build_attribution_snapshot(inputs: AttributionInputs) -> AttributionSnapshot:
+    """Build the reduced attribution payload persisted with each runtime cycle."""
+
+    hit_rate = (
+        Decimal("1")
+        if inputs.fill_count > 0 and inputs.realized_pnl_usd > Decimal("0")
+        else Decimal("0")
+    )
+    return AttributionSnapshot(
+        run_id=inputs.run_id,
+        observed_at=inputs.observed_at,
+        fill_count=inputs.fill_count,
+        realized_pnl_usd=inputs.realized_pnl_usd,
+        turnover_usd=inputs.turnover_usd,
+        realized_cost_usd=inputs.realized_cost_usd,
+        hit_rate=hit_rate,
+    )

--- a/services/torghut/app/trading/multifactor/contracts.py
+++ b/services/torghut/app/trading/multifactor/contracts.py
@@ -1,0 +1,153 @@
+"""Venue-neutral contracts for Torghut's generic multifactor machine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+
+Direction = Literal["buy", "sell", "hold"]
+
+
+def _empty_decimal_map() -> dict[str, Decimal]:
+    return {}
+
+
+def _empty_object_map() -> dict[str, object]:
+    return {}
+
+
+@dataclass(frozen=True)
+class AssetKey:
+    """Stable identity for a tradeable asset on a venue."""
+
+    venue: str
+    symbol: str
+    market_id: str
+    asset_class: str = "perp"
+
+    @property
+    def key(self) -> str:
+        return f"{self.venue}:{self.market_id}"
+
+
+@dataclass(frozen=True)
+class UniverseSnapshot:
+    """Assets selected for one multifactor cycle."""
+
+    run_id: str
+    observed_at: datetime
+    lane: str
+    assets: tuple[AssetKey, ...]
+    selection_reason: str
+    metadata: dict[str, object] = field(default_factory=_empty_object_map)
+
+
+@dataclass(frozen=True)
+class FactorVector:
+    """Raw and normalized factor exposures for one asset."""
+
+    run_id: str
+    asset: AssetKey
+    observed_at: datetime
+    source_event_at: datetime
+    raw_factors: dict[str, Decimal]
+    normalized_factors: dict[str, Decimal]
+    source_lag_seconds: int
+    quote_lag_seconds: int | None
+    freshness_blocker: str | None = None
+
+    @property
+    def fresh(self) -> bool:
+        return self.freshness_blocker is None
+
+
+@dataclass(frozen=True)
+class AlphaForecast:
+    """Refined expected-return forecast from normalized factor scores."""
+
+    run_id: str
+    asset: AssetKey
+    model_id: str
+    horizon_seconds: int
+    score: Decimal
+    residual_volatility_bps: Decimal
+    information_coefficient: Decimal
+    expected_return_bps: Decimal
+    direction: Direction
+    blocker: str | None = None
+
+
+@dataclass(frozen=True)
+class RiskForecast:
+    """Pre-trade risk and blocker estimate for one asset."""
+
+    run_id: str
+    asset: AssetKey
+    active_risk_bps: Decimal
+    gross_exposure_usd: Decimal
+    symbol_exposure_usd: Decimal
+    liquidity_capacity_usd: Decimal
+    concentration_bps: Decimal
+    blocker: str | None = None
+
+    @property
+    def allowed(self) -> bool:
+        return self.blocker is None
+
+
+@dataclass(frozen=True)
+class PortfolioTarget:
+    """Constrained target delta generated before venue order construction."""
+
+    run_id: str
+    asset: AssetKey
+    direction: Direction
+    current_notional_usd: Decimal
+    target_notional_usd: Decimal
+    delta_notional_usd: Decimal
+    expected_return_bps: Decimal
+    expected_cost_bps: Decimal
+    active_risk_bps: Decimal
+    risk_buffer_bps: Decimal
+    clip_reason: str | None = None
+
+    @property
+    def executable(self) -> bool:
+        return (
+            self.direction != "hold"
+            and self.delta_notional_usd > Decimal("0")
+            and self.clip_reason is None
+        )
+
+
+@dataclass(frozen=True)
+class ExecutionIntent:
+    """Venue-neutral intent emitted by portfolio construction."""
+
+    run_id: str
+    asset: AssetKey
+    venue: str
+    side: Literal["buy", "sell"]
+    notional_usd: Decimal
+    idempotency_key: str
+    status: str = "planned"
+    blocker: str | None = None
+
+
+@dataclass(frozen=True)
+class AttributionSnapshot:
+    """Reduced realized performance and signal-quality proof."""
+
+    run_id: str
+    observed_at: datetime
+    fill_count: int
+    realized_pnl_usd: Decimal
+    turnover_usd: Decimal
+    realized_cost_usd: Decimal
+    information_coefficient: Decimal | None = None
+    information_ratio: Decimal | None = None
+    hit_rate: Decimal | None = None
+    factor_contributions: dict[str, Decimal] = field(default_factory=_empty_decimal_map)

--- a/services/torghut/app/trading/multifactor/cost_model.py
+++ b/services/torghut/app/trading/multifactor/cost_model.py
@@ -1,0 +1,23 @@
+"""Transaction-cost estimates for deterministic runtime gating."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .contracts import FactorVector
+from .normalization import quantize_bps
+
+
+def estimate_transaction_cost(
+    vector: FactorVector,
+    *,
+    cost_buffer_bps: Decimal,
+    participation_rate: Decimal,
+) -> Decimal:
+    """Estimate spread, slippage, and impact in basis points."""
+
+    spread_bps = vector.raw_factors.get("spread_bps", Decimal("0"))
+    volatility_bps = vector.raw_factors.get("volatility_bps", Decimal("0"))
+    slippage_bps = min(volatility_bps * Decimal("0.01"), Decimal("5"))
+    impact_bps = min(participation_rate * Decimal("1000"), Decimal("10"))
+    return quantize_bps(spread_bps + slippage_bps + impact_bps + cost_buffer_bps)

--- a/services/torghut/app/trading/multifactor/factor_registry.py
+++ b/services/torghut/app/trading/multifactor/factor_registry.py
@@ -1,0 +1,40 @@
+"""Factor definitions and freshness policy for the runtime multifactor model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Literal
+
+
+FactorDirection = Literal["positive", "negative", "quality"]
+
+
+@dataclass(frozen=True)
+class FactorDefinition:
+    """Configuration for one runtime factor."""
+
+    name: str
+    direction: FactorDirection
+    weight: Decimal
+    required: bool = True
+
+
+DEFAULT_MODEL_ID = "active-portfolio-management-v1"
+DEFAULT_INFORMATION_COEFFICIENT = Decimal("0.05")
+DEFAULT_HORIZON_SECONDS = 300
+DEFAULT_RISK_BUFFER_BPS = Decimal("1")
+DEFAULT_LIQUIDITY_PARTICIPATION_RATE = Decimal("0.001")
+DEFAULT_FACTOR_DEFINITIONS = (
+    FactorDefinition("momentum_5m", "positive", Decimal("0.90")),
+    FactorDefinition("book_imbalance", "positive", Decimal("0.10")),
+    FactorDefinition("liquidity_usd", "quality", Decimal("0")),
+    FactorDefinition("spread_bps", "negative", Decimal("0")),
+    FactorDefinition("volatility_bps", "negative", Decimal("0")),
+)
+
+
+def factor_names() -> tuple[str, ...]:
+    """Return the default factor names in scoring order."""
+
+    return tuple(definition.name for definition in DEFAULT_FACTOR_DEFINITIONS)

--- a/services/torghut/app/trading/multifactor/normalization.py
+++ b/services/torghut/app/trading/multifactor/normalization.py
@@ -1,0 +1,43 @@
+"""Deterministic factor normalization utilities."""
+
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+
+
+_THREE = Decimal("3")
+_FOUR_DECIMALS = Decimal("0.0001")
+
+
+def clamp(value: Decimal, lower: Decimal, upper: Decimal) -> Decimal:
+    """Clamp a decimal to a bounded interval."""
+
+    return max(lower, min(upper, value))
+
+
+def quantize_bps(value: Decimal) -> Decimal:
+    """Keep bps values stable in JSON and DB assertions."""
+
+    return value.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
+
+
+def bounded_score(value: Decimal, scale: Decimal) -> Decimal:
+    """Scale a raw descriptor to a winsorized score."""
+
+    if scale <= Decimal("0"):
+        return Decimal("0")
+    return clamp(value / scale, -_THREE, _THREE).quantize(
+        _FOUR_DECIMALS, rounding=ROUND_HALF_UP
+    )
+
+
+def positive_quality_score(value: Decimal, floor: Decimal, scale: Decimal) -> Decimal:
+    """Map quality descriptors where larger is better into a bounded score."""
+
+    return bounded_score(value - floor, scale)
+
+
+def negative_quality_score(value: Decimal, cap: Decimal, scale: Decimal) -> Decimal:
+    """Map cost/risk descriptors where smaller is better into a bounded score."""
+
+    return bounded_score(cap - value, scale)

--- a/services/torghut/app/trading/multifactor/portfolio_construction.py
+++ b/services/torghut/app/trading/multifactor/portfolio_construction.py
@@ -1,0 +1,92 @@
+"""Deterministic portfolio construction for the runtime restore path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from .contracts import AlphaForecast, PortfolioTarget, RiskForecast
+from .factor_registry import DEFAULT_RISK_BUFFER_BPS
+
+
+@dataclass(frozen=True)
+class PortfolioCostInput:
+    """Cost and edge settings for target construction."""
+
+    expected_cost_bps: Decimal
+    min_edge_bps: Decimal
+    risk_buffer_bps: Decimal = DEFAULT_RISK_BUFFER_BPS
+
+
+@dataclass(frozen=True)
+class PortfolioLimits:
+    """Hard notional caps for one deterministic target."""
+
+    min_order_notional_usd: Decimal
+    max_order_notional_usd: Decimal
+    max_gross_exposure_usd: Decimal
+    max_symbol_exposure_usd: Decimal
+
+
+def build_portfolio_target(
+    *,
+    forecast: AlphaForecast,
+    risk: RiskForecast,
+    costs: PortfolioCostInput,
+    limits: PortfolioLimits,
+) -> PortfolioTarget:
+    """Create one clipped target notional for a forecast."""
+
+    required_edge_bps = max(
+        costs.min_edge_bps,
+        costs.expected_cost_bps + costs.risk_buffer_bps,
+    )
+    clip_reason = _clip_reason(
+        forecast=forecast,
+        risk=risk,
+        required_edge_bps=required_edge_bps,
+        min_order_notional_usd=limits.min_order_notional_usd,
+    )
+    remaining_gross = limits.max_gross_exposure_usd - risk.gross_exposure_usd
+    remaining_symbol = limits.max_symbol_exposure_usd - risk.symbol_exposure_usd
+    target_notional = min(
+        limits.max_order_notional_usd,
+        risk.liquidity_capacity_usd,
+        remaining_gross,
+        remaining_symbol,
+    )
+    if target_notional < limits.min_order_notional_usd and clip_reason is None:
+        clip_reason = "target_notional_below_min_order"
+    if clip_reason is not None:
+        target_notional = Decimal("0")
+    return PortfolioTarget(
+        run_id=forecast.run_id,
+        asset=forecast.asset,
+        direction=forecast.direction,
+        current_notional_usd=risk.symbol_exposure_usd,
+        target_notional_usd=target_notional,
+        delta_notional_usd=target_notional,
+        expected_return_bps=forecast.expected_return_bps,
+        expected_cost_bps=costs.expected_cost_bps,
+        active_risk_bps=risk.active_risk_bps,
+        risk_buffer_bps=costs.risk_buffer_bps,
+        clip_reason=clip_reason,
+    )
+
+
+def _clip_reason(
+    *,
+    forecast: AlphaForecast,
+    risk: RiskForecast,
+    required_edge_bps: Decimal,
+    min_order_notional_usd: Decimal,
+) -> str | None:
+    if risk.blocker is not None:
+        return risk.blocker
+    if forecast.blocker is not None and forecast.direction == "hold":
+        return forecast.blocker
+    if abs(forecast.expected_return_bps) <= required_edge_bps:
+        return "expected_edge_not_above_cost"
+    if risk.liquidity_capacity_usd < min_order_notional_usd:
+        return "liquidity_capacity_below_min_order"
+    return None

--- a/services/torghut/app/trading/multifactor/risk_model.py
+++ b/services/torghut/app/trading/multifactor/risk_model.py
@@ -1,0 +1,114 @@
+"""Generic deterministic risk forecast for the runtime multifactor path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from .contracts import AlphaForecast, FactorVector, RiskForecast
+from .factor_registry import (
+    DEFAULT_HORIZON_SECONDS,
+    DEFAULT_LIQUIDITY_PARTICIPATION_RATE,
+)
+from .normalization import quantize_bps
+
+
+@dataclass(frozen=True)
+class RiskExposureState:
+    """Current exposure state used by deterministic runtime risk checks."""
+
+    gross_exposure_usd: Decimal
+    symbol_exposure_usd: Decimal
+    daily_realized_pnl_usd: Decimal
+
+
+@dataclass(frozen=True)
+class RiskLimits:
+    """Hard risk caps for the restore-path multifactor engine."""
+
+    max_gross_exposure_usd: Decimal
+    max_symbol_exposure_usd: Decimal
+    max_daily_loss_usd: Decimal
+    participation_rate: Decimal = DEFAULT_LIQUIDITY_PARTICIPATION_RATE
+
+
+def build_risk_forecast(
+    *,
+    vector: FactorVector,
+    forecast: AlphaForecast,
+    exposure: RiskExposureState,
+    limits: RiskLimits,
+) -> RiskForecast:
+    """Estimate active risk and hard blockers before portfolio construction."""
+
+    liquidity_usd = vector.raw_factors.get("liquidity_usd", Decimal("0"))
+    volatility_bps = vector.raw_factors.get("volatility_bps", Decimal("0"))
+    active_risk_bps = _active_risk_bps(volatility_bps, forecast.horizon_seconds)
+    liquidity_capacity_usd = (liquidity_usd * limits.participation_rate).quantize(
+        Decimal("0.000001")
+    )
+    concentration_bps = _concentration_bps(
+        exposure.symbol_exposure_usd,
+        limits.max_gross_exposure_usd,
+    )
+    blocker = _first_risk_blocker(
+        vector=vector,
+        forecast=forecast,
+        exposure=exposure,
+        limits=limits,
+        liquidity_capacity_usd=liquidity_capacity_usd,
+    )
+    return RiskForecast(
+        run_id=vector.run_id,
+        asset=vector.asset,
+        active_risk_bps=active_risk_bps,
+        gross_exposure_usd=exposure.gross_exposure_usd,
+        symbol_exposure_usd=exposure.symbol_exposure_usd,
+        liquidity_capacity_usd=liquidity_capacity_usd,
+        concentration_bps=concentration_bps,
+        blocker=blocker,
+    )
+
+
+def _active_risk_bps(volatility_bps: Decimal, horizon_seconds: int) -> Decimal:
+    horizon = Decimal(str(horizon_seconds or DEFAULT_HORIZON_SECONDS))
+    return quantize_bps(volatility_bps * (horizon / Decimal("86400")))
+
+
+def _concentration_bps(
+    symbol_exposure_usd: Decimal,
+    max_gross_exposure_usd: Decimal,
+) -> Decimal:
+    if max_gross_exposure_usd <= Decimal("0"):
+        return Decimal("0")
+    return quantize_bps(
+        (symbol_exposure_usd / max_gross_exposure_usd) * Decimal("10000")
+    )
+
+
+def _first_risk_blocker(
+    *,
+    vector: FactorVector,
+    forecast: AlphaForecast,
+    exposure: RiskExposureState,
+    limits: RiskLimits,
+    liquidity_capacity_usd: Decimal,
+) -> str | None:
+    checks = (
+        (not vector.fresh, vector.freshness_blocker or "stale_factors"),
+        (forecast.direction == "hold", forecast.blocker or "forecast_hold"),
+        (
+            exposure.daily_realized_pnl_usd <= -limits.max_daily_loss_usd,
+            "daily_loss_stop",
+        ),
+        (
+            exposure.gross_exposure_usd >= limits.max_gross_exposure_usd,
+            "gross_exposure_cap",
+        ),
+        (
+            exposure.symbol_exposure_usd >= limits.max_symbol_exposure_usd,
+            "symbol_exposure_cap",
+        ),
+        (liquidity_capacity_usd <= Decimal("0"), "liquidity_capacity_zero"),
+    )
+    return next((reason for blocked, reason in checks if blocked), None)

--- a/services/torghut/app/trading/multifactor/status_payloads.py
+++ b/services/torghut/app/trading/multifactor/status_payloads.py
@@ -1,0 +1,310 @@
+"""Multifactor sections for the trading-loop operator status."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, cast
+
+LATEST_MULTIFACTOR_RUN_SQL = """
+SELECT
+  id::text,
+  lane,
+  model_version,
+  started_at,
+  finished_at,
+  status,
+  blockers,
+  selected_assets
+FROM multifactor_runs
+ORDER BY finished_at DESC
+LIMIT 1
+"""
+
+LATEST_FACTOR_SNAPSHOT_SQL = """
+SELECT
+  run_id::text,
+  asset_key,
+  venue,
+  symbol,
+  market_id,
+  source_event_at,
+  observed_at,
+  raw_factors,
+  normalized_factors,
+  source_lag_seconds,
+  quote_lag_seconds,
+  freshness_blocker
+FROM multifactor_factor_snapshots
+ORDER BY observed_at DESC
+LIMIT 1
+"""
+
+LATEST_FORECAST_SQL = """
+SELECT
+  run_id::text,
+  asset_key,
+  model_id,
+  horizon_seconds,
+  score::text,
+  residual_volatility_bps::text,
+  information_coefficient::text,
+  expected_return_bps::text,
+  direction,
+  blocker
+FROM multifactor_forecasts
+ORDER BY updated_at DESC
+LIMIT 1
+"""
+
+LATEST_RISK_FORECAST_SQL = """
+SELECT
+  run_id::text,
+  asset_key,
+  active_risk_bps::text,
+  gross_exposure_usd::text,
+  symbol_exposure_usd::text,
+  liquidity_capacity_usd::text,
+  concentration_bps::text,
+  blocker
+FROM multifactor_risk_forecasts
+ORDER BY updated_at DESC
+LIMIT 1
+"""
+
+LATEST_PORTFOLIO_TARGET_SQL = """
+SELECT
+  run_id::text,
+  asset_key,
+  direction,
+  current_notional_usd::text,
+  target_notional_usd::text,
+  delta_notional_usd::text,
+  expected_return_bps::text,
+  expected_cost_bps::text,
+  active_risk_bps::text,
+  risk_buffer_bps::text,
+  clip_reason
+FROM multifactor_portfolio_targets
+ORDER BY updated_at DESC
+LIMIT 1
+"""
+
+LATEST_EXECUTION_INTENT_SQL = """
+SELECT
+  run_id::text,
+  asset_key,
+  venue,
+  side,
+  notional_usd::text,
+  idempotency_key,
+  status,
+  blocker,
+  venue_order_id
+FROM multifactor_execution_intents
+ORDER BY updated_at DESC
+LIMIT 1
+"""
+
+LATEST_ATTRIBUTION_SQL = """
+SELECT
+  run_id::text,
+  observed_at,
+  fill_count,
+  realized_pnl_usd::text,
+  turnover_usd::text,
+  realized_cost_usd::text,
+  information_coefficient::text,
+  information_ratio::text,
+  hit_rate::text
+FROM multifactor_attribution_snapshots
+ORDER BY observed_at DESC
+LIMIT 1
+"""
+
+
+def alpha_model_payload(rows: Any, summary: Any) -> dict[str, object]:
+    return {
+        "present": summary.multifactor_run_present and summary.alpha_forecast_present,
+        "run_id": _optional_text(rows.latest_multifactor_run.get("id")),
+        "model_id": _optional_text(rows.latest_forecast.get("model_id")),
+        "factor_snapshot_present": summary.factor_snapshot_present,
+        "forecast_present": summary.alpha_forecast_present,
+        "expected_return_bps": _optional_text(
+            rows.latest_forecast.get("expected_return_bps")
+        ),
+        "expected_edge_above_cost": summary.alpha_edge_above_cost,
+        "score": _optional_text(rows.latest_forecast.get("score")),
+        "information_coefficient": _optional_text(
+            rows.latest_forecast.get("information_coefficient")
+        ),
+        "residual_volatility_bps": _optional_text(
+            rows.latest_forecast.get("residual_volatility_bps")
+        ),
+        "direction": _optional_text(rows.latest_forecast.get("direction")),
+        "freshness": _freshness_payload(rows.latest_factor_snapshot),
+        "raw_factors": _mapping_payload(rows.latest_factor_snapshot.get("raw_factors")),
+        "normalized_factors": _mapping_payload(
+            rows.latest_factor_snapshot.get("normalized_factors")
+        ),
+    }
+
+
+def risk_forecast_payload(rows: Any, summary: Any) -> dict[str, object]:
+    return {
+        "present": summary.risk_forecast_present,
+        "active_risk_bps": _optional_text(
+            rows.latest_risk_forecast.get("active_risk_bps")
+        ),
+        "gross_exposure_usd": _optional_text(
+            rows.latest_risk_forecast.get("gross_exposure_usd")
+        ),
+        "symbol_exposure_usd": _optional_text(
+            rows.latest_risk_forecast.get("symbol_exposure_usd")
+        ),
+        "liquidity_capacity_usd": _optional_text(
+            rows.latest_risk_forecast.get("liquidity_capacity_usd")
+        ),
+        "concentration_bps": _optional_text(
+            rows.latest_risk_forecast.get("concentration_bps")
+        ),
+        "blocker": _optional_text(rows.latest_risk_forecast.get("blocker")),
+    }
+
+
+def portfolio_target_payload(rows: Any, summary: Any) -> dict[str, object]:
+    return {
+        "present": summary.portfolio_target_present,
+        "target_notional_positive": summary.target_notional_positive,
+        "direction": _optional_text(rows.latest_portfolio_target.get("direction")),
+        "target_notional_usd": _optional_text(
+            rows.latest_portfolio_target.get("target_notional_usd")
+        ),
+        "delta_notional_usd": _optional_text(
+            rows.latest_portfolio_target.get("delta_notional_usd")
+        ),
+        "expected_return_bps": _optional_text(
+            rows.latest_portfolio_target.get("expected_return_bps")
+        ),
+        "expected_cost_bps": _optional_text(
+            rows.latest_portfolio_target.get("expected_cost_bps")
+        ),
+        "active_risk_bps": _optional_text(
+            rows.latest_portfolio_target.get("active_risk_bps")
+        ),
+        "risk_buffer_bps": _optional_text(
+            rows.latest_portfolio_target.get("risk_buffer_bps")
+        ),
+        "clip_reason": _optional_text(rows.latest_portfolio_target.get("clip_reason")),
+    }
+
+
+def execution_intent_payload(rows: Any, summary: Any) -> dict[str, object]:
+    return {
+        "present": summary.execution_intent_present,
+        "venue": _optional_text(rows.latest_execution_intent.get("venue")),
+        "side": _optional_text(rows.latest_execution_intent.get("side")),
+        "notional_usd": _optional_text(
+            rows.latest_execution_intent.get("notional_usd")
+        ),
+        "idempotency_key": _optional_text(
+            rows.latest_execution_intent.get("idempotency_key")
+        ),
+        "status": _optional_text(rows.latest_execution_intent.get("status")),
+        "venue_order_id": _optional_text(
+            rows.latest_execution_intent.get("venue_order_id")
+        ),
+        "blocker": _optional_text(rows.latest_execution_intent.get("blocker")),
+    }
+
+
+def attribution_payload(rows: Any) -> dict[str, object]:
+    return {
+        "present": bool(rows.latest_attribution),
+        "observed_at": _iso(
+            _datetime_value(rows.latest_attribution.get("observed_at"))
+        ),
+        "fill_count": _int(rows.latest_attribution.get("fill_count")),
+        "realized_pnl_usd": _optional_text(
+            rows.latest_attribution.get("realized_pnl_usd")
+        ),
+        "turnover_usd": _optional_text(rows.latest_attribution.get("turnover_usd")),
+        "realized_cost_usd": _optional_text(
+            rows.latest_attribution.get("realized_cost_usd")
+        ),
+        "hit_rate": _optional_text(rows.latest_attribution.get("hit_rate")),
+    }
+
+
+def _freshness_payload(row: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "source_lag_seconds": _optional_int(row.get("source_lag_seconds")),
+        "quote_lag_seconds": _optional_int(row.get("quote_lag_seconds")),
+        "freshness_blocker": _optional_text(row.get("freshness_blocker")),
+    }
+
+
+def _mapping_payload(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, object], value)
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(loaded, Mapping):
+            return cast(Mapping[str, object], loaded)
+    return {}
+
+
+def _datetime_value(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_aware(value)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _ensure_aware(parsed)
+    return None
+
+
+def _ensure_aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _int(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if value is None:
+        return 0
+    try:
+        return int(Decimal(str(value)))
+    except Exception:
+        return 0
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(Decimal(str(value)))
+    except Exception:
+        return None
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    return text_value or None

--- a/services/torghut/migrations/versions/0057_generic_multifactor_machine.py
+++ b/services/torghut/migrations/versions/0057_generic_multifactor_machine.py
@@ -1,0 +1,251 @@
+"""Generic multifactor machine proof tables.
+
+Revision ID: 0057_generic_multifactor_machine
+Revises: 0056_hyperliquid_execution_v2_hard_reset
+Create Date: 2026-06-25 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0057_generic_multifactor_machine"
+down_revision = "0056_hyperliquid_execution_v2_hard_reset"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "multifactor_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("lane", sa.String(length=64), nullable=False),
+        sa.Column("model_version", sa.String(length=128), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column(
+            "blockers",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "selected_assets",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "raw_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_multifactor_runs"),
+    )
+    op.create_index("ix_multifactor_runs_finished", "multifactor_runs", ["finished_at"])
+
+    op.create_table(
+        "multifactor_factor_snapshots",
+        sa.Column("run_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("asset_key", sa.String(length=256), nullable=False),
+        sa.Column("venue", sa.String(length=64), nullable=False),
+        sa.Column("symbol", sa.String(length=64), nullable=False),
+        sa.Column("market_id", sa.String(length=128), nullable=False),
+        sa.Column("source_event_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "raw_factors", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column(
+            "normalized_factors",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("source_lag_seconds", sa.Integer(), nullable=False),
+        sa.Column("quote_lag_seconds", sa.Integer(), nullable=True),
+        sa.Column("freshness_blocker", sa.String(length=128), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["multifactor_runs.id"], name="fk_multifactor_factors_run"
+        ),
+        sa.PrimaryKeyConstraint(
+            "run_id", "asset_key", name="pk_multifactor_factor_snapshots"
+        ),
+    )
+
+    op.create_table(
+        "multifactor_forecasts",
+        sa.Column("run_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("asset_key", sa.String(length=256), nullable=False),
+        sa.Column("model_id", sa.String(length=128), nullable=False),
+        sa.Column("signal_id", postgresql.UUID(as_uuid=False), nullable=True),
+        sa.Column("horizon_seconds", sa.Integer(), nullable=False),
+        sa.Column("score", sa.Numeric(18, 8), nullable=False),
+        sa.Column("residual_volatility_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("information_coefficient", sa.Numeric(18, 8), nullable=False),
+        sa.Column("expected_return_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("direction", sa.String(length=16), nullable=False),
+        sa.Column("blocker", sa.String(length=128), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["multifactor_runs.id"], name="fk_multifactor_forecasts_run"
+        ),
+        sa.PrimaryKeyConstraint("run_id", "asset_key", name="pk_multifactor_forecasts"),
+    )
+
+    op.create_table(
+        "multifactor_risk_forecasts",
+        sa.Column("run_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("asset_key", sa.String(length=256), nullable=False),
+        sa.Column("active_risk_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("gross_exposure_usd", sa.Numeric(28, 8), nullable=False),
+        sa.Column("symbol_exposure_usd", sa.Numeric(28, 8), nullable=False),
+        sa.Column("liquidity_capacity_usd", sa.Numeric(28, 8), nullable=False),
+        sa.Column("concentration_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("blocker", sa.String(length=128), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["multifactor_runs.id"], name="fk_multifactor_risk_run"
+        ),
+        sa.PrimaryKeyConstraint(
+            "run_id", "asset_key", name="pk_multifactor_risk_forecasts"
+        ),
+    )
+
+    op.create_table(
+        "multifactor_portfolio_targets",
+        sa.Column("run_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("asset_key", sa.String(length=256), nullable=False),
+        sa.Column("direction", sa.String(length=16), nullable=False),
+        sa.Column("current_notional_usd", sa.Numeric(28, 8), nullable=False),
+        sa.Column("target_notional_usd", sa.Numeric(28, 8), nullable=False),
+        sa.Column("delta_notional_usd", sa.Numeric(28, 8), nullable=False),
+        sa.Column("expected_return_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("expected_cost_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("active_risk_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("risk_buffer_bps", sa.Numeric(18, 8), nullable=False),
+        sa.Column("clip_reason", sa.String(length=128), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["multifactor_runs.id"], name="fk_multifactor_targets_run"
+        ),
+        sa.PrimaryKeyConstraint(
+            "run_id", "asset_key", name="pk_multifactor_portfolio_targets"
+        ),
+    )
+
+    op.create_table(
+        "multifactor_execution_intents",
+        sa.Column("run_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("asset_key", sa.String(length=256), nullable=False),
+        sa.Column("venue", sa.String(length=64), nullable=False),
+        sa.Column("side", sa.String(length=8), nullable=False),
+        sa.Column("notional_usd", sa.Numeric(28, 8), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("blocker", sa.Text(), nullable=True),
+        sa.Column("venue_order_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "raw_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["multifactor_runs.id"], name="fk_multifactor_intents_run"
+        ),
+        sa.PrimaryKeyConstraint(
+            "run_id", "asset_key", name="pk_multifactor_execution_intents"
+        ),
+    )
+
+    op.create_table(
+        "multifactor_attribution_snapshots",
+        sa.Column("run_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("fill_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "realized_pnl_usd", sa.Numeric(28, 8), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "turnover_usd", sa.Numeric(28, 8), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "realized_cost_usd", sa.Numeric(28, 8), nullable=False, server_default="0"
+        ),
+        sa.Column("information_coefficient", sa.Numeric(18, 8), nullable=True),
+        sa.Column("information_ratio", sa.Numeric(18, 8), nullable=True),
+        sa.Column("hit_rate", sa.Numeric(18, 8), nullable=True),
+        sa.Column(
+            "raw_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["multifactor_runs.id"], name="fk_multifactor_attribution_run"
+        ),
+        sa.PrimaryKeyConstraint("run_id", name="pk_multifactor_attribution_snapshots"),
+    )
+
+
+def downgrade() -> None:
+    for table_name in (
+        "multifactor_attribution_snapshots",
+        "multifactor_execution_intents",
+        "multifactor_portfolio_targets",
+        "multifactor_risk_forecasts",
+        "multifactor_forecasts",
+        "multifactor_factor_snapshots",
+        "multifactor_runs",
+    ):
+        op.drop_table(table_name)

--- a/services/torghut/scripts/verify_multifactor_machine.py
+++ b/services/torghut/scripts/verify_multifactor_machine.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from scripts.verify_trading_loop_status import main as verify_trading_loop_status_main
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Fail unless the generic multifactor trading machine has hard proof."""
+
+    return verify_trading_loop_status_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/scripts/verify_trading_loop_status.py
+++ b/services/torghut/scripts/verify_trading_loop_status.py
@@ -59,6 +59,46 @@ def evaluate_loop_status(
         "market_data_not_fresh",
         failures,
     )
+    alpha_model = _mapping(payload.get("alpha_model"))
+    _require(
+        alpha_model.get("present") is True, "multifactor_alpha_model_missing", failures
+    )
+    _require(
+        alpha_model.get("factor_snapshot_present") is True,
+        "multifactor_factor_snapshot_missing",
+        failures,
+    )
+    _require(
+        alpha_model.get("forecast_present") is True,
+        "multifactor_forecast_missing",
+        failures,
+    )
+    _require(
+        alpha_model.get("expected_edge_above_cost") is True,
+        "multifactor_expected_edge_not_above_cost",
+        failures,
+    )
+    _require(
+        _mapping(payload.get("risk_forecast")).get("present") is True,
+        "multifactor_risk_forecast_missing",
+        failures,
+    )
+    portfolio_target = _mapping(payload.get("portfolio_target"))
+    _require(
+        portfolio_target.get("present") is True,
+        "multifactor_portfolio_target_missing",
+        failures,
+    )
+    _require(
+        portfolio_target.get("target_notional_positive") is True,
+        "multifactor_target_notional_not_positive",
+        failures,
+    )
+    _require(
+        _mapping(payload.get("execution_intent")).get("present") is True,
+        "multifactor_execution_intent_missing",
+        failures,
+    )
     _require(
         _mapping(payload.get("submitted_order")).get("present") is True,
         "submitted_order_missing",

--- a/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
+++ b/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
@@ -10,6 +10,9 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 MIGRATION = (
     TORGHUT_ROOT / "migrations/versions/0056_hyperliquid_execution_v2_hard_reset.py"
 )
+MULTIFACTOR_MIGRATION = (
+    TORGHUT_ROOT / "migrations/versions/0057_generic_multifactor_machine.py"
+)
 CONFIGMAP = REPO_ROOT / "argocd/applications/torghut-hyperliquid-runtime/configmap.yaml"
 DEPLOYMENT = (
     REPO_ROOT / "argocd/applications/torghut-hyperliquid-runtime/deployment.yaml"
@@ -25,6 +28,22 @@ def test_hard_reset_migration_drops_v1_tables_and_creates_v2_tables() -> None:
     assert "hyperliquid_execution_cycles" in text
     assert "hyperliquid_execution_orders" in text
     assert "hyperliquid_execution_performance_snapshots" in text
+
+
+def test_generic_multifactor_migration_creates_proof_tables() -> None:
+    text = MULTIFACTOR_MIGRATION.read_text()
+
+    assert 'down_revision = "0056_hyperliquid_execution_v2_hard_reset"' in text
+    for table_name in (
+        "multifactor_runs",
+        "multifactor_factor_snapshots",
+        "multifactor_forecasts",
+        "multifactor_risk_forecasts",
+        "multifactor_portfolio_targets",
+        "multifactor_execution_intents",
+        "multifactor_attribution_snapshots",
+    ):
+        assert table_name in text
 
 
 def test_manifest_uses_v2_command_and_env_prefix_only() -> None:

--- a/services/torghut/tests/multifactor/test_import_boundaries.py
+++ b/services/torghut/tests/multifactor/test_import_boundaries.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+TORGHUT_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = TORGHUT_ROOT / "app"
+HOT_PATHS = (
+    APP_ROOT / "hyperliquid_execution",
+    APP_ROOT / "trading" / "multifactor",
+)
+FORBIDDEN_IMPORT_FAMILIES = (
+    "app.trading.discovery",
+    "app.trading.runtime_window_import",
+    "app.trading.llm",
+    "app.trading.proof_floor",
+    "app.trading.tigerbeetle",
+    "app.trading.empirical",
+    "app.trading.promotion_authority",
+    "autoresearch",
+    "bounded_route",
+    "empirical",
+    "proof_floor",
+    "promotion",
+    "route_materialization",
+    "runtime_window",
+    "tigerbeetle",
+    "whitepaper",
+)
+
+
+def test_multifactor_hot_path_does_not_import_legacy_authority_lanes() -> None:
+    offenders: list[str] = []
+    for root in HOT_PATHS:
+        for path in root.rglob("*.py"):
+            module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for imported in _imported_modules(module):
+                for forbidden in FORBIDDEN_IMPORT_FAMILIES:
+                    if forbidden in imported:
+                        offenders.append(
+                            f"{path.relative_to(TORGHUT_ROOT)} imports {imported}"
+                        )
+
+    assert offenders == []
+
+
+def _imported_modules(module: ast.Module) -> list[str]:
+    imported: list[str] = []
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported.append(node.module)
+    return imported

--- a/services/torghut/tests/multifactor/test_multifactor_machine.py
+++ b/services/torghut/tests/multifactor/test_multifactor_machine.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.hyperliquid_execution.models import FeatureSnapshot
+from app.trading.multifactor.adapters.hyperliquid import factor_vector_from_feature
+from app.trading.multifactor.alpha_model import build_alpha_forecast
+from app.trading.multifactor.cost_model import estimate_transaction_cost
+from app.trading.multifactor.portfolio_construction import (
+    PortfolioCostInput,
+    PortfolioLimits,
+    build_portfolio_target,
+)
+from app.trading.multifactor.risk_model import (
+    RiskExposureState,
+    RiskLimits,
+    build_risk_forecast,
+)
+
+
+def test_multifactor_machine_builds_executable_target_from_hyperliquid_features() -> (
+    None
+):
+    vector = factor_vector_from_feature(
+        run_id="run-1",
+        feature=_feature(momentum=Decimal("12")),
+        max_staleness_seconds=120,
+    )
+    forecast = build_alpha_forecast(
+        vector,
+        residual_volatility_bps=Decimal("50"),
+    )
+    risk = build_risk_forecast(
+        vector=vector,
+        forecast=forecast,
+        exposure=RiskExposureState(
+            gross_exposure_usd=Decimal("0"),
+            symbol_exposure_usd=Decimal("0"),
+            daily_realized_pnl_usd=Decimal("0"),
+        ),
+        limits=RiskLimits(
+            max_gross_exposure_usd=Decimal("100"),
+            max_symbol_exposure_usd=Decimal("25"),
+            max_daily_loss_usd=Decimal("25"),
+        ),
+    )
+    target = build_portfolio_target(
+        forecast=forecast,
+        risk=risk,
+        costs=PortfolioCostInput(
+            expected_cost_bps=estimate_transaction_cost(
+                vector,
+                cost_buffer_bps=Decimal("2"),
+                participation_rate=Decimal("0.001"),
+            ),
+            min_edge_bps=Decimal("5"),
+        ),
+        limits=PortfolioLimits(
+            min_order_notional_usd=Decimal("10"),
+            max_order_notional_usd=Decimal("10"),
+            max_gross_exposure_usd=Decimal("100"),
+            max_symbol_exposure_usd=Decimal("25"),
+        ),
+    )
+
+    assert vector.asset.key == "hyperliquid:hl:perp:default:BNB"
+    assert vector.normalized_factors["momentum_5m"] == Decimal("3.0000")
+    assert forecast.direction == "buy"
+    assert forecast.expected_return_bps > Decimal("5")
+    assert risk.allowed
+    assert target.executable
+    assert target.target_notional_usd == Decimal("10")
+
+
+def test_multifactor_machine_blocks_stale_quote_before_order_target() -> None:
+    vector = factor_vector_from_feature(
+        run_id="run-1",
+        feature=_feature(momentum=Decimal("20"), quote_lag_seconds=240),
+        max_staleness_seconds=120,
+    )
+    forecast = build_alpha_forecast(vector, residual_volatility_bps=Decimal("50"))
+    risk = build_risk_forecast(
+        vector=vector,
+        forecast=forecast,
+        exposure=RiskExposureState(
+            gross_exposure_usd=Decimal("0"),
+            symbol_exposure_usd=Decimal("0"),
+            daily_realized_pnl_usd=Decimal("0"),
+        ),
+        limits=RiskLimits(
+            max_gross_exposure_usd=Decimal("100"),
+            max_symbol_exposure_usd=Decimal("25"),
+            max_daily_loss_usd=Decimal("25"),
+        ),
+    )
+
+    assert vector.fresh is False
+    assert forecast.direction == "hold"
+    assert forecast.blocker == "stale_quote"
+    assert risk.blocker == "stale_quote"
+
+
+def _feature(
+    *,
+    momentum: Decimal,
+    quote_lag_seconds: int | None = 1,
+) -> FeatureSnapshot:
+    return FeatureSnapshot(
+        market_id="hl:perp:default:BNB",
+        coin="BNB",
+        dex="default",
+        event_ts=datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc),
+        price=Decimal("600"),
+        momentum_5m_bps=momentum,
+        spread_bps=Decimal("1"),
+        liquidity_usd=Decimal("100000"),
+        volatility_bps=Decimal("50"),
+        book_imbalance=Decimal("0"),
+        source_lag_seconds=1,
+        bid_price=Decimal("599.5"),
+        ask_price=Decimal("600.5"),
+        quote_lag_seconds=quote_lag_seconds,
+    )

--- a/services/torghut/tests/test_trading_loop_status.py
+++ b/services/torghut/tests/test_trading_loop_status.py
@@ -77,6 +77,69 @@ def test_loop_status_requires_real_execution_proof() -> None:
         stale_open_orders=[],
         unexpected_live_alpaca={"orders_24h": 0, "events_24h": 0},
         query_errors=[],
+        latest_multifactor_run={
+            "id": "cycle-1",
+            "lane": "hyperliquid_testnet",
+            "model_version": "active-portfolio-management-v1",
+            "finished_at": now.isoformat(),
+        },
+        latest_factor_snapshot={
+            "run_id": "cycle-1",
+            "asset_key": "hyperliquid:hl:perp:default:AMD",
+            "source_lag_seconds": 1,
+            "quote_lag_seconds": 1,
+            "raw_factors": {"momentum_5m": "12"},
+            "normalized_factors": {"momentum_5m": "3.0000"},
+        },
+        latest_forecast={
+            "run_id": "cycle-1",
+            "asset_key": "hyperliquid:hl:perp:default:AMD",
+            "model_id": "active-portfolio-management-v1",
+            "score": "3.0000",
+            "residual_volatility_bps": "50",
+            "information_coefficient": "0.05",
+            "expected_return_bps": "8",
+            "direction": "buy",
+        },
+        latest_risk_forecast={
+            "run_id": "cycle-1",
+            "asset_key": "hyperliquid:hl:perp:default:AMD",
+            "active_risk_bps": "1",
+            "gross_exposure_usd": "0",
+            "symbol_exposure_usd": "0",
+            "liquidity_capacity_usd": "10",
+            "concentration_bps": "0",
+        },
+        latest_portfolio_target={
+            "run_id": "cycle-1",
+            "asset_key": "hyperliquid:hl:perp:default:AMD",
+            "direction": "buy",
+            "target_notional_usd": "10",
+            "delta_notional_usd": "10",
+            "expected_return_bps": "8",
+            "expected_cost_bps": "4",
+            "active_risk_bps": "1",
+            "risk_buffer_bps": "1",
+        },
+        latest_execution_intent={
+            "run_id": "cycle-1",
+            "asset_key": "hyperliquid:hl:perp:default:AMD",
+            "venue": "hyperliquid",
+            "side": "buy",
+            "notional_usd": "10",
+            "idempotency_key": "loop-proof-1",
+            "status": "filled",
+            "venue_order_id": "12345",
+        },
+        latest_attribution={
+            "run_id": "cycle-1",
+            "observed_at": now.isoformat(),
+            "fill_count": 3,
+            "realized_pnl_usd": "0.12",
+            "turnover_usd": "30",
+            "realized_cost_usd": "0.03",
+            "hit_rate": "1",
+        },
     )
 
     payload = assemble_trading_loop_status(
@@ -94,6 +157,9 @@ def test_loop_status_requires_real_execution_proof() -> None:
     assert payload["restored"] is True
     assert payload["blocker_reasons"] == []
     assert payload["fills"]["recent_count"] == 3
+    assert payload["alpha_model"]["present"] is True
+    assert payload["portfolio_target"]["target_notional_positive"] is True
+    assert payload["execution_intent"]["present"] is True
     assert payload["exchange_order_state"]["ack_seen"] is True
     assert payload["alpaca_guard"]["unexpected_live_order_count_24h"] == 0
     assert payload["runtime"]["live_capital"]["allowed"] is False

--- a/services/torghut/tests/test_verify_trading_loop_status.py
+++ b/services/torghut/tests/test_verify_trading_loop_status.py
@@ -16,6 +16,18 @@ def _restored_payload() -> dict[str, object]:
         "blocker_reasons": [],
         "runtime": {"status": "ok"},
         "market_data": {"fresh": True},
+        "alpha_model": {
+            "present": True,
+            "factor_snapshot_present": True,
+            "forecast_present": True,
+            "expected_edge_above_cost": True,
+        },
+        "risk_forecast": {"present": True},
+        "portfolio_target": {
+            "present": True,
+            "target_notional_positive": True,
+        },
+        "execution_intent": {"present": True},
         "submitted_order": {"present": True},
         "exchange_order_state": {"ack_seen": True},
         "fills": {"recent_count": 3},
@@ -38,6 +50,17 @@ def test_verifier_rejects_green_runtime_without_fills() -> None:
 
     assert "loop_status_not_restored" in failures
     assert "recent_fills_below_floor" in failures
+
+
+def test_verifier_rejects_missing_multifactor_proof() -> None:
+    payload = _restored_payload()
+    payload["alpha_model"] = {"present": False}
+    payload["portfolio_target"] = {"present": True, "target_notional_positive": False}
+
+    failures = evaluate_loop_status(payload)
+
+    assert "multifactor_alpha_model_missing" in failures
+    assert "multifactor_target_notional_not_positive" in failures
 
 
 def test_verifier_main_reads_status_file_and_reports_json(


### PR DESCRIPTION
## Summary

- Adds a generic Torghut multifactor machine with venue-neutral contracts, factor registry, alpha/risk/cost models, deterministic portfolio construction, attribution, and a Hyperliquid adapter.
- Persists the generic proof trail through migration 0057: runs, factor snapshots, alpha forecasts, risk forecasts, portfolio targets, execution intents, and attribution snapshots.
- Wires the Hyperliquid runtime to emit generic proof rows while preserving the existing venue order/fill tables.
- Extends `/trading/loop/status` and the verifier so healthy/ready status is insufficient without generic multifactor proof, submitted order proof, fills, reconciliation, and stale-order checks.
- Adds import-boundary and multifactor tests proving the restore hot path stays isolated from legacy proof/authority lanes.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/hyperliquid_execution app/trading/multifactor scripts/verify_trading_loop_status.py scripts/verify_multifactor_machine.py tests/multifactor tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/hyperliquid_execution/test_migration_manifest.py tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py migrations/versions/0057_generic_multifactor_machine.py`
- `uv run --frozen pytest tests/multifactor tests/hyperliquid_execution tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`
- Live kubectl verifier was not run because this branch is not deployed yet; runtime restoration is not claimed by this PR.

## Screenshots (if applicable)

N/A

## Breaking Changes

Requires applying `services/torghut/migrations/versions/0057_generic_multifactor_machine.py` before the new proof endpoint/verifier can pass against a deployed runtime. Live capital remains disabled.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
