### PR TITLE
fix(torghut): use acknowledged proof orders for status

### DIFF
--- a/services/torghut/app/trading/loop_status.py
+++ b/services/torghut/app/trading/loop_status.py
@@ -558,10 +558,6 @@ def _blockers(
         blockers.append("multifactor_portfolio_target_missing")
     if not summary.execution_intent_present:
         blockers.append("multifactor_execution_intent_missing")
-    if not summary.alpha_edge_above_cost:
-        blockers.append("multifactor_expected_edge_not_above_cost")
-    if not summary.target_notional_positive:
-        blockers.append("multifactor_target_notional_not_positive")
     if not summary.latest_order_present:
         blockers.append("hyperliquid_order_submission_missing")
     if not summary.exchange_ack_seen:
@@ -832,6 +828,8 @@ SELECT
   notional_usd::text
 FROM hyperliquid_execution_orders
 WHERE execution_network = 'testnet'
+  AND exchange_order_id IS NOT NULL
+  AND status IN ('accepted', 'filled')
 ORDER BY created_at DESC
 LIMIT 1
 """

--- a/services/torghut/app/trading/multifactor/status_payloads.py
+++ b/services/torghut/app/trading/multifactor/status_payloads.py
@@ -212,6 +212,8 @@ SELECT
   blocker,
   venue_order_id
 FROM multifactor_execution_intents
+WHERE venue_order_id IS NOT NULL
+  AND status <> 'rejected'
 ORDER BY updated_at DESC
 LIMIT 1
 """

--- a/services/torghut/scripts/verify_trading_loop_status.py
+++ b/services/torghut/scripts/verify_trading_loop_status.py
@@ -171,11 +171,6 @@ def evaluate_loop_status(
         failures,
     )
     _require(
-        alpha_model.get("expected_edge_above_cost") is True,
-        "multifactor_expected_edge_not_above_cost",
-        failures,
-    )
-    _require(
         _mapping(payload.get("risk_forecast")).get("present") is True,
         "multifactor_risk_forecast_missing",
         failures,
@@ -184,11 +179,6 @@ def evaluate_loop_status(
     _require(
         portfolio_target.get("present") is True,
         "multifactor_portfolio_target_missing",
-        failures,
-    )
-    _require(
-        portfolio_target.get("target_notional_positive") is True,
-        "multifactor_target_notional_not_positive",
         failures,
     )
     _require(

--- a/services/torghut/tests/test_trading_loop_status.py
+++ b/services/torghut/tests/test_trading_loop_status.py
@@ -571,8 +571,8 @@ def test_loop_status_uses_current_multifactor_snapshot_with_historical_intent() 
             "score": "2.0000",
             "residual_volatility_bps": "50",
             "information_coefficient": "0.05",
-            "expected_return_bps": "8",
-            "direction": "buy",
+            "expected_return_bps": "2",
+            "direction": "hold",
         },
         latest_risk_forecast={
             "run_id": "current-run",
@@ -586,13 +586,14 @@ def test_loop_status_uses_current_multifactor_snapshot_with_historical_intent() 
         latest_portfolio_target={
             "run_id": "current-run",
             "asset_key": "hyperliquid:hl:perp:default:BNB",
-            "direction": "buy",
-            "target_notional_usd": "10",
-            "delta_notional_usd": "10",
-            "expected_return_bps": "8",
+            "direction": "hold",
+            "target_notional_usd": "0",
+            "delta_notional_usd": "0",
+            "expected_return_bps": "2",
             "expected_cost_bps": "4",
             "active_risk_bps": "1",
             "risk_buffer_bps": "1",
+            "clip_reason": "expected_edge_not_above_cost",
         },
         latest_execution_intent={
             "run_id": "historical-run",
@@ -624,7 +625,11 @@ def test_loop_status_uses_current_multifactor_snapshot_with_historical_intent() 
     assert payload["algorithm"]["run_id"] == "current-run"
     assert payload["algorithm"]["asset_key"] == "hyperliquid:hl:perp:default:BNB"
     assert payload["execution_intent"]["venue_order_id"] == "555"
+    assert payload["alpha_model"]["expected_edge_above_cost"] is False
+    assert payload["portfolio_target"]["target_notional_positive"] is False
     assert "hyperliquid_market_data_not_fresh" not in payload["blocker_reasons"]
+    assert "multifactor_expected_edge_not_above_cost" not in payload["blocker_reasons"]
+    assert "multifactor_target_notional_not_positive" not in payload["blocker_reasons"]
 
 
 def test_multifactor_status_queries_use_current_run_for_current_surfaces() -> None:
@@ -642,6 +647,13 @@ def test_multifactor_status_queries_use_current_run_for_current_surfaces() -> No
         assert "WITH latest_run AS" in query
         assert "JOIN latest_run USING (run_id)" in query
         assert "current_intent" in query
+
+
+def test_status_proof_queries_select_acknowledged_execution_rows() -> None:
+    assert "exchange_order_id IS NOT NULL" in loop_status_module._LATEST_ORDER_SQL
+    assert "status IN ('accepted', 'filled')" in loop_status_module._LATEST_ORDER_SQL
+    assert "venue_order_id IS NOT NULL" in status_payloads.LATEST_EXECUTION_INTENT_SQL
+    assert "status <> 'rejected'" in status_payloads.LATEST_EXECUTION_INTENT_SQL
 
 
 def test_loop_status_reads_nested_hyperliquid_dex_positions() -> None:

--- a/services/torghut/tests/test_verify_trading_loop_status.py
+++ b/services/torghut/tests/test_verify_trading_loop_status.py
@@ -41,6 +41,23 @@ def test_verifier_accepts_hard_proof_payload() -> None:
     assert evaluate_loop_status(_restored_payload()) == []
 
 
+def test_verifier_accepts_current_no_trade_decision_with_execution_proof() -> None:
+    payload = _restored_payload()
+    payload["alpha_model"] = {
+        "present": True,
+        "factor_snapshot_present": True,
+        "forecast_present": True,
+        "expected_edge_above_cost": False,
+    }
+    payload["portfolio_target"] = {
+        "present": True,
+        "target_notional_positive": False,
+        "clip_reason": "expected_edge_not_above_cost",
+    }
+
+    assert evaluate_loop_status(payload) == []
+
+
 def test_verifier_rejects_green_runtime_without_fills() -> None:
     payload = _restored_payload()
     payload["restored"] = False
@@ -60,7 +77,7 @@ def test_verifier_rejects_missing_multifactor_proof() -> None:
     failures = evaluate_loop_status(payload)
 
     assert "multifactor_alpha_model_missing" in failures
-    assert "multifactor_target_notional_not_positive" in failures
+    assert "multifactor_target_notional_not_positive" not in failures
 
 
 def test_verifier_main_reads_status_file_and_reports_json(


### PR DESCRIPTION
## Summary

- Treat current no-edge or zero-target multifactor decisions as valid no-trade observations, not restore blockers.
- Select acknowledged Hyperliquid testnet orders and non-rejected execution intents for the proof surface so rejected attempts do not hide existing fill proof.
- Add regressions for no-trade proof continuity and proof-row SQL boundaries.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py -q`
- `uv run --frozen pytest tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py tests/multifactor tests/hyperliquid_execution -q`
- `uv run --frozen ruff check app/trading/loop_status.py app/trading/multifactor/status_payloads.py scripts/verify_trading_loop_status.py tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py`
- `uv run --frozen ruff format --check app/trading/loop_status.py app/trading/multifactor/status_payloads.py scripts/verify_trading_loop_status.py tests/test_trading_loop_status.py tests/test_verify_trading_loop_status.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
