### PR TITLE
refactor(torghut): prune broker read compatibility

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -42,21 +42,13 @@ class _ReadOnlyTradingClientLike(Protocol):
 
     def get_all_positions(self) -> Iterable[Any]: ...
 
+    def get_asset(self, symbol_or_asset_id: str) -> Any: ...
+
     def get_orders(self, filter: Any | None = None) -> Iterable[Any]: ...
 
     def get_order_by_id(self, order_id: str) -> Any: ...
 
-
-class _AssetLookupTradingClientLike(Protocol):
-    def get_asset(self, symbol_or_asset_id: str) -> Any: ...
-
-
-class _ClientOrderLookupTradingClientLike(Protocol):
-    def get_order_by_client_order_id(self, client_order_id: str) -> Any: ...
-
-
-class _LegacyClientOrderLookupTradingClientLike(Protocol):
-    def get_order_by_client_id(self, client_order_id: str) -> Any: ...
+    def get_order_by_client_id(self, client_id: str) -> Any: ...
 
 
 class _TradingClientLike(_ReadOnlyTradingClientLike, Protocol):
@@ -89,26 +81,11 @@ class _ReadOnlyTradingClient:
     def get_order_by_id(self, order_id: str) -> Any:
         return self._trading_client.get_order_by_id(order_id)
 
-    def get_asset(self, symbol_or_asset_id: str) -> Any | None:
-        if not hasattr(self._trading_client, "get_asset"):
-            return None
-        asset_client = cast(_AssetLookupTradingClientLike, self._trading_client)
-        return asset_client.get_asset(symbol_or_asset_id)
+    def get_asset(self, symbol_or_asset_id: str) -> Any:
+        return self._trading_client.get_asset(symbol_or_asset_id)
 
-    def get_order_by_client_order_id(self, client_order_id: str) -> Any | None:
-        if hasattr(self._trading_client, "get_order_by_client_order_id"):
-            order_client = cast(
-                _ClientOrderLookupTradingClientLike,
-                self._trading_client,
-            )
-            return order_client.get_order_by_client_order_id(client_order_id)
-        if hasattr(self._trading_client, "get_order_by_client_id"):
-            legacy_order_client = cast(
-                _LegacyClientOrderLookupTradingClientLike,
-                self._trading_client,
-            )
-            return legacy_order_client.get_order_by_client_id(client_order_id)
-        return None
+    def get_order_by_client_id(self, client_id: str) -> Any:
+        return self._trading_client.get_order_by_client_id(client_id)
 
 
 class TorghutAlpacaClient:
@@ -191,7 +168,7 @@ class TorghutAlpacaClient:
         self, client_order_id: str
     ) -> Dict[str, Any] | None:
         try:
-            order = self.trading.get_order_by_client_order_id(client_order_id)
+            order = self.trading.get_order_by_client_id(client_order_id)
         except APIError as exc:
             status_code = getattr(exc, "status_code", None)
             if isinstance(status_code, int) and status_code == 404:

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 
 from ..alpaca_client import OrderFirewallToken
 from ..config import settings
@@ -120,56 +119,25 @@ class OrderFirewall:
         return self._client.cancel_order(alpaca_order_id, firewall_token=self._token)
 
     def cancel_all_orders(self) -> list[dict[str, Any]]:
-        orders = self._client.cancel_all_orders(firewall_token=self._token)
-        return _normalize_mapping_list(orders)
+        return self._client.cancel_all_orders(firewall_token=self._token)
 
     def get_order_by_client_order_id(
         self, client_order_id: str
     ) -> dict[str, Any] | None:
         # Reads are always allowed; this is used for idempotency backfills.
-        order = self._client.get_order_by_client_order_id(client_order_id)
-        return _normalize_mapping(order)
+        return self._client.get_order_by_client_order_id(client_order_id)
 
     def get_order(self, alpaca_order_id: str) -> dict[str, Any]:
-        order = self._client.get_order(alpaca_order_id)
-        normalized = _normalize_mapping(order)
-        if normalized is None:
-            return {}
-        return normalized
+        return self._client.get_order(alpaca_order_id)
 
     def list_orders(self, status: str = "all") -> list[dict[str, Any]]:
-        result = self._client.list_orders(status=status)
-        return _normalize_mapping_list(result)
+        return self._client.list_orders(status=status)
 
     def list_positions(self) -> list[dict[str, Any]] | None:
-        result = self._client.list_positions()
-        if result is None:
-            return None
-        return _normalize_mapping_list(result)
+        return self._client.list_positions()
 
     def get_account(self) -> dict[str, Any] | None:
-        result = self._client.get_account()
-        return _normalize_mapping(result)
+        return self._client.get_account()
 
     def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any] | None:
-        result = self._client.get_asset(symbol_or_asset_id)
-        return _normalize_mapping(result)
-
-
-def _normalize_mapping(value: object) -> dict[str, Any] | None:
-    if not isinstance(value, Mapping):
-        return None
-    mapping = cast(Mapping[object, Any], value)
-    return {str(key): item for key, item in mapping.items()}
-
-
-def _normalize_mapping_list(value: object) -> list[dict[str, Any]]:
-    if not isinstance(value, list):
-        return []
-    normalized: list[dict[str, Any]] = []
-    items = cast(list[object], value)
-    for item in items:
-        mapping = _normalize_mapping(item)
-        if mapping is not None:
-            normalized.append(mapping)
-    return normalized
+        return self._client.get_asset(symbol_or_asset_id)

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -39,11 +39,17 @@ class DummyTradingClient:
     def get_all_positions(self) -> list[DummyModel]:
         return [DummyModel(symbol="AAPL", qty="1")]
 
+    def get_asset(self, symbol_or_asset_id: str) -> DummyModel:
+        return DummyModel(symbol=symbol_or_asset_id, tradable=True)
+
     def get_orders(self, filter: GetOrdersRequest | None = None) -> list[DummyModel]:
         return [DummyModel(id="order-1", symbol="AAPL", uuid_id=uuid.uuid4())]
 
     def get_order_by_id(self, order_id: str) -> DummyModel:
         return DummyModel(id=order_id, symbol="AAPL")
+
+    def get_order_by_client_id(self, client_id: str) -> DummyModel:
+        return DummyModel(id="order-xyz", client_order_id=client_id)
 
     def submit_order(self, order_data: Any) -> DummyModel:
         return DummyModel(
@@ -166,16 +172,12 @@ class TestAlpacaClient(TestCase):
         with self.assertRaisesRegex(TypeError, "Unsupported model type"):
             client.get_account()
 
-    def test_get_order_by_client_order_id_falls_back_to_client_id(self) -> None:
-        class TradingClientWithClientId(DummyTradingClient):
-            def get_order_by_client_id(self, client_id: str) -> DummyModel:
-                return DummyModel(id="order-xyz", client_order_id=client_id)
-
+    def test_get_order_by_client_order_id_uses_alpaca_client_id_lookup(self) -> None:
         client = TorghutAlpacaClient(
             api_key="k",
             secret_key="s",
             base_url="https://paper-api.alpaca.markets",
-            trading_client=TradingClientWithClientId(),
+            trading_client=DummyTradingClient(),
             data_client=DummyDataClient(),
         )
 
@@ -184,45 +186,12 @@ class TestAlpacaClient(TestCase):
         self.assertEqual(order["id"], "order-xyz")
         self.assertEqual(order["client_order_id"], "client-123")
 
-    def test_get_order_by_client_order_id_prefers_named_lookup(self) -> None:
-        class TradingClientWithClientOrderId(DummyTradingClient):
-            def get_order_by_client_order_id(self, client_id: str) -> DummyModel:
-                return DummyModel(id="order-named", client_order_id=client_id)
-
-        client = TorghutAlpacaClient(
-            api_key="k",
-            secret_key="s",
-            base_url="https://paper-api.alpaca.markets",
-            trading_client=TradingClientWithClientOrderId(),
-            data_client=DummyDataClient(),
-        )
-
-        order = client.get_order_by_client_order_id("client-456")
-        assert order is not None
-        self.assertEqual(order["id"], "order-named")
-        self.assertEqual(order["client_order_id"], "client-456")
-
-    def test_get_order_by_client_order_id_returns_none_when_unavailable(self) -> None:
+    def test_get_asset_returns_model_from_read_surface(self) -> None:
         client = TorghutAlpacaClient(
             api_key="k",
             secret_key="s",
             base_url="https://paper-api.alpaca.markets",
             trading_client=DummyTradingClient(),
-            data_client=DummyDataClient(),
-        )
-
-        self.assertIsNone(client.get_order_by_client_order_id("client-123"))
-
-    def test_get_asset_returns_model_when_read_surface_supports_lookup(self) -> None:
-        class TradingClientWithAssetLookup(DummyTradingClient):
-            def get_asset(self, symbol_or_asset_id: str) -> DummyModel:
-                return DummyModel(symbol=symbol_or_asset_id, tradable=True)
-
-        client = TorghutAlpacaClient(
-            api_key="k",
-            secret_key="s",
-            base_url="https://paper-api.alpaca.markets",
-            trading_client=TradingClientWithAssetLookup(),
             data_client=DummyDataClient(),
         )
 
@@ -230,17 +199,6 @@ class TestAlpacaClient(TestCase):
         assert asset is not None
         self.assertEqual(asset["symbol"], "AAPL")
         self.assertTrue(asset["tradable"])
-
-    def test_get_asset_returns_none_when_lookup_unavailable(self) -> None:
-        client = TorghutAlpacaClient(
-            api_key="k",
-            secret_key="s",
-            base_url="https://paper-api.alpaca.markets",
-            trading_client=DummyTradingClient(),
-            data_client=DummyDataClient(),
-        )
-
-        self.assertIsNone(client.get_asset("AAPL"))
 
     def test_mutating_methods_require_firewall_boundary(self) -> None:
         client = TorghutAlpacaClient(


### PR DESCRIPTION
## Summary

- Removes Alpaca read-surface runtime probing for optional client-order and asset lookup methods.
- Makes the broker read-only protocol match the pinned Alpaca SDK methods directly.
- Deletes stale `OrderFirewall` mapping/list normalization helpers now that the broker contract is typed.
- Updates broker wrapper tests to cover the explicit SDK-backed read contract instead of missing-method fallbacks.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format app/alpaca_client.py app/trading/firewall.py tests/test_alpaca_client.py tests/test_order_firewall.py`
- `cd services/torghut && uv run --frozen ruff check app/alpaca_client.py app/trading/firewall.py tests/test_alpaca_client.py tests/test_order_firewall.py`
- `cd services/torghut && uv run --frozen pytest tests/test_alpaca_client.py tests/test_order_firewall.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/alpaca_client.py app/trading/firewall.py tests/test_alpaca_client.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/alpaca_client.py app/trading/firewall.py tests/test_alpaca_client.py`
- `cd services/torghut && uv run --frozen vulture app scripts --min-confidence 100`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The public `TorghutAlpacaClient.get_order_by_client_order_id` method remains intact; internally it now calls the SDK's `get_order_by_client_id` read method directly.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
