### PR TITLE
refactor(torghut): remove api facade private exports

### DIFF
--- a/services/torghut/app/api/maintenance.py
+++ b/services/torghut/app/api/maintenance.py
@@ -40,8 +40,8 @@ from .common import (
 from .common import main_runtime_value
 from .application import get_app
 from .readiness_helpers import (
-    evaluate_database_contract as _evaluate_database_contract,
-    evaluate_trading_health_payload as _evaluate_trading_health_payload,
+    evaluate_database_contract,
+    evaluate_trading_health_payload,
 )
 from .trading_status import trading_status
 
@@ -71,7 +71,7 @@ def _load_jangar_verify_trust_foreclosure_board(
 def trading_revenue_repair() -> dict[str, object]:
     """Return business-state and repair-priority evidence for revenue readiness."""
 
-    readyz_payload, _status_code = _evaluate_trading_health_payload(
+    readyz_payload, _status_code = evaluate_trading_health_payload(
         include_database_contract=True,
         allow_stale_dependency_cache=True,
     )
@@ -515,7 +515,7 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
     """Verify database connectivity and Alembic schema head alignment."""
 
     try:
-        database_contract = _evaluate_database_contract(session)
+        database_contract = evaluate_database_contract(session)
         schema_status = {
             "schema_current": bool(database_contract.get("schema_current")),
             "current_heads": database_contract.get("schema_current_heads"),

--- a/services/torghut/app/api/proof_floor_payloads/__init__.py
+++ b/services/torghut/app/api/proof_floor_payloads/__init__.py
@@ -7,50 +7,41 @@ from typing import Any, cast
 
 from . import shared_context
 from .build_jangar_reliability_settlement_ref import (
-    build_autonomy_capital_replay_projection as _build_autonomy_capital_replay_projection,
-    build_capital_replay_projection_payload as _build_capital_replay_projection_payload,
-    build_jangar_reliability_settlement_ref as _build_jangar_reliability_settlement_ref,
-    build_profit_signal_quorum_payload as _build_profit_signal_quorum_payload,
-    build_quality_adjusted_profit_frontier_payload as _build_quality_adjusted_profit_frontier_payload,
-    build_rejected_signal_outcome_learning_payload as _build_rejected_signal_outcome_learning_payload,
-    build_torghut_routeability_admission_ref as _build_torghut_routeability_admission_ref,
-    build_torghut_stage_clearance_packet_ref as _build_torghut_stage_clearance_packet_ref,
-    load_rejected_signal_outcome_learning_summary as _load_rejected_signal_outcome_learning_summary,
-    load_route_provenance_summary as _load_route_provenance_summary,
-    route_continuity_packet_for_proof_floor as _route_continuity_packet_for_proof_floor,
-    simple_lane_reject_reason_totals as _simple_lane_reject_reason_totals,
-    simulation_cache_status_payload as _simulation_cache_status_payload,
+    build_autonomy_capital_replay_projection,
+    build_capital_replay_projection_payload,
+    build_profit_signal_quorum_payload,
+    build_quality_adjusted_profit_frontier_payload,
+    build_rejected_signal_outcome_learning_payload,
+    load_rejected_signal_outcome_learning_summary,
+    load_route_provenance_summary,
+    route_continuity_packet_for_proof_floor,
+    simple_lane_reject_reason_totals,
 )
 from .paper_route_probe_targets import bounded_paper_route_probe_target_symbols
 from .shared_context import (
-    build_capital_reentry_cohort_ledger_payload as _build_capital_reentry_cohort_ledger_payload,
-    build_clock_settlement_payload as _build_clock_settlement_payload,
-    build_evidence_clock_payloads as _build_evidence_clock_payloads,
-    build_freshness_carry_ledger_payload as _build_freshness_carry_ledger_payload,
-    build_jangar_contract_graduation_ref as _build_jangar_contract_graduation_ref,
-    build_jangar_execution_trust_admission_ref as _build_jangar_execution_trust_admission_ref,
-    build_jangar_material_verdict_ref as _build_jangar_material_verdict_ref,
-    build_profit_carry_passport_ledger_payload as _build_profit_carry_passport_ledger_payload,
-    build_profit_freshness_frontier_payload as _build_profit_freshness_frontier_payload,
-    build_profit_repair_settlement_ledger_payload as _build_profit_repair_settlement_ledger_payload,
-    build_renewal_bond_profit_escrow_payload as _build_renewal_bond_profit_escrow_payload,
-    build_repair_bid_settlement_payload as _build_repair_bid_settlement_payload,
-    build_repair_outcome_dividend_ledger_payload as _build_repair_outcome_dividend_ledger_payload,
-    build_repair_receipt_frontier_payload as _build_repair_receipt_frontier_payload,
-    build_route_evidence_clearinghouse_payload as _build_route_evidence_clearinghouse_payload,
-    build_route_image_proof_summary as _build_route_image_proof_summary,
-    build_route_reacquisition_board_payload as _build_route_reacquisition_board_payload,
-    build_route_warrant_exchange_payload as _build_route_warrant_exchange_payload,
-    build_routeability_repair_acceptance_ledger_payload as _build_routeability_repair_acceptance_ledger_payload,
-    build_source_serving_repair_receipt_payload as _build_source_serving_repair_receipt_payload,
-    consumer_evidence_jangar_continuity_packet as _consumer_evidence_jangar_continuity_packet,
+    build_capital_reentry_cohort_ledger_payload,
+    build_clock_settlement_payload,
+    build_evidence_clock_payloads,
+    build_freshness_carry_ledger_payload,
+    build_profit_carry_passport_ledger_payload,
+    build_profit_freshness_frontier_payload,
+    build_profit_repair_settlement_ledger_payload,
+    build_renewal_bond_profit_escrow_payload,
+    build_repair_bid_settlement_payload,
+    build_repair_outcome_dividend_ledger_payload,
+    build_repair_receipt_frontier_payload,
+    build_route_evidence_clearinghouse_payload,
+    build_route_image_proof_summary,
+    build_route_reacquisition_board_payload,
+    build_route_warrant_exchange_payload,
+    build_routeability_repair_acceptance_ledger_payload,
+    build_source_serving_repair_receipt_payload,
+    consumer_evidence_jangar_continuity_packet,
 )
-from .status_refs import (
-    build_simple_lane_status_payload as _build_simple_lane_status_payload,
-)
+from .status_refs import build_simple_lane_status_payload
 
 
-def _build_profitability_proof_floor_payload(
+def build_profitability_proof_floor_payload(
     *,
     state: object,
     torghut_revision: str | None,
@@ -76,7 +67,7 @@ def _build_profitability_proof_floor_payload(
         quant_evidence=quant_evidence,
         market_context_status=market_context_status,
         tca_summary=tca_summary,
-        simple_lane_status=simple_lane_status or _build_simple_lane_status_payload(),
+        simple_lane_status=simple_lane_status or build_simple_lane_status_payload(),
         paper_route_probe_target_symbols=bounded_paper_route_probe_target_symbols(
             live_submission_gate
         ),
@@ -84,88 +75,8 @@ def _build_profitability_proof_floor_payload(
     )
 
 
-load_rejected_signal_outcome_learning_summary = (
-    _load_rejected_signal_outcome_learning_summary
-)
-build_profitability_proof_floor_payload = _build_profitability_proof_floor_payload
-build_renewal_bond_profit_escrow_payload = _build_renewal_bond_profit_escrow_payload
-build_route_reacquisition_board_payload = _build_route_reacquisition_board_payload
-consumer_evidence_jangar_continuity_packet = _consumer_evidence_jangar_continuity_packet
-build_capital_replay_projection_payload = _build_capital_replay_projection_payload
-build_profit_carry_passport_ledger_payload = _build_profit_carry_passport_ledger_payload
-build_capital_reentry_cohort_ledger_payload = (
-    _build_capital_reentry_cohort_ledger_payload
-)
-build_profit_repair_settlement_ledger_payload = (
-    _build_profit_repair_settlement_ledger_payload
-)
-build_profit_freshness_frontier_payload = _build_profit_freshness_frontier_payload
-build_routeability_repair_acceptance_ledger_payload = (
-    _build_routeability_repair_acceptance_ledger_payload
-)
-build_evidence_clock_payloads = _build_evidence_clock_payloads
-build_clock_settlement_payload = _build_clock_settlement_payload
-build_route_image_proof_summary = _build_route_image_proof_summary
-build_route_evidence_clearinghouse_payload = _build_route_evidence_clearinghouse_payload
-build_repair_bid_settlement_payload = _build_repair_bid_settlement_payload
-build_route_warrant_exchange_payload = _build_route_warrant_exchange_payload
-build_source_serving_repair_receipt_payload = (
-    _build_source_serving_repair_receipt_payload
-)
-build_freshness_carry_ledger_payload = _build_freshness_carry_ledger_payload
-build_repair_receipt_frontier_payload = _build_repair_receipt_frontier_payload
-build_repair_outcome_dividend_ledger_payload = (
-    _build_repair_outcome_dividend_ledger_payload
-)
-build_profit_signal_quorum_payload = _build_profit_signal_quorum_payload
-build_quality_adjusted_profit_frontier_payload = (
-    _build_quality_adjusted_profit_frontier_payload
-)
-build_autonomy_capital_replay_projection = _build_autonomy_capital_replay_projection
-route_continuity_packet_for_proof_floor = _route_continuity_packet_for_proof_floor
-simple_lane_reject_reason_totals = _simple_lane_reject_reason_totals
-build_rejected_signal_outcome_learning_payload = (
-    _build_rejected_signal_outcome_learning_payload
-)
-load_route_provenance_summary = _load_route_provenance_summary
-
 __all__ = (
-    "_build_profitability_proof_floor_payload",
-    "_build_renewal_bond_profit_escrow_payload",
-    "_build_route_reacquisition_board_payload",
-    "_build_jangar_contract_graduation_ref",
-    "_build_jangar_material_verdict_ref",
-    "_build_jangar_execution_trust_admission_ref",
-    "_consumer_evidence_jangar_continuity_packet",
-    "_build_capital_replay_projection_payload",
-    "_build_profit_carry_passport_ledger_payload",
-    "_build_capital_reentry_cohort_ledger_payload",
-    "_build_profit_repair_settlement_ledger_payload",
-    "_build_profit_freshness_frontier_payload",
-    "_build_routeability_repair_acceptance_ledger_payload",
-    "_build_evidence_clock_payloads",
-    "_build_clock_settlement_payload",
-    "_build_route_image_proof_summary",
-    "_build_route_evidence_clearinghouse_payload",
-    "_build_repair_bid_settlement_payload",
-    "_build_route_warrant_exchange_payload",
-    "_build_source_serving_repair_receipt_payload",
-    "_build_freshness_carry_ledger_payload",
-    "_build_repair_receipt_frontier_payload",
-    "_build_repair_outcome_dividend_ledger_payload",
-    "_build_jangar_reliability_settlement_ref",
-    "_build_torghut_routeability_admission_ref",
-    "_build_torghut_stage_clearance_packet_ref",
-    "_build_profit_signal_quorum_payload",
-    "_simulation_cache_status_payload",
-    "_build_quality_adjusted_profit_frontier_payload",
-    "_build_autonomy_capital_replay_projection",
-    "_route_continuity_packet_for_proof_floor",
-    "_simple_lane_reject_reason_totals",
-    "_build_rejected_signal_outcome_learning_payload",
-    "_load_rejected_signal_outcome_learning_summary",
     "load_rejected_signal_outcome_learning_summary",
-    "_load_route_provenance_summary",
     "build_profitability_proof_floor_payload",
     "build_renewal_bond_profit_escrow_payload",
     "build_route_reacquisition_board_payload",

--- a/services/torghut/app/api/readiness_helpers/__init__.py
+++ b/services/torghut/app/api/readiness_helpers/__init__.py
@@ -3,82 +3,21 @@
 from __future__ import annotations
 
 from .evaluate_trading_health_payload import (
-    evaluate_trading_health_payload as _evaluate_trading_health_payload,
+    evaluate_trading_health_payload,
 )
 from .evaluate_trading_health_payload_bounded import (
-    evaluate_trading_health_payload_bounded as _evaluate_trading_health_payload_bounded,
+    evaluate_trading_health_payload_bounded,
 )
 from .refresh_universe_state_for_readiness import (
-    check_account_scope_invariants_bounded as _check_account_scope_invariants_bounded,
-    evaluate_database_contract as _evaluate_database_contract,
-    execute_readiness_account_scope_query as _execute_readiness_account_scope_query,
-    refresh_universe_state_for_readiness as _refresh_universe_state_for_readiness,
-    resolve_universe_resolver_for_readiness as _resolve_universe_resolver_for_readiness,
+    evaluate_database_contract,
+    resolve_universe_resolver_for_readiness,
 )
-from .shared_context import (
-    append_unique_reason as _append_unique_reason,
-    cache_completed_trading_health_surface_payload as _cache_completed_trading_health_surface_payload,
-    cached_readiness_dependencies_for_health_surface as _cached_readiness_dependencies_for_health_surface,
-    cached_trading_health_surface_payload as _cached_trading_health_surface_payload,
-    core_readiness_live_submission_gate as _core_readiness_live_submission_gate,
-    evaluate_core_readiness_payload as _evaluate_core_readiness_payload,
-    fail_closed_health_evaluation_gate as _fail_closed_health_evaluation_gate,
-    guard_live_submission_gate_for_readiness as _guard_live_submission_gate_for_readiness,
-    health_surface_timeout_dependency_placeholder as _health_surface_timeout_dependency_placeholder,
-    health_surface_timeout_fallback_payload as _health_surface_timeout_fallback_payload,
-    minimal_health_surface_timeout_live_submission_gate as _minimal_health_surface_timeout_live_submission_gate,
-    minimal_health_surface_timeout_payload as _minimal_health_surface_timeout_payload,
-    minimal_health_surface_timeout_proof_floor as _minimal_health_surface_timeout_proof_floor,
-    readiness_authority_truthy as _readiness_authority_truthy,
-    readiness_dependency_cache_key as _readiness_dependency_cache_key,
-    readiness_dependency_checks as _readiness_dependency_checks,
-    readiness_dependency_degradation_reason_codes as _readiness_dependency_degradation_reason_codes,
-    readiness_dependency_snapshot as _readiness_dependency_snapshot,
-    record_trading_health_surface_completion as _record_trading_health_surface_completion,
-    strip_promotion_authority_claims_for_readiness as _strip_promotion_authority_claims_for_readiness,
-    trading_health_surface_cache_key as _trading_health_surface_cache_key,
+from .readiness_surface import (
+    evaluate_core_readiness_payload,
+    readiness_dependency_snapshot,
 )
-from .universe_dependency import (
-    evaluate_universe_dependency as _evaluate_universe_dependency,
-)
-
-evaluate_core_readiness_payload = _evaluate_core_readiness_payload
-evaluate_trading_health_payload_bounded = _evaluate_trading_health_payload_bounded
-evaluate_trading_health_payload = _evaluate_trading_health_payload
-evaluate_database_contract = _evaluate_database_contract
-readiness_dependency_snapshot = _readiness_dependency_snapshot
-resolve_universe_resolver_for_readiness = _resolve_universe_resolver_for_readiness
 
 __all__ = (
-    "_readiness_dependency_cache_key",
-    "_readiness_dependency_checks",
-    "_readiness_dependency_snapshot",
-    "_readiness_authority_truthy",
-    "_append_unique_reason",
-    "_readiness_dependency_degradation_reason_codes",
-    "_guard_live_submission_gate_for_readiness",
-    "_strip_promotion_authority_claims_for_readiness",
-    "_core_readiness_live_submission_gate",
-    "_evaluate_core_readiness_payload",
-    "_trading_health_surface_cache_key",
-    "_cache_completed_trading_health_surface_payload",
-    "_record_trading_health_surface_completion",
-    "_cached_trading_health_surface_payload",
-    "_cached_readiness_dependencies_for_health_surface",
-    "_fail_closed_health_evaluation_gate",
-    "_health_surface_timeout_dependency_placeholder",
-    "_minimal_health_surface_timeout_live_submission_gate",
-    "_minimal_health_surface_timeout_proof_floor",
-    "_minimal_health_surface_timeout_payload",
-    "_health_surface_timeout_fallback_payload",
-    "_evaluate_trading_health_payload_bounded",
-    "_evaluate_trading_health_payload",
-    "_evaluate_universe_dependency",
-    "_refresh_universe_state_for_readiness",
-    "_resolve_universe_resolver_for_readiness",
-    "_execute_readiness_account_scope_query",
-    "_check_account_scope_invariants_bounded",
-    "_evaluate_database_contract",
     "evaluate_core_readiness_payload",
     "evaluate_trading_health_payload_bounded",
     "evaluate_trading_health_payload",

--- a/services/torghut/app/api/readiness_helpers/refresh_universe_state_for_readiness.py
+++ b/services/torghut/app/api/readiness_helpers/refresh_universe_state_for_readiness.py
@@ -560,7 +560,7 @@ def _database_contract_account_scope(
     session: _ReadinessDatabaseSession,
 ) -> tuple[dict[str, object], list[str]]:
     try:
-        account_scope_checks = dict(_check_account_scope_invariants_bounded(session))
+        account_scope_checks = dict(check_account_scope_invariants_bounded(session))
     except (SQLAlchemyError, RuntimeError) as exc:
         account_scope_checks = {
             "account_scope_ready": False,
@@ -763,11 +763,6 @@ def evaluate_database_contract(
 
 __all__ = (
     "SessionLocal",
-    "_refresh_universe_state_for_readiness",
-    "_resolve_universe_resolver_for_readiness",
-    "_execute_readiness_account_scope_query",
-    "_check_account_scope_invariants_bounded",
-    "_evaluate_database_contract",
     "refresh_universe_state_for_readiness",
     "resolve_universe_resolver_for_readiness",
     "execute_readiness_account_scope_query",

--- a/services/torghut/app/api/trading_misc/__init__.py
+++ b/services/torghut/app/api/trading_misc/__init__.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from .shared_context import (
-    build_consumer_evidence_receipt_projection as _build_consumer_evidence_receipt_projection,
-    build_trading_consumer_evidence_payload as _build_trading_consumer_evidence_payload,
-    consumer_evidence_dependency_quorum as _consumer_evidence_dependency_quorum,
-    consumer_evidence_summary_view as _consumer_evidence_summary_view,
+    build_consumer_evidence_receipt_projection,
     get_lean_backtest,
     get_lean_shadow_parity,
-    revenue_repair_topline_fields as _revenue_repair_topline_fields,
+    revenue_repair_topline_fields,
     router,
     submit_lean_backtest,
     trading_consumer_evidence,
@@ -17,10 +14,8 @@ from .shared_context import (
     trading_simulation_progress,
 )
 from .trading_autonomy import (
-    build_current_evidence_epoch as _build_current_evidence_epoch,
-    daily_runtime_ledger_portfolio_summary as _daily_runtime_ledger_portfolio_summary,
+    daily_runtime_ledger_portfolio_summary,
     prometheus_metrics,
-    runtime_ledger_bucket_evidence_grade as _runtime_ledger_bucket_evidence_grade,
     trading_autonomy,
     trading_autonomy_evidence_continuity,
     trading_completion_doc29,
@@ -33,19 +28,10 @@ from .trading_autonomy import (
 )
 from .trading_executions import trading_executions
 
-build_consumer_evidence_receipt_projection = _build_consumer_evidence_receipt_projection
-revenue_repair_topline_fields = _revenue_repair_topline_fields
-daily_runtime_ledger_portfolio_summary = _daily_runtime_ledger_portfolio_summary
-
 __all__ = (
     "router",
-    "_consumer_evidence_dependency_quorum",
-    "_build_consumer_evidence_receipt_projection",
-    "_consumer_evidence_summary_view",
-    "_revenue_repair_topline_fields",
     "build_consumer_evidence_receipt_projection",
     "revenue_repair_topline_fields",
-    "_build_trading_consumer_evidence_payload",
     "trading_consumer_evidence",
     "trading_metrics",
     "trading_simulation_progress",
@@ -53,10 +39,7 @@ __all__ = (
     "get_lean_backtest",
     "get_lean_shadow_parity",
     "trading_autonomy",
-    "_runtime_ledger_bucket_evidence_grade",
-    "_daily_runtime_ledger_portfolio_summary",
     "daily_runtime_ledger_portfolio_summary",
-    "_build_current_evidence_epoch",
     "trading_evidence_epoch_latest",
     "trading_evidence_epoch_detail",
     "trading_empirical_jobs",

--- a/services/torghut/app/api/trading_misc/trading_autonomy.py
+++ b/services/torghut/app/api/trading_misc/trading_autonomy.py
@@ -15,7 +15,7 @@ from ..health_checks import (
     load_tca_summary as _load_tca_summary,
 )
 from ..readiness_helpers import (
-    evaluate_database_contract as _evaluate_database_contract,
+    evaluate_database_contract,
 )
 from ..trading_scheduler_state import get_trading_scheduler
 from ..vnext_helpers import (
@@ -384,7 +384,7 @@ def build_current_evidence_epoch(
     trading_status_ok, _scheduler_payload = _evaluate_scheduler_status(scheduler)
 
     try:
-        database_contract = _evaluate_database_contract(session)
+        database_contract = evaluate_database_contract(session)
         database_ok = bool(database_contract.get("ok"))
         schema_current = bool(database_contract.get("schema_current"))
         schema_lineage_ready = bool(database_contract.get("schema_graph_lineage_ready"))

--- a/services/torghut/tests/api/test_trading_api_db_contract.py
+++ b/services/torghut/tests/api/test_trading_api_db_contract.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from app.api import readiness_helpers as readiness_helpers_api
+from app.api.readiness_helpers import (
+    refresh_universe_state_for_readiness as readiness_universe_refresh,
+)
 
 from tests.api.trading_api_support import (
     AutoresearchCandidateSpec,
@@ -247,7 +249,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         },
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_reports_schema_heads(
@@ -301,7 +303,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         },
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_schema_lineage_divergence_returns_503_when_override_disabled(
@@ -354,7 +356,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         },
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_schema_lineage_warning_returns_200_when_override_enabled(
@@ -414,7 +416,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         },
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_schema_mismatch_returns_503(
@@ -545,7 +547,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
                 raise AssertionError(f"unexpected SQL: {sql}")
 
         fake_session = FakeSession()
-        payload = readiness_helpers_api._check_account_scope_invariants_bounded(
+        payload = readiness_universe_refresh.check_account_scope_invariants_bounded(
             fake_session
         )
 
@@ -646,7 +648,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         original_multi = settings.trading_multi_account_enabled
         settings.trading_multi_account_enabled = False
         try:
-            payload = readiness_helpers_api._check_account_scope_invariants_bounded(
+            payload = readiness_universe_refresh.check_account_scope_invariants_bounded(
                 FakeSession()
             )
         finally:
@@ -693,12 +695,12 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         settings.trading_multi_account_enabled = True
         try:
             with patch(
-                "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+                "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
                 side_effect=SQLAlchemyError(
                     "canceling statement due to statement timeout"
                 ),
             ):
-                payload = readiness_helpers_api._evaluate_database_contract(
+                payload = readiness_universe_refresh.evaluate_database_contract(
                     _FakeDatabaseContractSession()
                 )
         finally:
@@ -731,12 +733,12 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         settings.trading_multi_account_enabled = False
         try:
             with patch(
-                "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+                "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
                 side_effect=SQLAlchemyError(
                     "canceling statement due to statement timeout"
                 ),
             ):
-                payload = readiness_helpers_api._evaluate_database_contract(
+                payload = readiness_universe_refresh.evaluate_database_contract(
                     _FakeDatabaseContractSession()
                 )
         finally:
@@ -772,7 +774,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         settings.trading_multi_account_enabled = True
         try:
             with patch(
-                "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+                "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
                 return_value={
                     "account_scope_ready": False,
                     "account_scope_errors": [
@@ -815,7 +817,7 @@ class TestTradingApiDbContract(TradingApiTestCaseBase):
         settings.trading_multi_account_enabled = False
         try:
             with patch(
-                "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+                "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
                 return_value={
                     "account_scope_ready": False,
                     "account_scope_errors": ["legacy unique constraint/index detected"],

--- a/services/torghut/tests/api/test_trading_api_health_cache.py
+++ b/services/torghut/tests/api/test_trading_api_health_cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from app.api import common as common_api
-from app.api import readiness_helpers as readiness_helpers_api
+from app.api.readiness_helpers import readiness_surface as readiness_surface_helpers
 
 from tests.api.trading_api_support import (
     Event,
@@ -25,12 +25,10 @@ HEALTH_CHECKS_API = "app.api.health_checks"
 READINESS_CONTRACT_API = (
     "app.api.readiness_helpers.refresh_universe_state_for_readiness"
 )
-PATCH_ACCOUNT_SCOPE = (
-    f"{READINESS_CONTRACT_API}._check_account_scope_invariants_bounded"
-)
+PATCH_ACCOUNT_SCOPE = f"{READINESS_CONTRACT_API}.check_account_scope_invariants_bounded"
 PATCH_ALPACA = f"{HEALTH_CHECKS_API}.check_alpaca_dependency"
 PATCH_CLICKHOUSE = f"{HEALTH_CHECKS_API}.check_clickhouse_dependency"
-PATCH_DATABASE_CONTRACT = f"{READINESS_CONTRACT_API}._evaluate_database_contract"
+PATCH_DATABASE_CONTRACT = f"{READINESS_CONTRACT_API}.evaluate_database_contract"
 PATCH_POSTGRES = f"{HEALTH_CHECKS_API}.check_postgres_dependency"
 PATCH_SCHEMA_CURRENT = f"{READINESS_CONTRACT_API}.check_schema_current"
 PATCH_TIGERBEETLE = f"{HEALTH_CHECKS_API}.build_tigerbeetle_ledger_status"
@@ -111,7 +109,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
     def test_trading_health_timeout_uses_cached_dependency_shape(self) -> None:
         original_timeout = common_api.TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
         common_api.TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 0.01
-        health_cache_key = readiness_helpers_api._trading_health_surface_cache_key(
+        health_cache_key = readiness_surface_helpers.trading_health_surface_cache_key(
             include_database_contract=False,
             allow_stale_dependency_cache=False,
         )
@@ -175,7 +173,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
     def test_trading_health_serves_completed_health_cache_while_refreshing(
         self,
     ) -> None:
-        cache_key = readiness_helpers_api._trading_health_surface_cache_key(
+        cache_key = readiness_surface_helpers.trading_health_surface_cache_key(
             include_database_contract=False,
             allow_stale_dependency_cache=False,
         )
@@ -241,7 +239,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
     def test_trading_health_serves_cached_payload_during_inflight_refresh(
         self,
     ) -> None:
-        cache_key = readiness_helpers_api._trading_health_surface_cache_key(
+        cache_key = readiness_surface_helpers.trading_health_surface_cache_key(
             include_database_contract=False,
             allow_stale_dependency_cache=False,
         )
@@ -305,7 +303,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
     ) -> None:
         original_timeout = common_api.TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
         common_api.TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 0.01
-        cache_key = readiness_helpers_api._trading_health_surface_cache_key(
+        cache_key = readiness_surface_helpers.trading_health_surface_cache_key(
             include_database_contract=False,
             allow_stale_dependency_cache=False,
         )
@@ -381,7 +379,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
     def test_trading_health_starts_fresh_eval_when_completed_future_has_no_cache(
         self,
     ) -> None:
-        cache_key = readiness_helpers_api._trading_health_surface_cache_key(
+        cache_key = readiness_surface_helpers.trading_health_surface_cache_key(
             include_database_contract=False,
             allow_stale_dependency_cache=False,
         )
@@ -441,7 +439,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
             settings.trading_simple_submit_enabled = False
             settings.trading_live_submit_activation_expires_at = "2000-01-01T00:00:00Z"
 
-            gate = readiness_helpers_api._minimal_health_surface_timeout_live_submission_gate(
+            gate = readiness_surface_helpers.minimal_health_surface_timeout_live_submission_gate(
                 reason_code="readyz_evaluation_timeout",
                 detail="readyz evaluation exceeded 3.0s",
             )
@@ -478,7 +476,7 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
     def test_trading_health_timeout_uses_cached_blockers_fail_closed(self) -> None:
         original_timeout = common_api.TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
         common_api.TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 0.01
-        cache_key = readiness_helpers_api._trading_health_surface_cache_key(
+        cache_key = readiness_surface_helpers.trading_health_surface_cache_key(
             include_database_contract=False,
             allow_stale_dependency_cache=False,
         )

--- a/services/torghut/tests/api/test_trading_api_health_dependency.py
+++ b/services/torghut/tests/api/test_trading_api_health_dependency.py
@@ -35,7 +35,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -104,7 +104,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -184,7 +184,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -268,7 +268,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -356,7 +356,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -441,7 +441,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -536,7 +536,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -614,7 +614,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
             )
 
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._evaluate_database_contract",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.evaluate_database_contract",
         return_value={
             "ok": True,
             "schema_current": True,
@@ -682,7 +682,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
             settings.trading_readiness_dependency_cache_ttl_seconds = original_cache_ttl
 
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._evaluate_database_contract",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.evaluate_database_contract",
         return_value={
             "ok": True,
             "schema_current": True,
@@ -766,7 +766,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": False, "detail": "down"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -821,7 +821,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -891,7 +891,7 @@ class TestTradingApiHealthDependency(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(

--- a/services/torghut/tests/api/test_trading_api_readyz_contract.py
+++ b/services/torghut/tests/api/test_trading_api_readyz_contract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.api import readiness_helpers as readiness_helpers_api
+from app.api.readiness_helpers import readiness_surface as readiness_surface_helpers
 
 from tests.api.trading_api_support import (
     Any,
@@ -38,7 +38,7 @@ class TestTradingApiReadyzContract(TradingApiTestCaseBase):
         return_value={"ok": True, "detail": "ok"},
     )
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -122,7 +122,7 @@ class TestTradingApiReadyzContract(TradingApiTestCaseBase):
             settings.trading_simple_submit_enabled = False
             settings.trading_live_submit_activation_expires_at = "2000-01-01T00:00:00Z"
 
-            gate = readiness_helpers_api._core_readiness_live_submission_gate()
+            gate = readiness_surface_helpers.core_readiness_live_submission_gate()
         finally:
             settings.trading_mode = original["trading_mode"]
             settings.trading_enabled = original["trading_enabled"]
@@ -198,7 +198,7 @@ class TestTradingApiReadyzContract(TradingApiTestCaseBase):
                 ),
             ):
                 payload, status_code = (
-                    readiness_helpers_api._evaluate_core_readiness_payload(
+                    readiness_surface_helpers.evaluate_core_readiness_payload(
                         include_database_contract=True,
                         allow_stale_dependency_cache=True,
                     )
@@ -275,7 +275,7 @@ class TestTradingApiReadyzContract(TradingApiTestCaseBase):
         self.assertEqual(second["account_label"], "PA3SX7FYNUTF")
 
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._evaluate_database_contract",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.evaluate_database_contract",
         return_value={
             "ok": True,
             "schema_current": True,
@@ -367,7 +367,7 @@ class TestTradingApiReadyzContract(TradingApiTestCaseBase):
             settings.trading_universe_source = original_source
 
     @patch(
-        "app.api.readiness_helpers.refresh_universe_state_for_readiness._evaluate_database_contract",
+        "app.api.readiness_helpers.refresh_universe_state_for_readiness.evaluate_database_contract",
         return_value={
             "ok": True,
             "schema_current": True,

--- a/services/torghut/tests/api/test_trading_api_revenue_zero_repair.py
+++ b/services/torghut/tests/api/test_trading_api_revenue_zero_repair.py
@@ -138,7 +138,7 @@ class TestTradingApiRevenueZeroRepair(TradingApiTestCaseBase):
         }
         with (
             patch(
-                "app.api.maintenance._evaluate_trading_health_payload",
+                "app.api.maintenance.evaluate_trading_health_payload",
                 return_value=(readyz_payload, 503),
             ),
             patch("app.api.maintenance.trading_status", return_value=status_payload),

--- a/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
+++ b/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
@@ -928,7 +928,7 @@ class TestTradingApiSimpleLaneProfitFloor(TradingApiTestCaseBase):
                     return_value={"ok": True},
                 ),
                 patch(
-                    "app.api.readiness_helpers.refresh_universe_state_for_readiness._check_account_scope_invariants_bounded",
+                    "app.api.readiness_helpers.refresh_universe_state_for_readiness.check_account_scope_invariants_bounded",
                     return_value={
                         "account_scope_ready": True,
                         "account_scope_errors": [],

--- a/services/torghut/tests/api/test_trading_api_status_consumer_evidence.py
+++ b/services/torghut/tests/api/test_trading_api_status_consumer_evidence.py
@@ -160,7 +160,7 @@ class TestTradingApiStatusConsumerEvidence(TradingApiTestCaseBase):
 
         with (
             patch(
-                "app.api.maintenance._evaluate_trading_health_payload",
+                "app.api.maintenance.evaluate_trading_health_payload",
                 return_value=({"status": "degraded"}, 503),
             ),
             patch(
@@ -241,7 +241,7 @@ class TestTradingApiStatusConsumerEvidence(TradingApiTestCaseBase):
 
         with (
             patch(
-                "app.api.maintenance._evaluate_trading_health_payload",
+                "app.api.maintenance.evaluate_trading_health_payload",
                 return_value=({"status": "degraded"}, 503),
             ),
             patch(

--- a/services/torghut/tests/api/trading_api_support.py
+++ b/services/torghut/tests/api/trading_api_support.py
@@ -30,9 +30,9 @@ from app.api import health_checks as health_checks_api
 from app.api import maintenance as maintenance_api
 from app.api import proof_floor_payloads as proof_floor_payloads_api
 from app.api import proofs as proofs_api
-from app.api import readiness_helpers as readiness_helpers_api
 from app.api import status_helpers as status_helpers_api
 from app.api import trading_misc as trading_misc_api
+from app.api.readiness_helpers import readiness_surface as readiness_surface_helpers
 from app.db import get_session
 from app.main import app
 from app.trading.paper_route_target_plan import (
@@ -81,7 +81,7 @@ _build_live_submission_gate_payload = (
     health_checks_api.build_api_live_submission_gate_payload
 )
 _build_route_image_proof_summary = (
-    proof_floor_payloads_api._build_route_image_proof_summary
+    proof_floor_payloads_api.build_route_image_proof_summary
 )
 _check_alpaca = health_checks_api.check_alpaca_dependency
 _daily_runtime_ledger_portfolio_summary = (
@@ -97,18 +97,20 @@ _load_options_catalog_freshness_summary = (
     health_checks_api.load_options_catalog_freshness_summary
 )
 _load_rejected_signal_outcome_learning_summary = (
-    proof_floor_payloads_api._load_rejected_signal_outcome_learning_summary
+    proof_floor_payloads_api.load_rejected_signal_outcome_learning_summary
 )
 _merge_external_paper_route_target_plan = (
     proofs_api._merge_external_paper_route_target_plan
 )
 _paper_route_target_plan_from_payload = proofs_api._paper_route_target_plan_from_payload
-_readiness_dependency_cache_key = readiness_helpers_api._readiness_dependency_cache_key
-_readiness_dependency_checks = readiness_helpers_api._readiness_dependency_checks
+_readiness_dependency_cache_key = (
+    readiness_surface_helpers.readiness_dependency_cache_key
+)
+_readiness_dependency_checks = readiness_surface_helpers.readiness_dependency_checks
 _retryable_tca_recompute_error = common_api._retryable_tca_recompute_error
 _route_claim_symbols = health_checks_api.route_claim_symbols
 _route_continuity_packet_for_proof_floor = (
-    proof_floor_payloads_api._route_continuity_packet_for_proof_floor
+    proof_floor_payloads_api.route_continuity_packet_for_proof_floor
 )
 healthz = app_bootstrap.healthz
 
@@ -791,7 +793,6 @@ __all__: tuple[str, ...] = (
     "persist_completion_trace",
     "proof_floor_payloads_api",
     "proofs_api",
-    "readiness_helpers_api",
     "select",
     "sessionmaker",
     "settings",

--- a/services/torghut/tests/test_evidence_epochs.py
+++ b/services/torghut/tests/test_evidence_epochs.py
@@ -274,7 +274,7 @@ class TestEvidenceEpochs(TestCase):
             with (
                 session_local() as session,
                 patch(
-                    "app.api.trading_misc.trading_autonomy._evaluate_database_contract",
+                    "app.api.trading_misc.trading_autonomy.evaluate_database_contract",
                     return_value={
                         "ok": True,
                         "schema_current": True,
@@ -372,7 +372,7 @@ class TestEvidenceEpochs(TestCase):
             session.commit()
             with (
                 patch(
-                    "app.api.trading_misc.trading_autonomy._evaluate_database_contract",
+                    "app.api.trading_misc.trading_autonomy.evaluate_database_contract",
                     return_value={
                         "ok": True,
                         "schema_current": True,
@@ -512,7 +512,7 @@ class TestEvidenceEpochs(TestCase):
         with session_local() as session:
             with (
                 patch(
-                    "app.api.trading_misc.trading_autonomy._evaluate_database_contract",
+                    "app.api.trading_misc.trading_autonomy.evaluate_database_contract",
                     return_value={
                         "ok": True,
                         "schema_current": True,
@@ -554,7 +554,7 @@ class TestEvidenceEpochs(TestCase):
         with session_local() as session:
             with (
                 patch(
-                    "app.api.trading_misc.trading_autonomy._evaluate_database_contract",
+                    "app.api.trading_misc.trading_autonomy.evaluate_database_contract",
                     return_value={
                         "ok": True,
                         "schema_current": True,
@@ -958,7 +958,7 @@ class TestEvidenceEpochs(TestCase):
             )
 
             with patch(
-                "app.api.trading_misc.trading_autonomy._evaluate_database_contract",
+                "app.api.trading_misc.trading_autonomy.evaluate_database_contract",
                 side_effect=RuntimeError("database contract unavailable"),
             ):
                 degraded_response = client.get(


### PR DESCRIPTION
## Summary

- Removes private underscore exports from the proof-floor, trading-misc, and readiness API facades.
- Converts facade modules and runtime callers to direct public imports instead of private alias assignments.
- Moves API/evidence tests off private readiness facade names and publicizes the database-contract patch points they exercise.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen ruff check app scripts --select PLC0414`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main <changed files>`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines <changed files>`
- `uv run --frozen pytest tests/api/test_trading_api_readyz_contract.py tests/api/test_trading_api_health_cache.py tests/api/test_trading_api_health_dependency.py tests/api/test_trading_api_db_contract.py tests/api/test_trading_api_status_consumer_evidence.py tests/api/test_trading_api_revenue_zero_repair.py tests/api/test_trading_api_simple_lane_profit_floor.py tests/test_evidence_epochs.py tests/test_explicit_module_facade_exports.py`
- `uv run --frozen pytest tests/api tests/test_explicit_module_facade_exports.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

Private underscore package attributes are removed from API facades. Public package exports remain intact.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
