### PR TITLE
ci(torghut): block dead code and unused suppressions

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -458,7 +458,7 @@ jobs:
 
       - name: Unused import and suppression gate
         working-directory: services/torghut
-        run: uv run --frozen ruff check app tests scripts migrations --select RUF100,F401 --preview
+        run: uv run --frozen ruff check app tests scripts migrations --select F401 --preview
 
       - name: Pylint structural hardening gate
         working-directory: services/torghut

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -456,6 +456,10 @@ jobs:
         working-directory: services/torghut
         run: uv run --frozen ruff check app tests scripts migrations
 
+      - name: Unused import and suppression gate
+        working-directory: services/torghut
+        run: uv run --frozen ruff check app tests scripts migrations --select RUF100,F401 --preview
+
       - name: Pylint structural hardening gate
         working-directory: services/torghut
         run: uv run --frozen python scripts/run_pylint_torghut_structural_gate.py
@@ -927,6 +931,6 @@ jobs:
         working-directory: services/torghut
         run: uv run --frozen ruff check app scripts migrations --select S --statistics --exit-zero
 
-      - name: Dead-code scan (vulture, non-blocking)
+      - name: Dead-code scan (vulture)
         working-directory: services/torghut
-        run: uv run --frozen vulture --config pyproject.toml || true
+        run: uv run --frozen vulture --config pyproject.toml

--- a/services/torghut/scripts/build_revenue_repair_digest.py
+++ b/services/torghut/scripts/build_revenue_repair_digest.py
@@ -11,7 +11,7 @@ _SERVICE_ROOT = Path(__file__).resolve().parents[1]
 if str(_SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(_SERVICE_ROOT))
 
-from app.trading.revenue_repair import (
+from app.trading.revenue_repair import (  # noqa: E402
     SCHEMA_VERSION,
     bool_value as _bool,
     build_alpha_evidence_foundry,

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -16,13 +16,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from app.trading.tigerbeetle_journal import (
+from app.trading.tigerbeetle_journal import (  # noqa: E402
     SOURCE_TYPE_EXECUTION,
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
 )
-from scripts import journal_tigerbeetle_order_events as journal_script
+from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: E402
 
 MAX_TIGERBEETLE_BATCH_SIZE = 5000
 LIVE_ORDER_EVENT_BATCH_SIZE = 50

--- a/services/torghut/scripts/simple_lane_replay/shared_context.py
+++ b/services/torghut/scripts/simple_lane_replay/shared_context.py
@@ -29,26 +29,26 @@ REPO_ROOT = SERVICE_ROOT.parent.parent
 if str(SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(SERVICE_ROOT))
 
-from app import config
-from app.models import Base, Execution, Strategy, TradeDecision
-from app.strategies.catalog import (
+from app import config  # noqa: E402
+from app.models import Base, Execution, Strategy, TradeDecision  # noqa: E402
+from app.strategies.catalog import (  # noqa: E402
     StrategyConfig,
     _compose_strategy_description,
 )
-from app.trading.decisions import DecisionEngine
-from app.trading.execution import OrderExecutor
-from app.trading.execution_adapters import (
+from app.trading.decisions import DecisionEngine  # noqa: E402
+from app.trading.execution import OrderExecutor  # noqa: E402
+from app.trading.execution_adapters import (  # noqa: E402
     OrderSubmission,
     SimulationExecutionAdapter,
 )
-from app.trading.firewall import OrderFirewall
-from app.trading.ingest import ClickHouseSignalIngestor, SignalBatch
-from app.trading.models import SignalEnvelope
-from app.trading.reconcile import Reconciler
-from app.trading.risk import RiskEngine
-from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline
-from app.trading.scheduler.state import TradingState
-from app.trading.universe import UniverseResolver
+from app.trading.firewall import OrderFirewall  # noqa: E402
+from app.trading.ingest import ClickHouseSignalIngestor, SignalBatch  # noqa: E402
+from app.trading.models import SignalEnvelope  # noqa: E402
+from app.trading.reconcile import Reconciler  # noqa: E402
+from app.trading.risk import RiskEngine  # noqa: E402
+from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline  # noqa: E402
+from app.trading.scheduler.state import TradingState  # noqa: E402
+from app.trading.universe import UniverseResolver  # noqa: E402
 
 DEFAULT_SYMBOLS = [
     "NVDA",


### PR DESCRIPTION
## Summary

- Added a blocking Torghut CI gate for preview Ruff unused-import checks.
- Restored required `E402` suppressions for scripts that intentionally mutate `sys.path` before app imports.
- Made the configured vulture dead-code scan fail CI instead of reporting advisory output.
- Kept `RUF100` unused-suppression enforcement in the full Ruff lint job, where Ruff sees the complete configured rule set.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations --select F401 --preview`
- `uv run --frozen vulture --config pyproject.toml`
- `git diff --check`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-ci.yml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
