### PR TITLE
refactor(torghut): remove runtime private facade exports

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay/__init__.py
+++ b/services/torghut/app/trading/discovery/fast_replay/__init__.py
@@ -67,27 +67,6 @@ from .fast_replay_preview_result import (
     FastReplayPreviewResult,
     build_fast_replay_preview,
 )
-from .extract_price import (
-    Callable,
-    extract_microprice_bias_bps as _extract_microprice_bias_bps,
-    extract_ofi_memory_regime_score as _extract_ofi_memory_regime_score,
-    extract_ofi_pressure as _extract_ofi_pressure,
-    extract_price as _extract_price,
-    extract_quote_depth_imbalance as _extract_quote_depth_imbalance,
-    extract_spread_bps as _extract_spread_bps,
-    extract_volume as _extract_volume,
-    float_or_none as _float_or_none,
-    mapping as _mapping,
-)
-from .frontier_selection_blockers_for_row import (
-    candidate_direction as _candidate_direction,
-    candidate_symbols as _candidate_symbols,
-)
-from .preview_rank_key import (
-    preview_rank_key as _preview_rank_key,
-    row_with_rank_and_selection as _row_with_rank_and_selection,
-    select_frontier_buckets as _select_frontier_buckets,
-)
 
 __all__ = [
     "hashlib",
@@ -154,19 +133,4 @@ __all__ = [
     "FastReplayPreviewRow",
     "FastReplayPreviewResult",
     "build_fast_replay_preview",
-    "Callable",
-    "_candidate_direction",
-    "_candidate_symbols",
-    "_extract_microprice_bias_bps",
-    "_extract_ofi_memory_regime_score",
-    "_extract_ofi_pressure",
-    "_extract_price",
-    "_extract_quote_depth_imbalance",
-    "_extract_spread_bps",
-    "_extract_volume",
-    "_float_or_none",
-    "_mapping",
-    "_preview_rank_key",
-    "_row_with_rank_and_selection",
-    "_select_frontier_buckets",
 ]

--- a/services/torghut/app/trading/discovery/portfolio_optimizer/__init__.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer/__init__.py
@@ -26,31 +26,6 @@ from .shared_context import (
     PORTFOLIO_COMPOSABLE_SINGLE_SLEEVE_VETOES,
 )
 from .selected_from_state import optimize_portfolio_candidate
-from . import portfolio_trading_day_count as _portfolio_trading_day_count
-from . import shared_context as _shared_context
-
-_candidate_passes_minimums = getattr(_shared_context, "candidate_passes_minimums")
-_capital_safety_rejection = getattr(_shared_context, "capital_safety_rejection")
-_daily_net = getattr(_shared_context, "daily_net")
-_edge_risk_gross_exposure_budget_weights = getattr(
-    _shared_context, "_edge_risk_gross_exposure_budget_weights"
-)
-_exact_replay_ledger_artifact_refs = getattr(
-    _shared_context, "exact_replay_ledger_artifact_refs"
-)
-_exact_replay_ledger_fill_count = getattr(
-    _shared_context, "exact_replay_ledger_fill_count"
-)
-_exact_replay_ledger_row_count = getattr(
-    _shared_context, "exact_replay_ledger_row_count"
-)
-_gross_exposure_allocation_priority = getattr(
-    _shared_context, "_gross_exposure_allocation_priority"
-)
-_negative_cash_observation_count = getattr(
-    _shared_context, "negative_cash_observation_count"
-)
-_oracle_blocker_count = getattr(_portfolio_trading_day_count, "oracle_blocker_count")
 
 __all__ = [
     "Decimal",
@@ -78,14 +53,4 @@ __all__ = [
     "PORTFOLIO_RUNTIME_LEDGER_PNL_SOURCE",
     "PORTFOLIO_COMPOSABLE_SINGLE_SLEEVE_VETOES",
     "optimize_portfolio_candidate",
-    "_candidate_passes_minimums",
-    "_capital_safety_rejection",
-    "_daily_net",
-    "_edge_risk_gross_exposure_budget_weights",
-    "_exact_replay_ledger_artifact_refs",
-    "_exact_replay_ledger_fill_count",
-    "_exact_replay_ledger_row_count",
-    "_gross_exposure_allocation_priority",
-    "_negative_cash_observation_count",
-    "_oracle_blocker_count",
 ]

--- a/services/torghut/app/trading/discovery/replay_ledger_ranker/__init__.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker/__init__.py
@@ -34,26 +34,6 @@ from .shared_context import (
     rank_replay_ledger_files,
     build_replay_ledger_ranking_report,
 )
-from .promotion_blockers import (
-    daily_bucket_ranges as _daily_bucket_ranges,
-    dedupe_source_papers as _dedupe_source_papers,
-    lob_reality_gap_stress_summary as _lob_reality_gap_stress_summary,
-    lob_signal_rows as _lob_signal_rows,
-    mapping as _mapping,
-    microstructure_stress_summary as _microstructure_stress_summary,
-    stress_penalty_bps as _stress_penalty_bps,
-    utc as _utc,
-)
-from .row_has_fill_status import (
-    best_day_share as _best_day_share,
-    dedupe as _dedupe,
-    event_type as _event_type,
-    fill_notional as _fill_notional,
-    parse_window_datetime as _parse_window_datetime,
-    positive_decimal as _positive_decimal,
-    profit_factor as _profit_factor,
-    safe_divide as _safe_divide,
-)
 
 __all__ = [
     "json",
@@ -89,20 +69,4 @@ __all__ = [
     "rank_replay_ledger_payload",
     "rank_replay_ledger_files",
     "build_replay_ledger_ranking_report",
-    "_daily_bucket_ranges",
-    "_best_day_share",
-    "_dedupe",
-    "_event_type",
-    "_fill_notional",
-    "_lob_reality_gap_stress_summary",
-    "_lob_signal_rows",
-    "_dedupe_source_papers",
-    "_mapping",
-    "_microstructure_stress_summary",
-    "_parse_window_datetime",
-    "_positive_decimal",
-    "_profit_factor",
-    "_safe_divide",
-    "_stress_penalty_bps",
-    "_utc",
 ]

--- a/services/torghut/app/trading/submission_council/__init__.py
+++ b/services/torghut/app/trading/submission_council/__init__.py
@@ -11,16 +11,8 @@ from .common import (
     Session,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
-    CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT as _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
     LIVE_SUBMISSION_BLOCKING_TOGGLE_MISMATCHES as _LIVE_SUBMISSION_BLOCKING_TOGGLE_MISMATCHES,
-    PROMOTION_PORTFOLIO_READY_SCAN_LIMIT as _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
-    PROMOTION_TABLE_COUNT_SCAN_LIMIT as _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
-    QUANT_HEALTH_CACHE as _QUANT_HEALTH_CACHE,
-    coerce_aware_datetime as _coerce_aware_datetime,
-    maybe_set_runtime_ledger_status_statement_timeout as _maybe_set_runtime_ledger_status_statement_timeout,
     normalize_reason_codes as _normalize_reason_codes,
-    rollback_runtime_ledger_status_session as _rollback_runtime_ledger_status_session,
-    runtime_ledger_status_query_timeout_ms as _runtime_ledger_status_query_timeout_ms,
     safe_int as _safe_int,
     safe_text as _safe_text,
     stage_rank as _stage_rank,
@@ -39,7 +31,6 @@ from .common import (
 )
 from .quant_health import (
     runtime_window_import_health_gate_inputs as _runtime_window_import_health_gate_inputs,
-    autoresearch_portfolio_current_oracle_passed as _autoresearch_portfolio_current_oracle_passed,
     build_shadow_first_toggle_parity,
     critical_trading_toggle_snapshot,
     load_quant_evidence_status,
@@ -54,19 +45,12 @@ from .configured_collection import (
     with_configured_paper_collection_targets as _with_configured_paper_collection_targets,
 )
 from .runtime_summary import (
-    runtime_ledger_aggregate_candidate_payloads as _runtime_ledger_aggregate_candidate_payloads,
-    runtime_ledger_latest_payloads_per_symbol as _runtime_ledger_latest_payloads_per_symbol,
-    runtime_ledger_merge_count_maps as _runtime_ledger_merge_count_maps,
-    runtime_ledger_unique_sequence as _runtime_ledger_unique_sequence,
     build_hypothesis_runtime_summary,
 )
 from .paper_probation import (
     RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_BLOCKER as _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_BLOCKER,
-    bounded_source_collection_probe_window as _bounded_source_collection_probe_window,
-    runtime_ledger_paper_probation_blockers as _runtime_ledger_paper_probation_blockers,
     runtime_ledger_paper_probation_candidates as _runtime_ledger_paper_probation_candidates,
     runtime_ledger_source_collection_candidates as _runtime_ledger_source_collection_candidates,
-    runtime_ledger_source_collection_target_progress_payload as _runtime_ledger_source_collection_target_progress_payload,
 )
 from .import_plan import (
     paper_probation_eligible_total_with_runtime_ledger as _paper_probation_eligible_total_with_runtime_ledger,
@@ -80,10 +64,8 @@ from .repair_candidates import (
     build_submission_gate_market_context_status,
 )
 from .certificate_loading import (
-    certificate_evidence_selection_key as _certificate_evidence_selection_key,
     load_latest_certificate_evidence as _load_latest_certificate_evidence,
     merge_runtime_certificate_evidence as _merge_runtime_certificate_evidence,
-    metric_window_activity_reason_codes as _metric_window_activity_reason_codes,
 )
 from .certificate_eval import (
     attach_lineage_refs as _attach_lineage_refs,
@@ -94,17 +76,10 @@ from .certificate_eval import (
     runtime_ledger_hypothesis_ids_for_gate_scope as _runtime_ledger_hypothesis_ids_for_gate_scope,
     segment_summary as _segment_summary,
 )
-from .runtime_certificates import (
-    certificate_evidence_authority_score as _certificate_evidence_authority_score,
-    load_latest_runtime_ledger_summary as _load_latest_runtime_ledger_summary,
-    runtime_ledger_repair_reason_codes as _runtime_ledger_repair_reason_codes,
-    runtime_ledger_repair_score as _runtime_ledger_repair_score,
-)
 from .profit_readiness import (
     build_profit_data_readiness_summary as _build_profit_data_readiness_summary,
     build_profit_live_controls as _build_profit_live_controls,
     build_profit_rejection_summary as _build_profit_rejection_summary,
-    load_persisted_profit_rejection_summary as _load_persisted_profit_rejection_summary,
     load_profit_promotion_table_counts as _load_profit_promotion_table_counts,
 )
 from ..live_submit_activation import (
@@ -940,38 +915,6 @@ def _live_submission_gate_payload(
 
 
 __all__ = [
-    "_CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT",
-    "_PROMOTION_PORTFOLIO_READY_SCAN_LIMIT",
-    "_PROMOTION_TABLE_COUNT_SCAN_LIMIT",
-    "_QUANT_HEALTH_CACHE",
-    "_attach_lineage_refs",
-    "_autoresearch_portfolio_current_oracle_passed",
-    "_bounded_source_collection_probe_window",
-    "_certificate_evidence_authority_score",
-    "_certificate_evidence_selection_key",
-    "_coerce_aware_datetime",
-    "_load_latest_certificate_evidence",
-    "_load_latest_runtime_ledger_summary",
-    "_load_persisted_profit_rejection_summary",
-    "_load_profit_promotion_table_counts",
-    "_load_runtime_ledger_repair_candidates",
-    "_maybe_set_runtime_ledger_status_statement_timeout",
-    "_merge_runtime_certificate_evidence",
-    "_metric_window_activity_reason_codes",
-    "_refresh_runtime_summary_totals",
-    "_rollback_runtime_ledger_status_session",
-    "_runtime_ledger_aggregate_candidate_payloads",
-    "_runtime_ledger_latest_payloads_per_symbol",
-    "_runtime_ledger_merge_count_maps",
-    "_runtime_ledger_paper_probation_blockers",
-    "_runtime_ledger_paper_probation_candidates",
-    "_runtime_ledger_paper_probation_import_plan",
-    "_runtime_ledger_repair_reason_codes",
-    "_runtime_ledger_repair_score",
-    "_runtime_ledger_source_collection_candidates",
-    "_runtime_ledger_source_collection_target_progress_payload",
-    "_runtime_ledger_status_query_timeout_ms",
-    "_runtime_ledger_unique_sequence",
     "build_tca_gate_inputs",
     "build_hypothesis_runtime_summary",
     "build_live_submission_gate_payload",

--- a/services/torghut/tests/fast_replay/support.py
+++ b/services/torghut/tests/fast_replay/support.py
@@ -17,6 +17,26 @@ from app.trading.discovery.fast_replay import (
     FAST_REPLAY_PROOF_SEMANTICS_LABEL,
     build_fast_replay_preview,
 )
+from app.trading.discovery.fast_replay.extract_price import (
+    extract_microprice_bias_bps,
+    extract_ofi_memory_regime_score,
+    extract_ofi_pressure,
+    extract_price,
+    extract_quote_depth_imbalance,
+    extract_spread_bps,
+    extract_volume,
+    float_or_none,
+    mapping,
+)
+from app.trading.discovery.fast_replay.frontier_selection_blockers_for_row import (
+    candidate_direction,
+    candidate_symbols,
+)
+from app.trading.discovery.fast_replay.preview_rank_key import (
+    preview_rank_key,
+    row_with_rank_and_selection,
+    select_frontier_buckets,
+)
 from app.trading.discovery.replay_tape import (
     build_source_query_digest,
     load_replay_tape,
@@ -154,11 +174,25 @@ __all__: tuple[str, ...] = (
     "ast",
     "build_fast_replay_preview",
     "build_source_query_digest",
+    "candidate_direction",
+    "candidate_symbols",
     "date",
     "datetime",
+    "extract_microprice_bias_bps",
+    "extract_ofi_memory_regime_score",
+    "extract_ofi_pressure",
+    "extract_price",
+    "extract_quote_depth_imbalance",
+    "extract_spread_bps",
+    "extract_volume",
     "fast_replay",
+    "float_or_none",
     "load_replay_tape",
+    "mapping",
     "materialize_signal_tape",
+    "preview_rank_key",
+    "row_with_rank_and_selection",
+    "select_frontier_buckets",
     "timedelta",
     "timezone",
 )

--- a/services/torghut/tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py
+++ b/services/torghut/tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py
@@ -11,9 +11,14 @@ from tests.fast_replay.support import (
     build_source_query_digest,
     date,
     datetime,
+    extract_ofi_memory_regime_score,
+    extract_ofi_pressure,
+    preview_rank_key,
     fast_replay,
     load_replay_tape,
     materialize_signal_tape,
+    row_with_rank_and_selection,
+    select_frontier_buckets,
     timedelta,
     timezone,
 )
@@ -114,7 +119,7 @@ class TestLoadedHpairsReplayTapeFeaturesFeedOfflineRankingOnly(
             ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
         )
 
-        ofi_pressure = fast_replay._extract_ofi_pressure(signal)
+        ofi_pressure = extract_ofi_pressure(signal)
 
         self.assertIsNotNone(ofi_pressure)
         assert ofi_pressure is not None
@@ -148,8 +153,8 @@ class TestLoadedHpairsReplayTapeFeaturesFeedOfflineRankingOnly(
             ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
         )
 
-        ofi_pressure = fast_replay._extract_ofi_pressure(signal)
-        ofi_memory = fast_replay._extract_ofi_memory_regime_score(signal)
+        ofi_pressure = extract_ofi_pressure(signal)
+        ofi_memory = extract_ofi_memory_regime_score(signal)
 
         self.assertEqual(ofi_pressure, 0.275)
         self.assertEqual(ofi_memory, 0.35)
@@ -290,9 +295,9 @@ class TestLoadedHpairsReplayTapeFeaturesFeedOfflineRankingOnly(
                     is_hpairs_candidate=False,
                 ),
             ),
-            key=fast_replay._preview_rank_key,
+            key=preview_rank_key,
         )
-        selected = fast_replay._select_frontier_buckets(
+        selected = select_frontier_buckets(
             ranked_rows=ranked,
             exploitation_count=1,
             exploration_count=1,
@@ -497,17 +502,17 @@ class TestLoadedHpairsReplayTapeFeaturesFeedOfflineRankingOnly(
                     symbols=["FFF"],
                 ),
             ),
-            key=fast_replay._preview_rank_key,
+            key=preview_rank_key,
         )
 
-        selected = fast_replay._select_frontier_buckets(
+        selected = select_frontier_buckets(
             ranked_rows=ranked,
             exploitation_count=fast_replay.FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
             exploration_count=fast_replay.FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
             exact_replay_candidate_cap=fast_replay.FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP,
         )
         final_rows = [
-            fast_replay._row_with_rank_and_selection(
+            row_with_rank_and_selection(
                 row=item,
                 rank=index,
                 frontier_bucket=selected.get(item.candidate_spec_id, "not_selected"),
@@ -752,7 +757,7 @@ class TestLoadedHpairsReplayTapeFeaturesFeedOfflineRankingOnly(
                 row("mean-only-tail-risk", preview_score="100", robust_utility="-5"),
                 row("robust-frontier", preview_score="50", robust_utility="12"),
             ),
-            key=fast_replay._preview_rank_key,
+            key=preview_rank_key,
         )
 
         self.assertEqual(ranked[0].candidate_spec_id, "robust-frontier")

--- a/services/torghut/tests/portfolio_optimizer/support.py
+++ b/services/torghut/tests/portfolio_optimizer/support.py
@@ -15,6 +15,20 @@ from app.trading.discovery.portfolio_candidates import (
     portfolio_candidate_from_payload,
 )
 from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candidate
+from app.trading.discovery.portfolio_optimizer.portfolio_trading_day_count import (
+    oracle_blocker_count,
+)
+from app.trading.discovery.portfolio_optimizer.shared_context import (
+    _edge_risk_gross_exposure_budget_weights as edge_risk_gross_exposure_budget_weights,
+    _gross_exposure_allocation_priority as gross_exposure_allocation_priority,
+    candidate_passes_minimums,
+    capital_safety_rejection,
+    daily_net,
+    exact_replay_ledger_artifact_refs,
+    exact_replay_ledger_fill_count,
+    exact_replay_ledger_row_count,
+    negative_cash_observation_count,
+)
 from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
 
 
@@ -109,10 +123,20 @@ __all__: tuple[str, ...] = (
     "TestCase",
     "_TestPortfolioOptimizerBase",
     "_executable_scorecard_fields",
+    "candidate_passes_minimums",
+    "capital_safety_rejection",
+    "daily_net",
+    "edge_risk_gross_exposure_budget_weights",
     "evidence_bundle_blockers",
     "evidence_bundle_from_frontier_candidate",
     "evidence_bundle_from_payload",
+    "exact_replay_ledger_artifact_refs",
+    "exact_replay_ledger_fill_count",
+    "exact_replay_ledger_row_count",
+    "gross_exposure_allocation_priority",
+    "negative_cash_observation_count",
     "optimize_portfolio_candidate",
+    "oracle_blocker_count",
     "portfolio_candidate_from_payload",
     "portfolio_optimizer_module",
 )

--- a/services/torghut/tests/portfolio_optimizer/test_exact_replay_ledger_helpers_accept_exact_replay_refs_and_counts.py
+++ b/services/torghut/tests/portfolio_optimizer/test_exact_replay_ledger_helpers_accept_exact_replay_refs_and_counts.py
@@ -6,10 +6,18 @@ from tests.portfolio_optimizer.support import (
     ProfitTargetOraclePolicy,
     _TestPortfolioOptimizerBase,
     _executable_scorecard_fields,
+    candidate_passes_minimums,
+    capital_safety_rejection,
+    edge_risk_gross_exposure_budget_weights,
     evidence_bundle_blockers,
     evidence_bundle_from_frontier_candidate,
+    exact_replay_ledger_artifact_refs,
+    exact_replay_ledger_fill_count,
+    exact_replay_ledger_row_count,
+    gross_exposure_allocation_priority,
+    negative_cash_observation_count,
     optimize_portfolio_candidate,
-    portfolio_optimizer_module,
+    oracle_blocker_count,
 )
 
 
@@ -38,17 +46,17 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
         )
 
         self.assertEqual(
-            portfolio_optimizer_module._exact_replay_ledger_artifact_refs(bundle),
+            exact_replay_ledger_artifact_refs(bundle),
             [
                 "s3://proof/exact-ledger.json",
             ],
         )
         self.assertEqual(
-            portfolio_optimizer_module._exact_replay_ledger_row_count(bundle),
+            exact_replay_ledger_row_count(bundle),
             7,
         )
         self.assertEqual(
-            portfolio_optimizer_module._exact_replay_ledger_fill_count(bundle),
+            exact_replay_ledger_fill_count(bundle),
             6,
         )
 
@@ -75,7 +83,7 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
         )
 
         self.assertEqual(
-            portfolio_optimizer_module._exact_replay_ledger_artifact_refs(bundle),
+            exact_replay_ledger_artifact_refs(bundle),
             [],
         )
         self.assertNotIn(
@@ -83,11 +91,11 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
             bundle.replay_artifact_refs,
         )
         self.assertEqual(
-            portfolio_optimizer_module._exact_replay_ledger_row_count(bundle),
+            exact_replay_ledger_row_count(bundle),
             0,
         )
         self.assertEqual(
-            portfolio_optimizer_module._exact_replay_ledger_fill_count(bundle),
+            exact_replay_ledger_fill_count(bundle),
             0,
         )
 
@@ -136,11 +144,11 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
         self,
     ) -> None:
         self.assertEqual(
-            portfolio_optimizer_module._oracle_blocker_count({}),
+            oracle_blocker_count({}),
             Decimal("0"),
         )
         self.assertEqual(
-            portfolio_optimizer_module._oracle_blocker_count(
+            oracle_blocker_count(
                 {"profit_target_oracle": {"blockers": "missing_daily_net"}}
             ),
             Decimal("0"),
@@ -174,13 +182,13 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
             )
 
         self.assertEqual(
-            portfolio_optimizer_module._gross_exposure_allocation_priority(
+            gross_exposure_allocation_priority(
                 bundle("negative-edge", net_pnl_per_day="-1")
             ),
             Decimal("0"),
         )
         self.assertEqual(
-            portfolio_optimizer_module._gross_exposure_allocation_priority(
+            gross_exposure_allocation_priority(
                 bundle("inactive", net_pnl_per_day="100", active_day_ratio="0")
             ),
             Decimal("0"),
@@ -189,13 +197,11 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
     def test_edge_risk_gross_exposure_budget_weights_covers_saturation_and_noop(
         self,
     ) -> None:
-        saturated_weights = (
-            portfolio_optimizer_module._edge_risk_gross_exposure_budget_weights(
-                (Decimal("0.1"), Decimal("1.0")),
-                (Decimal("100"), Decimal("1")),
-                max_gross_exposure_pct_equity=Decimal("0.6"),
-                equal_scale=Decimal("0.6") / Decimal("1.1"),
-            )
+        saturated_weights = edge_risk_gross_exposure_budget_weights(
+            (Decimal("0.1"), Decimal("1.0")),
+            (Decimal("100"), Decimal("1")),
+            max_gross_exposure_pct_equity=Decimal("0.6"),
+            equal_scale=Decimal("0.6") / Decimal("1.1"),
         )
 
         self.assertIsNotNone(saturated_weights)
@@ -209,7 +215,7 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
         )
 
         self.assertIsNone(
-            portfolio_optimizer_module._edge_risk_gross_exposure_budget_weights(
+            edge_risk_gross_exposure_budget_weights(
                 (Decimal("0.25"), Decimal("0.75")),
                 (Decimal("1"), Decimal("3")),
                 max_gross_exposure_pct_equity=Decimal("0.5"),
@@ -256,31 +262,23 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
         zero_pnl = bundle("zero-pnl", {"net_pnl_per_day": "0"})
 
         self.assertEqual(
-            portfolio_optimizer_module._negative_cash_observation_count(
-                malformed_count
-            ),
+            negative_cash_observation_count(malformed_count),
             0,
         )
         self.assertEqual(
-            portfolio_optimizer_module._capital_safety_rejection(max_gross)["reason"],
+            capital_safety_rejection(max_gross)["reason"],
             "frontier_capital_violation",
         )
         self.assertEqual(
-            portfolio_optimizer_module._capital_safety_rejection(min_cash)["reason"],
+            capital_safety_rejection(min_cash)["reason"],
             "frontier_negative_cash",
         )
         self.assertEqual(
-            portfolio_optimizer_module._capital_safety_rejection(
-                observed_negative_cash
-            )["reason"],
+            capital_safety_rejection(observed_negative_cash)["reason"],
             "frontier_negative_cash_observed",
         )
-        self.assertFalse(
-            portfolio_optimizer_module._candidate_passes_minimums(max_gross)
-        )
-        self.assertFalse(
-            portfolio_optimizer_module._candidate_passes_minimums(zero_pnl)
-        )
+        self.assertFalse(candidate_passes_minimums(max_gross))
+        self.assertFalse(candidate_passes_minimums(zero_pnl))
 
     def test_capital_safety_rejection_uses_oracle_policy(self) -> None:
         def bundle(
@@ -331,32 +329,22 @@ class TestExactReplayLedgerHelpersAcceptExactReplayRefsAndCounts(
         )
 
         self.assertEqual(
-            portfolio_optimizer_module._capital_safety_rejection(
-                gross, oracle_policy=strict_policy
-            )["reason"],
+            capital_safety_rejection(gross, oracle_policy=strict_policy)["reason"],
             "frontier_capital_violation",
         )
         self.assertEqual(
-            portfolio_optimizer_module._capital_safety_rejection(
-                cash, oracle_policy=strict_policy
-            )["reason"],
+            capital_safety_rejection(cash, oracle_policy=strict_policy)["reason"],
             "frontier_negative_cash",
         )
         self.assertEqual(
-            portfolio_optimizer_module._capital_safety_rejection(
-                negative_cash, oracle_policy=strict_policy
-            )["reason"],
+            capital_safety_rejection(negative_cash, oracle_policy=strict_policy)[
+                "reason"
+            ],
             "frontier_negative_cash_observed",
         )
-        self.assertIsNone(
-            portfolio_optimizer_module._capital_safety_rejection(
-                gross, oracle_policy=relaxed_policy
-            )
-        )
+        self.assertIsNone(capital_safety_rejection(gross, oracle_policy=relaxed_policy))
         self.assertTrue(
-            portfolio_optimizer_module._candidate_passes_minimums(
-                negative_cash, oracle_policy=relaxed_policy
-            )
+            candidate_passes_minimums(negative_cash, oracle_policy=relaxed_policy)
         )
 
     def test_portfolio_uses_gross_exposure_budget_for_reported_low_gross_sleeves(

--- a/services/torghut/tests/portfolio_optimizer/test_portfolio_allows_research_candidates_pending_validation_contract.py
+++ b/services/torghut/tests/portfolio_optimizer/test_portfolio_allows_research_candidates_pending_validation_contract.py
@@ -6,10 +6,10 @@ from tests.portfolio_optimizer.support import (
     ProfitTargetOraclePolicy,
     _TestPortfolioOptimizerBase,
     _executable_scorecard_fields,
+    daily_net,
     evidence_bundle_from_frontier_candidate,
     optimize_portfolio_candidate,
     portfolio_candidate_from_payload,
-    portfolio_optimizer_module,
 )
 
 
@@ -604,7 +604,7 @@ class TestPortfolioAllowsResearchCandidatesPendingValidationContract(
             portfolio_size_max=1,
         )
 
-        self.assertEqual(portfolio_optimizer_module._daily_net(bundle), {})
+        self.assertEqual(daily_net(bundle), {})
         self.assertIsNotNone(portfolio)
         assert portfolio is not None
         scorecard = portfolio.objective_scorecard

--- a/services/torghut/tests/replay_ledger_ranker/support.py
+++ b/services/torghut/tests/replay_ledger_ranker/support.py
@@ -18,6 +18,25 @@ from app.trading.discovery.replay_ledger_ranker import (
     rank_replay_ledger_files,
     rank_replay_ledger_payload,
 )
+from app.trading.discovery.replay_ledger_ranker.promotion_blockers import (
+    daily_bucket_ranges,
+    dedupe_source_papers,
+    lob_reality_gap_stress_summary,
+    lob_signal_rows,
+    microstructure_stress_summary,
+    stress_penalty_bps,
+    utc,
+)
+from app.trading.discovery.replay_ledger_ranker.row_has_fill_status import (
+    best_day_share,
+    dedupe,
+    event_type,
+    fill_notional,
+    parse_window_datetime,
+    positive_decimal,
+    profit_factor,
+    safe_divide,
+)
 
 
 def _ts(day: int, minute: int = 0) -> str:
@@ -266,15 +285,30 @@ __all__: tuple[str, ...] = (
     "_with_execution_quality",
     "_with_lob_reality_gap_evidence",
     "_with_microstructure_stress_evidence",
+    "best_day_share",
     "build_replay_ledger_ranking_report",
+    "daily_bucket_ranges",
     "datetime",
+    "dedupe",
+    "dedupe_source_papers",
     "default_replay_ledger_ranking_policy",
+    "event_type",
+    "fill_notional",
     "json",
+    "lob_reality_gap_stress_summary",
+    "lob_signal_rows",
+    "microstructure_stress_summary",
+    "parse_window_datetime",
+    "positive_decimal",
+    "profit_factor",
     "pytest",
     "rank_replay_ledger_files",
     "rank_replay_ledger_payload",
     "rank_replay_ledgers_cli",
     "ranker",
+    "safe_divide",
+    "stress_penalty_bps",
     "sys",
     "timezone",
+    "utc",
 )

--- a/services/torghut/tests/replay_ledger_ranker/test_ranker_uses_runtime_ledger_net_pnl_and_window_day_ranking.py
+++ b/services/torghut/tests/replay_ledger_ranker/test_ranker_uses_runtime_ledger_net_pnl_and_window_day_ranking.py
@@ -10,15 +10,30 @@ from tests.replay_ledger_ranker.support import (
     _with_execution_quality,
     _with_lob_reality_gap_evidence,
     _with_microstructure_stress_evidence,
+    best_day_share,
     build_replay_ledger_ranking_report,
+    daily_bucket_ranges,
     datetime,
+    dedupe,
+    dedupe_source_papers,
     default_replay_ledger_ranking_policy,
+    event_type,
+    fill_notional,
     json,
+    lob_reality_gap_stress_summary,
+    lob_signal_rows,
+    microstructure_stress_summary,
+    parse_window_datetime,
+    positive_decimal,
+    profit_factor,
     pytest,
     rank_replay_ledger_files,
     rank_replay_ledger_payload,
     ranker,
+    safe_divide,
+    stress_penalty_bps,
     timezone,
+    utc,
 )
 
 
@@ -410,7 +425,7 @@ def test_ranker_discounts_microstructure_fragile_candidates(
 
 
 def test_lob_reality_gap_summary_fails_closed_without_signal_rows() -> None:
-    summary = ranker._lob_reality_gap_stress_summary(
+    summary = lob_reality_gap_stress_summary(
         [{"symbol": "NVDA", "executed_at": "bad-date"}]
     )
 
@@ -423,7 +438,7 @@ def test_lob_reality_gap_summary_fails_closed_without_signal_rows() -> None:
 
 
 def test_microstructure_stress_summary_fails_closed_without_signal_rows() -> None:
-    summary = ranker._microstructure_stress_summary(
+    summary = microstructure_stress_summary(
         [{"symbol": "NVDA", "executed_at": "bad-date"}]
     )
 
@@ -446,14 +461,14 @@ def test_microstructure_stress_summary_fails_closed_without_signal_rows() -> Non
 
 
 def test_microstructure_helpers_cover_nested_penalties_and_source_dedupe() -> None:
-    assert ranker._stress_penalty_bps(
+    assert stress_penalty_bps(
         {"ranking_features": {"replay_rank_penalty_bps": "-7"}}
     ) == Decimal("0")
-    assert ranker._stress_penalty_bps(
+    assert stress_penalty_bps(
         {"ranking_features": {"replay_rank_penalty_bps": "12.5"}}
     ) == Decimal("12.5")
 
-    papers = ranker._dedupe_source_papers(
+    papers = dedupe_source_papers(
         (
             "not-a-paper-list",
             [{"source_id": ""}, "not-a-paper", {"source_id": "paper-a"}],
@@ -465,7 +480,7 @@ def test_microstructure_helpers_cover_nested_penalties_and_source_dedupe() -> No
 
 
 def test_lob_signal_rows_use_fallback_timestamps_and_ingest_fields() -> None:
-    signals = ranker._lob_signal_rows(
+    signals = lob_signal_rows(
         [
             {
                 "symbol": "NVDA",
@@ -738,13 +753,13 @@ def test_ranker_flags_missing_equity_and_supports_helper_edge_cases() -> None:
     )
 
     assert "start_equity_missing_for_exposure_check" in ranking.promotion_blockers
-    assert ranker._daily_bucket_ranges(
+    assert daily_bucket_ranges(
         datetime(2026, 5, 18, 14, 30, tzinfo=timezone.utc),
         datetime(2026, 5, 18, 15, 0, tzinfo=timezone.utc),
     )[0][0] == datetime(2026, 5, 18, 14, 30, tzinfo=timezone.utc)
-    assert ranker._parse_window_datetime("") is None
-    assert ranker._parse_window_datetime("bad-date") is None
-    assert ranker._parse_window_datetime("2026-05-18T14:30:00Z") == datetime(
+    assert parse_window_datetime("") is None
+    assert parse_window_datetime("bad-date") is None
+    assert parse_window_datetime("2026-05-18T14:30:00Z") == datetime(
         2026,
         5,
         18,
@@ -752,7 +767,7 @@ def test_ranker_flags_missing_equity_and_supports_helper_edge_cases() -> None:
         30,
         tzinfo=timezone.utc,
     )
-    assert ranker._utc(datetime(2026, 5, 18, 14, 30)) == datetime(
+    assert utc(datetime(2026, 5, 18, 14, 30)) == datetime(
         2026,
         5,
         18,
@@ -760,19 +775,17 @@ def test_ranker_flags_missing_equity_and_supports_helper_edge_cases() -> None:
         30,
         tzinfo=timezone.utc,
     )
-    assert ranker._best_day_share(
-        {"2026-05-18": Decimal("-1")}, Decimal("-1")
-    ) == Decimal("1")
-    assert ranker._profit_factor(
+    assert best_day_share({"2026-05-18": Decimal("-1")}, Decimal("-1")) == Decimal("1")
+    assert profit_factor(
         {"2026-05-18": Decimal("3"), "2026-05-19": Decimal("-2")}
     ) == Decimal("1.5")
-    assert ranker._fill_notional({"filled_notional": "123.45"}) == Decimal("123.45")
-    assert ranker._fill_notional({"filled_qty": "0", "avg_fill_price": "100"}) is None
-    assert ranker._event_type({"event_type": "filled"}) == "fill"
-    assert ranker._event_type({"event_type": "trade_decision"}) == "decision"
-    assert ranker._event_type({"event_type": "submitted"}) == "order_submitted"
-    assert ranker._event_type({"filled_qty": "1"}) == "fill"
-    assert ranker._positive_decimal("0") is None
-    assert ranker._positive_decimal("not-decimal") is None
-    assert ranker._safe_divide(Decimal("1"), Decimal("0")) == Decimal("0")
-    assert ranker._dedupe(["a", "a", "b"]) == ["a", "b"]
+    assert fill_notional({"filled_notional": "123.45"}) == Decimal("123.45")
+    assert fill_notional({"filled_qty": "0", "avg_fill_price": "100"}) is None
+    assert event_type({"event_type": "filled"}) == "fill"
+    assert event_type({"event_type": "trade_decision"}) == "decision"
+    assert event_type({"event_type": "submitted"}) == "order_submitted"
+    assert event_type({"filled_qty": "1"}) == "fill"
+    assert positive_decimal("0") is None
+    assert positive_decimal("not-decimal") is None
+    assert safe_divide(Decimal("1"), Decimal("0")) == Decimal("0")
+    assert dedupe(["a", "a", "b"]) == ["a", "b"]

--- a/services/torghut/tests/submission_council/support.py
+++ b/services/torghut/tests/submission_council/support.py
@@ -41,41 +41,59 @@ from app.trading.runtime_decision_authority import (
     source_decision_mode_is_profit_proof_eligible,
 )
 from app.trading.submission_council import (
-    _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
-    _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
-    _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
-    _QUANT_HEALTH_CACHE,
-    _bounded_source_collection_probe_window,
-    _certificate_evidence_authority_score,
-    _certificate_evidence_selection_key,
-    _coerce_aware_datetime,
-    _load_latest_certificate_evidence,
-    _load_latest_runtime_ledger_summary,
-    _attach_lineage_refs,
-    _load_persisted_profit_rejection_summary,
-    _load_profit_promotion_table_counts,
-    _load_runtime_ledger_repair_candidates,
-    _merge_runtime_certificate_evidence,
-    _maybe_set_runtime_ledger_status_statement_timeout,
-    _metric_window_activity_reason_codes,
-    _rollback_runtime_ledger_status_session,
-    _runtime_ledger_aggregate_candidate_payloads,
-    _runtime_ledger_latest_payloads_per_symbol,
-    _runtime_ledger_merge_count_maps,
-    _runtime_ledger_paper_probation_candidates,
-    _runtime_ledger_repair_reason_codes,
-    _runtime_ledger_repair_score,
-    _runtime_ledger_status_query_timeout_ms,
-    _refresh_runtime_summary_totals,
-    _runtime_ledger_paper_probation_blockers,
-    _runtime_ledger_paper_probation_import_plan,
-    _runtime_ledger_source_collection_candidates,
-    _runtime_ledger_source_collection_target_progress_payload,
-    _runtime_ledger_unique_sequence,
     build_hypothesis_runtime_summary,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
     resolve_quant_health_url,
+)
+from app.trading.submission_council.certificate_eval import (
+    attach_lineage_refs as _attach_lineage_refs,
+)
+from app.trading.submission_council.certificate_loading import (
+    certificate_evidence_selection_key as _certificate_evidence_selection_key,
+    load_latest_certificate_evidence as _load_latest_certificate_evidence,
+    merge_runtime_certificate_evidence as _merge_runtime_certificate_evidence,
+    metric_window_activity_reason_codes as _metric_window_activity_reason_codes,
+)
+from app.trading.submission_council.common import (
+    CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT as _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
+    PROMOTION_PORTFOLIO_READY_SCAN_LIMIT as _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
+    PROMOTION_TABLE_COUNT_SCAN_LIMIT as _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
+    QUANT_HEALTH_CACHE as _QUANT_HEALTH_CACHE,
+    coerce_aware_datetime as _coerce_aware_datetime,
+    maybe_set_runtime_ledger_status_statement_timeout as _maybe_set_runtime_ledger_status_statement_timeout,
+    rollback_runtime_ledger_status_session as _rollback_runtime_ledger_status_session,
+    runtime_ledger_status_query_timeout_ms as _runtime_ledger_status_query_timeout_ms,
+)
+from app.trading.submission_council.import_plan import (
+    runtime_ledger_paper_probation_import_plan as _runtime_ledger_paper_probation_import_plan,
+)
+from app.trading.submission_council.paper_probation import (
+    _bounded_source_collection_probe_window,
+    _runtime_ledger_paper_probation_blockers,
+    runtime_ledger_paper_probation_candidates as _runtime_ledger_paper_probation_candidates,
+    runtime_ledger_source_collection_candidates as _runtime_ledger_source_collection_candidates,
+    runtime_ledger_source_collection_target_progress_payload as _runtime_ledger_source_collection_target_progress_payload,
+)
+from app.trading.submission_council.profit_readiness import (
+    load_persisted_profit_rejection_summary as _load_persisted_profit_rejection_summary,
+    load_profit_promotion_table_counts as _load_profit_promotion_table_counts,
+)
+from app.trading.submission_council.repair_candidates import (
+    load_runtime_ledger_repair_candidates as _load_runtime_ledger_repair_candidates,
+    refresh_runtime_summary_totals as _refresh_runtime_summary_totals,
+)
+from app.trading.submission_council.runtime_certificates import (
+    certificate_evidence_authority_score as _certificate_evidence_authority_score,
+    load_latest_runtime_ledger_summary as _load_latest_runtime_ledger_summary,
+    runtime_ledger_repair_reason_codes as _runtime_ledger_repair_reason_codes,
+    runtime_ledger_repair_score as _runtime_ledger_repair_score,
+)
+from app.trading.submission_council.runtime_summary import (
+    runtime_ledger_aggregate_candidate_payloads as _runtime_ledger_aggregate_candidate_payloads,
+    runtime_ledger_latest_payloads_per_symbol as _runtime_ledger_latest_payloads_per_symbol,
+    runtime_ledger_merge_count_maps as _runtime_ledger_merge_count_maps,
+    runtime_ledger_unique_sequence as _runtime_ledger_unique_sequence,
 )
 
 

--- a/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py
+++ b/services/torghut/tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py
@@ -3,6 +3,20 @@ from __future__ import annotations
 import app.trading.discovery.evidence_bundles as evidence_bundles
 import app.trading.discovery.replay_tape as replay_tape
 from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.fast_replay.extract_price import (
+    extract_microprice_bias_bps,
+    extract_ofi_pressure,
+    extract_price,
+    extract_quote_depth_imbalance,
+    extract_spread_bps,
+    extract_volume,
+    float_or_none,
+    mapping,
+)
+from app.trading.discovery.fast_replay.frontier_selection_blockers_for_row import (
+    candidate_direction,
+    candidate_symbols,
+)
 import scripts.local_intraday_tsmom_replay as replay_mod
 import scripts.materialize_replay_tape as replay_materializer
 import scripts.whitepaper_autoresearch_runner.artifact_io as artifact_io
@@ -18,7 +32,6 @@ from tests.whitepaper_autoresearch.autoresearch_runner_base import (
     WhitepaperAutoresearchRunnerTestCaseBase,
     date,
     datetime,
-    fast_replay,
     json,
     materialize_signal_tape,
     patch,
@@ -385,10 +398,10 @@ class TestAutoresearchRunnerMaterializedReplay(
                 }
             },
         )
-        self.assertEqual(fast_replay._candidate_symbols(no_universe_spec), ("NVDA",))
-        self.assertEqual(fast_replay._candidate_direction(no_universe_spec), 1.0)
+        self.assertEqual(candidate_symbols(no_universe_spec), ("NVDA",))
+        self.assertEqual(candidate_direction(no_universe_spec), 1.0)
         self.assertEqual(
-            fast_replay._extract_price(
+            extract_price(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -398,7 +411,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             101.0,
         )
         self.assertIsNone(
-            fast_replay._extract_price(
+            extract_price(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -406,7 +419,7 @@ class TestAutoresearchRunnerMaterializedReplay(
                 )
             )
         )
-        bid_ask_spread = fast_replay._extract_spread_bps(
+        bid_ask_spread = extract_spread_bps(
             SignalEnvelope(
                 event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                 symbol="NVDA",
@@ -415,7 +428,7 @@ class TestAutoresearchRunnerMaterializedReplay(
         )
         self.assertAlmostEqual(bid_ask_spread or 0.0, 99.50248756218905)
         self.assertEqual(
-            fast_replay._extract_spread_bps(
+            extract_spread_bps(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -425,7 +438,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             5.0,
         )
         self.assertAlmostEqual(
-            fast_replay._extract_quote_depth_imbalance(
+            extract_quote_depth_imbalance(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -439,7 +452,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             1.0 / 3.0,
         )
         self.assertAlmostEqual(
-            fast_replay._extract_ofi_pressure(
+            extract_ofi_pressure(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -450,7 +463,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             0.46211715726000974,
         )
         self.assertGreater(
-            fast_replay._extract_microprice_bias_bps(
+            extract_microprice_bias_bps(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -466,7 +479,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             0.0,
         )
         self.assertEqual(
-            fast_replay._extract_volume(
+            extract_volume(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -476,7 +489,7 @@ class TestAutoresearchRunnerMaterializedReplay(
             12345.0,
         )
         self.assertIsNone(
-            fast_replay._extract_spread_bps(
+            extract_spread_bps(
                 SignalEnvelope(
                     event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
@@ -484,9 +497,9 @@ class TestAutoresearchRunnerMaterializedReplay(
                 )
             )
         )
-        self.assertIsNone(fast_replay._float_or_none("not-a-number"))
-        self.assertIsNone(fast_replay._float_or_none(float("nan")))
-        self.assertEqual(fast_replay._mapping("not-a-mapping"), {})
+        self.assertIsNone(float_or_none("not-a-number"))
+        self.assertIsNone(float_or_none(float("nan")))
+        self.assertEqual(mapping("not-a-mapping"), {})
 
     def test_candidate_specs_replay_skips_compiler_and_replays_selected_specs(
         self,


### PR DESCRIPTION
## Summary

- Removes private helper exports from the `fast_replay`, `portfolio_optimizer`, `replay_ledger_ranker`, and `submission_council` app package facades.
- Rewrites tests to import helper functions from their owning modules instead of package-level private aliases.
- Deletes dead `getattr` and alias-only facade wiring while keeping public runtime imports stable.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/submission_council/__init__.py app/trading/discovery/portfolio_optimizer/__init__.py app/trading/discovery/replay_ledger_ranker/__init__.py app/trading/discovery/fast_replay/__init__.py tests/submission_council tests/portfolio_optimizer tests/replay_ledger_ranker tests/fast_replay/support.py tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py`
- `uv run --frozen ruff check app/trading/submission_council/__init__.py app/trading/discovery/portfolio_optimizer/__init__.py app/trading/discovery/replay_ledger_ranker/__init__.py app/trading/discovery/fast_replay/__init__.py tests/submission_council tests/portfolio_optimizer tests/replay_ledger_ranker tests/fast_replay/support.py tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py`
- `uv run --frozen pytest tests/submission_council tests/portfolio_optimizer tests/replay_ledger_ranker tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py tests/test_explicit_module_facade_exports.py`
- `uv run --frozen ruff format --check app scripts tests migrations`
- `uv run --frozen ruff check --select PLC0414 app scripts tests migrations`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines app/trading/discovery/fast_replay/__init__.py app/trading/discovery/portfolio_optimizer/__init__.py app/trading/discovery/replay_ledger_ranker/__init__.py app/trading/submission_council/__init__.py tests/fast_replay/support.py tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py tests/portfolio_optimizer/support.py tests/portfolio_optimizer/test_exact_replay_ledger_helpers_accept_exact_replay_refs_and_counts.py tests/portfolio_optimizer/test_portfolio_allows_research_candidates_pending_validation_contract.py tests/replay_ledger_ranker/support.py tests/replay_ledger_ranker/test_ranker_uses_runtime_ledger_net_pnl_and_window_day_ranking.py tests/submission_council/support.py tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/discovery/fast_replay/__init__.py app/trading/discovery/portfolio_optimizer/__init__.py app/trading/discovery/replay_ledger_ranker/__init__.py app/trading/submission_council/__init__.py tests/fast_replay/support.py tests/fast_replay/test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only.py tests/portfolio_optimizer/support.py tests/portfolio_optimizer/test_exact_replay_ledger_helpers_accept_exact_replay_refs_and_counts.py tests/portfolio_optimizer/test_portfolio_allows_research_candidates_pending_validation_contract.py tests/replay_ledger_ranker/support.py tests/replay_ledger_ranker/test_ranker_uses_runtime_ledger_net_pnl_and_window_day_ranking.py tests/submission_council/support.py tests/whitepaper_autoresearch/test_autoresearch_runner_materialized_replay.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None for public runtime APIs. Private package-level helper aliases are no longer exported from the touched app package facades.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
