### PR TITLE
fix(torghut): restart hyperliquid short proof runtime

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-execution-v2-proof-universe-20260625
+        proompteng.ai/config-revision: hyperliquid-execution-v2-testnet-short-proof-20260625
       labels:
         app: torghut-hyperliquid-runtime
     spec:


### PR DESCRIPTION
## Summary

- Bumps the Hyperliquid runtime pod-template config revision so the merged testnet short-entry ConfigMap is applied by a fresh pod.
- Leaves the Torghut image digest and all existing proof-lane risk caps unchanged.
- Keeps the change GitOps-driven instead of using a direct rollout restart patch.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hl-runtime-render.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
