### PR TITLE
fix(rook-ceph): ignore generated loki secret data

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -81,6 +81,12 @@ spec:
                     argocd.argoproj.io/sync-wave: "-1"
                   automation: manual
                   enabled: "true"
+                  ignoreDifferences:
+                    - kind: Secret
+                      name: rook-ceph-object-user-objectstore-loki
+                      namespace: rook-ceph
+                      jsonPointers:
+                        - /data
                 - name: local-path
                   path: argocd/applications/local-path
                   namespace: local-path-storage


### PR DESCRIPTION
## Summary

- Add an Argo CD ignore rule for generated data on the Rook-managed Loki RGW user secret.
- Keep GitOps ownership of the reflector annotations while ignoring Rook-generated credential bytes.
- Restore the `rook-ceph` app’s durable sync behavior after the monitor threshold rollout.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Live rollout observation: after syncing PR 11383, `rook-ceph` was on revision `46d5ed95f2b031d4d73192564aa1989fbfb2e97e` but reported `OutOfSync` only for `Secret/rook-ceph-object-user-objectstore-loki`.
- Live Ceph check during rollout: `ceph health detail` returned `HEALTH_OK`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
