### PR TITLE
fix(rook-ceph): lower mon disk warning threshold

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -29,7 +29,7 @@ cephClusterSpec:
       # Pools without an explicit size (e.g. `.mgr`) inherit these defaults.
       osd_pool_default_size: "2"
       osd_pool_default_min_size: "1"
-      mon_data_avail_warn: "20"
+      mon_data_avail_warn: "15"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Lower the Rook/Ceph monitor local-disk availability warning threshold from 20% to 15%.
- Make the live `mon_data_avail_warn=15` change durable in GitOps.
- Keep the existing critical threshold unchanged.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-kustomize.out`
- `bun run lint:argocd`
- Live pre-change verification already performed: `ceph config get mon mon_data_avail_warn` returned `15`, `ceph health detail` returned `HEALTH_OK`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
