### PR TITLE
refactor(torghut): split evidence bundle scorecard assembly

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles/evidence_bundle_blockers.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles/evidence_bundle_blockers.py
@@ -8,7 +8,71 @@ from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any, Literal, Mapping, Sequence, cast
 
-
+from .evidence_bundle_from_frontier_candidate import (
+    delay_depth_survival_blockers as _delay_depth_survival_blockers,
+)
+from .evidence_bundle_from_frontier_candidate import (
+    evidence_bundle_from_frontier_candidate,
+    evidence_bundle_from_payload,
+)
+from .evidence_bundle_from_frontier_candidate import (
+    has_artifact_ref as _has_artifact_ref,
+)
+from .evidence_bundle_from_frontier_candidate import (
+    implementation_uncertainty_blockers as _implementation_uncertainty_blockers,
+)
+from .evidence_bundle_from_frontier_candidate import (
+    market_impact_stress_blockers as _market_impact_stress_blockers,
+)
+from .evidence_bundle_from_frontier_candidate import (
+    order_type_execution_blockers as _order_type_execution_blockers,
+)
+from .evidence_bundle_from_frontier_candidate import (
+    requires_promotion_proof as _requires_promotion_proof,
+)
+from .implementation_risk_backtest_stability_blo import (
+    adaptive_signal_falsification_blockers as _adaptive_signal_falsification_blockers,
+)
+from .implementation_risk_backtest_stability_blo import (
+    alpha_decay_predictability_blockers as _alpha_decay_predictability_blockers,
+)
+from .implementation_risk_backtest_stability_blo import (
+    bootstrap_robust_optimization_blockers as _bootstrap_robust_optimization_blockers,
+)
+from .implementation_risk_backtest_stability_blo import (
+    conformal_tail_risk_blockers as _conformal_tail_risk_blockers,
+)
+from .implementation_risk_backtest_stability_blo import (
+    implementation_risk_backtest_stability_blockers as _implementation_risk_blockers,
+)
+from .implementation_risk_backtest_stability_blo import (
+    ofi_response_horizon_blockers as _ofi_response_horizon_blockers,
+)
+from .implementation_risk_backtest_stability_blo import (
+    stochastic_liquidity_resilience_blockers as _stochastic_liquidity_blockers,
+)
+from .runtime_ledger_lineage_handoff_blockers import (
+    CandidateEvidenceBundle,
+    evidence_bundle_id_for_payload,
+)
+from .runtime_ledger_lineage_handoff_blockers import (
+    decomposition_activity_counts as _decomposition_activity_counts,
+)
+from .runtime_ledger_lineage_handoff_blockers import (
+    delay_depth_fillability as _delay_depth_fillability,
+)
+from .runtime_ledger_lineage_handoff_blockers import (
+    is_synthetic_dataset_snapshot as _is_synthetic_dataset_snapshot,
+)
+from .runtime_ledger_lineage_handoff_blockers import (
+    p10 as _p10,
+)
+from .runtime_ledger_lineage_handoff_blockers import (
+    runtime_ledger_lineage_handoff_blockers as _runtime_ledger_lineage_handoff_blockers,
+)
+from .runtime_ledger_lineage_handoff_blockers import (
+    scorecard_with_freshness_lineage as _scorecard_with_freshness_lineage,
+)
 from .shared_context import (
     ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS,
     ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
@@ -28,58 +92,70 @@ from .shared_context import (
     RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS,
     STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
     VALID_COST_CALIBRATION_STATUSES,
+)
+from .shared_context import (
     artifact_refs_from_scorecard as _artifact_refs_from_scorecard,
+)
+from .shared_context import (
     bool_value as _bool,
+)
+from .shared_context import (
     decimal as _decimal,
+)
+from .shared_context import (
     decimal_mapping_total as _decimal_mapping_total,
+)
+from .shared_context import (
     frontier_replay_params as _frontier_replay_params,
+)
+from .shared_context import (
     frontier_strategy_overrides as _frontier_strategy_overrides,
-    int_value as _int,
+)
+from .shared_context import (
     int_mapping as _int_mapping,
+)
+from .shared_context import (
+    int_value as _int,
+)
+from .shared_context import (
     mapping as _mapping,
+)
+from .shared_context import (
     order_lifecycle_metrics as _order_lifecycle_metrics,
+)
+from .shared_context import (
     order_type_ablation_metrics as _order_type_ablation_metrics,
+)
+from .shared_context import (
     order_type_execution_metrics as _order_type_execution_metrics,
+)
+from .shared_context import (
     runtime_ledger_lineage_handoff as _runtime_ledger_lineage_handoff,
+)
+from .shared_context import (
     stable_hash as _stable_hash,
+)
+from .shared_context import (
     string as _string,
+)
+from .shared_context import (
     string_list as _string_list,
-)
-from .runtime_ledger_lineage_handoff_blockers import (
-    CandidateEvidenceBundle,
-    decomposition_activity_counts as _decomposition_activity_counts,
-    decomposition_symbol_contribution_shares as _decomposition_symbol_contribution_shares,
-    delay_depth_fillability as _delay_depth_fillability,
-    enrich_scorecard_with_replay_stress_metrics as _enrich_scorecard_with_replay_stress_metrics,
-    is_synthetic_dataset_snapshot as _is_synthetic_dataset_snapshot,
-    p10 as _p10,
-    runtime_ledger_lineage_handoff_blockers as _runtime_ledger_lineage_handoff_blockers,
-    scorecard_with_freshness_lineage as _scorecard_with_freshness_lineage,
-    evidence_bundle_id_for_payload,
-)
-from .evidence_bundle_from_frontier_candidate import (
-    delay_depth_survival_blockers as _delay_depth_survival_blockers,
-    has_artifact_ref as _has_artifact_ref,
-    implementation_risk_backtest_stability_required as _implementation_risk_backtest_stability_required,
-    implementation_uncertainty_blockers as _implementation_uncertainty_blockers,
-    market_impact_stress_blockers as _market_impact_stress_blockers,
-    order_type_execution_blockers as _order_type_execution_blockers,
-    requires_promotion_proof as _requires_promotion_proof,
-    evidence_bundle_from_frontier_candidate,
-    evidence_bundle_from_payload,
-)
-from .implementation_risk_backtest_stability_blo import (
-    adaptive_signal_falsification_blockers as _adaptive_signal_falsification_blockers,
-    alpha_decay_predictability_blockers as _alpha_decay_predictability_blockers,
-    bootstrap_robust_optimization_blockers as _bootstrap_robust_optimization_blockers,
-    conformal_tail_risk_blockers as _conformal_tail_risk_blockers,
-    implementation_risk_backtest_stability_blockers as _implementation_risk_backtest_stability_blockers,
-    ofi_response_horizon_blockers as _ofi_response_horizon_blockers,
-    stochastic_liquidity_resilience_blockers as _stochastic_liquidity_resilience_blockers,
 )
 
 
 def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
+    blockers: list[str] = []
+    scorecard = bundle.objective_scorecard
+    blockers.extend(_dataset_replay_blockers(bundle))
+    blockers.extend(_cost_calibration_blockers(bundle))
+    blockers.extend(_freshness_blockers(scorecard))
+    blockers.extend(_synthetic_policy_blockers(bundle=bundle, scorecard=scorecard))
+    if _requires_promotion_proof(bundle):
+        blockers.extend(_promotion_proof_blockers(bundle=bundle, scorecard=scorecard))
+    return tuple(dict.fromkeys(blockers))
+
+
+def _dataset_replay_blockers(bundle: CandidateEvidenceBundle) -> list[str]:
     blockers: list[str] = []
     if not _string(bundle.dataset_snapshot_id):
         blockers.append("dataset_snapshot_missing")
@@ -87,7 +163,11 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         _string(item) for item in bundle.replay_artifact_refs
     ):
         blockers.append("replay_artifact_missing")
+    return blockers
 
+
+def _cost_calibration_blockers(bundle: CandidateEvidenceBundle) -> list[str]:
+    blockers: list[str] = []
     cost_status = _string(bundle.cost_calibration.get("status")).lower()
     cost_source = _string(bundle.cost_calibration.get("source"))
     if not bundle.cost_calibration:
@@ -96,8 +176,11 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         blockers.append("cost_calibration_status_invalid")
     elif not cost_source:
         blockers.append("cost_calibration_source_missing")
+    return blockers
 
-    scorecard = bundle.objective_scorecard
+
+def _freshness_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if bool(scorecard.get("stale_tape")) or bool(scorecard.get("stale_override_used")):
         blockers.append("stale_tape")
     freshness = _string(
@@ -122,6 +205,14 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
     receipt_is_fresh = dataset_receipt.get("is_fresh")
     if receipt_is_fresh is not None and not _bool(receipt_is_fresh):
         blockers.append("stale_tape")
+    return blockers
+
+
+def _synthetic_policy_blockers(
+    *,
+    bundle: CandidateEvidenceBundle,
+    scorecard: Mapping[str, Any],
+) -> list[str]:
     validation_contract = _mapping(
         scorecard.get("validation_contract")
         or bundle.promotion_readiness.get("validation_contract")
@@ -131,38 +222,46 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
     ) == "validation_only_not_promotion_proof" and _is_synthetic_dataset_snapshot(
         bundle.dataset_snapshot_id
     ):
-        blockers.append("synthetic_evidence_not_promotion_proof")
-    if _requires_promotion_proof(bundle):
-        blockers.extend(
-            _runtime_ledger_lineage_handoff_blockers(
-                scorecard=scorecard,
-                promotion_readiness=bundle.promotion_readiness,
-            )
+        return ["synthetic_evidence_not_promotion_proof"]
+    return []
+
+
+def _promotion_proof_blockers(
+    *,
+    bundle: CandidateEvidenceBundle,
+    scorecard: Mapping[str, Any],
+) -> list[str]:
+    blockers: list[str] = []
+    blockers.extend(
+        _runtime_ledger_lineage_handoff_blockers(
+            scorecard=scorecard,
+            promotion_readiness=bundle.promotion_readiness,
         )
-        blockers.extend(_market_impact_stress_blockers(scorecard))
-        blockers.extend(_order_type_execution_blockers(scorecard))
-        blockers.extend(_implementation_uncertainty_blockers(scorecard))
-        blockers.extend(_implementation_risk_backtest_stability_blockers(scorecard))
-        blockers.extend(_bootstrap_robust_optimization_blockers(scorecard))
-        blockers.extend(
-            _adaptive_signal_falsification_blockers(
-                scorecard=scorecard,
-                null_comparator=bundle.null_comparator,
-            )
+    )
+    blockers.extend(_market_impact_stress_blockers(scorecard))
+    blockers.extend(_order_type_execution_blockers(scorecard))
+    blockers.extend(_implementation_uncertainty_blockers(scorecard))
+    blockers.extend(_implementation_risk_blockers(scorecard))
+    blockers.extend(_bootstrap_robust_optimization_blockers(scorecard))
+    blockers.extend(
+        _adaptive_signal_falsification_blockers(
+            scorecard=scorecard,
+            null_comparator=bundle.null_comparator,
         )
-        blockers.extend(_ofi_response_horizon_blockers(scorecard))
-        blockers.extend(_alpha_decay_predictability_blockers(scorecard))
-        blockers.extend(_stochastic_liquidity_resilience_blockers(scorecard))
-        blockers.extend(_conformal_tail_risk_blockers(scorecard))
-        blockers.extend(_delay_depth_survival_blockers(scorecard))
-    return tuple(dict.fromkeys(blockers))
+    )
+    blockers.extend(_ofi_response_horizon_blockers(scorecard))
+    blockers.extend(_alpha_decay_predictability_blockers(scorecard))
+    blockers.extend(_stochastic_liquidity_blockers(scorecard))
+    blockers.extend(_conformal_tail_risk_blockers(scorecard))
+    blockers.extend(_delay_depth_survival_blockers(scorecard))
+    return blockers
 
 
 def evidence_bundle_is_valid(bundle: CandidateEvidenceBundle) -> bool:
     return not evidence_bundle_blockers(bundle)
 
 
-# Explicit module exports; keeps re-export imports intentional without file-level Ruff ignores.
+# Explicit exports keep re-export imports intentional without file-level Ruff ignores.
 __all__: tuple[str, ...] = (
     "ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS",
     "ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS",
@@ -198,15 +297,12 @@ __all__: tuple[str, ...] = (
     "_decimal",
     "_decimal_mapping_total",
     "_decomposition_activity_counts",
-    "_decomposition_symbol_contribution_shares",
     "_delay_depth_fillability",
     "_delay_depth_survival_blockers",
-    "_enrich_scorecard_with_replay_stress_metrics",
     "_frontier_replay_params",
     "_frontier_strategy_overrides",
     "_has_artifact_ref",
-    "_implementation_risk_backtest_stability_blockers",
-    "_implementation_risk_backtest_stability_required",
+    "_implementation_risk_blockers",
     "_implementation_uncertainty_blockers",
     "_int",
     "_int_mapping",
@@ -224,7 +320,7 @@ __all__: tuple[str, ...] = (
     "_runtime_ledger_lineage_handoff_blockers",
     "_scorecard_with_freshness_lineage",
     "_stable_hash",
-    "_stochastic_liquidity_resilience_blockers",
+    "_stochastic_liquidity_blockers",
     "_string",
     "_string_list",
     "annotations",

--- a/services/torghut/app/trading/discovery/evidence_bundles/evidence_bundle_from_frontier_candidate.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles/evidence_bundle_from_frontier_candidate.py
@@ -4,43 +4,28 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Sequence, cast
 
-
-from .shared_context import (
-    ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS,
-    ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
-    BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
-    CONFORMAL_COST_BUFFER_SCORECARD_KEYS,
-    DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS,
-    EVIDENCE_BUNDLE_SCHEMA_VERSION,
-    FILL_SURVIVAL_SCORECARD_KEYS,
-    MARKET_IMPACT_SCORECARD_KEYS,
-    MARKET_IMPACT_STRESS_COST_BPS,
-    OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
-    REPLAY_ACTIVITY_SCORECARD_KEYS,
-    RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS,
-    STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
-    artifact_refs_from_scorecard as _artifact_refs_from_scorecard,
-    bool_value as _bool,
-    decimal as _decimal,
-    frontier_replay_params as _frontier_replay_params,
-    frontier_strategy_overrides as _frontier_strategy_overrides,
-    int_value as _int,
-    mapping as _mapping,
-    order_lifecycle_metrics as _order_lifecycle_metrics,
-    order_type_ablation_metrics as _order_type_ablation_metrics,
-    order_type_execution_metrics as _order_type_execution_metrics,
-    stable_hash as _stable_hash,
-    string as _string,
-    string_list as _string_list,
+from . import shared_context as _shared
+from .frontier_candidate_scorecard import (
+    frontier_candidate_adaptive_signal_falsification_stress,
+    frontier_candidate_null_comparator,
+    frontier_candidate_scorecard,
+    frontier_candidate_stress_metrics,
 )
 from .runtime_ledger_lineage_handoff_blockers import (
     CandidateEvidenceBundle,
-    decomposition_activity_counts as _decomposition_activity_counts,
-    decomposition_symbol_contribution_shares as _decomposition_symbol_contribution_shares,
-    enrich_scorecard_with_replay_stress_metrics as _enrich_scorecard_with_replay_stress_metrics,
-    scorecard_with_freshness_lineage as _scorecard_with_freshness_lineage,
     evidence_bundle_id_for_payload,
 )
+
+EVIDENCE_BUNDLE_SCHEMA_VERSION = _shared.EVIDENCE_BUNDLE_SCHEMA_VERSION
+MARKET_IMPACT_STRESS_COST_BPS = _shared.MARKET_IMPACT_STRESS_COST_BPS
+_artifact_refs_from_scorecard = _shared.artifact_refs_from_scorecard
+_bool = _shared.bool_value
+_decimal = _shared.decimal
+_int = _shared.int_value
+_mapping = _shared.mapping
+_stable_hash = _shared.stable_hash
+_string = _shared.string
+_string_list = _shared.string_list
 
 
 def evidence_bundle_from_frontier_candidate(
@@ -52,324 +37,13 @@ def evidence_bundle_from_frontier_candidate(
     code_commit: str = "unknown",
 ) -> CandidateEvidenceBundle:
     candidate_id = _string(candidate.get("candidate_id")) or candidate_spec_id
-    scorecard = _mapping(candidate.get("objective_scorecard"))
-    full_window = _mapping(candidate.get("full_window"))
-    summary = _mapping(candidate.get("summary"))
-    if not scorecard:
-        scorecard = {
-            "net_pnl_per_day": _string(full_window.get("net_per_day")),
-            "active_day_ratio": _string(full_window.get("active_day_ratio")),
-            "positive_day_ratio": _string(full_window.get("positive_day_ratio")),
-            "best_day_share": _string(full_window.get("best_day_share")),
-            "max_drawdown": _string(full_window.get("max_drawdown")),
-        }
-    adaptive_signal_falsification_stress = _mapping(
-        candidate.get("fast_replay_adaptive_signal_falsification_stress")
-        or candidate.get("adaptive_signal_falsification_stress")
-    )
-    adaptive_signal_falsification_scorecard_patch = _mapping(
-        candidate.get(
-            "fast_replay_adaptive_signal_falsification_objective_scorecard_patch"
-        )
-        or adaptive_signal_falsification_stress.get("objective_scorecard_patch")
-    )
-    if adaptive_signal_falsification_scorecard_patch:
-        for key in ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS:
-            if key in adaptive_signal_falsification_scorecard_patch:
-                scorecard = {
-                    **scorecard,
-                    key: adaptive_signal_falsification_scorecard_patch[key],
-                }
-    for key in REPLAY_ACTIVITY_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in MARKET_IMPACT_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in CONFORMAL_COST_BUFFER_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in (*DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS, *FILL_SURVIVAL_SCORECARD_KEYS):
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in OFI_RESPONSE_HORIZON_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for key in STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS:
-        if key in scorecard:
-            continue
-        for source in (candidate, summary, full_window):
-            if key in source:
-                scorecard = {**scorecard, key: source[key]}
-                break
-    for source in (candidate, summary, full_window):
-        for key, value in _order_type_execution_metrics(source).items():
-            if key not in scorecard:
-                scorecard = {**scorecard, key: value}
-    for source in (candidate, summary, full_window):
-        for key, value in _order_lifecycle_metrics(source).items():
-            if key not in scorecard:
-                scorecard = {**scorecard, key: value}
-    for source in (candidate, summary, full_window):
-        for key, value in _order_type_ablation_metrics(source).items():
-            if key not in scorecard or key in {
-                "order_type_ablation_artifact_ref",
-                "order_type_ablation_sample_count",
-                "order_type_ablation_passed",
-                "order_type_ablation_selected_order_type",
-                "order_type_opportunity_cost_bps",
-                "order_type_opportunity_cost_evidence_present",
-                "opportunity_cost_evidence_present",
-                "limit_fill_probability_sample_count",
-                "limit_fill_probability_evidence_present",
-            }:
-                scorecard = {**scorecard, key: value}
-    if (
-        scorecard.get("market_limit_order_mix_evidence_present")
-        and "order_type_execution_artifact_ref" not in scorecard
-    ):
-        scorecard = {**scorecard, "order_type_execution_artifact_ref": result_path}
-    if (
-        scorecard.get("market_limit_order_mix_evidence_present")
-        and "market_limit_order_mix_artifact_ref" not in scorecard
-    ):
-        scorecard = {**scorecard, "market_limit_order_mix_artifact_ref": result_path}
-    for key, value in _decomposition_activity_counts(candidate).items():
-        if key not in scorecard:
-            scorecard = {**scorecard, key: value}
-    daily_net = _mapping(full_window.get("daily_net"))
-    if daily_net and "daily_net" not in scorecard:
-        scorecard = {**scorecard, "daily_net": daily_net}
-    daily_filled_notional = _mapping(full_window.get("daily_filled_notional"))
-    if daily_filled_notional and "daily_filled_notional" not in scorecard:
-        scorecard = {**scorecard, "daily_filled_notional": daily_filled_notional}
-    if "trading_day_count" in full_window and "trading_day_count" not in scorecard:
-        scorecard = {**scorecard, "trading_day_count": full_window["trading_day_count"]}
-    raw_candidate_hard_vetoes = candidate.get("hard_vetoes")
-    if isinstance(raw_candidate_hard_vetoes, str):
-        raw_hard_vetoes: Sequence[Any] = (raw_candidate_hard_vetoes,)
-    else:
-        raw_hard_vetoes = cast(Sequence[Any], raw_candidate_hard_vetoes or ())
-    hard_vetoes = tuple(
-        item for item in (_string(value) for value in raw_hard_vetoes) if item
-    )
-    if hard_vetoes and "hard_vetoes" not in scorecard:
-        scorecard = {**scorecard, "hard_vetoes": list(hard_vetoes)}
-    for nested_contract in (
-        _mapping(candidate.get("hard_vetoes")),
-        _mapping(candidate.get("promotion_contract")),
-    ):
-        for key in (
-            *BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
-            *ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS,
-            *OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
-            *ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
-            *STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
-            *CONFORMAL_COST_BUFFER_SCORECARD_KEYS,
-        ):
-            if key in nested_contract and key not in scorecard:
-                scorecard = {**scorecard, key: nested_contract[key]}
-    replay_params = _frontier_replay_params(candidate)
-    if replay_params and "runtime_params" not in scorecard:
-        scorecard = {**scorecard, "runtime_params": replay_params}
-    strategy_overrides = _frontier_strategy_overrides(candidate)
-    if strategy_overrides and "candidate_strategy_overrides" not in scorecard:
-        scorecard = {**scorecard, "candidate_strategy_overrides": strategy_overrides}
-    universe_symbols = _string_list(strategy_overrides.get("universe_symbols"))
-    if universe_symbols and "universe_symbols" not in scorecard:
-        scorecard = {**scorecard, "universe_symbols": universe_symbols}
-    for key in ("max_notional_per_trade", "max_position_pct_equity"):
-        if key in scorecard:
-            continue
-        value = strategy_overrides.get(key)
-        if value is not None:
-            scorecard = {**scorecard, key: value}
-    if "symbol_contribution_shares" not in scorecard and "symbol" not in scorecard:
-        symbol_shares = _decomposition_symbol_contribution_shares(candidate)
-        if symbol_shares:
-            scorecard = {**scorecard, "symbol_contribution_shares": symbol_shares}
-    runtime_identity_fallbacks = {
-        "runtime_family": _string(candidate.get("family")),
-        "runtime_strategy_name": _string(candidate.get("strategy_name")),
-    }
-    for key in (
-        "family_template_id",
-        "runtime_family",
-        "runtime_strategy_name",
-        "execution_signature",
-        "execution_profile_id",
-        "execution_profile_index",
-        "feedback_risk_profile_key",
-        "feedback_shape_key",
-        "universe_key",
-        "signal_key",
-    ):
-        value = _string(candidate.get(key)) or runtime_identity_fallbacks.get(key, "")
-        if value and key not in scorecard:
-            scorecard = {**scorecard, key: value}
-    replay_lineage = _mapping(candidate.get("replay_lineage"))
-    if replay_lineage and "replay_lineage" not in scorecard:
-        scorecard = {**scorecard, "replay_lineage": replay_lineage}
-    replay_window_coverage = _mapping(
-        scorecard.get("replay_window_coverage")
-        or candidate.get("replay_window_coverage")
-        or replay_lineage.get("replay_window_coverage")
-    )
-    if replay_window_coverage and "replay_window_coverage" not in scorecard:
-        scorecard = {**scorecard, "replay_window_coverage": replay_window_coverage}
-    scorecard = _enrich_scorecard_with_replay_stress_metrics(
-        scorecard=scorecard,
-        full_window=full_window,
+    scorecard = frontier_candidate_scorecard(
+        candidate=candidate,
         result_path=result_path,
     )
-    scorecard = _scorecard_with_freshness_lineage(
-        scorecard=scorecard,
-        candidate=candidate,
+    adaptive_signal_falsification_stress = (
+        frontier_candidate_adaptive_signal_falsification_stress(candidate)
     )
-    stress_metrics = tuple(
-        cast(Sequence[Mapping[str, Any]], candidate.get("stress_metrics") or ())
-    )
-    if not stress_metrics:
-        stress_metrics = (
-            {
-                "source": "frontier_replay",
-                "stress_type": "market_impact",
-                "model": scorecard.get("market_impact_stress_model"),
-                "cost_bps": scorecard.get("market_impact_stress_cost_bps"),
-                "net_pnl_per_day": scorecard.get(
-                    "market_impact_stress_net_pnl_per_day"
-                ),
-                "passed": scorecard.get("market_impact_stress_passed"),
-                "artifact_ref": scorecard.get("market_impact_stress_artifact_ref"),
-            },
-            {
-                "source": "frontier_replay",
-                "stress_type": "delay_adjusted_depth",
-                "model": scorecard.get("delay_adjusted_depth_stress_model"),
-                "stress_ms": scorecard.get("delay_adjusted_depth_stress_ms"),
-                "latency_grid_ms": scorecard.get(
-                    "delay_adjusted_depth_latency_grid_ms"
-                ),
-                "grid_max_stress_ms": scorecard.get(
-                    "delay_adjusted_depth_grid_max_stress_ms"
-                ),
-                "fillable_notional_per_day": scorecard.get(
-                    "delay_adjusted_depth_fillable_notional_per_day"
-                ),
-                "worst_grid_fillable_notional_per_day": scorecard.get(
-                    "delay_adjusted_depth_worst_grid_fillable_notional_per_day"
-                ),
-                "worst_active_day_fillable_notional": scorecard.get(
-                    "delay_adjusted_depth_worst_active_day_fillable_notional"
-                ),
-                "p10_active_day_fillable_notional": scorecard.get(
-                    "delay_adjusted_depth_p10_active_day_fillable_notional"
-                ),
-                "tail_coverage_passed": scorecard.get(
-                    "delay_adjusted_depth_tail_coverage_passed"
-                ),
-                "liquidity_missing_day_count": scorecard.get(
-                    "delay_adjusted_depth_liquidity_missing_day_count"
-                ),
-                "fillable_ratio": scorecard.get("delay_adjusted_depth_fillable_ratio"),
-                "survival_adjusted_fillable_ratio": scorecard.get(
-                    "delay_adjusted_depth_survival_adjusted_fillable_ratio"
-                ),
-                "unfillable_notional_per_day": scorecard.get(
-                    "delay_adjusted_depth_unfillable_notional_per_day"
-                ),
-                "fill_survival_evidence_present": scorecard.get(
-                    "delay_adjusted_depth_fill_survival_evidence_present"
-                ),
-                "fill_survival_sample_count": scorecard.get(
-                    "delay_adjusted_depth_fill_survival_sample_count"
-                ),
-                "fill_survival_rate": scorecard.get(
-                    "delay_adjusted_depth_fill_survival_rate"
-                ),
-                "queue_ratio_p95": scorecard.get(
-                    "delay_adjusted_depth_queue_ratio_p95"
-                ),
-                "queue_ahead_depletion_evidence_present": scorecard.get(
-                    "delay_adjusted_depth_queue_ahead_depletion_evidence_present"
-                ),
-                "queue_ahead_depletion_sample_count": scorecard.get(
-                    "delay_adjusted_depth_queue_ahead_depletion_sample_count"
-                ),
-                "net_pnl_per_day": scorecard.get(
-                    "delay_adjusted_depth_stress_net_pnl_per_day"
-                ),
-                "passed": scorecard.get("delay_adjusted_depth_stress_passed"),
-                "artifact_ref": scorecard.get(
-                    "delay_adjusted_depth_stress_artifact_ref"
-                ),
-            },
-            {
-                "source": "frontier_replay",
-                "stress_type": "implementation_uncertainty",
-                "model": scorecard.get("implementation_uncertainty_model"),
-                "model_count": scorecard.get("implementation_uncertainty_model_count"),
-                "lower_net_pnl_per_day": scorecard.get(
-                    "implementation_uncertainty_lower_net_pnl_per_day"
-                ),
-                "upper_net_pnl_per_day": scorecard.get(
-                    "implementation_uncertainty_upper_net_pnl_per_day"
-                ),
-                "interval_width_per_day": scorecard.get(
-                    "implementation_uncertainty_interval_width_per_day"
-                ),
-                "scenarios": scorecard.get("implementation_uncertainty_scenarios"),
-                "passed": scorecard.get("implementation_uncertainty_stability_passed"),
-            },
-        )
     payload_seed = {
         "candidate_id": candidate_id,
         "candidate_spec_id": candidate_spec_id,
@@ -390,6 +64,10 @@ def evidence_bundle_from_frontier_candidate(
             ]
         )
     )
+    stress_metrics = frontier_candidate_stress_metrics(
+        candidate=candidate,
+        scorecard=scorecard,
+    )
     return CandidateEvidenceBundle(
         schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
         evidence_bundle_id=evidence_bundle_id_for_payload(payload_seed),
@@ -408,13 +86,11 @@ def evidence_bundle_from_frontier_candidate(
         stress_metrics=stress_metrics,
         cost_calibration=_mapping(candidate.get("cost_calibration"))
         or {"status": "provisional", "source": "frontier_replay"},
-        null_comparator=_mapping(candidate.get("null_comparator"))
-        or _mapping(adaptive_signal_falsification_stress.get("null_comparator_patch"))
-        or {
-            "baseline_outperformed": bool(
-                float(str(scorecard.get("net_pnl_per_day") or 0)) > 0
-            )
-        },
+        null_comparator=frontier_candidate_null_comparator(
+            candidate=candidate,
+            scorecard=scorecard,
+            adaptive_signal_falsification_stress=adaptive_signal_falsification_stress,
+        ),
         promotion_readiness=promotion_readiness,
     )
 
@@ -471,6 +147,15 @@ def requires_promotion_proof(bundle: CandidateEvidenceBundle) -> bool:
 
 def delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     blockers: list[str] = []
+    blockers.extend(_delay_depth_stress_blockers(scorecard))
+    blockers.extend(_fill_survival_blockers(scorecard))
+    blockers.extend(_queue_ahead_depletion_blockers(scorecard))
+    blockers.extend(_queue_position_survival_blockers(scorecard))
+    return blockers
+
+
+def _delay_depth_stress_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not _bool(scorecard.get("delay_adjusted_depth_stress_passed")):
         blockers.append("delay_adjusted_depth_stress_failed")
     if not _string(scorecard.get("delay_adjusted_depth_stress_model")):
@@ -495,6 +180,11 @@ def delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         blockers.append("delay_adjusted_depth_worst_fillable_non_positive")
     if _decimal(scorecard.get("delay_adjusted_depth_stress_net_pnl_per_day")) <= 0:
         blockers.append("delay_adjusted_depth_stress_net_pnl_non_positive")
+    return blockers
+
+
+def _fill_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not (
         _bool(scorecard.get("fill_survival_evidence_present"))
         or _bool(scorecard.get("delay_adjusted_depth_fill_survival_evidence_present"))
@@ -508,6 +198,11 @@ def delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         <= 0
     ):
         blockers.append("fill_survival_sample_count_zero")
+    return blockers
+
+
+def _queue_ahead_depletion_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not (
         _bool(scorecard.get("queue_ahead_depletion_evidence_present"))
         or _bool(
@@ -535,7 +230,11 @@ def delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         <= 0
     ):
         blockers.append("queue_ahead_depletion_sample_count_zero")
+    return blockers
 
+
+def _queue_position_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not _bool(scorecard.get("queue_position_survival_fill_curve_evidence_present")):
         blockers.append("queue_position_survival_fill_curve_evidence_missing")
     if _int(scorecard.get("queue_position_survival_sample_count")) <= 0:
@@ -628,6 +327,15 @@ def order_type_execution_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         return []
 
     blockers: list[str] = []
+    blockers.extend(_market_limit_order_mix_blockers(scorecard))
+    blockers.extend(_route_tca_blockers(scorecard))
+    blockers.extend(_order_type_ablation_blockers(scorecard))
+    blockers.extend(_execution_quality_blockers(scorecard))
+    return blockers
+
+
+def _market_limit_order_mix_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not _bool(scorecard.get("market_limit_order_mix_evidence_present")):
         blockers.append("market_limit_order_mix_evidence_missing")
     if _int(scorecard.get("market_limit_order_mix_sample_count")) <= 0:
@@ -637,12 +345,22 @@ def order_type_execution_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         or _bool(scorecard.get("market_limit_execution_policy_passed"))
     ):
         blockers.append("market_limit_order_mix_missing_or_failed")
+    return blockers
+
+
+def _route_tca_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not has_artifact_ref(
         scorecard,
         "route_tca_artifact_ref",
         "route_tca_artifact_refs",
     ) and not _bool(scorecard.get("route_tca_evidence_present")):
         blockers.append("route_tca_evidence_missing")
+    return blockers
+
+
+def _order_type_ablation_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not has_artifact_ref(
         scorecard,
         "order_type_ablation_artifact_ref",
@@ -653,6 +371,11 @@ def order_type_execution_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         blockers.append("order_type_ablation_sample_count_zero")
     if not _bool(scorecard.get("order_type_ablation_passed")):
         blockers.append("order_type_ablation_missing_or_failed")
+    return blockers
+
+
+def _execution_quality_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
     if not _bool(scorecard.get("limit_fill_probability_evidence_present")):
         blockers.append("limit_fill_probability_evidence_missing")
     if _int(scorecard.get("limit_fill_probability_sample_count")) <= 0:

--- a/services/torghut/app/trading/discovery/evidence_bundles/frontier_candidate_scorecard.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles/frontier_candidate_scorecard.py
@@ -1,0 +1,475 @@
+"""Scorecard assembly for frontier candidate evidence bundles."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence, cast
+
+from . import runtime_ledger_lineage_handoff_blockers as _lineage
+from . import shared_context as _shared
+
+ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS = (
+    _shared.ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS
+)
+ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS = (
+    _shared.ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS
+)
+BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS = (
+    _shared.BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS
+)
+CONFORMAL_COST_BUFFER_SCORECARD_KEYS = _shared.CONFORMAL_COST_BUFFER_SCORECARD_KEYS
+DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS = _shared.DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS
+FILL_SURVIVAL_SCORECARD_KEYS = _shared.FILL_SURVIVAL_SCORECARD_KEYS
+MARKET_IMPACT_SCORECARD_KEYS = _shared.MARKET_IMPACT_SCORECARD_KEYS
+OFI_RESPONSE_HORIZON_SCORECARD_KEYS = _shared.OFI_RESPONSE_HORIZON_SCORECARD_KEYS
+REPLAY_ACTIVITY_SCORECARD_KEYS = _shared.REPLAY_ACTIVITY_SCORECARD_KEYS
+RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS = (
+    _shared.RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS
+)
+STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS = (
+    _shared.STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS
+)
+_decomposition_activity_counts = _lineage.decomposition_activity_counts
+_symbol_contribution_shares = _lineage.decomposition_symbol_contribution_shares
+_enrich_replay_stress_metrics = _lineage.enrich_scorecard_with_replay_stress_metrics
+_scorecard_with_freshness_lineage = _lineage.scorecard_with_freshness_lineage
+_frontier_replay_params = _shared.frontier_replay_params
+_frontier_strategy_overrides = _shared.frontier_strategy_overrides
+_mapping = _shared.mapping
+_order_lifecycle_metrics = _shared.order_lifecycle_metrics
+_order_type_ablation_metrics = _shared.order_type_ablation_metrics
+_order_type_execution_metrics = _shared.order_type_execution_metrics
+_string = _shared.string
+_string_list = _shared.string_list
+
+_PROMOTION_CONTRACT_SCORECARD_KEYS = (
+    *BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
+    *ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS,
+    *OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
+    *ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
+    *STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
+    *CONFORMAL_COST_BUFFER_SCORECARD_KEYS,
+)
+
+_SCORECARD_SOURCE_KEY_GROUPS = (
+    REPLAY_ACTIVITY_SCORECARD_KEYS,
+    MARKET_IMPACT_SCORECARD_KEYS,
+    CONFORMAL_COST_BUFFER_SCORECARD_KEYS,
+    (*DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS, *FILL_SURVIVAL_SCORECARD_KEYS),
+    RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS,
+    BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
+    ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS,
+    OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
+    ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
+    STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
+)
+
+_ORDER_TYPE_ABLATION_OVERRIDE_KEYS = {
+    "order_type_ablation_artifact_ref",
+    "order_type_ablation_sample_count",
+    "order_type_ablation_passed",
+    "order_type_ablation_selected_order_type",
+    "order_type_opportunity_cost_bps",
+    "order_type_opportunity_cost_evidence_present",
+    "opportunity_cost_evidence_present",
+    "limit_fill_probability_sample_count",
+    "limit_fill_probability_evidence_present",
+}
+
+_RUNTIME_IDENTITY_KEYS = (
+    "family_template_id",
+    "runtime_family",
+    "runtime_strategy_name",
+    "execution_signature",
+    "execution_profile_id",
+    "execution_profile_index",
+    "feedback_risk_profile_key",
+    "feedback_shape_key",
+    "universe_key",
+    "signal_key",
+)
+
+
+def frontier_candidate_scorecard(
+    *,
+    candidate: Mapping[str, Any],
+    result_path: str,
+) -> dict[str, Any]:
+    """Build the objective scorecard carried by a candidate evidence bundle."""
+
+    full_window = _mapping(candidate.get("full_window"))
+    summary = _mapping(candidate.get("summary"))
+    sources = (candidate, summary, full_window)
+    scorecard = _base_scorecard(candidate=candidate, full_window=full_window)
+    _adaptive_stress, adaptive_patch = _adaptive_signal_falsification_context(candidate)
+    _merge_scorecard_patch(
+        scorecard,
+        adaptive_patch,
+        ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS,
+    )
+    _merge_candidate_source_key_groups(scorecard, sources)
+    _merge_order_execution_metrics(scorecard, sources, result_path=result_path)
+    _merge_decomposition_metrics(scorecard, candidate=candidate)
+    _merge_full_window_series(scorecard, full_window=full_window)
+    _merge_hard_vetoes(scorecard, candidate=candidate)
+    _merge_promotion_contract_fields(scorecard, candidate=candidate)
+    _merge_frontier_runtime_config(scorecard, candidate=candidate)
+    _merge_runtime_identity(scorecard, candidate=candidate)
+    _merge_replay_lineage(scorecard, candidate=candidate)
+    scorecard = _enrich_replay_stress_metrics(
+        scorecard=scorecard,
+        full_window=full_window,
+        result_path=result_path,
+    )
+    return _scorecard_with_freshness_lineage(
+        scorecard=scorecard,
+        candidate=candidate,
+    )
+
+
+def frontier_candidate_adaptive_signal_falsification_stress(
+    candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    stress, _patch = _adaptive_signal_falsification_context(candidate)
+    return stress
+
+
+def frontier_candidate_stress_metrics(
+    *,
+    candidate: Mapping[str, Any],
+    scorecard: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    stress_metrics = tuple(
+        cast(Sequence[Mapping[str, Any]], candidate.get("stress_metrics") or ())
+    )
+    if stress_metrics:
+        return stress_metrics
+    return _default_frontier_replay_stress_metrics(scorecard)
+
+
+def frontier_candidate_null_comparator(
+    *,
+    candidate: Mapping[str, Any],
+    scorecard: Mapping[str, Any],
+    adaptive_signal_falsification_stress: Mapping[str, Any],
+) -> dict[str, Any]:
+    return (
+        _mapping(candidate.get("null_comparator"))
+        or _mapping(adaptive_signal_falsification_stress.get("null_comparator_patch"))
+        or {
+            "baseline_outperformed": bool(
+                float(str(scorecard.get("net_pnl_per_day") or 0)) > 0
+            )
+        }
+    )
+
+
+def _base_scorecard(
+    *,
+    candidate: Mapping[str, Any],
+    full_window: Mapping[str, Any],
+) -> dict[str, Any]:
+    scorecard = _mapping(candidate.get("objective_scorecard"))
+    if scorecard:
+        return scorecard
+    return {
+        "net_pnl_per_day": _string(full_window.get("net_per_day")),
+        "active_day_ratio": _string(full_window.get("active_day_ratio")),
+        "positive_day_ratio": _string(full_window.get("positive_day_ratio")),
+        "best_day_share": _string(full_window.get("best_day_share")),
+        "max_drawdown": _string(full_window.get("max_drawdown")),
+    }
+
+
+def _adaptive_signal_falsification_context(
+    candidate: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    stress = _mapping(
+        candidate.get("fast_replay_adaptive_signal_falsification_stress")
+        or candidate.get("adaptive_signal_falsification_stress")
+    )
+    patch = _mapping(
+        candidate.get(
+            "fast_replay_adaptive_signal_falsification_objective_scorecard_patch"
+        )
+        or stress.get("objective_scorecard_patch")
+    )
+    return stress, patch
+
+
+def _merge_scorecard_patch(
+    scorecard: dict[str, Any],
+    patch: Mapping[str, Any],
+    keys: Sequence[str],
+) -> None:
+    for key in keys:
+        if key in patch:
+            scorecard[key] = patch[key]
+
+
+def _merge_candidate_source_key_groups(
+    scorecard: dict[str, Any],
+    sources: Sequence[Mapping[str, Any]],
+) -> None:
+    for keys in _SCORECARD_SOURCE_KEY_GROUPS:
+        _merge_missing_source_values(scorecard, sources, keys)
+
+
+def _merge_missing_source_values(
+    scorecard: dict[str, Any],
+    sources: Sequence[Mapping[str, Any]],
+    keys: Sequence[str],
+) -> None:
+    for key in keys:
+        if key in scorecard:
+            continue
+        for source in sources:
+            if key in source:
+                scorecard[key] = source[key]
+                break
+
+
+def _merge_order_execution_metrics(
+    scorecard: dict[str, Any],
+    sources: Sequence[Mapping[str, Any]],
+    *,
+    result_path: str,
+) -> None:
+    for source in sources:
+        _merge_missing_metrics(scorecard, _order_type_execution_metrics(source))
+        _merge_missing_metrics(scorecard, _order_lifecycle_metrics(source))
+        _merge_order_type_ablation_metrics(scorecard, source)
+    if scorecard.get("market_limit_order_mix_evidence_present"):
+        scorecard.setdefault("order_type_execution_artifact_ref", result_path)
+        scorecard.setdefault("market_limit_order_mix_artifact_ref", result_path)
+
+
+def _merge_missing_metrics(
+    scorecard: dict[str, Any],
+    metrics: Mapping[str, Any],
+) -> None:
+    for key, value in metrics.items():
+        scorecard.setdefault(key, value)
+
+
+def _merge_order_type_ablation_metrics(
+    scorecard: dict[str, Any],
+    source: Mapping[str, Any],
+) -> None:
+    for key, value in _order_type_ablation_metrics(source).items():
+        if key not in scorecard or key in _ORDER_TYPE_ABLATION_OVERRIDE_KEYS:
+            scorecard[key] = value
+
+
+def _merge_decomposition_metrics(
+    scorecard: dict[str, Any],
+    *,
+    candidate: Mapping[str, Any],
+) -> None:
+    _merge_missing_metrics(scorecard, _decomposition_activity_counts(candidate))
+    if "symbol_contribution_shares" in scorecard or "symbol" in scorecard:
+        return
+    symbol_shares = _symbol_contribution_shares(candidate)
+    if symbol_shares:
+        scorecard["symbol_contribution_shares"] = symbol_shares
+
+
+def _merge_full_window_series(
+    scorecard: dict[str, Any],
+    *,
+    full_window: Mapping[str, Any],
+) -> None:
+    for key in ("daily_net", "daily_filled_notional"):
+        value = _mapping(full_window.get(key))
+        if value and key not in scorecard:
+            scorecard[key] = value
+    if "trading_day_count" in full_window and "trading_day_count" not in scorecard:
+        scorecard["trading_day_count"] = full_window["trading_day_count"]
+
+
+def _merge_hard_vetoes(
+    scorecard: dict[str, Any],
+    *,
+    candidate: Mapping[str, Any],
+) -> None:
+    hard_vetoes = _candidate_hard_vetoes(candidate.get("hard_vetoes"))
+    if hard_vetoes and "hard_vetoes" not in scorecard:
+        scorecard["hard_vetoes"] = list(hard_vetoes)
+
+
+def _candidate_hard_vetoes(raw_hard_vetoes: object) -> tuple[str, ...]:
+    if isinstance(raw_hard_vetoes, str):
+        raw_values: Sequence[Any] = (raw_hard_vetoes,)
+    else:
+        raw_values = cast(Sequence[Any], raw_hard_vetoes or ())
+    return tuple(item for item in (_string(value) for value in raw_values) if item)
+
+
+def _merge_promotion_contract_fields(
+    scorecard: dict[str, Any],
+    *,
+    candidate: Mapping[str, Any],
+) -> None:
+    for nested_contract in (
+        _mapping(candidate.get("hard_vetoes")),
+        _mapping(candidate.get("promotion_contract")),
+    ):
+        _merge_missing_source_values(
+            scorecard,
+            (nested_contract,),
+            _PROMOTION_CONTRACT_SCORECARD_KEYS,
+        )
+
+
+def _merge_frontier_runtime_config(
+    scorecard: dict[str, Any],
+    *,
+    candidate: Mapping[str, Any],
+) -> None:
+    replay_params = _frontier_replay_params(candidate)
+    if replay_params and "runtime_params" not in scorecard:
+        scorecard["runtime_params"] = replay_params
+    strategy_overrides = _frontier_strategy_overrides(candidate)
+    if strategy_overrides and "candidate_strategy_overrides" not in scorecard:
+        scorecard["candidate_strategy_overrides"] = strategy_overrides
+    _merge_strategy_override_fields(scorecard, strategy_overrides)
+
+
+def _merge_strategy_override_fields(
+    scorecard: dict[str, Any],
+    strategy_overrides: Mapping[str, Any],
+) -> None:
+    universe_symbols = _string_list(strategy_overrides.get("universe_symbols"))
+    if universe_symbols and "universe_symbols" not in scorecard:
+        scorecard["universe_symbols"] = universe_symbols
+    for key in ("max_notional_per_trade", "max_position_pct_equity"):
+        if key not in scorecard and strategy_overrides.get(key) is not None:
+            scorecard[key] = strategy_overrides[key]
+
+
+def _merge_runtime_identity(
+    scorecard: dict[str, Any],
+    *,
+    candidate: Mapping[str, Any],
+) -> None:
+    runtime_identity_fallbacks = {
+        "runtime_family": _string(candidate.get("family")),
+        "runtime_strategy_name": _string(candidate.get("strategy_name")),
+    }
+    for key in _RUNTIME_IDENTITY_KEYS:
+        value = _string(candidate.get(key)) or runtime_identity_fallbacks.get(key, "")
+        if value and key not in scorecard:
+            scorecard[key] = value
+
+
+def _merge_replay_lineage(
+    scorecard: dict[str, Any],
+    *,
+    candidate: Mapping[str, Any],
+) -> None:
+    replay_lineage = _mapping(candidate.get("replay_lineage"))
+    if replay_lineage and "replay_lineage" not in scorecard:
+        scorecard["replay_lineage"] = replay_lineage
+    replay_window_coverage = _mapping(
+        scorecard.get("replay_window_coverage")
+        or candidate.get("replay_window_coverage")
+        or replay_lineage.get("replay_window_coverage")
+    )
+    if replay_window_coverage and "replay_window_coverage" not in scorecard:
+        scorecard["replay_window_coverage"] = replay_window_coverage
+
+
+def _default_frontier_replay_stress_metrics(
+    scorecard: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    return (
+        {
+            "source": "frontier_replay",
+            "stress_type": "market_impact",
+            "model": scorecard.get("market_impact_stress_model"),
+            "cost_bps": scorecard.get("market_impact_stress_cost_bps"),
+            "net_pnl_per_day": scorecard.get("market_impact_stress_net_pnl_per_day"),
+            "passed": scorecard.get("market_impact_stress_passed"),
+            "artifact_ref": scorecard.get("market_impact_stress_artifact_ref"),
+        },
+        {
+            "source": "frontier_replay",
+            "stress_type": "delay_adjusted_depth",
+            "model": scorecard.get("delay_adjusted_depth_stress_model"),
+            "stress_ms": scorecard.get("delay_adjusted_depth_stress_ms"),
+            "latency_grid_ms": scorecard.get("delay_adjusted_depth_latency_grid_ms"),
+            "grid_max_stress_ms": scorecard.get(
+                "delay_adjusted_depth_grid_max_stress_ms"
+            ),
+            "fillable_notional_per_day": scorecard.get(
+                "delay_adjusted_depth_fillable_notional_per_day"
+            ),
+            "worst_grid_fillable_notional_per_day": scorecard.get(
+                "delay_adjusted_depth_worst_grid_fillable_notional_per_day"
+            ),
+            "worst_active_day_fillable_notional": scorecard.get(
+                "delay_adjusted_depth_worst_active_day_fillable_notional"
+            ),
+            "p10_active_day_fillable_notional": scorecard.get(
+                "delay_adjusted_depth_p10_active_day_fillable_notional"
+            ),
+            "tail_coverage_passed": scorecard.get(
+                "delay_adjusted_depth_tail_coverage_passed"
+            ),
+            "liquidity_missing_day_count": scorecard.get(
+                "delay_adjusted_depth_liquidity_missing_day_count"
+            ),
+            "fillable_ratio": scorecard.get("delay_adjusted_depth_fillable_ratio"),
+            "survival_adjusted_fillable_ratio": scorecard.get(
+                "delay_adjusted_depth_survival_adjusted_fillable_ratio"
+            ),
+            "unfillable_notional_per_day": scorecard.get(
+                "delay_adjusted_depth_unfillable_notional_per_day"
+            ),
+            "fill_survival_evidence_present": scorecard.get(
+                "delay_adjusted_depth_fill_survival_evidence_present"
+            ),
+            "fill_survival_sample_count": scorecard.get(
+                "delay_adjusted_depth_fill_survival_sample_count"
+            ),
+            "fill_survival_rate": scorecard.get(
+                "delay_adjusted_depth_fill_survival_rate"
+            ),
+            "queue_ratio_p95": scorecard.get("delay_adjusted_depth_queue_ratio_p95"),
+            "queue_ahead_depletion_evidence_present": scorecard.get(
+                "delay_adjusted_depth_queue_ahead_depletion_evidence_present"
+            ),
+            "queue_ahead_depletion_sample_count": scorecard.get(
+                "delay_adjusted_depth_queue_ahead_depletion_sample_count"
+            ),
+            "net_pnl_per_day": scorecard.get(
+                "delay_adjusted_depth_stress_net_pnl_per_day"
+            ),
+            "passed": scorecard.get("delay_adjusted_depth_stress_passed"),
+            "artifact_ref": scorecard.get("delay_adjusted_depth_stress_artifact_ref"),
+        },
+        {
+            "source": "frontier_replay",
+            "stress_type": "implementation_uncertainty",
+            "model": scorecard.get("implementation_uncertainty_model"),
+            "model_count": scorecard.get("implementation_uncertainty_model_count"),
+            "lower_net_pnl_per_day": scorecard.get(
+                "implementation_uncertainty_lower_net_pnl_per_day"
+            ),
+            "upper_net_pnl_per_day": scorecard.get(
+                "implementation_uncertainty_upper_net_pnl_per_day"
+            ),
+            "interval_width_per_day": scorecard.get(
+                "implementation_uncertainty_interval_width_per_day"
+            ),
+            "scenarios": scorecard.get("implementation_uncertainty_scenarios"),
+            "passed": scorecard.get("implementation_uncertainty_stability_passed"),
+        },
+    )
+
+
+__all__ = (
+    "frontier_candidate_adaptive_signal_falsification_stress",
+    "frontier_candidate_null_comparator",
+    "frontier_candidate_scorecard",
+    "frontier_candidate_stress_metrics",
+)

--- a/services/torghut/tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_parses_serialized_false_survival_booleans.py
+++ b/services/torghut/tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_parses_serialized_false_survival_booleans.py
@@ -566,16 +566,19 @@ class TestEvidenceBundleParsesSerializedFalseSurvivalBooleans(
             )[0]
         ]
 
-        import builtins
+        import importlib
 
-        real_import = builtins.__import__
+        real_import_module = importlib.import_module
 
-        def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        def fake_import_module(name: str, *args: Any, **kwargs: Any) -> Any:
             if name == "mlx.core":
                 raise ModuleNotFoundError("mlx unavailable in test")
-            return real_import(name, *args, **kwargs)
+            return real_import_module(name, *args, **kwargs)
 
-        with patch("builtins.__import__", side_effect=fake_import):
+        with patch(
+            "app.trading.discovery.mlx_training_data.shared_context.importlib.import_module",
+            side_effect=fake_import_module,
+        ):
             model = train_mlx_ranker(rows, backend_preference="mlx", steps=2)
 
         self.assertEqual(model.backend, "numpy-fallback")


### PR DESCRIPTION
## Summary

- Extract frontier candidate scorecard assembly into `frontier_candidate_scorecard.py` with explicit semantic helpers for source fields, runtime config, replay lineage, stress metrics, and null comparator fallback.
- Reduce `evidence_bundle_from_frontier_candidate` to orchestration and split delay-depth/order-type blocker checks into focused helpers.
- Split `evidence_bundle_blockers` into dataset/replay, cost, freshness, synthetic-policy, and promotion-proof helpers; remove dead private lineage re-exports flagged by Vulture.
- Make the MLX fallback test deterministic by patching the actual `importlib.import_module` path used by the ranker.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen ruff format --check app scripts tests migrations`
- `uv run --frozen vulture app scripts --min-confidence 80`
- `uv run --frozen pytest tests/evidence_bundles tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_bool_parser_handles_numeric_and_unknown_values.py tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_parses_serialized_false_survival_booleans.py`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/discovery/evidence_bundles/evidence_bundle_blockers.py app/trading/discovery/evidence_bundles/evidence_bundle_from_frontier_candidate.py app/trading/discovery/evidence_bundles/frontier_candidate_scorecard.py tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_parses_serialized_false_survival_booleans.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines app/trading/discovery/evidence_bundles/evidence_bundle_blockers.py app/trading/discovery/evidence_bundles/evidence_bundle_from_frontier_candidate.py app/trading/discovery/evidence_bundles/frontier_candidate_scorecard.py tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_parses_serialized_false_survival_booleans.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
