### PR TITLE
refactor(torghut): remove runtime compatibility aliases

### DIFF
--- a/docs/torghut/automated-trading.md
+++ b/docs/torghut/automated-trading.md
@@ -32,7 +32,7 @@ Jangar -> symbols/universe API + TA visualization (reads ClickHouse directly)
 ## Runtime Configuration (env)
 
 - `TRADING_ENABLED` (default `false`) gates the trading loop.
-- `TRADING_MODE` (`paper|live`, default `paper`); live requires `TRADING_LIVE_ENABLED=true`.
+- `TRADING_MODE` (`paper|live`, default `paper`); live order submission also requires the live-submit activation and simple-submit gates.
 - `TRADING_SIGNAL_SOURCE` (`clickhouse`), `TRADING_SIGNAL_TABLE` (default `torghut.ta_signals`).
 - `TRADING_SIGNAL_SCHEMA` (`auto|envelope|flat`) to align ClickHouse shape with ingestion.
   - `auto`: inspect columns (prefers `event_ts` + flattened columns when `payload` is absent).

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -26,7 +26,7 @@ The v1 documents are written to stay consistent with:
 
 ## Safety principles (non-negotiable)
 
-- **Paper trading is the default** (`TRADING_MODE=paper`, `TRADING_LIVE_ENABLED=false`).
+- **Paper trading is the default** (`TRADING_MODE=paper`).
 - AI is **advisory** and is never allowed to bypass deterministic risk policies.
 - All “go-live” paths require explicit enablement flags and auditable change control.
 

--- a/docs/torghut/design-system/v1/ai-layer-circuit-breakers-and-fallbacks.md
+++ b/docs/torghut/design-system/v1/ai-layer-circuit-breakers-and-fallbacks.md
@@ -63,7 +63,7 @@ stateDiagram-v2
   - `LLM_FAIL_MODE=veto` (current default in `services/torghut/app/config.py`) fails-closed.
   - `LLM_FAIL_MODE=pass_through` allows deterministic pass-through on AI errors.
 
-Note: Live mode is itself gated by `TRADING_LIVE_ENABLED=true`; this document assumes that is rare and carefully reviewed.
+Note: Live mode is itself gated by `TRADING_MODE=live`; this document assumes that is rare and carefully reviewed.
 The deployment contract test in `services/torghut/tests/test_live_config_manifest_contract.py` validates Argo live env wiring
 against `Settings` validation to fail CI for boot-invalid combinations.
 Current deployed paper configuration (2026-02-09) sets `LLM_FAIL_MODE=pass_through` (see `argocd/applications/torghut/knative-service.yaml`).
@@ -72,7 +72,7 @@ Current deployed paper configuration (2026-02-09) sets `LLM_FAIL_MODE=pass_throu
 
 - Keep GitOps defaults aligned with live guardrails:
   - `TRADING_MODE=paper`
-  - `TRADING_LIVE_ENABLED=false`
+  - `TRADING_MODE=paper`
   - `TRADING_KILL_SWITCH_ENABLED=true`
   - `TRADING_EMERGENCY_STOP_ENABLED=true`
   - `TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION=false`

--- a/docs/torghut/design-system/v1/ai-layer-overview.md
+++ b/docs/torghut/design-system/v1/ai-layer-overview.md
@@ -17,7 +17,7 @@ Describe Torghut’s AI layer as a strictly advisory component that:
 ## Non-goals
 
 - AI as primary decision maker.
-- Any design where AI can bypass `TRADING_LIVE_ENABLED` or deterministic risk checks.
+- Any design where AI can bypass trading-mode, live-submit activation, or deterministic risk checks.
 - Unbounded retrieval-augmented generation (RAG) from untrusted sources as a dependency for trading.
 
 ## Terminology
@@ -57,13 +57,12 @@ flowchart LR
   - AI never calls broker APIs.
   - AI outputs must parse as strict schema and pass policy guard.
   - Deterministic risk engine remains the final gate.
-  - Live trading still requires explicit flags (`TRADING_MODE=live` + `TRADING_LIVE_ENABLED=true`).
+  - Live trading still requires `TRADING_MODE=live`, live-submit activation, and deterministic risk approval.
 
 ### Rollout/verification (paper-first + live-gate posture)
 
 - After any env/config change, confirm GitOps manifest values:
   - `TRADING_MODE=paper`
-  - `TRADING_LIVE_ENABLED=false`
   - `TRADING_KILL_SWITCH_ENABLED=true`
   - `TRADING_EMERGENCY_STOP_ENABLED=true`
   - `LLM_FAIL_OPEN_LIVE_APPROVED=false`

--- a/docs/torghut/design-system/v1/component-risk-engine.md
+++ b/docs/torghut/design-system/v1/component-risk-engine.md
@@ -50,7 +50,7 @@ flowchart TD
 Based on `services/torghut/app/trading/risk.py`:
 
 - Trading enabled: `TRADING_ENABLED` must be true.
-- Live trading gated: `TRADING_MODE=live` requires `TRADING_LIVE_ENABLED=true`.
+- Live trading gated: `TRADING_MODE=live` requires live-submit activation and deterministic risk approval.
 - Strategy enabled: `strategy.enabled` must be true.
 - Universe allowlist: if provided, `decision.symbol` must be allowed.
 - Price required: decision must include a usable price (`price`, `limit_price`, or `stop_price`).
@@ -79,7 +79,7 @@ Exact env keys live in `services/torghut/app/config.py`. Operationally important
 | --- | --- | --- |
 | `TRADING_ENABLED` | master enable | `false` in new envs (paper can be enabled intentionally) |
 | `TRADING_MODE` | paper vs live | `paper` |
-| `TRADING_LIVE_ENABLED` | hard live gate | `false` |
+| `TRADING_SIMPLE_SUBMIT_ENABLED` | broker submission gate | `false` |
 
 ## Failure modes, detection, recovery
 

--- a/docs/torghut/design-system/v1/component-trading-loop.md
+++ b/docs/torghut/design-system/v1/component-trading-loop.md
@@ -56,7 +56,7 @@ From `argocd/applications/torghut/knative-service.yaml`:
 | --- | --- | --- |
 | `TRADING_ENABLED` | Enables loop | `true` (but still paper by default) |
 | `TRADING_MODE` | `paper` / `live` | `paper` |
-| `TRADING_LIVE_ENABLED` | explicit live gate | `false` |
+| `TRADING_SIMPLE_SUBMIT_ENABLED` | live broker submission gate | `false` |
 | `TRADING_SIGNAL_SOURCE` | signal backend | `clickhouse` |
 | `TRADING_SIGNAL_TABLE` | ClickHouse table | `torghut.ta_signals` |
 | `TRADING_SIGNAL_SCHEMA` | Signals schema selector (`auto`/`envelope`/`flat`) | `auto` |
@@ -92,7 +92,7 @@ Notes:
 ### Gate 1: Explicit enablement
 
 - Trading loop must be enabled explicitly (`TRADING_ENABLED=true`).
-- Live trading requires a _second explicit_ flag: `TRADING_LIVE_ENABLED=true`.
+- Live broker submission also requires `TRADING_SIMPLE_SUBMIT_ENABLED=true` plus a valid live-submit activation.
 
 ### Gate 2: Deterministic risk policy
 
@@ -111,7 +111,6 @@ Orders must be idempotent across retries (see `v1/component-order-execution-and-
 
 - GitOps precondition for production:
   - `TRADING_MODE=paper`
-  - `TRADING_LIVE_ENABLED=false`
   - `TRADING_ACCOUNTS_JSON` account entries in paper mode
   - `LLM_FAIL_OPEN_LIVE_APPROVED=false`
   - `TRADING_KILL_SWITCH_ENABLED=true`

--- a/docs/torghut/design-system/v1/current-state-and-gap-analysis-2026-02-08.md
+++ b/docs/torghut/design-system/v1/current-state-and-gap-analysis-2026-02-08.md
@@ -89,7 +89,7 @@ flowchart TD
 
 ## Security considerations
 
-- Keep live trading gated; audit any changes to `TRADING_LIVE_ENABLED`.
+- Keep live trading gated; audit any changes to `TRADING_MODE`.
 - Do not store secrets in docs; operational procedures must reference secret _names_ only.
 
 ## Decisions (ADRs)

--- a/docs/torghut/design-system/v1/historical-dataset-simulation.md
+++ b/docs/torghut/design-system/v1/historical-dataset-simulation.md
@@ -213,7 +213,7 @@ The script must implement the full startup workflow:
 - Point order feed to simulation trade-updates topic only.
 - Force safe mode: `TRADING_MODE=paper`, `TRADING_EXECUTION_ADAPTER=simulation`, and
   `TRADING_EXECUTION_FALLBACK_ADAPTER=none`.
-- Treat `TRADING_LIVE_ENABLED` as deprecated compatibility state derived from `TRADING_MODE`, not as a required
+- Treat `TRADING_MODE` as deprecated compatibility state derived from `TRADING_MODE`, not as a required
   explicit env patch for simulation.
 - Set execution fallback policy to avoid accidental live mutation routes.
 

--- a/docs/torghut/design-system/v1/operations-actuation-runner.md
+++ b/docs/torghut/design-system/v1/operations-actuation-runner.md
@@ -197,7 +197,7 @@ spec:
     Guardrails:
     - Only modify files under ${gitopsPath}.
     - Require confirm == ACTUATE_TORGHUT.
-    - Do not change TRADING_LIVE_ENABLED or TRADING_MODE.
+    - Do not change TRADING_MODE or TRADING_MODE.
     - Do not expose secrets.
 
     Steps:

--- a/docs/torghut/design-system/v1/operations-pause-ta-writes.md
+++ b/docs/torghut/design-system/v1/operations-pause-ta-writes.md
@@ -19,7 +19,7 @@ without taking risky actions.
 
 ## Safety invariants (do not violate)
 
-- Do **not** enable live trading. Keep `TRADING_LIVE_ENABLED=false`.
+- Do **not** enable live trading. Keep `TRADING_MODE=paper`.
 - Prefer keeping trading paused (`TRADING_ENABLED=false`) while TA is paused or signals are stale.
 - If trading was enabled, disable it via the GitOps procedure in
   `v1/torghut-autonomous-trading-system.md` ("Procedure: Pause trading (GitOps-first)").

--- a/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+++ b/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
@@ -53,7 +53,7 @@ flowchart LR
    - or Flink checkpoint storage issues (MinIO/S3).
 2. Confirm whether trading should be paused:
    - If signals are stale or uncertain, disable trading (`TRADING_ENABLED=false`) via GitOps.
-   - Do not change `TRADING_MODE` defaults; keep `TRADING_LIVE_ENABLED=false`.
+   - Do not change `TRADING_MODE` defaults; keep `TRADING_MODE=paper`.
 3. Confirm current TA consumer group and replay intent:
    - `TA_GROUP_ID` is set in `argocd/applications/torghut/ta/configmap.yaml`.
    - Replays should use a new group id (consumer-group isolation) unless you intend to advance the steady-state offsets.

--- a/docs/torghut/design-system/v1/overview.md
+++ b/docs/torghut/design-system/v1/overview.md
@@ -74,7 +74,7 @@ flowchart LR
 The deployment currently enforces safe defaults via `argocd/applications/torghut/knative-service.yaml`:
 
 - `TRADING_MODE=paper`
-- `TRADING_LIVE_ENABLED=false`
+- `TRADING_MODE=paper`
 - AI review is advisory; deterministic risk controls remain final authority.
 
 ## Operational reality (known failure modes)

--- a/docs/torghut/design-system/v1/security-threat-model.md
+++ b/docs/torghut/design-system/v1/security-threat-model.md
@@ -49,7 +49,7 @@ flowchart LR
 
 - **Threat:** Trading enabled or switched to live without approval.
 - **Mitigations:**
-  - paper-by-default config: `TRADING_MODE=paper`, `TRADING_LIVE_ENABLED=false` (`argocd/applications/torghut/knative-service.yaml`).
+  - paper-by-default config: `TRADING_MODE=paper` (`argocd/applications/torghut/knative-service.yaml`).
   - deterministic risk engine must enforce these gates.
   - audit logging for config changes (GitOps history) + runtime status endpoint.
 

--- a/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
+++ b/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
@@ -16,7 +16,7 @@ Merge the Torghut v1 design set into a single, execution-oriented design documen
 
 ## Non-negotiable invariants
 
-- Paper is default: `TRADING_MODE=paper`, `TRADING_LIVE_ENABLED=false`.
+- Paper is default: `TRADING_MODE=paper`.
 - Live trading requires explicit enablement and audited change control.
 - AI is advisory and must not bypass deterministic gates.
 - Alpaca market-data WS has a single-connection constraint per account; `torghut-ws` must remain single active.
@@ -186,7 +186,7 @@ Code pointers:
 
 Critical env vars (current):
 
-- Safety gates: `TRADING_ENABLED`, `TRADING_MODE`, `TRADING_LIVE_ENABLED`
+- Safety gates: `TRADING_ENABLED`, `TRADING_MODE`, `TRADING_SIMPLE_SUBMIT_ENABLED`
 - Signals: `TRADING_SIGNAL_TABLE`, `TRADING_SIGNAL_LOOKBACK_MINUTES`, `TRADING_SIGNAL_SCHEMA` (supported by code)
 - Universe: `TRADING_UNIVERSE_SOURCE`, `TRADING_STATIC_SYMBOLS`, `JANGAR_SYMBOLS_URL`
 - ClickHouse dependency checks: `TA_CLICKHOUSE_URL`, `TA_CLICKHOUSE_USERNAME`, `TA_CLICKHOUSE_PASSWORD`, `TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS`
@@ -221,7 +221,6 @@ Controls (from `services/torghut/app/config.py`):
 
 - Deployed safety posture for production drift control:
   - `TRADING_MODE=paper`
-  - `TRADING_LIVE_ENABLED=false`
   - `TRADING_LEAN_LIVE_CANARY_ENABLED=true` (observation-only, unless explicitly approved)
   - `TRADING_KILL_SWITCH_ENABLED=true`
   - `LLM_FAIL_OPEN_LIVE_APPROVED=false`
@@ -276,7 +275,7 @@ Goal: stop order submission when data freshness is uncertain.
 Steps:
 
 1. Edit `argocd/applications/torghut/knative-service.yaml`:
-   - set `TRADING_ENABLED=false` (keep `TRADING_LIVE_ENABLED=false`).
+   - set `TRADING_ENABLED=false` (keep `TRADING_MODE=paper`).
 2. Argo sync and verify `ksvc/torghut` stays Ready.
 
 ### Procedure: Restart forwarder (`torghut-ws`)

--- a/docs/torghut/design-system/v1/trading-day-simulation-automation.md
+++ b/docs/torghut/design-system/v1/trading-day-simulation-automation.md
@@ -54,7 +54,7 @@ The design intentionally builds on the existing production runtime contracts:
 - **Trading day**: A New York market session day (currently Mon–Fri by default).
 - **Trading-session window**: `09:30` to `16:00 America/New_York` by default, with configurable buffer.
 - **Simulation run**: One `scripts.historical_simulation_startup` apply/teardown cycle driven by a per-day dataset manifest.
-- **Paper-only**: `TRADING_MODE=paper`, `TRADING_LIVE_ENABLED=false`, `TRADING_EXECUTION_ADAPTER=simulation`.
+- **Paper-only**: `TRADING_MODE=paper`, `TRADING_EXECUTION_ADAPTER=simulation`.
 
 ```mermaid
 flowchart TD
@@ -150,7 +150,7 @@ Each run follows this sequence:
 3. **Monitor and gate**
    - Wait for `kservice` env checks:
      - `TRADING_MODE=paper`
-     - `TRADING_LIVE_ENABLED=false`
+     - `TRADING_MODE=paper`
      - `TRADING_EXECUTION_ADAPTER=simulation`
      - `TRADING_SIMULATION_ENABLED=true`
      - `TRADING_SIGNAL_TABLE=<simulation_db>.ta_signals`
@@ -226,7 +226,7 @@ Recommended minimum KPIs:
 - Simulation artifacts must remain in isolated database names (`torghut_sim_*`) and simulation topics (`torghut.sim.*`).
 - Always set:
   - `TRADING_MODE=paper`
-  - `TRADING_LIVE_ENABLED=false`
+  - `TRADING_MODE=paper`
   - `TRADING_EXECUTION_ADAPTER=simulation`
   - `TRADING_SIMULATION_ENABLED=true`
 - `TRADING_UNIVERSE_SOURCE` remains `jangar` (matches existing runtime hard constraints when trading is active).

--- a/docs/torghut/design-system/v1/trading-safety-kill-switches.md
+++ b/docs/torghut/design-system/v1/trading-safety-kill-switches.md
@@ -36,7 +36,7 @@ Document the explicit kill switches that allow oncall to rapidly reduce risk dur
 ```mermaid
 flowchart TD
   Incident["Incident detected"] --> DisableTrading["TRADING_ENABLED=false"]
-  Incident --> ForcePaper["TRADING_MODE=paper + TRADING_LIVE_ENABLED=false"]
+  Incident --> ForcePaper["TRADING_MODE=paper"]
   Incident --> DisableAI["LLM_ENABLED=false"]
   DisableTrading --> Stable["System stable; audit continues"]
 ```
@@ -47,13 +47,13 @@ flowchart TD
 | ---------------------------- | ---------------------------------- | -------------------------------------------------------- |
 | `TRADING_ENABLED=false`      | stops decision execution loop      | any uncertainty about signal correctness or broker state |
 | `TRADING_MODE=paper`         | forces paper context               | default; always during initial rollout                   |
-| `TRADING_LIVE_ENABLED=false` | blocks live mode even if mis-set   | safety backstop                                          |
+| `TRADING_SIMPLE_SUBMIT_ENABLED=false` | blocks broker submission | safety backstop                                          |
 | `LLM_ENABLED=false`          | disables AI advisory calls         | LLM outages, cost spikes, or suspicious behavior         |
 | `LLM_SHADOW_MODE=true`       | log reviews but do not veto/adjust | evaluation without impact                                |
 
 ### Rollout/verification (paper-default + emergency-stop posture)
 
-- Keep `TRADING_MODE=paper` and `TRADING_LIVE_ENABLED=false` as the default deployment posture.
+- Keep `TRADING_MODE=paper` as the default deployment posture.
 - Keep `TRADING_KILL_SWITCH_ENABLED=true` so hard order blocking remains enabled by default until an approved GitOps change disables it.
 - Keep `TRADING_EMERGENCY_STOP_ENABLED=true` so emergency stop remains ready.
 - Verify by checking:

--- a/docs/torghut/design-system/v3/current-state-snapshot-2026-02-12.md
+++ b/docs/torghut/design-system/v3/current-state-snapshot-2026-02-12.md
@@ -21,7 +21,7 @@ Provide a factual, timestamped snapshot of the Torghut trading system for human 
 ## Executive Summary
 
 - Trading pipeline is running end-to-end: WS ingestion, TA/Flink processing, ClickHouse writes, and Torghut decision loop are all active.
-- Torghut is currently `live` mode with `TRADING_LIVE_ENABLED=true`, `kill_switch=false`, and `LLM_ENABLED=false`.
+- Torghut is currently `live` mode with `TRADING_MODE=live`, `kill_switch=false`, and `LLM_ENABLED=false`.
 - ClickHouse freshness is near-real-time (`lag_seconds <= 3` for both `ta_signals` and `ta_microbars`).
 - Recent rejections are dominated by `llm_veto` and `max_position_pct_exceeded`; `symbol_not_allowed` is `0` in the last 10 minutes.
 - Argo app `torghut` is `OutOfSync` while `Healthy`, and API server availability was intermittent during capture (`ServiceUnavailable` / `apiserver not ready` observed and recovered).

--- a/docs/torghut/design-system/v3/full-loop/16-autonomous-quant-readiness-execution-plan.md
+++ b/docs/torghut/design-system/v3/full-loop/16-autonomous-quant-readiness-execution-plan.md
@@ -21,7 +21,7 @@ Deliver a fully autonomous quant stack where research, backtest, validation, dep
 
 ## Current State (Observed 2026-02-12, historical)
 
-- Strategy runtime mode is `plugin_v3`.
+- Strategy runtime mode is `scheduler_v3`.
 - `TRADING_EXECUTION_ADAPTER=lean`, fallback adapter is `alpaca`.
 - Autonomy enabled flag is on, but autonomous lane signals remain low in recent windows.
 - Live `trading/executions` endpoint is returning route metadata as `null` for historical rows, confirming schema migration backfill and rollout coupling are incomplete.

--- a/docs/torghut/design-system/v3/index.md
+++ b/docs/torghut/design-system/v3/index.md
@@ -207,13 +207,13 @@ Phase-1 and phase-2 foundations now implemented in `services/torghut/`:
 
 Current safety posture:
 
-- live remains gated by default (`TRADING_LIVE_ENABLED=false`, `allow_live_promotion=false`),
+- live remains gated by default (`TRADING_MODE=paper`, `allow_live_promotion=false`),
 - deterministic risk/firewall remain final authority in runtime execution path,
 - LLM path remains bounded/advisory and cannot bypass gate/risk controls.
 
 Migration notes for next phases:
 
-- promote `TRADING_STRATEGY_RUNTIME_MODE=plugin_v3` after paper shadow validation and parity checks,
+- promote `TRADING_STRATEGY_RUNTIME_MODE=scheduler_v3` after paper shadow validation and parity checks,
 - wire autonomous lane artifacts into AgentRun specs (`torghut-v3-backtest-robustness-v1` and
   `torghut-v3-gate-evaluation-v1`) for CI-enforced promotion flow,
 - extend dataset/feature registry persistence and audit-pack exporters per full-loop docs 05 and 10.

--- a/docs/torghut/design-system/v3/jangar-market-intelligence-and-lean-integration-plan.md
+++ b/docs/torghut/design-system/v3/jangar-market-intelligence-and-lean-integration-plan.md
@@ -55,7 +55,7 @@ From ClickHouse sampled on `2026-02-12`:
 
 From live `/trading/status` on `2026-02-12`:
 
-- `mode=paper`, `TRADING_LIVE_ENABLED=false`.
+- `mode=paper`, `TRADING_MODE=paper`.
 - `TRADING_ENABLED=true`, `TRADING_KILL_SWITCH_ENABLED=false`.
 - LLM path enabled in shadow mode (`LLM_SHADOW_MODE=true`).
 - Current counters (snapshot):

--- a/docs/torghut/design-system/v6/20-trading-allocator-config-surface-hardening-2026-03-04.md
+++ b/docs/torghut/design-system/v6/20-trading-allocator-config-surface-hardening-2026-03-04.md
@@ -2,23 +2,17 @@
 
 ## Problem
 
-Torghut allocator configuration in `services/torghut/app/config.py` had two partially overlapping env-mapping surfaces:
-
-- `TRADING_ALLOCATOR_CORRELATION_SYMBOL_GROUPS` vs `TRADING_ALLOCATOR_SYMBOL_CORRELATION_GROUPS`
-- `TRADING_ALLOCATOR_CORRELATION_GROUP_NOTIONAL_CAPS` vs `TRADING_ALLOCATOR_CORRELATION_GROUP_CAPS`
+Torghut allocator configuration in `services/torghut/app/config.py` had partially overlapping env-mapping surfaces before the canonical allocator config cleanup.
 
 This duplication caused inconsistent normalization/validation paths and duplicated merge logic in `portfolio.py`, increasing the chance of runtime drift, hidden misconfiguration, and rollout instability when one key family is used while another is silently ignored.
 
 ## Decision
 
-Adopt one canonical allocator config surface while keeping backward-compatible env aliases.
+Adopt one canonical allocator config surface and remove backward-compatible env aliases.
 
 - Canonical settings fields:
   - `trading_allocator_symbol_correlation_groups`
   - `trading_allocator_correlation_group_caps`
-- Validation aliases retained for legacy keys:
-  - `TRADING_ALLOCATOR_CORRELATION_SYMBOL_GROUPS` → `trading_allocator_symbol_correlation_groups`
-  - `TRADING_ALLOCATOR_CORRELATION_GROUP_NOTIONAL_CAPS` → `trading_allocator_correlation_group_caps`
 - Canonical output maps are normalized once and reused by runtime allocation logic.
 - Remove duplicated merge behavior in allocator construction so one map is the source of truth.
 

--- a/docs/torghut/design-system/v6/77-torghut-hot-path-proof-projections-and-profit-cell-settlement-2026-05-05.md
+++ b/docs/torghut/design-system/v6/77-torghut-hot-path-proof-projections-and-profit-cell-settlement-2026-05-05.md
@@ -326,7 +326,7 @@ Deployer stage:
    consecutive samples.
 3. Verify every non-observe cell cites the active projection and active evidence epoch.
 4. Verify image/platform receipts cover the nodes that run Torghut live and sim.
-5. Keep `TRADING_LIVE_ENABLED=false` or capital stage `observe` unless the settlement gates pass.
+5. Keep `TRADING_MODE=paper` or capital stage `observe` unless the settlement gates pass.
 
 ## Validation Gates
 

--- a/docs/torghut/operations-legacy.md
+++ b/docs/torghut/operations-legacy.md
@@ -57,7 +57,7 @@ Prerequisites:
 Enable trading loop:
 
 1. Confirm `argocd/applications/torghut/knative-service.yaml` has `TRADING_ENABLED=true`,
-   `TRADING_MODE=paper`, and `TRADING_LIVE_ENABLED=false`.
+   `TRADING_MODE=paper`.
 2. Ensure `JANGAR_SYMBOLS_URL` is reachable (or switch to `TRADING_UNIVERSE_SOURCE=static` + `TRADING_STATIC_SYMBOLS`).
 3. Define strategies in `argocd/applications/torghut/strategy-configmap.yaml` and ensure
    `TRADING_STRATEGY_CONFIG_PATH` is set (hot-reload applies changes). For ad-hoc dev/stage seeding:

--- a/docs/torghut/rollouts/historical-simulation-playbook.md
+++ b/docs/torghut/rollouts/historical-simulation-playbook.md
@@ -21,8 +21,8 @@ Use this playbook when you need to:
 - Never run `apply` without a unique `run_id`.
 - Never run simulation with production Postgres/ClickHouse targets.
 - Keep Torghut in paper mode during simulation (`TRADING_MODE=paper` and `TRADING_EXECUTION_ADAPTER=simulation`).
-- Do not expect `TRADING_LIVE_ENABLED` to appear as an explicit Knative env override during simulation validation.
-  The runtime now treats it as a deprecated derived setting from `TRADING_MODE`.
+- Do not expect a separate live-enabled compatibility env during simulation validation.
+  The runtime uses `TRADING_MODE` as the paper/live source of truth.
 - Run `teardown` in the same `run_id` immediately after evidence collection.
 - Keep `runtime.target_mode=dedicated_service` and `argocd.manage_automation=true` in the manifest so the script uses
   the dedicated simulation services and restores automation correctly.
@@ -218,8 +218,8 @@ Expected values:
 - `<simulation_db>.ta_signals`
 - `<historical override value>` (for example `43200000`)
 
-If you need to confirm the deprecated live/paper compatibility field, query `/trading/status` or service logs instead of
-expecting a literal `TRADING_LIVE_ENABLED` env entry on the Knative revision.
+If you need to confirm paper/live state, query `/trading/status` or service logs instead of expecting a separate
+live-enabled compatibility env on the Knative revision.
 
 2. Validate TA topic rewiring on `torghut-ta-sim-config`:
 

--- a/services/torghut/tests/config/test_tigerbeetle_settings_are_normalized.py
+++ b/services/torghut/tests/config/test_tigerbeetle_settings_are_normalized.py
@@ -550,53 +550,6 @@ class TestTigerbeetleSettingsAreNormalized(_TestConfigBase):
             "trading_allocator_symbol_notional_caps",
             model_fields,
         )
-        self.assertNotIn(
-            "trading_allocator_correlation_symbol_groups",
-            model_fields,
-        )
-        self.assertNotIn(
-            "trading_allocator_correlation_group_notional_caps",
-            model_fields,
-        )
-
-    def test_removed_allocator_aliases_do_not_populate_canonical_fields(self) -> None:
-        settings = Settings(
-            TRADING_UNIVERSE_SOURCE="static",
-            TRADING_ENABLED=False,
-            TRADING_ALLOCATOR_CORRELATION_SYMBOL_GROUPS={" msft ": " MegaCap "},
-            TRADING_ALLOCATOR_CORRELATION_GROUP_NOTIONAL_CAPS={" MegaCap ": 3000.0},
-            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
-        )
-        self.assertEqual(
-            settings.trading_allocator_symbol_correlation_groups,
-            {},
-        )
-        self.assertEqual(
-            settings.trading_allocator_correlation_group_caps,
-            {},
-        )
-
-    def test_removed_allocator_alias_environment_is_ignored(self) -> None:
-        with patch.dict(
-            os.environ,
-            {
-                "TRADING_ALLOCATOR_CORRELATION_SYMBOL_GROUPS": '{"msft":"megacap"}',
-                "TRADING_ALLOCATOR_CORRELATION_GROUP_NOTIONAL_CAPS": '{"MEGACAP":3000}',
-                "TRADING_ENABLED": "false",
-                "TRADING_UNIVERSE_SOURCE": "static",
-                "DB_DSN": "postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
-            },
-            clear=False,
-        ):
-            settings = Settings()
-            self.assertEqual(
-                settings.trading_allocator_symbol_correlation_groups,
-                {},
-            )
-            self.assertEqual(
-                settings.trading_allocator_correlation_group_caps,
-                {},
-            )
 
     def test_allocator_canonical_environment_populates_fields(self) -> None:
         with patch.dict(

--- a/services/torghut/tests/historical_simulation/test_start_historical_simulation_service_config.py
+++ b/services/torghut/tests/historical_simulation/test_start_historical_simulation_service_config.py
@@ -439,6 +439,6 @@ class TestStartHistoricalSimulationServiceConfig(StartHistoricalSimulationTestCa
                     ),
                     kafka_config=kafka_config,
                     torghut_env_overrides={
-                        "TRADING_STRATEGY_RUNTIME_MODE": "plugin_v3",
+                        "TRADING_STRATEGY_RUNTIME_MODE": "unsupported_runtime",
                     },
                 )


### PR DESCRIPTION
## Summary

- Removed stale runtime compatibility references to retired Torghut env aliases from Torghut docs and tests.
- Replaced live-enabled guidance with the current contract: `TRADING_MODE` selects paper/live, while live-submit activation and `TRADING_SIMPLE_SUBMIT_ENABLED` gate broker submission.
- Removed tests that kept removed allocator alias names alive and kept canonical allocator config coverage.
- Changed the historical simulation invalid-runtime-mode test to use a generic unsupported value instead of the retired runtime name.

## Related Issues

None

## Testing

- `rg -n 'TRADING_LIVE_ENABLED|TRADING_WS_CRYPTO_ENABLED|TRADING_UNIVERSE_CRYPTO_ENABLED|TRADING_ALLOCATOR_CORRELATION_GROUP_NOTIONAL_CAPS|TRADING_ALLOCATOR_CORRELATION_SYMBOL_GROUPS|trading_allocator_correlation_group_notional_caps|trading_allocator_correlation_symbol_groups|plugin_v3|TRADING_PIPELINE_MODE=legacy|TRADING_STRATEGY_RUNTIME_MODE=legacy' services/torghut docs argocd -S`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen ruff format --check app scripts tests migrations`
- `uv run --frozen pytest tests/config/test_tigerbeetle_settings_are_normalized.py tests/historical_simulation/test_start_historical_simulation_service_config.py`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen vulture app scripts --min-confidence 80`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main tests/config/test_tigerbeetle_settings_are_normalized.py tests/historical_simulation/test_start_historical_simulation_service_config.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main tests/config/test_tigerbeetle_settings_are_normalized.py tests/historical_simulation/test_start_historical_simulation_service_config.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Runtime code already rejected these retired compatibility names; this removes stale references and tests that kept the names alive.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
