### PR TITLE
refactor(torghut): remove whitepaper test backchannels

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -5,23 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import subprocess
-from collections.abc import Callable
 from datetime import UTC, datetime
-from decimal import Decimal
 from pathlib import Path
-from typing import Any, Mapping, Sequence, TypeVar, cast
+from typing import Any, Sequence, cast
 
 
 from app.trading.discovery.autoresearch import (
     run_id,
-)
-from app.trading.discovery.candidate_specs import (
-    CandidateSpec,
-)
-from app.trading.discovery.fast_replay import (
-    build_fast_replay_preview,
 )
 from app.trading.discovery.whitepaper_candidate_compiler import (
     compile_whitepaper_candidate_specs,
@@ -31,124 +21,9 @@ from app.whitepapers.claim_compiler import (
     compile_sources_to_hypothesis_cards,
 )
 
-from scripts.whitepaper_autoresearch_runner import (
-    preview_narrowing as _preview_narrowing,
-)
-from scripts.whitepaper_autoresearch_runner import replay_execution as _replay_execution
-
-from scripts.whitepaper_autoresearch_runner.candidate_board_fields import (
-    _candidate_board_score_rows as _candidate_board_score_rows,
-    _candidate_board_decimal_field as _candidate_board_decimal_field,
-    _candidate_board_int_field as _candidate_board_int_field,
-    _candidate_board_first_int_field as _candidate_board_first_int_field,
-)
-from scripts.whitepaper_autoresearch_runner.candidate_board_paper_probation import (
-    _paper_probation_candidate_payload as _paper_probation_candidate_payload,
-    _candidate_board_paper_probation_candidates as _candidate_board_paper_probation_candidates,
-    _candidate_board_paper_probation_candidate as _candidate_board_paper_probation_candidate,
-    _candidate_board_status_digest as _candidate_board_status_digest,
-    _candidate_board_double_oos_summary as _candidate_board_double_oos_summary,
-    _candidate_board_portfolio_promotion_subject as _candidate_board_portfolio_promotion_subject,
-)
-from scripts.whitepaper_autoresearch_runner.candidate_board_payloads import (
-    _candidate_board_factor_acceptance_summary as _candidate_board_factor_acceptance_summary,
-    _candidate_board_payload as _candidate_board_payload,
-    _paper_probation_handoff_payload as _paper_probation_handoff_payload,
-    _portfolio_with_runtime_closure_proof as _portfolio_with_runtime_closure_proof,
-    _runtime_closure_program_for_candidate as _runtime_closure_program_for_candidate,
-)
-from scripts.whitepaper_autoresearch_runner.candidate_board_runtime_windows import (
-    _candidate_board_hypothesis_manifest_ref as _candidate_board_hypothesis_manifest_ref,
-    _candidate_board_runtime_window_bounds as _candidate_board_runtime_window_bounds,
-    _candidate_board_date_only as _candidate_board_date_only,
-    _candidate_board_regular_session_bound as _candidate_board_regular_session_bound,
-    _candidate_board_runtime_window_import_bounds as _candidate_board_runtime_window_import_bounds,
-    _candidate_board_exact_replay_ledger_refs as _candidate_board_exact_replay_ledger_refs,
-    _candidate_board_runtime_import_args as _candidate_board_runtime_import_args,
-    _candidate_board_runtime_window_import_plan as _candidate_board_runtime_window_import_plan,
-    _candidate_factor_acceptance_replay_metadata as _candidate_factor_acceptance_replay_metadata,
-)
-from scripts.whitepaper_autoresearch_runner.candidate_board_summaries import (
-    _candidate_board_rejected_signal_outcome_summary as _candidate_board_rejected_signal_outcome_summary,
-    _candidate_spec_requires_order_type_execution_quality as _candidate_spec_requires_order_type_execution_quality,
-    _candidate_spec_requires_predictability_decay_stress as _candidate_spec_requires_predictability_decay_stress,
-    _candidate_board_predictability_decay_summary as _candidate_board_predictability_decay_summary,
-    _candidate_board_scorecard_with_predictability_decay_blockers as _candidate_board_scorecard_with_predictability_decay_blockers,
-    _candidate_board_order_type_execution_quality_summary as _candidate_board_order_type_execution_quality_summary,
-    _candidate_board_scorecard_with_order_type_blockers as _candidate_board_scorecard_with_order_type_blockers,
-    _candidate_spec_requires_queue_position_survival as _candidate_spec_requires_queue_position_survival,
-    _candidate_board_queue_position_survival_summary as _candidate_board_queue_position_survival_summary,
-    _candidate_board_scorecard_with_queue_position_survival_blockers as _candidate_board_scorecard_with_queue_position_survival_blockers,
-    _candidate_board_scorecard_with_rejected_signal_blockers as _candidate_board_scorecard_with_rejected_signal_blockers,
-    _candidate_board_evidence_lineage_summary as _candidate_board_evidence_lineage_summary,
-    _candidate_board_scorecard_with_lineage_blockers as _candidate_board_scorecard_with_lineage_blockers,
-    _candidate_board_replay_window_coverage_summary as _candidate_board_replay_window_coverage_summary,
-    _candidate_board_market_impact_proof_summary as _candidate_board_market_impact_proof_summary,
-    _candidate_board_regime_specialist_summary as _candidate_board_regime_specialist_summary,
-    _candidate_board_scorecard_with_replay_window_blockers as _candidate_board_scorecard_with_replay_window_blockers,
-    _candidate_board_scorecard_with_evidence_blockers as _candidate_board_scorecard_with_evidence_blockers,
-)
-from scripts.whitepaper_autoresearch_runner.candidate_board_status import (
-    _candidate_board_blockers as _candidate_board_blockers,
-    _candidate_board_status as _candidate_board_status,
-    _candidate_board_activity_count as _candidate_board_activity_count,
-    _candidate_board_oracle_blocker_count as _candidate_board_oracle_blocker_count,
-    _candidate_board_net_pnl as _candidate_board_net_pnl,
-    _candidate_board_lower_bound_net_pnl as _candidate_board_lower_bound_net_pnl,
-    _candidate_board_target_progress_ratio as _candidate_board_target_progress_ratio,
-    _candidate_board_required_notional_repair_scale as _candidate_board_required_notional_repair_scale,
-    _candidate_board_best_executed_candidate as _candidate_board_best_executed_candidate,
-    _candidate_board_closest_promotion_candidate as _candidate_board_closest_promotion_candidate,
-    _candidate_board_paper_probation_admission_blockers as _candidate_board_paper_probation_admission_blockers,
-)
 from scripts.whitepaper_autoresearch_runner.common import (
-    _CANDIDATE_BOARD_RUNTIME_SESSION_TZ as _CANDIDATE_BOARD_RUNTIME_SESSION_TZ,
-    _CANDIDATE_BOARD_RUNTIME_SESSION_OPEN as _CANDIDATE_BOARD_RUNTIME_SESSION_OPEN,
-    _CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE as _CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE,
-    _PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS as _PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS,
-    _PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH as _PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH,
-    _SECOND_OOS_WINDOW_ID as _SECOND_OOS_WINDOW_ID,
-    _RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS as _RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS,
-    _resolve_existing_path as _resolve_existing_path,
-    _stable_hash as _stable_hash,
     _decimal as _decimal,
-    _decimal_payload as _decimal_payload,
-    _mapping as _mapping,
-    _string as _string,
     _list_of_mappings as _list_of_mappings,
-    _sequence_of_mappings as _sequence_of_mappings,
-    _rank_sort_value as _rank_sort_value,
-    _proposal_sort_value as _proposal_sort_value,
-    _string_list_from_value as _string_list_from_value,
-    _candidate_board_runtime_ledger_lineage_handoff as _candidate_board_runtime_ledger_lineage_handoff,
-    _candidate_board_runtime_ledger_required_materialized_artifacts as _candidate_board_runtime_ledger_required_materialized_artifacts,
-    _candidate_spec_requires_rejected_signal_outcome_learning as _candidate_spec_requires_rejected_signal_outcome_learning,
-    _boolish as _boolish,
-    _oracle_blockers as _oracle_blockers,
-)
-from scripts.whitepaper_autoresearch_runner.runtime_closure import (
-    _runtime_closure_payload as _runtime_closure_payload,
-    _portfolio_needs_runtime_closure_proof as _portfolio_needs_runtime_closure_proof,
-    _load_json_mapping_artifact as _load_json_mapping_artifact,
-    _runtime_closure_artifact_refs as _runtime_closure_artifact_refs,
-    _runtime_report_summary_int as _runtime_report_summary_int,
-    _runtime_report_int as _runtime_report_int,
-    _runtime_closure_ledger_datetime as _runtime_closure_ledger_datetime,
-    _runtime_closure_exact_replay_bucket_range as _runtime_closure_exact_replay_bucket_range,
-    _runtime_closure_replay_bucket_has_authority as _runtime_closure_replay_bucket_has_authority,
-    _runtime_closure_exact_replay_bucket as _runtime_closure_exact_replay_bucket,
-    _runtime_report_source_markers as _runtime_report_source_markers,
-    _market_impact_default_source_markers as _market_impact_default_source_markers,
-    _runtime_closure_start_equity as _runtime_closure_start_equity,
-    _portfolio_executable_max_notional as _portfolio_executable_max_notional,
-    _runtime_closure_exact_replay_ledger_update as _runtime_closure_exact_replay_ledger_update,
-    _runtime_closure_market_impact_stress_update as _runtime_closure_market_impact_stress_update,
-    _runtime_closure_delay_adjusted_depth_stress_update as _runtime_closure_delay_adjusted_depth_stress_update,
-    _runtime_closure_double_oos_update as _runtime_closure_double_oos_update,
-    _runtime_closure_scorecard_update as _runtime_closure_scorecard_update,
-    _runtime_closure_pending_promotion_steps as _runtime_closure_pending_promotion_steps,
-    _runtime_closure_promotion_prerequisite_blockers as _runtime_closure_promotion_prerequisite_blockers,
-    _promotion_readiness_payload as _promotion_readiness_payload,
 )
 
 from scripts.whitepaper_autoresearch_runner.cli_parsing import (
@@ -175,16 +50,8 @@ from scripts.whitepaper_autoresearch_runner.oracle_policy import (
 )
 
 
-from scripts.whitepaper_autoresearch_runner.preview_narrowing import (
-    _apply_fast_replay_preview_narrowing as _preview_narrowing_apply_fast_replay_preview_narrowing,
-)
-
 from scripts.whitepaper_autoresearch_runner.queue_metadata import (
     _maybe_preflight_materialized_replay_tape_window,
-)
-
-from scripts.whitepaper_autoresearch_runner.replay_models import (
-    EpochReplayResult,
 )
 
 from scripts.whitepaper_autoresearch_runner.run_arguments import (
@@ -198,12 +65,6 @@ from scripts.whitepaper_autoresearch_runner.run_candidate_preparation import (
 
 from scripts.whitepaper_autoresearch_runner.replay_selection import (
     _select_candidate_specs_for_replay,
-)
-
-from scripts.whitepaper_autoresearch_runner.replay_execution import (
-    _run_synthetic_replay as _replay_execution_run_synthetic_replay,
-    _run_real_replay as _replay_execution_run_real_replay,
-    _real_replay_result_from_factory_payload as _replay_execution_real_replay_result_from_factory_payload,
 )
 
 from scripts.whitepaper_autoresearch_runner.run_reporting import (
@@ -222,248 +83,6 @@ from scripts.whitepaper_autoresearch_runner.replay_shards import (
     _run_replay_with_optional_timeout,
     _load_epoch_program,
 )
-
-_MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES = 512
-_MAX_PERSISTED_FEEDBACK_EVIDENCE_EPOCHS = 12
-_PORTFOLIO_FEEDBACK_STATUSES = frozenset({"blocked", "paper_probation", "target_met"})
-
-_REJECTED_SIGNAL_OUTCOME_REQUIRED_FIELDS = (
-    "counterfactual_return",
-    "route_tca",
-    "post_cost_net_pnl",
-    "executable_quote",
-)
-
-_CODE_COMMIT_ENV_VARS = (
-    "TORGHUT_CODE_COMMIT",
-    "TORGHUT_COMMIT",
-    "TORGHUT_SOURCE_CI_REF",
-    "TORGHUT_IMAGE_COMMIT",
-    "GITHUB_SHA",
-    "BUILDKITE_COMMIT",
-    "SOURCE_COMMIT",
-    "GIT_COMMIT",
-    "REVISION",
-)
-
-_PROGRAM_SOURCE_DEFAULT_CONFIDENCE = "0.70"
-
-_FAMILY_PRIOR_HARD_BLOCK_ORACLE_BLOCKERS = frozenset(
-    {
-        "active_day_ratio_below_oracle",
-        "positive_day_ratio_below_oracle",
-        "best_day_share_above_oracle",
-    }
-)
-
-_RISK_PROFILE_FEEDBACK_ORACLE_BLOCKERS = frozenset(
-    {
-        "active_day_ratio_below_oracle",
-        "positive_day_ratio_below_oracle",
-        "best_day_share_above_oracle",
-        "active_day_ratio_failed",
-        "positive_day_ratio_failed",
-        "min_daily_net_pnl_failed",
-        "daily_net_observed_day_count_failed",
-        "best_day_share_failed",
-        "max_single_day_contribution_share_failed",
-        "max_single_symbol_contribution_share_failed",
-        "max_cluster_contribution_share_failed",
-    }
-)
-
-_PAPER_MECHANISM_PRIOR_SCORE_CAP = Decimal("42")
-
-_PAPER_MECHANISM_PRIOR_WEIGHTS: Mapping[str, Decimal] = {
-    "mixed_market_limit_execution_policy": Decimal("9"),
-    "queue_position_survival_fill_curve": Decimal("9"),
-    "mpc_dynamic_execution_schedule": Decimal("8"),
-    "delay_adjusted_depth_stress": Decimal("8"),
-    "simulation_reality_gap_implementation_risk": Decimal("8"),
-    "implementation_risk_backtest_stability": Decimal("8"),
-    "replay_paper_live_semantic_parity": Decimal("7"),
-    "rejected_signal_outcome_calibration": Decimal("7"),
-    "nonlinear_market_impact_tca": Decimal("6"),
-    "ofi_lob_continuation_response": Decimal("6"),
-    "order_flow_filtration_parent_trade_obi": Decimal("6"),
-    "alpha_decay_predictability_stress": Decimal("5"),
-    "cluster_lob_event_clustering": Decimal("5"),
-    "intraday_volume_periodicity_execution": Decimal("5"),
-    "macro_announcement_dvar_momentum": Decimal("4"),
-    "ohlcv_only_falsification": Decimal("3"),
-}
-
-_PAPER_EVIDENCE_REQUIREMENT_PRIOR_WEIGHTS: Mapping[str, Decimal] = {
-    "route_tca": Decimal("2"),
-    "execution_shortfall": Decimal("2"),
-    "market_impact_stress": Decimal("2"),
-    "live_paper_parity": Decimal("2"),
-    "runtime_ledger": Decimal("2"),
-    "fill_outcomes": Decimal("2"),
-    "order_lifecycle_fill_evidence": Decimal("2"),
-    "queue_position_survival_fill_curve": Decimal("2"),
-    "delay_adjusted_depth_stress": Decimal("2"),
-    "implementation_uncertainty_interval": Decimal("2"),
-    "implementation_uncertainty_stability": Decimal("2"),
-    "rejected_signal_log": Decimal("2"),
-    "counterfactual_return": Decimal("2"),
-    "executable_quote": Decimal("1"),
-}
-
-_LOSS_ADAPTIVE_FEEDBACK_REMEDIATION_PROFILES = frozenset(
-    {"adverse_selection_feedback_escape"}
-)
-
-_REPLAY_ACTIVITY_COUNT_KEYS = (
-    "decision_count",
-    "trade_decision_count",
-    "paper_decision_count",
-    "runtime_decision_count",
-    "orders_submitted_count",
-    "submitted_order_count",
-    "filled_count",
-    "fill_count",
-    "filled_order_count",
-)
-
-
-_EXACT_REPLAY_LEDGER_ARTIFACT_KIND = "exact_replay_ledger"
-
-_EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS = frozenset(
-    {
-        "torghut.exact_replay_ledger.rows.v1",
-        "torghut.exact_replay_ledger.v1",
-    }
-)
-
-_EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE = "exact_replay_runtime_ledger"
-
-_T = TypeVar("_T")
-
-
-def _current_code_commit() -> str:
-    for name in _CODE_COMMIT_ENV_VARS:
-        value = _string(os.getenv(name))
-        if value:
-            return value
-
-    script_path = Path(__file__).resolve()
-    fallback_repo_root = (
-        script_path.parents[3]
-        if len(script_path.parents) > 3
-        else script_path.parents[-1]
-    )
-    repo_root = next(
-        (parent for parent in script_path.parents if (parent / ".git").exists()),
-        fallback_repo_root,
-    )
-    try:
-        rev = subprocess.run(
-            ("git", "-C", str(repo_root), "rev-parse", "HEAD"),
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=3,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return "unknown"
-    commit = _string(rev.stdout)
-    if rev.returncode != 0 or not commit:
-        return "unknown"
-
-    dirty = False
-    for args in (
-        ("git", "-C", str(repo_root), "diff", "--quiet"),
-        ("git", "-C", str(repo_root), "diff", "--cached", "--quiet"),
-    ):
-        try:
-            result = subprocess.run(
-                args,
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=3,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            dirty = True
-            break
-        if result.returncode != 0:
-            dirty = True
-            break
-    return f"{commit}-dirty" if dirty else commit
-
-
-def _call_replay_execution_with_root_code_commit(
-    function: Callable[..., _T],
-    *args: Any,
-    **kwargs: Any,
-) -> _T:
-    original = _replay_execution._current_code_commit
-    _replay_execution._current_code_commit = _current_code_commit
-    try:
-        return function(*args, **kwargs)
-    finally:
-        _replay_execution._current_code_commit = original
-
-
-def _run_synthetic_replay(
-    *,
-    specs: Sequence[CandidateSpec],
-    output_dir: Path,
-    max_candidates: int,
-) -> EpochReplayResult:
-    return _call_replay_execution_with_root_code_commit(
-        _replay_execution_run_synthetic_replay,
-        specs=specs,
-        output_dir=output_dir,
-        max_candidates=max_candidates,
-    )
-
-
-def _run_real_replay(
-    args: argparse.Namespace,
-    *,
-    output_dir: Path,
-    specs: Sequence[CandidateSpec] = (),
-) -> EpochReplayResult:
-    return _call_replay_execution_with_root_code_commit(
-        _replay_execution_run_real_replay,
-        args,
-        output_dir=output_dir,
-        specs=specs,
-    )
-
-
-def _real_replay_result_from_factory_payload(
-    factory_payload: Mapping[str, Any],
-    *,
-    specs_by_id: Mapping[str, CandidateSpec] | None = None,
-) -> EpochReplayResult:
-    return _call_replay_execution_with_root_code_commit(
-        _replay_execution_real_replay_result_from_factory_payload,
-        factory_payload,
-        specs_by_id=specs_by_id,
-    )
-
-
-def _apply_fast_replay_preview_narrowing(
-    *,
-    args: argparse.Namespace,
-    output_dir: Path,
-    specs: Sequence[CandidateSpec],
-    candidate_selection: Mapping[str, Any],
-) -> tuple[list[CandidateSpec], dict[str, Any]]:
-    original = _preview_narrowing.build_fast_replay_preview
-    _preview_narrowing.build_fast_replay_preview = build_fast_replay_preview
-    try:
-        return _preview_narrowing_apply_fast_replay_preview_narrowing(
-            args=args,
-            output_dir=output_dir,
-            specs=specs,
-            candidate_selection=candidate_selection,
-        )
-    finally:
-        _preview_narrowing.build_fast_replay_preview = original
 
 
 def run_whitepaper_autoresearch_profit_target(

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_evidence.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_evidence.py
@@ -12,10 +12,15 @@ from decimal import Decimal
 from pathlib import Path
 
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_fields as candidate_board_fields
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.candidate_board_status as candidate_board_status
+import scripts.whitepaper_autoresearch_runner.candidate_board_summaries as candidate_board_summaries
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
+import scripts.whitepaper_autoresearch_runner.runtime_closure as runtime_closure
 
 
 class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
@@ -68,7 +73,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-factor-acceptance",
             output_dir=Path("/tmp/torghut-factor-acceptance"),
             target=Decimal("500"),
@@ -212,7 +217,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             row_by_spec[control_spec.candidate_spec_id]["rank"],
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(control_spec, paper_spec),
             proposal_rows=rows,
             top_k=1,
@@ -263,7 +268,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
         )
 
         exploration_selected, exploration_selection = (
-            runner._select_candidate_specs_for_replay(
+            replay_selection._select_candidate_specs_for_replay(
                 specs=(control_spec, paper_spec),
                 proposal_rows=rows,
                 top_k=0,
@@ -321,9 +326,12 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             promotion_readiness={},
         )
 
-        self.assertEqual(runner._candidate_board_int_field({"bad": object()}, "bad"), 0)
         self.assertEqual(
-            runner._candidate_board_market_impact_proof_summary(
+            candidate_board_fields._candidate_board_int_field({"bad": object()}, "bad"),
+            0,
+        )
+        self.assertEqual(
+            candidate_board_summaries._candidate_board_market_impact_proof_summary(
                 {
                     "market_impact_stress_model": "almgren_chriss_proxy",
                     "market_impact_stress_cost_bps": "150",
@@ -345,7 +353,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
         )
         self.assertIn(
             "double_square_root_impact_arxiv_2502_16246_2025",
-            runner._candidate_board_market_impact_proof_summary(
+            candidate_board_summaries._candidate_board_market_impact_proof_summary(
                 {
                     "market_impact_stress_model": "almgren_chriss_proxy",
                     "market_impact_stress_cost_bps": "150",
@@ -364,16 +372,20 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
                 }
             )["source_markers"],
         )
-        missing_impact = runner._candidate_board_market_impact_proof_summary(
-            {"target_met": True}
+        missing_impact = (
+            candidate_board_summaries._candidate_board_market_impact_proof_summary(
+                {"target_met": True}
+            )
         )
         self.assertEqual(missing_impact["state"], "blocked")
         self.assertIn(
             "nonlinear_market_impact_components_missing",
             missing_impact["blockers"],
         )
-        regime_summary = runner._candidate_board_regime_specialist_summary(
-            spec, {"regime_slice_pass_rate": "0.30"}
+        regime_summary = (
+            candidate_board_summaries._candidate_board_regime_specialist_summary(
+                spec, {"regime_slice_pass_rate": "0.30"}
+            )
         )
         self.assertEqual(regime_summary["state"], "blocked")
         self.assertIn(
@@ -385,7 +397,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             ["risk-sensitive-routing", "vvg-validation"],
         )
         self.assertEqual(
-            runner._candidate_board_blockers(
+            candidate_board_status._candidate_board_blockers(
                 selected_for_replay=True,
                 evidence=None,
                 scorecard={},
@@ -393,19 +405,21 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             ["replay_evidence_missing"],
         )
         self.assertEqual(
-            runner._candidate_board_blockers(
+            candidate_board_status._candidate_board_blockers(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={"target_met": True, "oracle_passed": False},
             ),
             ["profit_target_oracle_failed"],
         )
-        dirty_lineage = runner._candidate_board_evidence_lineage_summary(
-            replace(evidence, code_commit="commit-test-dirty")
+        dirty_lineage = (
+            candidate_board_summaries._candidate_board_evidence_lineage_summary(
+                replace(evidence, code_commit="commit-test-dirty")
+            )
         )
         self.assertEqual(dirty_lineage["blockers"], ["code_commit_dirty"])
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=None,
                 scorecard={},
@@ -415,7 +429,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             "selected_pending_replay_evidence",
         )
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={"oracle_passed": True},
@@ -425,7 +439,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             "candidate_oracle_passed",
         )
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={"target_met": True, "oracle_passed": False},
@@ -435,7 +449,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             "blocked_by_oracle",
         )
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={},
@@ -444,7 +458,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             ),
             "portfolio_component_passed_oracle",
         )
-        denied_readiness = runner._promotion_readiness_payload(
+        denied_readiness = runtime_closure._promotion_readiness_payload(
             oracle_candidate_found=True,
             status="ready_for_promotion_review",
             blockers=[],
@@ -462,7 +476,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             denied_readiness["status"], "blocked_pending_promotion_prerequisites"
         )
         self.assertEqual(denied_readiness["blockers"], ["promotion_gate_report_denied"])
-        allowed_readiness = runner._promotion_readiness_payload(
+        allowed_readiness = runtime_closure._promotion_readiness_payload(
             oracle_candidate_found=True,
             status="ready_for_promotion_review",
             blockers=[],
@@ -741,7 +755,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             optimizer_report={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-portfolio-promotion-subject",
             output_dir=Path("/tmp/torghut-test"),
             target=Decimal("500"),
@@ -825,7 +839,7 @@ class TestAutoresearchRunnerCandidateBoardEvidence(AutoresearchRunnerTestCase):
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-rejected-signal-board",
             output_dir=Path("/tmp/epoch-rejected-signal-board"),
             target=Decimal("500"),

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_paper_probation.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_paper_probation.py
@@ -8,10 +8,12 @@ from decimal import Decimal
 from pathlib import Path
 
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_paper_probation as candidate_board_paper_probation
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.candidate_board_status as candidate_board_status
 
 
 class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestCase):
@@ -112,7 +114,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-paper-probation-board",
             output_dir=Path("/tmp/epoch-paper-probation-board"),
             target=Decimal("500"),
@@ -424,7 +426,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
         self.assertFalse(target["final_promotion_authorized"])
         self.assertFalse(target["final_promotion_allowed"])
         self.assertEqual(target["selection_reason"], "target_met_but_oracle_blocked")
-        handoff = runner._paper_probation_handoff_payload(board)
+        handoff = candidate_board_payloads._paper_probation_handoff_payload(board)
         self.assertEqual(
             handoff["schema_version"], "torghut.paper-probation-handoff.v1"
         )
@@ -633,7 +635,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
             objective_scorecard=bridge_scorecard,
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-paper-probation-economics",
             output_dir=Path("/tmp/epoch-paper-probation-economics"),
             target=Decimal("500"),
@@ -761,7 +763,9 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
         }
 
         self.assertEqual(
-            runner._candidate_board_paper_probation_admission_blockers(generic_row),
+            candidate_board_status._candidate_board_paper_probation_admission_blockers(
+                generic_row
+            ),
             [
                 "paper_probation_exact_replay_ledger_artifact_missing",
                 "paper_probation_exact_replay_ledger_row_count_missing",
@@ -770,7 +774,9 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
             ],
         )
         self.assertEqual(
-            runner._candidate_board_paper_probation_admission_blockers(ledger_row),
+            candidate_board_status._candidate_board_paper_probation_admission_blockers(
+                ledger_row
+            ),
             [],
         )
 
@@ -820,9 +826,11 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
             "blockers": [],
         }
 
-        candidate = runner._candidate_board_paper_probation_candidate(
-            [row],
-            target=Decimal("500"),
+        candidate = (
+            candidate_board_paper_probation._candidate_board_paper_probation_candidate(
+                [row],
+                target=Decimal("500"),
+            )
         )
 
         self.assertIsNotNone(candidate)
@@ -834,7 +842,7 @@ class TestAutoresearchRunnerCandidateBoardPaperProbation(AutoresearchRunnerTestC
         )
         self.assertFalse(candidate["final_promotion_allowed"])
         self.assertIsNone(
-            runner._candidate_board_paper_probation_candidate(
+            candidate_board_paper_probation._candidate_board_paper_probation_candidate(
                 [],
                 target=Decimal("500"),
             )

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_rejects_unknown_code_commit_lineage.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_rejects_unknown_code_commit_lineage.py
@@ -7,10 +7,11 @@ from decimal import Decimal
 from pathlib import Path
 
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.candidate_board_summaries as candidate_board_summaries
 
 
 class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCase):
@@ -38,7 +39,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-unknown-lineage-board",
             output_dir=Path("/tmp/epoch-unknown-lineage-board"),
             target=Decimal("500"),
@@ -125,7 +126,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-board",
             output_dir=Path("/tmp/epoch-market-limit-board"),
             target=Decimal("500"),
@@ -238,7 +239,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-pass-board",
             output_dir=Path("/tmp/epoch-market-limit-pass-board"),
             target=Decimal("500"),
@@ -320,7 +321,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-queue-survival-board",
             output_dir=Path("/tmp/epoch-queue-survival-board"),
             target=Decimal("500"),
@@ -380,7 +381,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             },
         )
 
-        summary = runner._candidate_board_queue_position_survival_summary(
+        summary = candidate_board_summaries._candidate_board_queue_position_survival_summary(
             spec,
             {
                 "queue_position_survival_fill_curve_evidence_present": True,
@@ -458,7 +459,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-missing-artifact-ref-board",
             output_dir=Path("/tmp/epoch-market-limit-missing-artifact-ref-board"),
             target=Decimal("500"),
@@ -554,7 +555,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-route-bool-board",
             output_dir=Path("/tmp/epoch-market-limit-route-bool-board"),
             target=Decimal("500"),
@@ -637,7 +638,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-route-artifact-board",
             output_dir=Path("/tmp/epoch-market-limit-route-artifact-board"),
             target=Decimal("500"),
@@ -745,7 +746,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-candidate-board-split",
             output_dir=Path("/tmp/epoch-candidate-board-split"),
             target=Decimal("500"),
@@ -850,7 +851,7 @@ class TestCandidateBoardRejectsUnknownCodeCommitLineage(AutoresearchRunnerTestCa
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-alpha-decay-missing-stress",
             output_dir=Path("/tmp/epoch-alpha-decay-missing-stress"),
             target=Decimal("500"),

--- a/services/torghut/tests/autoresearch_runner/test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets.py
@@ -16,6 +16,8 @@ from tests.autoresearch_runner.helpers import (
     _CHIP_UNIVERSE,
     _compact_recent_whitepaper_sources,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_runtime_windows as candidate_board_runtime_windows
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestCandidateBoardRuntimeWindowPlanDedupesAndBlocksIncompleteTargets(
@@ -55,20 +57,24 @@ class TestCandidateBoardRuntimeWindowPlanDedupesAndBlocksIncompleteTargets(
             "runtime_window_end": "2026-05-21T20:00:00+00:00",
         }
 
-        plan = runner._candidate_board_runtime_window_import_plan(
-            rows=(row,),
-            paper_probation_candidate=row,
-            promotion_subject={
-                "target_met": True,
-                "sleeve_candidate_spec_ids": ["spec-runtime-plan"],
-            },
+        plan = (
+            candidate_board_runtime_windows._candidate_board_runtime_window_import_plan(
+                rows=(row,),
+                paper_probation_candidate=row,
+                promotion_subject={
+                    "target_met": True,
+                    "sleeve_candidate_spec_ids": ["spec-runtime-plan"],
+                },
+            )
         )
-        fallback_plan = runner._candidate_board_runtime_window_import_plan(
-            rows=(),
-            paper_probation_candidate=fallback_row,
-            promotion_subject=None,
+        fallback_plan = (
+            candidate_board_runtime_windows._candidate_board_runtime_window_import_plan(
+                rows=(),
+                paper_probation_candidate=fallback_row,
+                promotion_subject=None,
+            )
         )
-        incomplete_plan = runner._candidate_board_runtime_window_import_plan(
+        incomplete_plan = candidate_board_runtime_windows._candidate_board_runtime_window_import_plan(
             rows=(),
             paper_probation_candidate={
                 "candidate_spec_id": "spec-incomplete",
@@ -81,11 +87,13 @@ class TestCandidateBoardRuntimeWindowPlanDedupesAndBlocksIncompleteTargets(
         )
 
         self.assertEqual(
-            runner._candidate_board_hypothesis_manifest_ref(None),
+            candidate_board_runtime_windows._candidate_board_hypothesis_manifest_ref(
+                None
+            ),
             "",
         )
         self.assertEqual(
-            runner._candidate_board_runtime_window_bounds(
+            candidate_board_runtime_windows._candidate_board_runtime_window_bounds(
                 {
                     "runtime_window_start": "2026-05-01",
                     "runtime_window_end": "2026-05-02",
@@ -174,19 +182,19 @@ class TestCandidateBoardRuntimeWindowPlanDedupesAndBlocksIncompleteTargets(
         self,
     ) -> None:
         self.assertEqual(
-            runner._candidate_universe_symbols_for_compilation(
+            artifact_io._candidate_universe_symbols_for_compilation(
                 Namespace(symbols=",".join(_CHIP_UNIVERSE))
             ),
             (),
         )
         self.assertEqual(
-            runner._candidate_universe_symbols_for_compilation(
+            artifact_io._candidate_universe_symbols_for_compilation(
                 Namespace(symbols="MSFT,SHOP")
             ),
             (),
         )
         self.assertEqual(
-            runner._candidate_universe_symbols_for_compilation(
+            artifact_io._candidate_universe_symbols_for_compilation(
                 Namespace(symbols="NVDA,AMAT,AAPL")
             ),
             ("NVDA", "AAPL"),
@@ -417,7 +425,7 @@ class TestCandidateBoardRuntimeWindowPlanDedupesAndBlocksIncompleteTargets(
             runtime_strategy_name="late-day-continuation-long-v1",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(breakout_primary, breakout_secondary, intraday, late_day),
             proposal_rows=[
                 {

--- a/services/torghut/tests/autoresearch_runner/test_candidate_selection.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_selection.py
@@ -9,10 +9,10 @@ from decimal import Decimal
 from typing import Any, cast
 
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
@@ -59,7 +59,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(mutated_family_spec,),
             proposal_rows=rows,
             top_k=1,
@@ -141,7 +141,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
         )
         self.assertGreater(Decimal(str(rows[0]["proposal_score"])), Decimal("-999999"))
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(adaptive_spec,),
             proposal_rows=rows,
             top_k=0,
@@ -239,7 +239,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             rows[0]["consistency_repair_feedback_reasons"],
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(repair_spec,),
             proposal_rows=rows,
             top_k=0,
@@ -390,7 +390,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             runtime_strategy_name="late-day-continuation-long-v1",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(
                 active_breakout,
                 active_microbar,
@@ -493,7 +493,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             "pre_replay_mlx_no_activity_feedback_blocked",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=rows,
             top_k=1,
@@ -598,7 +598,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(probe_spec,),
             proposal_rows=rows,
             top_k=1,
@@ -661,7 +661,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             feedback_evidence_bundles=(feedback_bundle,),
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(blocked_spec, capital_unsafe_spec),
             proposal_rows=rows,
             top_k=1,
@@ -695,7 +695,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             entry_minute_after_open="75",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(synthetic_probe_spec, feedback_spec),
             proposal_rows=[
                 {
@@ -777,7 +777,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
         )
         self.assertGreater(Decimal(str(rows[0]["proposal_score"])), Decimal("-999999"))
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=rows,
             top_k=1,
@@ -827,7 +827,7 @@ class TestAutoresearchRunnerCandidateSelection(AutoresearchRunnerTestCase):
             },
         ]
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(unsafe_spec, safe_spec),
             proposal_rows=proposal_rows,
             top_k=1,

--- a/services/torghut/tests/autoresearch_runner/test_candidate_selection_keeps_positive_signature_feedback_repair_candidates.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_selection_keeps_positive_signature_feedback_repair_candidates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import app.trading.discovery.evidence_bundles as evidence_bundles
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
 import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
 import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
 import scripts.whitepaper_autoresearch_runner.feedback_blocking_rules as feedback_blocking_rules
@@ -14,10 +15,11 @@ from typing import Any, cast
 from unittest.mock import patch
 
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.replay_execution as replay_execution
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
@@ -67,7 +69,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
         )
         self.assertGreater(Decimal(str(rows[0]["proposal_score"])), Decimal("-999999"))
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(matching_spec,),
             proposal_rows=rows,
             top_k=1,
@@ -136,7 +138,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
             Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(matching_risk_probe,),
             proposal_rows=rows,
             top_k=1,
@@ -192,120 +194,122 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
         )
 
     def test_current_code_commit_uses_git_when_env_commit_is_missing(self) -> None:
-        rev_parse = runner.subprocess.CompletedProcess(
+        rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=0,
             stdout="abc123\n",
         )
-        clean_diff = runner.subprocess.CompletedProcess(
+        clean_diff = artifact_io.subprocess.CompletedProcess(
             args=("git", "diff", "--quiet"),
             returncode=0,
             stdout="",
         )
         with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess,
                 "run",
                 side_effect=[rev_parse, clean_diff, clean_diff],
             ) as run,
         ):
-            self.assertEqual(runner._current_code_commit(), "abc123")
+            self.assertEqual(artifact_io._current_code_commit(), "abc123")
 
         self.assertEqual(run.call_count, 3)
 
     def test_current_code_commit_prefers_env_commit(self) -> None:
         with (
             patch.object(
-                runner.os,
+                artifact_io.os,
                 "getenv",
                 side_effect=lambda name: (
                     "env123" if name == "TORGHUT_CODE_COMMIT" else ""
                 ),
             ),
-            patch.object(runner.subprocess, "run") as run,
+            patch.object(artifact_io.subprocess, "run") as run,
         ):
-            self.assertEqual(runner._current_code_commit(), "env123")
+            self.assertEqual(artifact_io._current_code_commit(), "env123")
 
         run.assert_not_called()
 
     def test_current_code_commit_handles_short_container_script_path(
         self,
     ) -> None:
-        bad_rev_parse = runner.subprocess.CompletedProcess(
+        bad_rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=128,
             stdout="",
         )
         with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner,
+                artifact_io,
                 "__file__",
                 "/app/scripts/run_whitepaper_autoresearch_profit_target.py",
             ),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess,
                 "run",
                 return_value=bad_rev_parse,
             ) as run,
         ):
-            self.assertEqual(runner._current_code_commit(), "unknown")
+            self.assertEqual(artifact_io._current_code_commit(), "unknown")
 
         self.assertEqual(run.call_args.args[0][0:3], ("git", "-C", "/"))
 
     def test_current_code_commit_marks_dirty_or_unknown_git_state(self) -> None:
-        rev_parse = runner.subprocess.CompletedProcess(
+        rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=0,
             stdout="abc123\n",
         )
-        dirty_diff = runner.subprocess.CompletedProcess(
+        dirty_diff = artifact_io.subprocess.CompletedProcess(
             args=("git", "diff", "--quiet"),
             returncode=1,
             stdout="",
         )
-        bad_rev_parse = runner.subprocess.CompletedProcess(
+        bad_rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=128,
             stdout="",
         )
         with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess,
                 "run",
                 side_effect=[rev_parse, dirty_diff],
             ),
         ):
-            self.assertEqual(runner._current_code_commit(), "abc123-dirty")
+            self.assertEqual(artifact_io._current_code_commit(), "abc123-dirty")
         with (
-            patch.object(runner.os, "getenv", return_value=""),
-            patch.object(runner.subprocess, "run", side_effect=OSError("git missing")),
-        ):
-            self.assertEqual(runner._current_code_commit(), "unknown")
-        with (
-            patch.object(runner.os, "getenv", return_value=""),
-            patch.object(runner.subprocess, "run", return_value=bad_rev_parse),
-        ):
-            self.assertEqual(runner._current_code_commit(), "unknown")
-        with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess, "run", side_effect=OSError("git missing")
+            ),
+        ):
+            self.assertEqual(artifact_io._current_code_commit(), "unknown")
+        with (
+            patch.object(artifact_io.os, "getenv", return_value=""),
+            patch.object(artifact_io.subprocess, "run", return_value=bad_rev_parse),
+        ):
+            self.assertEqual(artifact_io._current_code_commit(), "unknown")
+        with (
+            patch.object(artifact_io.os, "getenv", return_value=""),
+            patch.object(
+                artifact_io.subprocess,
                 "run",
                 side_effect=[rev_parse, OSError("diff missing")],
             ),
         ):
-            self.assertEqual(runner._current_code_commit(), "abc123-dirty")
+            self.assertEqual(artifact_io._current_code_commit(), "abc123-dirty")
 
     def test_synthetic_replay_evidence_carries_code_commit(self) -> None:
         spec = self._candidate_spec("spec-synthetic-replay-code-commit")
         with TemporaryDirectory() as tmpdir:
             with patch.object(
-                runner, "_current_code_commit", return_value="synthetic123"
+                replay_execution, "_current_code_commit", return_value="synthetic123"
             ):
-                replay = runner._run_synthetic_replay(
+                replay = replay_execution._run_synthetic_replay(
                     specs=(spec,),
                     output_dir=Path(tmpdir),
                     max_candidates=1,
@@ -319,7 +323,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
     ) -> None:
         spec = self._candidate_spec("spec-negative-synthetic-prior")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -352,7 +356,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
     ) -> None:
         spec = self._candidate_spec("spec-negative-synthetic-prior-probe")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -391,7 +395,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
     ) -> None:
         spec = self._candidate_spec("spec-capacity-short-synthetic-prior-probe")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -434,7 +438,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
     ) -> None:
         spec = self._candidate_spec("spec-malformed-feedback-context")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -470,7 +474,7 @@ class TestCandidateSelectionKeepsPositiveSignatureFeedbackRepairCandidates(
             },
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(scalar_universe_spec,),
             proposal_rows=[
                 {

--- a/services/torghut/tests/autoresearch_runner/test_candidate_sleeve_goal_proof_handoff_surfaces_runtime_ledger_materialization.py
+++ b/services/torghut/tests/autoresearch_runner/test_candidate_sleeve_goal_proof_handoff_surfaces_runtime_ledger_materialization.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import app.trading.discovery.evidence_bundles as evidence_bundles
 import scripts.whitepaper_autoresearch_runner.candidate_goal_metadata as candidate_goal_metadata
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.common as runner_common
 
 
 class TestCandidateSleeveGoalProofHandoffSurfacesRuntimeLedgerMaterialization(
@@ -70,17 +70,19 @@ class TestCandidateSleeveGoalProofHandoffSurfacesRuntimeLedgerMaterialization(
             proof_handoff["zero_authoritative_daily_pnl_until_materialized"]
         )
         self.assertEqual(
-            runner._candidate_board_runtime_ledger_required_materialized_artifacts({}),
+            runner_common._candidate_board_runtime_ledger_required_materialized_artifacts(
+                {}
+            ),
             [],
         )
         self.assertEqual(
-            runner._candidate_board_runtime_ledger_required_materialized_artifacts(
+            runner_common._candidate_board_runtime_ledger_required_materialized_artifacts(
                 {"required_materialized_artifacts": "runtime-ledger/string.json"}
             ),
             ["runtime-ledger/string.json"],
         )
         self.assertEqual(
-            runner._candidate_board_runtime_ledger_required_materialized_artifacts(
+            runner_common._candidate_board_runtime_ledger_required_materialized_artifacts(
                 {
                     "required_materialized_artifacts": [
                         {"path": "runtime-ledger/path.json"},

--- a/services/torghut/tests/autoresearch_runner/test_cli_preflight_sources.py
+++ b/services/torghut/tests/autoresearch_runner/test_cli_preflight_sources.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
 import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
 import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.runtime_closure as runtime_closure
 import socket
 
 import json
@@ -19,6 +20,9 @@ from tests.autoresearch_runner.helpers import (
     _CHIP_UNIVERSE,
     _compact_recent_whitepaper_sources,
 )
+import app.whitepapers.claim_compiler as claim_compiler
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
 
 
 class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
@@ -33,7 +37,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
                     tmpdir,
                 ],
             ):
-                args = runner._parse_args()
+                args = cli_parsing._parse_args()
 
         self.assertEqual(args.target_net_pnl_per_day, "500")
         self.assertEqual(args.epoch_id, "")
@@ -67,7 +71,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
                     ],
                 ),
             ):
-                args = runner._parse_args()
+                args = cli_parsing._parse_args()
 
         self.assertEqual(args.clickhouse_http_url, "http://127.0.0.1:8123")
         self.assertEqual(args.clickhouse_username, "reader")
@@ -95,7 +99,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
                     ],
                 ),
             ):
-                args = runner._parse_args()
+                args = cli_parsing._parse_args()
 
         self.assertEqual(args.clickhouse_http_url, "http://127.0.0.1:8123")
 
@@ -112,7 +116,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
             "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=socket.gaierror("not known"),
         ):
-            failure = runner._clickhouse_endpoint_preflight_failure(args)
+            failure = artifact_io._clickhouse_endpoint_preflight_failure(args)
 
         self.assertIn("clickhouse_endpoint_unreachable", failure)
         self.assertIn("TA_CLICKHOUSE_URL", failure)
@@ -129,7 +133,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
             "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("non-cluster endpoints are replay-checked"),
         ):
-            failure = runner._clickhouse_endpoint_preflight_failure(args)
+            failure = artifact_io._clickhouse_endpoint_preflight_failure(args)
 
         self.assertEqual(failure, "")
 
@@ -145,7 +149,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
             "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("replay tape should bypass DNS preflight"),
         ):
-            failure = runner._clickhouse_endpoint_preflight_failure(args)
+            failure = artifact_io._clickhouse_endpoint_preflight_failure(args)
 
         self.assertEqual(failure, "")
 
@@ -273,7 +277,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
                         tmpdir,
                     ],
                 ):
-                    args = runner._parse_args()
+                    args = cli_parsing._parse_args()
 
         self.assertEqual(args.strategy_configmap, Path("/etc/torghut/strategies.yaml"))
 
@@ -606,7 +610,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
                     ),
                 ) as optimizer_mock,
                 patch.object(
-                    runner,
+                    runtime_closure,
                     "_runtime_closure_payload",
                     side_effect=AssertionError(
                         "selection-only must not build runtime closure"
@@ -708,8 +712,8 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
             args.program = Path(
                 "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
-            program = runner._load_epoch_program(args)
-            sources = runner._program_whitepaper_sources(program)
+            program = replay_shards._load_epoch_program(args)
+            sources = persisted_feedback_sources._program_whitepaper_sources(program)
 
         source_ids = {source.run_id for source in sources}
         self.assertIn("weighted_microprice_momentum_2026", source_ids)
@@ -748,7 +752,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
         self.assertIn("feature_recipe", claim_types)
         self.assertIn("validation_requirement", claim_types)
         self.assertTrue(
-            runner.compile_sources_to_hypothesis_cards([weighted_microprice])
+            claim_compiler.compile_sources_to_hypothesis_cards([weighted_microprice])
         )
 
         impact_source = next(
@@ -763,7 +767,9 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
         self.assertIn("risk_constraint", impact_claim_types)
         self.assertIn("route_tca", impact_source.claims[0]["data_requirements"])
         self.assertEqual(impact_source.claims[0]["horizon_scope"], "intraday_execution")
-        self.assertTrue(runner.compile_sources_to_hypothesis_cards([impact_source]))
+        self.assertTrue(
+            claim_compiler.compile_sources_to_hypothesis_cards([impact_source])
+        )
 
         latent_regime_source = next(
             source
@@ -817,7 +823,7 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
             source for source in sources if source.run_id == "retail_limit_orders_2025"
         )
         self.assertTrue(
-            runner.compile_sources_to_hypothesis_cards([retail_limit_source])
+            claim_compiler.compile_sources_to_hypothesis_cards([retail_limit_source])
         )
         self.assertIn(
             "order_type_ablation", retail_limit_source.claims[0]["data_requirements"]
@@ -831,7 +837,9 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
             for source in sources
             if source.run_id == "intraday_ofi_news_dynamics_2025"
         )
-        self.assertTrue(runner.compile_sources_to_hypothesis_cards([ofi_news_source]))
+        self.assertTrue(
+            claim_compiler.compile_sources_to_hypothesis_cards([ofi_news_source])
+        )
         self.assertIn(
             "price_flow_impact", ofi_news_source.claims[0]["data_requirements"]
         )
@@ -843,7 +851,9 @@ class TestAutoresearchRunnerCliPreflightSources(AutoresearchRunnerTestCase):
             for source in sources
             if source.run_id == "order_flow_filtration_2025"
         )
-        self.assertTrue(runner.compile_sources_to_hypothesis_cards([filtration_source]))
+        self.assertTrue(
+            claim_compiler.compile_sources_to_hypothesis_cards([filtration_source])
+        )
         self.assertIn(
             "filtered_orderbook_imbalance",
             filtration_source.claims[0]["data_requirements"],

--- a/services/torghut/tests/autoresearch_runner/test_compiled_program_research_sources_have_no_missing_feature_aliases.py
+++ b/services/torghut/tests/autoresearch_runner/test_compiled_program_research_sources_have_no_missing_feature_aliases.py
@@ -28,6 +28,10 @@ from tests.autoresearch_runner.helpers import (
     _CHIP_UNIVERSE,
     _source_jsonl_payload,
 )
+import app.trading.discovery.whitepaper_candidate_compiler as whitepaper_candidate_compiler
+import app.whitepapers.claim_compiler as claim_compiler
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
 
 
 class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
@@ -40,22 +44,24 @@ class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
         args.program = Path(
             "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
         )
-        program = runner._load_epoch_program(args)
-        sources = runner._program_whitepaper_sources(program)
+        program = replay_shards._load_epoch_program(args)
+        sources = persisted_feedback_sources._program_whitepaper_sources(program)
         failures: dict[str, list[dict[str, object]]] = {}
         compiled_source_count = 0
 
         for source in sources:
-            cards = runner.compile_sources_to_hypothesis_cards([source])
+            cards = claim_compiler.compile_sources_to_hypothesis_cards([source])
             if not cards:
                 continue
             compiled_source_count += 1
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                target_net_pnl_per_day=Decimal("500"),
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
-                universe_symbols=("NVDA",),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    target_net_pnl_per_day=Decimal("500"),
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                    universe_symbols=("NVDA",),
+                )
             )
             missing_feature_blockers = [
                 blocker.to_payload()
@@ -351,7 +357,7 @@ class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
                     "--no-persist-results",
                 ],
             ):
-                parsed = runner._parse_args()
+                parsed = cli_parsing._parse_args()
 
         self.assertEqual(parsed.output_dir, output_dir)
         self.assertEqual(parsed.epoch_id, "whitepaper-autoresearch-cli-epoch")
@@ -423,13 +429,13 @@ class TestCompiledProgramResearchSourcesHaveNoMissingFeatureAliases(
         self,
     ) -> None:
         with patch.dict("os.environ", {"TORGHUT_TEST_CLICKHOUSE_PASSWORD": "from-env"}):
-            resolved = runner._resolved_clickhouse_password(
+            resolved = artifact_io._resolved_clickhouse_password(
                 Namespace(
                     clickhouse_password="",
                     clickhouse_password_env="TORGHUT_TEST_CLICKHOUSE_PASSWORD",
                 )
             )
-            direct = runner._resolved_clickhouse_password(
+            direct = artifact_io._resolved_clickhouse_password(
                 Namespace(
                     clickhouse_password="direct",
                     clickhouse_password_env="TORGHUT_TEST_CLICKHOUSE_PASSWORD",

--- a/services/torghut/tests/autoresearch_runner/test_epoch_persistence_remediation.py
+++ b/services/torghut/tests/autoresearch_runner/test_epoch_persistence_remediation.py
@@ -32,6 +32,7 @@ from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
     _compact_recent_whitepaper_sources,
 )
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
 
 
 class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCase):
@@ -506,7 +507,7 @@ class TestAutoresearchRunnerEpochPersistenceRemediation(AutoresearchRunnerTestCa
             patch.object(
                 run_reporting,
                 "_collect_partial_real_replay",
-                return_value=runner.EpochReplayResult(
+                return_value=replay_models.EpochReplayResult(
                     evidence_bundles=(
                         evidence_bundles.evidence_bundle_from_frontier_candidate(
                             candidate_spec_id="spec-partial",

--- a/services/torghut/tests/autoresearch_runner/test_feedback_evidence.py
+++ b/services/torghut/tests/autoresearch_runner/test_feedback_evidence.py
@@ -20,7 +20,6 @@ from unittest.mock import patch
 
 from sqlalchemy.orm import Session
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from scripts.whitepaper_autoresearch_runner import proposal_building
 from scripts.whitepaper_autoresearch_runner import proposal_training
 from app.models import (
@@ -33,6 +32,7 @@ from app.trading.discovery.evidence_bundles import evidence_bundle_blockers
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
 
 
 class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
@@ -105,7 +105,7 @@ class TestAutoresearchRunnerFeedbackEvidence(AutoresearchRunnerTestCase):
         args = self._args(Path("unused"))
         args.ranker_backend_preference = "not-a-backend"
 
-        self.assertEqual(runner._ranker_backend_preference(args), "mlx")
+        self.assertEqual(cli_parsing._ranker_backend_preference(args), "mlx")
 
     def test_candidate_feedback_metadata_preserves_runtime_params_for_closure(
         self,

--- a/services/torghut/tests/autoresearch_runner/test_portfolio_candidate_feedback_uses_fallback_sleeves_and_skips_invalid_ones.py
+++ b/services/torghut/tests/autoresearch_runner/test_portfolio_candidate_feedback_uses_fallback_sleeves_and_skips_invalid_ones.py
@@ -24,7 +24,6 @@ from unittest.mock import patch
 
 from sqlalchemy.orm import Session
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from app.models import (
     AutoresearchEpoch,
     AutoresearchPortfolioCandidate,
@@ -32,6 +31,7 @@ from app.models import (
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
@@ -317,7 +317,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
     def test_oracle_policy_from_args_carries_full_promotion_risk_parameters(
         self,
     ) -> None:
-        policy = runner._oracle_policy_from_args(
+        policy = oracle_policy._oracle_policy_from_args(
             Namespace(
                 min_profit_factor="1.65",
                 max_worst_day_loss="999999999",
@@ -587,7 +587,7 @@ class TestPortfolioCandidateFeedbackUsesFallbackSleevesAndSkipsInvalidOnes(
             original_spec.candidate_spec_id,
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(drifted_spec,),
             proposal_rows=rows,
             top_k=1,

--- a/services/torghut/tests/autoresearch_runner/test_real_replay_shards.py
+++ b/services/torghut/tests/autoresearch_runner/test_real_replay_shards.py
@@ -18,12 +18,14 @@ from unittest.mock import patch
 
 
 import scripts.compile_whitepaper_claims as claim_compiler_script
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from scripts.whitepaper_autoresearch_runner import replay_execution
 from scripts.whitepaper_autoresearch_runner import replay_shards
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import app.trading.discovery.whitepaper_candidate_compiler as whitepaper_candidate_compiler
+import app.whitepapers.claim_compiler as claim_compiler
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
 
 
 class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
@@ -49,8 +51,10 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 encoding="utf-8",
             )
 
-            with patch.object(runner, "_current_code_commit", return_value="abc123"):
-                replay = runner._real_replay_result_from_factory_payload(
+            with patch.object(
+                replay_execution, "_current_code_commit", return_value="abc123"
+            ):
+                replay = replay_execution._real_replay_result_from_factory_payload(
                     {
                         "experiments": [
                             {
@@ -105,7 +109,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 encoding="utf-8",
             )
 
-            replay = runner._real_replay_result_from_factory_payload(
+            replay = replay_execution._real_replay_result_from_factory_payload(
                 {
                     "experiments": [
                         {
@@ -160,7 +164,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 encoding="utf-8",
             )
 
-            replay = runner._real_replay_result_from_factory_payload(
+            replay = replay_execution._real_replay_result_from_factory_payload(
                 {
                     "experiments": [
                         {
@@ -230,7 +234,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 "run_strategy_factory_v2",
                 return_value=factory_payload,
             ):
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     self._args(output_dir), output_dir=output_dir
                 )
 
@@ -263,7 +267,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 ),
                 encoding="utf-8",
             )
-            result = runner._real_replay_result_from_factory_payload(
+            result = replay_execution._real_replay_result_from_factory_payload(
                 {
                     "experiments": [
                         {
@@ -339,17 +343,19 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.replay_tape_path = output_dir / "tape.jsonl"
                 args.replay_tape_manifest = output_dir / "tape.manifest.json"
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -409,17 +415,19 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.max_candidates = 24
                 args.max_total_frontier_candidates = 11
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -462,18 +470,20 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.max_candidates = 24
                 args.max_frontier_candidates_per_spec = 64
                 args.max_total_frontier_candidates = 8
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:8],
@@ -518,18 +528,20 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.max_candidates = 24
                 args.max_frontier_candidates_per_spec = 8
                 args.max_total_frontier_candidates = 0
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -606,12 +618,14 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.staged_train_screen_multiplier = 3
@@ -624,7 +638,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 args.loss_repair_candidates = 1
                 args.consistency_repair_iterations = 1
                 args.consistency_repair_candidates = 2
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -653,7 +667,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
         self,
     ) -> None:
         args = self._args(Path("/tmp/epoch"))
-        program = runner._load_epoch_program(args)
+        program = replay_shards._load_epoch_program(args)
         controls = replay_shards._resolved_real_replay_frontier_controls(args, program)
 
         self.assertEqual(
@@ -688,12 +702,14 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             calls: list[list[str]] = []
@@ -703,7 +719,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 *,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(spec_ids)
                 if len(calls) == 2:
@@ -721,7 +737,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                     dataset_snapshot_id="snap-shard",
                     result_path=str(output_dir / f"{spec_ids[0]}.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok", "spec_ids": spec_ids},),
                 )
@@ -739,7 +755,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 _ = timeout_seconds
                 return fake_replay(args, output_dir=output_dir, specs=specs)
 
@@ -748,7 +764,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 "_run_real_replay_once_with_optional_timeout",
                 side_effect=fake_replay_once,
             ):
-                result = runner._run_replay_with_optional_timeout(
+                result = replay_shards._run_replay_with_optional_timeout(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,
@@ -800,7 +816,7 @@ class TestAutoresearchRunnerRealReplayShards(AutoresearchRunnerTestCase):
                 patch.object(
                     replay_execution,
                     "_run_real_replay_once_in_child_process",
-                    return_value=runner.EpochReplayResult(
+                    return_value=replay_models.EpochReplayResult(
                         evidence_bundles=(bundle,),
                         replay_results=({"status": "ok"},),
                     ),

--- a/services/torghut/tests/autoresearch_runner/test_real_replay_worker_reports_success_error_and_error_payload.py
+++ b/services/torghut/tests/autoresearch_runner/test_real_replay_worker_reports_success_error_and_error_payload.py
@@ -20,6 +20,8 @@ from scripts.whitepaper_autoresearch_runner import replay_shards
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import app.trading.discovery.whitepaper_candidate_compiler as whitepaper_candidate_compiler
+import app.whitepapers.claim_compiler as claim_compiler
 
 
 class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
@@ -40,7 +42,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
 
         args = self._args(Path("unused"))
         spec = self._candidate_spec("spec-worker")
-        expected = runner.EpochReplayResult(
+        expected = replay_models.EpochReplayResult(
             evidence_bundles=(),
             replay_results=({"status": "ok"},),
         )
@@ -166,7 +168,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             output_dir = Path(tmpdir) / "epoch"
             args = self._args(output_dir)
             spec = self._candidate_spec("spec-child-ok")
-            expected = runner.EpochReplayResult(
+            expected = replay_models.EpochReplayResult(
                 evidence_bundles=(),
                 replay_results=({"status": "ok"},),
             )
@@ -319,12 +321,14 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             calls: list[tuple[list[str], int, int, int]] = []
@@ -334,7 +338,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 *,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(
                     (
@@ -359,7 +363,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                     dataset_snapshot_id="snap-shard",
                     result_path=str(output_dir / f"{spec_ids[0]}.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok", "spec_ids": spec_ids},),
                 )
@@ -379,7 +383,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 _ = timeout_seconds
                 return fake_replay(args, output_dir=output_dir, specs=specs)
 
@@ -388,7 +392,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 "_run_real_replay_once_with_optional_timeout",
                 side_effect=fake_replay_once,
             ):
-                result = runner._run_replay_with_optional_timeout(
+                result = replay_shards._run_replay_with_optional_timeout(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,
@@ -458,7 +462,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
-                result=runner.EpochReplayResult(
+                result=replay_models.EpochReplayResult(
                     evidence_bundles=(),
                     replay_results=(),
                 ),
@@ -528,7 +532,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
             return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
-                result=runner.EpochReplayResult(
+                result=replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok"},),
                 ),
@@ -569,12 +573,14 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             args = self._args(output_dir)
@@ -614,12 +620,14 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:8]
             args = self._args(output_dir)
@@ -646,12 +654,14 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             args = self._args(output_dir)
@@ -688,7 +698,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                             candidate_spec_ids=tuple(
                                 spec.candidate_spec_id for spec in plan.specs
                             ),
-                            result=runner.EpochReplayResult(
+                            result=replay_models.EpochReplayResult(
                                 evidence_bundles=(),
                                 replay_results=(
                                     {
@@ -736,12 +746,14 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:6]
             args = self._args(output_dir)
@@ -777,12 +789,14 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:4]
             args = self._args(output_dir)
@@ -815,7 +829,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                 args: Namespace,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 spec = specs[0]
                 bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec.candidate_spec_id,
@@ -837,7 +851,7 @@ class TestRealReplayWorkerReportsSuccessErrorAndErrorPayload(
                     dataset_snapshot_id="snap-incomplete",
                     result_path=str(output_dir / "incomplete.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "partial_replay_shards_interrupted"},),
                     incomplete=True,

--- a/services/torghut/tests/autoresearch_runner/test_replay_tape_preview.py
+++ b/services/torghut/tests/autoresearch_runner/test_replay_tape_preview.py
@@ -310,7 +310,7 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             }
 
             narrowed_specs, updated_selection = (
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,
@@ -624,7 +624,7 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
                 ValueError,
                 "replay_tape_cache_identity_mismatch:.*feature_schema_hash",
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -704,7 +704,7 @@ class TestAutoresearchRunnerReplayTapePreview(AutoresearchRunnerTestCase):
             }
 
             narrowed_specs, updated_selection = (
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],

--- a/services/torghut/tests/autoresearch_runner/test_runtime_closure.py
+++ b/services/torghut/tests/autoresearch_runner/test_runtime_closure.py
@@ -13,12 +13,15 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 
-import scripts.run_whitepaper_autoresearch_profit_target as runner
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
     _CHIP_UNIVERSE,
     _authoritative_exact_replay_ledger_rows,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.common as runner_common
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
+import scripts.whitepaper_autoresearch_runner.runtime_closure as runtime_closure
 
 
 class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
@@ -30,7 +33,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             args.program = Path(
                 "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
-            program = runner._load_epoch_program(args)
+            program = replay_shards._load_epoch_program(args)
 
         manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
@@ -65,11 +68,13 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             optimizer_report={},
         )
 
-        runtime_program = runner._runtime_closure_program_for_candidate(
-            program=program,
-            manifest=manifest,
-            portfolio=portfolio,
-            oracle_candidate_found=False,
+        runtime_program = (
+            candidate_board_payloads._runtime_closure_program_for_candidate(
+                program=program,
+                manifest=manifest,
+                portfolio=portfolio,
+                oracle_candidate_found=False,
+            )
         )
 
         self.assertFalse(runtime_program.runtime_closure_policy.execute_parity_replay)
@@ -84,7 +89,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
                 "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
             args.replay_mode = "real"
-            program = runner._load_epoch_program(args)
+            program = replay_shards._load_epoch_program(args)
 
         manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
@@ -130,11 +135,13 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             optimizer_report={},
         )
 
-        runtime_program = runner._runtime_closure_program_for_candidate(
-            program=program,
-            manifest=manifest,
-            portfolio=portfolio,
-            oracle_candidate_found=False,
+        runtime_program = (
+            candidate_board_payloads._runtime_closure_program_for_candidate(
+                program=program,
+                manifest=manifest,
+                portfolio=portfolio,
+                oracle_candidate_found=False,
+            )
         )
 
         self.assertTrue(runtime_program.runtime_closure_policy.execute_parity_replay)
@@ -143,18 +150,22 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
     def test_runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows(
         self,
     ) -> None:
-        self.assertIsNone(runner._runtime_closure_ledger_datetime(None))
-        self.assertIsNone(runner._runtime_closure_ledger_datetime("not-a-date"))
+        self.assertIsNone(runtime_closure._runtime_closure_ledger_datetime(None))
+        self.assertIsNone(
+            runtime_closure._runtime_closure_ledger_datetime("not-a-date")
+        )
         self.assertEqual(
-            runner._runtime_closure_ledger_datetime("2026-05-20T14:00:00"),
+            runtime_closure._runtime_closure_ledger_datetime("2026-05-20T14:00:00"),
             datetime(2026, 5, 20, 14, tzinfo=timezone.utc),
         )
         self.assertEqual(
-            runner._runtime_closure_ledger_datetime("2026-05-20T14:00:00-04:00"),
+            runtime_closure._runtime_closure_ledger_datetime(
+                "2026-05-20T14:00:00-04:00"
+            ),
             datetime(2026, 5, 20, 18, tzinfo=timezone.utc),
         )
         self.assertIsNone(
-            runner._runtime_closure_exact_replay_bucket(
+            runtime_closure._runtime_closure_exact_replay_bucket(
                 ledger={"window_start": "2026-05-20", "window_end": "2026-05-19"},
                 rows=_authoritative_exact_replay_ledger_rows(),
             )
@@ -164,7 +175,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             return_value=[],
         ):
             self.assertIsNone(
-                runner._runtime_closure_exact_replay_bucket(
+                runtime_closure._runtime_closure_exact_replay_bucket(
                     ledger={
                         "window_start": "2026-05-20",
                         "window_end": "2026-05-20",
@@ -188,7 +199,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -208,7 +219,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -229,7 +240,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -249,7 +260,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -272,7 +283,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -294,7 +305,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -315,7 +326,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
                 encoding="utf-8",
             )
 
-            update = runner._runtime_closure_exact_replay_ledger_update(
+            update = runtime_closure._runtime_closure_exact_replay_ledger_update(
                 {"exact_replay_ledger_artifact_path": str(artifact_path)}
             )
 
@@ -527,7 +538,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
                 optimizer_report={},
             )
 
-            updated = runner._portfolio_with_runtime_closure_proof(
+            updated = candidate_board_payloads._portfolio_with_runtime_closure_proof(
                 portfolio=portfolio,
                 runtime_closure={
                     "status": "ready_for_promotion_review",
@@ -696,7 +707,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             invalid_json_path = Path(tmpdir) / "invalid.json"
             invalid_json_path.write_text("{", encoding="utf-8")
             args = self._args(Path(tmpdir) / "epoch")
-            program = runner._load_epoch_program(args)
+            program = replay_shards._load_epoch_program(args)
 
         portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
@@ -734,19 +745,24 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             manifest_hash="hash",
         )
 
-        self.assertEqual(runner._oracle_blockers({}), frozenset())
-        self.assertEqual(runner._load_json_mapping_artifact(invalid_json_path), {})
+        self.assertEqual(runner_common._oracle_blockers({}), frozenset())
         self.assertEqual(
-            runner._runtime_report_summary_int(
+            runtime_closure._load_json_mapping_artifact(invalid_json_path), {}
+        )
+        self.assertEqual(
+            runtime_closure._runtime_report_summary_int(
                 {"summary": {"filled_count": "bad"}}, "filled_count", default=7
             ),
             7,
         )
-        self.assertEqual(runner._runtime_report_int("bad", default=11), 11)
+        self.assertEqual(runtime_closure._runtime_report_int("bad", default=11), 11)
         self.assertEqual(
-            runner._portfolio_executable_max_notional(portfolio), Decimal("50000")
+            runtime_closure._portfolio_executable_max_notional(portfolio),
+            Decimal("50000"),
         )
-        self.assertFalse(runner._portfolio_needs_runtime_closure_proof(portfolio))
+        self.assertFalse(
+            runtime_closure._portfolio_needs_runtime_closure_proof(portfolio)
+        )
         market_impact_only_portfolio = replace(
             portfolio,
             objective_scorecard={
@@ -766,10 +782,12 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
             },
         )
         self.assertTrue(
-            runner._portfolio_needs_runtime_closure_proof(market_impact_only_portfolio)
+            runtime_closure._portfolio_needs_runtime_closure_proof(
+                market_impact_only_portfolio
+            )
         )
         self.assertIs(
-            runner._runtime_closure_program_for_candidate(
+            candidate_board_payloads._runtime_closure_program_for_candidate(
                 program=program,
                 manifest=manifest,
                 portfolio=None,
@@ -794,8 +812,10 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
                 + "\n",
                 encoding="utf-8",
             )
-            default_marker_update = runner._runtime_closure_market_impact_stress_update(
-                {"market_impact_stress_report_path": str(default_marker_path)}
+            default_marker_update = (
+                runtime_closure._runtime_closure_market_impact_stress_update(
+                    {"market_impact_stress_report_path": str(default_marker_path)}
+                )
             )
             self.assertEqual(
                 default_marker_update["market_impact_stress_source_markers"],
@@ -837,7 +857,7 @@ class TestAutoresearchRunnerRuntimeClosure(AutoresearchRunnerTestCase):
                 encoding="utf-8",
             )
             component_marker_update = (
-                runner._runtime_closure_market_impact_stress_update(
+                runtime_closure._runtime_closure_market_impact_stress_update(
                     {"market_impact_stress_report_path": str(component_marker_path)}
                 )
             )

--- a/services/torghut/tests/autoresearch_runner/test_staged_replay_frontier_default_resolvers_enable_bounded_real_path.py
+++ b/services/torghut/tests/autoresearch_runner/test_staged_replay_frontier_default_resolvers_enable_bounded_real_path.py
@@ -37,6 +37,7 @@ from app.trading.models import SignalEnvelope
 from tests.autoresearch_runner.helpers import (
     AutoresearchRunnerTestCase,
 )
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
 
 
 class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
@@ -381,7 +382,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                 return_value=coverage,
             ) as fetch:
                 updated_args, receipt = (
-                    runner._maybe_preflight_materialized_replay_tape_window(
+                    queue_metadata._maybe_preflight_materialized_replay_tape_window(
                         args=args,
                         output_dir=output_dir,
                     )
@@ -460,7 +461,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             with self.assertRaisesRegex(
                 ValueError, "fast_replay_preview_requires_real_replay"
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -471,7 +472,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             with self.assertRaisesRegex(
                 ValueError, "fast_replay_preview_requires_replay_tape_path"
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -482,7 +483,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             with self.assertRaisesRegex(
                 ValueError, "fast_replay_preview_requires_full_window_start_date"
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -502,15 +503,17 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
             args.full_window_start_date = "2026-02-23"
             args.symbols = "NVDA"
             with patch.object(
-                runner,
+                preview_narrowing,
                 "build_fast_replay_preview",
                 return_value=UnknownPreview(),
             ):
-                narrowed, updated = runner._apply_fast_replay_preview_narrowing(
-                    args=args,
-                    output_dir=output_dir,
-                    specs=[spec],
-                    candidate_selection=selection,
+                narrowed, updated = (
+                    preview_narrowing._apply_fast_replay_preview_narrowing(
+                        args=args,
+                        output_dir=output_dir,
+                        specs=[spec],
+                        candidate_selection=selection,
+                    )
                 )
 
         self.assertEqual(
@@ -687,7 +690,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                 args: Namespace,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 del args
                 captured_spec_ids.extend(spec.candidate_spec_id for spec in specs)
                 bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
@@ -708,7 +711,7 @@ class TestStagedReplayFrontierDefaultResolversEnableBoundedRealPath(
                     dataset_snapshot_id="snap-direct",
                     result_path=str(output_dir / "direct-a.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok"},),
                 )

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_a.py
@@ -11,8 +11,12 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     WhitepaperAutoresearchRunnerTestCaseBase,
     json,
     replace,
-    runner,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_fields as candidate_board_fields
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.candidate_board_status as candidate_board_status
+import scripts.whitepaper_autoresearch_runner.candidate_board_summaries as candidate_board_summaries
+import scripts.whitepaper_autoresearch_runner.runtime_closure as runtime_closure
 
 
 class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -32,8 +36,10 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
                 + "\n",
                 encoding="utf-8",
             )
-            default_marker_update = runner._runtime_closure_market_impact_stress_update(
-                {"market_impact_stress_report_path": str(default_marker_path)}
+            default_marker_update = (
+                runtime_closure._runtime_closure_market_impact_stress_update(
+                    {"market_impact_stress_report_path": str(default_marker_path)}
+                )
             )
             self.assertEqual(
                 default_marker_update["market_impact_stress_source_markers"],
@@ -75,7 +81,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
                 encoding="utf-8",
             )
             component_marker_update = (
-                runner._runtime_closure_market_impact_stress_update(
+                runtime_closure._runtime_closure_market_impact_stress_update(
                     {"market_impact_stress_report_path": str(component_marker_path)}
                 )
             )
@@ -120,9 +126,12 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        self.assertEqual(runner._candidate_board_int_field({"bad": object()}, "bad"), 0)
         self.assertEqual(
-            runner._candidate_board_market_impact_proof_summary(
+            candidate_board_fields._candidate_board_int_field({"bad": object()}, "bad"),
+            0,
+        )
+        self.assertEqual(
+            candidate_board_summaries._candidate_board_market_impact_proof_summary(
                 {
                     "market_impact_stress_model": "almgren_chriss_proxy",
                     "market_impact_stress_cost_bps": "150",
@@ -144,7 +153,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
         )
         self.assertIn(
             "double_square_root_impact_arxiv_2502_16246_2025",
-            runner._candidate_board_market_impact_proof_summary(
+            candidate_board_summaries._candidate_board_market_impact_proof_summary(
                 {
                     "market_impact_stress_model": "almgren_chriss_proxy",
                     "market_impact_stress_cost_bps": "150",
@@ -163,16 +172,20 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
                 }
             )["source_markers"],
         )
-        missing_impact = runner._candidate_board_market_impact_proof_summary(
-            {"target_met": True}
+        missing_impact = (
+            candidate_board_summaries._candidate_board_market_impact_proof_summary(
+                {"target_met": True}
+            )
         )
         self.assertEqual(missing_impact["state"], "blocked")
         self.assertIn(
             "nonlinear_market_impact_components_missing",
             missing_impact["blockers"],
         )
-        regime_summary = runner._candidate_board_regime_specialist_summary(
-            spec, {"regime_slice_pass_rate": "0.30"}
+        regime_summary = (
+            candidate_board_summaries._candidate_board_regime_specialist_summary(
+                spec, {"regime_slice_pass_rate": "0.30"}
+            )
         )
         self.assertEqual(regime_summary["state"], "blocked")
         self.assertIn(
@@ -184,7 +197,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             ["risk-sensitive-routing", "vvg-validation"],
         )
         self.assertEqual(
-            runner._candidate_board_blockers(
+            candidate_board_status._candidate_board_blockers(
                 selected_for_replay=True,
                 evidence=None,
                 scorecard={},
@@ -192,19 +205,21 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             ["replay_evidence_missing"],
         )
         self.assertEqual(
-            runner._candidate_board_blockers(
+            candidate_board_status._candidate_board_blockers(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={"target_met": True, "oracle_passed": False},
             ),
             ["profit_target_oracle_failed"],
         )
-        dirty_lineage = runner._candidate_board_evidence_lineage_summary(
-            replace(evidence, code_commit="commit-test-dirty")
+        dirty_lineage = (
+            candidate_board_summaries._candidate_board_evidence_lineage_summary(
+                replace(evidence, code_commit="commit-test-dirty")
+            )
         )
         self.assertEqual(dirty_lineage["blockers"], ["code_commit_dirty"])
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=None,
                 scorecard={},
@@ -214,7 +229,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             "selected_pending_replay_evidence",
         )
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={"oracle_passed": True},
@@ -224,7 +239,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             "candidate_oracle_passed",
         )
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={"target_met": True, "oracle_passed": False},
@@ -234,7 +249,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             "blocked_by_oracle",
         )
         self.assertEqual(
-            runner._candidate_board_status(
+            candidate_board_status._candidate_board_status(
                 selected_for_replay=True,
                 evidence=evidence,
                 scorecard={},
@@ -243,7 +258,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             ),
             "portfolio_component_passed_oracle",
         )
-        denied_readiness = runner._promotion_readiness_payload(
+        denied_readiness = runtime_closure._promotion_readiness_payload(
             oracle_candidate_found=True,
             status="ready_for_promotion_review",
             blockers=[],
@@ -261,7 +276,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             denied_readiness["status"], "blocked_pending_promotion_prerequisites"
         )
         self.assertEqual(denied_readiness["blockers"], ["promotion_gate_report_denied"])
-        allowed_readiness = runner._promotion_readiness_payload(
+        allowed_readiness = runtime_closure._promotion_readiness_payload(
             oracle_candidate_found=True,
             status="ready_for_promotion_review",
             blockers=[],
@@ -540,7 +555,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             optimizer_report={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-portfolio-promotion-subject",
             output_dir=Path("/tmp/torghut-test"),
             target=Decimal("500"),
@@ -624,7 +639,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-rejected-signal-board",
             output_dir=Path("/tmp/epoch-rejected-signal-board"),
             target=Decimal("500"),
@@ -685,7 +700,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-unknown-lineage-board",
             output_dir=Path("/tmp/epoch-unknown-lineage-board"),
             target=Decimal("500"),
@@ -772,7 +787,7 @@ class TestAutoresearchRunnerCandidateBoardA(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-board",
             output_dir=Path("/tmp/epoch-market-limit-board"),
             target=Decimal("500"),

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_candidate_board_b.py
@@ -8,8 +8,10 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Path,
     WhitepaperAutoresearchRunnerTestCaseBase,
     replace,
-    runner,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.candidate_board_summaries as candidate_board_summaries
+import scripts.whitepaper_autoresearch_runner.common as runner_common
 
 
 class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -87,7 +89,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-pass-board",
             output_dir=Path("/tmp/epoch-market-limit-pass-board"),
             target=Decimal("500"),
@@ -169,7 +171,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-queue-survival-board",
             output_dir=Path("/tmp/epoch-queue-survival-board"),
             target=Decimal("500"),
@@ -229,7 +231,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             },
         )
 
-        summary = runner._candidate_board_queue_position_survival_summary(
+        summary = candidate_board_summaries._candidate_board_queue_position_survival_summary(
             spec,
             {
                 "queue_position_survival_fill_curve_evidence_present": True,
@@ -307,7 +309,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-missing-artifact-ref-board",
             output_dir=Path("/tmp/epoch-market-limit-missing-artifact-ref-board"),
             target=Decimal("500"),
@@ -403,7 +405,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-route-bool-board",
             output_dir=Path("/tmp/epoch-market-limit-route-bool-board"),
             target=Decimal("500"),
@@ -486,7 +488,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-market-limit-route-artifact-board",
             output_dir=Path("/tmp/epoch-market-limit-route-artifact-board"),
             target=Decimal("500"),
@@ -594,7 +596,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-candidate-board-split",
             output_dir=Path("/tmp/epoch-candidate-board-split"),
             target=Decimal("500"),
@@ -699,7 +701,7 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-alpha-decay-missing-stress",
             output_dir=Path("/tmp/epoch-alpha-decay-missing-stress"),
             target=Decimal("500"),
@@ -793,17 +795,19 @@ class TestAutoresearchRunnerCandidateBoardB(WhitepaperAutoresearchRunnerTestCase
             proof_handoff["zero_authoritative_daily_pnl_until_materialized"]
         )
         self.assertEqual(
-            runner._candidate_board_runtime_ledger_required_materialized_artifacts({}),
+            runner_common._candidate_board_runtime_ledger_required_materialized_artifacts(
+                {}
+            ),
             [],
         )
         self.assertEqual(
-            runner._candidate_board_runtime_ledger_required_materialized_artifacts(
+            runner_common._candidate_board_runtime_ledger_required_materialized_artifacts(
                 {"required_materialized_artifacts": "runtime-ledger/string.json"}
             ),
             ["runtime-ledger/string.json"],
         )
         self.assertEqual(
-            runner._candidate_board_runtime_ledger_required_materialized_artifacts(
+            runner_common._candidate_board_runtime_ledger_required_materialized_artifacts(
                 {
                     "required_materialized_artifacts": [
                         {"path": "runtime-ledger/path.json"},

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_fast_replay.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_fast_replay.py
@@ -17,7 +17,6 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     fast_replay,
     materialize_signal_tape,
     replace,
-    runner,
     timezone,
 )
 
@@ -105,7 +104,7 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
                 ValueError,
                 "replay_tape_cache_identity_mismatch:.*feature_schema_hash",
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -185,7 +184,7 @@ class TestAutoresearchRunnerFastReplay(WhitepaperAutoresearchRunnerTestCaseBase)
             }
 
             narrowed_specs, updated_selection = (
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py
@@ -26,6 +26,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     runner,
     timezone,
 )
+import scripts.whitepaper_autoresearch_runner.preview_narrowing as preview_narrowing
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
 
 
 class TestAutoresearchRunnerMaterializedReplay(
@@ -231,7 +233,7 @@ class TestAutoresearchRunnerMaterializedReplay(
                 return_value=coverage,
             ) as fetch:
                 updated_args, receipt = (
-                    runner._maybe_preflight_materialized_replay_tape_window(
+                    queue_metadata._maybe_preflight_materialized_replay_tape_window(
                         args=args,
                         output_dir=output_dir,
                     )
@@ -310,7 +312,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             with self.assertRaisesRegex(
                 ValueError, "fast_replay_preview_requires_real_replay"
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -321,7 +323,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             with self.assertRaisesRegex(
                 ValueError, "fast_replay_preview_requires_replay_tape_path"
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -332,7 +334,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             with self.assertRaisesRegex(
                 ValueError, "fast_replay_preview_requires_full_window_start_date"
             ):
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=[spec],
@@ -352,15 +354,17 @@ class TestAutoresearchRunnerMaterializedReplay(
             args.full_window_start_date = "2026-02-23"
             args.symbols = "NVDA"
             with patch.object(
-                runner,
+                preview_narrowing,
                 "build_fast_replay_preview",
                 return_value=UnknownPreview(),
             ):
-                narrowed, updated = runner._apply_fast_replay_preview_narrowing(
-                    args=args,
-                    output_dir=output_dir,
-                    specs=[spec],
-                    candidate_selection=selection,
+                narrowed, updated = (
+                    preview_narrowing._apply_fast_replay_preview_narrowing(
+                        args=args,
+                        output_dir=output_dir,
+                        specs=[spec],
+                        candidate_selection=selection,
+                    )
                 )
 
         self.assertEqual(
@@ -533,7 +537,7 @@ class TestAutoresearchRunnerMaterializedReplay(
                 args: Namespace,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 del args
                 captured_spec_ids.extend(spec.candidate_spec_id for spec in specs)
                 bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
@@ -554,7 +558,7 @@ class TestAutoresearchRunnerMaterializedReplay(
                     dataset_snapshot_id="snap-direct",
                     result_path=str(output_dir / "direct-a.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok"},),
                 )

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_a.py
@@ -8,8 +8,9 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     WhitepaperAutoresearchRunnerTestCaseBase,
     json,
     replace,
-    runner,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.candidate_board_status as candidate_board_status
 
 
 class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -110,7 +111,7 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-paper-probation-board",
             output_dir=Path("/tmp/epoch-paper-probation-board"),
             target=Decimal("500"),
@@ -422,7 +423,7 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
         self.assertFalse(target["final_promotion_authorized"])
         self.assertFalse(target["final_promotion_allowed"])
         self.assertEqual(target["selection_reason"], "target_met_but_oracle_blocked")
-        handoff = runner._paper_probation_handoff_payload(board)
+        handoff = candidate_board_payloads._paper_probation_handoff_payload(board)
         self.assertEqual(
             handoff["schema_version"], "torghut.paper-probation-handoff.v1"
         )
@@ -631,7 +632,7 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
             objective_scorecard=bridge_scorecard,
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-paper-probation-economics",
             output_dir=Path("/tmp/epoch-paper-probation-economics"),
             target=Decimal("500"),
@@ -759,7 +760,9 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
         }
 
         self.assertEqual(
-            runner._candidate_board_paper_probation_admission_blockers(generic_row),
+            candidate_board_status._candidate_board_paper_probation_admission_blockers(
+                generic_row
+            ),
             [
                 "paper_probation_exact_replay_ledger_artifact_missing",
                 "paper_probation_exact_replay_ledger_row_count_missing",
@@ -768,6 +771,8 @@ class TestAutoresearchRunnerPaperProbationA(WhitepaperAutoresearchRunnerTestCase
             ],
         )
         self.assertEqual(
-            runner._candidate_board_paper_probation_admission_blockers(ledger_row),
+            candidate_board_status._candidate_board_paper_probation_admission_blockers(
+                ledger_row
+            ),
             [],
         )

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_paper_probation_b.py
@@ -14,6 +14,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     json,
     runner,
 )
+import scripts.whitepaper_autoresearch_runner.candidate_board_paper_probation as candidate_board_paper_probation
+import scripts.whitepaper_autoresearch_runner.candidate_board_runtime_windows as candidate_board_runtime_windows
 
 
 class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -63,9 +65,11 @@ class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCase
             "blockers": [],
         }
 
-        candidate = runner._candidate_board_paper_probation_candidate(
-            [row],
-            target=Decimal("500"),
+        candidate = (
+            candidate_board_paper_probation._candidate_board_paper_probation_candidate(
+                [row],
+                target=Decimal("500"),
+            )
         )
 
         self.assertIsNotNone(candidate)
@@ -77,7 +81,7 @@ class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCase
         )
         self.assertFalse(candidate["final_promotion_allowed"])
         self.assertIsNone(
-            runner._candidate_board_paper_probation_candidate(
+            candidate_board_paper_probation._candidate_board_paper_probation_candidate(
                 [],
                 target=Decimal("500"),
             )
@@ -117,20 +121,24 @@ class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCase
             "runtime_window_end": "2026-05-21T20:00:00+00:00",
         }
 
-        plan = runner._candidate_board_runtime_window_import_plan(
-            rows=(row,),
-            paper_probation_candidate=row,
-            promotion_subject={
-                "target_met": True,
-                "sleeve_candidate_spec_ids": ["spec-runtime-plan"],
-            },
+        plan = (
+            candidate_board_runtime_windows._candidate_board_runtime_window_import_plan(
+                rows=(row,),
+                paper_probation_candidate=row,
+                promotion_subject={
+                    "target_met": True,
+                    "sleeve_candidate_spec_ids": ["spec-runtime-plan"],
+                },
+            )
         )
-        fallback_plan = runner._candidate_board_runtime_window_import_plan(
-            rows=(),
-            paper_probation_candidate=fallback_row,
-            promotion_subject=None,
+        fallback_plan = (
+            candidate_board_runtime_windows._candidate_board_runtime_window_import_plan(
+                rows=(),
+                paper_probation_candidate=fallback_row,
+                promotion_subject=None,
+            )
         )
-        incomplete_plan = runner._candidate_board_runtime_window_import_plan(
+        incomplete_plan = candidate_board_runtime_windows._candidate_board_runtime_window_import_plan(
             rows=(),
             paper_probation_candidate={
                 "candidate_spec_id": "spec-incomplete",
@@ -143,11 +151,13 @@ class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCase
         )
 
         self.assertEqual(
-            runner._candidate_board_hypothesis_manifest_ref(None),
+            candidate_board_runtime_windows._candidate_board_hypothesis_manifest_ref(
+                None
+            ),
             "",
         )
         self.assertEqual(
-            runner._candidate_board_runtime_window_bounds(
+            candidate_board_runtime_windows._candidate_board_runtime_window_bounds(
                 {
                     "runtime_window_start": "2026-05-01",
                     "runtime_window_end": "2026-05-02",
@@ -236,19 +246,19 @@ class TestAutoresearchRunnerPaperProbationB(WhitepaperAutoresearchRunnerTestCase
         self,
     ) -> None:
         self.assertEqual(
-            runner._candidate_universe_symbols_for_compilation(
+            artifact_io._candidate_universe_symbols_for_compilation(
                 Namespace(symbols=",".join(_CHIP_UNIVERSE))
             ),
             (),
         )
         self.assertEqual(
-            runner._candidate_universe_symbols_for_compilation(
+            artifact_io._candidate_universe_symbols_for_compilation(
                 Namespace(symbols="MSFT,SHOP")
             ),
             (),
         )
         self.assertEqual(
-            runner._candidate_universe_symbols_for_compilation(
+            artifact_io._candidate_universe_symbols_for_compilation(
                 Namespace(symbols="NVDA,AMAT,AAPL")
             ),
             ("NVDA", "AAPL"),

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_parser.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_parser.py
@@ -19,11 +19,14 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     evidence_bundle_blockers,
     patch,
     replace,
-    runner,
     sys,
 )
 from scripts.whitepaper_autoresearch_runner import proposal_building
 from scripts.whitepaper_autoresearch_runner import proposal_training
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -96,7 +99,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
         args = self._args(Path("unused"))
         args.ranker_backend_preference = "not-a-backend"
 
-        self.assertEqual(runner._ranker_backend_preference(args), "mlx")
+        self.assertEqual(cli_parsing._ranker_backend_preference(args), "mlx")
 
     def test_candidate_board_adds_factor_acceptance_replay_metadata(self) -> None:
         spec = replace(
@@ -147,7 +150,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             promotion_readiness={},
         )
 
-        board = runner._candidate_board_payload(
+        board = candidate_board_payloads._candidate_board_payload(
             epoch_id="epoch-factor-acceptance",
             output_dir=Path("/tmp/torghut-factor-acceptance"),
             target=Decimal("500"),
@@ -449,7 +452,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             row_by_spec[control_spec.candidate_spec_id]["rank"],
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(control_spec, paper_spec),
             proposal_rows=rows,
             top_k=1,
@@ -500,7 +503,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
         )
 
         exploration_selected, exploration_selection = (
-            runner._select_candidate_specs_for_replay(
+            replay_selection._select_candidate_specs_for_replay(
                 specs=(control_spec, paper_spec),
                 proposal_rows=rows,
                 top_k=0,
@@ -535,7 +538,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                     tmpdir,
                 ],
             ):
-                args = runner._parse_args()
+                args = cli_parsing._parse_args()
 
         self.assertEqual(args.target_net_pnl_per_day, "500")
         self.assertEqual(args.epoch_id, "")
@@ -569,7 +572,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                     ],
                 ),
             ):
-                args = runner._parse_args()
+                args = cli_parsing._parse_args()
 
         self.assertEqual(args.clickhouse_http_url, "http://127.0.0.1:8123")
         self.assertEqual(args.clickhouse_username, "reader")
@@ -597,7 +600,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
                     ],
                 ),
             ):
-                args = runner._parse_args()
+                args = cli_parsing._parse_args()
 
         self.assertEqual(args.clickhouse_http_url, "http://127.0.0.1:8123")
 
@@ -614,7 +617,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=socket.gaierror("not known"),
         ):
-            failure = runner._clickhouse_endpoint_preflight_failure(args)
+            failure = artifact_io._clickhouse_endpoint_preflight_failure(args)
 
         self.assertIn("clickhouse_endpoint_unreachable", failure)
         self.assertIn("TA_CLICKHOUSE_URL", failure)
@@ -631,7 +634,7 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("non-cluster endpoints are replay-checked"),
         ):
-            failure = runner._clickhouse_endpoint_preflight_failure(args)
+            failure = artifact_io._clickhouse_endpoint_preflight_failure(args)
 
         self.assertEqual(failure, "")
 
@@ -647,6 +650,6 @@ class TestAutoresearchRunnerParser(WhitepaperAutoresearchRunnerTestCaseBase):
             "scripts.whitepaper_autoresearch_runner.artifact_io.socket.getaddrinfo",
             side_effect=AssertionError("replay tape should bypass DNS preflight"),
         ):
-            failure = runner._clickhouse_endpoint_preflight_failure(args)
+            failure = artifact_io._clickhouse_endpoint_preflight_failure(args)
 
         self.assertEqual(failure, "")

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_persistence_remediation.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_persistence_remediation.py
@@ -27,6 +27,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     select,
 )
 from scripts.whitepaper_autoresearch_runner import replay_execution, run_reporting
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestAutoresearchRunnerPersistenceRemediation(
@@ -66,7 +68,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
             runtime_strategy_name="late-day-continuation-long-v1",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(breakout_primary, breakout_secondary, intraday, late_day),
             proposal_rows=[
                 {
@@ -707,7 +709,7 @@ class TestAutoresearchRunnerPersistenceRemediation(
             patch.object(
                 run_reporting,
                 "_collect_partial_real_replay",
-                return_value=runner.EpochReplayResult(
+                return_value=replay_models.EpochReplayResult(
                     evidence_bundles=(
                         evidence_bundles.evidence_bundle_from_frontier_candidate(
                             candidate_spec_id="spec-partial",

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_quality_oracle.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_quality_oracle.py
@@ -16,8 +16,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     TemporaryDirectory,
     WhitepaperAutoresearchRunnerTestCaseBase,
     replace,
-    runner,
 )
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -148,7 +148,7 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
     def test_oracle_policy_from_args_carries_full_promotion_risk_parameters(
         self,
     ) -> None:
-        policy = runner._oracle_policy_from_args(
+        policy = oracle_policy._oracle_policy_from_args(
             Namespace(
                 min_profit_factor="1.65",
                 max_worst_day_loss="999999999",
@@ -418,7 +418,7 @@ class TestAutoresearchRunnerQualityOracle(WhitepaperAutoresearchRunnerTestCaseBa
             original_spec.candidate_spec_id,
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(drifted_spec,),
             proposal_rows=rows,
             top_k=1,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py
@@ -15,10 +15,12 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     WhitepaperAutoresearchRunnerTestCaseBase,
     claim_compiler_script,
     patch,
-    runner,
 )
 from scripts.whitepaper_autoresearch_runner import replay_execution
 from scripts.whitepaper_autoresearch_runner import replay_shards
+import app.trading.discovery.whitepaper_candidate_compiler as whitepaper_candidate_compiler
+import app.whitepapers.claim_compiler as claim_compiler
+import scripts.whitepaper_autoresearch_runner.replay_models as replay_models
 
 
 class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -26,12 +28,14 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             calls: list[list[str]] = []
@@ -41,7 +45,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 *,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(spec_ids)
                 if len(calls) == 2:
@@ -59,7 +63,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                     dataset_snapshot_id="snap-shard",
                     result_path=str(output_dir / f"{spec_ids[0]}.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok", "spec_ids": spec_ids},),
                 )
@@ -77,7 +81,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 _ = timeout_seconds
                 return fake_replay(args, output_dir=output_dir, specs=specs)
 
@@ -86,7 +90,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 "_run_real_replay_once_with_optional_timeout",
                 side_effect=fake_replay_once,
             ):
-                result = runner._run_replay_with_optional_timeout(
+                result = replay_shards._run_replay_with_optional_timeout(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,
@@ -138,7 +142,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 patch.object(
                     replay_execution,
                     "_run_real_replay_once_in_child_process",
-                    return_value=runner.EpochReplayResult(
+                    return_value=replay_models.EpochReplayResult(
                         evidence_bundles=(bundle,),
                         replay_results=({"status": "ok"},),
                     ),
@@ -249,7 +253,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
 
         args = self._args(Path("unused"))
         spec = self._candidate_spec("spec-worker")
-        expected = runner.EpochReplayResult(
+        expected = replay_models.EpochReplayResult(
             evidence_bundles=(),
             replay_results=({"status": "ok"},),
         )
@@ -375,7 +379,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
             output_dir = Path(tmpdir) / "epoch"
             args = self._args(output_dir)
             spec = self._candidate_spec("spec-child-ok")
-            expected = runner.EpochReplayResult(
+            expected = replay_models.EpochReplayResult(
                 evidence_bundles=(),
                 replay_results=({"status": "ok"},),
             )
@@ -528,12 +532,14 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             calls: list[tuple[list[str], int, int, int]] = []
@@ -543,7 +549,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 *,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 spec_ids = [spec.candidate_spec_id for spec in specs]
                 calls.append(
                     (
@@ -568,7 +574,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                     dataset_snapshot_id="snap-shard",
                     result_path=str(output_dir / f"{spec_ids[0]}.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok", "spec_ids": spec_ids},),
                 )
@@ -588,7 +594,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
                 timeout_seconds: int,
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 _ = timeout_seconds
                 return fake_replay(args, output_dir=output_dir, specs=specs)
 
@@ -597,7 +603,7 @@ class TestAutoresearchRunnerRealReplayA(WhitepaperAutoresearchRunnerTestCaseBase
                 "_run_real_replay_once_with_optional_timeout",
                 side_effect=fake_replay_once,
             ):
-                result = runner._run_replay_with_optional_timeout(
+                result = replay_shards._run_replay_with_optional_timeout(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py
@@ -17,6 +17,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     runner,
 )
 from scripts.whitepaper_autoresearch_runner import replay_shards
+import app.trading.discovery.whitepaper_candidate_compiler as whitepaper_candidate_compiler
+import app.whitepapers.claim_compiler as claim_compiler
 
 
 class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -39,7 +41,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
-                result=runner.EpochReplayResult(
+                result=replay_models.EpochReplayResult(
                     evidence_bundles=(),
                     replay_results=(),
                 ),
@@ -109,7 +111,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
             return replay_models._ReplayShardOutcome(
                 shard_index=plan.shard_index,
                 candidate_spec_ids=(spec.candidate_spec_id,),
-                result=runner.EpochReplayResult(
+                result=replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "ok"},),
                 ),
@@ -150,12 +152,14 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             args = self._args(output_dir)
@@ -195,12 +199,14 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:8]
             args = self._args(output_dir)
@@ -227,12 +233,14 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:3]
             args = self._args(output_dir)
@@ -269,7 +277,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                             candidate_spec_ids=tuple(
                                 spec.candidate_spec_id for spec in plan.specs
                             ),
-                            result=runner.EpochReplayResult(
+                            result=replay_models.EpochReplayResult(
                                 evidence_bundles=(),
                                 replay_results=(
                                     {
@@ -317,12 +325,14 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:6]
             args = self._args(output_dir)
@@ -358,12 +368,14 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
             )
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
             )
             specs = compilation.executable_specs[:4]
             args = self._args(output_dir)
@@ -396,7 +408,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                 args: Namespace,
                 output_dir: Path,
                 specs: Sequence[CandidateSpec],
-            ) -> runner.EpochReplayResult:
+            ) -> replay_models.EpochReplayResult:
                 spec = specs[0]
                 bundle = evidence_bundles.evidence_bundle_from_frontier_candidate(
                     candidate_spec_id=spec.candidate_spec_id,
@@ -418,7 +430,7 @@ class TestAutoresearchRunnerRealReplayB(WhitepaperAutoresearchRunnerTestCaseBase
                     dataset_snapshot_id="snap-incomplete",
                     result_path=str(output_dir / "incomplete.json"),
                 )
-                return runner.EpochReplayResult(
+                return replay_models.EpochReplayResult(
                     evidence_bundles=(bundle,),
                     replay_results=({"status": "partial_replay_shards_interrupted"},),
                     incomplete=True,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_replay_budget.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_replay_budget.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
+
+from tests.whitepaper_autoresearch.autoresearch_runner_base import (
+    Path,
+    WhitepaperAutoresearchRunnerTestCaseBase,
+)
+
+
+class TestAutoresearchRunnerReplayBudget(WhitepaperAutoresearchRunnerTestCaseBase):
+    def test_program_replay_budget_supplies_staged_train_screen_multiplier(
+        self,
+    ) -> None:
+        args = self._args(Path("/tmp/epoch"))
+        program = replay_shards._load_epoch_program(args)
+        controls = replay_shards._resolved_real_replay_frontier_controls(args, program)
+
+        self.assertEqual(
+            replay_shards._resolved_staged_train_screen_multiplier(args, program),
+            3,
+        )
+        self.assertEqual(controls["symbol_prune_iterations"], 1)
+        self.assertEqual(controls["symbol_prune_candidates"], 2)
+        self.assertEqual(controls["symbol_prune_min_universe_size"], 5)
+        self.assertEqual(controls["loss_repair_iterations"], 1)
+        self.assertEqual(controls["loss_repair_candidates"], 1)
+        self.assertEqual(controls["consistency_repair_iterations"], 1)
+        self.assertEqual(controls["consistency_repair_candidates"], 2)
+        self.assertFalse(controls["capture_rejected_seed_full_window_ledger"])
+        self.assertEqual(controls["capture_positive_rejected_full_window_ledgers"], 0)
+        args.staged_train_screen_multiplier = 4
+        args.symbol_prune_candidates = 5
+        args.capture_positive_rejected_full_window_ledgers = 6
+        override_controls = replay_shards._resolved_real_replay_frontier_controls(
+            args, program
+        )
+        self.assertEqual(
+            replay_shards._resolved_staged_train_screen_multiplier(args, program),
+            4,
+        )
+        self.assertEqual(override_controls["symbol_prune_candidates"], 5)
+        positive_ledger_key = "capture_positive_rejected_full_window_ledgers"
+        self.assertEqual(override_controls[positive_ledger_key], 6)

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_runtime_closure.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_runtime_closure.py
@@ -17,9 +17,15 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     json,
     patch,
     replace,
-    runner,
     timezone,
 )
+import app.trading.discovery.whitepaper_candidate_compiler as whitepaper_candidate_compiler
+import app.whitepapers.claim_compiler as claim_compiler
+import scripts.whitepaper_autoresearch_runner.candidate_board_payloads as candidate_board_payloads
+import scripts.whitepaper_autoresearch_runner.common as runner_common
+import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
+import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
+import scripts.whitepaper_autoresearch_runner.runtime_closure as runtime_closure
 
 
 class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -36,8 +42,8 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             args.program = Path(
                 "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
-            program = runner._load_epoch_program(args)
-            sources = runner._program_whitepaper_sources(program)
+            program = replay_shards._load_epoch_program(args)
+            sources = persisted_feedback_sources._program_whitepaper_sources(program)
 
         source_ids = {source.run_id for source in sources}
         self.assertIn("weighted_microprice_momentum_2026", source_ids)
@@ -76,7 +82,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
         self.assertIn("feature_recipe", claim_types)
         self.assertIn("validation_requirement", claim_types)
         self.assertTrue(
-            runner.compile_sources_to_hypothesis_cards([weighted_microprice])
+            claim_compiler.compile_sources_to_hypothesis_cards([weighted_microprice])
         )
 
         impact_source = next(
@@ -91,7 +97,9 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
         self.assertIn("risk_constraint", impact_claim_types)
         self.assertIn("route_tca", impact_source.claims[0]["data_requirements"])
         self.assertEqual(impact_source.claims[0]["horizon_scope"], "intraday_execution")
-        self.assertTrue(runner.compile_sources_to_hypothesis_cards([impact_source]))
+        self.assertTrue(
+            claim_compiler.compile_sources_to_hypothesis_cards([impact_source])
+        )
 
         latent_regime_source = next(
             source
@@ -145,7 +153,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             source for source in sources if source.run_id == "retail_limit_orders_2025"
         )
         self.assertTrue(
-            runner.compile_sources_to_hypothesis_cards([retail_limit_source])
+            claim_compiler.compile_sources_to_hypothesis_cards([retail_limit_source])
         )
         self.assertIn(
             "order_type_ablation", retail_limit_source.claims[0]["data_requirements"]
@@ -159,7 +167,9 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             for source in sources
             if source.run_id == "intraday_ofi_news_dynamics_2025"
         )
-        self.assertTrue(runner.compile_sources_to_hypothesis_cards([ofi_news_source]))
+        self.assertTrue(
+            claim_compiler.compile_sources_to_hypothesis_cards([ofi_news_source])
+        )
         self.assertIn(
             "price_flow_impact", ofi_news_source.claims[0]["data_requirements"]
         )
@@ -171,7 +181,9 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             for source in sources
             if source.run_id == "order_flow_filtration_2025"
         )
-        self.assertTrue(runner.compile_sources_to_hypothesis_cards([filtration_source]))
+        self.assertTrue(
+            claim_compiler.compile_sources_to_hypothesis_cards([filtration_source])
+        )
         self.assertIn(
             "filtered_orderbook_imbalance",
             filtration_source.claims[0]["data_requirements"],
@@ -188,22 +200,24 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
         args.program = Path(
             "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
         )
-        program = runner._load_epoch_program(args)
-        sources = runner._program_whitepaper_sources(program)
+        program = replay_shards._load_epoch_program(args)
+        sources = persisted_feedback_sources._program_whitepaper_sources(program)
         failures: dict[str, list[dict[str, object]]] = {}
         compiled_source_count = 0
 
         for source in sources:
-            cards = runner.compile_sources_to_hypothesis_cards([source])
+            cards = claim_compiler.compile_sources_to_hypothesis_cards([source])
             if not cards:
                 continue
             compiled_source_count += 1
-            compilation = runner.compile_whitepaper_candidate_specs(
-                hypothesis_cards=cards,
-                target_net_pnl_per_day=Decimal("500"),
-                family_template_dir=Path("config/trading/families"),
-                seed_sweep_dir=Path("config/trading"),
-                universe_symbols=("NVDA",),
+            compilation = (
+                whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    target_net_pnl_per_day=Decimal("500"),
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                    universe_symbols=("NVDA",),
+                )
             )
             missing_feature_blockers = [
                 blocker.to_payload()
@@ -224,7 +238,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             args.program = Path(
                 "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
-            program = runner._load_epoch_program(args)
+            program = replay_shards._load_epoch_program(args)
 
         manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
@@ -259,11 +273,13 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             optimizer_report={},
         )
 
-        runtime_program = runner._runtime_closure_program_for_candidate(
-            program=program,
-            manifest=manifest,
-            portfolio=portfolio,
-            oracle_candidate_found=False,
+        runtime_program = (
+            candidate_board_payloads._runtime_closure_program_for_candidate(
+                program=program,
+                manifest=manifest,
+                portfolio=portfolio,
+                oracle_candidate_found=False,
+            )
         )
 
         self.assertFalse(runtime_program.runtime_closure_policy.execute_parity_replay)
@@ -278,7 +294,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
                 "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
             args.replay_mode = "real"
-            program = runner._load_epoch_program(args)
+            program = replay_shards._load_epoch_program(args)
 
         manifest = mlx_snapshot.MlxSnapshotManifest(
             snapshot_id="mlx-snap-test",
@@ -324,11 +340,13 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             optimizer_report={},
         )
 
-        runtime_program = runner._runtime_closure_program_for_candidate(
-            program=program,
-            manifest=manifest,
-            portfolio=portfolio,
-            oracle_candidate_found=False,
+        runtime_program = (
+            candidate_board_payloads._runtime_closure_program_for_candidate(
+                program=program,
+                manifest=manifest,
+                portfolio=portfolio,
+                oracle_candidate_found=False,
+            )
         )
 
         self.assertTrue(runtime_program.runtime_closure_policy.execute_parity_replay)
@@ -337,18 +355,22 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
     def test_runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows(
         self,
     ) -> None:
-        self.assertIsNone(runner._runtime_closure_ledger_datetime(None))
-        self.assertIsNone(runner._runtime_closure_ledger_datetime("not-a-date"))
+        self.assertIsNone(runtime_closure._runtime_closure_ledger_datetime(None))
+        self.assertIsNone(
+            runtime_closure._runtime_closure_ledger_datetime("not-a-date")
+        )
         self.assertEqual(
-            runner._runtime_closure_ledger_datetime("2026-05-20T14:00:00"),
+            runtime_closure._runtime_closure_ledger_datetime("2026-05-20T14:00:00"),
             datetime(2026, 5, 20, 14, tzinfo=timezone.utc),
         )
         self.assertEqual(
-            runner._runtime_closure_ledger_datetime("2026-05-20T14:00:00-04:00"),
+            runtime_closure._runtime_closure_ledger_datetime(
+                "2026-05-20T14:00:00-04:00"
+            ),
             datetime(2026, 5, 20, 18, tzinfo=timezone.utc),
         )
         self.assertIsNone(
-            runner._runtime_closure_exact_replay_bucket(
+            runtime_closure._runtime_closure_exact_replay_bucket(
                 ledger={"window_start": "2026-05-20", "window_end": "2026-05-19"},
                 rows=_authoritative_exact_replay_ledger_rows(),
             )
@@ -358,7 +380,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             return_value=[],
         ):
             self.assertIsNone(
-                runner._runtime_closure_exact_replay_bucket(
+                runtime_closure._runtime_closure_exact_replay_bucket(
                     ledger={
                         "window_start": "2026-05-20",
                         "window_end": "2026-05-20",
@@ -382,7 +404,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -402,7 +424,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -423,7 +445,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -443,7 +465,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -466,7 +488,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -488,7 +510,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             )
 
             self.assertEqual(
-                runner._runtime_closure_exact_replay_ledger_update(
+                runtime_closure._runtime_closure_exact_replay_ledger_update(
                     {"exact_replay_ledger_artifact_path": str(artifact_path)}
                 ),
                 {},
@@ -509,7 +531,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
                 encoding="utf-8",
             )
 
-            update = runner._runtime_closure_exact_replay_ledger_update(
+            update = runtime_closure._runtime_closure_exact_replay_ledger_update(
                 {"exact_replay_ledger_artifact_path": str(artifact_path)}
             )
 
@@ -721,7 +743,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
                 optimizer_report={},
             )
 
-            updated = runner._portfolio_with_runtime_closure_proof(
+            updated = candidate_board_payloads._portfolio_with_runtime_closure_proof(
                 portfolio=portfolio,
                 runtime_closure={
                     "status": "ready_for_promotion_review",
@@ -890,7 +912,7 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             invalid_json_path = Path(tmpdir) / "invalid.json"
             invalid_json_path.write_text("{", encoding="utf-8")
             args = self._args(Path(tmpdir) / "epoch")
-            program = runner._load_epoch_program(args)
+            program = replay_shards._load_epoch_program(args)
 
         portfolio = portfolio_optimizer.PortfolioCandidateSpec(
             schema_version="torghut.portfolio-candidate-spec.v1",
@@ -928,19 +950,25 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
             manifest_hash="hash",
         )
 
-        self.assertEqual(runner._oracle_blockers({}), frozenset())
-        self.assertEqual(runner._load_json_mapping_artifact(invalid_json_path), {})
+        self.assertEqual(runner_common._oracle_blockers({}), frozenset())
         self.assertEqual(
-            runner._runtime_report_summary_int(
+            runtime_closure._load_json_mapping_artifact(invalid_json_path), {}
+        )
+        self.assertEqual(
+            runtime_closure._runtime_report_summary_int(
                 {"summary": {"filled_count": "bad"}}, "filled_count", default=7
             ),
             7,
         )
-        self.assertEqual(runner._runtime_report_int("bad", default=11), 11)
+        self.assertEqual(runtime_closure._runtime_report_int("bad", default=11), 11)
         self.assertEqual(
-            runner._portfolio_executable_max_notional(portfolio), Decimal("50000")
+            runtime_closure._portfolio_executable_max_notional(portfolio),
+            Decimal("50000"),
         )
-        self.assertFalse(runner._portfolio_needs_runtime_closure_proof(portfolio))
+        needs_runtime_closure_proof = (
+            runtime_closure._portfolio_needs_runtime_closure_proof
+        )
+        self.assertFalse(needs_runtime_closure_proof(portfolio))
         market_impact_only_portfolio = replace(
             portfolio,
             objective_scorecard={
@@ -959,11 +987,9 @@ class TestAutoresearchRunnerRuntimeClosure(WhitepaperAutoresearchRunnerTestCaseB
                 },
             },
         )
-        self.assertTrue(
-            runner._portfolio_needs_runtime_closure_proof(market_impact_only_portfolio)
-        )
+        self.assertTrue(needs_runtime_closure_proof(market_impact_only_portfolio))
         self.assertIs(
-            runner._runtime_closure_program_for_candidate(
+            candidate_board_payloads._runtime_closure_program_for_candidate(
                 program=program,
                 manifest=manifest,
                 portfolio=None,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_seed_selection.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_seed_selection.py
@@ -4,6 +4,7 @@ import app.trading.discovery.portfolio_optimizer as portfolio_optimizer
 import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
 import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
 import scripts.whitepaper_autoresearch_runner.queue_metadata as queue_metadata
+import scripts.whitepaper_autoresearch_runner.runtime_closure as runtime_closure
 
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
@@ -23,6 +24,7 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     runner,
     timezone,
 )
+import scripts.whitepaper_autoresearch_runner.preview_narrowing as preview_narrowing
 
 
 class TestAutoresearchRunnerSeedSelection(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -355,7 +357,7 @@ class TestAutoresearchRunnerSeedSelection(WhitepaperAutoresearchRunnerTestCaseBa
                     ),
                 ) as optimizer_mock,
                 patch.object(
-                    runner,
+                    runtime_closure,
                     "_runtime_closure_payload",
                     side_effect=AssertionError(
                         "selection-only must not build runtime closure"
@@ -714,7 +716,7 @@ class TestAutoresearchRunnerSeedSelection(WhitepaperAutoresearchRunnerTestCaseBa
             }
 
             narrowed_specs, updated_selection = (
-                runner._apply_fast_replay_preview_narrowing(
+                preview_narrowing._apply_fast_replay_preview_narrowing(
                     args=args,
                     output_dir=output_dir,
                     specs=specs,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_a.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_a.py
@@ -9,8 +9,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     WhitepaperAutoresearchRunnerTestCaseBase,
     cast,
     replace,
-    runner,
 )
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -57,7 +57,7 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
             Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(mutated_family_spec,),
             proposal_rows=rows,
             top_k=1,
@@ -139,7 +139,7 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
         )
         self.assertGreater(Decimal(str(rows[0]["proposal_score"])), Decimal("-999999"))
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(adaptive_spec,),
             proposal_rows=rows,
             top_k=0,
@@ -237,7 +237,7 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
             rows[0]["consistency_repair_feedback_reasons"],
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(repair_spec,),
             proposal_rows=rows,
             top_k=0,
@@ -388,7 +388,7 @@ class TestAutoresearchRunnerSelectionA(WhitepaperAutoresearchRunnerTestCaseBase)
             runtime_strategy_name="late-day-continuation-long-v1",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(
                 active_breakout,
                 active_microbar,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_b.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_b.py
@@ -11,8 +11,8 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     WhitepaperAutoresearchRunnerTestCaseBase,
     cast,
     replace,
-    runner,
 )
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -52,7 +52,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             "pre_replay_mlx_no_activity_feedback_blocked",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=rows,
             top_k=1,
@@ -157,7 +157,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(probe_spec,),
             proposal_rows=rows,
             top_k=1,
@@ -220,7 +220,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             feedback_evidence_bundles=(feedback_bundle,),
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(blocked_spec, capital_unsafe_spec),
             proposal_rows=rows,
             top_k=1,
@@ -254,7 +254,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             entry_minute_after_open="75",
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(synthetic_probe_spec, feedback_spec),
             proposal_rows=[
                 {
@@ -336,7 +336,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
         )
         self.assertGreater(Decimal(str(rows[0]["proposal_score"])), Decimal("-999999"))
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=rows,
             top_k=1,
@@ -386,7 +386,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
             },
         ]
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(unsafe_spec, safe_spec),
             proposal_rows=proposal_rows,
             top_k=1,
@@ -457,7 +457,7 @@ class TestAutoresearchRunnerSelectionB(WhitepaperAutoresearchRunnerTestCaseBase)
         )
         self.assertGreater(Decimal(str(rows[0]["proposal_score"])), Decimal("-999999"))
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(matching_spec,),
             proposal_rows=rows,
             top_k=1,

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import app.trading.discovery.evidence_bundles as evidence_bundles
 import app.trading.discovery.profit_target_oracle as profit_target_oracle
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
 import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_identity
 import scripts.whitepaper_autoresearch_runner.candidate_prior_scoring as candidate_prior_scoring
 import scripts.whitepaper_autoresearch_runner.feedback_blocking_rules as feedback_blocking_rules
@@ -17,9 +18,11 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     json,
     patch,
     replace,
-    runner,
     sys,
 )
+import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
+import scripts.whitepaper_autoresearch_runner.replay_execution as replay_execution
+import scripts.whitepaper_autoresearch_runner.replay_selection as replay_selection
 
 
 class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -79,7 +82,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(matching_risk_probe,),
             proposal_rows=rows,
             top_k=1,
@@ -371,8 +374,10 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
                 encoding="utf-8",
             )
 
-            with patch.object(runner, "_current_code_commit", return_value="abc123"):
-                replay = runner._real_replay_result_from_factory_payload(
+            with patch.object(
+                replay_execution, "_current_code_commit", return_value="abc123"
+            ):
+                replay = replay_execution._real_replay_result_from_factory_payload(
                     {
                         "experiments": [
                             {
@@ -402,120 +407,122 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
         )
 
     def test_current_code_commit_uses_git_when_env_commit_is_missing(self) -> None:
-        rev_parse = runner.subprocess.CompletedProcess(
+        rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=0,
             stdout="abc123\n",
         )
-        clean_diff = runner.subprocess.CompletedProcess(
+        clean_diff = artifact_io.subprocess.CompletedProcess(
             args=("git", "diff", "--quiet"),
             returncode=0,
             stdout="",
         )
         with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess,
                 "run",
                 side_effect=[rev_parse, clean_diff, clean_diff],
             ) as run,
         ):
-            self.assertEqual(runner._current_code_commit(), "abc123")
+            self.assertEqual(artifact_io._current_code_commit(), "abc123")
 
         self.assertEqual(run.call_count, 3)
 
     def test_current_code_commit_prefers_env_commit(self) -> None:
         with (
             patch.object(
-                runner.os,
+                artifact_io.os,
                 "getenv",
                 side_effect=lambda name: (
                     "env123" if name == "TORGHUT_CODE_COMMIT" else ""
                 ),
             ),
-            patch.object(runner.subprocess, "run") as run,
+            patch.object(artifact_io.subprocess, "run") as run,
         ):
-            self.assertEqual(runner._current_code_commit(), "env123")
+            self.assertEqual(artifact_io._current_code_commit(), "env123")
 
         run.assert_not_called()
 
     def test_current_code_commit_handles_short_container_script_path(
         self,
     ) -> None:
-        bad_rev_parse = runner.subprocess.CompletedProcess(
+        bad_rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=128,
             stdout="",
         )
         with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner,
+                artifact_io,
                 "__file__",
                 "/app/scripts/run_whitepaper_autoresearch_profit_target.py",
             ),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess,
                 "run",
                 return_value=bad_rev_parse,
             ) as run,
         ):
-            self.assertEqual(runner._current_code_commit(), "unknown")
+            self.assertEqual(artifact_io._current_code_commit(), "unknown")
 
         self.assertEqual(run.call_args.args[0][0:3], ("git", "-C", "/"))
 
     def test_current_code_commit_marks_dirty_or_unknown_git_state(self) -> None:
-        rev_parse = runner.subprocess.CompletedProcess(
+        rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=0,
             stdout="abc123\n",
         )
-        dirty_diff = runner.subprocess.CompletedProcess(
+        dirty_diff = artifact_io.subprocess.CompletedProcess(
             args=("git", "diff", "--quiet"),
             returncode=1,
             stdout="",
         )
-        bad_rev_parse = runner.subprocess.CompletedProcess(
+        bad_rev_parse = artifact_io.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),
             returncode=128,
             stdout="",
         )
         with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess,
                 "run",
                 side_effect=[rev_parse, dirty_diff],
             ),
         ):
-            self.assertEqual(runner._current_code_commit(), "abc123-dirty")
+            self.assertEqual(artifact_io._current_code_commit(), "abc123-dirty")
         with (
-            patch.object(runner.os, "getenv", return_value=""),
-            patch.object(runner.subprocess, "run", side_effect=OSError("git missing")),
-        ):
-            self.assertEqual(runner._current_code_commit(), "unknown")
-        with (
-            patch.object(runner.os, "getenv", return_value=""),
-            patch.object(runner.subprocess, "run", return_value=bad_rev_parse),
-        ):
-            self.assertEqual(runner._current_code_commit(), "unknown")
-        with (
-            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(artifact_io.os, "getenv", return_value=""),
             patch.object(
-                runner.subprocess,
+                artifact_io.subprocess, "run", side_effect=OSError("git missing")
+            ),
+        ):
+            self.assertEqual(artifact_io._current_code_commit(), "unknown")
+        with (
+            patch.object(artifact_io.os, "getenv", return_value=""),
+            patch.object(artifact_io.subprocess, "run", return_value=bad_rev_parse),
+        ):
+            self.assertEqual(artifact_io._current_code_commit(), "unknown")
+        with (
+            patch.object(artifact_io.os, "getenv", return_value=""),
+            patch.object(
+                artifact_io.subprocess,
                 "run",
                 side_effect=[rev_parse, OSError("diff missing")],
             ),
         ):
-            self.assertEqual(runner._current_code_commit(), "abc123-dirty")
+            self.assertEqual(artifact_io._current_code_commit(), "abc123-dirty")
 
     def test_synthetic_replay_evidence_carries_code_commit(self) -> None:
         spec = self._candidate_spec("spec-synthetic-replay-code-commit")
         with TemporaryDirectory() as tmpdir:
             with patch.object(
-                runner, "_current_code_commit", return_value="synthetic123"
+                replay_execution, "_current_code_commit", return_value="synthetic123"
             ):
-                replay = runner._run_synthetic_replay(
+                replay = replay_execution._run_synthetic_replay(
                     specs=(spec,),
                     output_dir=Path(tmpdir),
                     max_candidates=1,
@@ -529,7 +536,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
     ) -> None:
         spec = self._candidate_spec("spec-negative-synthetic-prior")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -562,7 +569,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
     ) -> None:
         spec = self._candidate_spec("spec-negative-synthetic-prior-probe")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -601,7 +608,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
     ) -> None:
         spec = self._candidate_spec("spec-capacity-short-synthetic-prior-probe")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -665,7 +672,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
                 encoding="utf-8",
             )
 
-            replay = runner._real_replay_result_from_factory_payload(
+            replay = replay_execution._real_replay_result_from_factory_payload(
                 {
                     "experiments": [
                         {
@@ -720,7 +727,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
                 encoding="utf-8",
             )
 
-            replay = runner._real_replay_result_from_factory_payload(
+            replay = replay_execution._real_replay_result_from_factory_payload(
                 {
                     "experiments": [
                         {
@@ -743,7 +750,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
     ) -> None:
         spec = self._candidate_spec("spec-malformed-feedback-context")
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(spec,),
             proposal_rows=[
                 {
@@ -779,7 +786,7 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
             },
         )
 
-        selected, selection = runner._select_candidate_specs_for_replay(
+        selected, selection = replay_selection._select_candidate_specs_for_replay(
             specs=(scalar_universe_spec,),
             proposal_rows=[
                 {
@@ -813,6 +820,6 @@ class TestAutoresearchRunnerSelectionC(WhitepaperAutoresearchRunnerTestCaseBase)
                         tmpdir,
                     ],
                 ):
-                    args = runner._parse_args()
+                    args = cli_parsing._parse_args()
 
         self.assertEqual(args.strategy_configmap, Path("/etc/torghut/strategies.yaml"))

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py
@@ -5,7 +5,6 @@ import scripts.whitepaper_autoresearch_runner.candidate_identity as candidate_id
 import scripts.whitepaper_autoresearch_runner.cli_parsing as cli_parsing
 import scripts.whitepaper_autoresearch_runner.next_epoch_planning as next_epoch_planning
 import scripts.whitepaper_autoresearch_runner.persisted_feedback_sources as persisted_feedback_sources
-import scripts.whitepaper_autoresearch_runner.replay_shards as replay_shards
 
 from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     Decimal,
@@ -27,6 +26,10 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     patch,
     runner,
 )
+import app.trading.discovery.whitepaper_candidate_compiler as whitepaper_candidate_compiler
+import app.whitepapers.claim_compiler as claim_compiler
+import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
+import scripts.whitepaper_autoresearch_runner.replay_execution as replay_execution
 
 
 class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBase):
@@ -313,7 +316,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                     "--no-persist-results",
                 ],
             ):
-                parsed = runner._parse_args()
+                parsed = cli_parsing._parse_args()
 
         self.assertEqual(parsed.output_dir, output_dir)
         self.assertEqual(parsed.epoch_id, "whitepaper-autoresearch-cli-epoch")
@@ -385,13 +388,13 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
         self,
     ) -> None:
         with patch.dict("os.environ", {"TORGHUT_TEST_CLICKHOUSE_PASSWORD": "from-env"}):
-            resolved = runner._resolved_clickhouse_password(
+            resolved = artifact_io._resolved_clickhouse_password(
                 Namespace(
                     clickhouse_password="",
                     clickhouse_password_env="TORGHUT_TEST_CLICKHOUSE_PASSWORD",
                 )
             )
-            direct = runner._resolved_clickhouse_password(
+            direct = artifact_io._resolved_clickhouse_password(
                 Namespace(
                     clickhouse_password="direct",
                     clickhouse_password_env="TORGHUT_TEST_CLICKHOUSE_PASSWORD",
@@ -546,7 +549,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 "run_strategy_factory_v2",
                 return_value=factory_payload,
             ):
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     self._args(output_dir), output_dir=output_dir
                 )
 
@@ -579,7 +582,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 ),
                 encoding="utf-8",
             )
-            result = runner._real_replay_result_from_factory_payload(
+            result = replay_execution._real_replay_result_from_factory_payload(
                 {
                     "experiments": [
                         {
@@ -655,17 +658,19 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.replay_tape_path = output_dir / "tape.jsonl"
                 args.replay_tape_manifest = output_dir / "tape.manifest.json"
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -725,17 +730,19 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.max_candidates = 24
                 args.max_total_frontier_candidates = 11
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -778,18 +785,20 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.max_candidates = 24
                 args.max_frontier_candidates_per_spec = 64
                 args.max_total_frontier_candidates = 8
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:8],
@@ -834,18 +843,20 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.max_candidates = 24
                 args.max_frontier_candidates_per_spec = 8
                 args.max_total_frontier_candidates = 0
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -922,12 +933,14 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 side_effect=fake_run,
             ):
                 cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
-                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                    [claim_compiler.RECENT_WHITEPAPER_SEEDS[0]]
                 )
-                compilation = runner.compile_whitepaper_candidate_specs(
-                    hypothesis_cards=cards,
-                    family_template_dir=Path("config/trading/families"),
-                    seed_sweep_dir=Path("config/trading"),
+                compilation = (
+                    whitepaper_candidate_compiler.compile_whitepaper_candidate_specs(
+                        hypothesis_cards=cards,
+                        family_template_dir=Path("config/trading/families"),
+                        seed_sweep_dir=Path("config/trading"),
+                    )
                 )
                 args = self._args(output_dir)
                 args.staged_train_screen_multiplier = 3
@@ -940,7 +953,7 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
                 args.loss_repair_candidates = 1
                 args.consistency_repair_iterations = 1
                 args.consistency_repair_candidates = 2
-                result = runner._run_real_replay(
+                result = replay_execution._run_real_replay(
                     args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
@@ -964,37 +977,3 @@ class TestAutoresearchRunnerSourcesReplay(WhitepaperAutoresearchRunnerTestCaseBa
             ],
         )
         self.assertEqual(len(result.evidence_bundles), 0)
-
-    def test_program_replay_budget_supplies_staged_train_screen_multiplier(
-        self,
-    ) -> None:
-        args = self._args(Path("/tmp/epoch"))
-        program = runner._load_epoch_program(args)
-        controls = replay_shards._resolved_real_replay_frontier_controls(args, program)
-
-        self.assertEqual(
-            replay_shards._resolved_staged_train_screen_multiplier(args, program),
-            3,
-        )
-        self.assertEqual(controls["symbol_prune_iterations"], 1)
-        self.assertEqual(controls["symbol_prune_candidates"], 2)
-        self.assertEqual(controls["symbol_prune_min_universe_size"], 5)
-        self.assertEqual(controls["loss_repair_iterations"], 1)
-        self.assertEqual(controls["loss_repair_candidates"], 1)
-        self.assertEqual(controls["consistency_repair_iterations"], 1)
-        self.assertEqual(controls["consistency_repair_candidates"], 2)
-        self.assertFalse(controls["capture_rejected_seed_full_window_ledger"])
-        self.assertEqual(controls["capture_positive_rejected_full_window_ledgers"], 0)
-        args.staged_train_screen_multiplier = 4
-        args.symbol_prune_candidates = 5
-        args.capture_positive_rejected_full_window_ledgers = 6
-        override_controls = replay_shards._resolved_real_replay_frontier_controls(
-            args, program
-        )
-        self.assertEqual(
-            replay_shards._resolved_staged_train_screen_multiplier(args, program),
-            4,
-        )
-        self.assertEqual(override_controls["symbol_prune_candidates"], 5)
-        positive_ledger_key = "capture_positive_rejected_full_window_ledgers"
-        self.assertEqual(override_controls[positive_ledger_key], 6)


### PR DESCRIPTION
## Summary

- Removes direct private-helper access from whitepaper autoresearch tests through `scripts.run_whitepaper_autoresearch_profit_target`.
- Points tests at the owning modules for replay selection, replay execution, candidate board payloads, runtime closure, artifact IO, CLI parsing, and compiler helpers.
- Deletes the duplicated `_current_code_commit` implementation from the CLI entrypoint and uses `artifact_io._current_code_commit` for replay execution binding.
- Removes stale CLI facade imports, dead scoring constants, and unused replay/preview wrapper functions so the entrypoint exposes only `main` and `run_whitepaper_autoresearch_profit_target`.
- Splits replay-budget coverage into a semantic test file so file-length enforcement stays blocking without compressing assertions.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main scripts/run_whitepaper_autoresearch_profit_target.py tests/autoresearch_runner tests/whitepaper_autoresearch`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main scripts/run_whitepaper_autoresearch_profit_target.py tests/autoresearch_runner tests/whitepaper_autoresearch`
- `cd services/torghut && uv run --frozen pytest tests/autoresearch_runner/test_candidate_selection_keeps_positive_signature_feedback_repair_candidates.py tests/whitepaper_autoresearch/test_autoresearch_runner_selection_c.py tests/autoresearch_runner/test_real_replay_shards.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_a.py tests/whitepaper_autoresearch/test_autoresearch_runner_real_replay_b.py`
- `cd services/torghut && uv run --frozen pytest tests/autoresearch_runner tests/whitepaper_autoresearch`
- `cd services/torghut && uv run --frozen pytest tests/autoresearch_runner/test_cli_preflight_sources.py::TestAutoresearchRunnerCliPreflightSources::test_selection_only_writes_pre_replay_artifacts_without_replay_or_persistence tests/whitepaper_autoresearch/test_autoresearch_runner_seed_selection.py::TestAutoresearchRunnerSeedSelection::test_selection_only_writes_pre_replay_artifacts_without_replay_or_persistence`
- `cd services/torghut && uv run --frozen pytest tests/whitepaper_autoresearch/test_autoresearch_runner_sources_replay.py tests/whitepaper_autoresearch/test_autoresearch_runner_runtime_closure.py tests/whitepaper_autoresearch/test_autoresearch_runner_replay_budget.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None for runtime entrypoints. Whitepaper autoresearch tests now use owning modules for private helpers; the CLI entrypoint keeps `main` and `run_whitepaper_autoresearch_profit_target` as the stable surface.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
