### PR TITLE
refactor(torghut): type broker firewall reads

### DIFF
--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Optional, cast
+from typing import Any, Protocol, cast
 
-from ..alpaca_client import OrderFirewallToken, TorghutAlpacaClient
+from ..alpaca_client import OrderFirewallToken
 from ..config import settings
 
 logger = logging.getLogger(__name__)
@@ -23,10 +23,50 @@ class OrderFirewallStatus:
     reason: str
 
 
+class _OrderFirewallBrokerClient(Protocol):
+    """Broker methods the order firewall is allowed to call."""
+
+    def submit_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, Any] | None = None,
+        firewall_token: OrderFirewallToken,
+    ) -> dict[str, Any]: ...
+
+    def cancel_order(
+        self, alpaca_order_id: str, *, firewall_token: OrderFirewallToken
+    ) -> bool: ...
+
+    def cancel_all_orders(
+        self, *, firewall_token: OrderFirewallToken
+    ) -> list[dict[str, Any]]: ...
+
+    def get_order_by_client_order_id(
+        self, client_order_id: str
+    ) -> dict[str, Any] | None: ...
+
+    def get_order(self, alpaca_order_id: str) -> dict[str, Any]: ...
+
+    def list_orders(self, status: str = "all") -> list[dict[str, Any]]: ...
+
+    def list_positions(self) -> list[dict[str, Any]] | None: ...
+
+    def get_account(self) -> dict[str, Any] | None: ...
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any] | None: ...
+
+
 class OrderFirewall:
     """Single audited gateway for order submission/cancellation."""
 
-    def __init__(self, client: TorghutAlpacaClient) -> None:
+    def __init__(self, client: _OrderFirewallBrokerClient) -> None:
         self._client = client
         self._token = OrderFirewallToken()
 
@@ -57,9 +97,9 @@ class OrderFirewall:
         qty: float,
         order_type: str,
         time_in_force: str,
-        limit_price: Optional[float] = None,
-        stop_price: Optional[float] = None,
-        extra_params: Optional[dict[str, Any]] = None,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         status = self.status()
         if status.kill_switch_enabled:
@@ -98,33 +138,21 @@ class OrderFirewall:
         return normalized
 
     def list_orders(self, status: str = "all") -> list[dict[str, Any]]:
-        lister = getattr(self._client, "list_orders", None)
-        if not callable(lister):
-            return []
-        result = lister(status=status)
+        result = self._client.list_orders(status=status)
         return _normalize_mapping_list(result)
 
     def list_positions(self) -> list[dict[str, Any]] | None:
-        lister = getattr(self._client, "list_positions", None)
-        if not callable(lister):
-            return None
-        result = lister()
+        result = self._client.list_positions()
         if result is None:
             return None
         return _normalize_mapping_list(result)
 
     def get_account(self) -> dict[str, Any] | None:
-        getter = getattr(self._client, "get_account", None)
-        if not callable(getter):
-            return None
-        result = getter()
+        result = self._client.get_account()
         return _normalize_mapping(result)
 
     def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any] | None:
-        getter = getattr(self._client, "get_asset", None)
-        if not callable(getter):
-            return None
-        result = getter(symbol_or_asset_id)
+        result = self._client.get_asset(symbol_or_asset_id)
         return _normalize_mapping(result)
 
 

--- a/services/torghut/tests/pipeline/trading_pipeline_support.py
+++ b/services/torghut/tests/pipeline/trading_pipeline_support.py
@@ -382,6 +382,14 @@ class FakeAlpacaClient:
     def get_account(self) -> dict[str, str]:
         return {"equity": "10000", "cash": "10000", "buying_power": "10000"}
 
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, str | bool]:
+        return {
+            "symbol": symbol_or_asset_id,
+            "tradable": True,
+            "shortable": True,
+            "easy_to_borrow": True,
+        }
+
     def list_positions(self) -> list[dict[str, str]]:
         return []
 
@@ -396,7 +404,7 @@ class FakeAlpacaClient:
         time_in_force: str | None = None,
         limit_price: float | None = None,
         stop_price: float | None = None,
-        extra_params: dict[str, str] | None = None,
+        extra_params: dict[str, Any] | None = None,
         firewall_token: object | None = None,
     ) -> dict[str, str]:
         if isinstance(request, OrderSubmission):
@@ -482,7 +490,7 @@ class RejectingAlpacaClient(FakeAlpacaClient):
         time_in_force: str | None = None,
         limit_price: float | None = None,
         stop_price: float | None = None,
-        extra_params: dict[str, str] | None = None,
+        extra_params: dict[str, Any] | None = None,
         firewall_token: object | None = None,
     ) -> dict[str, str]:
         self.submit_calls += 1

--- a/services/torghut/tests/test_order_firewall.py
+++ b/services/torghut/tests/test_order_firewall.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest import TestCase
 
 from app.config import settings
@@ -8,8 +9,14 @@ from app.trading.firewall import OrderFirewall, OrderFirewallBlocked
 
 class FakeAlpacaClient:
     def __init__(self) -> None:
-        self.submissions: list[dict[str, str]] = []
+        self.submissions: list[dict[str, Any]] = []
         self.cancel_all_calls = 0
+        self.account_calls = 0
+        self.asset_calls: list[str] = []
+        self.position_calls = 0
+        self.order_list_calls: list[str] = []
+        self.order_lookup_calls: list[str] = []
+        self.client_order_lookup_calls: list[str] = []
 
     def submit_order(
         self,
@@ -20,10 +27,10 @@ class FakeAlpacaClient:
         time_in_force: str,
         limit_price: float | None = None,
         stop_price: float | None = None,
-        extra_params: dict[str, str] | None = None,
+        extra_params: dict[str, Any] | None = None,
         *,
         firewall_token: object | None = None,
-    ) -> dict[str, str]:
+    ) -> dict[str, Any]:
         order = {
             "id": "order-1",
             "symbol": symbol,
@@ -36,14 +43,41 @@ class FakeAlpacaClient:
 
     def cancel_all_orders(
         self, *, firewall_token: object | None = None
-    ) -> list[dict[str, str]]:
+    ) -> list[dict[str, Any]]:
         self.cancel_all_calls += 1
         return [{"id": "order-1"}]
 
     def cancel_order(
         self, alpaca_order_id: str, *, firewall_token: object | None = None
     ) -> bool:
+        _ = alpaca_order_id
         return True
+
+    def get_order_by_client_order_id(
+        self, client_order_id: str
+    ) -> dict[str, Any] | None:
+        self.client_order_lookup_calls.append(client_order_id)
+        return {"id": "order-1", "client_order_id": client_order_id}
+
+    def get_order(self, alpaca_order_id: str) -> dict[str, Any]:
+        self.order_lookup_calls.append(alpaca_order_id)
+        return {"id": alpaca_order_id, "status": "accepted"}
+
+    def list_orders(self, status: str = "all") -> list[dict[str, Any]]:
+        self.order_list_calls.append(status)
+        return [{"id": "order-1", "status": status}]
+
+    def list_positions(self) -> list[dict[str, Any]]:
+        self.position_calls += 1
+        return [{"symbol": "AAPL", "qty": "1"}]
+
+    def get_account(self) -> dict[str, Any]:
+        self.account_calls += 1
+        return {"equity": "10000"}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any]:
+        self.asset_calls.append(symbol_or_asset_id)
+        return {"symbol": symbol_or_asset_id, "tradable": True}
 
 
 class TestOrderFirewall(TestCase):
@@ -95,3 +129,30 @@ class TestOrderFirewall(TestCase):
         self.assertFalse(firewall.cancel_open_orders_if_kill_switch())
         self.assertEqual(client.cancel_all_calls, 0)
         self.assertEqual(firewall.status().reason, "ok")
+
+    def test_firewall_read_methods_use_explicit_broker_contract(self) -> None:
+        client = FakeAlpacaClient()
+        firewall = OrderFirewall(client)
+
+        self.assertEqual(
+            firewall.list_orders(status="open"), [{"id": "order-1", "status": "open"}]
+        )
+        self.assertEqual(firewall.list_positions(), [{"symbol": "AAPL", "qty": "1"}])
+        self.assertEqual(firewall.get_account(), {"equity": "10000"})
+        self.assertEqual(
+            firewall.get_asset("AAPL"), {"symbol": "AAPL", "tradable": True}
+        )
+        self.assertEqual(
+            firewall.get_order("order-123"), {"id": "order-123", "status": "accepted"}
+        )
+        self.assertEqual(
+            firewall.get_order_by_client_order_id("client-123"),
+            {"id": "order-1", "client_order_id": "client-123"},
+        )
+
+        self.assertEqual(client.order_list_calls, ["open"])
+        self.assertEqual(client.position_calls, 1)
+        self.assertEqual(client.account_calls, 1)
+        self.assertEqual(client.asset_calls, ["AAPL"])
+        self.assertEqual(client.order_lookup_calls, ["order-123"])
+        self.assertEqual(client.client_order_lookup_calls, ["client-123"])


### PR DESCRIPTION
## Summary

- Replaces `OrderFirewall` dynamic broker read fallbacks with a private typed broker protocol.
- Removes silent `getattr` fallback behavior for account, asset, order, and position reads through the firewall.
- Tightens Alpaca test fakes so firewall tests exercise the explicit broker read contract.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/alpaca_client.py app/trading/firewall.py tests/test_order_firewall.py tests/pipeline/trading_pipeline_support.py`
- `uv run --frozen ruff check app/alpaca_client.py app/trading/firewall.py tests/test_order_firewall.py tests/pipeline/trading_pipeline_support.py`
- `uv run --frozen pytest tests/test_order_firewall.py tests/test_alpaca_client.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/firewall.py tests/pipeline/trading_pipeline_support.py tests/test_order_firewall.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/firewall.py tests/pipeline/trading_pipeline_support.py tests/test_order_firewall.py`
- `uv run --frozen vulture app scripts --min-confidence 100`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
