### PR TITLE
refactor(torghut): remove target plan facade aliases

### DIFF
--- a/services/torghut/app/trading/decisions/__init__.py
+++ b/services/torghut/app/trading/decisions/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from . import aggregated_qty as _aggregated_qty
 from .count_open_short_positions import count_open_short_positions
 from .decision_engine_core_support import (
     build_runtime_position_exit_overlay,
@@ -18,9 +17,8 @@ from .resolve_runtime_trade_policy import (
     resolve_strategy_time_in_force,
 )
 from .shared_context import DecisionRuntimeTelemetry
+from .aggregated_qty import resolve_qty_for_aggregated
 from .single_strategy_qty import resolve_qty
-
-resolve_qty_for_aggregated = _aggregated_qty.resolve_qty_for_aggregated
 
 __all__ = (
     "DecisionEngine",

--- a/services/torghut/app/trading/paper_route_target_plan/__init__.py
+++ b/services/torghut/app/trading/paper_route_target_plan/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from http.client import HTTPConnection, HTTPSConnection
 from typing import Any
 
-from . import target_plan as _target_plan
 from .materialization import (
     blocked_target_readiness,
     materialize_bounded_paper_route_target_plan,
@@ -22,6 +21,7 @@ from .target_plan import (
     PAPER_ROUTE_MATERIALIZATION_STAGE,
     PAPER_ROUTE_TARGET_NOTIONAL_SOURCE_DECISION_SEED_QTY,
     PaperRouteTargetPlanFetchClient,
+    fetch_paper_route_target_plan_url as fetch_paper_route_target_plan_url_with_client,
     mapping_items,
     paper_route_target_plan_from_payload,
     paper_route_target_plan_probe_symbols,
@@ -41,7 +41,7 @@ def fetch_paper_route_target_plan_url(
     attempts: int = 1,
     retry_backoff_seconds: float = 0.25,
 ) -> dict[str, Any]:
-    return _target_plan.fetch_paper_route_target_plan_url(
+    return fetch_paper_route_target_plan_url_with_client(
         url,
         timeout_seconds=timeout_seconds,
         attempts=attempts,

--- a/services/torghut/app/trading/proof_floor/__init__.py
+++ b/services/torghut/app/trading/proof_floor/__init__.py
@@ -30,8 +30,6 @@ from .proof_floor_core import (
 
 from .receipt_builder import build_profitability_proof_floor_receipt
 
-_route_universe_adverse_slippage_clear = route_universe_adverse_slippage_clear
-
 __all__ = (
     "BLOCKING_STATES",
     "LIVE_MICRO_STAGES",
@@ -58,6 +56,5 @@ __all__ = (
     "tca_symbol_routes",
     "text_value",
     "truthy",
-    "_route_universe_adverse_slippage_clear",
     "build_profitability_proof_floor_receipt",
 )

--- a/services/torghut/tests/profitability_proof_floor/support.py
+++ b/services/torghut/tests/profitability_proof_floor/support.py
@@ -6,8 +6,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 from app.trading.proof_floor import (
-    _route_universe_adverse_slippage_clear,
     build_profitability_proof_floor_receipt,
+    route_universe_adverse_slippage_clear,
 )
 
 
@@ -107,11 +107,11 @@ __all__: tuple[str, ...] = (
     "_healthy_hypothesis_payload",
     "_healthy_market_context",
     "_healthy_quant_evidence",
-    "_route_universe_adverse_slippage_clear",
     "_simple_lane_status",
     "build_profitability_proof_floor_receipt",
     "cast",
     "datetime",
+    "route_universe_adverse_slippage_clear",
     "timedelta",
     "timezone",
 )

--- a/services/torghut/tests/profitability_proof_floor/test_execution_tca_route_universe_uses_widest_hypothesis_guardrail.py
+++ b/services/torghut/tests/profitability_proof_floor/test_execution_tca_route_universe_uses_widest_hypothesis_guardrail.py
@@ -9,10 +9,10 @@ from tests.profitability_proof_floor.support import (
     _healthy_hypothesis_payload,
     _healthy_market_context,
     _healthy_quant_evidence,
-    _route_universe_adverse_slippage_clear,
     _simple_lane_status,
     build_profitability_proof_floor_receipt,
     cast,
+    route_universe_adverse_slippage_clear,
     timedelta,
 )
 
@@ -395,7 +395,7 @@ def test_route_universe_adverse_slippage_clear_fails_closed() -> None:
 
     for case_name, symbol_routes, route_filter_enabled in cases:
         assert (
-            _route_universe_adverse_slippage_clear(
+            route_universe_adverse_slippage_clear(
                 symbol_routes,
                 route_filter_enabled=route_filter_enabled,
                 aggregate_tca_reason="execution_tca_slippage_guardrail_exceeded",


### PR DESCRIPTION
## Summary

- Removes alias-only private facade plumbing from trading decisions and paper-route target-plan packages.
- Drops the private proof-floor route-slippage facade alias and updates tests to use the public helper name.
- Keeps existing public package exports and target-plan fetch behavior intact.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen ruff check app scripts --select PLC0414`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main <changed files>`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines <changed files>`
- `uv run --frozen pytest tests/profitability_proof_floor tests/materialize_bounded_paper_route_targets tests/decisions tests/test_explicit_module_facade_exports.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

Private underscore package attributes are removed from selected trading facades. Public package exports remain intact.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
