### PR TITLE
refactor(torghut): remove autonomy gate dynamic wrappers

### DIFF
--- a/services/torghut/app/trading/autonomy/gates/__init__.py
+++ b/services/torghut/app/trading/autonomy/gates/__init__.py
@@ -1,15 +1,5 @@
 from __future__ import annotations
 from .shared_context import (
-    json,
-    dataclass,
-    field,
-    datetime,
-    timezone,
-    Decimal,
-    Path,
-    Any,
-    Literal,
-    cast,
     GateStatus,
     UncertaintyGateAction,
     PromotionTarget,
@@ -22,16 +12,6 @@ from .shared_context import (
 )
 
 __all__ = [
-    "json",
-    "dataclass",
-    "field",
-    "datetime",
-    "timezone",
-    "Decimal",
-    "Path",
-    "Any",
-    "Literal",
-    "cast",
     "GateStatus",
     "UncertaintyGateAction",
     "PromotionTarget",

--- a/services/torghut/app/trading/autonomy/gates/gate7_uncertainty_calibration.py
+++ b/services/torghut/app/trading/autonomy/gates/gate7_uncertainty_calibration.py
@@ -6,19 +6,17 @@ from decimal import Decimal
 from typing import Any, cast
 
 
-from .shared_context import (
-    GateEvaluationReport,
+from .gate_contracts import (
     GateInputs,
     GatePolicyMatrix,
     GateResult,
     PromotionTarget,
     UncertaintyGateAction,
     UncertaintyGateOutcome,
-    evaluate_gate_matrix,
 )
 
 
-def _gate7_uncertainty_calibration(
+def gate7_uncertainty_calibration(
     inputs: GateInputs,
     policy: GatePolicyMatrix,
     promotion_target: PromotionTarget,
@@ -30,11 +28,11 @@ def _gate7_uncertainty_calibration(
     confidence = _dict_from_any(
         _dict_from_any(inputs.profitability_evidence).get("confidence_calibration")
     )
-    coverage_error = _decimal(confidence.get("coverage_error"))
-    shift_score = _decimal(confidence.get("shift_score"))
-    avg_interval_width = _decimal(confidence.get("avg_interval_width"))
-    target_coverage = _decimal(confidence.get("target_coverage"))
-    observed_coverage = _decimal(confidence.get("observed_coverage"))
+    coverage_error = decimal(confidence.get("coverage_error"))
+    shift_score = decimal(confidence.get("shift_score"))
+    avg_interval_width = decimal(confidence.get("avg_interval_width"))
+    target_coverage = decimal(confidence.get("target_coverage"))
+    observed_coverage = decimal(confidence.get("observed_coverage"))
     recalibration_run_id_raw = confidence.get("recalibration_run_id")
     recalibration_run_id = (
         str(recalibration_run_id_raw).strip() if recalibration_run_id_raw else None
@@ -84,13 +82,13 @@ def _gate7_uncertainty_calibration(
     return gate, outcome
 
 
-def _gate2_base_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str]:
+def gate2_base_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str]:
     reasons: list[str] = []
     if not inputs.fragility_inputs_valid:
         return ["fragility_inputs_invalid"]
-    max_drawdown = _decimal(inputs.metrics.get("max_drawdown")) or Decimal("0")
-    turnover_ratio = _decimal(inputs.metrics.get("turnover_ratio")) or Decimal("0")
-    cost_bps = _decimal(inputs.metrics.get("cost_bps")) or Decimal("0")
+    max_drawdown = decimal(inputs.metrics.get("max_drawdown")) or Decimal("0")
+    turnover_ratio = decimal(inputs.metrics.get("turnover_ratio")) or Decimal("0")
+    cost_bps = decimal(inputs.metrics.get("cost_bps")) or Decimal("0")
     if max_drawdown > policy.gate2_max_drawdown:
         reasons.append("drawdown_exceeds_maximum")
     if turnover_ratio > policy.gate2_max_turnover_ratio:
@@ -111,7 +109,7 @@ def _gate2_base_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[st
     return reasons
 
 
-def _gate2_tca_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str]:
+def gate2_tca_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str]:
     order_count_raw = inputs.tca_metrics.get("order_count")
     if order_count_raw is None:
         return ["tca_order_count_missing"]
@@ -145,7 +143,7 @@ def _gate2_tca_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str
     elif avg_tca_shortfall > policy.gate2_max_tca_shortfall_notional:
         reasons.append("tca_shortfall_exceeds_maximum")
 
-    expected_shortfall_coverage = _decimal(
+    expected_shortfall_coverage = decimal(
         inputs.tca_metrics.get("expected_shortfall_coverage")
     )
     expected_shortfall_sample_count = _int_or_default(
@@ -170,7 +168,7 @@ def _gate2_tca_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str
     if avg_tca_divergence > policy.gate2_max_tca_divergence_bps:
         reasons.append("tca_divergence_bps_exceeds_maximum")
 
-    avg_tca_calibration_error = _decimal(
+    avg_tca_calibration_error = decimal(
         inputs.tca_metrics.get("avg_calibration_error_bps")
     )
     if avg_tca_calibration_error is None:
@@ -190,7 +188,7 @@ def _gate2_tca_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str
                 "tca_expected_shortfall_calibration_coverage_below_threshold"
             )
 
-    avg_tca_churn_ratio = _decimal(inputs.tca_metrics.get("avg_churn_ratio"))
+    avg_tca_churn_ratio = decimal(inputs.tca_metrics.get("avg_churn_ratio"))
     if avg_tca_churn_ratio is None:
         reasons.append("tca_churn_ratio_missing")
     elif avg_tca_churn_ratio > policy.gate2_max_tca_churn_ratio:
@@ -198,7 +196,7 @@ def _gate2_tca_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str
     return reasons
 
 
-def _gate6_early_result(
+def gate6_early_result(
     inputs: GateInputs,
     policy: GatePolicyMatrix,
     promotion_target: PromotionTarget,
@@ -220,7 +218,7 @@ def _gate6_early_result(
     return None
 
 
-def _gate6_schema_reasons(evidence: dict[str, Any]) -> list[str]:
+def gate6_schema_reasons(evidence: dict[str, Any]) -> list[str]:
     reasons: list[str] = []
     schema_version = str(evidence.get("schema_version", "")).strip()
     if schema_version != "profitability-evidence-v4":
@@ -234,38 +232,36 @@ def _gate6_schema_reasons(evidence: dict[str, Any]) -> list[str]:
     return reasons
 
 
-def _gate6_threshold_reasons(
+def gate6_threshold_reasons(
     evidence: dict[str, Any], policy: GatePolicyMatrix
 ) -> list[str]:
     reasons: list[str] = []
     risk_adjusted = _dict_from_any(evidence.get("risk_adjusted_metrics"))
-    market_delta = _decimal(risk_adjusted.get("market_net_pnl_delta")) or Decimal("0")
+    market_delta = decimal(risk_adjusted.get("market_net_pnl_delta")) or Decimal("0")
     if market_delta < policy.gate6_min_market_net_pnl_delta:
         reasons.append("profitability_market_net_pnl_delta_below_threshold")
-    regime_ratio = _decimal(risk_adjusted.get("regime_slice_pass_ratio")) or Decimal(
-        "0"
-    )
+    regime_ratio = decimal(risk_adjusted.get("regime_slice_pass_ratio")) or Decimal("0")
     if regime_ratio < policy.gate6_min_regime_slice_pass_ratio:
         reasons.append("profitability_regime_slice_ratio_below_threshold")
-    return_over_drawdown = _decimal(
+    return_over_drawdown = decimal(
         risk_adjusted.get("return_over_drawdown")
     ) or Decimal("0")
     if return_over_drawdown < policy.gate6_min_return_over_drawdown:
         reasons.append("profitability_return_over_drawdown_below_threshold")
 
     realism = _dict_from_any(evidence.get("cost_fill_realism"))
-    cost_bps = _decimal(realism.get("cost_bps")) or Decimal("0")
+    cost_bps = decimal(realism.get("cost_bps")) or Decimal("0")
     if cost_bps > policy.gate6_max_cost_bps:
         reasons.append("profitability_cost_bps_exceeds_threshold")
 
     confidence = _dict_from_any(evidence.get("confidence_calibration"))
-    calibration_error = _decimal(confidence.get("calibration_error")) or Decimal("1")
+    calibration_error = decimal(confidence.get("calibration_error")) or Decimal("1")
     if calibration_error > policy.gate6_max_calibration_error:
         reasons.append("profitability_calibration_error_exceeds_threshold")
     return reasons
 
 
-def _gate6_reproducibility_reasons(
+def gate6_reproducibility_reasons(
     evidence: dict[str, Any], policy: GatePolicyMatrix
 ) -> list[str]:
     reproducibility = _dict_from_any(evidence.get("reproducibility"))
@@ -279,7 +275,7 @@ def _gate6_reproducibility_reasons(
     return []
 
 
-def _gate6_janus_q_reasons(
+def gate6_janus_q_reasons(
     evidence: dict[str, Any], policy: GatePolicyMatrix
 ) -> list[str]:
     if not policy.gate6_require_janus_evidence:
@@ -396,7 +392,7 @@ def _gate7_action_with_reasons(
     return "pass", derived_reasons
 
 
-def _decimal(value: Any) -> Decimal | None:
+def decimal(value: Any) -> Decimal | None:
     if value is None:
         return None
     if isinstance(value, Decimal):
@@ -413,14 +409,14 @@ def _decimal(value: Any) -> Decimal | None:
 
 
 def _abs_decimal(value: Any) -> Decimal | None:
-    parsed = _decimal(value)
+    parsed = decimal(value)
     if parsed is None:
         return None
     return abs(parsed)
 
 
-def _decimal_or_default(value: Any, default: Decimal) -> Decimal:
-    parsed = _decimal(value)
+def decimal_or_default(value: Any, default: Decimal) -> Decimal:
+    parsed = decimal(value)
     if parsed is None:
         return default
     return parsed
@@ -449,25 +445,9 @@ def _fragility_state_rank(state: str) -> int:
     return ranks.get(normalized, 1)
 
 
-# Public aliases used by split-module consumers.
-decimal_or_default = _decimal_or_default
-gate2_base_reasons = _gate2_base_reasons
-gate2_tca_reasons = _gate2_tca_reasons
-gate6_early_result = _gate6_early_result
-gate6_janus_q_reasons = _gate6_janus_q_reasons
-gate6_reproducibility_reasons = _gate6_reproducibility_reasons
-gate6_schema_reasons = _gate6_schema_reasons
-gate6_threshold_reasons = _gate6_threshold_reasons
-gate7_uncertainty_calibration = _gate7_uncertainty_calibration
-
 __all__ = [
-    "GateEvaluationReport",
-    "GateInputs",
-    "GatePolicyMatrix",
-    "GateResult",
-    "PromotionTarget",
+    "decimal",
     "decimal_or_default",
-    "evaluate_gate_matrix",
     "gate2_base_reasons",
     "gate2_tca_reasons",
     "gate6_early_result",

--- a/services/torghut/app/trading/autonomy/gates/gate_contracts.py
+++ b/services/torghut/app/trading/autonomy/gates/gate_contracts.py
@@ -1,0 +1,428 @@
+"""Typed contracts for Torghut autonomy gate evaluation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Literal
+
+GateStatus = Literal["pass", "fail"]
+
+UncertaintyGateAction = Literal["pass", "degrade", "abstain", "fail"]
+
+PromotionTarget = Literal["shadow", "paper", "live"]
+
+
+def empty_str_list() -> list[str]:
+    return []
+
+
+def empty_artifact_refs() -> list[str]:
+    return []
+
+
+def empty_dict() -> dict[str, Any]:
+    return {}
+
+
+def _decimal_or_default(value: Any, default: Decimal) -> Decimal:
+    if value is None:
+        return default
+    try:
+        parsed = Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError):
+        return default
+    if not parsed.is_finite():
+        return default
+    return parsed
+
+
+@dataclass(frozen=True)
+class GateResult:
+    gate_id: str
+    status: GateStatus
+    reasons: list[str] = field(default_factory=empty_str_list)
+    artifact_refs: list[str] = field(default_factory=empty_artifact_refs)
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "gate_id": self.gate_id,
+            "status": self.status,
+            "reasons": list(self.reasons),
+            "artifact_refs": list(self.artifact_refs),
+        }
+
+
+@dataclass(frozen=True)
+class GateInputs:
+    feature_schema_version: str
+    required_feature_null_rate: Decimal
+    staleness_ms_p95: int | None
+    symbol_coverage: int
+    metrics: dict[str, Any]
+    robustness: dict[str, Any]
+    tca_metrics: dict[str, Any] = field(default_factory=empty_dict)
+    llm_metrics: dict[str, Any] = field(default_factory=empty_dict)
+    forecast_metrics: dict[str, Any] = field(default_factory=empty_dict)
+    profitability_evidence: dict[str, Any] = field(default_factory=empty_dict)
+    fragility_state: str = "elevated"
+    fragility_score: Decimal = Decimal("0.5")
+    stability_mode_active: bool = False
+    fragility_inputs_valid: bool = True
+    operational_ready: bool = True
+    runbook_validated: bool = True
+    kill_switch_dry_run_passed: bool = True
+    rollback_dry_run_passed: bool = True
+    approval_token: str | None = None
+
+
+@dataclass(frozen=True)
+class GatePolicyMatrix:
+    policy_version: str = "v3-gates-1"
+    required_feature_schema_version: str = "3.0.0"
+    gate0_max_null_rate: Decimal = Decimal("0.01")
+    gate0_max_staleness_ms: int = 120000
+    gate0_min_symbol_coverage: int = 1
+
+    gate1_min_decision_count: int = 1
+    gate1_min_trade_count: int = 1
+    gate1_min_net_pnl: Decimal = Decimal("0")
+    gate1_max_negative_fold_ratio: Decimal = Decimal("0.5")
+    gate1_max_net_pnl_cv: Decimal = Decimal("2.0")
+
+    gate2_max_drawdown: Decimal = Decimal("250")
+    gate2_max_turnover_ratio: Decimal = Decimal("8.0")
+    gate2_max_cost_bps: Decimal = Decimal("35")
+    gate2_max_tca_slippage_bps: Decimal = Decimal("25")
+    gate2_max_tca_shortfall_notional: Decimal = Decimal("25")
+    gate2_max_tca_churn_ratio: Decimal = Decimal("0.75")
+    gate2_max_tca_realized_shortfall_bps: Decimal = Decimal("25")
+    gate2_max_tca_divergence_bps: Decimal = Decimal("12")
+    gate2_max_tca_calibration_error_bps: Decimal = Decimal("12")
+    gate2_min_tca_expected_shortfall_coverage: Decimal = Decimal("0")
+    gate2_max_fragility_score: Decimal = Decimal("0.85")
+    gate2_max_fragility_state_rank: int = 2
+    gate2_require_stability_mode_under_stress: bool = True
+
+    gate3_max_llm_error_ratio: Decimal = Decimal("0.10")
+    gate3_max_forecast_fallback_rate: Decimal = Decimal("0.05")
+    gate3_max_forecast_latency_ms_p95: int = 200
+    gate3_min_forecast_calibration_score: Decimal = Decimal("0.85")
+    gate6_require_profitability_evidence: bool = True
+    gate6_min_market_net_pnl_delta: Decimal = Decimal("0")
+    gate6_min_regime_slice_pass_ratio: Decimal = Decimal("0.50")
+    gate6_min_return_over_drawdown: Decimal = Decimal("0")
+    gate6_max_cost_bps: Decimal = Decimal("35")
+    gate6_max_calibration_error: Decimal = Decimal("0.45")
+    gate6_min_reproducibility_hashes: int = 5
+    gate6_require_janus_evidence: bool = True
+    gate6_min_janus_event_count: int = 1
+    gate6_min_janus_reward_count: int = 1
+    gate7_target_coverage: Decimal = Decimal("0.90")
+    gate7_max_coverage_error_pass: Decimal = Decimal("0.03")
+    gate7_max_coverage_error_degrade: Decimal = Decimal("0.05")
+    gate7_max_coverage_error_abstain: Decimal = Decimal("0.08")
+    gate7_shift_score_degrade: Decimal = Decimal("0.60")
+    gate7_shift_score_abstain: Decimal = Decimal("0.80")
+    gate7_shift_score_fail: Decimal = Decimal("0.95")
+    gate7_max_interval_width_pass: Decimal = Decimal("1.25")
+    gate7_max_interval_width_degrade: Decimal = Decimal("1.75")
+
+    gate5_live_enabled: bool = False
+    gate5_require_approval_token: bool = True
+
+    @classmethod
+    def from_path(cls, path: Path) -> "GatePolicyMatrix":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return cls(
+            policy_version=str(payload.get("policy_version", "v3-gates-1")),
+            required_feature_schema_version=str(
+                payload.get("required_feature_schema_version", "3.0.0")
+            ),
+            gate0_max_null_rate=_decimal_or_default(
+                payload.get("gate0_max_null_rate"), Decimal("0.01")
+            ),
+            gate0_max_staleness_ms=int(payload.get("gate0_max_staleness_ms", 120000)),
+            gate0_min_symbol_coverage=int(payload.get("gate0_min_symbol_coverage", 1)),
+            gate1_min_decision_count=int(payload.get("gate1_min_decision_count", 1)),
+            gate1_min_trade_count=int(payload.get("gate1_min_trade_count", 1)),
+            gate1_min_net_pnl=_decimal_or_default(
+                payload.get("gate1_min_net_pnl"), Decimal("0")
+            ),
+            gate1_max_negative_fold_ratio=_decimal_or_default(
+                payload.get("gate1_max_negative_fold_ratio"),
+                Decimal("0.5"),
+            ),
+            gate1_max_net_pnl_cv=_decimal_or_default(
+                payload.get("gate1_max_net_pnl_cv"), Decimal("2.0")
+            ),
+            gate2_max_drawdown=_decimal_or_default(
+                payload.get("gate2_max_drawdown"), Decimal("250")
+            ),
+            gate2_max_turnover_ratio=_decimal_or_default(
+                payload.get("gate2_max_turnover_ratio"), Decimal("8.0")
+            ),
+            gate2_max_cost_bps=_decimal_or_default(
+                payload.get("gate2_max_cost_bps"), Decimal("35")
+            ),
+            gate2_max_tca_slippage_bps=_decimal_or_default(
+                payload.get("gate2_max_tca_slippage_bps"), Decimal("25")
+            ),
+            gate2_max_tca_shortfall_notional=_decimal_or_default(
+                payload.get("gate2_max_tca_shortfall_notional"),
+                Decimal("25"),
+            ),
+            gate2_max_tca_churn_ratio=_decimal_or_default(
+                payload.get("gate2_max_tca_churn_ratio"), Decimal("0.75")
+            ),
+            gate2_max_tca_realized_shortfall_bps=_decimal_or_default(
+                payload.get("gate2_max_tca_realized_shortfall_bps"), Decimal("25")
+            ),
+            gate2_max_tca_divergence_bps=_decimal_or_default(
+                payload.get("gate2_max_tca_divergence_bps"), Decimal("12")
+            ),
+            gate2_max_tca_calibration_error_bps=_decimal_or_default(
+                payload.get("gate2_max_tca_calibration_error_bps"),
+                Decimal("12"),
+            ),
+            gate2_min_tca_expected_shortfall_coverage=_decimal_or_default(
+                payload.get("gate2_min_tca_expected_shortfall_coverage"), Decimal("0")
+            ),
+            gate2_max_fragility_score=_decimal_or_default(
+                payload.get("gate2_max_fragility_score"), Decimal("0.85")
+            ),
+            gate2_max_fragility_state_rank=int(
+                payload.get("gate2_max_fragility_state_rank", 2)
+            ),
+            gate2_require_stability_mode_under_stress=bool(
+                payload.get("gate2_require_stability_mode_under_stress", True)
+            ),
+            gate3_max_llm_error_ratio=_decimal_or_default(
+                payload.get("gate3_max_llm_error_ratio"), Decimal("0.10")
+            ),
+            gate3_max_forecast_fallback_rate=_decimal_or_default(
+                payload.get("gate3_max_forecast_fallback_rate"), Decimal("0.05")
+            ),
+            gate3_max_forecast_latency_ms_p95=int(
+                payload.get("gate3_max_forecast_latency_ms_p95", 200)
+            ),
+            gate3_min_forecast_calibration_score=_decimal_or_default(
+                payload.get("gate3_min_forecast_calibration_score"), Decimal("0.85")
+            ),
+            gate6_require_profitability_evidence=bool(
+                payload.get("gate6_require_profitability_evidence", True)
+            ),
+            gate6_min_market_net_pnl_delta=_decimal_or_default(
+                payload.get("gate6_min_market_net_pnl_delta"),
+                Decimal("0"),
+            ),
+            gate6_min_regime_slice_pass_ratio=_decimal_or_default(
+                payload.get("gate6_min_regime_slice_pass_ratio"),
+                Decimal("0.50"),
+            ),
+            gate6_min_return_over_drawdown=_decimal_or_default(
+                payload.get("gate6_min_return_over_drawdown"),
+                Decimal("0"),
+            ),
+            gate6_max_cost_bps=_decimal_or_default(
+                payload.get("gate6_max_cost_bps"), Decimal("35")
+            ),
+            gate6_max_calibration_error=_decimal_or_default(
+                payload.get("gate6_max_calibration_error"),
+                Decimal("0.45"),
+            ),
+            gate6_min_reproducibility_hashes=int(
+                payload.get("gate6_min_reproducibility_hashes", 5)
+            ),
+            gate6_require_janus_evidence=bool(
+                payload.get("gate6_require_janus_evidence", True)
+            ),
+            gate6_min_janus_event_count=int(
+                payload.get("gate6_min_janus_event_count", 1)
+            ),
+            gate6_min_janus_reward_count=int(
+                payload.get("gate6_min_janus_reward_count", 1)
+            ),
+            gate7_target_coverage=_decimal_or_default(
+                payload.get("gate7_target_coverage"),
+                Decimal("0.90"),
+            ),
+            gate7_max_coverage_error_pass=_decimal_or_default(
+                payload.get("gate7_max_coverage_error_pass"),
+                Decimal("0.03"),
+            ),
+            gate7_max_coverage_error_degrade=_decimal_or_default(
+                payload.get("gate7_max_coverage_error_degrade"),
+                Decimal("0.05"),
+            ),
+            gate7_max_coverage_error_abstain=_decimal_or_default(
+                payload.get("gate7_max_coverage_error_abstain"),
+                Decimal("0.08"),
+            ),
+            gate7_shift_score_degrade=_decimal_or_default(
+                payload.get("gate7_shift_score_degrade"),
+                Decimal("0.60"),
+            ),
+            gate7_shift_score_abstain=_decimal_or_default(
+                payload.get("gate7_shift_score_abstain"),
+                Decimal("0.80"),
+            ),
+            gate7_shift_score_fail=_decimal_or_default(
+                payload.get("gate7_shift_score_fail"),
+                Decimal("0.95"),
+            ),
+            gate7_max_interval_width_pass=_decimal_or_default(
+                payload.get("gate7_max_interval_width_pass"),
+                Decimal("1.25"),
+            ),
+            gate7_max_interval_width_degrade=_decimal_or_default(
+                payload.get("gate7_max_interval_width_degrade"),
+                Decimal("1.75"),
+            ),
+            gate5_live_enabled=bool(payload.get("gate5_live_enabled", False)),
+            gate5_require_approval_token=bool(
+                payload.get("gate5_require_approval_token", True)
+            ),
+        )
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "policy_version": self.policy_version,
+            "required_feature_schema_version": self.required_feature_schema_version,
+            "gate0_max_null_rate": str(self.gate0_max_null_rate),
+            "gate0_max_staleness_ms": self.gate0_max_staleness_ms,
+            "gate0_min_symbol_coverage": self.gate0_min_symbol_coverage,
+            "gate1_min_decision_count": self.gate1_min_decision_count,
+            "gate1_min_trade_count": self.gate1_min_trade_count,
+            "gate1_min_net_pnl": str(self.gate1_min_net_pnl),
+            "gate1_max_negative_fold_ratio": str(self.gate1_max_negative_fold_ratio),
+            "gate1_max_net_pnl_cv": str(self.gate1_max_net_pnl_cv),
+            "gate2_max_drawdown": str(self.gate2_max_drawdown),
+            "gate2_max_turnover_ratio": str(self.gate2_max_turnover_ratio),
+            "gate2_max_cost_bps": str(self.gate2_max_cost_bps),
+            "gate2_max_tca_slippage_bps": str(self.gate2_max_tca_slippage_bps),
+            "gate2_max_tca_shortfall_notional": str(
+                self.gate2_max_tca_shortfall_notional
+            ),
+            "gate2_max_tca_churn_ratio": str(self.gate2_max_tca_churn_ratio),
+            "gate2_max_tca_realized_shortfall_bps": str(
+                self.gate2_max_tca_realized_shortfall_bps
+            ),
+            "gate2_max_tca_divergence_bps": str(self.gate2_max_tca_divergence_bps),
+            "gate2_max_tca_calibration_error_bps": str(
+                self.gate2_max_tca_calibration_error_bps
+            ),
+            "gate2_min_tca_expected_shortfall_coverage": str(
+                self.gate2_min_tca_expected_shortfall_coverage
+            ),
+            "gate2_max_fragility_score": str(self.gate2_max_fragility_score),
+            "gate2_max_fragility_state_rank": self.gate2_max_fragility_state_rank,
+            "gate2_require_stability_mode_under_stress": self.gate2_require_stability_mode_under_stress,
+            "gate3_max_llm_error_ratio": str(self.gate3_max_llm_error_ratio),
+            "gate3_max_forecast_fallback_rate": str(
+                self.gate3_max_forecast_fallback_rate
+            ),
+            "gate3_max_forecast_latency_ms_p95": self.gate3_max_forecast_latency_ms_p95,
+            "gate3_min_forecast_calibration_score": str(
+                self.gate3_min_forecast_calibration_score
+            ),
+            "gate6_require_profitability_evidence": self.gate6_require_profitability_evidence,
+            "gate6_min_market_net_pnl_delta": str(self.gate6_min_market_net_pnl_delta),
+            "gate6_min_regime_slice_pass_ratio": str(
+                self.gate6_min_regime_slice_pass_ratio
+            ),
+            "gate6_min_return_over_drawdown": str(self.gate6_min_return_over_drawdown),
+            "gate6_max_cost_bps": str(self.gate6_max_cost_bps),
+            "gate6_max_calibration_error": str(self.gate6_max_calibration_error),
+            "gate6_min_reproducibility_hashes": self.gate6_min_reproducibility_hashes,
+            "gate6_require_janus_evidence": self.gate6_require_janus_evidence,
+            "gate6_min_janus_event_count": self.gate6_min_janus_event_count,
+            "gate6_min_janus_reward_count": self.gate6_min_janus_reward_count,
+            "gate7_target_coverage": str(self.gate7_target_coverage),
+            "gate7_max_coverage_error_pass": str(self.gate7_max_coverage_error_pass),
+            "gate7_max_coverage_error_degrade": str(
+                self.gate7_max_coverage_error_degrade
+            ),
+            "gate7_max_coverage_error_abstain": str(
+                self.gate7_max_coverage_error_abstain
+            ),
+            "gate7_shift_score_degrade": str(self.gate7_shift_score_degrade),
+            "gate7_shift_score_abstain": str(self.gate7_shift_score_abstain),
+            "gate7_shift_score_fail": str(self.gate7_shift_score_fail),
+            "gate7_max_interval_width_pass": str(self.gate7_max_interval_width_pass),
+            "gate7_max_interval_width_degrade": str(
+                self.gate7_max_interval_width_degrade
+            ),
+            "gate5_live_enabled": self.gate5_live_enabled,
+            "gate5_require_approval_token": self.gate5_require_approval_token,
+        }
+
+
+@dataclass(frozen=True)
+class GateEvaluationReport:
+    policy_version: str
+    promotion_target: PromotionTarget
+    promotion_allowed: bool
+    recommended_mode: PromotionTarget
+    gates: list[GateResult]
+    reasons: list[str]
+    uncertainty_gate_action: UncertaintyGateAction
+    coverage_error: str | None
+    conformal_interval_width: str | None
+    shift_score: str | None
+    recalibration_run_id: str | None
+    evaluated_at: datetime
+    code_version: str
+    evidence_collection_allowed: bool = False
+    promotion_blockers: list[str] = field(default_factory=empty_str_list)
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "policy_version": self.policy_version,
+            "promotion_target": self.promotion_target,
+            "promotion_allowed": self.promotion_allowed,
+            "capital_promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "evidence_collection_allowed": self.evidence_collection_allowed,
+            "bounded_evidence_collection_authorized": self.evidence_collection_allowed,
+            "authority_source": "autonomy_gate_status_only",
+            "recommended_mode": self.recommended_mode,
+            "gates": [item.to_payload() for item in self.gates],
+            "reasons": list(self.reasons),
+            "promotion_blockers": list(self.promotion_blockers),
+            "uncertainty_gate_action": self.uncertainty_gate_action,
+            "coverage_error": self.coverage_error,
+            "conformal_interval_width": self.conformal_interval_width,
+            "shift_score": self.shift_score,
+            "recalibration_run_id": self.recalibration_run_id,
+            "evaluated_at": self.evaluated_at.isoformat(),
+            "code_version": self.code_version,
+        }
+
+
+@dataclass(frozen=True)
+class UncertaintyGateOutcome:
+    action: UncertaintyGateAction
+    coverage_error: Decimal | None
+    shift_score: Decimal | None
+    avg_interval_width: Decimal | None
+    recalibration_run_id: str | None
+
+
+__all__ = (
+    "GateEvaluationReport",
+    "GateInputs",
+    "GatePolicyMatrix",
+    "GateResult",
+    "GateStatus",
+    "PromotionTarget",
+    "UncertaintyGateAction",
+    "UncertaintyGateOutcome",
+    "empty_artifact_refs",
+    "empty_dict",
+    "empty_str_list",
+)

--- a/services/torghut/app/trading/autonomy/gates/shared_context.py
+++ b/services/torghut/app/trading/autonomy/gates/shared_context.py
@@ -2,455 +2,33 @@
 
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
-from pathlib import Path
-from typing import Any, Literal, cast
 
-
-GateStatus = Literal["pass", "fail"]
-
-UncertaintyGateAction = Literal["pass", "degrade", "abstain", "fail"]
-
-PromotionTarget = Literal["shadow", "paper", "live"]
-
-
-def empty_str_list() -> list[str]:
-    return []
-
-
-def empty_artifact_refs() -> list[str]:
-    return []
-
-
-def empty_dict() -> dict[str, Any]:
-    return {}
-
-
-def _decimal_or_default(value: Any, default: Decimal) -> Decimal:
-    if value is None:
-        return default
-    try:
-        return Decimal(str(value))
-    except (ArithmeticError, TypeError, ValueError):
-        return default
-
-
-def _gate7_helpers() -> Any:
-    import importlib
-
-    return importlib.import_module(f"{__package__}.gate7_uncertainty_calibration")
-
-
-def _decimal(value: Any) -> Decimal | None:
-    return _gate7_helpers()._decimal(value)
-
-
-def _gate2_base_reasons(*args: Any, **kwargs: Any) -> list[str]:
-    return _gate7_helpers()._gate2_base_reasons(*args, **kwargs)
-
-
-def _gate2_tca_reasons(*args: Any, **kwargs: Any) -> list[str]:
-    return _gate7_helpers()._gate2_tca_reasons(*args, **kwargs)
-
-
-def _gate6_early_result(*args: Any, **kwargs: Any) -> Any:
-    return _gate7_helpers()._gate6_early_result(*args, **kwargs)
-
-
-def _gate6_schema_reasons(*args: Any, **kwargs: Any) -> list[str]:
-    return _gate7_helpers()._gate6_schema_reasons(*args, **kwargs)
-
-
-def _gate6_threshold_reasons(*args: Any, **kwargs: Any) -> list[str]:
-    return _gate7_helpers()._gate6_threshold_reasons(*args, **kwargs)
-
-
-def _gate6_reproducibility_reasons(*args: Any, **kwargs: Any) -> list[str]:
-    return _gate7_helpers()._gate6_reproducibility_reasons(*args, **kwargs)
-
-
-def _gate6_janus_q_reasons(*args: Any, **kwargs: Any) -> list[str]:
-    return _gate7_helpers()._gate6_janus_q_reasons(*args, **kwargs)
-
-
-def _gate7_uncertainty_calibration(*args: Any, **kwargs: Any) -> Any:
-    return _gate7_helpers()._gate7_uncertainty_calibration(*args, **kwargs)
-
-
-@dataclass(frozen=True)
-class GateResult:
-    gate_id: str
-    status: GateStatus
-    reasons: list[str] = field(default_factory=empty_str_list)
-    artifact_refs: list[str] = field(default_factory=empty_artifact_refs)
-
-    def to_payload(self) -> dict[str, object]:
-        return {
-            "gate_id": self.gate_id,
-            "status": self.status,
-            "reasons": list(self.reasons),
-            "artifact_refs": list(self.artifact_refs),
-        }
-
-
-@dataclass(frozen=True)
-class GateInputs:
-    feature_schema_version: str
-    required_feature_null_rate: Decimal
-    staleness_ms_p95: int | None
-    symbol_coverage: int
-    metrics: dict[str, Any]
-    robustness: dict[str, Any]
-    tca_metrics: dict[str, Any] = field(default_factory=empty_dict)
-    llm_metrics: dict[str, Any] = field(default_factory=empty_dict)
-    forecast_metrics: dict[str, Any] = field(default_factory=empty_dict)
-    profitability_evidence: dict[str, Any] = field(default_factory=empty_dict)
-    fragility_state: str = "elevated"
-    fragility_score: Decimal = Decimal("0.5")
-    stability_mode_active: bool = False
-    fragility_inputs_valid: bool = True
-    operational_ready: bool = True
-    runbook_validated: bool = True
-    kill_switch_dry_run_passed: bool = True
-    rollback_dry_run_passed: bool = True
-    approval_token: str | None = None
-
-
-@dataclass(frozen=True)
-class GatePolicyMatrix:
-    policy_version: str = "v3-gates-1"
-    required_feature_schema_version: str = "3.0.0"
-    gate0_max_null_rate: Decimal = Decimal("0.01")
-    gate0_max_staleness_ms: int = 120000
-    gate0_min_symbol_coverage: int = 1
-
-    gate1_min_decision_count: int = 1
-    gate1_min_trade_count: int = 1
-    gate1_min_net_pnl: Decimal = Decimal("0")
-    gate1_max_negative_fold_ratio: Decimal = Decimal("0.5")
-    gate1_max_net_pnl_cv: Decimal = Decimal("2.0")
-
-    gate2_max_drawdown: Decimal = Decimal("250")
-    gate2_max_turnover_ratio: Decimal = Decimal("8.0")
-    gate2_max_cost_bps: Decimal = Decimal("35")
-    gate2_max_tca_slippage_bps: Decimal = Decimal("25")
-    gate2_max_tca_shortfall_notional: Decimal = Decimal("25")
-    gate2_max_tca_churn_ratio: Decimal = Decimal("0.75")
-    gate2_max_tca_realized_shortfall_bps: Decimal = Decimal("25")
-    gate2_max_tca_divergence_bps: Decimal = Decimal("12")
-    gate2_max_tca_calibration_error_bps: Decimal = Decimal("12")
-    gate2_min_tca_expected_shortfall_coverage: Decimal = Decimal("0")
-    gate2_max_fragility_score: Decimal = Decimal("0.85")
-    gate2_max_fragility_state_rank: int = 2
-    gate2_require_stability_mode_under_stress: bool = True
-
-    gate3_max_llm_error_ratio: Decimal = Decimal("0.10")
-    gate3_max_forecast_fallback_rate: Decimal = Decimal("0.05")
-    gate3_max_forecast_latency_ms_p95: int = 200
-    gate3_min_forecast_calibration_score: Decimal = Decimal("0.85")
-    gate6_require_profitability_evidence: bool = True
-    gate6_min_market_net_pnl_delta: Decimal = Decimal("0")
-    gate6_min_regime_slice_pass_ratio: Decimal = Decimal("0.50")
-    gate6_min_return_over_drawdown: Decimal = Decimal("0")
-    gate6_max_cost_bps: Decimal = Decimal("35")
-    gate6_max_calibration_error: Decimal = Decimal("0.45")
-    gate6_min_reproducibility_hashes: int = 5
-    gate6_require_janus_evidence: bool = True
-    gate6_min_janus_event_count: int = 1
-    gate6_min_janus_reward_count: int = 1
-    gate7_target_coverage: Decimal = Decimal("0.90")
-    gate7_max_coverage_error_pass: Decimal = Decimal("0.03")
-    gate7_max_coverage_error_degrade: Decimal = Decimal("0.05")
-    gate7_max_coverage_error_abstain: Decimal = Decimal("0.08")
-    gate7_shift_score_degrade: Decimal = Decimal("0.60")
-    gate7_shift_score_abstain: Decimal = Decimal("0.80")
-    gate7_shift_score_fail: Decimal = Decimal("0.95")
-    gate7_max_interval_width_pass: Decimal = Decimal("1.25")
-    gate7_max_interval_width_degrade: Decimal = Decimal("1.75")
-
-    gate5_live_enabled: bool = False
-    gate5_require_approval_token: bool = True
-
-    @classmethod
-    def from_path(cls, path: Path) -> "GatePolicyMatrix":
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        return cls(
-            policy_version=str(payload.get("policy_version", "v3-gates-1")),
-            required_feature_schema_version=str(
-                payload.get("required_feature_schema_version", "3.0.0")
-            ),
-            gate0_max_null_rate=_decimal_or_default(
-                payload.get("gate0_max_null_rate"), Decimal("0.01")
-            ),
-            gate0_max_staleness_ms=int(payload.get("gate0_max_staleness_ms", 120000)),
-            gate0_min_symbol_coverage=int(payload.get("gate0_min_symbol_coverage", 1)),
-            gate1_min_decision_count=int(payload.get("gate1_min_decision_count", 1)),
-            gate1_min_trade_count=int(payload.get("gate1_min_trade_count", 1)),
-            gate1_min_net_pnl=_decimal_or_default(
-                payload.get("gate1_min_net_pnl"), Decimal("0")
-            ),
-            gate1_max_negative_fold_ratio=_decimal_or_default(
-                payload.get("gate1_max_negative_fold_ratio"),
-                Decimal("0.5"),
-            ),
-            gate1_max_net_pnl_cv=_decimal_or_default(
-                payload.get("gate1_max_net_pnl_cv"), Decimal("2.0")
-            ),
-            gate2_max_drawdown=_decimal_or_default(
-                payload.get("gate2_max_drawdown"), Decimal("250")
-            ),
-            gate2_max_turnover_ratio=_decimal_or_default(
-                payload.get("gate2_max_turnover_ratio"), Decimal("8.0")
-            ),
-            gate2_max_cost_bps=_decimal_or_default(
-                payload.get("gate2_max_cost_bps"), Decimal("35")
-            ),
-            gate2_max_tca_slippage_bps=_decimal_or_default(
-                payload.get("gate2_max_tca_slippage_bps"), Decimal("25")
-            ),
-            gate2_max_tca_shortfall_notional=_decimal_or_default(
-                payload.get("gate2_max_tca_shortfall_notional"),
-                Decimal("25"),
-            ),
-            gate2_max_tca_churn_ratio=_decimal_or_default(
-                payload.get("gate2_max_tca_churn_ratio"), Decimal("0.75")
-            ),
-            gate2_max_tca_realized_shortfall_bps=_decimal_or_default(
-                payload.get("gate2_max_tca_realized_shortfall_bps"), Decimal("25")
-            ),
-            gate2_max_tca_divergence_bps=_decimal_or_default(
-                payload.get("gate2_max_tca_divergence_bps"), Decimal("12")
-            ),
-            gate2_max_tca_calibration_error_bps=_decimal_or_default(
-                payload.get("gate2_max_tca_calibration_error_bps"),
-                Decimal("12"),
-            ),
-            gate2_min_tca_expected_shortfall_coverage=_decimal_or_default(
-                payload.get("gate2_min_tca_expected_shortfall_coverage"), Decimal("0")
-            ),
-            gate2_max_fragility_score=_decimal_or_default(
-                payload.get("gate2_max_fragility_score"), Decimal("0.85")
-            ),
-            gate2_max_fragility_state_rank=int(
-                payload.get("gate2_max_fragility_state_rank", 2)
-            ),
-            gate2_require_stability_mode_under_stress=bool(
-                payload.get("gate2_require_stability_mode_under_stress", True)
-            ),
-            gate3_max_llm_error_ratio=_decimal_or_default(
-                payload.get("gate3_max_llm_error_ratio"), Decimal("0.10")
-            ),
-            gate3_max_forecast_fallback_rate=_decimal_or_default(
-                payload.get("gate3_max_forecast_fallback_rate"), Decimal("0.05")
-            ),
-            gate3_max_forecast_latency_ms_p95=int(
-                payload.get("gate3_max_forecast_latency_ms_p95", 200)
-            ),
-            gate3_min_forecast_calibration_score=_decimal_or_default(
-                payload.get("gate3_min_forecast_calibration_score"), Decimal("0.85")
-            ),
-            gate6_require_profitability_evidence=bool(
-                payload.get("gate6_require_profitability_evidence", True)
-            ),
-            gate6_min_market_net_pnl_delta=_decimal_or_default(
-                payload.get("gate6_min_market_net_pnl_delta"),
-                Decimal("0"),
-            ),
-            gate6_min_regime_slice_pass_ratio=_decimal_or_default(
-                payload.get("gate6_min_regime_slice_pass_ratio"),
-                Decimal("0.50"),
-            ),
-            gate6_min_return_over_drawdown=_decimal_or_default(
-                payload.get("gate6_min_return_over_drawdown"),
-                Decimal("0"),
-            ),
-            gate6_max_cost_bps=_decimal_or_default(
-                payload.get("gate6_max_cost_bps"), Decimal("35")
-            ),
-            gate6_max_calibration_error=_decimal_or_default(
-                payload.get("gate6_max_calibration_error"),
-                Decimal("0.45"),
-            ),
-            gate6_min_reproducibility_hashes=int(
-                payload.get("gate6_min_reproducibility_hashes", 5)
-            ),
-            gate6_require_janus_evidence=bool(
-                payload.get("gate6_require_janus_evidence", True)
-            ),
-            gate6_min_janus_event_count=int(
-                payload.get("gate6_min_janus_event_count", 1)
-            ),
-            gate6_min_janus_reward_count=int(
-                payload.get("gate6_min_janus_reward_count", 1)
-            ),
-            gate7_target_coverage=_decimal_or_default(
-                payload.get("gate7_target_coverage"),
-                Decimal("0.90"),
-            ),
-            gate7_max_coverage_error_pass=_decimal_or_default(
-                payload.get("gate7_max_coverage_error_pass"),
-                Decimal("0.03"),
-            ),
-            gate7_max_coverage_error_degrade=_decimal_or_default(
-                payload.get("gate7_max_coverage_error_degrade"),
-                Decimal("0.05"),
-            ),
-            gate7_max_coverage_error_abstain=_decimal_or_default(
-                payload.get("gate7_max_coverage_error_abstain"),
-                Decimal("0.08"),
-            ),
-            gate7_shift_score_degrade=_decimal_or_default(
-                payload.get("gate7_shift_score_degrade"),
-                Decimal("0.60"),
-            ),
-            gate7_shift_score_abstain=_decimal_or_default(
-                payload.get("gate7_shift_score_abstain"),
-                Decimal("0.80"),
-            ),
-            gate7_shift_score_fail=_decimal_or_default(
-                payload.get("gate7_shift_score_fail"),
-                Decimal("0.95"),
-            ),
-            gate7_max_interval_width_pass=_decimal_or_default(
-                payload.get("gate7_max_interval_width_pass"),
-                Decimal("1.25"),
-            ),
-            gate7_max_interval_width_degrade=_decimal_or_default(
-                payload.get("gate7_max_interval_width_degrade"),
-                Decimal("1.75"),
-            ),
-            gate5_live_enabled=bool(payload.get("gate5_live_enabled", False)),
-            gate5_require_approval_token=bool(
-                payload.get("gate5_require_approval_token", True)
-            ),
-        )
-
-    def to_payload(self) -> dict[str, object]:
-        return {
-            "policy_version": self.policy_version,
-            "required_feature_schema_version": self.required_feature_schema_version,
-            "gate0_max_null_rate": str(self.gate0_max_null_rate),
-            "gate0_max_staleness_ms": self.gate0_max_staleness_ms,
-            "gate0_min_symbol_coverage": self.gate0_min_symbol_coverage,
-            "gate1_min_decision_count": self.gate1_min_decision_count,
-            "gate1_min_trade_count": self.gate1_min_trade_count,
-            "gate1_min_net_pnl": str(self.gate1_min_net_pnl),
-            "gate1_max_negative_fold_ratio": str(self.gate1_max_negative_fold_ratio),
-            "gate1_max_net_pnl_cv": str(self.gate1_max_net_pnl_cv),
-            "gate2_max_drawdown": str(self.gate2_max_drawdown),
-            "gate2_max_turnover_ratio": str(self.gate2_max_turnover_ratio),
-            "gate2_max_cost_bps": str(self.gate2_max_cost_bps),
-            "gate2_max_tca_slippage_bps": str(self.gate2_max_tca_slippage_bps),
-            "gate2_max_tca_shortfall_notional": str(
-                self.gate2_max_tca_shortfall_notional
-            ),
-            "gate2_max_tca_churn_ratio": str(self.gate2_max_tca_churn_ratio),
-            "gate2_max_tca_realized_shortfall_bps": str(
-                self.gate2_max_tca_realized_shortfall_bps
-            ),
-            "gate2_max_tca_divergence_bps": str(self.gate2_max_tca_divergence_bps),
-            "gate2_max_tca_calibration_error_bps": str(
-                self.gate2_max_tca_calibration_error_bps
-            ),
-            "gate2_min_tca_expected_shortfall_coverage": str(
-                self.gate2_min_tca_expected_shortfall_coverage
-            ),
-            "gate2_max_fragility_score": str(self.gate2_max_fragility_score),
-            "gate2_max_fragility_state_rank": self.gate2_max_fragility_state_rank,
-            "gate2_require_stability_mode_under_stress": self.gate2_require_stability_mode_under_stress,
-            "gate3_max_llm_error_ratio": str(self.gate3_max_llm_error_ratio),
-            "gate3_max_forecast_fallback_rate": str(
-                self.gate3_max_forecast_fallback_rate
-            ),
-            "gate3_max_forecast_latency_ms_p95": self.gate3_max_forecast_latency_ms_p95,
-            "gate3_min_forecast_calibration_score": str(
-                self.gate3_min_forecast_calibration_score
-            ),
-            "gate6_require_profitability_evidence": self.gate6_require_profitability_evidence,
-            "gate6_min_market_net_pnl_delta": str(self.gate6_min_market_net_pnl_delta),
-            "gate6_min_regime_slice_pass_ratio": str(
-                self.gate6_min_regime_slice_pass_ratio
-            ),
-            "gate6_min_return_over_drawdown": str(self.gate6_min_return_over_drawdown),
-            "gate6_max_cost_bps": str(self.gate6_max_cost_bps),
-            "gate6_max_calibration_error": str(self.gate6_max_calibration_error),
-            "gate6_min_reproducibility_hashes": self.gate6_min_reproducibility_hashes,
-            "gate6_require_janus_evidence": self.gate6_require_janus_evidence,
-            "gate6_min_janus_event_count": self.gate6_min_janus_event_count,
-            "gate6_min_janus_reward_count": self.gate6_min_janus_reward_count,
-            "gate7_target_coverage": str(self.gate7_target_coverage),
-            "gate7_max_coverage_error_pass": str(self.gate7_max_coverage_error_pass),
-            "gate7_max_coverage_error_degrade": str(
-                self.gate7_max_coverage_error_degrade
-            ),
-            "gate7_max_coverage_error_abstain": str(
-                self.gate7_max_coverage_error_abstain
-            ),
-            "gate7_shift_score_degrade": str(self.gate7_shift_score_degrade),
-            "gate7_shift_score_abstain": str(self.gate7_shift_score_abstain),
-            "gate7_shift_score_fail": str(self.gate7_shift_score_fail),
-            "gate7_max_interval_width_pass": str(self.gate7_max_interval_width_pass),
-            "gate7_max_interval_width_degrade": str(
-                self.gate7_max_interval_width_degrade
-            ),
-            "gate5_live_enabled": self.gate5_live_enabled,
-            "gate5_require_approval_token": self.gate5_require_approval_token,
-        }
-
-
-@dataclass(frozen=True)
-class GateEvaluationReport:
-    policy_version: str
-    promotion_target: PromotionTarget
-    promotion_allowed: bool
-    recommended_mode: PromotionTarget
-    gates: list[GateResult]
-    reasons: list[str]
-    uncertainty_gate_action: UncertaintyGateAction
-    coverage_error: str | None
-    conformal_interval_width: str | None
-    shift_score: str | None
-    recalibration_run_id: str | None
-    evaluated_at: datetime
-    code_version: str
-    evidence_collection_allowed: bool = False
-    promotion_blockers: list[str] = field(default_factory=empty_str_list)
-
-    def to_payload(self) -> dict[str, object]:
-        return {
-            "policy_version": self.policy_version,
-            "promotion_target": self.promotion_target,
-            "promotion_allowed": self.promotion_allowed,
-            "capital_promotion_allowed": False,
-            "final_promotion_allowed": False,
-            "final_authority_ok": False,
-            "evidence_collection_allowed": self.evidence_collection_allowed,
-            "bounded_evidence_collection_authorized": self.evidence_collection_allowed,
-            "authority_source": "autonomy_gate_status_only",
-            "recommended_mode": self.recommended_mode,
-            "gates": [item.to_payload() for item in self.gates],
-            "reasons": list(self.reasons),
-            "promotion_blockers": list(self.promotion_blockers),
-            "uncertainty_gate_action": self.uncertainty_gate_action,
-            "coverage_error": self.coverage_error,
-            "conformal_interval_width": self.conformal_interval_width,
-            "shift_score": self.shift_score,
-            "recalibration_run_id": self.recalibration_run_id,
-            "evaluated_at": self.evaluated_at.isoformat(),
-            "code_version": self.code_version,
-        }
-
-
-@dataclass(frozen=True)
-class UncertaintyGateOutcome:
-    action: UncertaintyGateAction
-    coverage_error: Decimal | None
-    shift_score: Decimal | None
-    avg_interval_width: Decimal | None
-    recalibration_run_id: str | None
+from .gate_contracts import (
+    GateEvaluationReport,
+    GateInputs,
+    GatePolicyMatrix,
+    GateResult,
+    GateStatus,
+    PromotionTarget,
+    UncertaintyGateAction,
+    UncertaintyGateOutcome,
+    empty_artifact_refs,
+    empty_dict,
+    empty_str_list,
+)
+from .gate7_uncertainty_calibration import (
+    decimal as _decimal,
+    gate2_base_reasons,
+    gate2_tca_reasons,
+    gate6_early_result,
+    gate6_janus_q_reasons,
+    gate6_reproducibility_reasons,
+    gate6_schema_reasons,
+    gate6_threshold_reasons,
+    gate7_uncertainty_calibration,
+)
 
 
 def evaluate_gate_matrix(
@@ -470,7 +48,7 @@ def evaluate_gate_matrix(
     gates.append(gate3_shadow_paper_quality(inputs, policy))
     gates.append(gate4_operational_readiness(inputs))
     gates.append(gate6_profitability_evidence(inputs, policy, promotion_target))
-    uncertainty_gate, uncertainty_outcome = _gate7_uncertainty_calibration(
+    uncertainty_gate, uncertainty_outcome = gate7_uncertainty_calibration(
         inputs, policy, promotion_target
     )
     gates.append(uncertainty_gate)
@@ -599,8 +177,8 @@ def gate1_statistical_robustness(
 
 
 def gate2_risk_and_capacity(inputs: GateInputs, policy: GatePolicyMatrix) -> GateResult:
-    reasons = _gate2_base_reasons(inputs, policy)
-    reasons.extend(_gate2_tca_reasons(inputs, policy))
+    reasons = gate2_base_reasons(inputs, policy)
+    reasons.extend(gate2_tca_reasons(inputs, policy))
 
     return GateResult(
         gate_id="gate2_risk_capacity",
@@ -695,15 +273,15 @@ def gate6_profitability_evidence(
     policy: GatePolicyMatrix,
     promotion_target: PromotionTarget,
 ) -> GateResult:
-    early_result = _gate6_early_result(inputs, policy, promotion_target)
+    early_result = gate6_early_result(inputs, policy, promotion_target)
     if early_result is not None:
         return early_result
     evidence = inputs.profitability_evidence
     reasons: list[str] = []
-    reasons.extend(_gate6_schema_reasons(evidence))
-    reasons.extend(_gate6_threshold_reasons(evidence, policy))
-    reasons.extend(_gate6_reproducibility_reasons(evidence, policy))
-    reasons.extend(_gate6_janus_q_reasons(evidence, policy))
+    reasons.extend(gate6_schema_reasons(evidence))
+    reasons.extend(gate6_threshold_reasons(evidence, policy))
+    reasons.extend(gate6_reproducibility_reasons(evidence, policy))
+    reasons.extend(gate6_janus_q_reasons(evidence, policy))
 
     return GateResult(
         gate_id="gate6_profitability_evidence",
@@ -714,48 +292,18 @@ def gate6_profitability_evidence(
 
 # Explicit barrel exports; keeps re-export imports intentional without file-level Ruff ignores.
 __all__: tuple[str, ...] = (
-    "Any",
-    "Decimal",
     "GateEvaluationReport",
     "GateInputs",
     "GatePolicyMatrix",
     "GateResult",
     "GateStatus",
-    "Literal",
-    "Path",
     "PromotionTarget",
     "UncertaintyGateAction",
     "UncertaintyGateOutcome",
-    "_decimal",
-    "_decimal_or_default",
-    "empty_artifact_refs",
-    "empty_dict",
-    "empty_str_list",
-    "gate0_data_integrity",
-    "gate1_statistical_robustness",
-    "_gate2_base_reasons",
-    "gate2_risk_and_capacity",
-    "_gate2_tca_reasons",
-    "gate3_shadow_paper_quality",
-    "gate4_operational_readiness",
-    "gate5_live_ramp_readiness",
-    "_gate6_early_result",
-    "_gate6_janus_q_reasons",
-    "gate6_profitability_evidence",
-    "_gate6_reproducibility_reasons",
-    "_gate6_schema_reasons",
-    "_gate6_threshold_reasons",
-    "_gate7_helpers",
-    "_gate7_uncertainty_calibration",
-    "annotations",
-    "cast",
-    "dataclass",
-    "datetime",
     "empty_artifact_refs",
     "empty_dict",
     "empty_str_list",
     "evaluate_gate_matrix",
-    "field",
     "gate0_data_integrity",
     "gate1_statistical_robustness",
     "gate2_risk_and_capacity",
@@ -763,6 +311,4 @@ __all__: tuple[str, ...] = (
     "gate4_operational_readiness",
     "gate5_live_ramp_readiness",
     "gate6_profitability_evidence",
-    "json",
-    "timezone",
 )


### PR DESCRIPTION
## Summary

- Moves autonomy gate dataclasses, policy parsing, and payload contracts into `gate_contracts.py`.
- Removes the `shared_context.py` importlib trampoline and direct private helper wrapper layer.
- Renames gate helper functions to semantic public names and trims the package barrel to Torghut gate API symbols only.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen pytest tests/autonomy_gates tests/test_governance_policy_dry_run.py tests/policy_checks/test_policy_checks_runtime_evidence.py`
- `uv run --frozen python -m compileall -q app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/autonomy/gates/__init__.py app/trading/autonomy/gates/gate7_uncertainty_calibration.py app/trading/autonomy/gates/shared_context.py app/trading/autonomy/gates/gate_contracts.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/autonomy/gates/__init__.py app/trading/autonomy/gates/gate7_uncertainty_calibration.py app/trading/autonomy/gates/shared_context.py app/trading/autonomy/gates/gate_contracts.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
