### PR TITLE
fix(torghut): harden testnet proof continuity

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - pdb.yaml
+  - proof-verifier-cronjob.yaml

--- a/argocd/applications/torghut-hyperliquid-runtime/proof-verifier-cronjob.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/proof-verifier-cronjob.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-hyperliquid-runtime-proof-verifier
+  namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 180
+      template:
+        metadata:
+          labels:
+            app: torghut-hyperliquid-runtime-proof-verifier
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: verify
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ced3ed60b4e320b3f3c013f0825cd11bfdd576a28c6e69b7950c78869416c371
+              imagePullPolicy: Always
+              command:
+                - /opt/venv/bin/python
+                - scripts/verify_multifactor_machine.py
+              args:
+                - --status-url
+                - http://torghut.torghut.svc.cluster.local/trading/loop/status
+                - --min-fills
+                - "3"
+                - --required-passes
+                - "3"
+                - --interval-seconds
+                - "15"
+                - --max-attempts
+                - "6"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL

--- a/services/torghut/app/trading/loop_status.py
+++ b/services/torghut/app/trading/loop_status.py
@@ -94,6 +94,8 @@ class LoopProofSummary:
     """Reduced proof facts that decide restored versus blocked."""
 
     query_errors: Sequence[str]
+    market_feature_at: datetime | None
+    market_selected_symbol: str | None
     market_lag_seconds: int | None
     feature_source_lag_seconds: int | None
     feature_quote_lag_seconds: int | None
@@ -212,7 +214,10 @@ def assemble_trading_loop_status(
         "status": "restored" if restored else "blocked",
         "blocker_reasons": blockers,
         "runtime": _runtime_payload(rows, options, summary),
+        "operator_approval": _operator_approval_payload(),
+        "proof_trading": _proof_trading_payload(),
         "market_data": _market_data_payload(rows, options, summary),
+        "algorithm": _algorithm_payload(rows, summary),
         "alpha_model": alpha_model_payload(rows, summary),
         "risk_forecast": risk_forecast_payload(rows, summary),
         "portfolio_target": portfolio_target_payload(rows, summary),
@@ -239,13 +244,10 @@ def assemble_trading_loop_status(
 def _proof_summary(
     rows: LoopStatusRows, options: LoopStatusOptions
 ) -> LoopProofSummary:
-    latest_feature_at = _datetime_value(rows.latest_signal.get("feature_event_ts"))
-    feature_source_lag_seconds = _optional_int(
-        rows.latest_signal.get("feature_source_lag_seconds")
-    )
-    feature_quote_lag_seconds = _optional_int(
-        rows.latest_signal.get("feature_quote_lag_seconds")
-    )
+    market_source = _market_data_source(rows)
+    latest_feature_at = _datetime_value(market_source.get("feature_event_ts"))
+    feature_source_lag_seconds = _optional_int(market_source.get("source_lag_seconds"))
+    feature_quote_lag_seconds = _optional_int(market_source.get("quote_lag_seconds"))
     latest_account_at = _datetime_value(rows.latest_account.get("observed_at"))
     market_lag_seconds = _age_seconds(options.generated_at, latest_feature_at)
     account_lag_seconds = _age_seconds(options.generated_at, latest_account_at)
@@ -284,6 +286,8 @@ def _proof_summary(
     )
     return LoopProofSummary(
         query_errors=tuple(rows.query_errors),
+        market_feature_at=latest_feature_at,
+        market_selected_symbol=_optional_text(market_source.get("selected_symbol")),
         market_lag_seconds=market_lag_seconds,
         feature_source_lag_seconds=feature_source_lag_seconds,
         feature_quote_lag_seconds=feature_quote_lag_seconds,
@@ -339,22 +343,55 @@ def _runtime_payload(
     }
 
 
+def _operator_approval_payload() -> dict[str, object]:
+    return {
+        "scope": "testnet_only",
+        "live_capital_approved": False,
+        "reason": "operator_approved_testnet_proof_trading_only",
+    }
+
+
+def _proof_trading_payload() -> dict[str, object]:
+    return {
+        "allowed": True,
+        "lane": "hyperliquid_testnet",
+        "reason": "testnet_proof_trading_operator_approved",
+    }
+
+
 def _market_data_payload(
     rows: LoopStatusRows,
     options: LoopStatusOptions,
     summary: LoopProofSummary,
 ) -> dict[str, object]:
-    selected_symbols = _selected_symbols(rows)
     return {
         "fresh": summary.market_data_fresh,
-        "latest_feature_at": _iso(
-            _datetime_value(rows.latest_signal.get("feature_event_ts"))
-        ),
+        "latest_feature_at": _iso(summary.market_feature_at),
         "lag_seconds": summary.market_lag_seconds,
         "source_lag_seconds": summary.feature_source_lag_seconds,
         "quote_lag_seconds": summary.feature_quote_lag_seconds,
         "freshness_threshold_seconds": options.freshness_threshold_seconds,
-        "selected_symbol": selected_symbols[0] if selected_symbols else None,
+        "selected_symbol": summary.market_selected_symbol,
+    }
+
+
+def _algorithm_payload(
+    rows: LoopStatusRows,
+    summary: LoopProofSummary,
+) -> dict[str, object]:
+    return {
+        "name": "generic_multifactor_apm_v1",
+        "run_id": _optional_text(rows.latest_forecast.get("run_id"))
+        or _optional_text(rows.latest_execution_intent.get("run_id"))
+        or _optional_text(rows.latest_multifactor_run.get("id")),
+        "asset_key": _optional_text(rows.latest_execution_intent.get("asset_key"))
+        or _optional_text(rows.latest_factor_snapshot.get("asset_key")),
+        "factor_snapshot_present": summary.factor_snapshot_present,
+        "forecast_present": summary.alpha_forecast_present,
+        "risk_present": summary.risk_forecast_present,
+        "target_present": summary.portfolio_target_present,
+        "intent_present": summary.execution_intent_present,
+        "latest_order_id": _optional_text(rows.latest_order.get("exchange_order_id")),
     }
 
 
@@ -540,6 +577,34 @@ def _blockers(
     if summary.unexpected_live_total > 0:
         blockers.append("unexpected_live_alpaca_orders_present")
     return blockers
+
+
+def _market_data_source(rows: LoopStatusRows) -> dict[str, object]:
+    if rows.latest_execution_intent and rows.latest_factor_snapshot:
+        latest_feature_at = rows.latest_factor_snapshot.get(
+            "source_event_at"
+        ) or rows.latest_signal.get("feature_event_ts")
+        return {
+            "feature_event_ts": latest_feature_at,
+            "source_lag_seconds": rows.latest_factor_snapshot.get("source_lag_seconds"),
+            "quote_lag_seconds": rows.latest_factor_snapshot.get("quote_lag_seconds"),
+            "selected_symbol": _optional_text(rows.latest_factor_snapshot.get("symbol"))
+            or _symbol_from_asset_key(rows.latest_factor_snapshot.get("asset_key")),
+        }
+    selected_symbols = _selected_symbols(rows)
+    return {
+        "feature_event_ts": rows.latest_signal.get("feature_event_ts"),
+        "source_lag_seconds": rows.latest_signal.get("feature_source_lag_seconds"),
+        "quote_lag_seconds": rows.latest_signal.get("feature_quote_lag_seconds"),
+        "selected_symbol": selected_symbols[0] if selected_symbols else None,
+    }
+
+
+def _symbol_from_asset_key(value: object) -> str | None:
+    text = _optional_text(value)
+    if text is None:
+        return None
+    return text.rsplit(":", maxsplit=1)[-1]
 
 
 def _latest_fill_payload(row: Mapping[str, object]) -> dict[str, object]:

--- a/services/torghut/scripts/verify_trading_loop_status.py
+++ b/services/torghut/scripts/verify_trading_loop_status.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 from urllib.request import Request, urlopen
@@ -24,22 +26,117 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
     parser.add_argument("--min-fills", type=int, default=3)
+    parser.add_argument("--required-passes", type=int, default=1)
+    parser.add_argument("--interval-seconds", type=float, default=0.0)
+    parser.add_argument("--max-attempts", type=int, default=1)
     args = parser.parse_args(argv)
 
-    payload = _load_payload(args.status_file, args.status_url, args.timeout_seconds)
-    failures = evaluate_loop_status(payload, min_fills=args.min_fills)
+    if args.required_passes < 1:
+        raise SystemExit("--required-passes must be >= 1")
+    if args.max_attempts < args.required_passes:
+        raise SystemExit("--max-attempts must be >= --required-passes")
+    if args.interval_seconds < 0:
+        raise SystemExit("--interval-seconds must be >= 0")
+
+    request = VerificationRequest(
+        status_file=args.status_file,
+        status_url=args.status_url,
+        timeout_seconds=args.timeout_seconds,
+        min_fills=args.min_fills,
+        required_passes=args.required_passes,
+        interval_seconds=args.interval_seconds,
+        max_attempts=args.max_attempts,
+    )
+    result = _verify_with_retries(request)
     report = {
         "schema_version": "torghut.trading-loop-status-verifier.v1",
-        "ok": not failures,
-        "failures": failures,
-        "status": {
-            "generated_at": payload.get("generated_at"),
-            "restored": payload.get("restored"),
-            "blocker_reasons": payload.get("blocker_reasons"),
-        },
+        "ok": result.ok,
+        "failures": result.failures,
+        "attempts": result.attempts,
+        "consecutive_passes": result.consecutive_passes,
+        "required_passes": args.required_passes,
+        "status": result.status,
     }
+    if result.last_failure is not None:
+        report["last_failure"] = result.last_failure
     print(json.dumps(report, indent=2, sort_keys=True))
-    return 0 if not failures else 1
+    return 0 if result.ok else 1
+
+
+@dataclass(frozen=True)
+class VerificationRequest:
+    status_file: Path | None
+    status_url: str
+    timeout_seconds: float
+    min_fills: int
+    required_passes: int
+    interval_seconds: float
+    max_attempts: int
+
+
+class VerificationResult:
+    def __init__(
+        self,
+        *,
+        ok: bool,
+        failures: list[str],
+        attempts: int,
+        consecutive_passes: int,
+        status: Mapping[str, object],
+        last_failure: Mapping[str, object] | None,
+    ) -> None:
+        self.ok = ok
+        self.failures = failures
+        self.attempts = attempts
+        self.consecutive_passes = consecutive_passes
+        self.status = status
+        self.last_failure = last_failure
+
+
+def _verify_with_retries(request: VerificationRequest) -> VerificationResult:
+    consecutive_passes = 0
+    attempts = 0
+    last_payload: Mapping[str, Any] = {}
+    last_failures: list[str] = []
+    last_failure: Mapping[str, object] | None = None
+    for attempt_index in range(request.max_attempts):
+        attempts = attempt_index + 1
+        last_payload = _load_payload(
+            request.status_file,
+            request.status_url,
+            request.timeout_seconds,
+        )
+        failures = evaluate_loop_status(last_payload, min_fills=request.min_fills)
+        if failures:
+            consecutive_passes = 0
+            last_failures = failures
+            last_failure = {
+                "failures": failures,
+                "status": _status_summary(last_payload),
+            }
+        else:
+            consecutive_passes += 1
+            if consecutive_passes >= request.required_passes:
+                return VerificationResult(
+                    ok=True,
+                    failures=[],
+                    attempts=attempts,
+                    consecutive_passes=consecutive_passes,
+                    status=_status_summary(last_payload),
+                    last_failure=last_failure,
+                )
+        if attempt_index + 1 < request.max_attempts and request.interval_seconds > 0:
+            time.sleep(request.interval_seconds)
+    if not last_failures:
+        last_failures = ["required_consecutive_passes_not_met"]
+    return VerificationResult(
+        ok=False,
+        failures=last_failures,
+        attempts=attempts,
+        consecutive_passes=consecutive_passes,
+        status=_status_summary(last_payload),
+        last_failure=last_failure,
+    )
 
 
 def evaluate_loop_status(
@@ -151,6 +248,23 @@ def _load_payload(
     if not isinstance(loaded, Mapping):
         raise SystemExit("status payload must be a JSON object")
     return cast(Mapping[str, Any], loaded)
+
+
+def _status_summary(payload: Mapping[str, Any]) -> dict[str, object]:
+    return {
+        "generated_at": payload.get("generated_at"),
+        "restored": payload.get("restored"),
+        "blocker_reasons": payload.get("blocker_reasons"),
+        "market_data": _mapping(payload.get("market_data")),
+        "algorithm": _mapping(payload.get("algorithm")),
+        "execution_intent": _mapping(payload.get("execution_intent")),
+        "submitted_order": _mapping(payload.get("submitted_order")),
+        "exchange_order_state": _mapping(payload.get("exchange_order_state")),
+        "fills": _mapping(payload.get("fills")),
+        "position": _mapping(payload.get("position")),
+        "stale_open_orders": _mapping(payload.get("stale_open_orders")),
+        "alpaca_guard": _mapping(payload.get("alpaca_guard")),
+    }
 
 
 def _require(condition: bool, reason: str, failures: list[str]) -> None:

--- a/services/torghut/tests/test_trading_loop_status.py
+++ b/services/torghut/tests/test_trading_loop_status.py
@@ -162,7 +162,25 @@ def test_loop_status_requires_real_execution_proof() -> None:
     assert payload["execution_intent"]["present"] is True
     assert payload["exchange_order_state"]["ack_seen"] is True
     assert payload["alpaca_guard"]["unexpected_live_order_count_24h"] == 0
+    assert payload["operator_approval"]["scope"] == "testnet_only"
+    assert payload["proof_trading"] == {
+        "allowed": True,
+        "lane": "hyperliquid_testnet",
+        "reason": "testnet_proof_trading_operator_approved",
+    }
     assert payload["runtime"]["live_capital"]["allowed"] is False
+    assert payload["algorithm"] == {
+        "name": "generic_multifactor_apm_v1",
+        "run_id": "cycle-1",
+        "asset_key": "hyperliquid:hl:perp:default:AMD",
+        "factor_snapshot_present": True,
+        "forecast_present": True,
+        "risk_present": True,
+        "target_present": True,
+        "intent_present": True,
+        "latest_order_id": "12345",
+    }
+    assert "live_capital" not in ",".join(payload["blocker_reasons"])
 
 
 def test_loop_status_blocks_ready_runtime_without_fills_or_account_proof() -> None:
@@ -360,6 +378,127 @@ def test_loop_status_blocks_future_event_timestamp_with_stale_quote_lag() -> Non
     assert payload["market_data"]["fresh"] is False
     assert payload["market_data"]["quote_lag_seconds"] == 240
     assert "hyperliquid_market_data_not_fresh" in payload["blocker_reasons"]
+
+
+def test_loop_status_anchors_market_data_to_multifactor_proof_snapshot() -> None:
+    now = datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc)
+    stale_signal_at = datetime(2026, 6, 25, 10, 0, tzinfo=timezone.utc)
+    proof_feature_at = datetime(2026, 6, 25, 11, 59, 45, tzinfo=timezone.utc)
+    rows = LoopStatusRows(
+        latest_cycle={"finished_at": now.isoformat(), "selected_coins": ["BNB"]},
+        latest_signal={
+            "generated_at": now.isoformat(),
+            "feature_event_ts": stale_signal_at.isoformat(),
+            "feature_source_lag_seconds": 1,
+            "feature_quote_lag_seconds": 9999,
+            "coin": "BNB",
+            "action": "hold",
+            "edge_bps": "0",
+            "reason": "old_signal",
+        },
+        latest_order={
+            "created_at": now.isoformat(),
+            "coin": "ZRO",
+            "cloid": "proof-zro",
+            "exchange_order_id": "555",
+            "side": "buy",
+            "status": "filled",
+            "notional_usd": "10",
+        },
+        counts_24h={
+            "cycles_24h": 3,
+            "signals_24h": 3,
+            "orders_24h": 3,
+            "fills_24h": 3,
+            "account_snapshots_24h": 3,
+        },
+        fill_summary={"fills_24h": 3},
+        latest_fill={"event_ts": now.isoformat(), "coin": "ZRO"},
+        latest_account={
+            "observed_at": now.isoformat(),
+            "raw_payload": {"dexStates": {"default": {"assetPositions": []}}},
+        },
+        positions=[],
+        performance={"fill_count_24h": 3, "sample_ready": False},
+        stale_open_orders=[],
+        unexpected_live_alpaca={"orders_24h": 0, "events_24h": 0},
+        query_errors=[],
+        latest_multifactor_run={
+            "id": "run-zro",
+            "lane": "hyperliquid_testnet",
+            "model_version": "active-portfolio-management-v1",
+            "finished_at": now.isoformat(),
+        },
+        latest_factor_snapshot={
+            "run_id": "run-zro",
+            "asset_key": "hyperliquid:hl:perp:default:ZRO",
+            "symbol": "ZRO",
+            "source_event_at": proof_feature_at.isoformat(),
+            "source_lag_seconds": 0,
+            "quote_lag_seconds": 15,
+            "raw_factors": {"momentum_5m": "12"},
+            "normalized_factors": {"momentum_5m": "3.0000"},
+        },
+        latest_forecast={
+            "run_id": "run-zro",
+            "asset_key": "hyperliquid:hl:perp:default:ZRO",
+            "model_id": "active-portfolio-management-v1",
+            "score": "3.0000",
+            "residual_volatility_bps": "50",
+            "information_coefficient": "0.05",
+            "expected_return_bps": "8",
+            "direction": "buy",
+        },
+        latest_risk_forecast={
+            "run_id": "run-zro",
+            "asset_key": "hyperliquid:hl:perp:default:ZRO",
+            "active_risk_bps": "1",
+            "gross_exposure_usd": "0",
+            "symbol_exposure_usd": "0",
+            "liquidity_capacity_usd": "10",
+            "concentration_bps": "0",
+        },
+        latest_portfolio_target={
+            "run_id": "run-zro",
+            "asset_key": "hyperliquid:hl:perp:default:ZRO",
+            "direction": "buy",
+            "target_notional_usd": "10",
+            "delta_notional_usd": "10",
+            "expected_return_bps": "8",
+            "expected_cost_bps": "4",
+            "active_risk_bps": "1",
+            "risk_buffer_bps": "1",
+        },
+        latest_execution_intent={
+            "run_id": "run-zro",
+            "asset_key": "hyperliquid:hl:perp:default:ZRO",
+            "venue": "hyperliquid",
+            "side": "buy",
+            "notional_usd": "10",
+            "idempotency_key": "proof-zro",
+            "status": "filled",
+            "venue_order_id": "555",
+        },
+    )
+
+    payload = assemble_trading_loop_status(
+        rows=rows,
+        options=LoopStatusOptions(
+            generated_at=now,
+            trading_mode="paper",
+            trading_enabled=True,
+            min_recent_fills=3,
+            freshness_threshold_seconds=180,
+            account_freshness_seconds=300,
+        ),
+    )
+
+    assert payload["restored"] is True
+    assert payload["market_data"]["fresh"] is True
+    assert payload["market_data"]["selected_symbol"] == "ZRO"
+    assert payload["market_data"]["latest_feature_at"] == proof_feature_at.isoformat()
+    assert payload["market_data"]["quote_lag_seconds"] == 15
+    assert "hyperliquid_market_data_not_fresh" not in payload["blocker_reasons"]
 
 
 def test_loop_status_reads_nested_hyperliquid_dex_positions() -> None:

--- a/services/torghut/tests/test_verify_trading_loop_status.py
+++ b/services/torghut/tests/test_verify_trading_loop_status.py
@@ -75,6 +75,93 @@ def test_verifier_main_reads_status_file_and_reports_json(
     report = json.loads(capsys.readouterr().out)
     assert report["schema_version"] == "torghut.trading-loop-status-verifier.v1"
     assert report["ok"] is True
+    assert report["attempts"] == 1
+    assert report["consecutive_passes"] == 1
+
+
+def test_verifier_requires_consecutive_passing_samples(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    failing_payload = _restored_payload()
+    failing_payload["restored"] = False
+    failing_payload["blocker_reasons"] = ["hyperliquid_market_data_not_fresh"]
+    failing_payload["market_data"] = {"fresh": False, "selected_symbol": "ZRO"}
+    samples = [failing_payload, _restored_payload(), _restored_payload()]
+
+    def fake_load_payload(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return samples.pop(0)
+
+    monkeypatch.setattr(verifier, "_load_payload", fake_load_payload)
+
+    assert (
+        verifier.main(
+            [
+                "--required-passes",
+                "2",
+                "--max-attempts",
+                "3",
+                "--interval-seconds",
+                "0",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["attempts"] == 3
+    assert report["consecutive_passes"] == 2
+    assert report["last_failure"]["failures"] == [
+        "loop_status_not_restored",
+        "market_data_not_fresh",
+        "status_blocker_reasons_present",
+    ]
+    assert report["last_failure"]["status"]["market_data"]["selected_symbol"] == "ZRO"
+
+
+def test_verifier_failure_report_includes_last_failing_status_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    failing_payload = _restored_payload()
+    failing_payload["restored"] = False
+    failing_payload["generated_at"] = "2026-06-25T12:00:00+00:00"
+    failing_payload["blocker_reasons"] = ["stale_open_orders_present"]
+    failing_payload["stale_open_orders"] = {"count": 2}
+    failing_payload["algorithm"] = {
+        "name": "generic_multifactor_apm_v1",
+        "run_id": "run-1",
+    }
+
+    def fake_load_payload(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return failing_payload
+
+    monkeypatch.setattr(verifier, "_load_payload", fake_load_payload)
+
+    assert (
+        verifier.main(
+            [
+                "--required-passes",
+                "2",
+                "--max-attempts",
+                "2",
+                "--interval-seconds",
+                "0",
+            ]
+        )
+        == 1
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is False
+    assert report["attempts"] == 2
+    assert report["consecutive_passes"] == 0
+    assert report["last_failure"]["status"]["generated_at"] == (
+        "2026-06-25T12:00:00+00:00"
+    )
+    assert report["last_failure"]["status"]["algorithm"]["run_id"] == "run-1"
+    assert report["last_failure"]["status"]["stale_open_orders"]["count"] == 2
 
 
 def test_verifier_loads_url_payload_and_rejects_non_object(


### PR DESCRIPTION
## Summary

- Makes testnet-only operator approval explicit in `/trading/loop/status` with `operator_approval`, `proof_trading`, and algorithm proof fields while keeping live capital blocked.
- Anchors top-level market-data freshness to the same multifactor proof factor snapshot used by the latest execution intent, preventing stale unrelated signals from falsely blocking restored status.
- Adds consecutive-pass verifier support plus a read-only GitOps CronJob that continuously checks the live proof endpoint without exchange secrets.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py -q`
- `uv run --frozen pytest tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py tests/multifactor tests/hyperliquid_execution -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-hl-runtime-render.yaml`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
