### PR TITLE
refactor(torghut): remove dead service scaffolding

### DIFF
--- a/services/torghut/app/trading/decisions/decision_engine_runtime_methods.py
+++ b/services/torghut/app/trading/decisions/decision_engine_runtime_methods.py
@@ -325,7 +325,6 @@ class DecisionEngine(
     _DecisionEngineFields,
     _DecisionEngineCoreMethods,
     _DecisionEngineRuntimeMethods,
-    object,
 ):
     pass
 

--- a/services/torghut/app/trading/discovery/autoresearch_notebooks.py
+++ b/services/torghut/app/trading/discovery/autoresearch_notebooks.py
@@ -62,14 +62,7 @@ except ModuleNotFoundError:
 try:
     from IPython.display import HTML, Markdown, SVG, display
 except ModuleNotFoundError:
-    class HTML(str):
-        pass
-
-    class Markdown(str):
-        pass
-
-    class SVG(str):
-        pass
+    HTML = Markdown = SVG = str
 
     def display(*items: object) -> None:
         for item in items:
@@ -483,14 +476,7 @@ except ModuleNotFoundError:
 try:
     from IPython.display import HTML, Markdown, SVG, display
 except ModuleNotFoundError:
-    class HTML(str):
-        pass
-
-    class Markdown(str):
-        pass
-
-    class SVG(str):
-        pass
+    HTML = Markdown = SVG = str
 
     def display(*items: object) -> None:
         for item in items:

--- a/services/torghut/app/trading/evaluation/bootstrap_mean_samples.py
+++ b/services/torghut/app/trading/evaluation/bootstrap_mean_samples.py
@@ -2,12 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import hashlib
-from decimal import Decimal
-from typing import Any, cast
-
-
 from .signal_source import (
     FillPriceErrorBudgetReportV1,
     FixtureSignalSource,
@@ -31,132 +25,17 @@ from .signal_source import (
 from .build_simulation_calibration_report_v1 import (
     build_fill_price_error_budget_report_v1,
 )
+from .numeric_helpers import (
+    as_int,
+    bootstrap_mean_samples,
+    decimal_mean,
+    decimal_std,
+    quantile_decimal,
+    report_fold_net_pnls,
+    reproducibility_payload,
+    safe_ratio,
+)
 
-
-def _bootstrap_mean_samples(
-    values: list[Decimal], *, sample_count: int
-) -> list[Decimal]:
-    if not values:
-        return []
-    payload = [str(value) for value in values]
-    seed = int(
-        hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[
-            :16
-        ],
-        16,
-    )
-    samples: list[Decimal] = []
-    values_count = len(values)
-    for _ in range(sample_count):
-        sample_sum: Decimal = Decimal("0")
-        for _ in range(values_count):
-            seed = (1664525 * seed + 1013904223) % (2**32)
-            index: int = seed % values_count
-            sample_sum = sample_sum + values[index]
-        sample_mean: Decimal = sample_sum / Decimal(values_count)
-        samples.append(sample_mean)
-    return samples
-
-
-def _quantile_decimal(values: list[Decimal], quantile: Decimal) -> Decimal:
-    if not values:
-        return Decimal("0")
-    if quantile <= 0:
-        return values[0]
-    if quantile >= 1:
-        return values[-1]
-    index = int((Decimal(len(values) - 1) * quantile).to_integral_value())
-    index = max(0, min(index, len(values) - 1))
-    return values[index]
-
-
-def _reproducibility_payload(hashes: dict[str, str]) -> dict[str, object]:
-    normalized = {
-        str(key): str(value)
-        for key, value in hashes.items()
-        if str(key).strip() and str(value).strip()
-    }
-    manifest = json.dumps(sorted(normalized.items()), separators=(",", ":")).encode(
-        "utf-8"
-    )
-    manifest_hash = hashlib.sha256(manifest).hexdigest()
-    return {
-        "hash_algorithm": "sha256",
-        "artifact_hashes": normalized,
-        "manifest_hash": manifest_hash,
-    }
-
-
-def _report_fold_net_pnls(report_payload: dict[str, Any]) -> list[Decimal]:
-    robustness = _as_dict(report_payload.get("robustness"))
-    folds = robustness.get("folds")
-    if not isinstance(folds, list):
-        return []
-    values: list[Decimal] = []
-    for raw in cast(list[object], folds):
-        if not isinstance(raw, dict):
-            continue
-        fold = cast(dict[str, Any], raw)
-        value = _decimal(fold.get("net_pnl"))
-        if value is not None:
-            values.append(value)
-    return values
-
-
-def _decimal(value: Any) -> Decimal | None:
-    if value is None:
-        return None
-    if isinstance(value, Decimal):
-        return value
-    try:
-        return Decimal(str(value))
-    except (ArithmeticError, TypeError, ValueError):
-        return None
-
-
-def _decimal_mean(values: list[Decimal]) -> Decimal:
-    if not values:
-        return Decimal("0")
-    return sum(values, Decimal("0")) / Decimal(len(values))
-
-
-def _decimal_std(values: list[Decimal], mean: Decimal) -> Decimal:
-    if len(values) <= 1:
-        return Decimal("0")
-    variance = sum((value - mean) ** 2 for value in values) / Decimal(len(values))
-    return variance.sqrt()
-
-
-def _safe_ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
-    if denominator <= 0:
-        return Decimal("0")
-    return numerator / denominator
-
-
-def _as_dict(value: Any) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {}
-    return cast(dict[str, Any], value)
-
-
-def _as_int(value: Any) -> int | None:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-# Public aliases used by split-module consumers.
-as_int = _as_int
-bootstrap_mean_samples = _bootstrap_mean_samples
-decimal_mean = _decimal_mean
-decimal_std = _decimal_std
-quantile_decimal = _quantile_decimal
-reproducibility_payload = _reproducibility_payload
-report_fold_net_pnls = _report_fold_net_pnls
-safe_ratio = _safe_ratio
 
 __all__ = [
     "FixtureSignalSource",

--- a/services/torghut/app/trading/evaluation/build_simulation_calibration_report_v1.py
+++ b/services/torghut/app/trading/evaluation/build_simulation_calibration_report_v1.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import importlib
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, cast
 
 from ..evidence_contracts import (
     ArtifactProvenance,
@@ -16,52 +14,31 @@ from ..evidence_contracts import (
 
 from .signal_source import (
     FillPriceErrorBudgetReportV1,
-    ProfitabilityBenchmarkV4,
-    ProfitabilityEvidenceThresholdsV4,
     ProfitabilityEvidenceV4,
     ShadowLiveDeviationReportV1,
     SimulationCalibrationReportV1,
 )
-
-
-def _bootstrap_helpers() -> Any:
-    return importlib.import_module(f"{__package__}.bootstrap_mean_samples")
-
-
-def _as_dict(value: Any) -> dict[str, Any]:
-    return _bootstrap_helpers()._as_dict(value)
-
-
-def _as_int(value: Any) -> int | None:
-    return _bootstrap_helpers()._as_int(value)
-
-
-def _decimal(value: Any) -> Decimal | None:
-    return _bootstrap_helpers()._decimal(value)
-
-
-def _decimal_mean(values: list[Decimal]) -> Decimal:
-    return _bootstrap_helpers()._decimal_mean(values)
-
-
-def _decimal_std(values: list[Decimal], mean: Decimal) -> Decimal:
-    return _bootstrap_helpers()._decimal_std(values, mean)
-
-
-def _safe_ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
-    return _bootstrap_helpers()._safe_ratio(numerator, denominator)
-
-
-def _bootstrap_mean_samples(
-    values: list[Decimal], *, sample_count: int
-) -> list[Decimal]:
-    return _bootstrap_helpers()._bootstrap_mean_samples(
-        values, sample_count=sample_count
-    )
-
-
-def _quantile_decimal(values: list[Decimal], quantile: Decimal) -> Decimal:
-    return _bootstrap_helpers()._quantile_decimal(values, quantile)
+from .numeric_helpers import (
+    as_dict as _as_dict,
+    as_int as _as_int,
+    decimal as _decimal,
+)
+from .profitability_metrics_helpers import (
+    append_profitability_reason,
+    benchmark_summary,
+    confidence_summary,
+    empty_slice_metrics,
+    extract_report_slices,
+    significance_summary,
+    slice_deltas,
+    slice_metrics,
+    validate_profitability_confidence_metrics,
+    validate_profitability_cost_metrics,
+    validate_profitability_reproducibility,
+    validate_profitability_risk_metrics,
+    validate_profitability_schema_versions,
+    validate_profitability_significance_metrics,
+)
 
 
 def build_simulation_calibration_report_v1(
@@ -328,457 +305,22 @@ def build_fill_price_error_budget_report_v1(
     )
 
 
-def append_profitability_reason(
-    *,
-    reasons: list[str],
-    details: list[dict[str, object]],
-    reason: str,
-    payload: dict[str, object],
-) -> None:
-    reasons.append(reason)
-    detail_payload: dict[str, object] = {"reason": reason}
-    detail_payload.update(payload)
-    details.append(detail_payload)
-
-
-def validate_profitability_schema_versions(
-    *,
-    evidence: ProfitabilityEvidenceV4,
-    reasons: list[str],
-    details: list[dict[str, object]],
-) -> None:
-    if evidence.schema_version != "profitability-evidence-v4":
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="profitability_evidence_schema_invalid",
-            payload={"expected": "profitability-evidence-v4"},
-        )
-    if evidence.benchmark.schema_version != "profitability-benchmark-v4":
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="profitability_benchmark_schema_invalid",
-            payload={"expected": "profitability-benchmark-v4"},
-        )
-
-
-def validate_profitability_risk_metrics(
-    *,
-    evidence: ProfitabilityEvidenceV4,
-    policy: ProfitabilityEvidenceThresholdsV4,
-    reasons: list[str],
-    details: list[dict[str, object]],
-) -> None:
-    market_delta = _decimal(
-        evidence.risk_adjusted_metrics.get("market_net_pnl_delta")
-    ) or Decimal("0")
-    if market_delta < policy.min_market_net_pnl_delta:
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="market_net_pnl_delta_below_threshold",
-            payload={
-                "actual": str(market_delta),
-                "minimum": str(policy.min_market_net_pnl_delta),
-            },
-        )
-
-    return_over_drawdown = _decimal(
-        evidence.risk_adjusted_metrics.get("return_over_drawdown")
-    ) or Decimal("0")
-    if return_over_drawdown < policy.min_risk_adjusted_return_over_drawdown:
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="risk_adjusted_return_over_drawdown_below_threshold",
-            payload={
-                "actual": str(return_over_drawdown),
-                "minimum": str(policy.min_risk_adjusted_return_over_drawdown),
-            },
-        )
-
-    regime_ratio = _decimal(
-        evidence.risk_adjusted_metrics.get("regime_slice_pass_ratio")
-    ) or Decimal("0")
-    if regime_ratio < policy.min_regime_slice_pass_ratio:
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="regime_slice_pass_ratio_below_threshold",
-            payload={
-                "actual": str(regime_ratio),
-                "minimum": str(policy.min_regime_slice_pass_ratio),
-            },
-        )
-
-
-def validate_profitability_cost_metrics(
-    *,
-    evidence: ProfitabilityEvidenceV4,
-    policy: ProfitabilityEvidenceThresholdsV4,
-    reasons: list[str],
-    details: list[dict[str, object]],
-) -> None:
-    cost_bps = _decimal(evidence.cost_fill_realism.get("cost_bps")) or Decimal("0")
-    if cost_bps <= policy.max_cost_bps:
-        return
-    append_profitability_reason(
-        reasons=reasons,
-        details=details,
-        reason="cost_bps_exceeds_threshold",
-        payload={
-            "actual": str(cost_bps),
-            "maximum": str(policy.max_cost_bps),
-        },
-    )
-
-
-def validate_profitability_confidence_metrics(
-    *,
-    evidence: ProfitabilityEvidenceV4,
-    policy: ProfitabilityEvidenceThresholdsV4,
-    reasons: list[str],
-    details: list[dict[str, object]],
-) -> None:
-    confidence_samples = (
-        _as_int(evidence.confidence_calibration.get("sample_count")) or 0
-    )
-    if confidence_samples < policy.min_confidence_samples:
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="confidence_samples_below_minimum",
-            payload={
-                "actual": confidence_samples,
-                "minimum": policy.min_confidence_samples,
-            },
-        )
-
-    calibration_error = _decimal(
-        evidence.confidence_calibration.get("calibration_error")
-    ) or Decimal("1")
-    if calibration_error <= policy.max_calibration_error:
-        return
-    append_profitability_reason(
-        reasons=reasons,
-        details=details,
-        reason="calibration_error_exceeds_threshold",
-        payload={
-            "actual": str(calibration_error),
-            "maximum": str(policy.max_calibration_error),
-        },
-    )
-
-
-def validate_profitability_significance_metrics(
-    *,
-    evidence: ProfitabilityEvidenceV4,
-    policy: ProfitabilityEvidenceThresholdsV4,
-    reasons: list[str],
-    details: list[dict[str, object]],
-) -> None:
-    significance = _as_dict(evidence.significance)
-    schema_version = str(significance.get("schema_version", "")).strip()
-    if schema_version != "significance_snapshot_v1":
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="significance_schema_invalid",
-            payload={"expected": "significance_snapshot_v1"},
-        )
-    sample_count = _as_int(significance.get("sample_count")) or 0
-    if sample_count < policy.min_significance_samples:
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="significance_samples_below_minimum",
-            payload={
-                "actual": sample_count,
-                "minimum": policy.min_significance_samples,
-            },
-        )
-
-
-def validate_profitability_reproducibility(
-    *,
-    evidence: ProfitabilityEvidenceV4,
-    policy: ProfitabilityEvidenceThresholdsV4,
-    reasons: list[str],
-    details: list[dict[str, object]],
-) -> None:
-    reproducibility = _as_dict(evidence.reproducibility)
-    hashes = {
-        str(key): str(value)
-        for key, value in _as_dict(reproducibility.get("artifact_hashes")).items()
-        if str(key).strip() and str(value).strip()
-    }
-    if len(hashes) < policy.min_reproducibility_hashes:
-        append_profitability_reason(
-            reasons=reasons,
-            details=details,
-            reason="reproducibility_hash_count_below_minimum",
-            payload={
-                "actual": len(hashes),
-                "minimum": policy.min_reproducibility_hashes,
-            },
-        )
-
-    missing_hash_keys = sorted(
-        [key for key in policy.required_hash_keys if key not in hashes]
-    )
-    if not missing_hash_keys:
-        return
-    append_profitability_reason(
-        reasons=reasons,
-        details=details,
-        reason="reproducibility_hash_keys_missing",
-        payload={"missing_keys": missing_hash_keys},
-    )
-
-
-def _extract_report_slices(report_payload: dict[str, Any]) -> dict[str, dict[str, str]]:
-    metrics = _as_dict(report_payload.get("metrics"))
-    slices: dict[str, dict[str, str]] = {
-        "market:all": slice_metrics(
-            net_pnl=_decimal(metrics.get("net_pnl")),
-            max_drawdown=_decimal(metrics.get("max_drawdown")),
-            cost_bps=_decimal(metrics.get("cost_bps")),
-            turnover_ratio=_decimal(metrics.get("turnover_ratio")),
-            trade_count=_as_int(metrics.get("trade_count")),
-        )
-    }
-    robustness = _as_dict(report_payload.get("robustness"))
-    folds = robustness.get("folds")
-    if isinstance(folds, list):
-        grouped: dict[str, list[dict[str, Any]]] = {}
-        for raw in cast(list[object], folds):
-            if not isinstance(raw, dict):
-                continue
-            fold = cast(dict[str, Any], raw)
-            regime = str(fold.get("regime_label", "")).strip() or "unknown"
-            grouped.setdefault(regime, []).append(fold)
-        for regime, entries in grouped.items():
-            net_pnl = sum(
-                ((_decimal(item.get("net_pnl")) or Decimal("0")) for item in entries),
-                Decimal("0"),
-            )
-            max_drawdown = max(
-                (_decimal(item.get("max_drawdown")) or Decimal("0")) for item in entries
-            )
-            cost_values = [
-                (_decimal(item.get("cost_bps")) or Decimal("0")) for item in entries
-            ]
-            turnover_values = [
-                (_decimal(item.get("turnover_ratio")) or Decimal("0"))
-                for item in entries
-            ]
-            trade_count = sum(
-                (_as_int(item.get("trade_count")) or 0) for item in entries
-            )
-            slices[f"regime:{regime}"] = slice_metrics(
-                net_pnl=net_pnl,
-                max_drawdown=max_drawdown,
-                cost_bps=_decimal_mean(cost_values),
-                turnover_ratio=_decimal_mean(turnover_values),
-                trade_count=trade_count,
-            )
-    return slices
-
-
-def slice_metrics(
-    *,
-    net_pnl: Decimal | None,
-    max_drawdown: Decimal | None,
-    cost_bps: Decimal | None,
-    turnover_ratio: Decimal | None,
-    trade_count: int | None,
-) -> dict[str, str]:
-    return {
-        "net_pnl": str(net_pnl or Decimal("0")),
-        "max_drawdown": str(max_drawdown or Decimal("0")),
-        "cost_bps": str(cost_bps or Decimal("0")),
-        "turnover_ratio": str(turnover_ratio or Decimal("0")),
-        "trade_count": str(trade_count or 0),
-    }
-
-
-def empty_slice_metrics() -> dict[str, str]:
-    return slice_metrics(
-        net_pnl=Decimal("0"),
-        max_drawdown=Decimal("0"),
-        cost_bps=Decimal("0"),
-        turnover_ratio=Decimal("0"),
-        trade_count=0,
-    )
-
-
-def slice_deltas(candidate: dict[str, str], baseline: dict[str, str]) -> dict[str, str]:
-    candidate_net = _decimal(candidate.get("net_pnl")) or Decimal("0")
-    baseline_net = _decimal(baseline.get("net_pnl")) or Decimal("0")
-    candidate_dd = _decimal(candidate.get("max_drawdown")) or Decimal("0")
-    baseline_dd = _decimal(baseline.get("max_drawdown")) or Decimal("0")
-    candidate_cost = _decimal(candidate.get("cost_bps")) or Decimal("0")
-    baseline_cost = _decimal(baseline.get("cost_bps")) or Decimal("0")
-    candidate_trades = _as_int(candidate.get("trade_count")) or 0
-    baseline_trades = _as_int(baseline.get("trade_count")) or 0
-    return {
-        "net_pnl_delta": str(candidate_net - baseline_net),
-        "max_drawdown_delta": str(candidate_dd - baseline_dd),
-        "cost_bps_delta": str(candidate_cost - baseline_cost),
-        "trade_count_delta": str(candidate_trades - baseline_trades),
-    }
-
-
-def benchmark_summary(benchmark: ProfitabilityBenchmarkV4) -> dict[str, Decimal]:
-    market_delta = Decimal("0")
-    regime_total = 0
-    regime_pass = 0
-    for slice_item in benchmark.slices:
-        net_delta = _decimal(slice_item.deltas.get("net_pnl_delta")) or Decimal("0")
-        if slice_item.slice_key == "market:all":
-            market_delta = net_delta
-        if slice_item.slice_type == "regime":
-            regime_total += 1
-            if net_delta >= 0:
-                regime_pass += 1
-    pass_ratio = _safe_ratio(Decimal(regime_pass), Decimal(regime_total))
-    return {
-        "market_net_pnl_delta": market_delta,
-        "regime_slice_pass_ratio": pass_ratio,
-    }
-
-
-def confidence_summary(
-    confidence_values: list[Decimal], net_pnl: Decimal
-) -> dict[str, object]:
-    target_coverage = Decimal("0.90")
-    calibration_target = Decimal("1") if net_pnl > 0 else Decimal("0")
-    if not confidence_values:
-        return {
-            "sample_count": 0,
-            "mean_confidence": "0",
-            "std_confidence": "0",
-            "calibration_target": str(calibration_target),
-            "calibration_error": "1",
-            "target_coverage": str(target_coverage),
-            "observed_coverage": "0",
-            "coverage_error": "1",
-            "avg_interval_width": "0",
-            "shift_state": "unknown",
-            "shift_score": "1",
-            "gate_action": "abstain",
-            "schema_version": "calibration_snapshot_v1",
-            "recalibration_run_id": None,
-            "recalibration_artifact_ref": None,
-        }
-    mean_confidence = _decimal_mean(confidence_values)
-    std_confidence = _decimal_std(confidence_values, mean_confidence)
-    calibration_error = abs(mean_confidence - calibration_target)
-    coverage_error = min(
-        Decimal("1"),
-        (calibration_error * Decimal("0.08")) + (std_confidence * Decimal("0.02")),
-    )
-    observed_coverage = max(Decimal("0"), target_coverage - coverage_error)
-    avg_interval_width = min(
-        Decimal("2"),
-        Decimal("0.5") + (std_confidence * Decimal("2")) + calibration_error,
-    )
-    shift_score = min(
-        Decimal("1"),
-        abs(mean_confidence - calibration_target) + std_confidence,
-    )
-    if shift_score >= Decimal("0.95"):
-        shift_state = "severe"
-    elif shift_score >= Decimal("0.80"):
-        shift_state = "high"
-    elif shift_score >= Decimal("0.60"):
-        shift_state = "elevated"
-    else:
-        shift_state = "stable"
-    gate_action = "pass"
-    if shift_score >= Decimal("0.95"):
-        gate_action = "fail"
-    elif coverage_error > Decimal("0.08") or shift_score >= Decimal("0.80"):
-        gate_action = "abstain"
-    elif coverage_error > Decimal("0.05") or shift_score >= Decimal("0.60"):
-        gate_action = "degrade"
-    return {
-        "sample_count": len(confidence_values),
-        "mean_confidence": str(mean_confidence),
-        "std_confidence": str(std_confidence),
-        "calibration_target": str(calibration_target),
-        "calibration_error": str(calibration_error),
-        "target_coverage": str(target_coverage),
-        "observed_coverage": str(observed_coverage),
-        "coverage_error": str(coverage_error),
-        "avg_interval_width": str(avg_interval_width),
-        "shift_state": shift_state,
-        "shift_score": str(shift_score),
-        "gate_action": gate_action,
-        "schema_version": "calibration_snapshot_v1",
-        "recalibration_run_id": None,
-        "recalibration_artifact_ref": None,
-    }
-
-
-def significance_summary(benchmark: ProfitabilityBenchmarkV4) -> dict[str, object]:
-    deltas = [
-        _decimal(item.deltas.get("net_pnl_delta")) or Decimal("0")
-        for item in benchmark.slices
-        if item.slice_type in {"market", "regime"}
-    ]
-    if not deltas:
-        return {
-            "schema_version": "significance_snapshot_v1",
-            "sample_count": 0,
-            "net_pnl_delta_mean": "0",
-            "net_pnl_delta_std": "0",
-            "ci_95_low": "0",
-            "ci_95_high": "0",
-            "p_value_two_sided": "1",
-            "statistically_positive": False,
-            "statistically_negative": False,
-            "bootstrap_samples": 0,
-        }
-
-    mean_delta = _decimal_mean(deltas)
-    std_delta = _decimal_std(deltas, mean_delta)
-    bootstrap_samples = _bootstrap_mean_samples(deltas, sample_count=512)
-    sorted_samples = sorted(bootstrap_samples)
-    ci_low = _quantile_decimal(sorted_samples, Decimal("0.025"))
-    ci_high = _quantile_decimal(sorted_samples, Decimal("0.975"))
-    non_positive_count = sum(1 for value in sorted_samples if value <= 0)
-    non_negative_count = sum(1 for value in sorted_samples if value >= 0)
-    sample_size = max(len(sorted_samples), 1)
-    p_two_sided = min(
-        Decimal("1"),
-        Decimal("2")
-        * min(
-            Decimal(non_positive_count) / Decimal(sample_size),
-            Decimal(non_negative_count) / Decimal(sample_size),
-        ),
-    )
-    return {
-        "schema_version": "significance_snapshot_v1",
-        "sample_count": len(deltas),
-        "net_pnl_delta_mean": str(mean_delta),
-        "net_pnl_delta_std": str(std_delta),
-        "ci_95_low": str(ci_low),
-        "ci_95_high": str(ci_high),
-        "p_value_two_sided": str(p_two_sided),
-        "statistically_positive": bool(ci_low > 0),
-        "statistically_negative": bool(ci_high < 0),
-        "bootstrap_samples": len(sorted_samples),
-    }
-
-
-# Public aliases used by split-module consumers.
-extract_report_slices = _extract_report_slices
-
 __all__ = (
     "build_simulation_calibration_report_v1",
     "build_shadow_live_deviation_report_v1",
     "build_fill_price_error_budget_report_v1",
+    "append_profitability_reason",
+    "benchmark_summary",
+    "confidence_summary",
+    "empty_slice_metrics",
     "extract_report_slices",
+    "significance_summary",
+    "slice_deltas",
+    "slice_metrics",
+    "validate_profitability_confidence_metrics",
+    "validate_profitability_cost_metrics",
+    "validate_profitability_reproducibility",
+    "validate_profitability_risk_metrics",
+    "validate_profitability_schema_versions",
+    "validate_profitability_significance_metrics",
 )

--- a/services/torghut/app/trading/evaluation/numeric_helpers.py
+++ b/services/torghut/app/trading/evaluation/numeric_helpers.py
@@ -1,0 +1,158 @@
+"""Shared numeric helpers for evaluation reports."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from decimal import Decimal
+from typing import Any, cast
+
+
+def _bootstrap_mean_samples(
+    values: list[Decimal], *, sample_count: int
+) -> list[Decimal]:
+    if not values:
+        return []
+    payload = [str(value) for value in values]
+    seed = int(
+        hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[
+            :16
+        ],
+        16,
+    )
+    samples: list[Decimal] = []
+    values_count = len(values)
+    for _ in range(sample_count):
+        sample_sum: Decimal = Decimal("0")
+        for _ in range(values_count):
+            seed = (1664525 * seed + 1013904223) % (2**32)
+            index: int = seed % values_count
+            sample_sum = sample_sum + values[index]
+        sample_mean: Decimal = sample_sum / Decimal(values_count)
+        samples.append(sample_mean)
+    return samples
+
+
+def _quantile_decimal(values: list[Decimal], quantile: Decimal) -> Decimal:
+    if not values:
+        return Decimal("0")
+    if quantile <= 0:
+        return values[0]
+    if quantile >= 1:
+        return values[-1]
+    index = int((Decimal(len(values) - 1) * quantile).to_integral_value())
+    index = max(0, min(index, len(values) - 1))
+    return values[index]
+
+
+def _reproducibility_payload(hashes: dict[str, str]) -> dict[str, object]:
+    normalized = {
+        str(key): str(value)
+        for key, value in hashes.items()
+        if str(key).strip() and str(value).strip()
+    }
+    manifest = json.dumps(sorted(normalized.items()), separators=(",", ":")).encode(
+        "utf-8"
+    )
+    manifest_hash = hashlib.sha256(manifest).hexdigest()
+    return {
+        "hash_algorithm": "sha256",
+        "artifact_hashes": normalized,
+        "manifest_hash": manifest_hash,
+    }
+
+
+def _report_fold_net_pnls(report_payload: dict[str, Any]) -> list[Decimal]:
+    robustness = _as_dict(report_payload.get("robustness"))
+    folds = robustness.get("folds")
+    if not isinstance(folds, list):
+        return []
+    values: list[Decimal] = []
+    for raw in cast(list[object], folds):
+        if not isinstance(raw, dict):
+            continue
+        fold = cast(dict[str, Any], raw)
+        value = _decimal(fold.get("net_pnl"))
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError):
+        return None
+
+
+def _decimal_mean(values: list[Decimal]) -> Decimal:
+    if not values:
+        return Decimal("0")
+    return sum(values, Decimal("0")) / Decimal(len(values))
+
+
+def _decimal_std(values: list[Decimal], mean: Decimal) -> Decimal:
+    if len(values) <= 1:
+        return Decimal("0")
+    variance = sum((value - mean) ** 2 for value in values) / Decimal(len(values))
+    return variance.sqrt()
+
+
+def _safe_ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
+    if denominator <= 0:
+        return Decimal("0")
+    return numerator / denominator
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return cast(dict[str, Any], value)
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+as_dict = _as_dict
+as_int = _as_int
+bootstrap_mean_samples = _bootstrap_mean_samples
+decimal = _decimal
+decimal_mean = _decimal_mean
+decimal_std = _decimal_std
+quantile_decimal = _quantile_decimal
+report_fold_net_pnls = _report_fold_net_pnls
+reproducibility_payload = _reproducibility_payload
+safe_ratio = _safe_ratio
+
+__all__ = [
+    "_as_dict",
+    "_as_int",
+    "_bootstrap_mean_samples",
+    "_decimal",
+    "_decimal_mean",
+    "_decimal_std",
+    "_quantile_decimal",
+    "_report_fold_net_pnls",
+    "_reproducibility_payload",
+    "_safe_ratio",
+    "as_dict",
+    "as_int",
+    "bootstrap_mean_samples",
+    "decimal",
+    "decimal_mean",
+    "decimal_std",
+    "quantile_decimal",
+    "report_fold_net_pnls",
+    "reproducibility_payload",
+    "safe_ratio",
+]

--- a/services/torghut/app/trading/evaluation/profitability_metrics_helpers.py
+++ b/services/torghut/app/trading/evaluation/profitability_metrics_helpers.py
@@ -1,0 +1,554 @@
+"""Profitability evidence helpers without evaluation module import cycles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from typing import Any, Protocol, cast
+
+from .numeric_helpers import (
+    as_dict as _as_dict,
+    as_int as _as_int,
+    bootstrap_mean_samples as _bootstrap_mean_samples,
+    decimal as _decimal,
+    decimal_mean as _decimal_mean,
+    decimal_std as _decimal_std,
+    quantile_decimal as _quantile_decimal,
+    safe_ratio as _safe_ratio,
+)
+
+
+class ProfitabilityBenchmarkSliceLike(Protocol):
+    @property
+    def slice_key(self) -> str: ...
+
+    @property
+    def slice_type(self) -> str: ...
+
+    @property
+    def deltas(self) -> Mapping[str, str]: ...
+
+
+class ProfitabilityBenchmarkLike(Protocol):
+    @property
+    def schema_version(self) -> str: ...
+
+    @property
+    def slices(self) -> Sequence[ProfitabilityBenchmarkSliceLike]: ...
+
+
+class ProfitabilityEvidenceLike(Protocol):
+    @property
+    def schema_version(self) -> str: ...
+
+    @property
+    def benchmark(self) -> ProfitabilityBenchmarkLike: ...
+
+    @property
+    def risk_adjusted_metrics(self) -> Mapping[str, Any]: ...
+
+    @property
+    def cost_fill_realism(self) -> Mapping[str, Any]: ...
+
+    @property
+    def confidence_calibration(self) -> Mapping[str, Any]: ...
+
+    @property
+    def significance(self) -> Mapping[str, Any]: ...
+
+    @property
+    def reproducibility(self) -> Mapping[str, Any]: ...
+
+
+class ProfitabilityThresholdsLike(Protocol):
+    @property
+    def min_market_net_pnl_delta(self) -> Decimal: ...
+
+    @property
+    def min_risk_adjusted_return_over_drawdown(self) -> Decimal: ...
+
+    @property
+    def min_regime_slice_pass_ratio(self) -> Decimal: ...
+
+    @property
+    def max_cost_bps(self) -> Decimal: ...
+
+    @property
+    def min_confidence_samples(self) -> int: ...
+
+    @property
+    def max_calibration_error(self) -> Decimal: ...
+
+    @property
+    def min_significance_samples(self) -> int: ...
+
+    @property
+    def min_reproducibility_hashes(self) -> int: ...
+
+    @property
+    def required_hash_keys(self) -> Sequence[str]: ...
+
+
+def append_profitability_reason(
+    *,
+    reasons: list[str],
+    details: list[dict[str, object]],
+    reason: str,
+    payload: dict[str, object],
+) -> None:
+    reasons.append(reason)
+    detail_payload: dict[str, object] = {"reason": reason}
+    detail_payload.update(payload)
+    details.append(detail_payload)
+
+
+def validate_profitability_schema_versions(
+    *,
+    evidence: ProfitabilityEvidenceLike,
+    reasons: list[str],
+    details: list[dict[str, object]],
+) -> None:
+    if evidence.schema_version != "profitability-evidence-v4":
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="profitability_evidence_schema_invalid",
+            payload={"expected": "profitability-evidence-v4"},
+        )
+    if evidence.benchmark.schema_version != "profitability-benchmark-v4":
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="profitability_benchmark_schema_invalid",
+            payload={"expected": "profitability-benchmark-v4"},
+        )
+
+
+def validate_profitability_risk_metrics(
+    *,
+    evidence: ProfitabilityEvidenceLike,
+    policy: ProfitabilityThresholdsLike,
+    reasons: list[str],
+    details: list[dict[str, object]],
+) -> None:
+    market_delta = _decimal(
+        evidence.risk_adjusted_metrics.get("market_net_pnl_delta")
+    ) or Decimal("0")
+    if market_delta < policy.min_market_net_pnl_delta:
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="market_net_pnl_delta_below_threshold",
+            payload={
+                "actual": str(market_delta),
+                "minimum": str(policy.min_market_net_pnl_delta),
+            },
+        )
+
+    return_over_drawdown = _decimal(
+        evidence.risk_adjusted_metrics.get("return_over_drawdown")
+    ) or Decimal("0")
+    if return_over_drawdown < policy.min_risk_adjusted_return_over_drawdown:
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="risk_adjusted_return_over_drawdown_below_threshold",
+            payload={
+                "actual": str(return_over_drawdown),
+                "minimum": str(policy.min_risk_adjusted_return_over_drawdown),
+            },
+        )
+
+    regime_ratio = _decimal(
+        evidence.risk_adjusted_metrics.get("regime_slice_pass_ratio")
+    ) or Decimal("0")
+    if regime_ratio < policy.min_regime_slice_pass_ratio:
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="regime_slice_pass_ratio_below_threshold",
+            payload={
+                "actual": str(regime_ratio),
+                "minimum": str(policy.min_regime_slice_pass_ratio),
+            },
+        )
+
+
+def validate_profitability_cost_metrics(
+    *,
+    evidence: ProfitabilityEvidenceLike,
+    policy: ProfitabilityThresholdsLike,
+    reasons: list[str],
+    details: list[dict[str, object]],
+) -> None:
+    cost_bps = _decimal(evidence.cost_fill_realism.get("cost_bps")) or Decimal("0")
+    if cost_bps <= policy.max_cost_bps:
+        return
+    append_profitability_reason(
+        reasons=reasons,
+        details=details,
+        reason="cost_bps_exceeds_threshold",
+        payload={
+            "actual": str(cost_bps),
+            "maximum": str(policy.max_cost_bps),
+        },
+    )
+
+
+def validate_profitability_confidence_metrics(
+    *,
+    evidence: ProfitabilityEvidenceLike,
+    policy: ProfitabilityThresholdsLike,
+    reasons: list[str],
+    details: list[dict[str, object]],
+) -> None:
+    confidence_samples = (
+        _as_int(evidence.confidence_calibration.get("sample_count")) or 0
+    )
+    if confidence_samples < policy.min_confidence_samples:
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="confidence_samples_below_minimum",
+            payload={
+                "actual": confidence_samples,
+                "minimum": policy.min_confidence_samples,
+            },
+        )
+
+    calibration_error = _decimal(
+        evidence.confidence_calibration.get("calibration_error")
+    ) or Decimal("1")
+    if calibration_error <= policy.max_calibration_error:
+        return
+    append_profitability_reason(
+        reasons=reasons,
+        details=details,
+        reason="calibration_error_exceeds_threshold",
+        payload={
+            "actual": str(calibration_error),
+            "maximum": str(policy.max_calibration_error),
+        },
+    )
+
+
+def validate_profitability_significance_metrics(
+    *,
+    evidence: ProfitabilityEvidenceLike,
+    policy: ProfitabilityThresholdsLike,
+    reasons: list[str],
+    details: list[dict[str, object]],
+) -> None:
+    significance = _as_dict(evidence.significance)
+    schema_version = str(significance.get("schema_version", "")).strip()
+    if schema_version != "significance_snapshot_v1":
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="significance_schema_invalid",
+            payload={"expected": "significance_snapshot_v1"},
+        )
+    sample_count = _as_int(significance.get("sample_count")) or 0
+    if sample_count < policy.min_significance_samples:
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="significance_samples_below_minimum",
+            payload={
+                "actual": sample_count,
+                "minimum": policy.min_significance_samples,
+            },
+        )
+
+
+def validate_profitability_reproducibility(
+    *,
+    evidence: ProfitabilityEvidenceLike,
+    policy: ProfitabilityThresholdsLike,
+    reasons: list[str],
+    details: list[dict[str, object]],
+) -> None:
+    reproducibility = _as_dict(evidence.reproducibility)
+    hashes = {
+        str(key): str(value)
+        for key, value in _as_dict(reproducibility.get("artifact_hashes")).items()
+        if str(key).strip() and str(value).strip()
+    }
+    if len(hashes) < policy.min_reproducibility_hashes:
+        append_profitability_reason(
+            reasons=reasons,
+            details=details,
+            reason="reproducibility_hash_count_below_minimum",
+            payload={
+                "actual": len(hashes),
+                "minimum": policy.min_reproducibility_hashes,
+            },
+        )
+
+    missing_hash_keys = sorted(
+        [key for key in policy.required_hash_keys if key not in hashes]
+    )
+    if not missing_hash_keys:
+        return
+    append_profitability_reason(
+        reasons=reasons,
+        details=details,
+        reason="reproducibility_hash_keys_missing",
+        payload={"missing_keys": missing_hash_keys},
+    )
+
+
+def _extract_report_slices(report_payload: dict[str, Any]) -> dict[str, dict[str, str]]:
+    metrics = _as_dict(report_payload.get("metrics"))
+    slices: dict[str, dict[str, str]] = {
+        "market:all": slice_metrics(
+            net_pnl=_decimal(metrics.get("net_pnl")),
+            max_drawdown=_decimal(metrics.get("max_drawdown")),
+            cost_bps=_decimal(metrics.get("cost_bps")),
+            turnover_ratio=_decimal(metrics.get("turnover_ratio")),
+            trade_count=_as_int(metrics.get("trade_count")),
+        )
+    }
+    robustness = _as_dict(report_payload.get("robustness"))
+    folds = robustness.get("folds")
+    if isinstance(folds, list):
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for raw in cast(list[object], folds):
+            if not isinstance(raw, dict):
+                continue
+            fold = cast(dict[str, Any], raw)
+            regime = str(fold.get("regime_label", "")).strip() or "unknown"
+            grouped.setdefault(regime, []).append(fold)
+        for regime, entries in grouped.items():
+            net_pnl = sum(
+                ((_decimal(item.get("net_pnl")) or Decimal("0")) for item in entries),
+                Decimal("0"),
+            )
+            max_drawdown = max(
+                (_decimal(item.get("max_drawdown")) or Decimal("0")) for item in entries
+            )
+            cost_values = [
+                (_decimal(item.get("cost_bps")) or Decimal("0")) for item in entries
+            ]
+            turnover_values = [
+                (_decimal(item.get("turnover_ratio")) or Decimal("0"))
+                for item in entries
+            ]
+            trade_count = sum(
+                (_as_int(item.get("trade_count")) or 0) for item in entries
+            )
+            slices[f"regime:{regime}"] = slice_metrics(
+                net_pnl=net_pnl,
+                max_drawdown=max_drawdown,
+                cost_bps=_decimal_mean(cost_values),
+                turnover_ratio=_decimal_mean(turnover_values),
+                trade_count=trade_count,
+            )
+    return slices
+
+
+def slice_metrics(
+    *,
+    net_pnl: Decimal | None,
+    max_drawdown: Decimal | None,
+    cost_bps: Decimal | None,
+    turnover_ratio: Decimal | None,
+    trade_count: int | None,
+) -> dict[str, str]:
+    return {
+        "net_pnl": str(net_pnl or Decimal("0")),
+        "max_drawdown": str(max_drawdown or Decimal("0")),
+        "cost_bps": str(cost_bps or Decimal("0")),
+        "turnover_ratio": str(turnover_ratio or Decimal("0")),
+        "trade_count": str(trade_count or 0),
+    }
+
+
+def empty_slice_metrics() -> dict[str, str]:
+    return slice_metrics(
+        net_pnl=Decimal("0"),
+        max_drawdown=Decimal("0"),
+        cost_bps=Decimal("0"),
+        turnover_ratio=Decimal("0"),
+        trade_count=0,
+    )
+
+
+def slice_deltas(candidate: dict[str, str], baseline: dict[str, str]) -> dict[str, str]:
+    candidate_net = _decimal(candidate.get("net_pnl")) or Decimal("0")
+    baseline_net = _decimal(baseline.get("net_pnl")) or Decimal("0")
+    candidate_dd = _decimal(candidate.get("max_drawdown")) or Decimal("0")
+    baseline_dd = _decimal(baseline.get("max_drawdown")) or Decimal("0")
+    candidate_cost = _decimal(candidate.get("cost_bps")) or Decimal("0")
+    baseline_cost = _decimal(baseline.get("cost_bps")) or Decimal("0")
+    candidate_trades = _as_int(candidate.get("trade_count")) or 0
+    baseline_trades = _as_int(baseline.get("trade_count")) or 0
+    return {
+        "net_pnl_delta": str(candidate_net - baseline_net),
+        "max_drawdown_delta": str(candidate_dd - baseline_dd),
+        "cost_bps_delta": str(candidate_cost - baseline_cost),
+        "trade_count_delta": str(candidate_trades - baseline_trades),
+    }
+
+
+def benchmark_summary(benchmark: ProfitabilityBenchmarkLike) -> dict[str, Decimal]:
+    market_delta = Decimal("0")
+    regime_total = 0
+    regime_pass = 0
+    for slice_item in benchmark.slices:
+        net_delta = _decimal(slice_item.deltas.get("net_pnl_delta")) or Decimal("0")
+        if slice_item.slice_key == "market:all":
+            market_delta = net_delta
+        if slice_item.slice_type == "regime":
+            regime_total += 1
+            if net_delta >= 0:
+                regime_pass += 1
+    pass_ratio = _safe_ratio(Decimal(regime_pass), Decimal(regime_total))
+    return {
+        "market_net_pnl_delta": market_delta,
+        "regime_slice_pass_ratio": pass_ratio,
+    }
+
+
+def confidence_summary(
+    confidence_values: list[Decimal], net_pnl: Decimal
+) -> dict[str, object]:
+    target_coverage = Decimal("0.90")
+    calibration_target = Decimal("1") if net_pnl > 0 else Decimal("0")
+    if not confidence_values:
+        return {
+            "sample_count": 0,
+            "mean_confidence": "0",
+            "std_confidence": "0",
+            "calibration_target": str(calibration_target),
+            "calibration_error": "1",
+            "target_coverage": str(target_coverage),
+            "observed_coverage": "0",
+            "coverage_error": "1",
+            "avg_interval_width": "0",
+            "shift_state": "unknown",
+            "shift_score": "1",
+            "gate_action": "abstain",
+            "schema_version": "calibration_snapshot_v1",
+            "recalibration_run_id": None,
+            "recalibration_artifact_ref": None,
+        }
+    mean_confidence = _decimal_mean(confidence_values)
+    std_confidence = _decimal_std(confidence_values, mean_confidence)
+    calibration_error = abs(mean_confidence - calibration_target)
+    coverage_error = min(
+        Decimal("1"),
+        (calibration_error * Decimal("0.08")) + (std_confidence * Decimal("0.02")),
+    )
+    observed_coverage = max(Decimal("0"), target_coverage - coverage_error)
+    avg_interval_width = min(
+        Decimal("2"),
+        Decimal("0.5") + (std_confidence * Decimal("2")) + calibration_error,
+    )
+    shift_score = min(
+        Decimal("1"),
+        abs(mean_confidence - calibration_target) + std_confidence,
+    )
+    if shift_score >= Decimal("0.95"):
+        shift_state = "severe"
+    elif shift_score >= Decimal("0.80"):
+        shift_state = "high"
+    elif shift_score >= Decimal("0.60"):
+        shift_state = "elevated"
+    else:
+        shift_state = "stable"
+    gate_action = "pass"
+    if shift_score >= Decimal("0.95"):
+        gate_action = "fail"
+    elif coverage_error > Decimal("0.08") or shift_score >= Decimal("0.80"):
+        gate_action = "abstain"
+    elif coverage_error > Decimal("0.05") or shift_score >= Decimal("0.60"):
+        gate_action = "degrade"
+    return {
+        "sample_count": len(confidence_values),
+        "mean_confidence": str(mean_confidence),
+        "std_confidence": str(std_confidence),
+        "calibration_target": str(calibration_target),
+        "calibration_error": str(calibration_error),
+        "target_coverage": str(target_coverage),
+        "observed_coverage": str(observed_coverage),
+        "coverage_error": str(coverage_error),
+        "avg_interval_width": str(avg_interval_width),
+        "shift_state": shift_state,
+        "shift_score": str(shift_score),
+        "gate_action": gate_action,
+        "schema_version": "calibration_snapshot_v1",
+        "recalibration_run_id": None,
+        "recalibration_artifact_ref": None,
+    }
+
+
+def significance_summary(benchmark: ProfitabilityBenchmarkLike) -> dict[str, object]:
+    deltas = [
+        _decimal(item.deltas.get("net_pnl_delta")) or Decimal("0")
+        for item in benchmark.slices
+        if item.slice_type in {"market", "regime"}
+    ]
+    if not deltas:
+        return {
+            "schema_version": "significance_snapshot_v1",
+            "sample_count": 0,
+            "net_pnl_delta_mean": "0",
+            "net_pnl_delta_std": "0",
+            "ci_95_low": "0",
+            "ci_95_high": "0",
+            "p_value_two_sided": "1",
+            "statistically_positive": False,
+            "statistically_negative": False,
+            "bootstrap_samples": 0,
+        }
+
+    mean_delta = _decimal_mean(deltas)
+    std_delta = _decimal_std(deltas, mean_delta)
+    bootstrap_samples = _bootstrap_mean_samples(deltas, sample_count=512)
+    sorted_samples = sorted(bootstrap_samples)
+    ci_low = _quantile_decimal(sorted_samples, Decimal("0.025"))
+    ci_high = _quantile_decimal(sorted_samples, Decimal("0.975"))
+    non_positive_count = sum(1 for value in sorted_samples if value <= 0)
+    non_negative_count = sum(1 for value in sorted_samples if value >= 0)
+    sample_size = max(len(sorted_samples), 1)
+    p_two_sided = min(
+        Decimal("1"),
+        Decimal("2")
+        * min(
+            Decimal(non_positive_count) / Decimal(sample_size),
+            Decimal(non_negative_count) / Decimal(sample_size),
+        ),
+    )
+    return {
+        "schema_version": "significance_snapshot_v1",
+        "sample_count": len(deltas),
+        "net_pnl_delta_mean": str(mean_delta),
+        "net_pnl_delta_std": str(std_delta),
+        "ci_95_low": str(ci_low),
+        "ci_95_high": str(ci_high),
+        "p_value_two_sided": str(p_two_sided),
+        "statistically_positive": bool(ci_low > 0),
+        "statistically_negative": bool(ci_high < 0),
+        "bootstrap_samples": len(sorted_samples),
+    }
+
+
+extract_report_slices = _extract_report_slices
+
+__all__ = [
+    "append_profitability_reason",
+    "benchmark_summary",
+    "confidence_summary",
+    "empty_slice_metrics",
+    "extract_report_slices",
+    "significance_summary",
+    "slice_deltas",
+    "slice_metrics",
+    "validate_profitability_confidence_metrics",
+    "validate_profitability_cost_metrics",
+    "validate_profitability_reproducibility",
+    "validate_profitability_risk_metrics",
+    "validate_profitability_schema_versions",
+    "validate_profitability_significance_metrics",
+]

--- a/services/torghut/app/trading/evaluation/signal_source.py
+++ b/services/torghut/app/trading/evaluation/signal_source.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import importlib
 import json
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -20,101 +19,30 @@ from ..evidence_contracts import (
 )
 from ..features import SignalFeatures, extract_signal_features
 from ..models import SignalEnvelope, StrategyDecision
-
-
-def _bootstrap_helpers() -> Any:
-    return importlib.import_module(f"{__package__}.bootstrap_mean_samples")
-
-
-def _calibration_helpers() -> Any:
-    return importlib.import_module(
-        f"{__package__}.build_simulation_calibration_report_v1"
-    )
-
-
-def _decimal(value: Any) -> Decimal | None:
-    return _bootstrap_helpers()._decimal(value)
-
-
-def _as_dict(value: Any) -> dict[str, Any]:
-    return _bootstrap_helpers()._as_dict(value)
-
-
-def _as_int(value: Any) -> int | None:
-    return _bootstrap_helpers()._as_int(value)
-
-
-def _report_fold_net_pnls(report_payload: dict[str, Any]) -> list[Decimal]:
-    return _bootstrap_helpers()._report_fold_net_pnls(report_payload)
-
-
-def _decimal_mean(values: list[Decimal]) -> Decimal:
-    return _bootstrap_helpers()._decimal_mean(values)
-
-
-def _decimal_std(values: list[Decimal], mean: Decimal) -> Decimal:
-    return _bootstrap_helpers()._decimal_std(values, mean)
-
-
-def _reproducibility_payload(hashes: dict[str, str]) -> dict[str, object]:
-    return _bootstrap_helpers()._reproducibility_payload(hashes)
-
-
-def _safe_ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
-    return _bootstrap_helpers()._safe_ratio(numerator, denominator)
-
-
-def _extract_report_slices(report_payload: dict[str, Any]) -> dict[str, dict[str, str]]:
-    return _calibration_helpers()._extract_report_slices(report_payload)
-
-
-def _empty_slice_metrics() -> dict[str, str]:
-    return _calibration_helpers().empty_slice_metrics()
-
-
-def _slice_deltas(
-    candidate: dict[str, str],
-    baseline: dict[str, str],
-) -> dict[str, str]:
-    return _calibration_helpers().slice_deltas(candidate, baseline)
-
-
-def _benchmark_summary(benchmark: Any) -> dict[str, Decimal]:
-    return _calibration_helpers().benchmark_summary(benchmark)
-
-
-def _confidence_summary(
-    confidence_values: list[Decimal], net_pnl: Decimal
-) -> dict[str, object]:
-    return _calibration_helpers().confidence_summary(confidence_values, net_pnl)
-
-
-def _significance_summary(benchmark: Any) -> dict[str, object]:
-    return _calibration_helpers().significance_summary(benchmark)
-
-
-def _validate_profitability_schema_versions(*args: Any, **kwargs: Any) -> None:
-    _calibration_helpers().validate_profitability_schema_versions(*args, **kwargs)
-
-
-def _validate_profitability_risk_metrics(*args: Any, **kwargs: Any) -> None:
-    _calibration_helpers().validate_profitability_risk_metrics(*args, **kwargs)
-
-
-def _validate_profitability_cost_metrics(*args: Any, **kwargs: Any) -> None:
-    _calibration_helpers().validate_profitability_cost_metrics(*args, **kwargs)
-
-
-def _validate_profitability_confidence_metrics(*args: Any, **kwargs: Any) -> None:
-    _calibration_helpers().validate_profitability_confidence_metrics(*args, **kwargs)
-
-
-def _validate_profitability_significance_metrics(*args: Any, **kwargs: Any) -> None:
-    _calibration_helpers().validate_profitability_significance_metrics(*args, **kwargs)
-
-
-def _validate_profitability_reproducibility(*args: Any, **kwargs: Any) -> None:
-    _calibration_helpers().validate_profitability_reproducibility(*args, **kwargs)
+from .numeric_helpers import (
+    as_dict as _as_dict,
+    as_int as _as_int,
+    decimal as _decimal,
+    decimal_mean as _decimal_mean,
+    decimal_std as _decimal_std,
+    report_fold_net_pnls as _report_fold_net_pnls,
+    reproducibility_payload as _reproducibility_payload,
+    safe_ratio as _safe_ratio,
+)
+from .profitability_metrics_helpers import (
+    benchmark_summary as _benchmark_summary,
+    confidence_summary as _confidence_summary,
+    empty_slice_metrics as _empty_slice_metrics,
+    extract_report_slices as _extract_report_slices,
+    significance_summary as _significance_summary,
+    slice_deltas as _slice_deltas,
+    validate_profitability_confidence_metrics as _validate_profitability_confidence_metrics,
+    validate_profitability_cost_metrics as _validate_profitability_cost_metrics,
+    validate_profitability_reproducibility as _validate_profitability_reproducibility,
+    validate_profitability_risk_metrics as _validate_profitability_risk_metrics,
+    validate_profitability_schema_versions as _validate_profitability_schema_versions,
+    validate_profitability_significance_metrics as _validate_profitability_significance_metrics,
+)
 
 
 class SignalSource(Protocol):
@@ -884,8 +812,6 @@ __all__: tuple[str, ...] = (
     "_as_dict",
     "_as_int",
     "_benchmark_summary",
-    "_bootstrap_helpers",
-    "_calibration_helpers",
     "_confidence_summary",
     "_decimal",
     "_decimal_mean",
@@ -922,7 +848,6 @@ __all__: tuple[str, ...] = (
     "fold_regime_payload",
     "generate_walk_forward_folds",
     "hashlib",
-    "importlib",
     "json",
     "run_walk_forward",
     "timedelta",

--- a/services/torghut/app/trading/execution/order_executor_submission_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_submission_methods.py
@@ -478,7 +478,6 @@ class OrderExecutor(
     _OrderExecutorFields,
     _OrderExecutorCoreMethods,
     _OrderExecutorSubmissionMethods,
-    object,
 ):
     pass
 

--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
@@ -147,7 +147,6 @@ class ClickHouseSignalIngestor(
     _ClickHouseSignalIngestorCoreMethods,
     _ClickHouseSignalIngestorMarketMethods,
     _ClickHouseSignalIngestorPersistenceMethods,
-    object,
 ):
     pass
 

--- a/services/torghut/app/trading/order_feed/order_feed_ingestor.py
+++ b/services/torghut/app/trading/order_feed/order_feed_ingestor.py
@@ -7,13 +7,12 @@ from typing import Any, Callable, cast
 
 from sqlalchemy.orm import Session
 
-from ...config import Settings, settings
+from ...config import settings
 from ...models import (
     Execution,
     ExecutionOrderEvent,
     OrderFeedSourceWindow,
 )
-from ..tigerbeetle_client import TigerBeetleClientProtocol
 from . import shared_context as _shared_context
 from .shared_context import (
     AccountAliasResolution as _AccountAliasResolution,
@@ -48,8 +47,6 @@ from .shared_context import (
     logger,
     normalize_order_feed_record,
 )
-
-_TigerBeetleClientFactory = Callable[[Settings], TigerBeetleClientProtocol]
 
 
 class OrderFeedIngestor:
@@ -120,36 +117,13 @@ class OrderFeedIngestor:
         if not settings.tigerbeetle_enabled or not settings.tigerbeetle_journal_enabled:
             return
         try:
-            client = self._reconciliation_client_override()
-            if client is None:
-                _shared_context.reconcile_tigerbeetle_transfers(session)
-            else:
-                _shared_context.reconcile_tigerbeetle_transfers(session, client=client)
+            _shared_context.reconcile_tigerbeetle_transfers(session)
         except Exception as exc:
             if settings.tigerbeetle_reconcile_required:
                 raise
             logger.warning(
                 "TigerBeetle reconciliation failed after order-feed ingest: %s", exc
             )
-
-    @staticmethod
-    def _reconciliation_client_override() -> TigerBeetleClientProtocol | None:
-        import importlib
-
-        from ..tigerbeetle_client import (
-            create_tigerbeetle_client as default_create_tigerbeetle_client,
-        )
-
-        public_factory = cast(
-            _TigerBeetleClientFactory,
-            getattr(
-                importlib.import_module("app.trading.tigerbeetle_reconcile"),
-                "create_tigerbeetle_client",
-            ),
-        )
-        if public_factory is default_create_tigerbeetle_client:
-            return None
-        return public_factory(settings)
 
     @staticmethod
     def _new_counters() -> dict[str, int]:

--- a/services/torghut/app/trading/scheduler/governance/governance_mixin_runtime_methods.py
+++ b/services/torghut/app/trading/scheduler/governance/governance_mixin_runtime_methods.py
@@ -496,7 +496,6 @@ class TradingSchedulerGovernanceMixin(
     _TradingSchedulerGovernanceLifecycleMethods,
     _TradingSchedulerGovernanceDecisionMethods,
     _TradingSchedulerGovernanceRuntimeMethods,
-    object,
 ):
     pass
 

--- a/services/torghut/app/trading/scheduler/paper_route_probe/mixin.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/mixin.py
@@ -9,7 +9,6 @@ from .retry_decisions import SimplePipelinePaperRouteProbeRetryDecisionMixin
 class SimplePipelinePaperRouteProbeMixin(
     SimplePipelinePaperRouteProbeRetryDecisionMixin,
     SimplePipelinePaperRouteProbeProcessingMixin,
-    object,
 ):
     pass
 

--- a/services/torghut/app/trading/scheduler/pipeline/trading_pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline/trading_pipeline.py
@@ -20,7 +20,6 @@ class TradingPipeline(
     TradingPipelineRuntimeGatesMixin,
     TradingPipelineReviewMixin,
     TradingPipelineReviewOutcomeMixin,
-    object,
 ):
     pass
 

--- a/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
@@ -792,6 +792,5 @@ class SimplePipelineSubmissionPreparationMixin(
     SimplePipelineSubmissionQuoteSizingMixin,
     SimplePipelineSubmissionQuoteRouteabilityMixin,
     SimplePipelineDirectSubmissionMixin,
-    object,
 ):
     pass

--- a/services/torghut/app/whitepapers/workflow/whitepaper_workflow_service.py
+++ b/services/torghut/app/whitepapers/workflow/whitepaper_workflow_service.py
@@ -48,7 +48,6 @@ class WhitepaperWorkflowService(
     _WhitepaperWorkflowVerdictMethods,
     _WhitepaperWorkflowRolloutMethods,
     _WhitepaperWorkflowApiMethods,
-    object,
 ):
     pass
 

--- a/services/torghut/tests/order_feed/support.py
+++ b/services/torghut/tests/order_feed/support.py
@@ -4,7 +4,6 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-import importlib
 from types import SimpleNamespace
 
 from sqlalchemy import create_engine, func, select
@@ -55,10 +54,6 @@ from app.trading.order_feed import (
     repair_order_feed_execution_links,
     repair_order_feed_execution_states,
     repair_order_feed_fill_deltas,
-)
-
-order_feed_repair_module = importlib.import_module(
-    "app.trading.order_feed.repair_order_feed_execution_links"
 )
 
 
@@ -283,7 +278,6 @@ __all__ = [
     "merge_execution_raw_order_update",
     "normalize_order_feed_record",
     "order_feed_module",
-    "order_feed_repair_module",
     "patch",
     "persist_order_event",
     "repair_order_feed_execution_links",

--- a/services/torghut/tests/order_feed/test_order_feed_backfill_and_cursor_a.py
+++ b/services/torghut/tests/order_feed/test_order_feed_backfill_and_cursor_a.py
@@ -18,7 +18,6 @@ from tests.order_feed.support import (
     datetime,
     func,
     order_feed_module,
-    order_feed_repair_module,
     patch,
     repair_order_feed_execution_links,
     repair_order_feed_execution_states,
@@ -266,9 +265,8 @@ class TestOrderFeedBackfillAndCursorA(OrderFeedTestCase):
                 order_id="race-order",
                 client_order_id="race-client",
             )
-            with patch.object(
-                order_feed_repair_module,
-                "latest_order_event_for_execution",
+            with patch(
+                "app.trading.order_feed.repair_order_feed_execution_links.latest_order_event_for_execution",
                 return_value=ExecutionOrderEvent(
                     event_fingerprint="race-existing",
                     source_topic="torghut.trade-updates.v2",
@@ -299,9 +297,8 @@ class TestOrderFeedBackfillAndCursorA(OrderFeedTestCase):
                 )
             )
             session.commit()
-            with patch.object(
-                order_feed_repair_module,
-                "_stable_execution_source_offset",
+            with patch(
+                "app.trading.order_feed.repair_order_feed_execution_links._stable_execution_source_offset",
                 return_value=77,
             ):
                 collision_result = backfill_order_feed_events_from_executions(

--- a/services/torghut/tests/order_feed/test_order_feed_repair_links_a.py
+++ b/services/torghut/tests/order_feed/test_order_feed_repair_links_a.py
@@ -10,7 +10,6 @@ from tests.order_feed.support import (
     Session,
     datetime,
     order_feed_module,
-    order_feed_repair_module,
     patch,
     repair_order_feed_execution_links,
     repair_order_feed_execution_states,
@@ -252,14 +251,12 @@ class TestOrderFeedRepairLinksA(OrderFeedTestCase):
             session.commit()
 
             with (
-                patch.object(
-                    order_feed_repair_module,
-                    "latest_order_event_for_execution",
+                patch(
+                    "app.trading.order_feed.repair_order_feed_execution_links.latest_order_event_for_execution",
                     side_effect=[None, linked_events[1], linked_events[2]],
                 ) as latest_event,
-                patch.object(
-                    order_feed_repair_module,
-                    "apply_order_event_to_execution",
+                patch(
+                    "app.trading.order_feed.repair_order_feed_execution_links.apply_order_event_to_execution",
                     side_effect=[(False, True), (False, False)],
                 ) as apply_event,
             ):


### PR DESCRIPTION
## Summary

- Removes the dead order-feed TigerBeetle reconciliation override that supported patching the public reconciliation facade instead of the owning module.
- Simplifies generated autoresearch notebook display fallbacks by replacing three no-op fallback classes with direct `str` aliases.
- Removes redundant `object` bases from Torghut service composition classes and deletes a stale order-feed test module alias.
- Splits evaluation numeric/profitability helpers into explicit owner modules and removes first-party dynamic helper loading from the evaluation package.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/order_feed/test_order_feed_core.py tests/order_feed/test_order_feed_repair_links_a.py tests/order_feed/test_order_feed_backfill_and_cursor_a.py tests/strategy_autoresearch/test_autoresearch_loop_a.py`
- `uv run --frozen pytest tests/test_profitability_evidence_v4.py tests/test_walkforward.py tests/test_robustness_report.py tests/test_evaluation_report.py tests/test_regime_classifier.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/decisions/decision_engine_runtime_methods.py app/trading/discovery/autoresearch_notebooks.py app/trading/execution/order_executor_submission_methods.py app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py app/trading/order_feed/order_feed_ingestor.py app/trading/scheduler/governance/governance_mixin_runtime_methods.py app/trading/scheduler/paper_route_probe/mixin.py app/trading/scheduler/pipeline/trading_pipeline.py app/trading/scheduler/submission_preparation/direct_submission.py app/whitepapers/workflow/whitepaper_workflow_service.py tests/order_feed/support.py tests/order_feed/test_order_feed_backfill_and_cursor_a.py tests/order_feed/test_order_feed_repair_links_a.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/decisions/decision_engine_runtime_methods.py app/trading/discovery/autoresearch_notebooks.py app/trading/execution/order_executor_submission_methods.py app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py app/trading/order_feed/order_feed_ingestor.py app/trading/scheduler/governance/governance_mixin_runtime_methods.py app/trading/scheduler/paper_route_probe/mixin.py app/trading/scheduler/pipeline/trading_pipeline.py app/trading/scheduler/submission_preparation/direct_submission.py app/whitepapers/workflow/whitepaper_workflow_service.py tests/order_feed/support.py tests/order_feed/test_order_feed_backfill_and_cursor_a.py tests/order_feed/test_order_feed_repair_links_a.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
