### PR TITLE
fix(torghut): unblock multifactor proof loop

### DIFF
--- a/services/torghut/app/hyperliquid_execution/maintenance.py
+++ b/services/torghut/app/hyperliquid_execution/maintenance.py
@@ -145,10 +145,24 @@ def _requested_symbols(
 
 
 def _raw_position_rows(account: AccountState) -> list[dict[str, object]]:
-    raw_positions = account.account.raw_payload.get("assetPositions")
-    if not isinstance(raw_positions, list):
-        return []
     rows: list[dict[str, object]] = []
+    _append_raw_position_rows(rows, account.account.raw_payload)
+    return sorted(rows, key=lambda row: str(row["coin"]))
+
+
+def _append_raw_position_rows(
+    rows: list[dict[str, object]],
+    payload: Mapping[str, object],
+) -> None:
+    dex_states = payload.get("dexStates")
+    if isinstance(dex_states, dict):
+        for dex_payload in cast(Mapping[str, object], dex_states).values():
+            if isinstance(dex_payload, dict):
+                _append_raw_position_rows(rows, cast(Mapping[str, object], dex_payload))
+
+    raw_positions = payload.get("assetPositions")
+    if not isinstance(raw_positions, list):
+        return
     for item in cast(list[object], raw_positions):
         if not isinstance(item, dict):
             continue
@@ -170,7 +184,6 @@ def _raw_position_rows(account: AccountState) -> list[dict[str, object]]:
                 "unrealized_pnl_usd": str(position_map.get("unrealizedPnl") or "0"),
             }
         )
-    return sorted(rows, key=lambda row: str(row["coin"]))
 
 
 def _position_exposure_usd(position: Mapping[str, object]) -> Decimal:

--- a/services/torghut/app/hyperliquid_execution/risk.py
+++ b/services/torghut/app/hyperliquid_execution/risk.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from decimal import Decimal
 
+from app.trading.multifactor.contracts import PortfolioTarget, RiskForecast
 from app.trading.multifactor.cost_model import estimate_transaction_cost
 from app.trading.multifactor.portfolio_construction import (
     PortfolioCostInput,
@@ -27,50 +29,19 @@ def evaluate_signal_risk(
 ) -> RiskVerdict:
     """Block stale, duplicate, over-cap, disabled, and excluded orders."""
 
+    multifactor = _multifactor_controls(signal, state, config)
     reason = _blocked_reason(signal, state, config)
     if reason is not None:
-        return RiskVerdict("blocked", reason, Decimal("0"))
+        return _blocked_verdict(reason, multifactor)
     remaining_gross = config.max_gross_exposure_usd - state.gross_exposure_usd
     if remaining_gross < config.min_order_notional_usd:
-        return RiskVerdict("blocked", "gross_exposure_cap", Decimal("0"))
+        return _blocked_verdict("gross_exposure_cap", multifactor)
     symbol_exposure = state.symbol_exposure_usd_by_coin.get(signal.coin, Decimal("0"))
     remaining_symbol = config.max_symbol_exposure_usd - symbol_exposure
     if remaining_symbol < config.min_order_notional_usd:
-        return RiskVerdict("blocked", "symbol_exposure_cap", Decimal("0"))
-    if signal.factor_vector is not None and signal.alpha_forecast is not None:
-        risk_forecast = build_risk_forecast(
-            vector=signal.factor_vector,
-            forecast=signal.alpha_forecast,
-            exposure=RiskExposureState(
-                gross_exposure_usd=state.gross_exposure_usd,
-                symbol_exposure_usd=symbol_exposure,
-                daily_realized_pnl_usd=state.daily_realized_pnl_usd,
-            ),
-            limits=RiskLimits(
-                max_gross_exposure_usd=config.max_gross_exposure_usd,
-                max_symbol_exposure_usd=config.max_symbol_exposure_usd,
-                max_daily_loss_usd=config.max_daily_loss_usd,
-            ),
-        )
-        expected_cost_bps = estimate_transaction_cost(
-            signal.factor_vector,
-            cost_buffer_bps=config.cost_buffer_bps,
-            participation_rate=Decimal("0.001"),
-        )
-        portfolio_target = build_portfolio_target(
-            forecast=signal.alpha_forecast,
-            risk=risk_forecast,
-            costs=PortfolioCostInput(
-                expected_cost_bps=expected_cost_bps,
-                min_edge_bps=config.min_edge_bps,
-            ),
-            limits=PortfolioLimits(
-                min_order_notional_usd=config.min_order_notional_usd,
-                max_order_notional_usd=config.max_order_notional_usd,
-                max_gross_exposure_usd=config.max_gross_exposure_usd,
-                max_symbol_exposure_usd=config.max_symbol_exposure_usd,
-            ),
-        )
+        return _blocked_verdict("symbol_exposure_cap", multifactor)
+    if multifactor is not None:
+        risk_forecast, portfolio_target = multifactor
         if not portfolio_target.executable:
             return RiskVerdict(
                 "blocked",
@@ -104,6 +75,74 @@ def evaluate_signal_risk(
         config.max_order_notional_usd, remaining_gross, remaining_symbol
     )
     return RiskVerdict("allowed", "allowed", order_notional)
+
+
+def _multifactor_controls(
+    signal: Signal,
+    state: RiskState,
+    config: HyperliquidExecutionConfig,
+) -> tuple[RiskForecast, PortfolioTarget] | None:
+    if signal.factor_vector is None or signal.alpha_forecast is None:
+        return None
+    symbol_exposure = state.symbol_exposure_usd_by_coin.get(signal.coin, Decimal("0"))
+    risk_forecast = build_risk_forecast(
+        vector=signal.factor_vector,
+        forecast=signal.alpha_forecast,
+        exposure=RiskExposureState(
+            gross_exposure_usd=state.gross_exposure_usd,
+            symbol_exposure_usd=symbol_exposure,
+            daily_realized_pnl_usd=state.daily_realized_pnl_usd,
+        ),
+        limits=RiskLimits(
+            max_gross_exposure_usd=config.max_gross_exposure_usd,
+            max_symbol_exposure_usd=config.max_symbol_exposure_usd,
+            max_daily_loss_usd=config.max_daily_loss_usd,
+        ),
+    )
+    expected_cost_bps = estimate_transaction_cost(
+        signal.factor_vector,
+        cost_buffer_bps=config.cost_buffer_bps,
+        participation_rate=Decimal("0.001"),
+    )
+    portfolio_target = build_portfolio_target(
+        forecast=signal.alpha_forecast,
+        risk=risk_forecast,
+        costs=PortfolioCostInput(
+            expected_cost_bps=expected_cost_bps,
+            min_edge_bps=config.min_edge_bps,
+        ),
+        limits=PortfolioLimits(
+            min_order_notional_usd=config.min_order_notional_usd,
+            max_order_notional_usd=config.max_order_notional_usd,
+            max_gross_exposure_usd=config.max_gross_exposure_usd,
+            max_symbol_exposure_usd=config.max_symbol_exposure_usd,
+        ),
+    )
+    return risk_forecast, portfolio_target
+
+
+def _blocked_verdict(
+    reason: str,
+    multifactor: tuple[RiskForecast, PortfolioTarget] | None,
+) -> RiskVerdict:
+    if multifactor is None:
+        return RiskVerdict("blocked", reason, Decimal("0"))
+    risk_forecast, portfolio_target = multifactor
+    blocked_target = portfolio_target
+    if getattr(portfolio_target, "clip_reason", None) is None:
+        blocked_target = replace(
+            portfolio_target,
+            target_notional_usd=Decimal("0"),
+            delta_notional_usd=Decimal("0"),
+            clip_reason=reason,
+        )
+    return RiskVerdict(
+        "blocked",
+        reason,
+        Decimal("0"),
+        risk_forecast,
+        blocked_target,
+    )
 
 
 def _blocked_reason(

--- a/services/torghut/app/hyperliquid_execution/service.py
+++ b/services/torghut/app/hyperliquid_execution/service.py
@@ -193,6 +193,7 @@ class HyperliquidExecutionService:
                 config=self._config,
             )
             counts.orders_submitted += 1
+            break
 
     def _cycle_record(
         self,

--- a/services/torghut/app/trading/multifactor/status_payloads.py
+++ b/services/torghut/app/trading/multifactor/status_payloads.py
@@ -9,6 +9,23 @@ from decimal import Decimal
 from typing import Any, cast
 
 LATEST_MULTIFACTOR_RUN_SQL = """
+WITH proof AS (
+  SELECT run_id
+  FROM multifactor_execution_intents
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+fallback AS (
+  SELECT id AS run_id
+  FROM multifactor_runs
+  ORDER BY finished_at DESC
+  LIMIT 1
+),
+selected AS (
+  SELECT run_id FROM proof
+  UNION ALL
+  SELECT run_id FROM fallback WHERE NOT EXISTS (SELECT 1 FROM proof)
+)
 SELECT
   id::text,
   lane,
@@ -19,14 +36,31 @@ SELECT
   blockers,
   selected_assets
 FROM multifactor_runs
-ORDER BY finished_at DESC
+JOIN selected ON multifactor_runs.id = selected.run_id
 LIMIT 1
 """
 
 LATEST_FACTOR_SNAPSHOT_SQL = """
+WITH proof AS (
+  SELECT run_id, asset_key
+  FROM multifactor_execution_intents
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+fallback AS (
+  SELECT run_id, asset_key
+  FROM multifactor_factor_snapshots
+  ORDER BY observed_at DESC
+  LIMIT 1
+),
+selected AS (
+  SELECT run_id, asset_key FROM proof
+  UNION ALL
+  SELECT run_id, asset_key FROM fallback WHERE NOT EXISTS (SELECT 1 FROM proof)
+)
 SELECT
-  run_id::text,
-  asset_key,
+  snapshots.run_id::text,
+  snapshots.asset_key,
   venue,
   symbol,
   market_id,
@@ -37,15 +71,34 @@ SELECT
   source_lag_seconds,
   quote_lag_seconds,
   freshness_blocker
-FROM multifactor_factor_snapshots
-ORDER BY observed_at DESC
+FROM multifactor_factor_snapshots snapshots
+JOIN selected
+  ON snapshots.run_id = selected.run_id
+ AND snapshots.asset_key = selected.asset_key
 LIMIT 1
 """
 
 LATEST_FORECAST_SQL = """
+WITH proof AS (
+  SELECT run_id, asset_key
+  FROM multifactor_execution_intents
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+fallback AS (
+  SELECT run_id, asset_key
+  FROM multifactor_forecasts
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+selected AS (
+  SELECT run_id, asset_key FROM proof
+  UNION ALL
+  SELECT run_id, asset_key FROM fallback WHERE NOT EXISTS (SELECT 1 FROM proof)
+)
 SELECT
-  run_id::text,
-  asset_key,
+  forecasts.run_id::text,
+  forecasts.asset_key,
   model_id,
   horizon_seconds,
   score::text,
@@ -54,30 +107,68 @@ SELECT
   expected_return_bps::text,
   direction,
   blocker
-FROM multifactor_forecasts
-ORDER BY updated_at DESC
+FROM multifactor_forecasts forecasts
+JOIN selected
+  ON forecasts.run_id = selected.run_id
+ AND forecasts.asset_key = selected.asset_key
 LIMIT 1
 """
 
 LATEST_RISK_FORECAST_SQL = """
+WITH proof AS (
+  SELECT run_id, asset_key
+  FROM multifactor_execution_intents
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+fallback AS (
+  SELECT run_id, asset_key
+  FROM multifactor_risk_forecasts
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+selected AS (
+  SELECT run_id, asset_key FROM proof
+  UNION ALL
+  SELECT run_id, asset_key FROM fallback WHERE NOT EXISTS (SELECT 1 FROM proof)
+)
 SELECT
-  run_id::text,
-  asset_key,
+  risk.run_id::text,
+  risk.asset_key,
   active_risk_bps::text,
   gross_exposure_usd::text,
   symbol_exposure_usd::text,
   liquidity_capacity_usd::text,
   concentration_bps::text,
   blocker
-FROM multifactor_risk_forecasts
-ORDER BY updated_at DESC
+FROM multifactor_risk_forecasts risk
+JOIN selected
+  ON risk.run_id = selected.run_id
+ AND risk.asset_key = selected.asset_key
 LIMIT 1
 """
 
 LATEST_PORTFOLIO_TARGET_SQL = """
+WITH proof AS (
+  SELECT run_id, asset_key
+  FROM multifactor_execution_intents
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+fallback AS (
+  SELECT run_id, asset_key
+  FROM multifactor_portfolio_targets
+  ORDER BY updated_at DESC
+  LIMIT 1
+),
+selected AS (
+  SELECT run_id, asset_key FROM proof
+  UNION ALL
+  SELECT run_id, asset_key FROM fallback WHERE NOT EXISTS (SELECT 1 FROM proof)
+)
 SELECT
-  run_id::text,
-  asset_key,
+  targets.run_id::text,
+  targets.asset_key,
   direction,
   current_notional_usd::text,
   target_notional_usd::text,
@@ -87,8 +178,10 @@ SELECT
   active_risk_bps::text,
   risk_buffer_bps::text,
   clip_reason
-FROM multifactor_portfolio_targets
-ORDER BY updated_at DESC
+FROM multifactor_portfolio_targets targets
+JOIN selected
+  ON targets.run_id = selected.run_id
+ AND targets.asset_key = selected.asset_key
 LIMIT 1
 """
 
@@ -128,7 +221,7 @@ LIMIT 1
 def alpha_model_payload(rows: Any, summary: Any) -> dict[str, object]:
     return {
         "present": summary.multifactor_run_present and summary.alpha_forecast_present,
-        "run_id": _optional_text(rows.latest_multifactor_run.get("id")),
+        "run_id": _optional_text(rows.latest_forecast.get("run_id")),
         "model_id": _optional_text(rows.latest_forecast.get("model_id")),
         "factor_snapshot_present": summary.factor_snapshot_present,
         "forecast_present": summary.alpha_forecast_present,

--- a/services/torghut/tests/hyperliquid_execution/test_maintenance.py
+++ b/services/torghut/tests/hyperliquid_execution/test_maintenance.py
@@ -91,25 +91,29 @@ class _MaintenanceExchange:
                 withdrawable_usd=Decimal("899.1"),
                 gross_exposure_usd=Decimal("99.094016"),
                 raw_payload={
-                    "assetPositions": [
-                        {
-                            "position": {
-                                "coin": "SPX",
-                                "szi": "275.2",
-                                "entryPx": "0.36221",
-                                "positionValue": "99.094016",
-                                "unrealizedPnl": "-0.58",
-                            }
-                        },
-                        {
-                            "position": {
-                                "coin": "NVDA",
-                                "szi": "0.1",
-                                "entryPx": "100",
-                                "positionValue": "10",
-                            }
-                        },
-                    ]
+                    "dexStates": {
+                        "default": {
+                            "assetPositions": [
+                                {
+                                    "position": {
+                                        "coin": "SPX",
+                                        "szi": "275.2",
+                                        "entryPx": "0.36221",
+                                        "positionValue": "99.094016",
+                                        "unrealizedPnl": "-0.58",
+                                    }
+                                },
+                                {
+                                    "position": {
+                                        "coin": "NVDA",
+                                        "szi": "0.1",
+                                        "entryPx": "100",
+                                        "positionValue": "10",
+                                    }
+                                },
+                            ]
+                        }
+                    }
                 },
             ),
             positions=(),

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
@@ -308,6 +308,31 @@ def test_service_cycle_cancels_reconciles_submits_and_records_cycle() -> None:
     assert cycle_calls[0] < signal_call < cycle_calls[-1]
 
 
+def test_service_cycle_submits_at_most_one_order() -> None:
+    now = _now()
+    config = HyperliquidExecutionConfig.from_env(
+        {
+            "HYPERLIQUID_EXECUTION_TRADING_ENABLED": "true",
+            "HYPERLIQUID_EXECUTION_API_WALLET_PRIVATE_KEY": "0x1",
+            "HYPERLIQUID_EXECUTION_ACCOUNT_ADDRESS": "0xabc",
+            "HYPERLIQUID_EXECUTION_TRADE_COINS": "xyz:NVDA,xyz:MU",
+        }
+    )
+    session = _FakeSession()
+    exchange = _ServiceExchange(now)
+    service = HyperliquidExecutionService(
+        config=config,
+        feed=_TwoExecutableServiceFeed(now),
+        exchange=exchange,
+    )
+
+    result = service.run_once(session)
+
+    assert result.signals_written == 1
+    assert result.orders_submitted == 1
+    assert exchange.submitted_coins == ["NVDA"]
+
+
 def test_service_selects_only_fresh_execution_markets() -> None:
     now = _now()
     config = HyperliquidExecutionConfig.from_env(
@@ -556,10 +581,24 @@ class _PartialFeatureServiceFeed(_ServiceFeed):
         return [_feature(event_ts=self.now)]
 
 
+class _TwoExecutableServiceFeed(_PartialFeatureServiceFeed):
+    def load_feature_rows(self, market_ids: list[str]) -> list[FeatureSnapshot]:
+        assert market_ids == ["hl:perp:xyz:NVDA", "hl:perp:xyz:MU"]
+        return [
+            _feature(event_ts=self.now),
+            _feature(
+                event_ts=self.now,
+                market_id="hl:perp:xyz:MU",
+                coin="MU",
+            ),
+        ]
+
+
 class _ServiceExchange:
     def __init__(self, now: datetime) -> None:
         self.now = now
         self.reconciled_coins: set[str] = set()
+        self.submitted_coins: list[str] = []
 
     def filter_supported_markets(
         self,
@@ -576,6 +615,7 @@ class _ServiceExchange:
 
     def submit_order(self, intent: OrderIntent) -> OrderResult:
         assert intent.tif == "Ioc"
+        self.submitted_coins.append(intent.coin)
         return OrderResult("filled", "456", {"filled": {"oid": 456}})
 
     def cancel_order(self, _order: Any) -> OrderResult:
@@ -758,10 +798,12 @@ def _feature(
     *,
     event_ts: datetime | None = None,
     momentum_5m_bps: Decimal = Decimal("20"),
+    market_id: str = "hl:perp:xyz:NVDA",
+    coin: str = "NVDA",
 ) -> FeatureSnapshot:
     return FeatureSnapshot(
-        market_id="hl:perp:xyz:NVDA",
-        coin="NVDA",
+        market_id=market_id,
+        coin=coin,
         dex="xyz",
         event_ts=event_ts or _now(),
         price=Decimal("100"),

--- a/services/torghut/tests/hyperliquid_execution/test_strategy_risk_universe.py
+++ b/services/torghut/tests/hyperliquid_execution/test_strategy_risk_universe.py
@@ -183,6 +183,10 @@ def test_risk_blocks_short_entries_by_default() -> None:
     allowed = evaluate_signal_risk(sell_signal, state, short_config)
 
     assert blocked.reason == "short_entries_disabled"
+    assert blocked.risk_forecast is not None
+    assert blocked.portfolio_target is not None
+    assert blocked.portfolio_target.clip_reason == "short_entries_disabled"
+    assert blocked.portfolio_target.target_notional_usd == Decimal("0")
     assert allowed.allowed
 
 


### PR DESCRIPTION
## Summary

- Fix Hyperliquid reduce-only maintenance discovery for nested per-dex account payloads so stale testnet positions can be closed through the guarded operator command.
- Persist generic multifactor risk and target rows even when operational gates block an order, with the blocker recorded on the target.
- Limit the restore loop to one submitted order per cycle and anchor `/trading/loop/status` multifactor proof sections to the latest generic execution intent when present.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/hyperliquid_execution/test_maintenance.py tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py -q`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/multifactor tests/hyperliquid_execution tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py -q`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/hyperliquid_execution/maintenance.py app/hyperliquid_execution/risk.py app/hyperliquid_execution/service.py app/trading/multifactor/status_payloads.py tests/hyperliquid_execution/test_maintenance.py tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-branches,too-many-statements,too-many-return-statements,too-many-public-methods,too-many-instance-attributes,too-many-lines,duplicate-code,unused-import,unused-argument,undefined-variable,used-before-assignment app/hyperliquid_execution/maintenance.py app/hyperliquid_execution/risk.py app/hyperliquid_execution/service.py app/trading/multifactor/status_payloads.py tests/hyperliquid_execution/test_maintenance.py tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
