### PR TITLE
refactor(torghut): remove trading facade private exports

### DIFF
--- a/services/torghut/app/trading/alpha/lane/__init__.py
+++ b/services/torghut/app/trading/alpha/lane/__init__.py
@@ -1,7 +1,7 @@
 """Public exports for app.trading.alpha.lane."""
 
 from __future__ import annotations
-from .alpha_lane_result import normalize_prices as _normalize_prices
+
 from .run_alpha_discovery_lane import AlphaLaneResult, run_alpha_discovery_lane
 
-__all__ = ["AlphaLaneResult", "run_alpha_discovery_lane", "_normalize_prices"]
+__all__ = ["AlphaLaneResult", "run_alpha_discovery_lane"]

--- a/services/torghut/app/trading/completion/__init__.py
+++ b/services/torghut/app/trading/completion/__init__.py
@@ -53,17 +53,6 @@ from .runtime_matrix_path import (
     persist_completion_trace,
 )
 from .runtime_ledger_bucket_existing_blockers import dataclass
-from .runtime_matrix_path import (
-    median_decimal as _median_decimal,
-    p10_decimal as _p10_decimal,
-    runtime_ledger_trading_day_key as _runtime_ledger_trading_day_key,
-)
-from .runtime_ledger_bucket_existing_blockers import (
-    runtime_ledger_bucket_matches_window as _runtime_ledger_bucket_matches_window,
-    runtime_ledger_bucket_refs_for_windows as _runtime_ledger_bucket_refs_for_windows,
-    runtime_ledger_bucket_summary as _runtime_ledger_bucket_summary,
-    runtime_ledger_daily_summary as _runtime_ledger_daily_summary,
-)
 from .effective_row_status import build_doc29_completion_status
 
 __all__ = [
@@ -120,11 +109,4 @@ __all__ = [
     "persist_completion_trace",
     "dataclass",
     "build_doc29_completion_status",
-    "_median_decimal",
-    "_p10_decimal",
-    "_runtime_ledger_bucket_matches_window",
-    "_runtime_ledger_bucket_refs_for_windows",
-    "_runtime_ledger_bucket_summary",
-    "_runtime_ledger_daily_summary",
-    "_runtime_ledger_trading_day_key",
 ]

--- a/services/torghut/app/trading/discovery/evidence_bundles/__init__.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles/__init__.py
@@ -27,7 +27,6 @@ from .evidence_bundle_blockers import (
     evidence_bundle_blockers,
     evidence_bundle_is_valid,
 )
-from .shared_context import bool_value as _bool
 
 __all__ = [
     "EVIDENCE_BUNDLE_SCHEMA_VERSION",
@@ -54,5 +53,4 @@ __all__ = [
     "evidence_bundle_from_payload",
     "evidence_bundle_blockers",
     "evidence_bundle_is_valid",
-    "_bool",
 ]

--- a/services/torghut/app/trading/discovery/mlx_training_data/__init__.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data/__init__.py
@@ -22,17 +22,12 @@ from .shared_context import (
     MlxRankedCandidate,
     MlxRankBucketLift,
     MlxRankedRowsPolicyResult,
-    hard_veto_count as _hard_veto_count,
-    import_array_backend as _import_array_backend,
-    import_torch_array_backend as _import_torch_array_backend,
-    sequence_strings as _sequence_strings,
 )
 from .paper_contract_feature_values import (
     candidate_spec_capital_features,
     capital_budget_penalty,
     configured_daily_notional_capacity_penalty,
     observed_capital_penalty,
-    observed_replay_viability_penalty as _observed_replay_viability_penalty,
 )
 from .build_mlx_training_rows import (
     build_mlx_training_rows,
@@ -66,15 +61,10 @@ __all__ = [
     "MlxRankedCandidate",
     "MlxRankBucketLift",
     "MlxRankedRowsPolicyResult",
-    "_hard_veto_count",
-    "_import_array_backend",
-    "_import_torch_array_backend",
-    "_sequence_strings",
     "candidate_spec_capital_features",
     "capital_budget_penalty",
     "configured_daily_notional_capacity_penalty",
     "observed_capital_penalty",
-    "_observed_replay_viability_penalty",
     "build_mlx_training_rows",
     "train_mlx_ranker",
     "rank_training_rows",

--- a/services/torghut/app/trading/runtime_ledger/__init__.py
+++ b/services/torghut/app/trading/runtime_ledger/__init__.py
@@ -14,11 +14,6 @@ from .shared_context import (
     RuntimeLedgerFill,
     RuntimeLedgerBucket,
     build_runtime_ledger_buckets,
-    NormalizedFill as _NormalizedFill,
-    build_bucket as _build_bucket,
-)
-from .order_lifecycle_blockers import (
-    coerce_fill_quantity_basis as _coerce_fill_quantity_basis,
 )
 
 __all__ = [
@@ -36,7 +31,4 @@ __all__ = [
     "RuntimeLedgerFill",
     "RuntimeLedgerBucket",
     "build_runtime_ledger_buckets",
-    "_NormalizedFill",
-    "_build_bucket",
-    "_coerce_fill_quantity_basis",
 ]

--- a/services/torghut/app/trading/scheduler/governance/__init__.py
+++ b/services/torghut/app/trading/scheduler/governance/__init__.py
@@ -36,9 +36,6 @@ from .shared_context import (
     TradingState,
 )
 from .governance_mixin_runtime_methods import TradingSchedulerGovernanceMixin
-from .shared_context import (
-    resolve_autonomy_artifact_root as _resolve_autonomy_artifact_root,
-)
 
 logger = _logging_for_module.getLogger(__name__)
 __all__ = [
@@ -77,5 +74,4 @@ __all__ = [
     "TradingState",
     "logger",
     "TradingSchedulerGovernanceMixin",
-    "_resolve_autonomy_artifact_root",
 ]

--- a/services/torghut/tests/completion_trace/support.py
+++ b/services/torghut/tests/completion_trace/support.py
@@ -27,17 +27,21 @@ from app.trading.completion import (
     DOC29_SIMULATION_FULL_DAY_GATE,
     DOC29_SIMULATION_SMOKE_GATE,
     TRACE_STATUS_SATISFIED,
-    _median_decimal,
-    _p10_decimal,
-    _runtime_ledger_bucket_matches_window,
-    _runtime_ledger_bucket_refs_for_windows,
-    _runtime_ledger_bucket_summary,
-    _runtime_ledger_daily_summary,
-    _runtime_ledger_trading_day_key,
     build_completion_trace,
     build_doc29_completion_status,
     persist_completion_trace,
     runtime_and_doc_completion_matrices_match,
+)
+from app.trading.completion.runtime_ledger_bucket_existing_blockers import (
+    runtime_ledger_bucket_matches_window as _runtime_ledger_bucket_matches_window,
+    runtime_ledger_bucket_refs_for_windows as _runtime_ledger_bucket_refs_for_windows,
+    runtime_ledger_bucket_summary as _runtime_ledger_bucket_summary,
+    runtime_ledger_daily_summary as _runtime_ledger_daily_summary,
+)
+from app.trading.completion.runtime_matrix_path import (
+    median_decimal as _median_decimal,
+    p10_decimal as _p10_decimal,
+    runtime_ledger_trading_day_key as _runtime_ledger_trading_day_key,
 )
 
 

--- a/services/torghut/tests/mlx_training_data/test_training_feedback_helpers_handle_string_vetoes_and_scalar_sequences.py
+++ b/services/torghut/tests/mlx_training_data/test_training_feedback_helpers_handle_string_vetoes_and_scalar_sequences.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+from app.trading.discovery.mlx_training_data.paper_contract_feature_values import (
+    observed_replay_viability_penalty,
+)
+from app.trading.discovery.mlx_training_data.shared_context import (
+    hard_veto_count,
+    sequence_strings,
+)
+
 from tests.mlx_training_data.support import (
     CandidateSpec,
     Decimal,
@@ -10,7 +18,6 @@ from tests.mlx_training_data.support import (
     candidate_spec_capital_features,
     compile_candidate_specs,
     evidence_bundle_from_frontier_candidate,
-    mlx_training_data_module,
     rank_training_rows,
     train_mlx_ranker,
 )
@@ -23,18 +30,13 @@ class TestTrainingFeedbackHelpersHandleStringVetoesAndScalarSequences(
         self,
     ) -> None:
         self.assertEqual(
-            mlx_training_data_module._hard_veto_count(
-                {"hard_vetoes": "positive_day_ratio_below_oracle"}
-            ),
+            hard_veto_count({"hard_vetoes": "positive_day_ratio_below_oracle"}),
             1.0,
         )
+        self.assertEqual(hard_veto_count({"hard_vetoes": "  "}), 0.0)
+        self.assertEqual(sequence_strings("NVDA"), ())
         self.assertEqual(
-            mlx_training_data_module._hard_veto_count({"hard_vetoes": "  "}),
-            0.0,
-        )
-        self.assertEqual(mlx_training_data_module._sequence_strings("NVDA"), ())
-        self.assertEqual(
-            mlx_training_data_module._sequence_strings(["NVDA", "", "AMD"]),
+            sequence_strings(["NVDA", "", "AMD"]),
             ("NVDA", "AMD"),
         )
 
@@ -180,7 +182,7 @@ class TestTrainingFeedbackHelpersHandleStringVetoesAndScalarSequences(
     def test_observed_replay_viability_penalty_marks_zero_activity_notional_gap(
         self,
     ) -> None:
-        penalty = mlx_training_data_module._observed_replay_viability_penalty(
+        penalty = observed_replay_viability_penalty(
             {
                 "active_day_ratio": "0",
                 "positive_day_ratio": "0",

--- a/services/torghut/tests/runtime_ledger/support.py
+++ b/services/torghut/tests/runtime_ledger/support.py
@@ -9,10 +9,14 @@ import pytest
 from app.trading.runtime_ledger import (
     EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
     RuntimeLedgerFill,
-    _build_bucket,
-    _coerce_fill_quantity_basis,
-    _NormalizedFill,
     build_runtime_ledger_buckets,
+)
+from app.trading.runtime_ledger.order_lifecycle_blockers import (
+    coerce_fill_quantity_basis as _coerce_fill_quantity_basis,
+)
+from app.trading.runtime_ledger.shared_context import (
+    NormalizedFill as _NormalizedFill,
+    build_bucket as _build_bucket,
 )
 
 

--- a/services/torghut/tests/test_alpha_lane.py
+++ b/services/torghut/tests/test_alpha_lane.py
@@ -22,7 +22,8 @@ from app.models import (
     ResearchSequentialTrial,
     ResearchValidationTest,
 )
-from app.trading.alpha.lane import run_alpha_discovery_lane, _normalize_prices
+from app.trading.alpha.lane import run_alpha_discovery_lane
+from app.trading.alpha.lane.alpha_lane_result import normalize_prices
 from app.trading.discovery.sequential_trials import build_sequential_trial_summary
 
 
@@ -409,7 +410,7 @@ class TestAlphaLane(TestCase):
                 "B": [201.0, 202.0, 203.0, 204.0],
             }
         )
-        normalized = _normalize_prices(prices, label="train")
+        normalized = normalize_prices(prices, label="train")
 
         self.assertEqual(normalized.shape, (4, 2))
         self.assertIn("A", normalized.columns)

--- a/services/torghut/tests/test_autonomy_artifact_root.py
+++ b/services/torghut/tests/test_autonomy_artifact_root.py
@@ -5,19 +5,21 @@ import tempfile
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from app.trading.scheduler.governance import _resolve_autonomy_artifact_root
+from app.trading.scheduler.governance.shared_context import (
+    resolve_autonomy_artifact_root,
+)
 
 
 class TestAutonomyArtifactRoot(TestCase):
     def test_prefers_configured_root_when_writable(self) -> None:
         with TemporaryDirectory() as tmpdir:
             configured_root = Path(tmpdir) / "custom-artifacts"
-            resolved = _resolve_autonomy_artifact_root(configured_root)
+            resolved = resolve_autonomy_artifact_root(configured_root)
             self.assertEqual(resolved, configured_root)
             self.assertTrue(resolved.is_dir())
 
     def test_falls_back_when_configured_root_unwritable(self) -> None:
         configured_root = Path("/dev/null")
-        resolved = _resolve_autonomy_artifact_root(configured_root)
+        resolved = resolve_autonomy_artifact_root(configured_root)
         self.assertNotEqual(resolved, configured_root)
         self.assertEqual(resolved, Path(tempfile.gettempdir()) / "torghut" / "autonomy")

--- a/services/torghut/tests/whitepaper_autoresearch_artifacts/support.py
+++ b/services/torghut/tests/whitepaper_autoresearch_artifacts/support.py
@@ -10,7 +10,9 @@ import numpy as np
 
 import app.trading.discovery.candidate_specs as candidate_specs_module
 import app.trading.discovery.evidence_bundles as evidence_bundles_module
-import app.trading.discovery.mlx_training_data as mlx_training_data_module
+from app.trading.discovery.mlx_training_data import (
+    shared_context as mlx_training_data_shared_context,
+)
 from app.trading.discovery.candidate_specs import (
     candidate_spec_from_payload,
     compile_candidate_specs,
@@ -20,6 +22,7 @@ from app.trading.discovery.evidence_bundles import (
     evidence_bundle_from_frontier_candidate,
     evidence_bundle_from_payload,
 )
+from app.trading.discovery.evidence_bundles.shared_context import bool_value
 from app.trading.discovery.hypothesis_cards import (
     HYPOTHESIS_CARD_SCHEMA_VERSION,
     HypothesisCard,
@@ -147,13 +150,14 @@ __all__: tuple[str, ...] = (
     "candidate_spec_from_payload",
     "candidate_specs_module",
     "compile_candidate_specs",
+    "bool_value",
     "evidence_bundle_blockers",
     "evidence_bundle_from_frontier_candidate",
     "evidence_bundle_from_payload",
     "evidence_bundles_module",
     "hypothesis_card_from_payload",
     "mlx_ranker_model_from_payload",
-    "mlx_training_data_module",
+    "mlx_training_data_shared_context",
     "np",
     "optimize_portfolio_candidate",
     "patch",

--- a/services/torghut/tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_bool_parser_handles_numeric_and_unknown_values.py
+++ b/services/torghut/tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_bool_parser_handles_numeric_and_unknown_values.py
@@ -9,6 +9,7 @@ from tests.whitepaper_autoresearch_artifacts.support import (
     _FakeTorchModule,
     _TestWhitepaperAutoresearchArtifactsBase,
     _profile_ids_for_family,
+    bool_value,
     build_hypothesis_cards,
     build_mlx_training_rows,
     candidate_spec_from_payload,
@@ -17,9 +18,8 @@ from tests.whitepaper_autoresearch_artifacts.support import (
     evidence_bundle_blockers,
     evidence_bundle_from_frontier_candidate,
     evidence_bundle_from_payload,
-    evidence_bundles_module,
     hypothesis_card_from_payload,
-    mlx_training_data_module,
+    mlx_training_data_shared_context,
     optimize_portfolio_candidate,
     patch,
     rank_training_rows,
@@ -33,9 +33,9 @@ class TestEvidenceBundleBoolParserHandlesNumericAndUnknownValues(
     def test_evidence_bundle_bool_parser_handles_numeric_and_unknown_values(
         self,
     ) -> None:
-        self.assertEqual(evidence_bundles_module._bool(Decimal("1")), True)
-        self.assertEqual(evidence_bundles_module._bool(0), False)
-        self.assertEqual(evidence_bundles_module._bool("custom-truthy-marker"), True)
+        self.assertEqual(bool_value(Decimal("1")), True)
+        self.assertEqual(bool_value(0), False)
+        self.assertEqual(bool_value("custom-truthy-marker"), True)
 
     def test_hypothesis_and_candidate_specs_round_trip(self) -> None:
         cards = build_hypothesis_cards(
@@ -246,41 +246,47 @@ class TestEvidenceBundleBoolParserHandlesNumericAndUnknownValues(
 
     def test_torch_ranker_backend_selection_covers_fallback_edges(self) -> None:
         with patch.object(
-            mlx_training_data_module.importlib,
+            mlx_training_data_shared_context.importlib,
             "import_module",
             side_effect=ModuleNotFoundError("torch"),
         ):
             self.assertIsNone(
-                mlx_training_data_module._import_torch_array_backend("torch-cuda")
+                mlx_training_data_shared_context.import_torch_array_backend(
+                    "torch-cuda"
+                )
             )
 
         with patch.object(
-            mlx_training_data_module.importlib,
+            mlx_training_data_shared_context.importlib,
             "import_module",
             return_value=_FakeTorchCpuModule(),
         ):
             self.assertIsNone(
-                mlx_training_data_module._import_torch_array_backend("torch-cuda")
+                mlx_training_data_shared_context.import_torch_array_backend(
+                    "torch-cuda"
+                )
             )
             self.assertEqual(
-                mlx_training_data_module._import_array_backend("cuda")[0],
+                mlx_training_data_shared_context.import_array_backend("cuda")[0],
                 "numpy-fallback",
             )
             self.assertEqual(
-                mlx_training_data_module._import_torch_array_backend("torch")[0],
+                mlx_training_data_shared_context.import_torch_array_backend("torch")[0],
                 "torch",
             )
             self.assertIsNone(
-                mlx_training_data_module._import_torch_array_backend("unsupported")
+                mlx_training_data_shared_context.import_torch_array_backend(
+                    "unsupported"
+                )
             )
 
         with patch.object(
-            mlx_training_data_module.importlib,
+            mlx_training_data_shared_context.importlib,
             "import_module",
             return_value=_FakeTorchModule(),
         ):
             self.assertEqual(
-                mlx_training_data_module._import_torch_array_backend("torch")[0],
+                mlx_training_data_shared_context.import_torch_array_backend("torch")[0],
                 "torch-cuda",
             )
 


### PR DESCRIPTION
## Summary

- Removes private underscore exports from alpha lane, completion, evidence bundle, MLX training, runtime ledger, and scheduler governance facades.
- Rewires tests and shared test support to import concrete helper modules instead of package-level private aliases.
- Keeps the public package exports intact while reducing private namespace compatibility surface.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen ruff check app scripts --select PLC0414`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main <changed files>`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines <changed files>`
- `uv run --frozen pytest tests/test_alpha_lane.py tests/test_autonomy_artifact_root.py tests/completion_trace tests/mlx_training_data tests/evidence_bundles tests/runtime_ledger tests/whitepaper_autoresearch_artifacts/test_evidence_bundle_bool_parser_handles_numeric_and_unknown_values.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

Private underscore package attributes are removed from selected trading facades. Public package exports remain intact.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
