### PR TITLE
refactor(torghut): trim whitepaper runner facade

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -4,124 +4,33 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
-import multiprocessing
 import os
-import queue
-import signal
-import socket
 import subprocess
-import time as monotonic_time
 from collections.abc import Callable
-from concurrent.futures import ProcessPoolExecutor, as_completed
-from dataclasses import dataclass, replace
-from datetime import UTC, date, datetime, time, timedelta
+from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, Sequence, TypeVar, cast
-from urllib.parse import urlparse
-from zoneinfo import ZoneInfo
 
-from sqlalchemy import select
 
-from app.db import SessionLocal
-from app.models import (
-    AutoresearchCandidateSpec,
-    AutoresearchEpoch,
-    AutoresearchPortfolioCandidate,
-    AutoresearchProposalScore,
-    RejectedSignalOutcomeEvent,
-    WhitepaperAnalysisRun,
-    VNextExperimentSpec,
-)
 from app.trading.discovery.autoresearch import (
-    ResearchClaim,
-    ResearchSource,
-    StrategyAutoresearchProgram,
-    load_strategy_autoresearch_program,
     run_id,
 )
 from app.trading.discovery.candidate_specs import (
-    LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE,
     CandidateSpec,
 )
-from app.trading.discovery.candidate_specs import candidate_spec_id_for_payload
-from app.trading.discovery.candidate_specs import candidate_spec_from_payload
-from app.trading.discovery.evidence_bundles import (
-    CandidateEvidenceBundle,
-    evidence_bundle_blockers,
-    evidence_bundle_from_frontier_candidate,
-    evidence_bundle_from_payload,
-)
-from app.trading.discovery.factor_acceptance import (
-    build_factor_acceptance_artifact_from_scorecard,
-)
 from app.trading.discovery.fast_replay import (
-    FAST_REPLAY_PROOF_SEMANTICS_LABEL,
-    FAST_REPLAY_WHITEPAPER_MECHANISMS,
     build_fast_replay_preview,
 )
-from app.trading.discovery.hypothesis_cards import HypothesisCard
-from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
-from app.trading.discovery.mlx_snapshot import MlxSnapshotManifest
-from app.trading.discovery.mlx_snapshot import write_mlx_snapshot_manifest
-from app.trading.discovery.mlx_training_data import build_mlx_training_rows
-from app.trading.discovery.mlx_training_data import (
-    capital_budget_penalty,
-    candidate_spec_capital_features,
-    rank_training_rows,
-    rank_training_rows_with_lift_policy,
-    train_mlx_ranker,
-)
-from app.trading.discovery.objectives import (
-    deployable_lower_bound_missing_count,
-    deployable_lower_bound_net_pnl_per_day,
-    deployable_proof_failed_gate_count,
-)
-from app.trading.discovery.portfolio_optimizer import (
-    PortfolioCandidateSpec,
-    optimize_portfolio_candidate,
-)
-from app.trading.discovery.profit_target_oracle import (
-    ProfitTargetOraclePolicy,
-    evaluate_profit_target_oracle,
-)
-from app.trading.runtime_ledger import (
-    POST_COST_PNL_BASIS,
-    RuntimeLedgerBucket,
-    build_runtime_ledger_buckets,
-)
-from app.trading.discovery.replay_tape import (
-    ReplayTapeManifest,
-    build_source_query_digest,
-    load_replay_tape,
-    materialize_signal_tape,
-    slice_tape_by_symbols,
-    slice_tape_by_window,
-    validate_tape_freshness,
-)
-from app.trading.discovery.runtime_closure import (
-    RuntimeClosureExecutionContext,
-    write_runtime_closure_bundle,
-)
-from app.trading.discovery.whitepaper_autoresearch_notebooks import (
-    write_whitepaper_autoresearch_diagnostics_notebook,
-)
 from app.trading.discovery.whitepaper_candidate_compiler import (
-    CandidateCompilationBlocker,
     compile_whitepaper_candidate_specs,
 )
 from app.whitepapers.claim_compiler import (
     RECENT_WHITEPAPER_SEEDS,
-    WhitepaperResearchSource,
     compile_sources_to_hypothesis_cards,
-    sources_from_jsonl,
 )
 
-import scripts.local_intraday_tsmom_replay as replay_mod
-import scripts.materialize_replay_tape as replay_materializer
-import scripts.run_strategy_factory_v2 as strategy_factory_runner
 from scripts.whitepaper_autoresearch_runner import (
     preview_narrowing as _preview_narrowing,
 )
@@ -243,187 +152,39 @@ from scripts.whitepaper_autoresearch_runner.runtime_closure import (
 )
 
 from scripts.whitepaper_autoresearch_runner.cli_parsing import (
-    _default_strategy_config_path,
-    _default_clickhouse_http_url,
+    _DEFAULT_DAILY_PROFIT_TARGET,
     _ranker_backend_preference,
     _parse_args,
 )
 
 from scripts.whitepaper_autoresearch_runner.artifact_io import (
-    _write_json,
-    _write_jsonl,
     _write_failure_summary,
     _resolved_clickhouse_password,
-    _clickhouse_host_requires_dns_preflight,
     _clickhouse_endpoint_preflight_failure,
-    _candidate_universe_symbols_from_args,
     _candidate_universe_symbols_for_compilation,
 )
 
-from scripts.whitepaper_autoresearch_runner.feedback_loading import (
-    _load_feedback_evidence_bundles,
-    _dedupe_feedback_evidence_bundles,
-    _evidence_bundle_payloads_for_epoch_summary,
-    _candidate_spec_from_payload,
-    _load_candidate_specs_jsonl,
-    _summary_scorecard_feedback_bundles_for_epoch,
-    _outcome_payload_has_complete_rejected_signal_fields,
-)
-
-from scripts.whitepaper_autoresearch_runner.rejected_signal_feedback import (
-    _rejected_signal_outcome_payload_to_feedback_bundle,
-    _ordered_unique_strings,
-    _portfolio_candidate_feedback_blockers,
-    _portfolio_sleeve_feedback_metadata,
-    _portfolio_candidate_row_to_feedback_bundles,
-)
 
 from scripts.whitepaper_autoresearch_runner.persisted_feedback_sources import (
-    _load_recent_persisted_feedback_evidence_bundles,
-    _load_autoresearch_feedback_evidence_bundles,
-    _program_claim_type,
-    _program_research_source_to_whitepaper_source,
     _program_whitepaper_sources,
-    _dedupe_whitepaper_sources,
-    _load_sources_from_db,
     _persist_vnext_specs,
-    _persist_epoch_ledgers,
 )
 
 from scripts.whitepaper_autoresearch_runner.oracle_policy import (
-    _scorecard_start_equity,
-    _scorecard_total_net_pnl,
-    _scorecard_profit_factor,
-    _risk_adjusted_drawdown_passes,
     _oracle_policy_from_args,
-    _candidate_spec_with_oracle_policy,
-    _candidate_specs_with_oracle_policy,
 )
 
-from scripts.whitepaper_autoresearch_runner.proposal_training import (
-    _proposal_model_and_rows,
-    _candidate_quality_gate_failures,
-    _false_positive_table,
-    _replay_diagnostic_proposal_rows,
-    _best_false_negative_table,
-    _recent_trading_days_shortfall,
-    _stale_tape_diagnostics,
-)
-
-from scripts.whitepaper_autoresearch_runner.candidate_remediation import (
-    _candidate_search_remediation,
-)
-
-from scripts.whitepaper_autoresearch_runner.candidate_goal_metadata import (
-    _selected_candidate_spec_ids,
-    _candidate_family_goal_rows,
-    _candidate_sleeve_goal_proof_handoff_fields,
-    _candidate_sleeve_goal_rows,
-)
-
-from scripts.whitepaper_autoresearch_runner.next_epoch_planning import (
-    _profitability_system_change_backlog,
-    _profitability_next_epoch_flags,
-    _int_arg,
-    _flag_int,
-    _unsafe_next_epoch_remediation_flag,
-    _decimal_arg_or_default,
-    _profitability_next_epoch_plan,
-    _profitability_search_goal,
-)
-
-from scripts.whitepaper_autoresearch_runner.feedback_blocking_rules import (
-    _feedback_scorecard_has_hard_veto,
-    _feedback_daily_net_has_loss,
-    _feedback_has_no_replay_activity,
-    _feedback_family_prior_has_hard_block,
-    _feedback_risk_profile_has_penalty,
-    _feedback_risk_profile_has_terminal_block,
-    _feedback_has_policy_penalty,
-    _feedback_is_blocked,
-    _feedback_has_nonpositive_expected_value,
-    _feedback_bundle_sort_value,
-    _feedback_family_template_id,
-    _feedback_execution_signature,
-    _feedback_shape_key,
-    _feedback_risk_profile_key_from_scorecard,
-    _feedback_risk_profile_key,
-)
-
-from scripts.whitepaper_autoresearch_runner.candidate_prior_scoring import (
-    _pre_replay_candidate_score,
-    _candidate_spec_mechanism_overlay_ids,
-    _candidate_spec_required_evidence_tokens,
-    _paper_mechanism_prior_score,
-    _candidate_spec_universe_key,
-    _candidate_spec_signal_key,
-    _candidate_spec_is_false_negative_rescue,
-    _candidate_spec_is_loss_adaptive_feedback_escape,
-    _candidate_spec_active_loss_counter_tags,
-    _feedback_active_loss_counter_candidate_reasons,
-    _candidate_spec_matches_active_loss_counter_feedback,
-    _feedback_consistency_repair_candidate_reasons,
-    _candidate_spec_matches_consistency_repair_feedback,
-    _active_loss_counter_proposal_score,
-    _consistency_repair_proposal_score,
-    _scorecard_is_false_negative_rescue_feedback,
-    _candidate_spec_execution_profile,
-    _candidate_spec_feedback_risk_profile_key,
-    _candidate_spec_feedback_shape_key,
-    _candidate_spec_feedback_metadata,
-    _candidate_payload_with_feedback_metadata,
-)
-from scripts.whitepaper_autoresearch_runner.feedback_risk_profiles import (
-    _feedback_risk_profile_key_payload,
-)
-
-from scripts.whitepaper_autoresearch_runner.feedback_bundle_builders import (
-    _pre_replay_prior_bundle,
-    _execution_signature_feedback_bundle_for_spec,
-    _shape_feedback_bundle_for_spec,
-    _risk_profile_feedback_bundle_for_spec,
-    _family_feedback_bundle_for_spec,
-)
-
-from scripts.whitepaper_autoresearch_runner.proposal_building import (
-    _PRE_REPLAY_FEEDBACK_BLOCK_REASONS,
-    _PRE_REPLAY_SELECTION_BLOCK_REASONS,
-    _pre_replay_proposal_model_and_rows,
-    _proposal_score_confidence,
-    _selection_reason_blocks_replay,
-)
-from scripts.whitepaper_autoresearch_runner.candidate_identity import (
-    _candidate_spec_execution_signature,
-)
 
 from scripts.whitepaper_autoresearch_runner.preview_narrowing import (
-    _candidate_selection_for_direct_replay,
     _apply_fast_replay_preview_narrowing as _preview_narrowing_apply_fast_replay_preview_narrowing,
-    _resolved_fast_replay_preview_top_k,
-    _resolved_fast_replay_exact_candidate_cap,
 )
 
 from scripts.whitepaper_autoresearch_runner.queue_metadata import (
-    _fast_replay_preview_proof_semantics,
-    _fast_replay_discovery_stage_semantics,
-    _fast_replay_queue_stage_metadata,
-    _bounded_sim_target_queue_metadata,
-    _fast_replay_exact_handoff_lineage,
-    _maybe_materialize_epoch_replay_tape,
-    _auto_materialize_staged_replay_tape,
     _maybe_preflight_materialized_replay_tape_window,
-    _materialized_replay_tape_date_arg,
-    _materialized_replay_tape_source_query_digest,
-    _materialized_replay_tape_feature_schema_hash,
-    _materialized_replay_tape_cost_model_hash,
-    _materialized_replay_tape_strategy_family,
-    _fast_replay_preview_date_arg,
 )
 
 from scripts.whitepaper_autoresearch_runner.replay_models import (
     EpochReplayResult,
-    _ReplayShardPlan,
-    _ReplayShardOutcome,
 )
 
 from scripts.whitepaper_autoresearch_runner.run_arguments import (
@@ -440,19 +201,9 @@ from scripts.whitepaper_autoresearch_runner.replay_selection import (
 )
 
 from scripts.whitepaper_autoresearch_runner.replay_execution import (
-    _synthetic_net_for_spec,
-    _synthetic_symbol_contribution_shares,
-    _synthetic_candidate_payload,
     _run_synthetic_replay as _replay_execution_run_synthetic_replay,
     _run_real_replay as _replay_execution_run_real_replay,
     _real_replay_result_from_factory_payload as _replay_execution_real_replay_result_from_factory_payload,
-    _dedupe_replay_evidence,
-    _candidate_spec_id_from_experiment_result_path,
-    _collect_partial_real_replay,
-    _run_real_replay_once_with_optional_timeout,
-    _real_replay_worker,
-    _terminate_process,
-    _run_real_replay_once_in_child_process,
 )
 
 from scripts.whitepaper_autoresearch_runner.run_reporting import (
@@ -469,58 +220,9 @@ from scripts.whitepaper_autoresearch_runner.run_success_evaluation import (
 
 from scripts.whitepaper_autoresearch_runner.replay_shards import (
     _run_replay_with_optional_timeout,
-    _build_real_replay_shards,
-    _execute_real_replay_shard,
-    _failed_shard_spec_ids,
-    _evidenced_spec_ids,
-    _retry_real_replay_failed_shard_specs,
-    _replay_shard_frontier_candidate_budget,
-    _bounded_real_replay_shard_workers,
-    _bounded_real_replay_shard_timeout_seconds,
-    _run_real_replay_shards,
     _load_epoch_program,
-    _resolved_staged_train_screen_multiplier,
-    _resolved_program_family_int_arg,
-    _resolved_real_replay_frontier_controls,
-    _epoch_mlx_snapshot_manifest,
 )
 
-_DEFAULT_CHIP_UNIVERSE_CSV = ",".join(LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
-_DEFAULT_DAILY_PROFIT_TARGET = "500"
-_DEFAULT_RANKER_BACKEND_PREFERENCE = "mlx"
-_RANKER_BACKEND_CHOICES = (
-    "mlx",
-    "numpy",
-    "numpy-fallback",
-    "torch",
-    "torch-cuda",
-    "cuda",
-)
-_DEFAULT_PORTFOLIO_PROFIT_PROGRAM = Path(
-    "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
-)
-_DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
-_DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS = 900
-_DEFAULT_REAL_REPLAY_SHARD_WORKERS = 2
-_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES = 6
-_DEFAULT_FAST_REPLAY_PREVIEW_TOP_K = 48
-_DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP = 6
-_DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS = 4
-_DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS = 2
-
-_UNSAFE_NEXT_EPOCH_REMEDIATION_FLAG_MARKERS = (
-    "agentrun",
-    "agent-run",
-    "broker",
-    "fanout",
-    "kubectl",
-    "kubernetes",
-    "live-trading",
-    "promotion",
-)
-_DEFAULT_CLICKHOUSE_HTTP_URL = (
-    "http://torghut-clickhouse.torghut.svc.cluster.local:8123"
-)
 _MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES = 512
 _MAX_PERSISTED_FEEDBACK_EVIDENCE_EPOCHS = 12
 _PORTFOLIO_FEEDBACK_STATUSES = frozenset({"blocked", "paper_probation", "target_met"})
@@ -990,6 +692,4 @@ def main() -> int:
 if __name__ == "__main__":
     raise SystemExit(main())
 
-# fmt: off
-__all__ = ('Any', 'AutoresearchCandidateSpec', 'AutoresearchEpoch', 'AutoresearchPortfolioCandidate', 'AutoresearchProposalScore', 'CandidateCompilationBlocker', 'CandidateEvidenceBundle', 'CandidateSpec', 'Decimal', 'EpochReplayResult', 'FAST_REPLAY_PROOF_SEMANTICS_LABEL', 'FAST_REPLAY_WHITEPAPER_MECHANISMS', 'HypothesisCard', 'LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE', 'Mapping', 'MlxSnapshotManifest', 'POST_COST_PNL_BASIS', 'Path', 'PortfolioCandidateSpec', 'ProcessPoolExecutor', 'ProfitTargetOraclePolicy', 'RECENT_WHITEPAPER_SEEDS', 'RejectedSignalOutcomeEvent', 'ReplayTapeManifest', 'ResearchClaim', 'ResearchSource', 'RuntimeClosureExecutionContext', 'RuntimeLedgerBucket', 'Sequence', 'SessionLocal', 'StrategyAutoresearchProgram', 'UTC', 'VNextExperimentSpec', 'WhitepaperAnalysisRun', 'WhitepaperResearchSource', 'ZoneInfo', '_CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE', '_CANDIDATE_BOARD_RUNTIME_SESSION_OPEN', '_CANDIDATE_BOARD_RUNTIME_SESSION_TZ', '_CODE_COMMIT_ENV_VARS', '_DEFAULT_CHIP_UNIVERSE_CSV', '_DEFAULT_CLICKHOUSE_HTTP_URL', '_DEFAULT_DAILY_PROFIT_TARGET', '_DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP', '_DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS', '_DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS', '_DEFAULT_FAST_REPLAY_PREVIEW_TOP_K', '_DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC', '_DEFAULT_PORTFOLIO_PROFIT_PROGRAM', '_DEFAULT_RANKER_BACKEND_PREFERENCE', '_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES', '_DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS', '_DEFAULT_REAL_REPLAY_SHARD_WORKERS', '_EXACT_REPLAY_LEDGER_ARTIFACT_KIND', '_EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS', '_EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE', '_FAMILY_PRIOR_HARD_BLOCK_ORACLE_BLOCKERS', '_LOSS_ADAPTIVE_FEEDBACK_REMEDIATION_PROFILES', '_MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES', '_MAX_PERSISTED_FEEDBACK_EVIDENCE_EPOCHS', '_PAPER_EVIDENCE_REQUIREMENT_PRIOR_WEIGHTS', '_PAPER_MECHANISM_PRIOR_SCORE_CAP', '_PAPER_MECHANISM_PRIOR_WEIGHTS', '_PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS', '_PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH', '_PORTFOLIO_FEEDBACK_STATUSES', '_PRE_REPLAY_FEEDBACK_BLOCK_REASONS', '_PRE_REPLAY_SELECTION_BLOCK_REASONS', '_PROGRAM_SOURCE_DEFAULT_CONFIDENCE', '_RANKER_BACKEND_CHOICES', '_REJECTED_SIGNAL_OUTCOME_REQUIRED_FIELDS', '_REPLAY_ACTIVITY_COUNT_KEYS', '_RISK_PROFILE_FEEDBACK_ORACLE_BLOCKERS', '_RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS', '_ReplayShardOutcome', '_ReplayShardPlan', '_SECOND_OOS_WINDOW_ID', '_UNSAFE_NEXT_EPOCH_REMEDIATION_FLAG_MARKERS', '_active_loss_counter_proposal_score', '_apply_fast_replay_preview_narrowing', '_auto_materialize_staged_replay_tape', '_best_false_negative_table', '_boolish', '_bounded_real_replay_shard_timeout_seconds', '_bounded_real_replay_shard_workers', '_bounded_sim_target_queue_metadata', '_build_real_replay_shards', '_candidate_board_activity_count', '_candidate_board_best_executed_candidate', '_candidate_board_blockers', '_candidate_board_closest_promotion_candidate', '_candidate_board_date_only', '_candidate_board_decimal_field', '_candidate_board_double_oos_summary', '_candidate_board_evidence_lineage_summary', '_candidate_board_exact_replay_ledger_refs', '_candidate_board_factor_acceptance_summary', '_candidate_board_first_int_field', '_candidate_board_hypothesis_manifest_ref', '_candidate_board_int_field', '_candidate_board_lower_bound_net_pnl', '_candidate_board_market_impact_proof_summary', '_candidate_board_net_pnl', '_candidate_board_oracle_blocker_count', '_candidate_board_order_type_execution_quality_summary', '_candidate_board_paper_probation_admission_blockers', '_candidate_board_paper_probation_candidate', '_candidate_board_paper_probation_candidates', '_candidate_board_payload', '_candidate_board_portfolio_promotion_subject', '_candidate_board_predictability_decay_summary', '_candidate_board_queue_position_survival_summary', '_candidate_board_regime_specialist_summary', '_candidate_board_regular_session_bound', '_candidate_board_rejected_signal_outcome_summary', '_candidate_board_replay_window_coverage_summary', '_candidate_board_required_notional_repair_scale', '_candidate_board_runtime_import_args', '_candidate_board_runtime_ledger_lineage_handoff', '_candidate_board_runtime_ledger_required_materialized_artifacts', '_candidate_board_runtime_window_bounds', '_candidate_board_runtime_window_import_bounds', '_candidate_board_runtime_window_import_plan', '_candidate_board_score_rows', '_candidate_board_scorecard_with_evidence_blockers', '_candidate_board_scorecard_with_lineage_blockers', '_candidate_board_scorecard_with_order_type_blockers', '_candidate_board_scorecard_with_predictability_decay_blockers', '_candidate_board_scorecard_with_queue_position_survival_blockers', '_candidate_board_scorecard_with_rejected_signal_blockers', '_candidate_board_scorecard_with_replay_window_blockers', '_candidate_board_status', '_candidate_board_status_digest', '_candidate_board_target_progress_ratio', '_candidate_factor_acceptance_replay_metadata', '_candidate_family_goal_rows', '_candidate_payload_with_feedback_metadata', '_candidate_quality_gate_failures', '_candidate_search_remediation', '_candidate_selection_for_direct_replay', '_candidate_sleeve_goal_proof_handoff_fields', '_candidate_sleeve_goal_rows', '_candidate_spec_active_loss_counter_tags', '_candidate_spec_execution_profile', '_candidate_spec_execution_signature', '_candidate_spec_feedback_metadata', '_candidate_spec_feedback_risk_profile_key', '_candidate_spec_feedback_shape_key', '_candidate_spec_from_payload', '_candidate_spec_id_from_experiment_result_path', '_candidate_spec_is_false_negative_rescue', '_candidate_spec_is_loss_adaptive_feedback_escape', '_candidate_spec_matches_active_loss_counter_feedback', '_candidate_spec_matches_consistency_repair_feedback', '_candidate_spec_mechanism_overlay_ids', '_candidate_spec_required_evidence_tokens', '_candidate_spec_requires_order_type_execution_quality', '_candidate_spec_requires_predictability_decay_stress', '_candidate_spec_requires_queue_position_survival', '_candidate_spec_requires_rejected_signal_outcome_learning', '_candidate_spec_signal_key', '_candidate_spec_universe_key', '_candidate_spec_with_oracle_policy', '_candidate_specs_with_oracle_policy', '_candidate_universe_symbols_for_compilation', '_candidate_universe_symbols_from_args', '_clickhouse_endpoint_preflight_failure', '_clickhouse_host_requires_dns_preflight', '_collect_partial_real_replay', '_consistency_repair_proposal_score', '_current_code_commit', '_decimal', '_decimal_arg_or_default', '_decimal_payload', '_dedupe_feedback_evidence_bundles', '_dedupe_replay_evidence', '_dedupe_whitepaper_sources', '_default_clickhouse_http_url', '_default_strategy_config_path', '_epoch_mlx_snapshot_manifest', '_evidence_bundle_payloads_for_epoch_summary', '_evidenced_spec_ids', '_execute_real_replay_shard', '_execution_signature_feedback_bundle_for_spec', '_failed_shard_spec_ids', '_false_positive_table', '_family_feedback_bundle_for_spec', '_fast_replay_discovery_stage_semantics', '_fast_replay_exact_handoff_lineage', '_fast_replay_preview_date_arg', '_fast_replay_preview_proof_semantics', '_fast_replay_queue_stage_metadata', '_feedback_active_loss_counter_candidate_reasons', '_feedback_bundle_sort_value', '_feedback_consistency_repair_candidate_reasons', '_feedback_daily_net_has_loss', '_feedback_execution_signature', '_feedback_family_prior_has_hard_block', '_feedback_family_template_id', '_feedback_has_no_replay_activity', '_feedback_has_nonpositive_expected_value', '_feedback_has_policy_penalty', '_feedback_is_blocked', '_feedback_risk_profile_has_penalty', '_feedback_risk_profile_has_terminal_block', '_feedback_risk_profile_key', '_feedback_risk_profile_key_from_scorecard', '_feedback_risk_profile_key_payload', '_feedback_scorecard_has_hard_veto', '_feedback_shape_key', '_flag_int', '_int_arg', '_list_of_mappings', '_load_autoresearch_feedback_evidence_bundles', '_load_candidate_specs_jsonl', '_load_epoch_program', '_load_feedback_evidence_bundles', '_load_json_mapping_artifact', '_load_recent_persisted_feedback_evidence_bundles', '_load_sources_from_db', '_mapping', '_market_impact_default_source_markers', '_materialized_replay_tape_cost_model_hash', '_materialized_replay_tape_date_arg', '_materialized_replay_tape_feature_schema_hash', '_materialized_replay_tape_source_query_digest', '_materialized_replay_tape_strategy_family', '_maybe_materialize_epoch_replay_tape', '_maybe_preflight_materialized_replay_tape_window', '_oracle_blockers', '_oracle_policy_from_args', '_ordered_unique_strings', '_outcome_payload_has_complete_rejected_signal_fields', '_paper_mechanism_prior_score', '_paper_probation_candidate_payload', '_paper_probation_handoff_payload', '_parse_args', '_persist_epoch_ledgers', '_persist_vnext_specs', '_portfolio_candidate_feedback_blockers', '_portfolio_candidate_row_to_feedback_bundles', '_portfolio_executable_max_notional', '_portfolio_needs_runtime_closure_proof', '_portfolio_sleeve_feedback_metadata', '_portfolio_with_runtime_closure_proof', '_pre_replay_candidate_score', '_pre_replay_prior_bundle', '_pre_replay_proposal_model_and_rows', '_profitability_next_epoch_flags', '_profitability_next_epoch_plan', '_profitability_search_goal', '_profitability_system_change_backlog', '_program_claim_type', '_program_research_source_to_whitepaper_source', '_program_whitepaper_sources', '_promotion_readiness_payload', '_proposal_model_and_rows', '_proposal_score_confidence', '_proposal_sort_value', '_rank_sort_value', '_ranker_backend_preference', '_real_replay_result_from_factory_payload', '_real_replay_worker', '_recent_trading_days_shortfall', '_rejected_signal_outcome_payload_to_feedback_bundle', '_replay_diagnostic_proposal_rows', '_replay_shard_frontier_candidate_budget', '_resolve_existing_path', '_resolved_clickhouse_password', '_resolved_fast_replay_exact_candidate_cap', '_resolved_fast_replay_preview_top_k', '_resolved_program_family_int_arg', '_resolved_real_replay_frontier_controls', '_resolved_staged_train_screen_multiplier', '_retry_real_replay_failed_shard_specs', '_risk_adjusted_drawdown_passes', '_risk_profile_feedback_bundle_for_spec', '_run_real_replay', '_run_real_replay_once_in_child_process', '_run_real_replay_once_with_optional_timeout', '_run_real_replay_shards', '_run_replay_with_optional_timeout', '_run_synthetic_replay', '_runtime_closure_artifact_refs', '_runtime_closure_delay_adjusted_depth_stress_update', '_runtime_closure_double_oos_update', '_runtime_closure_exact_replay_bucket', '_runtime_closure_exact_replay_bucket_range', '_runtime_closure_exact_replay_ledger_update', '_runtime_closure_ledger_datetime', '_runtime_closure_market_impact_stress_update', '_runtime_closure_payload', '_runtime_closure_pending_promotion_steps', '_runtime_closure_program_for_candidate', '_runtime_closure_promotion_prerequisite_blockers', '_runtime_closure_replay_bucket_has_authority', '_runtime_closure_scorecard_update', '_runtime_closure_start_equity', '_runtime_report_int', '_runtime_report_source_markers', '_runtime_report_summary_int', '_scorecard_is_false_negative_rescue_feedback', '_scorecard_profit_factor', '_scorecard_start_equity', '_scorecard_total_net_pnl', '_select_candidate_specs_for_replay', '_selected_candidate_spec_ids', '_selection_reason_blocks_replay', '_sequence_of_mappings', '_shape_feedback_bundle_for_spec', '_stable_hash', '_stale_tape_diagnostics', '_string', '_string_list_from_value', '_summary_scorecard_feedback_bundles_for_epoch', '_synthetic_candidate_payload', '_synthetic_net_for_spec', '_synthetic_symbol_contribution_shares', '_terminate_process', '_unsafe_next_epoch_remediation_flag', '_write_failure_summary', '_write_json', '_write_jsonl', 'argparse', 'as_completed', 'build_factor_acceptance_artifact_from_scorecard', 'build_fast_replay_preview', 'build_mlx_snapshot_manifest', 'build_mlx_training_rows', 'build_runtime_ledger_buckets', 'build_source_query_digest', 'candidate_spec_capital_features', 'candidate_spec_from_payload', 'candidate_spec_id_for_payload', 'capital_budget_penalty', 'cast', 'compile_sources_to_hypothesis_cards', 'compile_whitepaper_candidate_specs', 'dataclass', 'date', 'datetime', 'deployable_lower_bound_missing_count', 'deployable_lower_bound_net_pnl_per_day', 'deployable_proof_failed_gate_count', 'evaluate_profit_target_oracle', 'evidence_bundle_blockers', 'evidence_bundle_from_frontier_candidate', 'evidence_bundle_from_payload', 'hashlib', 'json', 'load_replay_tape', 'load_strategy_autoresearch_program', 'main', 'materialize_signal_tape', 'monotonic_time', 'multiprocessing', 'optimize_portfolio_candidate', 'os', 'queue', 'rank_training_rows', 'rank_training_rows_with_lift_policy', 'replace', 'replay_materializer', 'replay_mod', 'run_id', 'run_whitepaper_autoresearch_profit_target', 'select', 'signal', 'slice_tape_by_symbols', 'slice_tape_by_window', 'socket', 'sources_from_jsonl', 'strategy_factory_runner', 'subprocess', 'time', 'timedelta', 'train_mlx_ranker', 'urlparse', 'validate_tape_freshness', 'write_mlx_snapshot_manifest', 'write_runtime_closure_bundle', 'write_whitepaper_autoresearch_diagnostics_notebook')
-# fmt: on
+__all__ = ("main", "run_whitepaper_autoresearch_profit_target")

--- a/services/torghut/tests/autoresearch_runner/helpers.py
+++ b/services/torghut/tests/autoresearch_runner/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import app.whitepapers.claim_compiler as claim_compiler
+
 import json
 from argparse import Namespace
 from contextlib import contextmanager
@@ -11,12 +13,17 @@ from unittest.mock import patch
 from sqlalchemy import create_engine
 
 import scripts.run_whitepaper_autoresearch_profit_target as runner
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
 from app.models import (
     Base,
 )
+from app.trading.discovery.candidate_specs import (
+    CandidateSpec,
+    LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE,
+)
 
 
-_CHIP_UNIVERSE = list(runner.LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
+_CHIP_UNIVERSE = list(LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
 
 
 class _FakeSigalrmSignal:
@@ -148,8 +155,10 @@ def _source_jsonl_payload() -> dict[str, object]:
     }
 
 
-def _source_from_payload(payload: dict[str, object]) -> runner.WhitepaperResearchSource:
-    return runner.WhitepaperResearchSource(
+def _source_from_payload(
+    payload: dict[str, object],
+) -> claim_compiler.WhitepaperResearchSource:
+    return claim_compiler.WhitepaperResearchSource(
         run_id=str(payload["run_id"]),
         title=str(payload["title"]),
         source_url=str(payload["source_url"]),
@@ -169,7 +178,7 @@ def _source_from_payload(payload: dict[str, object]) -> runner.WhitepaperResearc
 def _compact_recent_whitepaper_sources(
     source_count: int = 4,
 ) -> Any:
-    sources: list[runner.WhitepaperResearchSource] = []
+    sources: list[claim_compiler.WhitepaperResearchSource] = []
     for index in range(source_count):
         payload = _source_jsonl_payload()
         payload["run_id"] = f"compact-seed-2026-{index}"
@@ -227,7 +236,7 @@ class AutoresearchRunnerTestCase(TestCase):
             chunk_minutes=10,
             symbols=",".join(_CHIP_UNIVERSE),
             progress_log_seconds=30,
-            max_frontier_candidates_per_spec=runner._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
+            max_frontier_candidates_per_spec=cli_parsing._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
             max_total_frontier_candidates=0,
             staged_train_screen_multiplier=0,
             capture_rejected_seed_full_window_ledger=False,
@@ -241,9 +250,9 @@ class AutoresearchRunnerTestCase(TestCase):
             consistency_repair_candidates=0,
             real_replay_timeout_seconds=0,
             real_replay_shard_size=0,
-            real_replay_shard_timeout_seconds=runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
-            real_replay_shard_workers=runner._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
-            real_replay_max_parallel_frontier_candidates=runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+            real_replay_shard_timeout_seconds=cli_parsing._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            real_replay_shard_workers=cli_parsing._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+            real_replay_max_parallel_frontier_candidates=cli_parsing._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
             real_replay_failed_spec_retries=1,
             real_replay_retry_timeout_seconds=0,
             real_replay_retry_max_frontier_candidates_per_spec=1,
@@ -258,9 +267,9 @@ class AutoresearchRunnerTestCase(TestCase):
             replay_tape_manifest=None,
             replay_tape_preview_top_k=0,
             replay_tape_preview_min_rows=2,
-            replay_tape_exact_candidate_cap=runner._DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
-            replay_tape_frontier_exploitation_slots=runner._DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS,
-            replay_tape_frontier_exploration_slots=runner._DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS,
+            replay_tape_exact_candidate_cap=cli_parsing._DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+            replay_tape_frontier_exploitation_slots=cli_parsing._DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS,
+            replay_tape_frontier_exploration_slots=cli_parsing._DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS,
             materialize_replay_tape=False,
             coverage_diagnostic_output=None,
             latest_complete_window_min_days=0,
@@ -322,8 +331,8 @@ class AutoresearchRunnerTestCase(TestCase):
         family_template_id: str = "microbar_cross_sectional_pairs_v1",
         entry_minute_after_open: str = "45",
         selection_mode: str = "reversal",
-    ) -> runner.CandidateSpec:
-        return runner.CandidateSpec(
+    ) -> CandidateSpec:
+        return CandidateSpec(
             schema_version="torghut.candidate-spec.v1",
             candidate_spec_id=candidate_spec_id,
             hypothesis_id=f"hyp-{candidate_spec_id}",

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_evidence.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_evidence.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+import scripts.whitepaper_autoresearch_runner.candidate_goal_metadata as candidate_goal_metadata
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.feedback_bundle_builders as feedback_bundle_builders
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+
 from dataclasses import replace
 from decimal import Decimal
 from pathlib import Path
@@ -34,7 +41,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
                 "mechanism_overlay_ids": ["rankic_factor_acceptance_harness"]
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-factor-acceptance",
             candidate_id="candidate-factor-acceptance",
@@ -177,11 +184,11 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
         )
 
         self.assertGreater(
-            runner._pre_replay_candidate_score(paper_spec),
-            runner._pre_replay_candidate_score(control_spec),
+            candidate_prior_scoring._pre_replay_candidate_score(paper_spec),
+            candidate_prior_scoring._pre_replay_candidate_score(control_spec),
         )
 
-        prior_bundle = runner._pre_replay_prior_bundle(paper_spec)
+        prior_bundle = feedback_bundle_builders._pre_replay_prior_bundle(paper_spec)
         self.assertFalse(prior_bundle.promotion_readiness["promotable"])
         self.assertIn(
             "runtime_replay_required", prior_bundle.promotion_readiness["blockers"]
@@ -191,7 +198,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             prior_bundle.promotion_readiness["blockers"],
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(control_spec, paper_spec),
         )
         row_by_spec = {row["candidate_spec_id"]: row for row in rows}
@@ -297,7 +304,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
                 ]
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-test",
             candidate_id="candidate-test",
@@ -494,7 +501,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
                 "requires_market_limit_order_mix": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-sleeve-order-type-proof",
             candidate_id="cand-sleeve-order-type-proof",
@@ -554,7 +561,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             ]
         }
 
-        rows = runner._candidate_sleeve_goal_rows(
+        rows = candidate_goal_metadata._candidate_sleeve_goal_rows(
             candidate_specs=(spec,),
             candidate_selection=candidate_selection,
             evidence_bundles=(evidence,),
@@ -603,7 +610,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
         self.assertEqual(rows[0]["exact_replay_ledger_artifact_row_count"], 30)
         self.assertEqual(rows[0]["exact_replay_ledger_artifact_fill_count"], 10)
         self.assertEqual(rows[0]["runtime_window_start"], "2026-05-18T13:30:00+00:00")
-        fallback_rows = runner._candidate_sleeve_goal_rows(
+        fallback_rows = candidate_goal_metadata._candidate_sleeve_goal_rows(
             candidate_specs=(spec,),
             candidate_selection={
                 "rows": [
@@ -630,7 +637,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
         self.assertIn("route_tca", fallback_rows[0]["paper_required_evidence_tokens"])
         self.assertGreater(fallback_rows[0]["paper_required_evidence_count"], 0)
 
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-sleeve-order-type-proof",
             source_candidate_ids=(evidence.candidate_id,),
@@ -649,7 +656,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             objective_scorecard={"target_met": True, "oracle_passed": True},
             optimizer_report={},
         )
-        portfolio_rows = runner._candidate_sleeve_goal_rows(
+        portfolio_rows = candidate_goal_metadata._candidate_sleeve_goal_rows(
             candidate_specs=(spec,),
             candidate_selection=candidate_selection,
             evidence_bundles=(evidence,),
@@ -680,7 +687,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
         self,
     ) -> None:
         spec = self._candidate_spec("spec-portfolio-promotion-subject")
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-portfolio-promotion-subject",
             candidate_id="cand-portfolio-promotion-subject",
@@ -700,7 +707,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             null_comparator={},
             promotion_readiness={},
         )
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-promotion-subject",
             source_candidate_ids=(evidence.candidate_id,),
@@ -794,7 +801,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             },
             promotion_contract={"requires_rejected_signal_outcome_learning": True},
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-rejected-signal-proof",
             candidate_id="cand-rejected-signal-proof",

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_paper_probation.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_paper_probation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+
 from dataclasses import replace
 import json
 from decimal import Decimal
@@ -17,7 +19,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
         self,
     ) -> None:
         spec = self._candidate_spec("spec-paper-probation")
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-paper-probation",
             candidate_id="cand-paper-probation",
@@ -446,7 +448,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
         close_spec = self._candidate_spec("spec-close-probation")
         bridge_spec = self._candidate_spec("spec-bridge-probation")
         raw_only_spec = self._candidate_spec("spec-raw-only-probation")
-        weak_evidence = runner.CandidateEvidenceBundle(
+        weak_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-weak-probation",
             candidate_id="cand-weak-probation",
@@ -501,7 +503,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
             null_comparator={},
             promotion_readiness={},
         )
-        close_evidence = runner.CandidateEvidenceBundle(
+        close_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-close-probation",
             candidate_id="cand-close-probation",
@@ -573,7 +575,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
             null_comparator={},
             promotion_readiness={},
         )
-        raw_only_evidence = runner.CandidateEvidenceBundle(
+        raw_only_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-raw-only-probation",
             candidate_id="cand-raw-only-probation",

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_rejects_unknown_code_commit_lineage.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_rejects_unknown_code_commit_lineage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+
 from dataclasses import replace
 from decimal import Decimal
 from pathlib import Path
@@ -14,7 +16,7 @@ from tests.autoresearch_runner.helpers import (
 class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCase):
     def test_candidate_board_rejects_unknown_code_commit_lineage(self) -> None:
         spec = self._candidate_spec("spec-unknown-lineage")
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-unknown-lineage",
             candidate_id="cand-unknown-lineage",
@@ -98,7 +100,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-proof",
             candidate_id="cand-market-limit-proof",
@@ -187,7 +189,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-pass",
             candidate_id="cand-market-limit-pass",
@@ -289,7 +291,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
                 "requires_order_lifecycle_fill_evidence": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-queue-survival-proof",
             candidate_id="cand-queue-survival-proof",
@@ -423,7 +425,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-missing-artifact-ref",
             candidate_id="cand-market-limit-missing-artifact-ref",
@@ -519,7 +521,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-route-bool",
             candidate_id="cand-market-limit-route-bool",
@@ -602,7 +604,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-route-artifact",
             candidate_id="cand-market-limit-route-artifact",
@@ -672,7 +674,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             "spec-hmicro-proof",
             family_template_id="microstructure_continuation_matched_filter_v1",
         )
-        executed_evidence = runner.CandidateEvidenceBundle(
+        executed_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-hmicro-proof",
             candidate_id="chip-paper-microbar-composite@execution-proof",
@@ -823,7 +825,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
                 "requires_spread_adjusted_label_replay": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-alpha-decay-missing-stress",
             candidate_id="cand-alpha-decay-missing-stress",

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.proposal_training as proposal_training
+
 from dataclasses import replace
 import json
 from argparse import Namespace
@@ -161,7 +164,7 @@ class TestCandidateBoardRuntimeWindowPlanDedupesAndBlocksIncompleteTargets(
     def test_candidate_universe_symbols_default_to_chip_coverage_when_empty(
         self,
     ) -> None:
-        symbols = runner._candidate_universe_symbols_from_args(
+        symbols = artifact_io._candidate_universe_symbols_from_args(
             Namespace(symbols="MSFT,SHOP")
         )
 
@@ -288,7 +291,7 @@ class TestCandidateBoardRuntimeWindowPlanDedupesAndBlocksIncompleteTargets(
         )
 
     def test_best_false_negative_table_excludes_pre_replay_blocked_specs(self) -> None:
-        table = runner._best_false_negative_table(
+        table = proposal_training._best_false_negative_table(
             candidate_selection={
                 "rows": [
                     {

--- a/services/torghut/tests/autoresearch_runner/test_candidate_selection.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_selection.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+
 from dataclasses import replace
 from decimal import Decimal
 from typing import Any, cast
@@ -18,29 +22,31 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             "spec-family-negative-mutated",
             entry_minute_after_open="60",
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-family-negative-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "-250",
-                    "active_day_ratio": "1",
-                    "positive_day_ratio": "0",
-                    "negative_day_count": 4,
-                    "daily_net": {
-                        "2026-05-01": "-150",
-                        "2026-05-04": "-350",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-family-negative-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "-250",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "0",
+                        "negative_day_count": 4,
+                        "daily_net": {
+                            "2026-05-01": "-150",
+                            "2026-05-04": "-350",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-family-negative-feedback",
-            result_path="feedback://family-negative",
+                dataset_snapshot_id="snap-family-negative-feedback",
+                result_path="feedback://family-negative",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(mutated_family_spec,),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )
@@ -94,34 +100,36 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
                 "params": adaptive_params,
             },
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-active-loss-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "-50",
-                    "active_day_ratio": "0.67",
-                    "positive_day_ratio": "0",
-                    "negative_day_count": 2,
-                    "decision_count": 4,
-                    "filled_count": 4,
-                    "avg_filled_notional_per_day": "40000",
-                    "worst_day_loss": "90",
-                    "max_drawdown": "130",
-                    "daily_net": {
-                        "2026-05-06": "-40",
-                        "2026-05-07": "-90",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-active-loss-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "-50",
+                        "active_day_ratio": "0.67",
+                        "positive_day_ratio": "0",
+                        "negative_day_count": 2,
+                        "decision_count": 4,
+                        "filled_count": 4,
+                        "avg_filled_notional_per_day": "40000",
+                        "worst_day_loss": "90",
+                        "max_drawdown": "130",
+                        "daily_net": {
+                            "2026-05-06": "-40",
+                            "2026-05-07": "-90",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-active-loss-feedback",
-            result_path="feedback://active-loss",
+                dataset_snapshot_id="snap-active-loss-feedback",
+                result_path="feedback://active-loss",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(adaptive_spec,),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )
@@ -174,37 +182,39 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
                 "params": repair_params,
             },
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-consistency-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "900",
-                    "active_day_ratio": "0.40",
-                    "positive_day_ratio": "0.20",
-                    "negative_day_count": 0,
-                    "decision_count": 5,
-                    "filled_count": 5,
-                    "avg_filled_notional_per_day": "350000",
-                    "best_day_share": "0.84",
-                    "max_cluster_contribution_share": "0.70",
-                    "worst_day_loss": "0",
-                    "max_drawdown": "0",
-                    "min_daily_net_pnl": "0",
-                    "daily_net": {
-                        "2026-05-06": "4500",
-                        "2026-05-07": "0",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-consistency-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "900",
+                        "active_day_ratio": "0.40",
+                        "positive_day_ratio": "0.20",
+                        "negative_day_count": 0,
+                        "decision_count": 5,
+                        "filled_count": 5,
+                        "avg_filled_notional_per_day": "350000",
+                        "best_day_share": "0.84",
+                        "max_cluster_contribution_share": "0.70",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "min_daily_net_pnl": "0",
+                        "daily_net": {
+                            "2026-05-06": "4500",
+                            "2026-05-07": "0",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-consistency-feedback",
-            result_path="feedback://consistency",
+                dataset_snapshot_id="snap-consistency-feedback",
+                result_path="feedback://consistency",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(repair_spec,),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )
@@ -281,34 +291,36 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
                 "params": adverse_params,
             },
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-active-loss-score-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "-50",
-                    "active_day_ratio": "0.50",
-                    "positive_day_ratio": "0",
-                    "negative_day_count": 2,
-                    "decision_count": 4,
-                    "filled_count": 4,
-                    "avg_filled_notional_per_day": "40000",
-                    "worst_day_loss": "90",
-                    "max_drawdown": "130",
-                    "daily_net": {
-                        "2026-05-06": "-40",
-                        "2026-05-07": "-90",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-active-loss-score-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "-50",
+                        "active_day_ratio": "0.50",
+                        "positive_day_ratio": "0",
+                        "negative_day_count": 2,
+                        "decision_count": 4,
+                        "filled_count": 4,
+                        "avg_filled_notional_per_day": "40000",
+                        "worst_day_loss": "90",
+                        "max_drawdown": "130",
+                        "daily_net": {
+                            "2026-05-06": "-40",
+                            "2026-05-07": "-90",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-active-loss-score-feedback",
-            result_path="feedback://active-loss-score",
+                dataset_snapshot_id="snap-active-loss-score-feedback",
+                result_path="feedback://active-loss-score",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(daily_spec, adverse_spec),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )
@@ -449,7 +461,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
         self,
     ) -> None:
         spec = self._candidate_spec("spec-no-activity-feedback")
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-no-activity-feedback",
@@ -470,7 +482,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             result_path="feedback://no-activity",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -550,9 +562,9 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
                 },
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=source_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=source_spec,
                 candidate={
                     "candidate_id": "cand-fn-rescue-negative-source",
@@ -572,7 +584,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             result_path="feedback://fn-rescue-negative",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(probe_spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -625,7 +637,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
                 "max_position_pct_equity": "4",
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=source_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-reaudit-source",
@@ -644,7 +656,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             result_path="feedback://reaudit",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(blocked_spec, capital_unsafe_spec),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -730,7 +742,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
         self,
     ) -> None:
         spec = self._candidate_spec("spec-positive-blocked-feedback")
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-positive-blocked-feedback",
@@ -754,7 +766,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             result_path="feedback://positive-blocked",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )

--- a/services/torghut/tests/autoresearch_runner/test_candidate_selection_keeps_positive_signature_feedback_repair_candidates.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_selection_keeps_positive_signature_feedback_repair_candidates.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.feedback_blocking_rules as feedback_blocking_rules
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+
 from dataclasses import replace
 from decimal import Decimal
 from pathlib import Path
@@ -22,14 +28,14 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
     ) -> None:
         source_spec = self._candidate_spec("spec-positive-signature-source")
         matching_spec = self._candidate_spec("spec-positive-signature-match")
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=source_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-positive-signature-source",
                 "family_template_id": source_spec.family_template_id,
                 "runtime_family": source_spec.runtime_family,
                 "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "execution_signature": runner._candidate_spec_execution_signature(
+                "execution_signature": candidate_identity._candidate_spec_execution_signature(
                     source_spec
                 ),
                 "objective_scorecard": {
@@ -47,7 +53,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
             result_path="feedback://positive-signature",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(matching_spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -89,9 +95,9 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
                 },
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=failed_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=failed_spec,
                 candidate={
                     "candidate_id": "cand-terminal-risk-feedback",
@@ -115,7 +121,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
             result_path="feedback://terminal-risk",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(matching_risk_probe,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -147,7 +153,9 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
         )
 
     def test_terminal_risk_profile_block_covers_capital_paths(self) -> None:
-        self.assertFalse(runner._feedback_risk_profile_has_terminal_block({}))
+        self.assertFalse(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block({})
+        )
 
         penalty_scorecard = {
             "profit_target_oracle": {
@@ -159,7 +167,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
             "best_day_share": "0.25",
         }
         self.assertTrue(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **penalty_scorecard,
                     "max_gross_exposure_pct_equity": "1.01",
@@ -167,7 +175,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
             )
         )
         self.assertTrue(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **penalty_scorecard,
                     "min_cash": "-0.01",
@@ -175,7 +183,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
             )
         )
         self.assertTrue(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **penalty_scorecard,
                     "negative_cash_observation_count": "1",

--- a/services/torghut/tests/autoresearch_runner/test_candidate_sleeve_goal_proof_handoff_surfaces_runtime_ledger_materialization.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_sleeve_goal_proof_handoff_surfaces_runtime_ledger_materialization.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.candidate_goal_metadata as candidate_goal_metadata
+
 import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
@@ -20,7 +23,7 @@ class TestCandidateSleeveGoalProofHandoffSurfacesRuntimeLedgerMaterialization(
             "zero_authoritative_daily_pnl_until_materialized": True,
             "required_artifacts": "runtime-ledger/daily-pnl.json",
         }
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-sleeve-runtime-ledger-handoff",
             candidate_id="cand-sleeve-runtime-ledger-handoff",
@@ -41,12 +44,14 @@ class TestCandidateSleeveGoalProofHandoffSurfacesRuntimeLedgerMaterialization(
             },
         )
 
-        proof_handoff = runner._candidate_sleeve_goal_proof_handoff_fields(
-            selection={"selected_for_replay": True},
-            spec=spec,
-            scorecard=evidence.objective_scorecard,
-            evidence=evidence,
-            selected_for_replay=True,
+        proof_handoff = (
+            candidate_goal_metadata._candidate_sleeve_goal_proof_handoff_fields(
+                selection={"selected_for_replay": True},
+                spec=spec,
+                scorecard=evidence.objective_scorecard,
+                evidence=evidence,
+                selected_for_replay=True,
+            )
         )
 
         self.assertEqual(
@@ -101,14 +106,16 @@ class TestCandidateSleeveGoalProofHandoffSurfacesRuntimeLedgerMaterialization(
                 {"ref": "runtime-ledger/scorecard-ref.json"}
             ],
         }
-        scorecard_proof_handoff = runner._candidate_sleeve_goal_proof_handoff_fields(
-            selection={},
-            spec=None,
-            scorecard={
-                "runtime_ledger_lineage_materialization_handoff": scorecard_handoff
-            },
-            evidence=None,
-            selected_for_replay=False,
+        scorecard_proof_handoff = (
+            candidate_goal_metadata._candidate_sleeve_goal_proof_handoff_fields(
+                selection={},
+                spec=None,
+                scorecard={
+                    "runtime_ledger_lineage_materialization_handoff": scorecard_handoff
+                },
+                evidence=None,
+                selected_for_replay=False,
+            )
         )
         self.assertEqual(
             scorecard_proof_handoff["runtime_ledger_lineage_materialization_handoff"],

--- a/services/torghut/tests/autoresearch_runner/test_cli_preflight_sources.py
+++ b/services/torghut/tests/autoresearch_runner/test_cli_preflight_sources.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import socket
+
 import json
 import sys
 from argparse import Namespace
@@ -104,8 +109,8 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
         )
 
         with patch(
-            "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
-            side_effect=runner.socket.gaierror("not known"),
+            "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
+            side_effect=socket.gaierror("not known"),
         ):
             failure = runner._clickhouse_endpoint_preflight_failure(args)
 
@@ -121,7 +126,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
         )
 
         with patch(
-            "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
+            "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("non-cluster endpoints are replay-checked"),
         ):
             failure = runner._clickhouse_endpoint_preflight_failure(args)
@@ -137,7 +142,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
         )
 
         with patch(
-            "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
+            "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("replay tape should bypass DNS preflight"),
         ):
             failure = runner._clickhouse_endpoint_preflight_failure(args)
@@ -587,14 +592,14 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
                     side_effect=AssertionError("selection-only must not persist specs"),
                 ) as persist_mock,
                 patch.object(
-                    runner,
+                    persisted_feedback_sources,
                     "_persist_epoch_ledgers",
                     side_effect=AssertionError(
                         "selection-only must not persist epoch ledgers"
                     ),
                 ) as ledger_mock,
                 patch.object(
-                    runner,
+                    portfolio_optimizer,
                     "optimize_portfolio_candidate",
                     side_effect=AssertionError(
                         "selection-only must not optimize a portfolio"
@@ -691,7 +696,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
         self.assertEqual(exit_code, 0)
 
     def test_candidate_universe_symbols_filter_to_live_chip_coverage(self) -> None:
-        symbols = runner._candidate_universe_symbols_from_args(
+        symbols = artifact_io._candidate_universe_symbols_from_args(
             Namespace(symbols="NVDA,AAPL,MSFT,AMAT,TSM,nvda")
         )
 

--- a/services/torghut/tests/autoresearch_runner/test_compiled_program_research_sources_have_no_missing_feature_aliases.py
+++ b/services/torghut/tests/autoresearch_runner/test_compiled_program_research_sources_have_no_missing_feature_aliases.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import scripts.whitepaper_autoresearch_runner.next_epoch_planning as next_epoch_planning
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
+
 import json
 from argparse import Namespace
 from decimal import Decimal
@@ -290,7 +294,9 @@ class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            sources = runner._load_sources_from_db(["paper-completed", "paper-running"])
+            sources = persisted_feedback_sources._load_sources_from_db(
+                ["paper-completed", "paper-running"]
+            )
 
         self.assertEqual([source.run_id for source in sources], ["paper-completed"])
 
@@ -359,7 +365,7 @@ class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
         self.assertEqual(parsed.symbols, ",".join(_CHIP_UNIVERSE))
         self.assertEqual(
             parsed.max_frontier_candidates_per_spec,
-            runner._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
+            cli_parsing._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
         )
         self.assertEqual(parsed.max_total_frontier_candidates, 7)
         self.assertEqual(parsed.staged_train_screen_multiplier, 4)
@@ -375,15 +381,15 @@ class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
         self.assertEqual(parsed.real_replay_shard_size, 0)
         self.assertEqual(
             parsed.real_replay_shard_timeout_seconds,
-            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            cli_parsing._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
         self.assertEqual(
             parsed.real_replay_shard_workers,
-            runner._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+            cli_parsing._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
         )
         self.assertEqual(
             parsed.real_replay_max_parallel_frontier_candidates,
-            runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+            cli_parsing._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
         )
         self.assertEqual(parsed.replay_tape_path, Path(tmpdir) / "tape.jsonl")
         self.assertEqual(
@@ -405,7 +411,7 @@ class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
         self.assertFalse(parsed.persist_results)
 
     def test_decimal_arg_or_default_uses_explicit_cli_override(self) -> None:
-        value = runner._decimal_arg_or_default(
+        value = next_epoch_planning._decimal_arg_or_default(
             Namespace(min_daily_net_pnl="-125.50"),
             "min_daily_net_pnl",
             Decimal("-350"),

--- a/services/torghut/tests/autoresearch_runner/test_epoch_persistence_remediation.py
+++ b/services/torghut/tests/autoresearch_runner/test_epoch_persistence_remediation.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.whitepaper_autoresearch_runner.candidate_remediation as candidate_remediation
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+
 from dataclasses import replace
 import json
 from argparse import Namespace
@@ -134,7 +140,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
     def test_epoch_ledgers_allow_repeated_candidate_specs_across_epochs(
         self,
     ) -> None:
-        candidate_spec = runner.CandidateSpec(
+        candidate_spec = CandidateSpec(
             schema_version="torghut.candidate-spec.v1",
             candidate_spec_id="spec-repeatable",
             hypothesis_id="hyp-repeatable",
@@ -158,7 +164,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
             side_effect=lambda: Session(self.engine),
         ):
             for epoch_id in ("epoch-repeat-1", "epoch-repeat-2"):
-                runner._persist_epoch_ledgers(
+                persisted_feedback_sources._persist_epoch_ledgers(
                     epoch_id=epoch_id,
                     status="no_profit_target_candidate",
                     target_net_pnl_per_day=Decimal("300"),
@@ -195,7 +201,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
     def test_epoch_ledgers_persist_promotion_ready_only_from_readiness_payload(
         self,
     ) -> None:
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-readiness-test",
             source_candidate_ids=("candidate-test",),
@@ -215,7 +221,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-readiness-blocked",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -235,7 +241,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
                 started_at=started_at,
                 completed_at=completed_at,
             )
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-readiness-ready",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -285,7 +291,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
     def test_epoch_ledgers_persist_target_met_oracle_failed_as_paper_probation(
         self,
     ) -> None:
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-paper-probation",
             source_candidate_ids=("candidate-test",),
@@ -305,7 +311,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-paper-probation",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -344,7 +350,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
     def test_epoch_ledgers_keep_target_met_oracle_failed_blocked_without_paper_probation_authority(
         self,
     ) -> None:
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-paper-probation-blocked",
             source_candidate_ids=("candidate-test",),
@@ -364,7 +370,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-paper-probation-blocked",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -502,7 +508,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
                 "_collect_partial_real_replay",
                 return_value=runner.EpochReplayResult(
                     evidence_bundles=(
-                        runner.evidence_bundle_from_frontier_candidate(
+                        evidence_bundles.evidence_bundle_from_frontier_candidate(
                             candidate_spec_id="spec-partial",
                             candidate={
                                 "candidate_id": "cand-partial",
@@ -560,7 +566,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
         self.assertIn("candidate_search_remediation", summary)
 
     def test_timeout_remediation_recommends_smaller_replay_frontier(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="TimeoutError:real_replay_timeout_seconds:3600",
             candidate_selection={
                 "rows": [
@@ -591,7 +597,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
         )
 
     def test_remediation_surfaces_recent_trading_day_shortfall(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="ValueError:insufficient_recent_trading_days:9<11",
             candidate_selection={
                 "rows": [
@@ -660,7 +666,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
         )
 
     def test_remediation_surfaces_stale_tape_shortfall(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason=(
                 "ValueError:stale_tape:"
                 "expected_last_trading_day=2026-05-19:end_day=2026-05-18"
@@ -701,7 +707,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
         self.assertIn("2026-05-18", stale_action["diagnostic_replay_note"])
 
     def test_remediation_prioritizes_missing_promotion_proof(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {"compiled_candidate_count": "not-an-int"},
@@ -765,7 +771,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
         )
 
     def test_remediation_defers_promotion_proof_until_profit_gates_pass(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_candidate_failed_profit_target_oracle",
             candidate_selection={
                 "rows": [
@@ -821,7 +827,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
         self.assertEqual(proof_action["priority"], 7)
 
     def test_remediation_increases_breadth_from_current_epoch(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "rows": [

--- a/services/torghut/tests/autoresearch_runner/test_feedback_evidence.py
+++ b/services/torghut/tests/autoresearch_runner/test_feedback_evidence.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.mlx_training_data as mlx_training_data
+import app.trading.discovery.profit_target_oracle as profit_target_oracle
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.feedback_loading as feedback_loading
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.rejected_signal_feedback as rejected_signal_feedback
+
 from dataclasses import replace
 import json
 from datetime import datetime
@@ -32,8 +41,8 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             self._candidate_spec("spec-low"),
             self._candidate_spec("spec-high"),
         ]
-        evidence_bundles = [
-            runner.evidence_bundle_from_frontier_candidate(
+        candidate_evidence_bundles = [
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=specs[0].candidate_spec_id,
                 candidate={
                     "candidate_id": "candidate-low",
@@ -42,7 +51,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
                 dataset_snapshot_id="snapshot",
                 result_path="/tmp/low.json",
             ),
-            runner.evidence_bundle_from_frontier_candidate(
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=specs[1].candidate_spec_id,
                 candidate={
                     "candidate_id": "candidate-high",
@@ -53,7 +62,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             ),
         ]
         captured_backend_preferences: list[str] = []
-        real_train_mlx_ranker = runner.train_mlx_ranker
+        real_train_mlx_ranker = mlx_training_data.train_mlx_ranker
 
         def capture_train_mlx_ranker(rows: Sequence[Any], **kwargs: Any) -> Any:
             captured_backend_preferences.append(str(kwargs.get("backend_preference")))
@@ -75,15 +84,15 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
                 side_effect=capture_train_mlx_ranker,
             ),
         ):
-            runner._pre_replay_proposal_model_and_rows(
+            proposal_building._pre_replay_proposal_model_and_rows(
                 specs=specs,
                 feedback_evidence_bundles=(),
-                oracle_policy=runner.ProfitTargetOraclePolicy(),
+                oracle_policy=profit_target_oracle.ProfitTargetOraclePolicy(),
                 ranker_backend_preference="torch-cuda",
             )
-            runner._proposal_model_and_rows(
+            proposal_training._proposal_model_and_rows(
                 specs=specs,
-                evidence_bundles=evidence_bundles,
+                evidence_bundles=candidate_evidence_bundles,
                 replay_selection_by_spec=None,
                 ranker_backend_preference="cuda",
             )
@@ -125,7 +134,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             },
         )
 
-        candidate = runner._candidate_payload_with_feedback_metadata(
+        candidate = candidate_prior_scoring._candidate_payload_with_feedback_metadata(
             spec=spec,
             candidate={
                 "candidate_id": "candidate-prevclose",
@@ -177,7 +186,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             },
         )
 
-        candidate = runner._candidate_payload_with_feedback_metadata(
+        candidate = candidate_prior_scoring._candidate_payload_with_feedback_metadata(
             spec=spec,
             candidate={
                 "candidate_id": "candidate-validation-contract",
@@ -190,7 +199,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
                 },
             },
         )
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate=candidate,
             dataset_snapshot_id="historical-market-replay-2026-05-18",
@@ -236,7 +245,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
                 "synthetic_evidence_policy": "validation_only_not_promotion_proof",
             },
         )
-        candidate = runner._candidate_payload_with_feedback_metadata(
+        candidate = candidate_prior_scoring._candidate_payload_with_feedback_metadata(
             spec=spec,
             candidate={
                 "candidate_id": "candidate-synthetic-contract",
@@ -244,7 +253,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             },
         )
 
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate=candidate,
             dataset_snapshot_id="synthetic-recent-whitepaper-2025-2026",
@@ -274,7 +283,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             entry_minute_after_open="75",
             selection_mode="continuation",
         )
-        losing_bundle = runner.evidence_bundle_from_frontier_candidate(
+        losing_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=losing_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-losing",
@@ -300,32 +309,34 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             dataset_snapshot_id="snap-feedback",
             result_path="feedback://losing",
         )
-        capital_unsafe_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=capital_unsafe_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-capital-unsafe",
-                "family_template_id": capital_unsafe_spec.family_template_id,
-                "runtime_family": capital_unsafe_spec.runtime_family,
-                "runtime_strategy_name": capital_unsafe_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "750",
-                    "active_day_ratio": "1",
-                    "positive_day_ratio": "1",
-                    "negative_day_count": 0,
-                    "best_day_share": "0.25",
-                    "worst_day_loss": "0",
-                    "max_drawdown": "0",
-                    "max_gross_exposure_pct_equity": "2.5",
-                    "min_cash": "-500",
-                    "negative_cash_observation_count": 8,
-                    "avg_filled_notional_per_day": "500000",
+        capital_unsafe_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=capital_unsafe_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-capital-unsafe",
+                    "family_template_id": capital_unsafe_spec.family_template_id,
+                    "runtime_family": capital_unsafe_spec.runtime_family,
+                    "runtime_strategy_name": capital_unsafe_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "750",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                        "negative_day_count": 0,
+                        "best_day_share": "0.25",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "max_gross_exposure_pct_equity": "2.5",
+                        "min_cash": "-500",
+                        "negative_cash_observation_count": 8,
+                        "avg_filled_notional_per_day": "500000",
+                    },
                 },
-            },
-            dataset_snapshot_id="snap-feedback",
-            result_path="feedback://capital-unsafe",
+                dataset_snapshot_id="snap-feedback",
+                result_path="feedback://capital-unsafe",
+            )
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(losing_spec, unexplored_spec, capital_unsafe_spec),
             feedback_evidence_bundles=(losing_bundle, capital_unsafe_bundle),
         )
@@ -380,7 +391,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
 
     def test_feedback_evidence_jsonl_round_trips(self) -> None:
         spec = self._candidate_spec("spec-feedback-jsonl")
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-jsonl",
@@ -399,14 +410,14 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
                 json.dumps(bundle.to_payload(), sort_keys=True) + "\n",
                 encoding="utf-8",
             )
-            loaded = runner._load_feedback_evidence_bundles((path,))
+            loaded = feedback_loading._load_feedback_evidence_bundles((path,))
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
 
     def test_feedback_evidence_loads_recent_persisted_epoch_bundles(self) -> None:
         spec = self._candidate_spec("spec-feedback-persisted")
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-persisted",
@@ -452,11 +463,13 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             )
             session.commit()
 
-            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
-                (), include_persisted=True
+            loaded, manifest = (
+                persisted_feedback_sources._load_autoresearch_feedback_evidence_bundles(
+                    (), include_persisted=True
+                )
             )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -567,11 +580,13 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             )
             session.commit()
 
-            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
-                (), include_persisted=True
+            loaded, manifest = (
+                persisted_feedback_sources._load_autoresearch_feedback_evidence_bundles(
+                    (), include_persisted=True
+                )
             )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -600,7 +615,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
 
     def test_feedback_evidence_dedupe_handles_missing_bundle_ids(self) -> None:
         spec = self._candidate_spec("spec-feedback-dedupe")
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-dedupe",
@@ -611,7 +626,9 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
         )
         no_id_bundle = replace(bundle, evidence_bundle_id="")
 
-        deduped = runner._dedupe_feedback_evidence_bundles((no_id_bundle, no_id_bundle))
+        deduped = feedback_loading._dedupe_feedback_evidence_bundles(
+            (no_id_bundle, no_id_bundle)
+        )
 
         self.assertEqual(len(deduped), 1)
         self.assertEqual(deduped[0].candidate_spec_id, spec.candidate_spec_id)
@@ -621,8 +638,10 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=RuntimeError("db unavailable"),
         ):
-            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
-                (), include_persisted=True
+            loaded, manifest = (
+                persisted_feedback_sources._load_autoresearch_feedback_evidence_bundles(
+                    (), include_persisted=True
+                )
             )
 
         self.assertEqual(loaded, ())
@@ -636,7 +655,9 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
         spec = self._candidate_spec("spec-summary-scorecard")
         scorecard = {
             "candidate_id": "cand-summary-scorecard",
-            "execution_signature": runner._candidate_spec_execution_signature(spec),
+            "execution_signature": candidate_identity._candidate_spec_execution_signature(
+                spec
+            ),
             "family_template_id": spec.family_template_id,
             "runtime_family": spec.runtime_family,
             "runtime_strategy_name": spec.runtime_strategy_name,
@@ -693,7 +714,9 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles()
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles()
+            )
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
@@ -712,7 +735,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
         self.assertEqual(manifest["legacy_summary_unmatched_scorecard_count"], 1)
         self.assertEqual(manifest["legacy_summary_bundle_count"], 1)
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -792,7 +815,9 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles()
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles()
+            )
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
@@ -823,7 +848,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
             manifest["portfolio_candidate_ids"], ["portfolio-feedback-blocked"]
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -863,10 +888,14 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
         )
 
         self.assertEqual(
-            runner._portfolio_candidate_row_to_feedback_bundles(non_feedback_status),
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                non_feedback_status
+            ),
             (),
         )
         self.assertEqual(
-            runner._portfolio_candidate_row_to_feedback_bundles(empty_scorecard),
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                empty_scorecard
+            ),
             (),
         )

--- a/services/torghut/tests/autoresearch_runner/test_feedback_shape_prior_penalizes_cash_blocks_without_family_veto.py
+++ b/services/torghut/tests/autoresearch_runner/test_feedback_shape_prior_penalizes_cash_blocks_without_family_veto.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.feedback_blocking_rules as feedback_blocking_rules
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+
 from dataclasses import replace
 from decimal import Decimal
 from unittest.mock import patch
 
 from sqlalchemy.orm import Session
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from app.models import (
     AutoresearchPortfolioCandidate,
 )
@@ -28,9 +33,9 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
             hypothesis_id="hyp-spec-shape-cash-probe",
             hard_vetoes={"required_min_daily_notional": "400000"},
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=failed_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=failed_spec,
                 candidate={
                     "candidate_id": "cand-shape-cash-source",
@@ -47,7 +52,7 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
             result_path="feedback://shape-cash",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(same_shape_probe,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -67,9 +72,12 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
                 "universe_symbols": "NVDA",
             },
         )
-        self.assertEqual(runner._candidate_spec_universe_key(invalid_universe_spec), "")
+        self.assertEqual(
+            candidate_prior_scoring._candidate_spec_universe_key(invalid_universe_spec),
+            "",
+        )
         self.assertTrue(
-            runner._feedback_scorecard_has_hard_veto(
+            feedback_blocking_rules._feedback_scorecard_has_hard_veto(
                 {
                     "profit_target_oracle": {
                         "blockers": ["positive_day_ratio_below_oracle"]
@@ -78,11 +86,15 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
             )
         )
         self.assertTrue(
-            runner._feedback_scorecard_has_hard_veto({"oracle_passed": False})
+            feedback_blocking_rules._feedback_scorecard_has_hard_veto(
+                {"oracle_passed": False}
+            )
         )
-        self.assertFalse(runner._feedback_daily_net_has_loss({"daily_net": "bad"}))
+        self.assertFalse(
+            feedback_blocking_rules._feedback_daily_net_has_loss({"daily_net": "bad"})
+        )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block(
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
                 {
                     "profit_target_oracle": {
                         "blockers": ["active_day_ratio_below_oracle"]
@@ -91,13 +103,17 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
             )
         )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block({"positive_day_ratio": "0.5"})
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
+                {"positive_day_ratio": "0.5"}
+            )
         )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block({"best_day_share": "0.51"})
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
+                {"best_day_share": "0.51"}
+            )
         )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block(
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
                 {
                     "active_day_ratio": "1",
                     "positive_day_ratio": "1",
@@ -117,11 +133,15 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
             {"max_single_symbol_contribution_share": "0.36"},
             {"max_cluster_contribution_share": "0.41"},
         ):
-            self.assertTrue(runner._feedback_risk_profile_has_penalty(scorecard))
-        self.assertEqual(runner._feedback_risk_profile_key_from_scorecard({}), "")
+            self.assertTrue(
+                feedback_blocking_rules._feedback_risk_profile_has_penalty(scorecard)
+            )
+        self.assertEqual(
+            feedback_blocking_rules._feedback_risk_profile_key_from_scorecard({}), ""
+        )
 
         spec = self._candidate_spec("spec-empty-risk-key")
-        orphan_bundle = runner.evidence_bundle_from_frontier_candidate(
+        orphan_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-unmatched-risk-feedback",
             candidate={
                 "candidate_id": "cand-unmatched-risk-feedback",
@@ -130,7 +150,7 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
             dataset_snapshot_id="snap-empty-risk-key",
             result_path="feedback://empty-risk-key",
         )
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,),
             feedback_evidence_bundles=(orphan_bundle,),
         )
@@ -203,7 +223,9 @@ class TestFeedbackShapePriorPenalizesCashBlocksWithoutFamilyVeto(
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles()
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles()
+            )
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)

--- a/services/torghut/tests/autoresearch_runner/test_portfolio_candidate_feedback_uses_fallback_sleeves_and_skips_invalid_ones.py
+++ b/services/torghut/tests/autoresearch_runner/test_portfolio_candidate_feedback_uses_fallback_sleeves_and_skips_invalid_ones.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.profit_target_oracle as profit_target_oracle
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.feedback_blocking_rules as feedback_blocking_rules
+import scripts.whitepaper_autoresearch_runner.feedback_loading as feedback_loading
+import scripts.whitepaper_autoresearch_runner.oracle_policy as oracle_policy
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+import scripts.whitepaper_autoresearch_runner.proposal_training as proposal_training
+import scripts.whitepaper_autoresearch_runner.rejected_signal_feedback as rejected_signal_feedback
+
 from dataclasses import replace
 from argparse import Namespace
 from datetime import datetime
@@ -55,8 +68,10 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             status="blocked",
         )
 
-        fallback_bundles = runner._portfolio_candidate_row_to_feedback_bundles(
-            fallback_row
+        fallback_bundles = (
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                fallback_row
+            )
         )
 
         self.assertEqual(len(fallback_bundles), 1)
@@ -72,7 +87,9 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             fallback_bundles[0].objective_scorecard["portfolio_blockers"],
         )
         self.assertEqual(
-            runner._portfolio_candidate_row_to_feedback_bundles(invalid_sleeve_row),
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                invalid_sleeve_row
+            ),
             (),
         )
 
@@ -80,7 +97,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
         self,
     ) -> None:
         valid_spec = self._candidate_spec("spec-feedback-limit")
-        valid_bundle = runner.evidence_bundle_from_frontier_candidate(
+        valid_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=valid_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-limit",
@@ -89,7 +106,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             dataset_snapshot_id="snap-feedback-limit",
             result_path="feedback://limit",
         )
-        extra_bundle = runner.evidence_bundle_from_frontier_candidate(
+        extra_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-feedback-extra",
             candidate={
                 "candidate_id": "cand-feedback-extra",
@@ -159,8 +176,10 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles(
-                limit=1
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles(
+                    limit=1
+                )
             )
 
         self.assertEqual(len(loaded), 1)
@@ -178,7 +197,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
                 ValueError,
                 "feedback_evidence_jsonl_missing",
             ):
-                runner._load_feedback_evidence_bundles((missing_path,))
+                feedback_loading._load_feedback_evidence_bundles((missing_path,))
 
             invalid_path = Path(tmpdir) / "invalid.jsonl"
             invalid_path.write_text("\n[]\n", encoding="utf-8")
@@ -186,12 +205,12 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
                 ValueError,
                 "feedback_evidence_jsonl_invalid",
             ):
-                runner._load_feedback_evidence_bundles((invalid_path,))
+                feedback_loading._load_feedback_evidence_bundles((invalid_path,))
 
     def test_candidate_quality_gate_flags_capital_safety_failures(self) -> None:
-        policy = runner.ProfitTargetOraclePolicy()
+        policy = profit_target_oracle.ProfitTargetOraclePolicy()
 
-        failures = runner._candidate_quality_gate_failures(
+        failures = proposal_training._candidate_quality_gate_failures(
             {
                 "net_pnl_per_day": "750",
                 "active_day_ratio": "1",
@@ -220,9 +239,9 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
         self.assertIn("negative_cash_observed", failures)
 
     def test_candidate_quality_gate_preserves_current_oracle_blockers(self) -> None:
-        policy = runner.ProfitTargetOraclePolicy()
+        policy = profit_target_oracle.ProfitTargetOraclePolicy()
 
-        failures = runner._candidate_quality_gate_failures(
+        failures = proposal_training._candidate_quality_gate_failures(
             {
                 "net_pnl_per_day": "750",
                 "active_day_ratio": "1",
@@ -266,9 +285,9 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
         self.assertIn("delay_adjusted_depth_stress_model_failed", failures)
 
     def test_candidate_quality_gate_flags_weak_profit_factor(self) -> None:
-        policy = runner.ProfitTargetOraclePolicy()
+        policy = profit_target_oracle.ProfitTargetOraclePolicy()
 
-        failures = runner._candidate_quality_gate_failures(
+        failures = proposal_training._candidate_quality_gate_failures(
             {
                 "net_pnl_per_day": "750",
                 "active_day_ratio": "1",
@@ -328,13 +347,13 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
     def test_candidate_spec_contract_exposes_full_promotion_risk_parameters(
         self,
     ) -> None:
-        policy = runner.ProfitTargetOraclePolicy(
+        policy = profit_target_oracle.ProfitTargetOraclePolicy(
             max_gross_exposure_pct_equity=Decimal("0.85"),
             min_cash=Decimal("250"),
             max_negative_cash_observation_count=0,
         )
 
-        updated = runner._candidate_spec_with_oracle_policy(
+        updated = oracle_policy._candidate_spec_with_oracle_policy(
             self._candidate_spec("spec-full-promotion-policy"),
             oracle_policy=policy,
         )
@@ -369,12 +388,12 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
         )
 
         def feedback(
-            spec: runner.CandidateSpec,
+            spec: CandidateSpec,
             *,
             candidate_id: str,
             scorecard: dict[str, object],
-        ) -> runner.CandidateEvidenceBundle:
-            return runner.evidence_bundle_from_frontier_candidate(
+        ) -> evidence_bundles.CandidateEvidenceBundle:
+            return evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=spec.candidate_spec_id,
                 candidate={
                     "candidate_id": candidate_id,
@@ -467,7 +486,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             scorecard={"negative_cash_observation_count": "1"},
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(
                 string_veto_spec,
                 min_cash_spec,
@@ -525,14 +544,14 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
                 "source_run_id": "source-spec-drifted-signature",
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=original_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-original-signature",
                 "family_template_id": original_spec.family_template_id,
                 "runtime_family": original_spec.runtime_family,
                 "runtime_strategy_name": original_spec.runtime_strategy_name,
-                "execution_signature": runner._candidate_spec_execution_signature(
+                "execution_signature": candidate_identity._candidate_spec_execution_signature(
                     original_spec
                 ),
                 "objective_scorecard": {
@@ -550,7 +569,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             result_path="feedback://signature-drift",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(drifted_spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -601,28 +620,30 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             entry_minute_after_open="90",
             selection_mode="continuation",
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-family-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "125",
-                    "active_day_ratio": "1",
-                    "positive_day_ratio": "1",
-                    "negative_day_count": 0,
-                    "daily_net": {
-                        "2026-05-01": "250",
-                        "2026-05-04": "-25",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-family-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "125",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                        "negative_day_count": 0,
+                        "daily_net": {
+                            "2026-05-01": "250",
+                            "2026-05-04": "-25",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-family-feedback",
-            result_path="feedback://family",
+                dataset_snapshot_id="snap-family-feedback",
+                result_path="feedback://family",
+            )
         )
-        no_family_bundle = runner.evidence_bundle_from_frontier_candidate(
+        no_family_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-not-in-current-epoch",
             candidate={
                 "candidate_id": "cand-no-family",
@@ -635,7 +656,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             result_path="feedback://no-family",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(mutated_family_spec, unrelated_spec),
             feedback_evidence_bundles=(family_feedback_bundle, no_family_bundle),
         )
@@ -696,26 +717,32 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             selection_mode="continuation",
         )
         self.assertNotEqual(
-            runner._candidate_spec_execution_signature(failed_spec),
-            runner._candidate_spec_execution_signature(same_shape_probe),
+            candidate_identity._candidate_spec_execution_signature(failed_spec),
+            candidate_identity._candidate_spec_execution_signature(same_shape_probe),
         )
         self.assertEqual(
-            runner._candidate_spec_feedback_shape_key(failed_spec),
-            runner._candidate_spec_feedback_shape_key(same_shape_probe),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(failed_spec),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(
+                same_shape_probe
+            ),
         )
         self.assertNotEqual(
-            runner._candidate_spec_feedback_shape_key(failed_spec),
-            runner._candidate_spec_feedback_shape_key(different_shape_same_risk_probe),
-        )
-        self.assertEqual(
-            runner._candidate_spec_feedback_risk_profile_key(failed_spec),
-            runner._candidate_spec_feedback_risk_profile_key(
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(failed_spec),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(
                 different_shape_same_risk_probe
             ),
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        self.assertEqual(
+            candidate_prior_scoring._candidate_spec_feedback_risk_profile_key(
+                failed_spec
+            ),
+            candidate_prior_scoring._candidate_spec_feedback_risk_profile_key(
+                different_shape_same_risk_probe
+            ),
+        )
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=failed_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=failed_spec,
                 candidate={
                     "candidate_id": "cand-daily-coverage-source",
@@ -736,7 +763,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             result_path="feedback://daily-coverage",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(same_shape_probe, different_shape_same_risk_probe, clean_probe),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -788,7 +815,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
     def test_feedback_risk_profile_uses_oracle_policy_and_allows_down_days(
         self,
     ) -> None:
-        policy = runner.ProfitTargetOraclePolicy(
+        policy = profit_target_oracle.ProfitTargetOraclePolicy(
             min_active_day_ratio=Decimal("0.90"),
             min_positive_day_ratio=Decimal("0.60"),
             max_best_day_share=Decimal("0.25"),
@@ -817,16 +844,22 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
         }
 
         self.assertFalse(
-            runner._feedback_risk_profile_has_penalty(scorecard, oracle_policy=policy)
-        )
-        self.assertFalse(runner._feedback_is_blocked(scorecard, oracle_policy=policy))
-        self.assertFalse(
-            runner._feedback_family_prior_has_hard_block(
+            feedback_blocking_rules._feedback_risk_profile_has_penalty(
                 scorecard, oracle_policy=policy
             )
         )
         self.assertFalse(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_is_blocked(
+                scorecard, oracle_policy=policy
+            )
+        )
+        self.assertFalse(
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
+                scorecard, oracle_policy=policy
+            )
+        )
+        self.assertFalse(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **scorecard,
                     "profit_target_oracle": {
@@ -844,10 +877,12 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             max_negative_cash_observation_count=0,
         )
         self.assertTrue(
-            runner._feedback_is_blocked(scorecard, oracle_policy=strict_policy)
+            feedback_blocking_rules._feedback_is_blocked(
+                scorecard, oracle_policy=strict_policy
+            )
         )
         self.assertTrue(
-            runner._feedback_risk_profile_has_penalty(
+            feedback_blocking_rules._feedback_risk_profile_has_penalty(
                 {
                     "active_day_ratio": "1",
                     "positive_day_ratio": "1",

--- a/services/torghut/tests/autoresearch_runner/test_real_replay_shards.py
+++ b/services/torghut/tests/autoresearch_runner/test_real_replay_shards.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+from app.trading.discovery.candidate_specs import CandidateSpec
+import multiprocessing
+import queue
+import scripts.run_strategy_factory_v2 as strategy_factory_runner
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import time as monotonic_time
+
 import json
 from argparse import Namespace
 from pathlib import Path
@@ -59,15 +68,15 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
         scorecard = replay.evidence_bundles[0].objective_scorecard
         self.assertEqual(
             scorecard["feedback_shape_key"],
-            runner._candidate_spec_feedback_shape_key(spec),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(spec),
         )
         self.assertEqual(
             scorecard["feedback_risk_profile_key"],
-            runner._candidate_spec_feedback_risk_profile_key(spec),
+            candidate_prior_scoring._candidate_spec_feedback_risk_profile_key(spec),
         )
         self.assertEqual(
             scorecard["execution_signature"],
-            runner._candidate_spec_execution_signature(spec),
+            candidate_identity._candidate_spec_execution_signature(spec),
         )
 
     def test_real_replay_evidence_promotes_summary_activity_counts(self) -> None:
@@ -217,7 +226,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
             }
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2",
                 return_value=factory_payload,
             ):
@@ -275,7 +284,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
         self.assertEqual(scorecard["runtime_strategy_name"], spec.runtime_strategy_name)
         self.assertEqual(
             scorecard["execution_signature"],
-            runner._candidate_spec_execution_signature(spec),
+            candidate_identity._candidate_spec_execution_signature(spec),
         )
 
     def test_real_replay_uses_spec_universe_instead_of_global_symbols(self) -> None:
@@ -325,7 +334,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -395,7 +404,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -448,7 +457,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -504,7 +513,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -592,7 +601,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -645,10 +654,10 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
     ) -> None:
         args = self._args(Path("/tmp/epoch"))
         program = runner._load_epoch_program(args)
-        controls = runner._resolved_real_replay_frontier_controls(args, program)
+        controls = replay_shards._resolved_real_replay_frontier_controls(args, program)
 
         self.assertEqual(
-            runner._resolved_staged_train_screen_multiplier(args, program),
+            replay_shards._resolved_staged_train_screen_multiplier(args, program),
             3,
         )
         self.assertEqual(controls["symbol_prune_iterations"], 1)
@@ -663,11 +672,11 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
         args.staged_train_screen_multiplier = 4
         args.symbol_prune_candidates = 5
         args.capture_positive_rejected_full_window_ledgers = 6
-        override_controls = runner._resolved_real_replay_frontier_controls(
+        override_controls = replay_shards._resolved_real_replay_frontier_controls(
             args, program
         )
         self.assertEqual(
-            runner._resolved_staged_train_screen_multiplier(args, program),
+            replay_shards._resolved_staged_train_screen_multiplier(args, program),
             4,
         )
         self.assertEqual(override_controls["symbol_prune_candidates"], 5)
@@ -693,13 +702,13 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 _args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(spec_ids)
                 if len(calls) == 2:
                     raise TimeoutError("real_replay_timeout_seconds:7")
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec_ids[0],
                     candidate={
                         "candidate_id": f"cand-{spec_ids[0]}",
@@ -728,7 +737,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
             ) -> runner.EpochReplayResult:
                 _ = timeout_seconds
@@ -772,7 +781,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
             args = self._args(output_dir)
             args.replay_mode = "real"
             spec = self._candidate_spec("spec-no-sigalrm")
-            bundle = runner.evidence_bundle_from_frontier_candidate(
+            bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=spec.candidate_spec_id,
                 candidate={
                     "candidate_id": "candidate-no-sigalrm",
@@ -797,7 +806,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                     ),
                 ) as child_replay,
             ):
-                result = runner._run_real_replay_once_with_optional_timeout(
+                result = replay_execution._run_real_replay_once_with_optional_timeout(
                     args=args,
                     output_dir=output_dir,
                     specs=(spec,),
@@ -820,7 +829,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
             joined = False
 
             def get(self, *, timeout: float) -> Any:
-                raise runner.queue.Empty
+                raise queue.Empty
 
             def close(self) -> None:
                 self.closed = True
@@ -866,18 +875,16 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
 
             with (
                 patch.object(
-                    runner.multiprocessing,
+                    multiprocessing,
                     "get_context",
                     return_value=fake_context,
                 ),
-                patch.object(
-                    runner.monotonic_time, "monotonic", side_effect=[0.0, 0.0, 8.0]
-                ),
+                patch.object(monotonic_time, "monotonic", side_effect=[0.0, 0.0, 8.0]),
             ):
                 with self.assertRaisesRegex(
                     TimeoutError, "real_replay_timeout_seconds:7"
                 ):
-                    runner._run_real_replay_once_in_child_process(
+                    replay_execution._run_real_replay_once_in_child_process(
                         args=args,
                         output_dir=output_dir,
                         specs=(spec,),

--- a/services/torghut/tests/autoresearch_runner/test_real_replay_worker_reports_success_error_and_error_payload.py
+++ b/services/torghut/tests/autoresearch_runner/test_real_replay_worker_reports_success_error_and_error_payload.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+from app.trading.discovery.candidate_specs import CandidateSpec
+import multiprocessing
+import queue
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
+
 from argparse import Namespace
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -40,7 +46,9 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         )
         success_queue = CaptureQueue()
         with patch.object(replay_execution, "_run_real_replay", return_value=expected):
-            runner._real_replay_worker(success_queue, args, "worker-output", (spec,))
+            replay_execution._real_replay_worker(
+                success_queue, args, "worker-output", (spec,)
+            )
         self.assertEqual(success_queue.items, [("ok", expected)])
 
         error_queue = CaptureQueue()
@@ -49,7 +57,9 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             "_run_real_replay",
             side_effect=ValueError("worker-failed"),
         ):
-            runner._real_replay_worker(error_queue, args, "worker-output", (spec,))
+            replay_execution._real_replay_worker(
+                error_queue, args, "worker-output", (spec,)
+            )
         self.assertEqual(error_queue.items[0][0], "error")
         self.assertIsInstance(error_queue.items[0][1], ValueError)
 
@@ -59,7 +69,9 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             "_run_real_replay",
             side_effect=ValueError("worker-failed"),
         ):
-            runner._real_replay_worker(payload_queue, args, "worker-output", (spec,))
+            replay_execution._real_replay_worker(
+                payload_queue, args, "worker-output", (spec,)
+            )
         self.assertEqual(
             payload_queue.items,
             [("error_payload", ("ValueError", "worker-failed"))],
@@ -76,7 +88,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 self.terminated = True
 
         inactive = InactiveProcess()
-        runner._terminate_process(inactive)
+        replay_execution._terminate_process(inactive)
         self.assertFalse(inactive.terminated)
 
         class StubbornProcess:
@@ -98,7 +110,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 self.join_calls += 1
 
         stubborn = StubbornProcess()
-        runner._terminate_process(stubborn)
+        replay_execution._terminate_process(stubborn)
         self.assertTrue(stubborn.terminated)
         self.assertTrue(stubborn.killed)
         self.assertEqual(stubborn.join_calls, 2)
@@ -163,9 +175,9 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             fake_context = FakeContext(fake_queue, fake_process)
 
             with patch.object(
-                runner.multiprocessing, "get_context", return_value=fake_context
+                multiprocessing, "get_context", return_value=fake_context
             ):
-                result = runner._run_real_replay_once_in_child_process(
+                result = replay_execution._run_real_replay_once_in_child_process(
                     args=args,
                     output_dir=output_dir,
                     specs=(spec,),
@@ -231,13 +243,13 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 with (
                     self.subTest(status=item[0]),
                     patch.object(
-                        runner.multiprocessing,
+                        multiprocessing,
                         "get_context",
                         return_value=fake_context,
                     ),
                     self.assertRaises(expected_error),
                 ):
-                    runner._run_real_replay_once_in_child_process(
+                    replay_execution._run_real_replay_once_in_child_process(
                         args=args,
                         output_dir=output_dir,
                         specs=(spec,),
@@ -254,7 +266,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             joined = False
 
             def get(self, *, timeout: float) -> Any:
-                raise runner.queue.Empty
+                raise queue.Empty
 
             def close(self) -> None:
                 self.closed = True
@@ -288,14 +300,12 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             fake_context = FakeContext()
 
             with (
-                patch.object(
-                    runner.multiprocessing, "get_context", return_value=fake_context
-                ),
+                patch.object(multiprocessing, "get_context", return_value=fake_context),
                 self.assertRaisesRegex(
                     RuntimeError, "real_replay_worker_exited_without_result"
                 ),
             ):
-                runner._run_real_replay_once_in_child_process(
+                replay_execution._run_real_replay_once_in_child_process(
                     args=args,
                     output_dir=output_dir,
                     specs=(spec,),
@@ -323,7 +333,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(
@@ -336,7 +346,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 )
                 if len(calls) == 2:
                     raise TimeoutError("real_replay_timeout_seconds:7")
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec_ids[0],
                     candidate={
                         "candidate_id": f"cand-{spec_ids[0]}",
@@ -367,7 +377,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
             ) -> runner.EpochReplayResult:
                 _ = timeout_seconds
@@ -402,7 +412,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
 
     def test_failed_shard_retry_skips_malformed_and_unknown_spec_ids(self) -> None:
         self.assertEqual(
-            runner._failed_shard_spec_ids(
+            replay_shards._failed_shard_spec_ids(
                 (
                     {"candidate_spec_ids": "spec-not-a-list"},
                     {"candidate_spec_ids": ["spec-a", "", "spec-a", "spec-b"]},
@@ -414,7 +424,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         with TemporaryDirectory() as tmpdir:
             args = self._args(Path(tmpdir) / "epoch")
             evidence, replay_results, failures, summary = (
-                runner._retry_real_replay_failed_shard_specs(
+                replay_shards._retry_real_replay_failed_shard_specs(
                     args=args,
                     output_dir=Path(tmpdir) / "epoch",
                     specs=(self._candidate_spec("spec-known"),),
@@ -436,8 +446,8 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         calls: list[tuple[int, int, int]] = []
 
         def fake_execute(
-            plan: runner._ReplayShardPlan,
-        ) -> runner._ReplayShardOutcome:
+            plan: replay_models._ReplayShardPlan,
+        ) -> replay_models._ReplayShardOutcome:
             calls.append(
                 (
                     plan.shard_index,
@@ -445,7 +455,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                     int(plan.args.max_total_frontier_candidates),
                 )
             )
-            return runner._ReplayShardOutcome(
+            return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
                 result=runner.EpochReplayResult(
@@ -468,7 +478,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 replay_shards, "_execute_real_replay_shard", side_effect=fake_execute
             ):
                 evidence, replay_results, failures, summary = (
-                    runner._retry_real_replay_failed_shard_specs(
+                    replay_shards._retry_real_replay_failed_shard_specs(
                         args=args,
                         output_dir=Path(tmpdir) / "epoch",
                         specs=(spec,),
@@ -499,10 +509,10 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         calls: list[int] = []
 
         def fake_execute(
-            plan: runner._ReplayShardPlan,
-        ) -> runner._ReplayShardOutcome:
+            plan: replay_models._ReplayShardPlan,
+        ) -> replay_models._ReplayShardOutcome:
             calls.append(plan.shard_index)
-            bundle = runner.evidence_bundle_from_frontier_candidate(
+            bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=spec.candidate_spec_id,
                 candidate={
                     "candidate_id": "cand-retry-completes",
@@ -515,7 +525,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 dataset_snapshot_id="snap-retry-completes",
                 result_path="feedback://retry-completes",
             )
-            return runner._ReplayShardOutcome(
+            return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
                 result=runner.EpochReplayResult(
@@ -531,7 +541,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 replay_shards, "_execute_real_replay_shard", side_effect=fake_execute
             ):
                 evidence, replay_results, failures, summary = (
-                    runner._retry_real_replay_failed_shard_specs(
+                    replay_shards._retry_real_replay_failed_shard_specs(
                         args=args,
                         output_dir=Path(tmpdir) / "epoch",
                         specs=(spec,),
@@ -573,7 +583,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             args.max_frontier_candidates_per_spec = 2
             args.max_total_frontier_candidates = 5
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -618,7 +628,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             args.max_frontier_candidates_per_spec = 64
             args.max_total_frontier_candidates = 8
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -647,13 +657,13 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             args = self._args(output_dir)
             args.real_replay_shard_workers = 8
             workers_seen: list[int] = []
-            submitted: list[tuple[Any, runner._ReplayShardPlan]] = []
+            submitted: list[tuple[Any, replay_models._ReplayShardPlan]] = []
 
             class _FakeFuture:
-                def __init__(self, outcome: runner._ReplayShardOutcome) -> None:
+                def __init__(self, outcome: replay_models._ReplayShardOutcome) -> None:
                     self._outcome = outcome
 
-                def result(self) -> runner._ReplayShardOutcome:
+                def result(self) -> replay_models._ReplayShardOutcome:
                     return self._outcome
 
             class _FakeExecutor:
@@ -669,11 +679,11 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 def submit(
                     self,
                     fn: Any,
-                    plan: runner._ReplayShardPlan,
+                    plan: replay_models._ReplayShardPlan,
                 ) -> _FakeFuture:
                     submitted.append((fn, plan))
                     return _FakeFuture(
-                        runner._ReplayShardOutcome(
+                        replay_models._ReplayShardOutcome(
                             shard_index=plan.shard_index,
                             candidate_spec_ids=tuple(
                                 spec.candidate_spec_id for spec in plan.specs
@@ -699,7 +709,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                     replay_shards, "as_completed", side_effect=fake_as_completed
                 ),
             ):
-                result = runner._run_real_replay_shards(
+                result = replay_shards._run_real_replay_shards(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,
@@ -740,7 +750,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             args.real_replay_shard_workers = 8
             args.real_replay_max_parallel_frontier_candidates = 10
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -749,12 +759,15 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             )
 
         self.assertEqual(
-            [runner._replay_shard_frontier_candidate_budget(plan) for plan in plans],
+            [
+                replay_shards._replay_shard_frontier_candidate_budget(plan)
+                for plan in plans
+            ],
             [8, 8, 8],
         )
         self.assertEqual([plan.timeout_seconds for plan in plans], [900, 900, 900])
         self.assertEqual(
-            runner._bounded_real_replay_shard_workers(args=args, plans=plans),
+            replay_shards._bounded_real_replay_shard_workers(args=args, plans=plans),
             1,
         )
 
@@ -778,7 +791,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             args.real_replay_shard_workers = 8
             args.real_replay_max_parallel_frontier_candidates = 99
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -787,7 +800,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             )
 
         self.assertEqual(
-            runner._bounded_real_replay_shard_workers(args=args, plans=plans),
+            replay_shards._bounded_real_replay_shard_workers(args=args, plans=plans),
             2,
         )
 
@@ -801,10 +814,10 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 *,
                 args: Namespace,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 spec = specs[0]
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec.candidate_spec_id,
                     candidate={
                         "candidate_id": "cand-incomplete",

--- a/services/torghut/tests/autoresearch_runner/test_remediation_recommends_profile_surface_when_selection_budget_exhausted.py
+++ b/services/torghut/tests/autoresearch_runner/test_remediation_recommends_profile_surface_when_selection_budget_exhausted.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import scripts.whitepaper_autoresearch_runner.candidate_remediation as candidate_remediation
+import scripts.whitepaper_autoresearch_runner.next_epoch_planning as next_epoch_planning
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
+
 import json
 from decimal import Decimal
 from pathlib import Path
@@ -38,7 +42,7 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
                 start=1,
             )
         ]
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -111,7 +115,7 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
                 "selected_for_replay": True,
             }
         ]
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -169,7 +173,7 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
     def test_remediation_recommends_surface_mutation_when_mlx_blocks_synthetic_prior(
         self,
     ) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -212,7 +216,7 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
     def test_remediation_recommends_surface_mutation_when_feedback_blocks_all_candidates(
         self,
     ) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -273,7 +277,7 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
@@ -324,7 +328,7 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
@@ -362,10 +366,10 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
-            flags = runner._profitability_next_epoch_flags(
+            flags = next_epoch_planning._profitability_next_epoch_flags(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
@@ -475,17 +479,17 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
         self.assertEqual(
-            runner._bounded_real_replay_shard_timeout_seconds(0),
-            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            replay_shards._bounded_real_replay_shard_timeout_seconds(0),
+            replay_shards._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
         self.assertEqual(
-            runner._bounded_real_replay_shard_timeout_seconds(-1),
-            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            replay_shards._bounded_real_replay_shard_timeout_seconds(-1),
+            replay_shards._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
         self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
         self.assertIn(
@@ -516,7 +520,7 @@ class TestRemediationRecommendsProfileSurfaceWhenSelectionBudgetExhausted(
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 

--- a/services/torghut/tests/autoresearch_runner/test_replay_tape_preview.py
+++ b/services/torghut/tests/autoresearch_runner/test_replay_tape_preview.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.preview_narrowing as preview_narrowing
+import scripts.whitepaper_autoresearch_runner.queue_metadata as queue_metadata
+
 from dataclasses import replace
 import json
 from datetime import date, datetime, timezone
@@ -63,7 +67,7 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             args.replay_tape_preview_top_k = 1
             args.symbols = "NVDA"
             args.replay_tape_dataset_snapshot_ref = "preview-snapshot"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -96,17 +100,21 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 27),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 27),
                 ),
-                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                feature_schema_hash=queue_metadata._materialized_replay_tape_feature_schema_hash(
                     args
                 ),
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
 
             payload = runner.run_whitepaper_autoresearch_profit_target(args)
@@ -247,18 +255,24 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             args.replay_tape_exact_candidate_cap = 99
             args.replay_tape_dataset_snapshot_ref = "frontier-preview"
             args.allow_unsafe_replay_tape_exact_cap_override = True
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
-            source_query_digest = runner._materialized_replay_tape_source_query_digest(
-                args=args,
-                symbols=requested_symbols,
-                start_date=date(2026, 2, 23),
-                end_date=date(2026, 2, 23),
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
+            source_query_digest = (
+                queue_metadata._materialized_replay_tape_source_query_digest(
+                    args=args,
+                    symbols=requested_symbols,
+                    start_date=date(2026, 2, 23),
+                    end_date=date(2026, 2, 23),
+                )
             )
-            feature_schema_hash = runner._materialized_replay_tape_feature_schema_hash(
+            feature_schema_hash = (
+                queue_metadata._materialized_replay_tape_feature_schema_hash(args)
+            )
+            cost_model_hash = queue_metadata._materialized_replay_tape_cost_model_hash(
                 args
             )
-            cost_model_hash = runner._materialized_replay_tape_cost_model_hash(args)
-            strategy_family = runner._materialized_replay_tape_strategy_family(args)
+            strategy_family = queue_metadata._materialized_replay_tape_strategy_family(
+                args
+            )
             materialize_signal_tape(
                 rows=rows,
                 tape_path=tape_path,
@@ -543,7 +557,7 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             args.replay_tape_path = tape_path
             args.replay_tape_preview_top_k = 2
             args.replay_tape_dataset_snapshot_ref = "frontier-preview"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -578,15 +592,19 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 23),
                 ),
                 feature_schema_hash="stale-feature-schema",
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
             spec = self._candidate_spec("spec-frontier-0")
             candidate_selection = {
@@ -639,7 +657,7 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             args.replay_tape_path = tape_path
             args.replay_tape_preview_top_k = 1
             args.replay_tape_dataset_snapshot_ref = "blocked-preview"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=rows,
                 tape_path=tape_path,
@@ -647,17 +665,21 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 23),
                 ),
-                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                feature_schema_hash=queue_metadata._materialized_replay_tape_feature_schema_hash(
                     args
                 ),
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
             base_spec = self._candidate_spec("spec-lineage-blocked")
             spec = replace(
@@ -796,7 +818,7 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             },
         ]
 
-        queue_payload = runner._bounded_sim_target_queue_metadata(
+        queue_payload = queue_metadata._bounded_sim_target_queue_metadata(
             preview_rows=duplicate_rows,
             replay_tape_manifest=manifest,
             exact_replay_candidate_cap=6,
@@ -850,34 +872,42 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             args.full_window_start_date = "2026-02-23"
             args.full_window_end_date = "2026-02-27"
 
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.staged_replay_frontier_default = True
             args.disable_staged_replay_frontier = True
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.disable_staged_replay_frontier = False
             args.replay_mode = "synthetic"
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.replay_mode = "real"
             args.replay_tape_path = None
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
 
             args.selection_only = True
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.selection_only = False
             args.replay_tape_path = Path(tmpdir) / "provided-tape.jsonl"
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.replay_tape_path = None
             args.full_window_start_date = ""
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.full_window_start_date = "2026-02-23"
             args.full_window_end_date = ""
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))

--- a/services/torghut/tests/autoresearch_runner/test_runtime_closure.py
+++ b/services/torghut/tests/autoresearch_runner/test_runtime_closure.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import app.trading.discovery.mlx_snapshot as mlx_snapshot
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+import app.trading.discovery.profit_target_oracle as profit_target_oracle
+
 from dataclasses import replace
 import json
 from datetime import datetime, timezone
@@ -28,7 +32,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             )
             program = runner._load_epoch_program(args)
 
-        manifest = runner.MlxSnapshotManifest(
+        manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
             created_at="2026-05-06T00:00:00+00:00",
             source_window_start="",
@@ -47,7 +51,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             tensor_bundle_paths={},
             manifest_hash="hash",
         )
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-test",
             source_candidate_ids=("candidate-test",),
@@ -82,7 +86,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             args.replay_mode = "real"
             program = runner._load_epoch_program(args)
 
-        manifest = runner.MlxSnapshotManifest(
+        manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
             created_at="2026-05-06T00:00:00+00:00",
             source_window_start="2026-03-20",
@@ -101,7 +105,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             tensor_bundle_paths={},
             manifest_hash="hash",
         )
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-test",
             source_candidate_ids=("candidate-test",),
@@ -462,7 +466,9 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
                 + "\n",
                 encoding="utf-8",
             )
-            policy = runner.ProfitTargetOraclePolicy(min_observed_trading_days=2)
+            policy = profit_target_oracle.ProfitTargetOraclePolicy(
+                min_observed_trading_days=2
+            )
             scorecard: dict[str, object] = {
                 "net_pnl_per_day": "620",
                 "portfolio_post_cost_net_pnl_per_day": "620",
@@ -487,17 +493,19 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
                 "executable_replay_account_buying_power": "0",
                 "executable_replay_max_notional_per_trade": "0",
             }
-            scorecard["profit_target_oracle"] = runner.evaluate_profit_target_oracle(
-                scorecard,
-                target_net_pnl_per_day=Decimal("500"),
-                policy=policy,
+            scorecard["profit_target_oracle"] = (
+                profit_target_oracle.evaluate_profit_target_oracle(
+                    scorecard,
+                    target_net_pnl_per_day=Decimal("500"),
+                    policy=policy,
+                )
             )
             scorecard["oracle_passed"] = False
             self.assertIn(
                 "market_impact_stress_artifact_present_failed",
                 scorecard["profit_target_oracle"]["blockers"],
             )
-            portfolio = runner.PortfolioCandidateSpec(
+            portfolio = portfolio_optimizer.PortfolioCandidateSpec(
                 schema_version="torghut.portfolio-candidate-spec.v1",
                 portfolio_candidate_id="portfolio-test",
                 source_candidate_ids=("candidate-test",),
@@ -690,7 +698,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             args = self._args(Path(tmpdir) / "epoch")
             program = runner._load_epoch_program(args)
 
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-test",
             source_candidate_ids=("candidate-test",),
@@ -706,7 +714,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             objective_scorecard={"target_met": True, "oracle_passed": True},
             optimizer_report={},
         )
-        manifest = runner.MlxSnapshotManifest(
+        manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
             created_at="2026-05-06T00:00:00+00:00",
             source_window_start="2026-03-20",

--- a/services/torghut/tests/autoresearch_runner/test_staged_replay_frontier_default_resolvers_enable_bounded_real_path.py
+++ b/services/torghut/tests/autoresearch_runner/test_staged_replay_frontier_default_resolvers_enable_bounded_real_path.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.replay_tape as replay_tape
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.local_intraday_tsmom_replay as replay_mod
+import scripts.materialize_replay_tape as replay_materializer
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.preview_narrowing as preview_narrowing
+import scripts.whitepaper_autoresearch_runner.queue_metadata as queue_metadata
+
 from dataclasses import replace
 import json
 from argparse import Namespace
@@ -48,10 +57,12 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             args.full_window_start_date = "2026-02-23"
             args.full_window_end_date = "2026-02-27"
 
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 77)
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 77
+            )
 
             args.replay_tape_path = None
-            self.assertTrue(runner._auto_materialize_staged_replay_tape(args))
+            self.assertTrue(queue_metadata._auto_materialize_staged_replay_tape(args))
 
     def test_fast_replay_preview_scores_microstructure_diagnostics_preview_only(
         self,
@@ -196,15 +207,15 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                 for seq, day in enumerate(range(23, 28), start=1)
             ]
 
-            with patch.object(
-                runner.replay_mod, "_iter_signal_rows", return_value=rows
-            ):
-                updated_args, receipt = runner._maybe_materialize_epoch_replay_tape(
-                    args=args,
-                    output_dir=output_dir,
-                    epoch_id="epoch-materialized",
+            with patch.object(replay_mod, "_iter_signal_rows", return_value=rows):
+                updated_args, receipt = (
+                    queue_metadata._maybe_materialize_epoch_replay_tape(
+                        args=args,
+                        output_dir=output_dir,
+                        epoch_id="epoch-materialized",
+                    )
                 )
-            tape = runner.load_replay_tape(updated_args.replay_tape_path)
+            tape = replay_tape.load_replay_tape(updated_args.replay_tape_path)
             self.assertIsNotNone(receipt)
             assert receipt is not None
             self.assertEqual(
@@ -245,14 +256,12 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                 )
             ]
 
-            with patch.object(
-                runner.replay_mod, "_iter_signal_rows", return_value=rows
-            ):
+            with patch.object(replay_mod, "_iter_signal_rows", return_value=rows):
                 with self.assertRaisesRegex(
                     ValueError,
                     "replay_tape_incomplete_coverage:missing_days=2026-02-24,2026-02-25,2026-02-26,2026-02-27",
                 ):
-                    runner._maybe_materialize_epoch_replay_tape(
+                    queue_metadata._maybe_materialize_epoch_replay_tape(
                         args=args,
                         output_dir=output_dir,
                         epoch_id="epoch-materialized",
@@ -272,7 +281,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             args.materialize_replay_tape = True
             args.replay_tape_path = root / "provided-tape.jsonl"
 
-            updated_args, receipt = runner._maybe_materialize_epoch_replay_tape(
+            updated_args, receipt = queue_metadata._maybe_materialize_epoch_replay_tape(
                 args=args,
                 output_dir=output_dir,
                 epoch_id="epoch-skip",
@@ -286,7 +295,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             with self.assertRaisesRegex(
                 ValueError, "replay_tape_materialization_requires_real_replay"
             ):
-                runner._maybe_materialize_epoch_replay_tape(
+                queue_metadata._maybe_materialize_epoch_replay_tape(
                     args=args,
                     output_dir=output_dir,
                     epoch_id="epoch-synthetic",
@@ -297,7 +306,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             with self.assertRaisesRegex(
                 ValueError, "replay_tape_materialization_requires_replay_execution"
             ):
-                runner._maybe_materialize_epoch_replay_tape(
+                queue_metadata._maybe_materialize_epoch_replay_tape(
                     args=args,
                     output_dir=output_dir,
                     epoch_id="epoch-selection-only",
@@ -309,7 +318,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                 ValueError,
                 "replay_tape_materialization_requires_full_window_start_date",
             ):
-                runner._maybe_materialize_epoch_replay_tape(
+                queue_metadata._maybe_materialize_epoch_replay_tape(
                     args=args,
                     output_dir=output_dir,
                     epoch_id="epoch-missing-window",
@@ -367,7 +376,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             }
 
             with patch.object(
-                runner.replay_materializer,
+                replay_materializer,
                 "_fetch_coverage_diagnostics",
                 return_value=coverage,
             ) as fetch:
@@ -403,7 +412,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             args.full_window_end_date = "2026-02-27"
             args.symbols = "NVDA"
             args.replay_tape_dataset_snapshot_ref = "preview-snapshot"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -421,17 +430,21 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 27),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 27),
                 ),
-                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                feature_schema_hash=queue_metadata._materialized_replay_tape_feature_schema_hash(
                     args
                 ),
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
             spec = self._candidate_spec("spec-preview-fallback")
             selection = {
@@ -673,11 +686,11 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                 *,
                 args: Namespace,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 del args
                 captured_spec_ids.extend(spec.candidate_spec_id for spec in specs)
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=specs[0].candidate_spec_id,
                     candidate={
                         "candidate_id": "cand-direct-a",

--- a/services/torghut/tests/test_explicit_module_facade_exports.py
+++ b/services/torghut/tests/test_explicit_module_facade_exports.py
@@ -251,6 +251,16 @@ def test_flatten_package_does_not_patch_through_public_script_shim() -> None:
     assert shim_backchannel_paths == []
 
 
+def test_whitepaper_autoresearch_entrypoint_exports_only_cli_surface() -> None:
+    module = importlib.import_module(
+        "scripts.run_whitepaper_autoresearch_profit_target"
+    )
+
+    assert module.__all__ == ("main", "run_whitepaper_autoresearch_profit_target")
+    assert "Any" not in module.__all__
+    assert "_candidate_board_payload" not in module.__all__
+
+
 def test_historical_simulation_startup_module_entrypoint_exits_with_cli_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/torghut/tests/whitepaper_autoresearch/autoresearch_runner_base.py
+++ b/services/torghut/tests/whitepaper_autoresearch/autoresearch_runner_base.py
@@ -47,6 +47,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_support import (
     sys,
     timezone,
 )
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
 
 
 class WhitepaperAutoresearchRunnerTestCaseBase(TestCase):
@@ -90,7 +92,7 @@ class WhitepaperAutoresearchRunnerTestCaseBase(TestCase):
             chunk_minutes=10,
             symbols=",".join(_CHIP_UNIVERSE),
             progress_log_seconds=30,
-            max_frontier_candidates_per_spec=runner._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
+            max_frontier_candidates_per_spec=cli_parsing._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
             max_total_frontier_candidates=0,
             staged_train_screen_multiplier=0,
             capture_rejected_seed_full_window_ledger=False,
@@ -104,9 +106,9 @@ class WhitepaperAutoresearchRunnerTestCaseBase(TestCase):
             consistency_repair_candidates=0,
             real_replay_timeout_seconds=0,
             real_replay_shard_size=0,
-            real_replay_shard_timeout_seconds=runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
-            real_replay_shard_workers=runner._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
-            real_replay_max_parallel_frontier_candidates=runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+            real_replay_shard_timeout_seconds=cli_parsing._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            real_replay_shard_workers=cli_parsing._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+            real_replay_max_parallel_frontier_candidates=cli_parsing._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
             real_replay_failed_spec_retries=1,
             real_replay_retry_timeout_seconds=0,
             real_replay_retry_max_frontier_candidates_per_spec=1,
@@ -121,9 +123,9 @@ class WhitepaperAutoresearchRunnerTestCaseBase(TestCase):
             replay_tape_manifest=None,
             replay_tape_preview_top_k=0,
             replay_tape_preview_min_rows=2,
-            replay_tape_exact_candidate_cap=runner._DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
-            replay_tape_frontier_exploitation_slots=runner._DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS,
-            replay_tape_frontier_exploration_slots=runner._DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS,
+            replay_tape_exact_candidate_cap=cli_parsing._DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+            replay_tape_frontier_exploitation_slots=cli_parsing._DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS,
+            replay_tape_frontier_exploration_slots=cli_parsing._DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS,
             materialize_replay_tape=False,
             coverage_diagnostic_output=None,
             latest_complete_window_min_days=0,
@@ -185,8 +187,8 @@ class WhitepaperAutoresearchRunnerTestCaseBase(TestCase):
         family_template_id: str = "microbar_cross_sectional_pairs_v1",
         entry_minute_after_open: str = "45",
         selection_mode: str = "reversal",
-    ) -> runner.CandidateSpec:
-        return runner.CandidateSpec(
+    ) -> CandidateSpec:
+        return CandidateSpec(
             schema_version="torghut.candidate-spec.v1",
             candidate_spec_id=candidate_spec_id,
             hypothesis_id=f"hyp-{candidate_spec_id}",

--- a/services/torghut/tests/whitepaper_autoresearch/autoresearch_runner_support.py
+++ b/services/torghut/tests/whitepaper_autoresearch/autoresearch_runner_support.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import app.whitepapers.claim_compiler as claim_compiler
+
 from contextlib import contextmanager
 from dataclasses import replace
 import json
@@ -33,6 +35,9 @@ from app.models import (
     WhitepaperDocumentVersion,
 )
 from app.trading.discovery import fast_replay
+from app.trading.discovery.candidate_specs import (
+    LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE,
+)
 from app.trading.discovery.replay_tape import (
     REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
     ReplayTapeManifest,
@@ -41,7 +46,7 @@ from app.trading.discovery.replay_tape import (
 from app.trading.discovery.evidence_bundles import evidence_bundle_blockers
 from app.trading.models import SignalEnvelope
 
-_CHIP_UNIVERSE = list(runner.LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
+_CHIP_UNIVERSE = list(LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
 
 
 class _FakeSigalrmSignal:
@@ -173,8 +178,10 @@ def _source_jsonl_payload() -> dict[str, object]:
     }
 
 
-def _source_from_payload(payload: dict[str, object]) -> runner.WhitepaperResearchSource:
-    return runner.WhitepaperResearchSource(
+def _source_from_payload(
+    payload: dict[str, object],
+) -> claim_compiler.WhitepaperResearchSource:
+    return claim_compiler.WhitepaperResearchSource(
         run_id=str(payload["run_id"]),
         title=str(payload["title"]),
         source_url=str(payload["source_url"]),
@@ -194,7 +201,7 @@ def _source_from_payload(payload: dict[str, object]) -> runner.WhitepaperResearc
 def _compact_recent_whitepaper_sources(
     source_count: int = 4,
 ) -> Any:
-    sources: list[runner.WhitepaperResearchSource] = []
+    sources: list[claim_compiler.WhitepaperResearchSource] = []
     for index in range(source_count):
         payload = _source_jsonl_payload()
         payload["run_id"] = f"compact-seed-2026-{index}"

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_a.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+import scripts.whitepaper_autoresearch_runner.candidate_goal_metadata as candidate_goal_metadata
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Path,
@@ -99,7 +103,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
                 ]
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-test",
             candidate_id="candidate-test",
@@ -296,7 +300,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
                 "requires_market_limit_order_mix": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-sleeve-order-type-proof",
             candidate_id="cand-sleeve-order-type-proof",
@@ -356,7 +360,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             ]
         }
 
-        rows = runner._candidate_sleeve_goal_rows(
+        rows = candidate_goal_metadata._candidate_sleeve_goal_rows(
             candidate_specs=(spec,),
             candidate_selection=candidate_selection,
             evidence_bundles=(evidence,),
@@ -405,7 +409,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
         self.assertEqual(rows[0]["exact_replay_ledger_artifact_row_count"], 30)
         self.assertEqual(rows[0]["exact_replay_ledger_artifact_fill_count"], 10)
         self.assertEqual(rows[0]["runtime_window_start"], "2026-05-18T13:30:00+00:00")
-        fallback_rows = runner._candidate_sleeve_goal_rows(
+        fallback_rows = candidate_goal_metadata._candidate_sleeve_goal_rows(
             candidate_specs=(spec,),
             candidate_selection={
                 "rows": [
@@ -432,7 +436,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
         self.assertIn("route_tca", fallback_rows[0]["paper_required_evidence_tokens"])
         self.assertGreater(fallback_rows[0]["paper_required_evidence_count"], 0)
 
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-sleeve-order-type-proof",
             source_candidate_ids=(evidence.candidate_id,),
@@ -451,7 +455,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             objective_scorecard={"target_met": True, "oracle_passed": True},
             optimizer_report={},
         )
-        portfolio_rows = runner._candidate_sleeve_goal_rows(
+        portfolio_rows = candidate_goal_metadata._candidate_sleeve_goal_rows(
             candidate_specs=(spec,),
             candidate_selection=candidate_selection,
             evidence_bundles=(evidence,),
@@ -482,7 +486,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
         self,
     ) -> None:
         spec = self._candidate_spec("spec-portfolio-promotion-subject")
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-portfolio-promotion-subject",
             candidate_id="cand-portfolio-promotion-subject",
@@ -502,7 +506,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             null_comparator={},
             promotion_readiness={},
         )
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-promotion-subject",
             source_candidate_ids=(evidence.candidate_id,),
@@ -596,7 +600,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             },
             promotion_contract={"requires_rejected_signal_outcome_learning": True},
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-rejected-signal-proof",
             candidate_id="cand-rejected-signal-proof",
@@ -659,7 +663,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
 
     def test_candidate_board_rejects_unknown_code_commit_lineage(self) -> None:
         spec = self._candidate_spec("spec-unknown-lineage")
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-unknown-lineage",
             candidate_id="cand-unknown-lineage",
@@ -743,7 +747,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-proof",
             candidate_id="cand-market-limit-proof",

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_b.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.candidate_goal_metadata as candidate_goal_metadata
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Path,
@@ -35,7 +38,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-pass",
             candidate_id="cand-market-limit-pass",
@@ -137,7 +140,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
                 "requires_order_lifecycle_fill_evidence": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-queue-survival-proof",
             candidate_id="cand-queue-survival-proof",
@@ -271,7 +274,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-missing-artifact-ref",
             candidate_id="cand-market-limit-missing-artifact-ref",
@@ -367,7 +370,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-route-bool",
             candidate_id="cand-market-limit-route-bool",
@@ -450,7 +453,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
                 "requires_execution_shortfall": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-market-limit-route-artifact",
             candidate_id="cand-market-limit-route-artifact",
@@ -520,7 +523,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             "spec-hmicro-proof",
             family_template_id="microstructure_continuation_matched_filter_v1",
         )
-        executed_evidence = runner.CandidateEvidenceBundle(
+        executed_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-hmicro-proof",
             candidate_id="chip-paper-microbar-composite@execution-proof",
@@ -671,7 +674,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
                 "requires_spread_adjusted_label_replay": True,
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-alpha-decay-missing-stress",
             candidate_id="cand-alpha-decay-missing-stress",
@@ -743,7 +746,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             "zero_authoritative_daily_pnl_until_materialized": True,
             "required_artifacts": "runtime-ledger/daily-pnl.json",
         }
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-sleeve-runtime-ledger-handoff",
             candidate_id="cand-sleeve-runtime-ledger-handoff",
@@ -764,12 +767,14 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             },
         )
 
-        proof_handoff = runner._candidate_sleeve_goal_proof_handoff_fields(
-            selection={"selected_for_replay": True},
-            spec=spec,
-            scorecard=evidence.objective_scorecard,
-            evidence=evidence,
-            selected_for_replay=True,
+        proof_handoff = (
+            candidate_goal_metadata._candidate_sleeve_goal_proof_handoff_fields(
+                selection={"selected_for_replay": True},
+                spec=spec,
+                scorecard=evidence.objective_scorecard,
+                evidence=evidence,
+                selected_for_replay=True,
+            )
         )
 
         self.assertEqual(
@@ -824,14 +829,16 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
                 {"ref": "runtime-ledger/scorecard-ref.json"}
             ],
         }
-        scorecard_proof_handoff = runner._candidate_sleeve_goal_proof_handoff_fields(
-            selection={},
-            spec=None,
-            scorecard={
-                "runtime_ledger_lineage_materialization_handoff": scorecard_handoff
-            },
-            evidence=None,
-            selected_for_replay=False,
+        scorecard_proof_handoff = (
+            candidate_goal_metadata._candidate_sleeve_goal_proof_handoff_fields(
+                selection={},
+                spec=None,
+                scorecard={
+                    "runtime_ledger_lineage_materialization_handoff": scorecard_handoff
+                },
+                evidence=None,
+                selected_for_replay=False,
+            )
         )
         self.assertEqual(
             scorecard_proof_handoff["runtime_ledger_lineage_materialization_handoff"],

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_fast_replay.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_fast_replay.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.preview_narrowing as preview_narrowing
+import scripts.whitepaper_autoresearch_runner.queue_metadata as queue_metadata
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Path,
@@ -34,7 +38,7 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
             args.replay_tape_path = tape_path
             args.replay_tape_preview_top_k = 2
             args.replay_tape_dataset_snapshot_ref = "frontier-preview"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -69,15 +73,19 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 23),
                 ),
                 feature_schema_hash="stale-feature-schema",
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
             spec = self._candidate_spec("spec-frontier-0")
             candidate_selection = {
@@ -130,7 +138,7 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
             args.replay_tape_path = tape_path
             args.replay_tape_preview_top_k = 1
             args.replay_tape_dataset_snapshot_ref = "blocked-preview"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=rows,
                 tape_path=tape_path,
@@ -138,17 +146,21 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 23),
                 ),
-                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                feature_schema_hash=queue_metadata._materialized_replay_tape_feature_schema_hash(
                     args
                 ),
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
             base_spec = self._candidate_spec("spec-lineage-blocked")
             spec = replace(
@@ -287,7 +299,7 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
             },
         ]
 
-        queue_payload = runner._bounded_sim_target_queue_metadata(
+        queue_payload = queue_metadata._bounded_sim_target_queue_metadata(
             preview_rows=duplicate_rows,
             replay_tape_manifest=manifest,
             exact_replay_candidate_cap=6,
@@ -341,37 +353,45 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
             args.full_window_start_date = "2026-02-23"
             args.full_window_end_date = "2026-02-27"
 
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.staged_replay_frontier_default = True
             args.disable_staged_replay_frontier = True
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.disable_staged_replay_frontier = False
             args.replay_mode = "synthetic"
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.replay_mode = "real"
             args.replay_tape_path = None
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 0
+            )
 
             args.selection_only = True
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.selection_only = False
             args.replay_tape_path = Path(tmpdir) / "provided-tape.jsonl"
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.replay_tape_path = None
             args.full_window_start_date = ""
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
             args.full_window_start_date = "2026-02-23"
             args.full_window_end_date = ""
-            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+            self.assertFalse(queue_metadata._auto_materialize_staged_replay_tape(args))
 
     def test_staged_replay_frontier_default_resolvers_enable_bounded_real_path(
         self,
@@ -388,7 +408,9 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
             args.full_window_start_date = "2026-02-23"
             args.full_window_end_date = "2026-02-27"
 
-            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 77)
+            self.assertEqual(
+                preview_narrowing._resolved_fast_replay_preview_top_k(args), 77
+            )
 
             args.replay_tape_path = None
-            self.assertTrue(runner._auto_materialize_staged_replay_tape(args))
+            self.assertTrue(queue_metadata._auto_materialize_staged_replay_tape(args))

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_feedback_loading.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_feedback_loading.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.feedback_loading as feedback_loading
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+import scripts.whitepaper_autoresearch_runner.rejected_signal_feedback as rejected_signal_feedback
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     AutoresearchCandidateSpec,
     AutoresearchEpoch,
@@ -14,7 +21,6 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     json,
     patch,
     replace,
-    runner,
 )
 
 
@@ -146,7 +152,7 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             entry_minute_after_open="75",
             selection_mode="continuation",
         )
-        losing_bundle = runner.evidence_bundle_from_frontier_candidate(
+        losing_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=losing_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-losing",
@@ -172,32 +178,34 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             dataset_snapshot_id="snap-feedback",
             result_path="feedback://losing",
         )
-        capital_unsafe_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=capital_unsafe_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-capital-unsafe",
-                "family_template_id": capital_unsafe_spec.family_template_id,
-                "runtime_family": capital_unsafe_spec.runtime_family,
-                "runtime_strategy_name": capital_unsafe_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "750",
-                    "active_day_ratio": "1",
-                    "positive_day_ratio": "1",
-                    "negative_day_count": 0,
-                    "best_day_share": "0.25",
-                    "worst_day_loss": "0",
-                    "max_drawdown": "0",
-                    "max_gross_exposure_pct_equity": "2.5",
-                    "min_cash": "-500",
-                    "negative_cash_observation_count": 8,
-                    "avg_filled_notional_per_day": "500000",
+        capital_unsafe_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=capital_unsafe_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-capital-unsafe",
+                    "family_template_id": capital_unsafe_spec.family_template_id,
+                    "runtime_family": capital_unsafe_spec.runtime_family,
+                    "runtime_strategy_name": capital_unsafe_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "750",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                        "negative_day_count": 0,
+                        "best_day_share": "0.25",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "max_gross_exposure_pct_equity": "2.5",
+                        "min_cash": "-500",
+                        "negative_cash_observation_count": 8,
+                        "avg_filled_notional_per_day": "500000",
+                    },
                 },
-            },
-            dataset_snapshot_id="snap-feedback",
-            result_path="feedback://capital-unsafe",
+                dataset_snapshot_id="snap-feedback",
+                result_path="feedback://capital-unsafe",
+            )
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(losing_spec, unexplored_spec, capital_unsafe_spec),
             feedback_evidence_bundles=(losing_bundle, capital_unsafe_bundle),
         )
@@ -252,7 +260,7 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
 
     def test_feedback_evidence_jsonl_round_trips(self) -> None:
         spec = self._candidate_spec("spec-feedback-jsonl")
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-jsonl",
@@ -271,14 +279,14 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
                 json.dumps(bundle.to_payload(), sort_keys=True) + "\n",
                 encoding="utf-8",
             )
-            loaded = runner._load_feedback_evidence_bundles((path,))
+            loaded = feedback_loading._load_feedback_evidence_bundles((path,))
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
 
     def test_feedback_evidence_loads_recent_persisted_epoch_bundles(self) -> None:
         spec = self._candidate_spec("spec-feedback-persisted")
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-persisted",
@@ -324,11 +332,13 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             )
             session.commit()
 
-            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
-                (), include_persisted=True
+            loaded, manifest = (
+                persisted_feedback_sources._load_autoresearch_feedback_evidence_bundles(
+                    (), include_persisted=True
+                )
             )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -439,11 +449,13 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             )
             session.commit()
 
-            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
-                (), include_persisted=True
+            loaded, manifest = (
+                persisted_feedback_sources._load_autoresearch_feedback_evidence_bundles(
+                    (), include_persisted=True
+                )
             )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -472,7 +484,7 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
 
     def test_feedback_evidence_dedupe_handles_missing_bundle_ids(self) -> None:
         spec = self._candidate_spec("spec-feedback-dedupe")
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-dedupe",
@@ -483,7 +495,9 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
         )
         no_id_bundle = replace(bundle, evidence_bundle_id="")
 
-        deduped = runner._dedupe_feedback_evidence_bundles((no_id_bundle, no_id_bundle))
+        deduped = feedback_loading._dedupe_feedback_evidence_bundles(
+            (no_id_bundle, no_id_bundle)
+        )
 
         self.assertEqual(len(deduped), 1)
         self.assertEqual(deduped[0].candidate_spec_id, spec.candidate_spec_id)
@@ -493,8 +507,10 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=RuntimeError("db unavailable"),
         ):
-            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
-                (), include_persisted=True
+            loaded, manifest = (
+                persisted_feedback_sources._load_autoresearch_feedback_evidence_bundles(
+                    (), include_persisted=True
+                )
             )
 
         self.assertEqual(loaded, ())
@@ -508,7 +524,9 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
         spec = self._candidate_spec("spec-summary-scorecard")
         scorecard = {
             "candidate_id": "cand-summary-scorecard",
-            "execution_signature": runner._candidate_spec_execution_signature(spec),
+            "execution_signature": candidate_identity._candidate_spec_execution_signature(
+                spec
+            ),
             "family_template_id": spec.family_template_id,
             "runtime_family": spec.runtime_family,
             "runtime_strategy_name": spec.runtime_strategy_name,
@@ -565,7 +583,9 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles()
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles()
+            )
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
@@ -584,7 +604,7 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
         self.assertEqual(manifest["legacy_summary_unmatched_scorecard_count"], 1)
         self.assertEqual(manifest["legacy_summary_bundle_count"], 1)
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -664,7 +684,9 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles()
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles()
+            )
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
@@ -695,7 +717,7 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             manifest["portfolio_candidate_ids"], ["portfolio-feedback-blocked"]
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,), feedback_evidence_bundles=loaded
         )
 
@@ -735,11 +757,15 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
         )
 
         self.assertEqual(
-            runner._portfolio_candidate_row_to_feedback_bundles(non_feedback_status),
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                non_feedback_status
+            ),
             (),
         )
         self.assertEqual(
-            runner._portfolio_candidate_row_to_feedback_bundles(empty_scorecard),
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                empty_scorecard
+            ),
             (),
         )
 
@@ -774,8 +800,10 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             status="blocked",
         )
 
-        fallback_bundles = runner._portfolio_candidate_row_to_feedback_bundles(
-            fallback_row
+        fallback_bundles = (
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                fallback_row
+            )
         )
 
         self.assertEqual(len(fallback_bundles), 1)
@@ -791,7 +819,9 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             fallback_bundles[0].objective_scorecard["portfolio_blockers"],
         )
         self.assertEqual(
-            runner._portfolio_candidate_row_to_feedback_bundles(invalid_sleeve_row),
+            rejected_signal_feedback._portfolio_candidate_row_to_feedback_bundles(
+                invalid_sleeve_row
+            ),
             (),
         )
 
@@ -799,7 +829,7 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
         self,
     ) -> None:
         valid_spec = self._candidate_spec("spec-feedback-limit")
-        valid_bundle = runner.evidence_bundle_from_frontier_candidate(
+        valid_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=valid_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-feedback-limit",
@@ -808,7 +838,7 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             dataset_snapshot_id="snap-feedback-limit",
             result_path="feedback://limit",
         )
-        extra_bundle = runner.evidence_bundle_from_frontier_candidate(
+        extra_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-feedback-extra",
             candidate={
                 "candidate_id": "cand-feedback-extra",
@@ -878,8 +908,10 @@ class TestAutoresearchRunnerFeedbackLoading(WhitepaperAutoresearchRunnerTestCase
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles(
-                limit=1
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles(
+                    limit=1
+                )
             )
 
         self.assertEqual(len(loaded), 1)

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.replay_tape as replay_tape
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.local_intraday_tsmom_replay as replay_mod
+import scripts.materialize_replay_tape as replay_materializer
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.queue_metadata as queue_metadata
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Namespace,
@@ -49,15 +57,15 @@ class TestAutoresearchRunnerMaterializedReplay(
                 for seq, day in enumerate(range(23, 28), start=1)
             ]
 
-            with patch.object(
-                runner.replay_mod, "_iter_signal_rows", return_value=rows
-            ):
-                updated_args, receipt = runner._maybe_materialize_epoch_replay_tape(
-                    args=args,
-                    output_dir=output_dir,
-                    epoch_id="epoch-materialized",
+            with patch.object(replay_mod, "_iter_signal_rows", return_value=rows):
+                updated_args, receipt = (
+                    queue_metadata._maybe_materialize_epoch_replay_tape(
+                        args=args,
+                        output_dir=output_dir,
+                        epoch_id="epoch-materialized",
+                    )
                 )
-            tape = runner.load_replay_tape(updated_args.replay_tape_path)
+            tape = replay_tape.load_replay_tape(updated_args.replay_tape_path)
             self.assertIsNotNone(receipt)
             assert receipt is not None
             self.assertEqual(
@@ -98,14 +106,12 @@ class TestAutoresearchRunnerMaterializedReplay(
                 )
             ]
 
-            with patch.object(
-                runner.replay_mod, "_iter_signal_rows", return_value=rows
-            ):
+            with patch.object(replay_mod, "_iter_signal_rows", return_value=rows):
                 with self.assertRaisesRegex(
                     ValueError,
                     "replay_tape_incomplete_coverage:missing_days=2026-02-24,2026-02-25,2026-02-26,2026-02-27",
                 ):
-                    runner._maybe_materialize_epoch_replay_tape(
+                    queue_metadata._maybe_materialize_epoch_replay_tape(
                         args=args,
                         output_dir=output_dir,
                         epoch_id="epoch-materialized",
@@ -125,7 +131,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             args.materialize_replay_tape = True
             args.replay_tape_path = root / "provided-tape.jsonl"
 
-            updated_args, receipt = runner._maybe_materialize_epoch_replay_tape(
+            updated_args, receipt = queue_metadata._maybe_materialize_epoch_replay_tape(
                 args=args,
                 output_dir=output_dir,
                 epoch_id="epoch-skip",
@@ -139,7 +145,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             with self.assertRaisesRegex(
                 ValueError, "replay_tape_materialization_requires_real_replay"
             ):
-                runner._maybe_materialize_epoch_replay_tape(
+                queue_metadata._maybe_materialize_epoch_replay_tape(
                     args=args,
                     output_dir=output_dir,
                     epoch_id="epoch-synthetic",
@@ -150,7 +156,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             with self.assertRaisesRegex(
                 ValueError, "replay_tape_materialization_requires_replay_execution"
             ):
-                runner._maybe_materialize_epoch_replay_tape(
+                queue_metadata._maybe_materialize_epoch_replay_tape(
                     args=args,
                     output_dir=output_dir,
                     epoch_id="epoch-selection-only",
@@ -162,7 +168,7 @@ class TestAutoresearchRunnerMaterializedReplay(
                 ValueError,
                 "replay_tape_materialization_requires_full_window_start_date",
             ):
-                runner._maybe_materialize_epoch_replay_tape(
+                queue_metadata._maybe_materialize_epoch_replay_tape(
                     args=args,
                     output_dir=output_dir,
                     epoch_id="epoch-missing-window",
@@ -220,7 +226,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             }
 
             with patch.object(
-                runner.replay_materializer,
+                replay_materializer,
                 "_fetch_coverage_diagnostics",
                 return_value=coverage,
             ) as fetch:
@@ -256,7 +262,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             args.full_window_end_date = "2026-02-27"
             args.symbols = "NVDA"
             args.replay_tape_dataset_snapshot_ref = "preview-snapshot"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -274,17 +280,21 @@ class TestAutoresearchRunnerMaterializedReplay(
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 27),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 27),
                 ),
-                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                feature_schema_hash=queue_metadata._materialized_replay_tape_feature_schema_hash(
                     args
                 ),
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
             spec = self._candidate_spec("spec-preview-fallback")
             selection = {
@@ -522,11 +532,11 @@ class TestAutoresearchRunnerMaterializedReplay(
                 *,
                 args: Namespace,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 del args
                 captured_spec_ids.extend(spec.candidate_spec_id for spec in specs)
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=specs[0].candidate_spec_id,
                     candidate={
                         "candidate_id": "cand-direct-a",

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_next_epoch.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_next_epoch.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import scripts.whitepaper_autoresearch_runner.candidate_remediation as candidate_remediation
+import scripts.whitepaper_autoresearch_runner.next_epoch_planning as next_epoch_planning
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Path,
@@ -14,7 +18,7 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
 
 class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
     def test_remediation_prioritizes_missing_promotion_proof(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {"compiled_candidate_count": "not-an-int"},
@@ -78,7 +82,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
         )
 
     def test_remediation_defers_promotion_proof_until_profit_gates_pass(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_candidate_failed_profit_target_oracle",
             candidate_selection={
                 "rows": [
@@ -134,7 +138,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
         self.assertEqual(proof_action["priority"], 7)
 
     def test_remediation_increases_breadth_from_current_epoch(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "rows": [
@@ -203,7 +207,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
                 start=1,
             )
         ]
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -276,7 +280,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
                 "selected_for_replay": True,
             }
         ]
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -334,7 +338,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
     def test_remediation_recommends_surface_mutation_when_mlx_blocks_synthetic_prior(
         self,
     ) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -377,7 +381,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
     def test_remediation_recommends_surface_mutation_when_feedback_blocks_all_candidates(
         self,
     ) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="portfolio_optimizer_produced_no_candidate",
             candidate_selection={
                 "budget": {
@@ -438,7 +442,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
@@ -489,7 +493,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
@@ -527,10 +531,10 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
-            flags = runner._profitability_next_epoch_flags(
+            flags = next_epoch_planning._profitability_next_epoch_flags(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
@@ -640,17 +644,17 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 
         self.assertEqual(
-            runner._bounded_real_replay_shard_timeout_seconds(0),
-            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            replay_shards._bounded_real_replay_shard_timeout_seconds(0),
+            replay_shards._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
         self.assertEqual(
-            runner._bounded_real_replay_shard_timeout_seconds(-1),
-            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            replay_shards._bounded_real_replay_shard_timeout_seconds(-1),
+            replay_shards._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
         self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
         self.assertIn(
@@ -681,7 +685,7 @@ class TestAutoresearchRunnerNextEpoch(WhitepaperAutoresearchRunnerTestCaseBase):
                 ]
             }
 
-            plan = runner._profitability_next_epoch_plan(
+            plan = next_epoch_planning._profitability_next_epoch_plan(
                 args=args, target=Decimal("500"), remediation=remediation
             )
 

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_a.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Path,
@@ -15,7 +17,7 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
         self,
     ) -> None:
         spec = self._candidate_spec("spec-paper-probation")
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-paper-probation",
             candidate_id="cand-paper-probation",
@@ -444,7 +446,7 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
         close_spec = self._candidate_spec("spec-close-probation")
         bridge_spec = self._candidate_spec("spec-bridge-probation")
         raw_only_spec = self._candidate_spec("spec-raw-only-probation")
-        weak_evidence = runner.CandidateEvidenceBundle(
+        weak_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-weak-probation",
             candidate_id="cand-weak-probation",
@@ -499,7 +501,7 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
             null_comparator={},
             promotion_readiness={},
         )
-        close_evidence = runner.CandidateEvidenceBundle(
+        close_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-close-probation",
             candidate_id="cand-close-probation",
@@ -571,7 +573,7 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
             null_comparator={},
             promotion_readiness={},
         )
-        raw_only_evidence = runner.CandidateEvidenceBundle(
+        raw_only_evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-raw-only-probation",
             candidate_id="cand-raw-only-probation",

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_b.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.proposal_training as proposal_training
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Namespace,
@@ -223,7 +226,7 @@ class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCase
     def test_candidate_universe_symbols_default_to_chip_coverage_when_empty(
         self,
     ) -> None:
-        symbols = runner._candidate_universe_symbols_from_args(
+        symbols = artifact_io._candidate_universe_symbols_from_args(
             Namespace(symbols="MSFT,SHOP")
         )
 
@@ -350,7 +353,7 @@ class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCase
         )
 
     def test_best_false_negative_table_excludes_pre_replay_blocked_specs(self) -> None:
-        table = runner._best_false_negative_table(
+        table = proposal_training._best_false_negative_table(
             candidate_selection={
                 "rows": [
                     {

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_parser.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_parser.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.mlx_training_data as mlx_training_data
+import app.trading.discovery.profit_target_oracle as profit_target_oracle
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.feedback_bundle_builders as feedback_bundle_builders
+import socket
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Any,
     Decimal,
@@ -25,8 +32,8 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             self._candidate_spec("spec-low"),
             self._candidate_spec("spec-high"),
         ]
-        evidence_bundles = [
-            runner.evidence_bundle_from_frontier_candidate(
+        candidate_evidence_bundles = [
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=specs[0].candidate_spec_id,
                 candidate={
                     "candidate_id": "candidate-low",
@@ -35,7 +42,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                 dataset_snapshot_id="snapshot",
                 result_path="/tmp/low.json",
             ),
-            runner.evidence_bundle_from_frontier_candidate(
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=specs[1].candidate_spec_id,
                 candidate={
                     "candidate_id": "candidate-high",
@@ -46,7 +53,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             ),
         ]
         captured_backend_preferences: list[str] = []
-        real_train_mlx_ranker = runner.train_mlx_ranker
+        real_train_mlx_ranker = mlx_training_data.train_mlx_ranker
 
         def capture_train_mlx_ranker(rows: Sequence[Any], **kwargs: Any) -> Any:
             captured_backend_preferences.append(str(kwargs.get("backend_preference")))
@@ -68,15 +75,15 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                 side_effect=capture_train_mlx_ranker,
             ),
         ):
-            runner._pre_replay_proposal_model_and_rows(
+            proposal_building._pre_replay_proposal_model_and_rows(
                 specs=specs,
                 feedback_evidence_bundles=(),
-                oracle_policy=runner.ProfitTargetOraclePolicy(),
+                oracle_policy=profit_target_oracle.ProfitTargetOraclePolicy(),
                 ranker_backend_preference="torch-cuda",
             )
-            runner._proposal_model_and_rows(
+            proposal_training._proposal_model_and_rows(
                 specs=specs,
-                evidence_bundles=evidence_bundles,
+                evidence_bundles=candidate_evidence_bundles,
                 replay_selection_by_spec=None,
                 ranker_backend_preference="cuda",
             )
@@ -113,7 +120,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                 "mechanism_overlay_ids": ["rankic_factor_acceptance_harness"]
             },
         )
-        evidence = runner.CandidateEvidenceBundle(
+        evidence = evidence_bundles.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
             evidence_bundle_id="ev-factor-acceptance",
             candidate_id="candidate-factor-acceptance",
@@ -217,7 +224,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             },
         )
 
-        candidate = runner._candidate_payload_with_feedback_metadata(
+        candidate = candidate_prior_scoring._candidate_payload_with_feedback_metadata(
             spec=spec,
             candidate={
                 "candidate_id": "candidate-prevclose",
@@ -269,7 +276,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             },
         )
 
-        candidate = runner._candidate_payload_with_feedback_metadata(
+        candidate = candidate_prior_scoring._candidate_payload_with_feedback_metadata(
             spec=spec,
             candidate={
                 "candidate_id": "candidate-validation-contract",
@@ -282,7 +289,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                 },
             },
         )
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate=candidate,
             dataset_snapshot_id="historical-market-replay-2026-05-18",
@@ -328,7 +335,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                 "synthetic_evidence_policy": "validation_only_not_promotion_proof",
             },
         )
-        candidate = runner._candidate_payload_with_feedback_metadata(
+        candidate = candidate_prior_scoring._candidate_payload_with_feedback_metadata(
             spec=spec,
             candidate={
                 "candidate_id": "candidate-synthetic-contract",
@@ -336,7 +343,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             },
         )
 
-        bundle = runner.evidence_bundle_from_frontier_candidate(
+        bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate=candidate,
             dataset_snapshot_id="synthetic-recent-whitepaper-2025-2026",
@@ -414,11 +421,11 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
         )
 
         self.assertGreater(
-            runner._pre_replay_candidate_score(paper_spec),
-            runner._pre_replay_candidate_score(control_spec),
+            candidate_prior_scoring._pre_replay_candidate_score(paper_spec),
+            candidate_prior_scoring._pre_replay_candidate_score(control_spec),
         )
 
-        prior_bundle = runner._pre_replay_prior_bundle(paper_spec)
+        prior_bundle = feedback_bundle_builders._pre_replay_prior_bundle(paper_spec)
         self.assertFalse(prior_bundle.promotion_readiness["promotable"])
         self.assertIn(
             "runtime_replay_required", prior_bundle.promotion_readiness["blockers"]
@@ -428,7 +435,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             prior_bundle.promotion_readiness["blockers"],
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(control_spec, paper_spec),
         )
         row_by_spec = {row["candidate_spec_id"]: row for row in rows}
@@ -604,8 +611,8 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
         )
 
         with patch(
-            "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
-            side_effect=runner.socket.gaierror("not known"),
+            "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
+            side_effect=socket.gaierror("not known"),
         ):
             failure = runner._clickhouse_endpoint_preflight_failure(args)
 
@@ -621,7 +628,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
         )
 
         with patch(
-            "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
+            "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("non-cluster endpoints are replay-checked"),
         ):
             failure = runner._clickhouse_endpoint_preflight_failure(args)
@@ -637,7 +644,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
         )
 
         with patch(
-            "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
+            "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("replay tape should bypass DNS preflight"),
         ):
             failure = runner._clickhouse_endpoint_preflight_failure(args)

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_persistence_remediation.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_persistence_remediation.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.whitepaper_autoresearch_runner.candidate_remediation as candidate_remediation
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     AutoresearchCandidateSpec,
     AutoresearchEpoch,
@@ -255,7 +261,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
     def test_epoch_ledgers_allow_repeated_candidate_specs_across_epochs(
         self,
     ) -> None:
-        candidate_spec = runner.CandidateSpec(
+        candidate_spec = CandidateSpec(
             schema_version="torghut.candidate-spec.v1",
             candidate_spec_id="spec-repeatable",
             hypothesis_id="hyp-repeatable",
@@ -279,7 +285,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
             side_effect=lambda: Session(self.engine),
         ):
             for epoch_id in ("epoch-repeat-1", "epoch-repeat-2"):
-                runner._persist_epoch_ledgers(
+                persisted_feedback_sources._persist_epoch_ledgers(
                     epoch_id=epoch_id,
                     status="no_profit_target_candidate",
                     target_net_pnl_per_day=Decimal("300"),
@@ -316,7 +322,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
     def test_epoch_ledgers_persist_promotion_ready_only_from_readiness_payload(
         self,
     ) -> None:
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-readiness-test",
             source_candidate_ids=("candidate-test",),
@@ -336,7 +342,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-readiness-blocked",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -356,7 +362,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
                 started_at=started_at,
                 completed_at=completed_at,
             )
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-readiness-ready",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -406,7 +412,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
     def test_epoch_ledgers_persist_target_met_oracle_failed_as_paper_probation(
         self,
     ) -> None:
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-paper-probation",
             source_candidate_ids=("candidate-test",),
@@ -426,7 +432,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-paper-probation",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -465,7 +471,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
     def test_epoch_ledgers_keep_target_met_oracle_failed_blocked_without_paper_probation_authority(
         self,
     ) -> None:
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-paper-probation-blocked",
             source_candidate_ids=("candidate-test",),
@@ -485,7 +491,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            runner._persist_epoch_ledgers(
+            persisted_feedback_sources._persist_epoch_ledgers(
                 epoch_id="epoch-paper-probation-blocked",
                 status="ok",
                 target_net_pnl_per_day=Decimal("500"),
@@ -577,7 +583,9 @@ class TestAutoresearchRunnerPersistenceRemediation(
             )
             session.commit()
 
-            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles()
+            loaded, manifest = (
+                persisted_feedback_sources._load_recent_persisted_feedback_evidence_bundles()
+            )
 
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
@@ -701,7 +709,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
                 "_collect_partial_real_replay",
                 return_value=runner.EpochReplayResult(
                     evidence_bundles=(
-                        runner.evidence_bundle_from_frontier_candidate(
+                        evidence_bundles.evidence_bundle_from_frontier_candidate(
                             candidate_spec_id="spec-partial",
                             candidate={
                                 "candidate_id": "cand-partial",
@@ -759,7 +767,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
         self.assertIn("candidate_search_remediation", summary)
 
     def test_timeout_remediation_recommends_smaller_replay_frontier(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="TimeoutError:real_replay_timeout_seconds:3600",
             candidate_selection={
                 "rows": [
@@ -790,7 +798,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
         )
 
     def test_remediation_surfaces_recent_trading_day_shortfall(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason="ValueError:insufficient_recent_trading_days:9<11",
             candidate_selection={
                 "rows": [
@@ -859,7 +867,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
         )
 
     def test_remediation_surfaces_stale_tape_shortfall(self) -> None:
-        remediation = runner._candidate_search_remediation(
+        remediation = candidate_remediation._candidate_search_remediation(
             failure_reason=(
                 "ValueError:stale_tape:"
                 "expected_last_trading_day=2026-05-19:end_day=2026-05-18"

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_quality_oracle.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_quality_oracle.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.profit_target_oracle as profit_target_oracle
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.feedback_loading as feedback_loading
+import scripts.whitepaper_autoresearch_runner.oracle_policy as oracle_policy
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+import scripts.whitepaper_autoresearch_runner.proposal_training as proposal_training
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Namespace,
@@ -19,7 +28,7 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
                 ValueError,
                 "feedback_evidence_jsonl_missing",
             ):
-                runner._load_feedback_evidence_bundles((missing_path,))
+                feedback_loading._load_feedback_evidence_bundles((missing_path,))
 
             invalid_path = Path(tmpdir) / "invalid.jsonl"
             invalid_path.write_text("\n[]\n", encoding="utf-8")
@@ -27,12 +36,12 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
                 ValueError,
                 "feedback_evidence_jsonl_invalid",
             ):
-                runner._load_feedback_evidence_bundles((invalid_path,))
+                feedback_loading._load_feedback_evidence_bundles((invalid_path,))
 
     def test_candidate_quality_gate_flags_capital_safety_failures(self) -> None:
-        policy = runner.ProfitTargetOraclePolicy()
+        policy = profit_target_oracle.ProfitTargetOraclePolicy()
 
-        failures = runner._candidate_quality_gate_failures(
+        failures = proposal_training._candidate_quality_gate_failures(
             {
                 "net_pnl_per_day": "750",
                 "active_day_ratio": "1",
@@ -61,9 +70,9 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
         self.assertIn("negative_cash_observed", failures)
 
     def test_candidate_quality_gate_preserves_current_oracle_blockers(self) -> None:
-        policy = runner.ProfitTargetOraclePolicy()
+        policy = profit_target_oracle.ProfitTargetOraclePolicy()
 
-        failures = runner._candidate_quality_gate_failures(
+        failures = proposal_training._candidate_quality_gate_failures(
             {
                 "net_pnl_per_day": "750",
                 "active_day_ratio": "1",
@@ -107,9 +116,9 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
         self.assertIn("delay_adjusted_depth_stress_model_failed", failures)
 
     def test_candidate_quality_gate_flags_weak_profit_factor(self) -> None:
-        policy = runner.ProfitTargetOraclePolicy()
+        policy = profit_target_oracle.ProfitTargetOraclePolicy()
 
-        failures = runner._candidate_quality_gate_failures(
+        failures = proposal_training._candidate_quality_gate_failures(
             {
                 "net_pnl_per_day": "750",
                 "active_day_ratio": "1",
@@ -169,13 +178,13 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
     def test_candidate_spec_contract_exposes_full_promotion_risk_parameters(
         self,
     ) -> None:
-        policy = runner.ProfitTargetOraclePolicy(
+        policy = profit_target_oracle.ProfitTargetOraclePolicy(
             max_gross_exposure_pct_equity=Decimal("0.85"),
             min_cash=Decimal("250"),
             max_negative_cash_observation_count=0,
         )
 
-        updated = runner._candidate_spec_with_oracle_policy(
+        updated = oracle_policy._candidate_spec_with_oracle_policy(
             self._candidate_spec("spec-full-promotion-policy"),
             oracle_policy=policy,
         )
@@ -210,12 +219,12 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
         )
 
         def feedback(
-            spec: runner.CandidateSpec,
+            spec: CandidateSpec,
             *,
             candidate_id: str,
             scorecard: dict[str, object],
-        ) -> runner.CandidateEvidenceBundle:
-            return runner.evidence_bundle_from_frontier_candidate(
+        ) -> evidence_bundles.CandidateEvidenceBundle:
+            return evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=spec.candidate_spec_id,
                 candidate={
                     "candidate_id": candidate_id,
@@ -308,7 +317,7 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
             scorecard={"negative_cash_observation_count": "1"},
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(
                 string_veto_spec,
                 min_cash_spec,
@@ -366,14 +375,14 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
                 "source_run_id": "source-spec-drifted-signature",
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=original_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-original-signature",
                 "family_template_id": original_spec.family_template_id,
                 "runtime_family": original_spec.runtime_family,
                 "runtime_strategy_name": original_spec.runtime_strategy_name,
-                "execution_signature": runner._candidate_spec_execution_signature(
+                "execution_signature": candidate_identity._candidate_spec_execution_signature(
                     original_spec
                 ),
                 "objective_scorecard": {
@@ -391,7 +400,7 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
             result_path="feedback://signature-drift",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(drifted_spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -442,28 +451,30 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
             entry_minute_after_open="90",
             selection_mode="continuation",
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-family-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "125",
-                    "active_day_ratio": "1",
-                    "positive_day_ratio": "1",
-                    "negative_day_count": 0,
-                    "daily_net": {
-                        "2026-05-01": "250",
-                        "2026-05-04": "-25",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-family-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "125",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                        "negative_day_count": 0,
+                        "daily_net": {
+                            "2026-05-01": "250",
+                            "2026-05-04": "-25",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-family-feedback",
-            result_path="feedback://family",
+                dataset_snapshot_id="snap-family-feedback",
+                result_path="feedback://family",
+            )
         )
-        no_family_bundle = runner.evidence_bundle_from_frontier_candidate(
+        no_family_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-not-in-current-epoch",
             candidate={
                 "candidate_id": "cand-no-family",
@@ -476,7 +487,7 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
             result_path="feedback://no-family",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(mutated_family_spec, unrelated_spec),
             feedback_evidence_bundles=(family_feedback_bundle, no_family_bundle),
         )

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+from app.trading.discovery.candidate_specs import CandidateSpec
+import multiprocessing
+import queue
+import time as monotonic_time
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Any,
     Namespace,
@@ -34,13 +40,13 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 _args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(spec_ids)
                 if len(calls) == 2:
                     raise TimeoutError("real_replay_timeout_seconds:7")
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec_ids[0],
                     candidate={
                         "candidate_id": f"cand-{spec_ids[0]}",
@@ -69,7 +75,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
             ) -> runner.EpochReplayResult:
                 _ = timeout_seconds
@@ -113,7 +119,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             args = self._args(output_dir)
             args.replay_mode = "real"
             spec = self._candidate_spec("spec-no-sigalrm")
-            bundle = runner.evidence_bundle_from_frontier_candidate(
+            bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=spec.candidate_spec_id,
                 candidate={
                     "candidate_id": "candidate-no-sigalrm",
@@ -138,7 +144,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                     ),
                 ) as child_replay,
             ):
-                result = runner._run_real_replay_once_with_optional_timeout(
+                result = replay_execution._run_real_replay_once_with_optional_timeout(
                     args=args,
                     output_dir=output_dir,
                     specs=(spec,),
@@ -161,7 +167,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             joined = False
 
             def get(self, *, timeout: float) -> Any:
-                raise runner.queue.Empty
+                raise queue.Empty
 
             def close(self) -> None:
                 self.closed = True
@@ -207,18 +213,16 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
 
             with (
                 patch.object(
-                    runner.multiprocessing,
+                    multiprocessing,
                     "get_context",
                     return_value=fake_context,
                 ),
-                patch.object(
-                    runner.monotonic_time, "monotonic", side_effect=[0.0, 0.0, 8.0]
-                ),
+                patch.object(monotonic_time, "monotonic", side_effect=[0.0, 0.0, 8.0]),
             ):
                 with self.assertRaisesRegex(
                     TimeoutError, "real_replay_timeout_seconds:7"
                 ):
-                    runner._run_real_replay_once_in_child_process(
+                    replay_execution._run_real_replay_once_in_child_process(
                         args=args,
                         output_dir=output_dir,
                         specs=(spec,),
@@ -251,7 +255,9 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
         )
         success_queue = CaptureQueue()
         with patch.object(replay_execution, "_run_real_replay", return_value=expected):
-            runner._real_replay_worker(success_queue, args, "worker-output", (spec,))
+            replay_execution._real_replay_worker(
+                success_queue, args, "worker-output", (spec,)
+            )
         self.assertEqual(success_queue.items, [("ok", expected)])
 
         error_queue = CaptureQueue()
@@ -260,7 +266,9 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             "_run_real_replay",
             side_effect=ValueError("worker-failed"),
         ):
-            runner._real_replay_worker(error_queue, args, "worker-output", (spec,))
+            replay_execution._real_replay_worker(
+                error_queue, args, "worker-output", (spec,)
+            )
         self.assertEqual(error_queue.items[0][0], "error")
         self.assertIsInstance(error_queue.items[0][1], ValueError)
 
@@ -270,7 +278,9 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             "_run_real_replay",
             side_effect=ValueError("worker-failed"),
         ):
-            runner._real_replay_worker(payload_queue, args, "worker-output", (spec,))
+            replay_execution._real_replay_worker(
+                payload_queue, args, "worker-output", (spec,)
+            )
         self.assertEqual(
             payload_queue.items,
             [("error_payload", ("ValueError", "worker-failed"))],
@@ -287,7 +297,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 self.terminated = True
 
         inactive = InactiveProcess()
-        runner._terminate_process(inactive)
+        replay_execution._terminate_process(inactive)
         self.assertFalse(inactive.terminated)
 
         class StubbornProcess:
@@ -309,7 +319,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 self.join_calls += 1
 
         stubborn = StubbornProcess()
-        runner._terminate_process(stubborn)
+        replay_execution._terminate_process(stubborn)
         self.assertTrue(stubborn.terminated)
         self.assertTrue(stubborn.killed)
         self.assertEqual(stubborn.join_calls, 2)
@@ -374,9 +384,9 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             fake_context = FakeContext(fake_queue, fake_process)
 
             with patch.object(
-                runner.multiprocessing, "get_context", return_value=fake_context
+                multiprocessing, "get_context", return_value=fake_context
             ):
-                result = runner._run_real_replay_once_in_child_process(
+                result = replay_execution._run_real_replay_once_in_child_process(
                     args=args,
                     output_dir=output_dir,
                     specs=(spec,),
@@ -442,13 +452,13 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 with (
                     self.subTest(status=item[0]),
                     patch.object(
-                        runner.multiprocessing,
+                        multiprocessing,
                         "get_context",
                         return_value=fake_context,
                     ),
                     self.assertRaises(expected_error),
                 ):
-                    runner._run_real_replay_once_in_child_process(
+                    replay_execution._run_real_replay_once_in_child_process(
                         args=args,
                         output_dir=output_dir,
                         specs=(spec,),
@@ -465,7 +475,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             joined = False
 
             def get(self, *, timeout: float) -> Any:
-                raise runner.queue.Empty
+                raise queue.Empty
 
             def close(self) -> None:
                 self.closed = True
@@ -499,14 +509,12 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             fake_context = FakeContext()
 
             with (
-                patch.object(
-                    runner.multiprocessing, "get_context", return_value=fake_context
-                ),
+                patch.object(multiprocessing, "get_context", return_value=fake_context),
                 self.assertRaisesRegex(
                     RuntimeError, "real_replay_worker_exited_without_result"
                 ),
             ):
-                runner._run_real_replay_once_in_child_process(
+                replay_execution._run_real_replay_once_in_child_process(
                     args=args,
                     output_dir=output_dir,
                     specs=(spec,),
@@ -534,7 +542,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(
@@ -547,7 +555,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 )
                 if len(calls) == 2:
                     raise TimeoutError("real_replay_timeout_seconds:7")
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec_ids[0],
                     candidate={
                         "candidate_id": f"cand-{spec_ids[0]}",
@@ -578,7 +586,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 args: Namespace,
                 *,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
             ) -> runner.EpochReplayResult:
                 _ = timeout_seconds
@@ -613,7 +621,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
 
     def test_failed_shard_retry_skips_malformed_and_unknown_spec_ids(self) -> None:
         self.assertEqual(
-            runner._failed_shard_spec_ids(
+            replay_shards._failed_shard_spec_ids(
                 (
                     {"candidate_spec_ids": "spec-not-a-list"},
                     {"candidate_spec_ids": ["spec-a", "", "spec-a", "spec-b"]},
@@ -625,7 +633,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             args = self._args(Path(tmpdir) / "epoch")
             evidence, replay_results, failures, summary = (
-                runner._retry_real_replay_failed_shard_specs(
+                replay_shards._retry_real_replay_failed_shard_specs(
                     args=args,
                     output_dir=Path(tmpdir) / "epoch",
                     specs=(self._candidate_spec("spec-known"),),

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+from app.trading.discovery.candidate_specs import CandidateSpec
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Any,
     Namespace,
@@ -23,8 +27,8 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
         calls: list[tuple[int, int, int]] = []
 
         def fake_execute(
-            plan: runner._ReplayShardPlan,
-        ) -> runner._ReplayShardOutcome:
+            plan: replay_models._ReplayShardPlan,
+        ) -> replay_models._ReplayShardOutcome:
             calls.append(
                 (
                     plan.shard_index,
@@ -32,7 +36,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                     int(plan.args.max_total_frontier_candidates),
                 )
             )
-            return runner._ReplayShardOutcome(
+            return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
                 result=runner.EpochReplayResult(
@@ -55,7 +59,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                 replay_shards, "_execute_real_replay_shard", side_effect=fake_execute
             ):
                 evidence, replay_results, failures, summary = (
-                    runner._retry_real_replay_failed_shard_specs(
+                    replay_shards._retry_real_replay_failed_shard_specs(
                         args=args,
                         output_dir=Path(tmpdir) / "epoch",
                         specs=(spec,),
@@ -86,10 +90,10 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
         calls: list[int] = []
 
         def fake_execute(
-            plan: runner._ReplayShardPlan,
-        ) -> runner._ReplayShardOutcome:
+            plan: replay_models._ReplayShardPlan,
+        ) -> replay_models._ReplayShardOutcome:
             calls.append(plan.shard_index)
-            bundle = runner.evidence_bundle_from_frontier_candidate(
+            bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=spec.candidate_spec_id,
                 candidate={
                     "candidate_id": "cand-retry-completes",
@@ -102,7 +106,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                 dataset_snapshot_id="snap-retry-completes",
                 result_path="feedback://retry-completes",
             )
-            return runner._ReplayShardOutcome(
+            return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
                 result=runner.EpochReplayResult(
@@ -118,7 +122,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                 replay_shards, "_execute_real_replay_shard", side_effect=fake_execute
             ):
                 evidence, replay_results, failures, summary = (
-                    runner._retry_real_replay_failed_shard_specs(
+                    replay_shards._retry_real_replay_failed_shard_specs(
                         args=args,
                         output_dir=Path(tmpdir) / "epoch",
                         specs=(spec,),
@@ -160,7 +164,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             args.max_frontier_candidates_per_spec = 2
             args.max_total_frontier_candidates = 5
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -205,7 +209,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             args.max_frontier_candidates_per_spec = 64
             args.max_total_frontier_candidates = 8
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -234,13 +238,13 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             args = self._args(output_dir)
             args.real_replay_shard_workers = 8
             workers_seen: list[int] = []
-            submitted: list[tuple[Any, runner._ReplayShardPlan]] = []
+            submitted: list[tuple[Any, replay_models._ReplayShardPlan]] = []
 
             class _FakeFuture:
-                def __init__(self, outcome: runner._ReplayShardOutcome) -> None:
+                def __init__(self, outcome: replay_models._ReplayShardOutcome) -> None:
                     self._outcome = outcome
 
-                def result(self) -> runner._ReplayShardOutcome:
+                def result(self) -> replay_models._ReplayShardOutcome:
                     return self._outcome
 
             class _FakeExecutor:
@@ -256,11 +260,11 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                 def submit(
                     self,
                     fn: Any,
-                    plan: runner._ReplayShardPlan,
+                    plan: replay_models._ReplayShardPlan,
                 ) -> _FakeFuture:
                     submitted.append((fn, plan))
                     return _FakeFuture(
-                        runner._ReplayShardOutcome(
+                        replay_models._ReplayShardOutcome(
                             shard_index=plan.shard_index,
                             candidate_spec_ids=tuple(
                                 spec.candidate_spec_id for spec in plan.specs
@@ -286,7 +290,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                     replay_shards, "as_completed", side_effect=fake_as_completed
                 ),
             ):
-                result = runner._run_real_replay_shards(
+                result = replay_shards._run_real_replay_shards(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,
@@ -327,7 +331,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             args.real_replay_shard_workers = 8
             args.real_replay_max_parallel_frontier_candidates = 10
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -336,12 +340,15 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             )
 
         self.assertEqual(
-            [runner._replay_shard_frontier_candidate_budget(plan) for plan in plans],
+            [
+                replay_shards._replay_shard_frontier_candidate_budget(plan)
+                for plan in plans
+            ],
             [8, 8, 8],
         )
         self.assertEqual([plan.timeout_seconds for plan in plans], [900, 900, 900])
         self.assertEqual(
-            runner._bounded_real_replay_shard_workers(args=args, plans=plans),
+            replay_shards._bounded_real_replay_shard_workers(args=args, plans=plans),
             1,
         )
 
@@ -365,7 +372,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             args.real_replay_shard_workers = 8
             args.real_replay_max_parallel_frontier_candidates = 99
 
-            plans = runner._build_real_replay_shards(
+            plans = replay_shards._build_real_replay_shards(
                 args=args,
                 output_dir=output_dir,
                 specs=specs,
@@ -374,7 +381,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             )
 
         self.assertEqual(
-            runner._bounded_real_replay_shard_workers(args=args, plans=plans),
+            replay_shards._bounded_real_replay_shard_workers(args=args, plans=plans),
             2,
         )
 
@@ -388,10 +395,10 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                 *,
                 args: Namespace,
                 output_dir: Path,
-                specs: Sequence[runner.CandidateSpec],
+                specs: Sequence[CandidateSpec],
             ) -> runner.EpochReplayResult:
                 spec = specs[0]
-                bundle = runner.evidence_bundle_from_frontier_candidate(
+                bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec.candidate_spec_id,
                     candidate={
                         "candidate_id": "cand-incomplete",

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_runtime_closure.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_runtime_closure.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import app.trading.discovery.mlx_snapshot as mlx_snapshot
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+import app.trading.discovery.profit_target_oracle as profit_target_oracle
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Namespace,
@@ -19,7 +24,7 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
 
 class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseBase):
     def test_candidate_universe_symbols_filter_to_live_chip_coverage(self) -> None:
-        symbols = runner._candidate_universe_symbols_from_args(
+        symbols = artifact_io._candidate_universe_symbols_from_args(
             Namespace(symbols="NVDA,AAPL,MSFT,AMAT,TSM,nvda")
         )
 
@@ -221,7 +226,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             )
             program = runner._load_epoch_program(args)
 
-        manifest = runner.MlxSnapshotManifest(
+        manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
             created_at="2026-05-06T00:00:00+00:00",
             source_window_start="",
@@ -240,7 +245,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             tensor_bundle_paths={},
             manifest_hash="hash",
         )
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-test",
             source_candidate_ids=("candidate-test",),
@@ -275,7 +280,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             args.replay_mode = "real"
             program = runner._load_epoch_program(args)
 
-        manifest = runner.MlxSnapshotManifest(
+        manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
             created_at="2026-05-06T00:00:00+00:00",
             source_window_start="2026-03-20",
@@ -294,7 +299,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             tensor_bundle_paths={},
             manifest_hash="hash",
         )
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-test",
             source_candidate_ids=("candidate-test",),
@@ -655,7 +660,9 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
                 + "\n",
                 encoding="utf-8",
             )
-            policy = runner.ProfitTargetOraclePolicy(min_observed_trading_days=2)
+            policy = profit_target_oracle.ProfitTargetOraclePolicy(
+                min_observed_trading_days=2
+            )
             scorecard: dict[str, object] = {
                 "net_pnl_per_day": "620",
                 "portfolio_post_cost_net_pnl_per_day": "620",
@@ -680,17 +687,19 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
                 "executable_replay_account_buying_power": "0",
                 "executable_replay_max_notional_per_trade": "0",
             }
-            scorecard["profit_target_oracle"] = runner.evaluate_profit_target_oracle(
-                scorecard,
-                target_net_pnl_per_day=Decimal("500"),
-                policy=policy,
+            scorecard["profit_target_oracle"] = (
+                profit_target_oracle.evaluate_profit_target_oracle(
+                    scorecard,
+                    target_net_pnl_per_day=Decimal("500"),
+                    policy=policy,
+                )
             )
             scorecard["oracle_passed"] = False
             self.assertIn(
                 "market_impact_stress_artifact_present_failed",
                 scorecard["profit_target_oracle"]["blockers"],
             )
-            portfolio = runner.PortfolioCandidateSpec(
+            portfolio = portfolio_optimizer.PortfolioCandidateSpec(
                 schema_version="torghut.portfolio-candidate-spec.v1",
                 portfolio_candidate_id="portfolio-test",
                 source_candidate_ids=("candidate-test",),
@@ -883,7 +892,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             args = self._args(Path(tmpdir) / "epoch")
             program = runner._load_epoch_program(args)
 
-        portfolio = runner.PortfolioCandidateSpec(
+        portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
             portfolio_candidate_id="portfolio-test",
             source_candidate_ids=("candidate-test",),
@@ -899,7 +908,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             objective_scorecard={"target_met": True, "oracle_passed": True},
             optimizer_report={},
         )
-        manifest = runner.MlxSnapshotManifest(
+        manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
             created_at="2026-05-06T00:00:00+00:00",
             source_window_start="2026-03-20",

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_seed_selection.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_seed_selection.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.queue_metadata as queue_metadata
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Path,
@@ -336,14 +341,14 @@ class TestAutoresearchRunnerSeedSelection(WhitepaperAutoresearchRunnerTestCaseBa
                     side_effect=AssertionError("selection-only must not persist specs"),
                 ) as persist_mock,
                 patch.object(
-                    runner,
+                    persisted_feedback_sources,
                     "_persist_epoch_ledgers",
                     side_effect=AssertionError(
                         "selection-only must not persist epoch ledgers"
                     ),
                 ) as ledger_mock,
                 patch.object(
-                    runner,
+                    portfolio_optimizer,
                     "optimize_portfolio_candidate",
                     side_effect=AssertionError(
                         "selection-only must not optimize a portfolio"
@@ -466,7 +471,7 @@ class TestAutoresearchRunnerSeedSelection(WhitepaperAutoresearchRunnerTestCaseBa
             args.replay_tape_preview_top_k = 1
             args.symbols = "NVDA"
             args.replay_tape_dataset_snapshot_ref = "preview-snapshot"
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -499,17 +504,21 @@ class TestAutoresearchRunnerSeedSelection(WhitepaperAutoresearchRunnerTestCaseBa
                 symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 27),
-                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                source_query_digest=queue_metadata._materialized_replay_tape_source_query_digest(
                     args=args,
                     symbols=requested_symbols,
                     start_date=date(2026, 2, 23),
                     end_date=date(2026, 2, 27),
                 ),
-                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                feature_schema_hash=queue_metadata._materialized_replay_tape_feature_schema_hash(
                     args
                 ),
-                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
-                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+                cost_model_hash=queue_metadata._materialized_replay_tape_cost_model_hash(
+                    args
+                ),
+                strategy_family=queue_metadata._materialized_replay_tape_strategy_family(
+                    args
+                ),
             )
 
             payload = runner.run_whitepaper_autoresearch_profit_target(args)
@@ -650,18 +659,24 @@ class TestAutoresearchRunnerSeedSelection(WhitepaperAutoresearchRunnerTestCaseBa
             args.replay_tape_exact_candidate_cap = 99
             args.replay_tape_dataset_snapshot_ref = "frontier-preview"
             args.allow_unsafe_replay_tape_exact_cap_override = True
-            requested_symbols = runner._candidate_universe_symbols_from_args(args)
-            source_query_digest = runner._materialized_replay_tape_source_query_digest(
-                args=args,
-                symbols=requested_symbols,
-                start_date=date(2026, 2, 23),
-                end_date=date(2026, 2, 23),
+            requested_symbols = artifact_io._candidate_universe_symbols_from_args(args)
+            source_query_digest = (
+                queue_metadata._materialized_replay_tape_source_query_digest(
+                    args=args,
+                    symbols=requested_symbols,
+                    start_date=date(2026, 2, 23),
+                    end_date=date(2026, 2, 23),
+                )
             )
-            feature_schema_hash = runner._materialized_replay_tape_feature_schema_hash(
+            feature_schema_hash = (
+                queue_metadata._materialized_replay_tape_feature_schema_hash(args)
+            )
+            cost_model_hash = queue_metadata._materialized_replay_tape_cost_model_hash(
                 args
             )
-            cost_model_hash = runner._materialized_replay_tape_cost_model_hash(args)
-            strategy_family = runner._materialized_replay_tape_strategy_family(args)
+            strategy_family = queue_metadata._materialized_replay_tape_strategy_family(
+                args
+            )
             materialize_signal_tape(
                 rows=rows,
                 tape_path=tape_path,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_a.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Any,
     Decimal,
@@ -17,29 +20,31 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
             "spec-family-negative-mutated",
             entry_minute_after_open="60",
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-family-negative-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "-250",
-                    "active_day_ratio": "1",
-                    "positive_day_ratio": "0",
-                    "negative_day_count": 4,
-                    "daily_net": {
-                        "2026-05-01": "-150",
-                        "2026-05-04": "-350",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-family-negative-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "-250",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "0",
+                        "negative_day_count": 4,
+                        "daily_net": {
+                            "2026-05-01": "-150",
+                            "2026-05-04": "-350",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-family-negative-feedback",
-            result_path="feedback://family-negative",
+                dataset_snapshot_id="snap-family-negative-feedback",
+                result_path="feedback://family-negative",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(mutated_family_spec,),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )
@@ -93,34 +98,36 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
                 "params": adaptive_params,
             },
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-active-loss-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "-50",
-                    "active_day_ratio": "0.67",
-                    "positive_day_ratio": "0",
-                    "negative_day_count": 2,
-                    "decision_count": 4,
-                    "filled_count": 4,
-                    "avg_filled_notional_per_day": "40000",
-                    "worst_day_loss": "90",
-                    "max_drawdown": "130",
-                    "daily_net": {
-                        "2026-05-06": "-40",
-                        "2026-05-07": "-90",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-active-loss-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "-50",
+                        "active_day_ratio": "0.67",
+                        "positive_day_ratio": "0",
+                        "negative_day_count": 2,
+                        "decision_count": 4,
+                        "filled_count": 4,
+                        "avg_filled_notional_per_day": "40000",
+                        "worst_day_loss": "90",
+                        "max_drawdown": "130",
+                        "daily_net": {
+                            "2026-05-06": "-40",
+                            "2026-05-07": "-90",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-active-loss-feedback",
-            result_path="feedback://active-loss",
+                dataset_snapshot_id="snap-active-loss-feedback",
+                result_path="feedback://active-loss",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(adaptive_spec,),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )
@@ -173,37 +180,39 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
                 "params": repair_params,
             },
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-consistency-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "900",
-                    "active_day_ratio": "0.40",
-                    "positive_day_ratio": "0.20",
-                    "negative_day_count": 0,
-                    "decision_count": 5,
-                    "filled_count": 5,
-                    "avg_filled_notional_per_day": "350000",
-                    "best_day_share": "0.84",
-                    "max_cluster_contribution_share": "0.70",
-                    "worst_day_loss": "0",
-                    "max_drawdown": "0",
-                    "min_daily_net_pnl": "0",
-                    "daily_net": {
-                        "2026-05-06": "4500",
-                        "2026-05-07": "0",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-consistency-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "900",
+                        "active_day_ratio": "0.40",
+                        "positive_day_ratio": "0.20",
+                        "negative_day_count": 0,
+                        "decision_count": 5,
+                        "filled_count": 5,
+                        "avg_filled_notional_per_day": "350000",
+                        "best_day_share": "0.84",
+                        "max_cluster_contribution_share": "0.70",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "min_daily_net_pnl": "0",
+                        "daily_net": {
+                            "2026-05-06": "4500",
+                            "2026-05-07": "0",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-consistency-feedback",
-            result_path="feedback://consistency",
+                dataset_snapshot_id="snap-consistency-feedback",
+                result_path="feedback://consistency",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(repair_spec,),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )
@@ -280,34 +289,36 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
                 "params": adverse_params,
             },
         )
-        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
-            candidate_spec_id=source_spec.candidate_spec_id,
-            candidate={
-                "candidate_id": "cand-active-loss-score-source",
-                "family_template_id": source_spec.family_template_id,
-                "runtime_family": source_spec.runtime_family,
-                "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "objective_scorecard": {
-                    "net_pnl_per_day": "-50",
-                    "active_day_ratio": "0.50",
-                    "positive_day_ratio": "0",
-                    "negative_day_count": 2,
-                    "decision_count": 4,
-                    "filled_count": 4,
-                    "avg_filled_notional_per_day": "40000",
-                    "worst_day_loss": "90",
-                    "max_drawdown": "130",
-                    "daily_net": {
-                        "2026-05-06": "-40",
-                        "2026-05-07": "-90",
+        family_feedback_bundle = (
+            evidence_bundles.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=source_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-active-loss-score-source",
+                    "family_template_id": source_spec.family_template_id,
+                    "runtime_family": source_spec.runtime_family,
+                    "runtime_strategy_name": source_spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "-50",
+                        "active_day_ratio": "0.50",
+                        "positive_day_ratio": "0",
+                        "negative_day_count": 2,
+                        "decision_count": 4,
+                        "filled_count": 4,
+                        "avg_filled_notional_per_day": "40000",
+                        "worst_day_loss": "90",
+                        "max_drawdown": "130",
+                        "daily_net": {
+                            "2026-05-06": "-40",
+                            "2026-05-07": "-90",
+                        },
                     },
                 },
-            },
-            dataset_snapshot_id="snap-active-loss-score-feedback",
-            result_path="feedback://active-loss-score",
+                dataset_snapshot_id="snap-active-loss-score-feedback",
+                result_path="feedback://active-loss-score",
+            )
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(daily_spec, adverse_spec),
             feedback_evidence_bundles=(family_feedback_bundle,),
         )

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_b.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Any,
     Decimal,
@@ -15,7 +20,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
         self,
     ) -> None:
         spec = self._candidate_spec("spec-no-activity-feedback")
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-no-activity-feedback",
@@ -36,7 +41,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://no-activity",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -116,9 +121,9 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
                 },
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=source_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=source_spec,
                 candidate={
                     "candidate_id": "cand-fn-rescue-negative-source",
@@ -138,7 +143,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://fn-rescue-negative",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(probe_spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -191,7 +196,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
                 "max_position_pct_equity": "4",
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=source_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-reaudit-source",
@@ -210,7 +215,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://reaudit",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(blocked_spec, capital_unsafe_spec),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -296,7 +301,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
         self,
     ) -> None:
         spec = self._candidate_spec("spec-positive-blocked-feedback")
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-positive-blocked-feedback",
@@ -320,7 +325,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://positive-blocked",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -413,14 +418,14 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
     ) -> None:
         source_spec = self._candidate_spec("spec-positive-signature-source")
         matching_spec = self._candidate_spec("spec-positive-signature-match")
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=source_spec.candidate_spec_id,
             candidate={
                 "candidate_id": "cand-positive-signature-source",
                 "family_template_id": source_spec.family_template_id,
                 "runtime_family": source_spec.runtime_family,
                 "runtime_strategy_name": source_spec.runtime_strategy_name,
-                "execution_signature": runner._candidate_spec_execution_signature(
+                "execution_signature": candidate_identity._candidate_spec_execution_signature(
                     source_spec
                 ),
                 "objective_scorecard": {
@@ -438,7 +443,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://positive-signature",
         )
 
-        _model, rows = runner._pre_replay_proposal_model_and_rows(
+        _model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(matching_spec,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -495,26 +500,32 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             selection_mode="continuation",
         )
         self.assertNotEqual(
-            runner._candidate_spec_execution_signature(failed_spec),
-            runner._candidate_spec_execution_signature(same_shape_probe),
+            candidate_identity._candidate_spec_execution_signature(failed_spec),
+            candidate_identity._candidate_spec_execution_signature(same_shape_probe),
         )
         self.assertEqual(
-            runner._candidate_spec_feedback_shape_key(failed_spec),
-            runner._candidate_spec_feedback_shape_key(same_shape_probe),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(failed_spec),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(
+                same_shape_probe
+            ),
         )
         self.assertNotEqual(
-            runner._candidate_spec_feedback_shape_key(failed_spec),
-            runner._candidate_spec_feedback_shape_key(different_shape_same_risk_probe),
-        )
-        self.assertEqual(
-            runner._candidate_spec_feedback_risk_profile_key(failed_spec),
-            runner._candidate_spec_feedback_risk_profile_key(
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(failed_spec),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(
                 different_shape_same_risk_probe
             ),
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        self.assertEqual(
+            candidate_prior_scoring._candidate_spec_feedback_risk_profile_key(
+                failed_spec
+            ),
+            candidate_prior_scoring._candidate_spec_feedback_risk_profile_key(
+                different_shape_same_risk_probe
+            ),
+        )
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=failed_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=failed_spec,
                 candidate={
                     "candidate_id": "cand-daily-coverage-source",
@@ -535,7 +546,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://daily-coverage",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(same_shape_probe, different_shape_same_risk_probe, clean_probe),
             feedback_evidence_bundles=(feedback_bundle,),
         )

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import app.trading.discovery.evidence_bundles as evidence_bundles
+import app.trading.discovery.profit_target_oracle as profit_target_oracle
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
+import scripts.whitepaper_autoresearch_runner.feedback_blocking_rules as feedback_blocking_rules
+import scripts.whitepaper_autoresearch_runner.proposal_building as proposal_building
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Any,
     Decimal,
@@ -31,9 +38,9 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
                 },
             },
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=failed_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=failed_spec,
                 candidate={
                     "candidate_id": "cand-terminal-risk-feedback",
@@ -57,7 +64,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://terminal-risk",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(matching_risk_probe,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -89,7 +96,9 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
         )
 
     def test_terminal_risk_profile_block_covers_capital_paths(self) -> None:
-        self.assertFalse(runner._feedback_risk_profile_has_terminal_block({}))
+        self.assertFalse(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block({})
+        )
 
         penalty_scorecard = {
             "profit_target_oracle": {
@@ -101,7 +110,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             "best_day_share": "0.25",
         }
         self.assertTrue(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **penalty_scorecard,
                     "max_gross_exposure_pct_equity": "1.01",
@@ -109,7 +118,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             )
         )
         self.assertTrue(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **penalty_scorecard,
                     "min_cash": "-0.01",
@@ -117,7 +126,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             )
         )
         self.assertTrue(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **penalty_scorecard,
                     "negative_cash_observation_count": "1",
@@ -128,7 +137,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
     def test_feedback_risk_profile_uses_oracle_policy_and_allows_down_days(
         self,
     ) -> None:
-        policy = runner.ProfitTargetOraclePolicy(
+        policy = profit_target_oracle.ProfitTargetOraclePolicy(
             min_active_day_ratio=Decimal("0.90"),
             min_positive_day_ratio=Decimal("0.60"),
             max_best_day_share=Decimal("0.25"),
@@ -157,16 +166,22 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
         }
 
         self.assertFalse(
-            runner._feedback_risk_profile_has_penalty(scorecard, oracle_policy=policy)
-        )
-        self.assertFalse(runner._feedback_is_blocked(scorecard, oracle_policy=policy))
-        self.assertFalse(
-            runner._feedback_family_prior_has_hard_block(
+            feedback_blocking_rules._feedback_risk_profile_has_penalty(
                 scorecard, oracle_policy=policy
             )
         )
         self.assertFalse(
-            runner._feedback_risk_profile_has_terminal_block(
+            feedback_blocking_rules._feedback_is_blocked(
+                scorecard, oracle_policy=policy
+            )
+        )
+        self.assertFalse(
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
+                scorecard, oracle_policy=policy
+            )
+        )
+        self.assertFalse(
+            feedback_blocking_rules._feedback_risk_profile_has_terminal_block(
                 {
                     **scorecard,
                     "profit_target_oracle": {
@@ -184,10 +199,12 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             max_negative_cash_observation_count=0,
         )
         self.assertTrue(
-            runner._feedback_is_blocked(scorecard, oracle_policy=strict_policy)
+            feedback_blocking_rules._feedback_is_blocked(
+                scorecard, oracle_policy=strict_policy
+            )
         )
         self.assertTrue(
-            runner._feedback_risk_profile_has_penalty(
+            feedback_blocking_rules._feedback_risk_profile_has_penalty(
                 {
                     "active_day_ratio": "1",
                     "positive_day_ratio": "1",
@@ -207,9 +224,9 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             hypothesis_id="hyp-spec-shape-cash-probe",
             hard_vetoes={"required_min_daily_notional": "400000"},
         )
-        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+        feedback_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id=failed_spec.candidate_spec_id,
-            candidate=runner._candidate_payload_with_feedback_metadata(
+            candidate=candidate_prior_scoring._candidate_payload_with_feedback_metadata(
                 spec=failed_spec,
                 candidate={
                     "candidate_id": "cand-shape-cash-source",
@@ -226,7 +243,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             result_path="feedback://shape-cash",
         )
 
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(same_shape_probe,),
             feedback_evidence_bundles=(feedback_bundle,),
         )
@@ -246,9 +263,12 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
                 "universe_symbols": "NVDA",
             },
         )
-        self.assertEqual(runner._candidate_spec_universe_key(invalid_universe_spec), "")
+        self.assertEqual(
+            candidate_prior_scoring._candidate_spec_universe_key(invalid_universe_spec),
+            "",
+        )
         self.assertTrue(
-            runner._feedback_scorecard_has_hard_veto(
+            feedback_blocking_rules._feedback_scorecard_has_hard_veto(
                 {
                     "profit_target_oracle": {
                         "blockers": ["positive_day_ratio_below_oracle"]
@@ -257,11 +277,15 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             )
         )
         self.assertTrue(
-            runner._feedback_scorecard_has_hard_veto({"oracle_passed": False})
+            feedback_blocking_rules._feedback_scorecard_has_hard_veto(
+                {"oracle_passed": False}
+            )
         )
-        self.assertFalse(runner._feedback_daily_net_has_loss({"daily_net": "bad"}))
+        self.assertFalse(
+            feedback_blocking_rules._feedback_daily_net_has_loss({"daily_net": "bad"})
+        )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block(
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
                 {
                     "profit_target_oracle": {
                         "blockers": ["active_day_ratio_below_oracle"]
@@ -270,13 +294,17 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             )
         )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block({"positive_day_ratio": "0.5"})
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
+                {"positive_day_ratio": "0.5"}
+            )
         )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block({"best_day_share": "0.51"})
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
+                {"best_day_share": "0.51"}
+            )
         )
         self.assertTrue(
-            runner._feedback_family_prior_has_hard_block(
+            feedback_blocking_rules._feedback_family_prior_has_hard_block(
                 {
                     "active_day_ratio": "1",
                     "positive_day_ratio": "1",
@@ -296,11 +324,15 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             {"max_single_symbol_contribution_share": "0.36"},
             {"max_cluster_contribution_share": "0.41"},
         ):
-            self.assertTrue(runner._feedback_risk_profile_has_penalty(scorecard))
-        self.assertEqual(runner._feedback_risk_profile_key_from_scorecard({}), "")
+            self.assertTrue(
+                feedback_blocking_rules._feedback_risk_profile_has_penalty(scorecard)
+            )
+        self.assertEqual(
+            feedback_blocking_rules._feedback_risk_profile_key_from_scorecard({}), ""
+        )
 
         spec = self._candidate_spec("spec-empty-risk-key")
-        orphan_bundle = runner.evidence_bundle_from_frontier_candidate(
+        orphan_bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-unmatched-risk-feedback",
             candidate={
                 "candidate_id": "cand-unmatched-risk-feedback",
@@ -309,7 +341,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             dataset_snapshot_id="snap-empty-risk-key",
             result_path="feedback://empty-risk-key",
         )
-        model, rows = runner._pre_replay_proposal_model_and_rows(
+        model, rows = proposal_building._pre_replay_proposal_model_and_rows(
             specs=(spec,),
             feedback_evidence_bundles=(orphan_bundle,),
         )
@@ -358,15 +390,15 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
         scorecard = replay.evidence_bundles[0].objective_scorecard
         self.assertEqual(
             scorecard["feedback_shape_key"],
-            runner._candidate_spec_feedback_shape_key(spec),
+            candidate_prior_scoring._candidate_spec_feedback_shape_key(spec),
         )
         self.assertEqual(
             scorecard["feedback_risk_profile_key"],
-            runner._candidate_spec_feedback_risk_profile_key(spec),
+            candidate_prior_scoring._candidate_spec_feedback_risk_profile_key(spec),
         )
         self.assertEqual(
             scorecard["execution_signature"],
-            runner._candidate_spec_execution_signature(spec),
+            candidate_identity._candidate_spec_execution_signature(spec),
         )
 
     def test_current_code_commit_uses_git_when_env_commit_is_missing(self) -> None:

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import scripts.run_strategy_factory_v2 as strategy_factory_runner
+import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
+import scripts.whitepaper_autoresearch_runner.next_epoch_planning as next_epoch_planning
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
+
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
     Namespace,
@@ -249,7 +256,9 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
             "scripts.whitepaper_autoresearch_runner.persisted_feedback_sources.SessionLocal",
             side_effect=lambda: Session(self.engine),
         ):
-            sources = runner._load_sources_from_db(["paper-completed", "paper-running"])
+            sources = persisted_feedback_sources._load_sources_from_db(
+                ["paper-completed", "paper-running"]
+            )
 
         self.assertEqual([source.run_id for source in sources], ["paper-completed"])
 
@@ -318,7 +327,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
         self.assertEqual(parsed.symbols, ",".join(_CHIP_UNIVERSE))
         self.assertEqual(
             parsed.max_frontier_candidates_per_spec,
-            runner._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
+            cli_parsing._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
         )
         self.assertEqual(parsed.max_total_frontier_candidates, 7)
         self.assertEqual(parsed.staged_train_screen_multiplier, 4)
@@ -334,15 +343,15 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
         self.assertEqual(parsed.real_replay_shard_size, 0)
         self.assertEqual(
             parsed.real_replay_shard_timeout_seconds,
-            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            cli_parsing._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
         self.assertEqual(
             parsed.real_replay_shard_workers,
-            runner._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+            cli_parsing._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
         )
         self.assertEqual(
             parsed.real_replay_max_parallel_frontier_candidates,
-            runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+            cli_parsing._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
         )
         self.assertEqual(parsed.replay_tape_path, Path(tmpdir) / "tape.jsonl")
         self.assertEqual(
@@ -364,7 +373,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
         self.assertFalse(parsed.persist_results)
 
     def test_decimal_arg_or_default_uses_explicit_cli_override(self) -> None:
-        value = runner._decimal_arg_or_default(
+        value = next_epoch_planning._decimal_arg_or_default(
             Namespace(min_daily_net_pnl="-125.50"),
             "min_daily_net_pnl",
             Decimal("-350"),
@@ -533,7 +542,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
             }
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2",
                 return_value=factory_payload,
             ):
@@ -591,7 +600,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
         self.assertEqual(scorecard["runtime_strategy_name"], spec.runtime_strategy_name)
         self.assertEqual(
             scorecard["execution_signature"],
-            runner._candidate_spec_execution_signature(spec),
+            candidate_identity._candidate_spec_execution_signature(spec),
         )
 
     def test_real_replay_uses_spec_universe_instead_of_global_symbols(self) -> None:
@@ -641,7 +650,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -711,7 +720,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -764,7 +773,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -820,7 +829,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -908,7 +917,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 return factory_payload
 
             with patch.object(
-                runner.strategy_factory_runner,
+                strategy_factory_runner,
                 "run_strategy_factory_v2_from_specs",
                 side_effect=fake_run,
             ):
@@ -961,10 +970,10 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
     ) -> None:
         args = self._args(Path("/tmp/epoch"))
         program = runner._load_epoch_program(args)
-        controls = runner._resolved_real_replay_frontier_controls(args, program)
+        controls = replay_shards._resolved_real_replay_frontier_controls(args, program)
 
         self.assertEqual(
-            runner._resolved_staged_train_screen_multiplier(args, program),
+            replay_shards._resolved_staged_train_screen_multiplier(args, program),
             3,
         )
         self.assertEqual(controls["symbol_prune_iterations"], 1)
@@ -979,14 +988,13 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
         args.staged_train_screen_multiplier = 4
         args.symbol_prune_candidates = 5
         args.capture_positive_rejected_full_window_ledgers = 6
-        override_controls = runner._resolved_real_replay_frontier_controls(
+        override_controls = replay_shards._resolved_real_replay_frontier_controls(
             args, program
         )
         self.assertEqual(
-            runner._resolved_staged_train_screen_multiplier(args, program),
+            replay_shards._resolved_staged_train_screen_multiplier(args, program),
             4,
         )
         self.assertEqual(override_controls["symbol_prune_candidates"], 5)
-        self.assertEqual(
-            override_controls["capture_positive_rejected_full_window_ledgers"], 6
-        )
+        positive_ledger_key = "capture_positive_rejected_full_window_ledgers"
+        self.assertEqual(override_controls[positive_ledger_key], 6)


### PR DESCRIPTION
## Summary

- Removes the generated whitepaper autoresearch entrypoint export list and trims the unused imports it masked.
- Replaces duplicated whitepaper runner default constants with the canonical CLI parsing defaults.
- Rewrites autoresearch tests to import and patch owning modules instead of the CLI facade for defaults, `CandidateSpec`, chip universe data, and internal helper ownership.
- Adds a regression test that the entrypoint exports only `main` and `run_whitepaper_autoresearch_profit_target`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main scripts/run_whitepaper_autoresearch_profit_target.py tests/test_explicit_module_facade_exports.py tests/autoresearch_runner tests/whitepaper_autoresearch`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main scripts/run_whitepaper_autoresearch_profit_target.py tests/test_explicit_module_facade_exports.py tests/autoresearch_runner tests/whitepaper_autoresearch`
- `cd services/torghut && uv run --frozen pytest tests/test_explicit_module_facade_exports.py tests/autoresearch_runner/test_cli_preflight_sources.py tests/whitepaper_autoresearch/test_autoresearch_runner_parser.py`
- `cd services/torghut && uv run --frozen pytest tests/autoresearch_runner tests/whitepaper_autoresearch`
- `cd services/torghut && uv run --frozen pytest tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None for runtime entrypoints. The whitepaper autoresearch script now explicitly exposes only `main` and `run_whitepaper_autoresearch_profit_target`; test-only/private backchannel access should use the owning modules directly.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
