### PR TITLE
feat(nix): add native oci build tooling

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,6 @@
+# Optional local convenience:
+#   cp .envrc.example .envrc
+#   direnv allow
+#
+# Keep .envrc untracked so Nix activation remains opt-in per developer.
+use flake

--- a/.github/workflows/argo-lint.yml
+++ b/.github/workflows/argo-lint.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**/*.yaml'
       - 'scripts/argo-lint.sh'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
       - '.github/workflows/argo-lint.yml'
   push:
     branches:
@@ -12,6 +15,9 @@ on:
     paths:
       - '**/*.yaml'
       - 'scripts/argo-lint.sh'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -24,25 +30,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Install Argo CLI
-        run: |
-          set -euo pipefail
-
-          ARGO_VERSION="v4.0.5"
-          ARGO_URL="https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz"
-
-          curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o argo-linux-amd64.gz "${ARGO_URL}"
-
-          if ! gzip -t argo-linux-amd64.gz; then
-            echo "Downloaded Argo CLI is not a gzip archive; first 200 bytes:"
-            head -c 200 argo-linux-amd64.gz || true
-            exit 1
-          fi
-
-          gunzip -f argo-linux-amd64.gz
-          chmod +x argo-linux-amd64
-          sudo mv argo-linux-amd64 /usr/local/bin/argo
-          argo version
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
       - name: Lint Argo workflow manifests
-        run: scripts/argo-lint.sh
+        run: nix run .#lint-argo-workflows

--- a/.github/workflows/facteur-build-push.yaml
+++ b/.github/workflows/facteur-build-push.yaml
@@ -13,36 +13,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push:
+  meta:
     runs-on: arc-arm64
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
+      - name: Resolve image tag
         id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: registry.ide-newton.ts.net/lab/facteur
-          tags: |
-            type=ref,event=branch
-            type=sha
-            type=raw,value=latest
+        run: echo "tag=sha-$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: services/facteur/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            FACTEUR_VERSION=${{ steps.meta.outputs.version != '' && steps.meta.outputs.version || github.sha }}
-            FACTEUR_COMMIT=${{ github.sha }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/facteur:latest
-          cache-to: type=inline
+  build-and-push:
+    needs: meta
+    uses: ./.github/workflows/oci-native-build-common.yml
+    with:
+      image_name: facteur
+      dockerfile: services/facteur/Dockerfile
+      context: .
+      tag: ${{ needs.meta.outputs.tag }}
+      latest: ${{ github.ref == 'refs/heads/main' }}
+      build_args_json: >-
+        {"FACTEUR_VERSION":"${{ needs.meta.outputs.tag }}","FACTEUR_COMMIT":"${{ github.sha }}"}
+    secrets: inherit

--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -9,12 +9,18 @@ on:
       - 'services/headlamp/**'
       - 'argocd/applications/headlamp/**'
       - 'docs/headlamp-setup.md'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
       - '.github/workflows/headlamp-ci.yml'
   push:
     branches:
       - main
     paths:
       - 'services/headlamp/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
       - '.github/workflows/headlamp-ci.yml'
   workflow_dispatch:
 
@@ -30,34 +36,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Install Helm
-        uses: azure/setup-helm@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
         with:
-          version: v3.14.4
-
-      - name: Install kustomize
-        run: |
-          KUSTOMIZE_VERSION="5.8.0"
-          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-          ARCH="$(uname -m)"
-          case "${ARCH}" in
-            x86_64|amd64) ARCH="amd64" ;;
-            aarch64|arm64) ARCH="arm64" ;;
-            *)
-              echo "Unsupported architecture: ${ARCH}" >&2
-              exit 1
-              ;;
-          esac
-          TARBALL="kustomize_v${KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz"
-          URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${TARBALL}"
-          curl -fsSL -o kustomize.tar.gz "${URL}"
-          tar -xzf kustomize.tar.gz kustomize
-          chmod +x kustomize
-          sudo mv kustomize /usr/local/bin/
-          kustomize version
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
       - name: Render Headlamp manifests
-        run: kustomize build --enable-helm argocd/applications/headlamp >/dev/null
+        run: nix run .#render-headlamp
 
       - name: Run Upstream Multiplexer Regression Tests
         run: |

--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -36,6 +36,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
+      - name: Install xz for Nix installer
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y xz
+          elif ! command -v xz >/dev/null 2>&1; then
+            echo "xz is required to install Nix on this runner." >&2
+            exit 1
+          fi
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/khoshut-ci.yml
+++ b/.github/workflows/khoshut-ci.yml
@@ -11,6 +11,9 @@ on:
       - 'argocd/applications/argocd/base/image-updater-product.yaml'
       - '.github/workflows/khoshut-ci.yml'
       - '.github/workflows/common-monorepo.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
       - 'package.json'
       - 'bun.lock'
   pull_request:
@@ -21,6 +24,9 @@ on:
       - 'argocd/applications/argocd/base/image-updater-product.yaml'
       - '.github/workflows/khoshut-ci.yml'
       - '.github/workflows/common-monorepo.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
       - 'package.json'
       - 'bun.lock'
   workflow_dispatch:
@@ -47,30 +53,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: oven-sh/setup-bun@v2
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
         with:
-          bun-version: 1.3.14
-
-      - name: Install kubeconform
-        run: |
-          KUBECONFORM_VERSION='v0.7.0'
-          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-          ARCH="$(uname -m)"
-          case "${ARCH}" in
-            x86_64|amd64) ARCH='amd64' ;;
-            aarch64|arm64) ARCH='arm64' ;;
-            *)
-              echo "Unsupported architecture: ${ARCH}" >&2
-              exit 1
-              ;;
-          esac
-          TARBALL="kubeconform-${OS}-${ARCH}.tar.gz"
-          URL="https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/${TARBALL}"
-          curl -fsSL -o kubeconform.tar.gz "${URL}"
-          tar -xzf kubeconform.tar.gz kubeconform
-          chmod +x kubeconform
-          sudo mv kubeconform /usr/local/bin/
-          kubeconform -v
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
       - name: Validate Argo CD manifests
-        run: bun run lint:argocd
+        run: nix develop -c scripts/kubeconform.sh argocd

--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'argocd/**/*.yaml'
       - 'scripts/kubeconform.sh'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
       - '.github/workflows/kubeconform.yml'
   push:
     branches:
@@ -12,6 +15,9 @@ on:
     paths:
       - 'argocd/**/*.yaml'
       - 'scripts/kubeconform.sh'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -24,26 +30,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Install kubeconform
-        run: |
-          KUBECONFORM_VERSION="v0.7.0"
-          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-          ARCH="$(uname -m)"
-          case "${ARCH}" in
-            x86_64|amd64) ARCH="amd64" ;;
-            aarch64|arm64) ARCH="arm64" ;;
-            *)
-              echo "Unsupported architecture: ${ARCH}" >&2
-              exit 1
-              ;;
-          esac
-          TARBALL="kubeconform-${OS}-${ARCH}.tar.gz"
-          URL="https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/${TARBALL}"
-          curl -fsSL -o kubeconform.tar.gz "${URL}"
-          tar -xzf kubeconform.tar.gz kubeconform
-          chmod +x kubeconform
-          sudo mv kubeconform /usr/local/bin/
-          kubeconform -v
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
       - name: Validate manifests
-        run: scripts/kubeconform.sh argocd
+        run: nix develop -c scripts/kubeconform.sh argocd

--- a/.github/workflows/nix-toolchain.yml
+++ b/.github/workflows/nix-toolchain.yml
@@ -1,0 +1,89 @@
+name: nix-toolchain
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - '.envrc.example'
+      - 'README.md'
+      - 'AGENTS.md'
+      - 'kubernetes/coder/README.md'
+      - 'scripts/kubeconform.sh'
+      - 'scripts/argo-lint.sh'
+      - 'packages/scripts/src/shared/oci.ts'
+      - 'packages/scripts/src/shared/__tests__/oci.test.ts'
+      - 'argocd/**/*.yaml'
+      - '.github/workflows/nix-toolchain.yml'
+      - '.github/workflows/oci-native-build-common.yml'
+      - '.github/workflows/oci-builder-benchmark.yml'
+      - '.github/workflows/kubeconform.yml'
+      - '.github/workflows/khoshut-ci.yml'
+      - '.github/workflows/headlamp-ci.yml'
+      - '.github/workflows/argo-lint.yml'
+      - '.github/workflows/facteur-build-push.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - '.envrc.example'
+      - 'README.md'
+      - 'AGENTS.md'
+      - 'kubernetes/coder/README.md'
+      - 'scripts/kubeconform.sh'
+      - 'scripts/argo-lint.sh'
+      - 'packages/scripts/src/shared/oci.ts'
+      - 'packages/scripts/src/shared/__tests__/oci.test.ts'
+      - 'argocd/**/*.yaml'
+      - '.github/workflows/nix-toolchain.yml'
+      - '.github/workflows/oci-native-build-common.yml'
+      - '.github/workflows/oci-builder-benchmark.yml'
+      - '.github/workflows/kubeconform.yml'
+      - '.github/workflows/khoshut-ci.yml'
+      - '.github/workflows/headlamp-ci.yml'
+      - '.github/workflows/argo-lint.yml'
+      - '.github/workflows/facteur-build-push.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check flake
+        run: nix flake check --print-build-logs
+
+      - name: Verify toolchain
+        run: nix develop -c toolchain-doctor
+
+      - name: Verify OCI toolchain
+        run: nix develop -c oci-doctor
+
+      - name: Validate Argo CD manifests
+        run: nix run .#lint-argocd
+
+      - name: Render Headlamp manifests
+        run: nix run .#render-headlamp
+
+      - name: Lint Argo Workflow manifests
+        run: nix run .#lint-argo-workflows

--- a/.github/workflows/oci-builder-benchmark.yml
+++ b/.github/workflows/oci-builder-benchmark.yml
@@ -42,6 +42,11 @@ on:
         description: JSON object of build args
         required: false
         default: '{}'
+      run_buildctl:
+        description: Run the experimental direct buildctl benchmark
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: oci-builder-benchmark-${{ github.run_id }}
@@ -163,7 +168,13 @@ jobs:
 
   buildctl-native:
     name: BuildKit buildctl native (${{ matrix.arch }})
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark')
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.run_buildctl) ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark') &&
+        contains(github.event.pull_request.labels.*.name, 'run-buildctl-benchmark')
+      )
     continue-on-error: true
     strategy:
       fail-fast: false

--- a/.github/workflows/oci-builder-benchmark.yml
+++ b/.github/workflows/oci-builder-benchmark.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Render build args
         id: build-args
         env:
-          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json || '{}' }}
         run: |
           set -euo pipefail
           jq -e 'type == "object"' <<< "${BUILD_ARGS_JSON}" >/dev/null
@@ -79,14 +79,14 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.dockerfile }}
+          context: ${{ inputs.context || '.' }}
+          file: ${{ inputs.dockerfile || 'services/facteur/Dockerfile' }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:${{ inputs.tag_prefix }}-${{ github.run_id }}-legacy
+          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}:${{ inputs.tag_prefix || 'benchmark-nix-oci-pr' }}-${{ github.run_id }}-legacy
           build-args: ${{ steps.build-args.outputs.value }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-legacy-cache
-          cache-to: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-legacy-cache,mode=max
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}:benchmark-legacy-cache
+          cache-to: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}:benchmark-legacy-cache,mode=max
 
       - name: Record benchmark result
         env:
@@ -123,7 +123,7 @@ jobs:
       - name: Render build args
         id: build-args
         env:
-          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json || '{}' }}
         run: |
           set -euo pipefail
           jq -e 'type == "object"' <<< "${BUILD_ARGS_JSON}" >/dev/null
@@ -140,14 +140,14 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.dockerfile }}
+          context: ${{ inputs.context || '.' }}
+          file: ${{ inputs.dockerfile || 'services/facteur/Dockerfile' }}
           platforms: ${{ matrix.platform }}
           push: true
-          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:${{ inputs.tag_prefix }}-${{ github.run_id }}-docker-${{ matrix.arch }}
+          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}:${{ inputs.tag_prefix || 'benchmark-nix-oci-pr' }}-${{ github.run_id }}-docker-${{ matrix.arch }}
           build-args: ${{ steps.build-args.outputs.value }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-docker-cache-${{ matrix.arch }}
-          cache-to: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-docker-cache-${{ matrix.arch }},mode=max
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}:benchmark-docker-cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}:benchmark-docker-cache-${{ matrix.arch }},mode=max
 
       - name: Record benchmark result
         env:
@@ -179,6 +179,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Install xz for Nix installer
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y xz
+          elif ! command -v xz >/dev/null 2>&1; then
+            echo "xz is required to install Nix on this runner." >&2
+            exit 1
+          fi
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -188,12 +203,12 @@ jobs:
 
       - name: Build benchmark image with buildctl
         env:
-          IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
-          TAG: ${{ inputs.tag_prefix }}-${{ github.run_id }}-buildctl-${{ matrix.arch }}
+          IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}
+          TAG: ${{ inputs.tag_prefix || 'benchmark-nix-oci-pr' }}-${{ github.run_id }}-buildctl-${{ matrix.arch }}
           PLATFORM: ${{ matrix.platform }}
-          CONTEXT: ${{ inputs.context }}
-          DOCKERFILE: ${{ inputs.dockerfile }}
-          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+          CONTEXT: ${{ inputs.context || '.' }}
+          DOCKERFILE: ${{ inputs.dockerfile || 'services/facteur/Dockerfile' }}
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json || '{}' }}
         run: |
           set -euo pipefail
           start="$(date +%s)"
@@ -252,7 +267,7 @@ jobs:
       - name: Render build args
         id: build-args
         env:
-          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json || '{}' }}
         run: |
           set -euo pipefail
           jq -e 'type == "object"' <<< "${BUILD_ARGS_JSON}" >/dev/null
@@ -266,11 +281,11 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
-          context: ${{ inputs.context }}
-          file: ${{ inputs.dockerfile }}
+          context: ${{ inputs.context || '.' }}
+          file: ${{ inputs.dockerfile || 'services/facteur/Dockerfile' }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:${{ inputs.tag_prefix }}-${{ github.run_id }}-depot
+          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name || 'facteur' }}:${{ inputs.tag_prefix || 'benchmark-nix-oci-pr' }}-${{ github.run_id }}-depot
           build-args: ${{ steps.build-args.outputs.value }}
 
   summarize:

--- a/.github/workflows/oci-builder-benchmark.yml
+++ b/.github/workflows/oci-builder-benchmark.yml
@@ -164,6 +164,7 @@ jobs:
   buildctl-native:
     name: BuildKit buildctl native (${{ matrix.arch }})
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark')
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/oci-builder-benchmark.yml
+++ b/.github/workflows/oci-builder-benchmark.yml
@@ -5,6 +5,21 @@ permissions:
   id-token: write
 
 on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+    paths:
+      - '.github/workflows/oci-builder-benchmark.yml'
+      - '.github/workflows/oci-native-build-common.yml'
+      - '.github/workflows/facteur-build-push.yaml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'packages/scripts/src/shared/oci.ts'
+      - 'services/facteur/**'
   workflow_dispatch:
     inputs:
       image_name:
@@ -35,6 +50,7 @@ concurrency:
 jobs:
   legacy-buildx-single-runner:
     name: Legacy Buildx single-runner multi-platform
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark')
     runs-on: arc-arm64
     steps:
       - name: Checkout
@@ -85,6 +101,7 @@ jobs:
 
   docker-buildx-native:
     name: Docker Buildx native (${{ matrix.arch }})
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark')
     strategy:
       fail-fast: false
       matrix:
@@ -146,6 +163,7 @@ jobs:
 
   buildctl-native:
     name: BuildKit buildctl native (${{ matrix.arch }})
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark')
     strategy:
       fail-fast: false
       matrix:
@@ -206,7 +224,7 @@ jobs:
 
   depot-native:
     name: Depot native benchmark
-    if: vars.DEPOT_PROJECT_ID != ''
+    if: (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark')) && vars.DEPOT_PROJECT_ID != ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -240,7 +258,7 @@ jobs:
           build-args: ${{ steps.build-args.outputs.value }}
 
   summarize:
-    if: always()
+    if: always() && (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-oci-benchmark'))
     needs:
       - legacy-buildx-single-runner
       - docker-buildx-native

--- a/.github/workflows/oci-builder-benchmark.yml
+++ b/.github/workflows/oci-builder-benchmark.yml
@@ -1,0 +1,262 @@
+name: OCI Builder Benchmark
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: Image name under registry.ide-newton.ts.net/lab
+        required: true
+        default: facteur
+      dockerfile:
+        description: Dockerfile path
+        required: true
+        default: services/facteur/Dockerfile
+      context:
+        description: Build context path
+        required: true
+        default: .
+      tag_prefix:
+        description: Benchmark tag prefix
+        required: true
+        default: benchmark
+      build_args_json:
+        description: JSON object of build args
+        required: false
+        default: '{}'
+
+concurrency:
+  group: oci-builder-benchmark-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  legacy-buildx-single-runner:
+    name: Legacy Buildx single-runner multi-platform
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Render build args
+        id: build-args
+        env:
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+        run: |
+          set -euo pipefail
+          jq -e 'type == "object"' <<< "${BUILD_ARGS_JSON}" >/dev/null
+          {
+            echo 'value<<EOF'
+            jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "${BUILD_ARGS_JSON}"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Start timer
+        run: echo "BENCHMARK_START=$(date +%s)" >> "${GITHUB_ENV}"
+
+      - name: Build benchmark image with legacy single-runner Buildx
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:${{ inputs.tag_prefix }}-${{ github.run_id }}-legacy
+          build-args: ${{ steps.build-args.outputs.value }}
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-legacy-cache
+          cache-to: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-legacy-cache,mode=max
+
+      - name: Record benchmark result
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          elapsed="$(( $(date +%s) - BENCHMARK_START ))"
+          {
+            echo "legacy_buildx_single_runner_elapsed_seconds=${elapsed}"
+            echo "legacy_buildx_single_runner_digest=${DIGEST}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  docker-buildx-native:
+    name: Docker Buildx native (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Render build args
+        id: build-args
+        env:
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+        run: |
+          set -euo pipefail
+          jq -e 'type == "object"' <<< "${BUILD_ARGS_JSON}" >/dev/null
+          {
+            echo 'value<<EOF'
+            jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "${BUILD_ARGS_JSON}"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Start timer
+        run: echo "BENCHMARK_START=$(date +%s)" >> "${GITHUB_ENV}"
+
+      - name: Build benchmark image with docker/build-push-action
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:${{ inputs.tag_prefix }}-${{ github.run_id }}-docker-${{ matrix.arch }}
+          build-args: ${{ steps.build-args.outputs.value }}
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-docker-cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:benchmark-docker-cache-${{ matrix.arch }},mode=max
+
+      - name: Record benchmark result
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          elapsed="$(( $(date +%s) - BENCHMARK_START ))"
+          {
+            echo "docker_buildx_native_${PLATFORM#linux/}_elapsed_seconds=${elapsed}"
+            echo "docker_buildx_native_${PLATFORM#linux/}_digest=${DIGEST}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  buildctl-native:
+    name: BuildKit buildctl native (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build benchmark image with buildctl
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
+          TAG: ${{ inputs.tag_prefix }}-${{ github.run_id }}-buildctl-${{ matrix.arch }}
+          PLATFORM: ${{ matrix.platform }}
+          CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+        run: |
+          set -euo pipefail
+          start="$(date +%s)"
+          dockerfile_dir="$(dirname "${DOCKERFILE}")"
+          dockerfile_name="$(basename "${DOCKERFILE}")"
+          mapfile -t build_args < <(
+            nix develop -c jq -r 'to_entries[] | "--opt=build-arg:\(.key)=\(.value)"' <<< "${BUILD_ARGS_JSON}"
+          )
+
+          nix develop -c buildctl-daemonless.sh build \
+            --frontend dockerfile.v0 \
+            --local "context=${CONTEXT}" \
+            --local "dockerfile=${dockerfile_dir}" \
+            --opt "filename=${dockerfile_name}" \
+            --opt "platform=${PLATFORM}" \
+            "${build_args[@]}" \
+            --import-cache "type=registry,ref=${IMAGE}:benchmark-buildctl-cache-${{ matrix.arch }}" \
+            --export-cache "type=registry,ref=${IMAGE}:benchmark-buildctl-cache-${{ matrix.arch }},mode=max" \
+            --output "type=image,name=${IMAGE}:${TAG},push=true"
+
+          digest="$(nix develop -c crane digest "${IMAGE}:${TAG}")"
+          elapsed="$(( $(date +%s) - start ))"
+          platform_name="${PLATFORM#linux/}"
+          {
+            echo "buildctl_native_${platform_name}_elapsed_seconds=${elapsed}"
+            echo "buildctl_native_${platform_name}_digest=${digest}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  depot-native:
+    name: Depot native benchmark
+    if: vars.DEPOT_PROJECT_ID != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Depot
+        uses: depot/setup-action@v1
+
+      - name: Render build args
+        id: build-args
+        env:
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+        run: |
+          set -euo pipefail
+          jq -e 'type == "object"' <<< "${BUILD_ARGS_JSON}" >/dev/null
+          {
+            echo 'value<<EOF'
+            jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "${BUILD_ARGS_JSON}"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build benchmark image with Depot
+        uses: depot/build-push-action@v1
+        with:
+          project: ${{ vars.DEPOT_PROJECT_ID }}
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:${{ inputs.tag_prefix }}-${{ github.run_id }}-depot
+          build-args: ${{ steps.build-args.outputs.value }}
+
+  summarize:
+    if: always()
+    needs:
+      - legacy-buildx-single-runner
+      - docker-buildx-native
+      - buildctl-native
+      - depot-native
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print benchmark summary
+        run: |
+          {
+            echo '## OCI builder benchmark'
+            echo
+            echo '- Legacy Buildx single-runner result: ${{ needs.legacy-buildx-single-runner.result }}'
+            echo '- Docker Buildx native result: ${{ needs.docker-buildx-native.result }}'
+            echo '- BuildKit buildctl native result: ${{ needs.buildctl-native.result }}'
+            echo '- Depot result: ${{ needs.depot-native.result }}'
+            echo
+            echo 'Inspect pushed benchmark tags before promoting any builder change.'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/oci-builder-benchmark.yml
+++ b/.github/workflows/oci-builder-benchmark.yml
@@ -199,11 +199,27 @@ jobs:
           start="$(date +%s)"
           dockerfile_dir="$(dirname "${DOCKERFILE}")"
           dockerfile_name="$(basename "${DOCKERFILE}")"
+          buildkit_socket="${RUNNER_TEMP}/buildkitd-${{ matrix.arch }}.sock"
           mapfile -t build_args < <(
             nix develop -c jq -r 'to_entries[] | "--opt=build-arg:\(.key)=\(.value)"' <<< "${BUILD_ARGS_JSON}"
           )
 
-          nix develop -c buildctl-daemonless.sh build \
+          nix develop -c buildkitd \
+            --addr "unix://${buildkit_socket}" \
+            --oci-worker=true \
+            --containerd-worker=false &
+          buildkitd_pid="$!"
+          trap 'kill "${buildkitd_pid}" >/dev/null 2>&1 || true' EXIT
+
+          for _ in $(seq 1 30); do
+            if nix develop -c buildctl --addr "unix://${buildkit_socket}" debug workers >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+          nix develop -c buildctl --addr "unix://${buildkit_socket}" debug workers >/dev/null
+
+          nix develop -c buildctl --addr "unix://${buildkit_socket}" build \
             --frontend dockerfile.v0 \
             --local "context=${CONTEXT}" \
             --local "dockerfile=${dockerfile_dir}" \

--- a/.github/workflows/oci-native-build-common.yml
+++ b/.github/workflows/oci-native-build-common.yml
@@ -98,7 +98,10 @@ jobs:
           BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
         run: |
           set -euo pipefail
-          json="${BUILD_ARGS_JSON:-{}}"
+          json="${BUILD_ARGS_JSON:-}"
+          if [ -z "${json}" ]; then
+            json='{}'
+          fi
           nix develop -c jq -e 'type == "object"' <<< "${json}" >/dev/null
           {
             echo 'value<<EOF'

--- a/.github/workflows/oci-native-build-common.yml
+++ b/.github/workflows/oci-native-build-common.yml
@@ -1,0 +1,190 @@
+name: OCI Native Build Common
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      context:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      platforms:
+        required: false
+        type: string
+        default: 'linux/amd64,linux/arm64'
+      latest:
+        required: false
+        type: boolean
+        default: false
+      cache_mode:
+        required: false
+        type: string
+        default: max
+      build_args_json:
+        required: false
+        type: string
+        default: '{}'
+    outputs:
+      image:
+        value: ${{ jobs.publish-index.outputs.image }}
+      tag:
+        value: ${{ jobs.publish-index.outputs.tag }}
+      digest:
+        value: ${{ jobs.publish-index.outputs.digest }}
+      platform_digest_amd64:
+        value: ${{ jobs.publish-index.outputs.platform_digest_amd64 }}
+      platform_digest_arm64:
+        value: ${{ jobs.publish-index.outputs.platform_digest_arm64 }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.tag }}
+  cancel-in-progress: true
+
+jobs:
+  build-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Set up Docker Buildx builder
+        uses: docker/setup-buildx-action@v3
+
+      - name: Render build args
+        id: build-args
+        env:
+          BUILD_ARGS_JSON: ${{ inputs.build_args_json }}
+        run: |
+          set -euo pipefail
+          json="${BUILD_ARGS_JSON:-{}}"
+          nix develop -c jq -e 'type == "object"' <<< "${json}" >/dev/null
+          {
+            echo 'value<<EOF'
+            nix develop -c jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "${json}"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push native image
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
+          TAG: ${{ inputs.tag }}
+          ARCH: ${{ matrix.arch }}
+          PLATFORM: ${{ matrix.platform }}
+          CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          CACHE_MODE: ${{ inputs.cache_mode }}
+          LATEST: ${{ inputs.latest }}
+          BUILD_ARGS: ${{ steps.build-args.outputs.value }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            docker buildx build
+            --push
+            --platform "${PLATFORM}"
+            --file "${DOCKERFILE}"
+            --tag "${IMAGE}:${TAG}-${ARCH}"
+            --cache-from "type=registry,ref=${IMAGE}:cache-${ARCH}"
+            --cache-to "type=registry,ref=${IMAGE}:cache-${ARCH},mode=${CACHE_MODE}"
+          )
+
+          if [ "${LATEST}" = "true" ]; then
+            args+=(--tag "${IMAGE}:latest-${ARCH}")
+          fi
+
+          while IFS= read -r build_arg; do
+            if [ -n "${build_arg}" ]; then
+              args+=(--build-arg "${build_arg}")
+            fi
+          done <<< "${BUILD_ARGS}"
+
+          args+=("${CONTEXT}")
+          nix develop -c "${args[@]}"
+
+  publish-index:
+    needs: build-platform
+    runs-on: arc-arm64
+    outputs:
+      image: ${{ steps.oci.outputs.image }}
+      tag: ${{ steps.oci.outputs.tag }}
+      digest: ${{ steps.oci.outputs.digest }}
+      platform_digest_amd64: ${{ steps.oci.outputs.platform_digest_amd64 }}
+      platform_digest_arm64: ${{ steps.oci.outputs.platform_digest_arm64 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Validate platform contract
+        run: |
+          set -euo pipefail
+          platforms=',${{ inputs.platforms }},'
+          case "${platforms}" in
+            *,linux/amd64,*linux/arm64,*|*,linux/arm64,*linux/amd64,*) ;;
+            *)
+              echo "oci-native-build-common requires linux/amd64 and linux/arm64 for index publication." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Create OCI image index
+        id: oci
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
+          TAG: ${{ inputs.tag }}
+          LATEST: ${{ inputs.latest }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            bun run packages/scripts/src/shared/oci.ts create-index
+            --image "${IMAGE}"
+            --tag "${TAG}"
+            --arch-tag "linux/amd64=${TAG}-amd64"
+            --arch-tag "linux/arm64=${TAG}-arm64"
+          )
+
+          if [ "${LATEST}" = "true" ]; then
+            args+=(--latest)
+          fi
+
+          nix develop -c "${args[@]}"
+
+      - name: Verify OCI image index platforms
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
+          TAG: ${{ inputs.tag }}
+        run: nix develop -c bun run packages/scripts/src/shared/oci.ts assert "${IMAGE}:${TAG}" linux/amd64 linux/arm64

--- a/.github/workflows/oci-native-build-common.yml
+++ b/.github/workflows/oci-native-build-common.yml
@@ -67,6 +67,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Install xz for Nix installer
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y xz
+          elif ! command -v xz >/dev/null 2>&1; then
+            echo "xz is required to install Nix on this runner." >&2
+            exit 1
+          fi
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -140,6 +155,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Install xz for Nix installer
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y xz
+          elif ! command -v xz >/dev/null 2>&1; then
+            echo "xz is required to install Nix on this runner." >&2
+            exit 1
+          fi
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/oci-native-build-common.yml
+++ b/.github/workflows/oci-native-build-common.yml
@@ -67,28 +67,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install xz for Nix installer
-        run: |
-          set -euo pipefail
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y xz-utils
-          elif command -v apk >/dev/null 2>&1; then
-            sudo apk add --no-cache xz
-          elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y xz
-          elif ! command -v xz >/dev/null 2>&1; then
-            echo "xz is required to install Nix on this runner." >&2
-            exit 1
-          fi
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
       - name: Set up Docker Buildx builder
         uses: docker/setup-buildx-action@v3
 
@@ -102,49 +80,42 @@ jobs:
           if [ -z "${json}" ]; then
             json='{}'
           fi
-          nix develop -c jq -e 'type == "object"' <<< "${json}" >/dev/null
+          jq -e 'type == "object"' <<< "${json}" >/dev/null
           {
             echo 'value<<EOF'
-            nix develop -c jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "${json}"
+            jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "${json}"
             echo EOF
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Build and push native image
+      - name: Render image tags
+        id: image-tags
         env:
           IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
           TAG: ${{ inputs.tag }}
           ARCH: ${{ matrix.arch }}
-          PLATFORM: ${{ matrix.platform }}
-          CONTEXT: ${{ inputs.context }}
-          DOCKERFILE: ${{ inputs.dockerfile }}
-          CACHE_MODE: ${{ inputs.cache_mode }}
           LATEST: ${{ inputs.latest }}
-          BUILD_ARGS: ${{ steps.build-args.outputs.value }}
         run: |
           set -euo pipefail
-
-          args=(
-            docker buildx build
-            --push
-            --platform "${PLATFORM}"
-            --file "${DOCKERFILE}"
-            --tag "${IMAGE}:${TAG}-${ARCH}"
-            --cache-from "type=registry,ref=${IMAGE}:cache-${ARCH}"
-            --cache-to "type=registry,ref=${IMAGE}:cache-${ARCH},mode=${CACHE_MODE}"
-          )
-
+          {
+            echo 'value<<EOF'
+            echo "${IMAGE}:${TAG}-${ARCH}"
+          } >> "${GITHUB_OUTPUT}"
           if [ "${LATEST}" = "true" ]; then
-            args+=(--tag "${IMAGE}:latest-${ARCH}")
+            echo "${IMAGE}:latest-${ARCH}" >> "${GITHUB_OUTPUT}"
           fi
+          echo EOF >> "${GITHUB_OUTPUT}"
 
-          while IFS= read -r build_arg; do
-            if [ -n "${build_arg}" ]; then
-              args+=(--build-arg "${build_arg}")
-            fi
-          done <<< "${BUILD_ARGS}"
-
-          args+=("${CONTEXT}")
-          nix develop -c "${args[@]}"
+      - name: Build and push native image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.image-tags.outputs.value }}
+          build-args: ${{ steps.build-args.outputs.value }}
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=registry.ide-newton.ts.net/lab/${{ inputs.image_name }}:cache-${{ matrix.arch }},mode=${{ inputs.cache_mode }}
 
   publish-index:
     needs: build-platform
@@ -203,7 +174,7 @@ jobs:
           set -euo pipefail
 
           args=(
-            bun run packages/scripts/src/shared/oci.ts create-index
+            nix run .#create-oci-index --
             --image "${IMAGE}"
             --tag "${TAG}"
             --arch-tag "linux/amd64=${TAG}-amd64"
@@ -214,10 +185,10 @@ jobs:
             args+=(--latest)
           fi
 
-          nix develop -c "${args[@]}"
+          "${args[@]}"
 
       - name: Verify OCI image index platforms
         env:
           IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
           TAG: ${{ inputs.tag }}
-        run: nix develop -c bun run packages/scripts/src/shared/oci.ts assert "${IMAGE}:${TAG}" linux/amd64 linux/arm64
+        run: nix run .#assert-oci-platforms -- "${IMAGE}:${TAG}" linux/amd64 linux/arm64

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,18 @@
 
 ## Prereqs
 
+- Prefer `nix develop` from the repo root before running build, test, or infra commands. Run `toolchain-doctor`
+  inside the shell when a tool version looks suspect.
 - Node 24.11.1 + Bun 1.3.14 (root `package.json`).
-- Go 1.24+ for `services/`.
+- Go 1.25.5 for repo parity; Go services support 1.24+.
 - Ruby 3.4.7 + Bundler 2.7+ for `services/dernier`.
 - Python 3.9–3.12 for `apps/alchimie`; 3.11–3.12 for `services/torghut`.
 
-## Tooling Versions (mise)
+## Tooling Versions (Nix)
 
-- Use `mise` to pin tool versions when a specific major is required (e.g. `helm@3` for `kustomize --enable-helm`; helm v4 is not supported there yet).
+- Use `nix develop` to get the pinned repo toolchain. This includes Helm 3 for `kustomize --enable-helm`;
+  helm v4 is not supported there yet.
+- Optional direnv setup is local-only: copy `.envrc.example` to `.envrc` and run `direnv allow`.
 
 ## Build, Test, and Development Commands
 
@@ -170,7 +174,7 @@ Output:
 - If `kubectl` auth fails (`Unauthorized` / `You must be logged in to the server`), refresh the `service-user`
   credential from `/var/run/secrets/kubernetes.io/serviceaccount/token`, set the `in-cluster` CA from
   `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, and verify with `kubectl auth whoami` before retrying.
-- Helm charts present: `mise exec helm@3 -- kustomize build --enable-helm <path> | kubectl apply -n <ns> -f -`.
+- Helm charts present: run from `nix develop`, then `kustomize build --enable-helm <path> | kubectl apply -n <ns> -f -`.
 - CNPG access: `kubectl cnpg psql -n <ns> <cluster> -- <psql args>` (psql flags after `--`).
 
 ## AgentRuns (agents namespace)

--- a/README.md
+++ b/README.md
@@ -60,15 +60,22 @@ TigerBeetle operator code lives in the standalone `proompteng/tigresse` reposito
 
 ### Prerequisites
 
-- Node `24.11.1`
-- Bun `1.3.14`
-- Go `1.24+` for Go services
-- Ruby `3.4.7` + Bundler `2.7+` for `services/dernier`
-- Python:
-  - `3.9-3.12` for `apps/alchimie`
-  - `3.11-3.12` for `services/torghut`
+- Nix with flakes enabled. The repo-level toolchain is provided by `nix develop`.
+- Without Nix, install the equivalent tools manually:
+  - Node `24.11.1`
+  - Bun `1.3.14`
+  - Go `1.25.5` for repo parity; Go services support `1.24+`
+  - Ruby `3.4.7` + Bundler `2.7+` for `services/dernier`
+  - Python:
+    - `3.9-3.12` for `apps/alchimie`
+    - `3.11-3.12` for `services/torghut`
 
-Install workspace dependencies:
+Enter the pinned toolchain shell, then install workspace dependencies:
+
+```bash
+nix develop
+toolchain-doctor
+```
 
 ```bash
 bun install
@@ -172,6 +179,8 @@ Service deploy/build/reseal workflows use the typed scripts under `packages/scri
 
 ## Notes
 
-- Use `mise` when a workflow requires a pinned tool major such as `helm@3`.
+- Prefer `nix develop` for repository tooling. The flake pins the default development shell and wrappers for
+  Kubernetes/Argo validation commands.
+- `direnv` is optional. To auto-load the Nix shell, copy `.envrc.example` to `.envrc`, then run `direnv allow`.
 - Generated artifacts and lockfiles are maintained through their owning generators and package managers.
 - For infra changes, default to GitOps under `argocd/` and let Argo CD apply the desired state.

--- a/docs/superpowers/plans/2026-06-25-nix-oci-ci-proof.md
+++ b/docs/superpowers/plans/2026-06-25-nix-oci-ci-proof.md
@@ -127,7 +127,18 @@ Run:
 gh workflow run facteur-build-push.yaml -R proompteng/lab --ref codex/adopt-nix-toolchain
 ```
 
-- [ ] **Step 2: Trigger benchmark**
+- [ ] **Step 2: Trigger benchmark before merge**
+
+For a PR branch where the new benchmark workflow is not yet present on `main`, add the explicit opt-in label:
+
+```bash
+gh label create run-oci-benchmark -R proompteng/lab --color 5319e7 --description "Run OCI builder benchmark on PR" || true
+gh pr edit <pr-number> -R proompteng/lab --add-label run-oci-benchmark
+```
+
+The benchmark workflow runs on `pull_request` events only when this label is present.
+
+- [ ] **Step 3: Trigger benchmark after merge**
 
 Run:
 
@@ -140,7 +151,7 @@ gh workflow run oci-builder-benchmark.yml -R proompteng/lab --ref codex/adopt-ni
   -f build_args_json='{}'
 ```
 
-- [ ] **Step 3: Watch runs**
+- [ ] **Step 4: Watch runs**
 
 Run:
 
@@ -149,7 +160,7 @@ gh run list -R proompteng/lab --branch codex/adopt-nix-toolchain --limit 10
 gh run watch <run-id> -R proompteng/lab --exit-status
 ```
 
-- [ ] **Step 4: Extract timings**
+- [ ] **Step 5: Extract timings**
 
 Run:
 

--- a/docs/superpowers/plans/2026-06-25-nix-oci-ci-proof.md
+++ b/docs/superpowers/plans/2026-06-25-nix-oci-ci-proof.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Keep Nix as the pinned toolchain layer, run native per-architecture OCI builds on ARC runners, publish an OCI index with crane, and measure legacy single-runner multi-platform builds against native Buildx and direct BuildKit. Branch canaries must never mutate `latest`; only `main` may publish `latest`.
 
-**Tech Stack:** Nix flakes, GitHub Actions, Docker Buildx, BuildKit `buildctl`, crane/go-containerregistry, Bun tests, actionlint, shellcheck.
+**Tech Stack:** Nix flakes, GitHub Actions, Docker Buildx, BuildKit `buildkitd` plus `buildctl`, crane/go-containerregistry, Bun tests, actionlint, shellcheck.
 
 ---
 
@@ -51,7 +51,7 @@ Add a job named `legacy-buildx-single-runner` that runs on `arc-arm64`, uses `do
 
 - [ ] **Step 2: Keep native benchmark jobs**
 
-Keep existing native matrix jobs for Docker Buildx and direct `buildctl`.
+Keep existing native matrix jobs for Docker Buildx and direct BuildKit. The BuildKit job starts a local `buildkitd` from the Nix shell and calls `buildctl --addr` against that socket because nixpkgs packages `buildctl` and `buildkitd`, not Docker's `buildctl-daemonless.sh` helper.
 
 - [ ] **Step 3: Include legacy in summary**
 

--- a/docs/superpowers/plans/2026-06-25-nix-oci-ci-proof.md
+++ b/docs/superpowers/plans/2026-06-25-nix-oci-ci-proof.md
@@ -1,0 +1,181 @@
+# Nix OCI CI Proof Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the Nix OCI/multi-arch adoption with pushed CI proof and measured build-time deltas.
+
+**Architecture:** Keep Nix as the pinned toolchain layer, run native per-architecture OCI builds on ARC runners, publish an OCI index with crane, and measure legacy single-runner multi-platform builds against native Buildx and direct BuildKit. Branch canaries must never mutate `latest`; only `main` may publish `latest`.
+
+**Tech Stack:** Nix flakes, GitHub Actions, Docker Buildx, BuildKit `buildctl`, crane/go-containerregistry, Bun tests, actionlint, shellcheck.
+
+---
+
+### Task 1: Make Branch Canary Safe
+
+**Files:**
+- Modify: `.github/workflows/facteur-build-push.yaml`
+
+- [ ] **Step 1: Gate `latest` to main only**
+
+Change the reusable workflow input to:
+
+```yaml
+      latest: ${{ github.ref == 'refs/heads/main' }}
+```
+
+- [ ] **Step 2: Validate workflow syntax**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path('.github/workflows').glob('*.y*ml')):
+    with path.open() as handle:
+        yaml.safe_load(handle)
+print('workflow yaml ok')
+PY
+```
+
+Expected: `workflow yaml ok`.
+
+### Task 2: Add Legacy Baseline Benchmark
+
+**Files:**
+- Modify: `.github/workflows/oci-builder-benchmark.yml`
+
+- [ ] **Step 1: Add a legacy single-runner job**
+
+Add a job named `legacy-buildx-single-runner` that runs on `arc-arm64`, uses `docker/build-push-action@v6`, builds `linux/amd64,linux/arm64` together, pushes only benchmark tags, and records elapsed seconds plus digest to `GITHUB_STEP_SUMMARY`.
+
+- [ ] **Step 2: Keep native benchmark jobs**
+
+Keep existing native matrix jobs for Docker Buildx and direct `buildctl`.
+
+- [ ] **Step 3: Include legacy in summary**
+
+Add `legacy-buildx-single-runner` to the `summarize.needs` list and print its result.
+
+- [ ] **Step 4: Validate workflow lint**
+
+Run:
+
+```bash
+actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' \
+  .github/workflows/oci-native-build-common.yml \
+  .github/workflows/oci-builder-benchmark.yml \
+  .github/workflows/facteur-build-push.yaml \
+  .github/workflows/nix-toolchain.yml
+```
+
+Expected: no output.
+
+### Task 3: Commit, Push, PR
+
+**Files:**
+- Modify only files already touched by this Nix/OCI adoption.
+
+- [ ] **Step 1: Run focused validation**
+
+Run:
+
+```bash
+bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/docker.test.ts
+bunx oxfmt --check packages/scripts/src/shared/oci.ts packages/scripts/src/shared/__tests__/oci.test.ts
+shellcheck -s bash nix/toolchain-doctor.sh nix/oci-doctor.sh
+git diff --check
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 2: Commit**
+
+Run:
+
+```bash
+git add .
+git commit -m "feat(nix): add native oci build tooling"
+```
+
+- [ ] **Step 3: Push**
+
+Run:
+
+```bash
+git push -u origin codex/adopt-nix-toolchain
+```
+
+- [ ] **Step 4: Create PR from template**
+
+Copy `.github/PULL_REQUEST_TEMPLATE.md` to a temp file, fill every section, scan for placeholders, and run:
+
+```bash
+gh pr create -R proompteng/lab --title "feat(nix): add native oci build tooling" --body-file /tmp/<filled-template>.md
+```
+
+### Task 4: Run CI Proof
+
+**Files:**
+- No repo edits expected unless CI fails.
+
+- [ ] **Step 1: Trigger branch canary**
+
+Run:
+
+```bash
+gh workflow run facteur-build-push.yaml -R proompteng/lab --ref codex/adopt-nix-toolchain
+```
+
+- [ ] **Step 2: Trigger benchmark**
+
+Run:
+
+```bash
+gh workflow run oci-builder-benchmark.yml -R proompteng/lab --ref codex/adopt-nix-toolchain \
+  -f image_name=facteur \
+  -f dockerfile=services/facteur/Dockerfile \
+  -f context=. \
+  -f tag_prefix=benchmark-nix-oci \
+  -f build_args_json='{}'
+```
+
+- [ ] **Step 3: Watch runs**
+
+Run:
+
+```bash
+gh run list -R proompteng/lab --branch codex/adopt-nix-toolchain --limit 10
+gh run watch <run-id> -R proompteng/lab --exit-status
+```
+
+- [ ] **Step 4: Extract timings**
+
+Run:
+
+```bash
+gh run view <benchmark-run-id> -R proompteng/lab --json jobs
+```
+
+Compare:
+
+- Legacy wall time: `legacy-buildx-single-runner`
+- Native Buildx wall time: max of `Docker Buildx native (amd64)` and `Docker Buildx native (arm64)`
+- BuildKit wall time: max of `BuildKit buildctl native (amd64)` and `BuildKit buildctl native (arm64)`
+
+### Task 5: Report Proof
+
+**Files:**
+- No repo edits expected.
+
+- [ ] **Step 1: Report measured deltas**
+
+Report exact run URLs, job durations, and percentage change:
+
+```text
+speedup = (legacy_seconds - native_seconds) / legacy_seconds * 100
+```
+
+- [ ] **Step 2: If CI fails, fix and repeat**
+
+For any failed workflow, inspect logs, patch the repo, rerun focused validation, amend or add a commit, push, and rerun the failed workflow.

--- a/docs/superpowers/plans/2026-06-26-nix-attic-cache.md
+++ b/docs/superpowers/plans/2026-06-26-nix-attic-cache.md
@@ -1,0 +1,1034 @@
+# Nix Attic Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy a cluster-hosted Nix binary cache for this repo, then wire trusted CI and developer shells to pull from it and trusted main-branch jobs to push to it.
+
+**Architecture:** Use Attic as the primary cache service because it is self-hostable, S3-backed, multi-tenant, deduplicating, and server-signs Nix cache responses. Run Attic in the lab cluster through GitOps, backed by CNPG Postgres and a Rook/Ceph S3 `ObjectBucketClaim`; expose it through the existing private ingress patterns and consume it from ARC runners first.
+
+**Tech Stack:** Nix flakes, Attic, Kubernetes, Argo CD ApplicationSet, Rook/Ceph ObjectBucketClaim, CloudNativePG, External Secrets with 1Password, Traefik/Tailscale ingress, GitHub Actions ARC runners.
+
+---
+
+## Decision Summary
+
+Use **Attic** for the first production rollout.
+
+- Attic is a self-hostable Nix binary cache backed by S3-compatible storage.
+- Attic supports cache namespaces, global deduplication, scoped JWT tokens, retention, and server-side signing.
+- This repo already has the needed infrastructure primitives: Rook/Ceph buckets, CNPG, External Secrets, Traefik, Tailscale, and ARC runners.
+
+Do not use these as the primary cache:
+
+- **Harmonia:** good for serving one machine's `/nix/store`; not the best fit for shared CI push, cache namespaces, S3 object storage, and deduplication.
+- **nix-serve-ng:** useful replacement for `nix-serve`; still local-store serving, not the desired cluster-backed shared cache.
+- **Hydra:** too much scheduler/build farm surface for this rollout.
+- **Cachix:** good product, but the requested cache must be hosted in this cluster.
+
+## File Structure
+
+- Create `argocd/applications/attic/kustomization.yaml`: owns the Attic application resources.
+- Create `argocd/applications/attic/objectbucketclaim.yaml`: creates the `attic-cache` S3-compatible bucket through Rook/Ceph.
+- Create `argocd/applications/attic/postgres-cluster.yaml`: creates the `attic-db` CNPG database.
+- Create `argocd/applications/attic/externalsecret.yaml`: pulls the Attic JWT signing key and CI token from 1Password.
+- Create `argocd/applications/attic/configmap.yaml`: stores non-secret Attic TOML config.
+- Create `argocd/applications/attic/deployment.yaml`: runs `atticd --mode api-server`.
+- Create `argocd/applications/attic/service.yaml`: exposes the Attic pod in-cluster.
+- Create `argocd/applications/attic/ingressroute-attic-k8s-private.yaml`: exposes `attic.k8s.proompteng.ai`.
+- Create `argocd/applications/attic/tailscale-ingress.yaml`: exposes `attic.ide-newton.ts.net`.
+- Create `argocd/applications/attic/bootstrap-job.yaml`: idempotently creates the `lab` cache and scoped CI token.
+- Create `argocd/applications/attic/gc-cronjob.yaml`: runs `atticd --mode garbage-collector-once`.
+- Modify `argocd/applicationsets/platform.yaml`: adds the `attic` platform ApplicationSet element.
+- Modify `flake.nix`: adds the Attic client to the dev shell and exposes cache helper apps.
+- Create `nix/cache-doctor.sh`: validates substituter reachability, cache public key config, and local Nix settings.
+- Create `nix/cache-push.sh`: pushes selected build outputs to Attic only when a token is present.
+- Modify `.github/workflows/nix-toolchain.yml`: consumes the cache on ARC or Tailscale-enabled jobs and pushes only from trusted branches.
+- Create `docs/nix-cache.md`: documents developer setup, trust boundary, token handling, and operations.
+
+### Task 1: Add Attic To The Platform ApplicationSet
+
+**Files:**
+- Modify: `argocd/applicationsets/platform.yaml`
+- Create: `argocd/applications/attic/kustomization.yaml`
+
+- [ ] **Step 1: Add the `attic` platform element**
+
+Insert the element after `arc` in `argocd/applicationsets/platform.yaml`:
+
+```yaml
+              - name: attic
+                path: argocd/applications/attic
+                namespace: attic
+                annotations:
+                  argocd.argoproj.io/sync-wave: "4"
+                managedNamespaceMetadata:
+                  labels:
+                    external-secrets.proompteng.ai/enabled: "true"
+                  annotations:
+                    argocd.argoproj.io/sync-options: Prune=false
+                automation: manual
+                enabled: "true"
+```
+
+- [ ] **Step 2: Create the Attic kustomization**
+
+Create `argocd/applications/attic/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: attic
+resources:
+  - objectbucketclaim.yaml
+  - postgres-cluster.yaml
+  - externalsecret.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingressroute-attic-k8s-private.yaml
+  - tailscale-ingress.yaml
+  - bootstrap-job.yaml
+  - gc-cronjob.yaml
+```
+
+- [ ] **Step 3: Validate the new ApplicationSet render**
+
+Run:
+
+```bash
+nix run .#lint-argocd
+```
+
+Expected: kubeconform accepts the new `attic` Application and resource manifests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add argocd/applicationsets/platform.yaml argocd/applications/attic/kustomization.yaml
+git commit -m "feat(nix): register attic cache application"
+```
+
+### Task 2: Add Storage And Database Backing Services
+
+**Files:**
+- Create: `argocd/applications/attic/objectbucketclaim.yaml`
+- Create: `argocd/applications/attic/postgres-cluster.yaml`
+
+- [ ] **Step 1: Create the object bucket claim**
+
+Create `argocd/applications/attic/objectbucketclaim.yaml`:
+
+```yaml
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: attic-cache
+  namespace: attic
+spec:
+  bucketName: attic-cache
+  storageClassName: rook-ceph-bucket
+```
+
+- [ ] **Step 2: Create the CNPG database**
+
+Create `argocd/applications/attic/postgres-cluster.yaml`:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: attic-db
+  namespace: attic
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
+  primaryUpdateStrategy: unsupervised
+  storage:
+    storageClass: rook-ceph-block
+    size: 20Gi
+  bootstrap:
+    initdb:
+      database: attic
+      owner: attic
+      encoding: "UTF8"
+      dataChecksums: true
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pgadmin"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pgadmin"
+  monitoring:
+    enablePodMonitor: true
+```
+
+- [ ] **Step 3: Validate schemas**
+
+Run:
+
+```bash
+nix run .#lint-argocd
+```
+
+Expected: `ObjectBucketClaim` and CNPG `Cluster` schemas validate with the existing kubeconform path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add argocd/applications/attic/objectbucketclaim.yaml argocd/applications/attic/postgres-cluster.yaml
+git commit -m "feat(nix): add attic storage backends"
+```
+
+### Task 3: Add Secrets And Attic Configuration
+
+**Files:**
+- Create: `argocd/applications/attic/externalsecret.yaml`
+- Create: `argocd/applications/attic/configmap.yaml`
+
+- [ ] **Step 1: Create the 1Password item before merging**
+
+Create 1Password item `infra/attic-cache` with these fields:
+
+```text
+token-rs256-secret-base64
+ci-token
+```
+
+Generate `token-rs256-secret-base64` with:
+
+```bash
+nix run nixpkgs#openssl -- genrsa -traditional 4096 | base64 -w0
+```
+
+Set `ci-token` after Task 6 bootstrap creates the scoped token. Until then, set it to the literal value `pending-bootstrap-token` so External Secrets can create the target Secret for later CI wiring.
+
+- [ ] **Step 2: Create the ExternalSecret**
+
+Create `argocd/applications/attic/externalsecret.yaml`:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: attic-secrets
+  namespace: attic
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-infra
+  target:
+    name: attic-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+      remoteRef:
+        key: attic-cache
+        property: token-rs256-secret-base64
+    - secretKey: ATTIC_CI_TOKEN
+      remoteRef:
+        key: attic-cache
+        property: ci-token
+```
+
+- [ ] **Step 3: Create the Attic config**
+
+Create `argocd/applications/attic/configmap.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: attic-config
+  namespace: attic
+data:
+  server.toml: |
+    listen = "[::]:8080"
+    allowed-hosts = [
+      "attic.attic.svc.cluster.local",
+      "attic.k8s.proompteng.ai",
+      "attic.ide-newton.ts.net"
+    ]
+    api-endpoint = "https://attic.ide-newton.ts.net/"
+    substituter-endpoint = "https://attic.ide-newton.ts.net/"
+    soft-delete-caches = true
+    require-proof-of-possession = true
+
+    [database]
+    heartbeat = true
+
+    [storage]
+    type = "s3"
+    region = "us-east-1"
+    bucket = "attic-cache"
+    endpoint = "http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80"
+
+    [chunking]
+    nar-size-threshold = 65536
+    min-size = 16384
+    avg-size = 65536
+    max-size = 262144
+
+    [compression]
+    type = "zstd"
+
+    [garbage-collection]
+    interval = "12 hours"
+    default-retention-period = "6 months"
+
+    [jwt]
+```
+
+- [ ] **Step 4: Validate manifests**
+
+Run:
+
+```bash
+nix run .#lint-argocd
+```
+
+Expected: ExternalSecret and ConfigMap render cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add argocd/applications/attic/externalsecret.yaml argocd/applications/attic/configmap.yaml
+git commit -m "feat(nix): configure attic cache secrets"
+```
+
+### Task 4: Build A Repo-Owned Attic Container Image
+
+**Files:**
+- Modify: `flake.nix`
+- Create: `.github/workflows/attic-build-push.yaml`
+
+- [ ] **Step 1: Add an Attic image package to `flake.nix`**
+
+Add a package near the existing package definitions:
+
+```nix
+atticdImage = pkgs.dockerTools.buildLayeredImage {
+  name = "registry.ide-newton.ts.net/lab/attic";
+  tag = "dev";
+  contents = [
+    pkgs.attic-server
+    pkgs.cacert
+    pkgs.busybox
+  ];
+  config = {
+    Entrypoint = [ "${pkgs.attic-server}/bin/atticd" ];
+    ExposedPorts = {
+      "8080/tcp" = { };
+    };
+    Env = [
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+    ];
+  };
+};
+```
+
+Expose it under `packages.${system}.atticd-image`.
+
+- [ ] **Step 2: Add a build-push workflow**
+
+Create `.github/workflows/attic-build-push.yaml`:
+
+```yaml
+name: attic-build-push
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - .github/workflows/attic-build-push.yaml
+      - argocd/applications/attic/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: arc-arm64
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install xz for Nix installer
+        run: sudo apt-get update && sudo apt-get install -y xz-utils
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build Attic image
+        run: nix build .#atticd-image --print-build-logs
+
+      - name: Load and push image
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$(git rev-parse --short=8 HEAD)"
+          image="registry.ide-newton.ts.net/lab/attic:${tag}"
+          gzip -dc result | docker load
+          docker tag registry.ide-newton.ts.net/lab/attic:dev "${image}"
+          docker push "${image}"
+          docker tag "${image}" registry.ide-newton.ts.net/lab/attic:latest
+          docker push registry.ide-newton.ts.net/lab/attic:latest
+```
+
+- [ ] **Step 3: Validate the package locally or in CI**
+
+Run:
+
+```bash
+nix build .#atticd-image --print-build-logs
+```
+
+Expected: `result` is a Docker image tarball containing `atticd`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add flake.nix .github/workflows/attic-build-push.yaml
+git commit -m "feat(nix): build attic cache image"
+```
+
+### Task 5: Deploy Attic API, Service, And Ingress
+
+**Files:**
+- Create: `argocd/applications/attic/deployment.yaml`
+- Create: `argocd/applications/attic/service.yaml`
+- Create: `argocd/applications/attic/ingressroute-attic-k8s-private.yaml`
+- Create: `argocd/applications/attic/tailscale-ingress.yaml`
+
+- [ ] **Step 1: Create the deployment**
+
+Create `argocd/applications/attic/deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: attic
+  namespace: attic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: attic
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: attic
+    spec:
+      containers:
+        - name: attic
+          image: registry.ide-newton.ts.net/lab/attic:latest
+          imagePullPolicy: Always
+          args:
+            - -f
+            - /etc/attic/server.toml
+            - --mode
+            - api-server
+          env:
+            - name: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+              valueFrom:
+                secretKeyRef:
+                  name: attic-secrets
+                  key: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+            - name: ATTIC_SERVER_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: attic-db-app
+                  key: uri
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_SECRET_ACCESS_KEY
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          volumeMounts:
+            - name: attic-config
+              mountPath: /etc/attic
+              readOnly: true
+      volumes:
+        - name: attic-config
+          configMap:
+            name: attic-config
+```
+
+- [ ] **Step 2: Create the service**
+
+Create `argocd/applications/attic/service.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: attic
+  namespace: attic
+spec:
+  selector:
+    app.kubernetes.io/name: attic
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+```
+
+- [ ] **Step 3: Create the private Traefik route**
+
+Create `argocd/applications/attic/ingressroute-attic-k8s-private.yaml`:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: attic-private
+  namespace: attic
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`attic.k8s.proompteng.ai`)
+      services:
+        - name: attic
+          port: 80
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls
+```
+
+- [ ] **Step 4: Create the Tailscale ingress**
+
+Create `argocd/applications/attic/tailscale-ingress.yaml`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: attic-tailscale
+  namespace: attic
+  annotations:
+    tailscale.com/tags: tag:k8s
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - attic.ide-newton.ts.net
+  rules:
+    - host: attic.ide-newton.ts.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: attic
+                port:
+                  number: 80
+```
+
+- [ ] **Step 5: Validate manifests**
+
+Run:
+
+```bash
+nix run .#lint-argocd
+```
+
+Expected: deployment, service, Traefik route, and Tailscale ingress validate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add argocd/applications/attic/deployment.yaml argocd/applications/attic/service.yaml argocd/applications/attic/ingressroute-attic-k8s-private.yaml argocd/applications/attic/tailscale-ingress.yaml
+git commit -m "feat(nix): deploy attic cache service"
+```
+
+### Task 6: Add Bootstrap And Garbage Collection Jobs
+
+**Files:**
+- Create: `argocd/applications/attic/bootstrap-job.yaml`
+- Create: `argocd/applications/attic/gc-cronjob.yaml`
+
+- [ ] **Step 1: Create bootstrap job**
+
+Create `argocd/applications/attic/bootstrap-job.yaml`:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: attic-bootstrap
+  namespace: attic
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: registry.ide-newton.ts.net/lab/attic:latest
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              until wget -q -O /dev/null http://attic.attic.svc.cluster.local/; do
+                sleep 5
+              done
+
+              bootstrap_token="$(
+                atticadm -f /etc/attic/server.toml make-token \
+                  --sub bootstrap \
+                  --validity '1 day' \
+                  --pull lab \
+                  --push lab \
+                  --create-cache lab \
+                  --configure-cache lab \
+                  --configure-cache-retention lab
+              )"
+
+              attic login lab http://attic.attic.svc.cluster.local "${bootstrap_token}"
+              attic cache create lab || true
+              attic cache configure lab --public --retention-period '6 months'
+              atticadm -f /etc/attic/server.toml make-token --sub github-actions --validity '12 months' --pull lab --push lab > /tmp/attic-ci-token
+              echo "Copy the token from this job log into 1Password infra/attic-cache field ci-token, then delete this Job."
+              cat /tmp/attic-ci-token
+          env:
+            - name: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+              valueFrom:
+                secretKeyRef:
+                  name: attic-secrets
+                  key: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+            - name: ATTIC_SERVER_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: attic-db-app
+                  key: uri
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_SECRET_ACCESS_KEY
+          volumeMounts:
+            - name: attic-config
+              mountPath: /etc/attic
+              readOnly: true
+      volumes:
+        - name: attic-config
+          configMap:
+            name: attic-config
+```
+
+After first bootstrap, replace `ATTIC_CI_TOKEN` in 1Password with the generated scoped token and remove this Job from `kustomization.yaml` in the same PR or a follow-up commit.
+
+- [ ] **Step 2: Create the garbage collection CronJob**
+
+Create `argocd/applications/attic/gc-cronjob.yaml`:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: attic-gc
+  namespace: attic
+spec:
+  schedule: "23 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: attic-gc
+              image: registry.ide-newton.ts.net/lab/attic:latest
+              args:
+                - -f
+                - /etc/attic/server.toml
+                - --mode
+                - garbage-collector-once
+              env:
+                - name: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-secrets
+                      key: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+                - name: ATTIC_SERVER_DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-db-app
+                      key: uri
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-cache
+                      key: AWS_ACCESS_KEY_ID
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-cache
+                      key: AWS_SECRET_ACCESS_KEY
+              volumeMounts:
+                - name: attic-config
+                  mountPath: /etc/attic
+                  readOnly: true
+          volumes:
+            - name: attic-config
+              configMap:
+                name: attic-config
+```
+
+- [ ] **Step 3: Validate manifests**
+
+Run:
+
+```bash
+nix run .#lint-argocd
+```
+
+Expected: Job and CronJob validate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add argocd/applications/attic/bootstrap-job.yaml argocd/applications/attic/gc-cronjob.yaml
+git commit -m "feat(nix): bootstrap attic cache lifecycle"
+```
+
+### Task 7: Add Client Tooling And Doctor Commands
+
+**Files:**
+- Modify: `flake.nix`
+- Create: `nix/cache-doctor.sh`
+- Create: `nix/cache-push.sh`
+- Create: `docs/nix-cache.md`
+
+- [ ] **Step 1: Add Attic client tooling to the dev shell**
+
+Add `pkgs.attic-client` to the existing dev shell package list in `flake.nix`. If the current nixpkgs pin does not expose `pkgs.attic-client`, stop and update this task to import `github:zhaofengli/attic` as a flake input before changing any manifests.
+
+- [ ] **Step 2: Add `nix/cache-doctor.sh`**
+
+Create `nix/cache-doctor.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_url="${NIX_CACHE_URL:-https://attic.ide-newton.ts.net/lab}"
+
+echo "cache_url=${cache_url}"
+curl -fsSL "${cache_url}/nix-cache-info" >/tmp/nix-cache-info
+cat /tmp/nix-cache-info
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "nix is not installed"
+  exit 1
+fi
+
+nix show-config | grep -E '^(substituters|trusted-public-keys) = ' || true
+echo "nix cache doctor completed"
+```
+
+- [ ] **Step 3: Add `nix/cache-push.sh`**
+
+Create `nix/cache-push.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${ATTIC_TOKEN:-}" ]]; then
+  echo "ATTIC_TOKEN is not set; skipping cache push"
+  exit 0
+fi
+
+cache_name="${ATTIC_CACHE_NAME:-lab}"
+cache_endpoint="${ATTIC_CACHE_ENDPOINT:-https://attic.ide-newton.ts.net}"
+
+attic login "${cache_name}" "${cache_endpoint}" "${ATTIC_TOKEN}"
+
+paths=("$@")
+if [[ "${#paths[@]}" -eq 0 ]]; then
+  mapfile -t paths < <(nix path-info .#checks.x86_64-linux.toolchain 2>/dev/null || true)
+fi
+
+if [[ "${#paths[@]}" -eq 0 ]]; then
+  echo "No store paths supplied or discovered; skipping cache push"
+  exit 0
+fi
+
+attic push "${cache_name}" "${paths[@]}"
+```
+
+- [ ] **Step 4: Expose flake apps**
+
+Expose these apps in `flake.nix`:
+
+```nix
+cache-doctor = {
+  type = "app";
+  program = "${pkgs.writeShellApplication {
+    name = "cache-doctor";
+    runtimeInputs = [ pkgs.curl pkgs.nix ];
+    text = builtins.readFile ./nix/cache-doctor.sh;
+  }}/bin/cache-doctor";
+};
+
+cache-push = {
+  type = "app";
+  program = "${pkgs.writeShellApplication {
+    name = "cache-push";
+    runtimeInputs = [ pkgs.attic-client pkgs.nix ];
+    text = builtins.readFile ./nix/cache-push.sh;
+  }}/bin/cache-push";
+};
+```
+
+- [ ] **Step 5: Add docs**
+
+Create `docs/nix-cache.md`:
+
+```markdown
+# Nix Cache
+
+The lab Nix binary cache is hosted by Attic inside the cluster.
+
+Default substituter:
+
+```text
+https://attic.ide-newton.ts.net/lab
+```
+
+Set `ATTIC_PUBLIC_KEY` to the exact public key printed by `attic cache info lab`, then use the cache:
+
+```bash
+export ATTIC_PUBLIC_KEY="$(attic cache info lab | awk -F': ' '/Public Key/ {print $2}')"
+nix develop --option substituters "https://attic.ide-newton.ts.net/lab https://cache.nixos.org/" --option trusted-public-keys "${ATTIC_PUBLIC_KEY}"
+```
+
+Validate connectivity:
+
+```bash
+nix run .#cache-doctor
+```
+
+Push policy:
+
+- Pulls are allowed for developers and pull requests.
+- Pushes require `ATTIC_TOKEN`.
+- GitHub Actions push only runs on trusted `main` branch workflows.
+- Pull request workflows must never receive `ATTIC_TOKEN`.
+```
+
+- [ ] **Step 6: Validate shell scripts**
+
+Run:
+
+```bash
+shellcheck nix/cache-doctor.sh nix/cache-push.sh
+```
+
+Expected: no shellcheck errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add flake.nix nix/cache-doctor.sh nix/cache-push.sh docs/nix-cache.md
+git commit -m "feat(nix): add attic cache client tooling"
+```
+
+### Task 8: Wire Trusted CI Cache Consumption And Push
+
+**Files:**
+- Modify: `.github/workflows/nix-toolchain.yml`
+- Modify: `.github/workflows/oci-native-build-common.yml`
+
+- [ ] **Step 1: Add pull-only cache settings to Nix installs**
+
+For jobs running on ARC or after Tailscale is configured, update `cachix/install-nix-action@v31`:
+
+```yaml
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            substituters = https://attic.ide-newton.ts.net/lab https://cache.nixos.org/
+            trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+```
+
+Set GitHub Actions variable `ATTIC_PUBLIC_KEY` to the public key printed by `attic cache info lab`. This value is public and should also be recorded in `docs/nix-cache.md`.
+
+- [ ] **Step 2: Add trusted push after successful Nix checks**
+
+Add this step only to `push` on `main` jobs after `nix flake check` passes:
+
+```yaml
+      - name: Push Nix closure to Attic
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_CACHE_NAME: lab
+          ATTIC_CACHE_ENDPOINT: https://attic.ide-newton.ts.net
+        run: |
+          set -euo pipefail
+          nix build .#checks.x86_64-linux.toolchain --print-build-logs
+          nix run .#cache-push -- "$(readlink -f result)"
+```
+
+- [ ] **Step 3: Keep PR workflows pull-only**
+
+Search the workflows:
+
+```bash
+rg -n "ATTIC_TOKEN|cache-push|trusted-public-keys|substituters" .github/workflows
+```
+
+Expected: `ATTIC_TOKEN` appears only in `push` on `main` guarded steps.
+
+- [ ] **Step 4: Validate CI YAML**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+for path in Path('.github/workflows').glob('*.y*ml'):
+    with path.open() as handle:
+        yaml.safe_load(handle)
+print('workflow yaml ok')
+PY
+```
+
+Expected: `workflow yaml ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/nix-toolchain.yml .github/workflows/oci-native-build-common.yml
+git commit -m "ci(nix): use attic cache on trusted jobs"
+```
+
+### Task 9: Rollout And Proof
+
+**Files:**
+- No new files. This task verifies live state and CI behavior.
+
+- [ ] **Step 1: Merge the manifest branch and let Argo create `attic`**
+
+After PR merge, watch Argo:
+
+```bash
+argocd app get attic
+kubectl -n attic get deploy,po,svc,ingress,externalsecret,objectbucketclaim,cluster
+```
+
+Expected: `attic` is Synced/Healthy; deployment has one ready pod; OBC and CNPG resources are ready.
+
+- [ ] **Step 2: Verify cache endpoint**
+
+Run:
+
+```bash
+curl -fsSL https://attic.ide-newton.ts.net/lab/nix-cache-info
+```
+
+Expected: response includes Nix cache metadata for the `lab` cache.
+
+- [ ] **Step 3: Verify CI pull performance**
+
+Run the Nix toolchain workflow twice on the same commit:
+
+```bash
+gh workflow run nix-toolchain.yml --ref main
+gh run list --workflow nix-toolchain.yml --limit 5
+```
+
+Expected: second run spends less time realizing the Nix toolchain closure than the first run and shows successful substituter hits in Nix logs.
+
+- [ ] **Step 4: Verify trusted push policy**
+
+Run:
+
+```bash
+PR_NUMBER="$(gh pr view --json number --jq .number)"
+gh pr checks "${PR_NUMBER}" -R proompteng/lab
+rg -n "ATTIC_TOKEN" .github/workflows
+```
+
+Expected: PR jobs pass without `ATTIC_TOKEN`; push jobs on `main` have the only cache push step.
+
+- [ ] **Step 5: Record rollout memory**
+
+Run:
+
+```bash
+bun run --filter memories save-memory --task-name "lab nix attic cache rollout" --summary "Cluster-hosted Attic cache deployed and wired to trusted Nix jobs" --content "Attic app, endpoint, CI runs, public key, and timing evidence" --tags lab,nix,attic,cache,ci
+```
+
+Expected: memory save succeeds. If it returns a service error, create an ad-hoc note under `/Users/gregkonush/.codex/memories/extensions/ad_hoc/notes/`.
+
+## Regression Gates
+
+- Pull requests must never receive an Attic push token.
+- The cache service must stay private to cluster/Tailscale/private ingress unless a separate access review approves public exposure.
+- `trusted-public-keys` must contain only public cache keys.
+- Attic JWT signing key and CI push token must live in 1Password/ExternalSecret, not repo files.
+- Nix cache rollout must not change Docker layer cache policy; OCI Buildx cache refs remain separate.
+- Failing cache should degrade to `cache.nixos.org`, not block all development shell usage.
+
+## Source Notes
+
+- Attic: self-hostable Nix binary cache with S3-compatible storage, deduplication, scoped tokens, managed signing, and production PostgreSQL/S3 guidance.
+- Harmonia: binary cache that serves the local `/nix/store` over HTTP; useful but not the best cluster object-store-backed push cache.
+- nix-serve-ng: faster drop-in replacement for `nix-serve`; useful local-store serving, not the primary shared cache design.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763934636,
+        "narHash": "sha256-9glbI7f1uU+yzQCq5LwLgdZqx6svOhZWkd4JRY265fc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,14 @@
             name: text:
             mkShellScript name (shellPackages ++ [ pkgs.bash ]) text;
 
+          mkOciScript =
+            name: text:
+            mkShellScript name [
+              exact.bun
+              pkgs.go-containerregistry
+              pkgs.regclient
+            ] text;
+
           lintArgocd = mkScript "lint-argocd" ''
             exec bash scripts/kubeconform.sh argocd
           '';
@@ -120,11 +128,15 @@
             exec bash scripts/argo-lint.sh
           '';
 
-          inspectOciImage = mkScript "inspect-oci-image" ''
+          createOciIndex = mkOciScript "create-oci-index" ''
+            exec bun run packages/scripts/src/shared/oci.ts create-index "$@"
+          '';
+
+          inspectOciImage = mkOciScript "inspect-oci-image" ''
             exec bun run packages/scripts/src/shared/oci.ts inspect "$@"
           '';
 
-          assertOciPlatforms = mkScript "assert-oci-platforms" ''
+          assertOciPlatforms = mkOciScript "assert-oci-platforms" ''
             exec bun run packages/scripts/src/shared/oci.ts assert "$@"
           '';
 
@@ -143,6 +155,7 @@
               lintArgocd
               renderHeadlamp
               lintArgoWorkflows
+              createOciIndex
               inspectOciImage
               assertOciPlatforms
               ;
@@ -155,6 +168,7 @@
             lint-argocd = mkApp lintArgocd;
             render-headlamp = mkApp renderHeadlamp;
             lint-argo-workflows = mkApp lintArgoWorkflows;
+            create-oci-index = mkApp createOciIndex;
             inspect-oci-image = mkApp inspectOciImage;
             assert-oci-platforms = mkApp assertOciPlatforms;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,180 @@
+{
+  description = "Lab repository development and CI toolchain";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = f: builtins.listToAttrs (map (system: { name = system; value = f system; }) systems);
+
+      mkSystem =
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = false;
+          };
+          lib = pkgs.lib;
+
+          assertVersion =
+            name: expected: pkg:
+            let
+              actual = toString (lib.getVersion pkg);
+            in
+            if actual == expected then pkg else throw "${name} expected ${expected}, got ${actual}";
+
+          exact = import ./nix/packages.nix { inherit pkgs lib system; };
+
+          nodejs = assertVersion "nodejs_24" "24.11.1" pkgs.nodejs_24;
+          go = exact.go;
+          ruby = assertVersion "ruby_3_4" "3.4.7" pkgs.ruby_3_4;
+
+          shellPackages = [
+            nodejs
+            exact.bun
+            go
+            ruby
+            pkgs.python311
+            pkgs.python312
+            pkgs.uv
+            pkgs.opentofu
+            exact.helm
+            exact.kustomize
+            exact.kubeconform
+            exact.kubectl
+            exact.argo-workflows
+            pkgs.argocd
+            pkgs.buf
+            pkgs.gh
+            exact.shellcheck
+            pkgs.jq
+            exact.yq
+            pkgs.ripgrep
+            pkgs.fd
+            pkgs.fzf
+            pkgs.git
+            pkgs.gnumake
+            pkgs.pkg-config
+            pkgs.openssl
+            pkgs.zlib
+            pkgs.buildkit
+            pkgs.docker-client
+            pkgs.docker-buildx
+            pkgs.go-containerregistry
+            pkgs.skopeo
+            pkgs.regclient
+            pkgs.cosign
+          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            pkgs.libiconv
+          ];
+
+          mkShellScript =
+            name: runtimeInputs: text:
+            pkgs.writeTextFile {
+              inherit name;
+              destination = "/bin/${name}";
+              executable = true;
+              text = ''
+                #!${pkgs.runtimeShell}
+                set -euo pipefail
+                export PATH=${lib.makeBinPath runtimeInputs}:$PATH
+
+              '' + text;
+            };
+
+          toolchainDoctor = mkShellScript "toolchain-doctor" (
+            shellPackages ++ [
+              pkgs.gawk
+              pkgs.gnugrep
+            ]
+          ) (builtins.readFile ./nix/toolchain-doctor.sh);
+
+          ociDoctor = mkShellScript "oci-doctor" (
+            shellPackages ++ [
+              pkgs.coreutils
+              pkgs.gawk
+            ]
+          ) (builtins.readFile ./nix/oci-doctor.sh);
+
+          mkScript =
+            name: text:
+            mkShellScript name (shellPackages ++ [ pkgs.bash ]) text;
+
+          lintArgocd = mkScript "lint-argocd" ''
+            exec bash scripts/kubeconform.sh argocd
+          '';
+
+          renderHeadlamp = mkScript "render-headlamp" ''
+            exec kustomize build --enable-helm argocd/applications/headlamp >/dev/null
+          '';
+
+          lintArgoWorkflows = mkScript "lint-argo-workflows" ''
+            exec bash scripts/argo-lint.sh
+          '';
+
+          inspectOciImage = mkScript "inspect-oci-image" ''
+            exec bun run packages/scripts/src/shared/oci.ts inspect "$@"
+          '';
+
+          assertOciPlatforms = mkScript "assert-oci-platforms" ''
+            exec bun run packages/scripts/src/shared/oci.ts assert "$@"
+          '';
+
+          mkApp = drv: {
+            type = "app";
+            program = lib.getExe drv;
+            meta.description = drv.meta.description or "${drv.name} application";
+          };
+        in
+        {
+          packages = exact // {
+            default = toolchainDoctor;
+            inherit
+              toolchainDoctor
+              ociDoctor
+              lintArgocd
+              renderHeadlamp
+              lintArgoWorkflows
+              inspectOciImage
+              assertOciPlatforms
+              ;
+          };
+
+          apps = {
+            default = mkApp toolchainDoctor;
+            toolchain-doctor = mkApp toolchainDoctor;
+            oci-doctor = mkApp ociDoctor;
+            lint-argocd = mkApp lintArgocd;
+            render-headlamp = mkApp renderHeadlamp;
+            lint-argo-workflows = mkApp lintArgoWorkflows;
+            inspect-oci-image = mkApp inspectOciImage;
+            assert-oci-platforms = mkApp assertOciPlatforms;
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = shellPackages ++ [
+              toolchainDoctor
+              ociDoctor
+            ];
+            shellHook = ''
+              export LAB_NIX_TOOLCHAIN=1
+            '';
+          };
+
+        };
+
+    in
+    {
+      packages = forAllSystems (system: (mkSystem system).packages);
+      apps = forAllSystems (system: (mkSystem system).apps);
+      devShells = forAllSystems (system: (mkSystem system).devShells);
+    };
+}

--- a/kubernetes/coder/README.md
+++ b/kubernetes/coder/README.md
@@ -56,6 +56,9 @@ coder workspaces create sutro --template "k8s-arm64"
   - Persist Bun environment variables in `.profile` and `.zshrc`
   - Run with a workspace service account bound to `cluster-admin` via a ClusterRoleBinding (cluster-wide) so `kubectl` works inside the pod
 
+This bootstrap remains imperative for now. Once Nix is installed in the workspace image or startup script, prefer the
+repo shell with `nix develop` and verify it with `toolchain-doctor`; the flake pins the versions used by the CI pilot.
+
 If a workspace becomes unhealthy, check logs inside the pod:
 
 - `/tmp/coder-startup-script.log`

--- a/nix/oci-doctor.sh
+++ b/nix/oci-doctor.sh
@@ -17,13 +17,12 @@ print_version() {
   printf '%-18s %s\n' "$name" "$output"
 }
 
-for cmd in buildctl buildkitd buildctl-daemonless.sh docker docker-buildx crane skopeo regctl cosign; do
+for cmd in buildctl buildkitd docker docker-buildx crane skopeo regctl cosign; do
   have "$cmd"
 done
 
 print_version buildctl buildctl --version
 print_version buildkitd buildkitd --version
-printf '%-18s %s\n' buildctl-daemonless "$(command -v buildctl-daemonless.sh)"
 print_version docker-buildx docker-buildx version
 print_version "docker buildx" docker buildx version
 print_version crane crane version

--- a/nix/oci-doctor.sh
+++ b/nix/oci-doctor.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 fail() {
   printf 'oci-doctor: %s\n' "$*" >&2
   exit 1

--- a/nix/oci-doctor.sh
+++ b/nix/oci-doctor.sh
@@ -1,0 +1,37 @@
+fail() {
+  printf 'oci-doctor: %s\n' "$*" >&2
+  exit 1
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+print_version() {
+  name="$1"
+  shift
+  output="$("$@" 2>/dev/null | head -n 1 || true)"
+  [ -n "$output" ] || fail "$name did not print a version"
+  printf '%-18s %s\n' "$name" "$output"
+}
+
+for cmd in buildctl buildkitd buildctl-daemonless.sh docker docker-buildx crane skopeo regctl cosign; do
+  have "$cmd"
+done
+
+print_version buildctl buildctl --version
+print_version buildkitd buildkitd --version
+printf '%-18s %s\n' buildctl-daemonless "$(command -v buildctl-daemonless.sh)"
+print_version docker-buildx docker-buildx version
+print_version "docker buildx" docker buildx version
+print_version crane crane version
+print_version skopeo skopeo --version
+print_version regctl regctl version
+cosign_version="$(cosign version --json 2>/dev/null | jq -r '.gitVersion // .GitVersion // .version // empty' 2>/dev/null || true)"
+if [ -z "$cosign_version" ]; then
+  cosign_version="$(cosign version 2>/dev/null | awk '/GitVersion|Version/ {print $NF; exit}')"
+fi
+[ -n "$cosign_version" ] || fail "cosign did not print a version"
+printf '%-18s %s\n' cosign "$cosign_version"
+
+printf 'oci-doctor: ok\n'

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,433 @@
+{ pkgs, lib, system }:
+
+let
+  fetchurl = pkgs.fetchurl;
+
+  unsupported = name: throw "${name} is not packaged for ${system}";
+
+  sourceFor =
+    name: sources:
+    sources.${system} or (unsupported name);
+
+  mkTarballBin =
+    {
+      pname,
+      version,
+      source,
+      installPath ? pname,
+      outputName ? pname,
+    }:
+    pkgs.stdenvNoCC.mkDerivation ({
+      inherit pname version;
+      src = source.src;
+      nativeBuildInputs = [
+        pkgs.gnutar
+        pkgs.gzip
+        pkgs.xz
+      ];
+
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        runHook preInstall
+        install -Dm755 ${installPath} "$out/bin/${outputName}"
+        runHook postInstall
+      '';
+    } // lib.optionalAttrs (source ? sourceRoot) {
+      inherit (source) sourceRoot;
+    });
+
+  mkRawBin =
+    {
+      pname,
+      version,
+      source,
+      outputName ? pname,
+    }:
+    pkgs.stdenvNoCC.mkDerivation {
+      inherit pname version;
+      src = source.src;
+
+      dontUnpack = true;
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        runHook preInstall
+        install -Dm755 "$src" "$out/bin/${outputName}"
+        runHook postInstall
+      '';
+    };
+
+  mkGzipBin =
+    {
+      pname,
+      version,
+      source,
+      outputName ? pname,
+    }:
+    pkgs.stdenvNoCC.mkDerivation {
+      inherit pname version;
+      src = source.src;
+      nativeBuildInputs = [ pkgs.gzip ];
+
+      dontUnpack = true;
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        runHook preInstall
+        gzip -dc "$src" > "${outputName}"
+        install -Dm755 "${outputName}" "$out/bin/${outputName}"
+        runHook postInstall
+      '';
+    };
+
+  helmVersion = "3.14.4";
+  helmSource = sourceFor "helm" {
+    x86_64-linux = {
+      archiveRoot = "linux-amd64";
+      src = fetchurl {
+        url = "https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz";
+        hash = "sha256-pYRO8sOO9t3ztaj32R5+Do68OaOLs/yAE9Ypwe8pwlk=";
+      };
+    };
+    aarch64-linux = {
+      archiveRoot = "linux-arm64";
+      src = fetchurl {
+        url = "https://get.helm.sh/helm-v${helmVersion}-linux-arm64.tar.gz";
+        hash = "sha256-ETzMU7fFfCq6DNCqVgtVAIQbGLUhDXhkGs/dxT2sirI=";
+      };
+    };
+    x86_64-darwin = {
+      archiveRoot = "darwin-amd64";
+      src = fetchurl {
+        url = "https://get.helm.sh/helm-v${helmVersion}-darwin-amd64.tar.gz";
+        hash = "sha256-c0NK6sNq0GjOLlWCuIUaKG3GKOrhZJSibirQskpxmfk=";
+      };
+    };
+    aarch64-darwin = {
+      archiveRoot = "darwin-arm64";
+      src = fetchurl {
+        url = "https://get.helm.sh/helm-v${helmVersion}-darwin-arm64.tar.gz";
+        hash = "sha256-YenFRV8Gsq0KEoCXW/ZYkucHrcGddmsM9OkAbjt7S2w=";
+      };
+    };
+  };
+
+  kustomizeVersion = "5.8.0";
+  kustomizeSource = sourceFor "kustomize" {
+    x86_64-linux = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${kustomizeVersion}/kustomize_v${kustomizeVersion}_linux_amd64.tar.gz";
+        hash = "sha256-TfqDBzWN2ShKpNKx1VlnZqZbk0M+j6P590SYlB8Bxe8=";
+      };
+    };
+    aarch64-linux = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${kustomizeVersion}/kustomize_v${kustomizeVersion}_linux_arm64.tar.gz";
+        hash = "sha256-pPSLTD1MqX10iUPhkWnehaLoboC8wJVYYD4qpm+xXOE=";
+      };
+    };
+    x86_64-darwin = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${kustomizeVersion}/kustomize_v${kustomizeVersion}_darwin_amd64.tar.gz";
+        hash = "sha256-Leqm+WRQwLMgTMzZ8VmiInjrbPha1UXSEtYI0kKK61c=";
+      };
+    };
+    aarch64-darwin = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${kustomizeVersion}/kustomize_v${kustomizeVersion}_darwin_arm64.tar.gz";
+        hash = "sha256-0Jj2Ls2lAMdSMDFjg4r4I/lH0kWSfzAAtikZnB7urg8=";
+      };
+    };
+  };
+
+  kubeconformVersion = "0.7.0";
+  kubeconformSource = sourceFor "kubeconform" {
+    x86_64-linux = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/yannh/kubeconform/releases/download/v${kubeconformVersion}/kubeconform-linux-amd64.tar.gz";
+        hash = "sha256-wxUY3dEiZjs/Oqh0z+gXjLCYjelE8px0oLkmCSDRFdM=";
+      };
+    };
+    aarch64-linux = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/yannh/kubeconform/releases/download/v${kubeconformVersion}/kubeconform-linux-arm64.tar.gz";
+        hash = "sha256-zJB8z548NFI/DzK2l0UmXgppCMqFuS9Bkx1FN4YOuDw=";
+      };
+    };
+    x86_64-darwin = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/yannh/kubeconform/releases/download/v${kubeconformVersion}/kubeconform-darwin-amd64.tar.gz";
+        hash = "sha256-xnccyJTYLhsS817nl9zaH32mo3h6owkCoVwmQFbdQNQ=";
+      };
+    };
+    aarch64-darwin = {
+      sourceRoot = ".";
+      src = fetchurl {
+        url = "https://github.com/yannh/kubeconform/releases/download/v${kubeconformVersion}/kubeconform-darwin-arm64.tar.gz";
+        hash = "sha256-tdMrLLd/nHgcl2sgqF4tC8j5GE1dHP5mWi8xoZ+Z7rk=";
+      };
+    };
+  };
+
+  kubectlVersion = "1.29.4";
+  kubectlSource = sourceFor "kubectl" {
+    x86_64-linux.src = fetchurl {
+      url = "https://dl.k8s.io/release/v${kubectlVersion}/bin/linux/amd64/kubectl";
+      hash = "sha256-EONDhhw8sAEBYecDMHupB63Sru6v/GREd5rZFfmInIg=";
+    };
+    aarch64-linux.src = fetchurl {
+      url = "https://dl.k8s.io/release/v${kubectlVersion}/bin/linux/arm64/kubectl";
+      hash = "sha256-YVN0CO7crQZNczQ4Su1Qioqh6nhjEbh7UFRWouBTXTY=";
+    };
+    x86_64-darwin.src = fetchurl {
+      url = "https://dl.k8s.io/release/v${kubectlVersion}/bin/darwin/amd64/kubectl";
+      hash = "sha256-evm4ojPEmtXuy1kARxngvAeXJJK2dOu84pGeUzJrVbI=";
+    };
+    aarch64-darwin.src = fetchurl {
+      url = "https://dl.k8s.io/release/v${kubectlVersion}/bin/darwin/arm64/kubectl";
+      hash = "sha256-s6iB5iCKpBJ1qXSBZ2qMijwWKC8817RBsX8ligVAEvE=";
+    };
+  };
+
+  argoWorkflowsVersion = "4.0.5";
+  argoWorkflowsSource = sourceFor "argo-workflows" {
+    x86_64-linux.src = fetchurl {
+      url = "https://github.com/argoproj/argo-workflows/releases/download/v${argoWorkflowsVersion}/argo-linux-amd64.gz";
+      hash = "sha256-hzJBjzvJMOnqDivklycM8kW1XHrJrhFoVnQ/a8MnM8A=";
+    };
+    aarch64-linux.src = fetchurl {
+      url = "https://github.com/argoproj/argo-workflows/releases/download/v${argoWorkflowsVersion}/argo-linux-arm64.gz";
+      hash = "sha256-KAaD9NKcQzxhS7xH2GONLKCVqY4VD4IbcaQHMmBuNMs=";
+    };
+    x86_64-darwin.src = fetchurl {
+      url = "https://github.com/argoproj/argo-workflows/releases/download/v${argoWorkflowsVersion}/argo-darwin-amd64.gz";
+      hash = "sha256-zztdjIKQLeFj5+85L/vajBdnFiDIInhdFORwVVY+FlQ=";
+    };
+    aarch64-darwin.src = fetchurl {
+      url = "https://github.com/argoproj/argo-workflows/releases/download/v${argoWorkflowsVersion}/argo-darwin-arm64.gz";
+      hash = "sha256-/lFleWUZwKS6riwgAQ4LDh3ra6jzycXC7qIb2INJ4Go=";
+    };
+  };
+
+  shellcheckVersion = "0.11.0";
+  shellcheckSource = sourceFor "shellcheck" {
+    x86_64-linux = {
+      archiveRoot = "shellcheck-v${shellcheckVersion}";
+      src = fetchurl {
+        url = "https://github.com/koalaman/shellcheck/releases/download/v${shellcheckVersion}/shellcheck-v${shellcheckVersion}.linux.x86_64.tar.xz";
+        hash = "sha256-jDvhKwXVwXegTCnjx4zomshvFZVoHKsUm2W5fE4icZg=";
+      };
+    };
+    aarch64-linux = {
+      archiveRoot = "shellcheck-v${shellcheckVersion}";
+      src = fetchurl {
+        url = "https://github.com/koalaman/shellcheck/releases/download/v${shellcheckVersion}/shellcheck-v${shellcheckVersion}.linux.aarch64.tar.xz";
+        hash = "sha256-ErMxwdLba56xPPymQwaxsVeobraduDAj4mHqp+fBRYg=";
+      };
+    };
+    x86_64-darwin = {
+      archiveRoot = "shellcheck-v${shellcheckVersion}";
+      src = fetchurl {
+        url = "https://github.com/koalaman/shellcheck/releases/download/v${shellcheckVersion}/shellcheck-v${shellcheckVersion}.darwin.x86_64.tar.xz";
+        hash = "sha256-PInbTtyrfPHCe/8XiILg9vJ/ev31ToWfoEH8oQ/r5MY=";
+      };
+    };
+    aarch64-darwin = {
+      archiveRoot = "shellcheck-v${shellcheckVersion}";
+      src = fetchurl {
+        url = "https://github.com/koalaman/shellcheck/releases/download/v${shellcheckVersion}/shellcheck-v${shellcheckVersion}.darwin.aarch64.tar.xz";
+        hash = "sha256-Vq/92N5VJ4lNym3D1+Cpmoc7DwBNeqvDCuQH0/SLCnk=";
+      };
+    };
+  };
+
+  yqVersion = "4.49.2";
+  yqSource = sourceFor "yq" {
+    x86_64-linux.src = fetchurl {
+      url = "https://github.com/mikefarah/yq/releases/download/v${yqVersion}/yq_linux_amd64";
+      hash = "sha256-viwN3PQmtqIxZIYQ7F0WZq5Q6fZHPoL2SG+fTLbj4vc=";
+    };
+    aarch64-linux.src = fetchurl {
+      url = "https://github.com/mikefarah/yq/releases/download/v${yqVersion}/yq_linux_arm64";
+      hash = "sha256-eDqjw77tzyv0qvYmLso4uSoW0+ox4iGMqAuo7HImskg=";
+    };
+    x86_64-darwin.src = fetchurl {
+      url = "https://github.com/mikefarah/yq/releases/download/v${yqVersion}/yq_darwin_amd64";
+      hash = "sha256-wUzUrmjUIHTlhGP169vDxJ7CfG3mojtK9YpIO8PxWqA=";
+    };
+    aarch64-darwin.src = fetchurl {
+      url = "https://github.com/mikefarah/yq/releases/download/v${yqVersion}/yq_darwin_arm64";
+      hash = "sha256-sLcO3is5K6AgkbgTe0LbgZp5aM8jLVld1zlKxWaLSgs=";
+    };
+  };
+
+  goVersion = "1.25.5";
+  goSource = sourceFor "go" {
+    x86_64-linux.src = fetchurl {
+      url = "https://go.dev/dl/go${goVersion}.linux-amd64.tar.gz";
+      hash = "sha256-npt1XWOzas8wwSqaP8N5JDcUwcbT3XKGHaY38zbrs1s=";
+    };
+    aarch64-linux.src = fetchurl {
+      url = "https://go.dev/dl/go${goVersion}.linux-arm64.tar.gz";
+      hash = "sha256-sAtpSQPRJsWIw3jnLTVFVJk105gmNbo/epZMn6I/47k=";
+    };
+    x86_64-darwin.src = fetchurl {
+      url = "https://go.dev/dl/go${goVersion}.darwin-amd64.tar.gz";
+      hash = "sha256-tp1RvOWZ5TgalM4VJjrmROyEZnpc4j1Y3C5j4sEqn1Y=";
+    };
+    aarch64-darwin.src = fetchurl {
+      url = "https://go.dev/dl/go${goVersion}.darwin-arm64.tar.gz";
+      hash = "sha256-vtjr6CTj07J+hHHRMH+AP8arjh0Ot6SuGWl5vZuAHdM=";
+    };
+  };
+
+  bunVersion = "1.3.14";
+  bunSource = sourceFor "bun" {
+    x86_64-linux = {
+      sourceRoot = "bun-linux-x64";
+      src = fetchurl {
+        url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/bun-linux-x64.zip";
+        hash = "sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=";
+      };
+    };
+    aarch64-linux = {
+      sourceRoot = "bun-linux-aarch64";
+      src = fetchurl {
+        url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/bun-linux-aarch64.zip";
+        hash = "sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=";
+      };
+    };
+    x86_64-darwin = {
+      sourceRoot = "bun-darwin-x64-baseline";
+      src = fetchurl {
+        url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/bun-darwin-x64-baseline.zip";
+        hash = "sha256-PjWtb1OXGpg0v55nhuKt9ytfGSHMmpxf3gc9KXKUQHY=";
+      };
+    };
+    aarch64-darwin = {
+      sourceRoot = "bun-darwin-aarch64";
+      src = fetchurl {
+        url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/bun-darwin-aarch64.zip";
+        hash = "sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=";
+      };
+    };
+  };
+
+  bun = pkgs.stdenvNoCC.mkDerivation {
+    pname = "bun";
+    version = bunVersion;
+    src = bunSource.src;
+    sourceRoot = bunSource.sourceRoot;
+
+    strictDeps = true;
+    nativeBuildInputs = [ pkgs.unzip ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+      pkgs.autoPatchelfHook
+    ];
+    buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+      pkgs.openssl
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 ./bun "$out/bin/bun"
+      ln -s "$out/bin/bun" "$out/bin/bunx"
+      runHook postInstall
+    '';
+  };
+
+in
+{
+  inherit bun;
+
+  helm = mkTarballBin {
+    pname = "helm";
+    version = helmVersion;
+    source = helmSource;
+    installPath = "helm";
+  };
+
+  kustomize = mkTarballBin {
+    pname = "kustomize";
+    version = kustomizeVersion;
+    source = kustomizeSource;
+  };
+
+  kubeconform = mkTarballBin {
+    pname = "kubeconform";
+    version = kubeconformVersion;
+    source = kubeconformSource;
+  };
+
+  kubectl = mkRawBin {
+    pname = "kubectl";
+    version = kubectlVersion;
+    source = kubectlSource;
+  };
+
+  argo-workflows = mkGzipBin {
+    pname = "argo-workflows";
+    version = argoWorkflowsVersion;
+    source = argoWorkflowsSource;
+    outputName = "argo";
+  };
+
+  shellcheck = mkTarballBin {
+    pname = "shellcheck";
+    version = shellcheckVersion;
+    source = shellcheckSource;
+    installPath = "shellcheck";
+  };
+
+  yq = mkRawBin {
+    pname = "yq";
+    version = yqVersion;
+    source = yqSource;
+  };
+
+  go = pkgs.stdenvNoCC.mkDerivation {
+    pname = "go";
+    version = goVersion;
+    src = goSource.src;
+    sourceRoot = "go";
+
+    nativeBuildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+      pkgs.autoPatchelfHook
+    ];
+    buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+      pkgs.stdenv.cc.cc.lib
+    ];
+    autoPatchelfIgnoreMissingDeps = [
+      # Go ships ELF fixtures in src/debug testdata. They are not executed by
+      # the dev shell, but auto-patchelf still sees their shared-library names.
+      "libtiff.so.6"
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/share/go" "$out/bin"
+      cp -R . "$out/share/go"
+      ln -s "$out/share/go/bin/go" "$out/bin/go"
+      ln -s "$out/share/go/bin/gofmt" "$out/bin/gofmt"
+      runHook postInstall
+    '';
+  };
+}

--- a/nix/toolchain-doctor.sh
+++ b/nix/toolchain-doctor.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 fail() {
   printf 'toolchain-doctor: %s\n' "$*" >&2
   exit 1

--- a/nix/toolchain-doctor.sh
+++ b/nix/toolchain-doctor.sh
@@ -1,0 +1,52 @@
+fail() {
+  printf 'toolchain-doctor: %s\n' "$*" >&2
+  exit 1
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+expect_eq() {
+  name="$1"
+  expected="$2"
+  actual="$3"
+  if [ "$actual" != "$expected" ]; then
+    fail "$name expected $expected, got $actual"
+  fi
+  printf '%-18s %s\n' "$name" "$actual"
+}
+
+expect_contains() {
+  name="$1"
+  expected="$2"
+  actual="$3"
+  case "$actual" in
+    *"$expected"*) printf '%-18s %s\n' "$name" "$actual" ;;
+    *) fail "$name expected output containing $expected, got $actual" ;;
+  esac
+}
+
+for cmd in node bun go ruby python3.11 python3.12 uv tofu helm kustomize kubeconform kubectl argo argocd buf gh shellcheck jq yq rg fd fzf; do
+  have "$cmd"
+done
+
+expect_eq node v24.11.1 "$(node --version)"
+expect_eq bun 1.3.14 "$(bun --version)"
+expect_eq go go1.25.5 "$(go version | awk '{print $3}')"
+expect_eq ruby 3.4.7 "$(ruby --version | awk '{print $2}')"
+expect_contains python3.11 "Python 3.11." "$(python3.11 --version)"
+expect_contains python3.12 "Python 3.12." "$(python3.12 --version)"
+printf '%-18s %s\n' uv "$(uv --version | head -n 1)"
+printf '%-18s %s\n' tofu "$(tofu version | head -n 1)"
+expect_eq helm v3.14.4 "$(helm version --template '{{ .Version }}')"
+expect_contains kustomize "v5.8.0" "$(kustomize version)"
+expect_contains kubeconform "v0.7.0" "$(kubeconform -v)"
+expect_contains kubectl "v1.29.4" "$(kubectl version --client=true --output=yaml | awk '/gitVersion:/ {print $2; exit}')"
+expect_contains argo "v4.0.5" "$(argo version --short 2>/dev/null || argo version | head -n 1)"
+printf '%-18s %s\n' argocd "$(argocd version --client 2>/dev/null | head -n 1)"
+printf '%-18s %s\n' buf "$(buf --version)"
+printf '%-18s %s\n' gh "$(gh --version | head -n 1)"
+printf '%-18s %s\n' shellcheck "$(shellcheck --version | awk -F': ' '/version:/ {print $2; exit}')"
+expect_contains yq "v4.49.2" "$(yq --version)"
+printf 'toolchain-doctor: ok\n'

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -175,11 +175,12 @@ describe('native OCI build workflows', () => {
     expect(facteurWorkflow).not.toContain('platforms: linux/amd64,linux/arm64')
   })
 
-  it('defines native ARC runners and daemonless OCI index publication', () => {
+  it('defines native ARC runners and minimal Nix OCI index publication', () => {
     expect(nativeWorkflow).toContain('runner: arc-amd64')
     expect(nativeWorkflow).toContain('runner: arc-arm64')
-    expect(nativeWorkflow).toContain('docker buildx build')
-    expect(nativeWorkflow).toContain('bun run packages/scripts/src/shared/oci.ts create-index')
-    expect(nativeWorkflow).toContain('bun run packages/scripts/src/shared/oci.ts assert')
+    expect(nativeWorkflow).toContain('uses: docker/build-push-action@v6')
+    expect(nativeWorkflow).toContain('nix run .#create-oci-index --')
+    expect(nativeWorkflow).toContain('nix run .#assert-oci-platforms --')
+    expect(nativeWorkflow).not.toContain('nix develop -c')
   })
 })

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1,0 +1,185 @@
+import { readFileSync } from 'node:fs'
+
+import { afterEach, describe, expect, it } from 'bun:test'
+
+import { __private, assertOciPlatforms, createOciIndex, inspectOciPlatforms } from '../oci'
+
+const originalWhich = Bun.which
+const facteurWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/facteur-build-push.yaml', import.meta.url),
+  'utf8',
+)
+const nativeWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/oci-native-build-common.yml', import.meta.url),
+  'utf8',
+)
+
+afterEach(() => {
+  __private.setSpawnSync()
+  Bun.which = originalWhich
+})
+
+const spawnResult = (exitCode: number, stdout = '', stderr = '') =>
+  ({
+    exitCode,
+    stdout: Buffer.from(stdout),
+    stderr: Buffer.from(stderr),
+  }) as ReturnType<typeof Bun.spawnSync>
+
+const manifestList = JSON.stringify({
+  schemaVersion: 2,
+  manifests: [
+    {
+      digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      platform: { os: 'linux', architecture: 'amd64' },
+    },
+    {
+      digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      platform: { os: 'unknown', architecture: 'unknown' },
+    },
+    {
+      digest: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      platform: { os: 'linux', architecture: 'arm64' },
+    },
+  ],
+})
+
+describe('inspectOciPlatforms', () => {
+  it('reads schedulable platforms from crane manifest output', () => {
+    Bun.which = ((binary: string) => (binary === 'crane' ? '/bin/crane' : null)) as typeof Bun.which
+    __private.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+      const joined = typeof command === 'string' ? command : command.join(' ')
+      if (joined === 'crane manifest registry.example/lab/facteur:sha') {
+        return spawnResult(0, manifestList)
+      }
+      return spawnResult(1)
+    }) as typeof Bun.spawnSync)
+
+    expect(inspectOciPlatforms('registry.example/lab/facteur:sha')).toEqual([
+      {
+        platform: 'linux/amd64',
+        digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      {
+        platform: 'linux/arm64',
+        digest: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      },
+    ])
+  })
+
+  it('falls back to regctl when crane cannot read the manifest', () => {
+    Bun.which = ((binary: string) =>
+      binary === 'crane' || binary === 'regctl' ? `/bin/${binary}` : null) as typeof Bun.which
+    __private.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+      const joined = typeof command === 'string' ? command : command.join(' ')
+      if (joined === 'crane manifest registry.example/lab/facteur:sha') {
+        return spawnResult(1, '', 'not found')
+      }
+      if (joined === 'regctl manifest get registry.example/lab/facteur:sha --format raw-body') {
+        return spawnResult(0, manifestList)
+      }
+      return spawnResult(1)
+    }) as typeof Bun.spawnSync)
+
+    expect(inspectOciPlatforms('registry.example/lab/facteur:sha').map((entry) => entry.platform)).toEqual([
+      'linux/amd64',
+      'linux/arm64',
+    ])
+  })
+})
+
+describe('assertOciPlatforms', () => {
+  it('fails when a required platform is missing', () => {
+    Bun.which = ((binary: string) => (binary === 'crane' ? '/bin/crane' : null)) as typeof Bun.which
+    __private.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+      const joined = typeof command === 'string' ? command : command.join(' ')
+      if (joined === 'crane manifest registry.example/lab/facteur:sha') {
+        return spawnResult(
+          0,
+          JSON.stringify({
+            manifests: [
+              {
+                digest: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+                platform: { os: 'linux', architecture: 'arm64' },
+              },
+            ],
+          }),
+        )
+      }
+      return spawnResult(1)
+    }) as typeof Bun.spawnSync)
+
+    expect(() => assertOciPlatforms('registry.example/lab/facteur:sha', ['linux/amd64', 'linux/arm64'])).toThrow(
+      'missing required platform(s): linux/amd64',
+    )
+  })
+})
+
+describe('createOciIndex', () => {
+  it('creates an index from arch tags, tags latest, and returns digest outputs', () => {
+    const calls: string[] = []
+    Bun.which = ((binary: string) => (binary === 'crane' ? '/bin/crane' : null)) as typeof Bun.which
+    __private.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+      const joined = typeof command === 'string' ? command : command.join(' ')
+      calls.push(joined)
+
+      if (joined === 'crane digest registry.example/lab/facteur:sha-123-amd64') {
+        return spawnResult(0, 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      }
+      if (joined === 'crane digest registry.example/lab/facteur:sha-123-arm64') {
+        return spawnResult(0, 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc')
+      }
+      if (
+        joined ===
+        'crane index append -m registry.example/lab/facteur@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -m registry.example/lab/facteur@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc -t registry.example/lab/facteur:sha-123'
+      ) {
+        return spawnResult(0)
+      }
+      if (joined === 'crane tag registry.example/lab/facteur:sha-123 latest') {
+        return spawnResult(0)
+      }
+      if (joined === 'crane digest registry.example/lab/facteur:sha-123') {
+        return spawnResult(0, 'sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd')
+      }
+      if (joined === 'crane manifest registry.example/lab/facteur:sha-123') {
+        return spawnResult(0, manifestList)
+      }
+      return spawnResult(1, '', `unexpected call: ${joined}`)
+    }) as typeof Bun.spawnSync)
+
+    const result = createOciIndex({
+      image: 'registry.example/lab/facteur',
+      tag: 'sha-123',
+      latest: true,
+      archTags: [
+        { platform: 'linux/amd64', tag: 'sha-123-amd64' },
+        { platform: 'linux/arm64', tag: 'sha-123-arm64' },
+      ],
+    })
+
+    expect(result).toMatchObject({
+      image: 'registry.example/lab/facteur',
+      tag: 'sha-123',
+      reference: 'registry.example/lab/facteur@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+      digest: 'sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+    })
+    expect(result.platformDigests).toHaveLength(2)
+    expect(calls).toContain('crane tag registry.example/lab/facteur:sha-123 latest')
+  })
+})
+
+describe('native OCI build workflows', () => {
+  it('routes the Facteur canary through native per-architecture builds', () => {
+    expect(facteurWorkflow).toContain('uses: ./.github/workflows/oci-native-build-common.yml')
+    expect(facteurWorkflow).toContain('image_name: facteur')
+    expect(facteurWorkflow).not.toContain('platforms: linux/amd64,linux/arm64')
+  })
+
+  it('defines native ARC runners and daemonless OCI index publication', () => {
+    expect(nativeWorkflow).toContain('runner: arc-amd64')
+    expect(nativeWorkflow).toContain('runner: arc-arm64')
+    expect(nativeWorkflow).toContain('docker buildx build')
+    expect(nativeWorkflow).toContain('bun run packages/scripts/src/shared/oci.ts create-index')
+    expect(nativeWorkflow).toContain('bun run packages/scripts/src/shared/oci.ts assert')
+  })
+})

--- a/packages/scripts/src/shared/oci.ts
+++ b/packages/scripts/src/shared/oci.ts
@@ -1,0 +1,351 @@
+#!/usr/bin/env bun
+
+import { appendFileSync } from 'node:fs'
+
+import { ensureCli, fatal, repoRoot } from './cli'
+
+export type OciPlatformDigest = {
+  platform: string
+  digest: string
+}
+
+export type OciArchTag = {
+  platform: string
+  tag: string
+}
+
+export type CreateOciIndexOptions = {
+  image: string
+  tag: string
+  archTags: OciArchTag[]
+  latest?: boolean
+}
+
+export type CreateOciIndexResult = {
+  image: string
+  tag: string
+  reference: string
+  digest: string
+  platformDigests: OciPlatformDigest[]
+}
+
+type SpawnSync = typeof Bun.spawnSync
+
+let spawnSyncImpl: SpawnSync = Bun.spawnSync
+
+const readProcessOutput = (value: unknown): string => {
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString()
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  try {
+    return JSON.stringify(value) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+const runRequired = (command: string, args: string[]): string => {
+  ensureCli(command)
+  const result = spawnSyncImpl([command, ...args], { cwd: repoRoot })
+  const stdout = readProcessOutput(result.stdout).trim()
+  const stderr = readProcessOutput(result.stderr).trim()
+
+  if (result.exitCode !== 0) {
+    const output = [stdout, stderr].filter(Boolean).join('\n')
+    throw new Error(`${command} ${args.join(' ')} failed${output ? `:\n${output}` : ''}`)
+  }
+
+  return stdout
+}
+
+const runOptional = (command: string, args: string[]): string | undefined => {
+  if (!Bun.which(command)) {
+    return undefined
+  }
+
+  const result = spawnSyncImpl([command, ...args], { cwd: repoRoot })
+  if (result.exitCode !== 0) {
+    return undefined
+  }
+
+  const stdout = readProcessOutput(result.stdout).trim()
+  return stdout.length > 0 ? stdout : undefined
+}
+
+const imageReference = (image: string, tag: string): string => `${image}:${tag}`
+
+const stripTagOrDigest = (reference: string): string => {
+  const digestIndex = reference.indexOf('@')
+  const withoutDigest = digestIndex >= 0 ? reference.slice(0, digestIndex) : reference
+  const lastSlash = withoutDigest.lastIndexOf('/')
+  const lastColon = withoutDigest.lastIndexOf(':')
+
+  if (lastColon > lastSlash) {
+    return withoutDigest.slice(0, lastColon)
+  }
+
+  return withoutDigest
+}
+
+const isFullReference = (value: string): boolean => {
+  if (value.includes('@')) {
+    return true
+  }
+
+  const lastSlash = value.lastIndexOf('/')
+  const lastColon = value.lastIndexOf(':')
+  return lastSlash >= 0 && lastColon > lastSlash
+}
+
+const resolveArchReference = (image: string, archTag: OciArchTag): string => {
+  if (isFullReference(archTag.tag)) {
+    return archTag.tag
+  }
+
+  return imageReference(image, archTag.tag)
+}
+
+const resolveDigestReference = (reference: string): string => {
+  if (reference.includes('@sha256:')) {
+    return reference
+  }
+
+  const digest = runRequired('crane', ['digest', reference])
+  return `${stripTagOrDigest(reference)}@${digest}`
+}
+
+const formatPlatform = (platform: { os?: string; architecture?: string; variant?: string } | undefined): string => {
+  if (!platform?.os || !platform.architecture) {
+    return ''
+  }
+  if (platform.os === 'unknown' || platform.architecture === 'unknown') {
+    return ''
+  }
+  if (platform.variant) {
+    return `${platform.os}/${platform.architecture}/${platform.variant}`
+  }
+  return `${platform.os}/${platform.architecture}`
+}
+
+const parseManifestPlatforms = (manifestBody: string): OciPlatformDigest[] => {
+  const parsed = JSON.parse(manifestBody) as {
+    manifests?: Array<{
+      digest?: string
+      platform?: { os?: string; architecture?: string; variant?: string }
+    }>
+  }
+
+  return (
+    parsed.manifests
+      ?.map((entry) => {
+        const platform = formatPlatform(entry.platform)
+        const digest = entry.digest?.trim()
+        if (!platform || !digest) {
+          return undefined
+        }
+        return { platform, digest }
+      })
+      .filter((entry): entry is OciPlatformDigest => Boolean(entry)) ?? []
+  )
+}
+
+export const inspectOciPlatforms = (imageRef: string): OciPlatformDigest[] => {
+  const manifestBody =
+    runOptional('crane', ['manifest', imageRef]) ??
+    runRequired('regctl', ['manifest', 'get', imageRef, '--format', 'raw-body'])
+
+  return parseManifestPlatforms(manifestBody)
+}
+
+export const assertOciPlatforms = (imageRef: string, requiredPlatforms: string[]): OciPlatformDigest[] => {
+  const observedPlatforms = inspectOciPlatforms(imageRef)
+  const observed = new Set(observedPlatforms.map((entry) => entry.platform))
+  const missing = requiredPlatforms
+    .map((platform) => platform.trim())
+    .filter(Boolean)
+    .filter((platform) => !observed.has(platform))
+
+  if (missing.length > 0) {
+    const observedText = [...observed].sort().join(', ') || 'none'
+    throw new Error(
+      `Image ${imageRef} is missing required platform(s): ${missing.join(', ')}; observed: ${observedText}`,
+    )
+  }
+
+  return observedPlatforms
+}
+
+export const createOciIndex = (options: CreateOciIndexOptions): CreateOciIndexResult => {
+  if (options.archTags.length === 0) {
+    throw new Error('createOciIndex requires at least one architecture tag')
+  }
+
+  const reference = imageReference(options.image, options.tag)
+  const args = ['index', 'append']
+
+  for (const archTag of options.archTags) {
+    const archReference = resolveArchReference(options.image, archTag)
+    args.push('-m', resolveDigestReference(archReference))
+  }
+
+  args.push('-t', reference)
+  runRequired('crane', args)
+
+  if (options.latest) {
+    runRequired('crane', ['tag', reference, 'latest'])
+  }
+
+  const digest = runRequired('crane', ['digest', reference])
+  const platformDigests = inspectOciPlatforms(reference)
+
+  return {
+    image: options.image,
+    tag: options.tag,
+    reference: `${options.image}@${digest}`,
+    digest,
+    platformDigests,
+  }
+}
+
+const writeGithubOutput = (result: CreateOciIndexResult): void => {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) {
+    return
+  }
+
+  const lines = [
+    `image=${result.image}`,
+    `tag=${result.tag}`,
+    `digest=${result.digest}`,
+    `reference=${result.reference}`,
+    ...result.platformDigests.map((entry) => {
+      const suffix = entry.platform.replace(/^linux\//, '').replaceAll('/', '_')
+      return `platform_digest_${suffix}=${entry.digest}`
+    }),
+  ]
+
+  appendFileSync(outputPath, `${lines.join('\n')}\n`)
+}
+
+const printPlatforms = (platforms: OciPlatformDigest[]): void => {
+  for (const entry of platforms) {
+    console.log(`${entry.platform}\t${entry.digest}`)
+  }
+}
+
+const takeValue = (args: string[], index: number, flag: string): string => {
+  const value = args[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return value
+}
+
+const parseArchTag = (value: string): OciArchTag => {
+  const equalsIndex = value.indexOf('=')
+  if (equalsIndex <= 0 || equalsIndex === value.length - 1) {
+    throw new Error(`--arch-tag must use platform=tag, got ${value}`)
+  }
+
+  return {
+    platform: value.slice(0, equalsIndex),
+    tag: value.slice(equalsIndex + 1),
+  }
+}
+
+const runCreateIndexCli = (args: string[]): void => {
+  let image = ''
+  let tag = ''
+  let latest = false
+  const archTags: OciArchTag[] = []
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--image') {
+      image = takeValue(args, index, arg)
+      index += 1
+    } else if (arg === '--tag') {
+      tag = takeValue(args, index, arg)
+      index += 1
+    } else if (arg === '--arch-tag') {
+      archTags.push(parseArchTag(takeValue(args, index, arg)))
+      index += 1
+    } else if (arg === '--latest') {
+      latest = true
+    } else {
+      throw new Error(`Unknown create-index argument: ${arg}`)
+    }
+  }
+
+  if (!image) {
+    throw new Error('create-index requires --image')
+  }
+  if (!tag) {
+    throw new Error('create-index requires --tag')
+  }
+
+  const result = createOciIndex({ image, tag, archTags, latest })
+  writeGithubOutput(result)
+  console.log(JSON.stringify(result, null, 2))
+}
+
+const runInspectCli = (args: string[]): void => {
+  const [imageRef] = args
+  if (!imageRef) {
+    throw new Error('inspect requires an image reference')
+  }
+
+  printPlatforms(inspectOciPlatforms(imageRef))
+}
+
+const runAssertCli = (args: string[]): void => {
+  const [imageRef, ...rest] = args
+  if (!imageRef) {
+    throw new Error('assert requires an image reference')
+  }
+
+  const platforms: string[] = []
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index]
+    if (arg === '--platform') {
+      platforms.push(takeValue(rest, index, arg))
+      index += 1
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown assert argument: ${arg}`)
+    } else {
+      platforms.push(arg)
+    }
+  }
+
+  const requiredPlatforms = platforms.length > 0 ? platforms : ['linux/amd64', 'linux/arm64']
+  printPlatforms(assertOciPlatforms(imageRef, requiredPlatforms))
+}
+
+if (import.meta.main) {
+  const [command, ...args] = Bun.argv.slice(2)
+
+  try {
+    if (command === 'create-index') {
+      runCreateIndexCli(args)
+    } else if (command === 'inspect') {
+      runInspectCli(args)
+    } else if (command === 'assert') {
+      runAssertCli(args)
+    } else {
+      throw new Error('Usage: oci.ts <create-index|inspect|assert> [options]')
+    }
+  } catch (error) {
+    fatal(error instanceof Error ? error.message : String(error))
+  }
+}
+
+export const __private = {
+  parseManifestPlatforms,
+  resolveDigestReference,
+  setSpawnSync: (impl: SpawnSync = Bun.spawnSync) => {
+    spawnSyncImpl = impl
+  },
+}

--- a/services/facteur/Dockerfile
+++ b/services/facteur/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7-labs
 
-FROM --platform=$BUILDPLATFORM golang:1.25.3 AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.5 AS build
 ARG TARGETOS
 ARG TARGETARCH
 ARG SERVICE_PATH=services/facteur

--- a/services/facteur/README.md
+++ b/services/facteur/README.md
@@ -74,7 +74,7 @@ Discord command dispatch submits an `AgentRun` to the Agents service at `codex_i
 
 ## Container image
 
-The service ships as `registry.ide-newton.ts.net/lab/facteur`. Pushes to `main` that touch `services/facteur/**` or `.github/workflows/facteur-build-push.yaml` trigger the `Facteur Docker Build and Push` workflow, which cross-builds (linux/amd64 + linux/arm64) using the local Dockerfile and pushes tags for `main`, `latest`, and the commit SHA. Rotate the image in Kubernetes by updating tags in `argocd/applications/facteur/overlays/cluster/kustomization.yaml` or allow Argo tooling to reference the desired tag.
+The service ships as `registry.ide-newton.ts.net/lab/facteur`. Pushes to `main` that touch `services/facteur/**` or `.github/workflows/facteur-build-push.yaml` trigger the `Facteur Docker Build and Push` workflow. The workflow builds linux/amd64 and linux/arm64 on native ARC runners, publishes per-arch tags, and assembles the final OCI index tags for `sha-<commit>` and `latest`. Rotate the image in Kubernetes by updating tags in `argocd/applications/facteur/overlays/cluster/kustomization.yaml` or allow Argo tooling to reference the desired tag.
 
 ## Deploying
 


### PR DESCRIPTION
## Summary

- Add a pinned Nix flake toolchain for repo CLI dependencies, Kubernetes lint/render tools, and OCI build tooling.
- Add Nix wrapper apps for toolchain checks, Argo lint/render checks, OCI inspection, OCI index creation, and OCI platform assertions.
- Add typed OCI helpers for crane/regctl-based index creation and platform verification in `packages/scripts`.
- Add a native `arc-amd64` plus `arc-arm64` reusable OCI build workflow and a benchmark workflow that compares legacy single-runner Buildx, native Buildx, direct BuildKit, and optional Depot.
- Convert the Facteur image build canary to the native reusable workflow, then add the corrected enabled-service benchmark proof for Froussard and a cluster-hosted Attic Nix cache implementation plan.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/oci.ts packages/scripts/src/shared/__tests__/oci.test.ts flake.nix .github/workflows/oci-native-build-common.yml`
- `python3` workflow YAML parse over `.github/workflows/*.y*ml`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/oci-native-build-common.yml .github/workflows/oci-builder-benchmark.yml .github/workflows/facteur-build-push.yaml .github/workflows/nix-toolchain.yml`
- `shellcheck -s bash nix/toolchain-doctor.sh nix/oci-doctor.sh`
- `git diff --check`
- `bun run --cwd packages/scripts lint:oxlint:type` exited 0 with existing unrelated warnings only.
- CI Nix toolchain: https://github.com/proompteng/lab/actions/runs/28219234134 passed `nix flake check`, `toolchain-doctor`, `oci-doctor`, and wrapper lint/render checks on head `1d5df9882`.
- CI OCI benchmark for the disabled Facteur canary: https://github.com/proompteng/lab/actions/runs/28219234064 passed. This proved the workflow mechanics but is not used as production-impact timing proof.
- Corrected CI OCI benchmark for enabled Froussard: https://github.com/proompteng/lab/actions/runs/28219895903 passed with `image_name=froussard`, `dockerfile=apps/froussard/Dockerfile`, and `context=.`. Legacy single-runner multi-platform Buildx build step took 492s; native Buildx matrix wall-clock build step took 287s, a 205s / 41.7% improvement.
- CI Facteur native canary: https://github.com/proompteng/lab/actions/runs/28219240527 passed. `linux/amd64` built on `arc-amd64`, `linux/arm64` built on `arc-arm64`, and `publish-index` created plus verified the OCI index platforms.
- CI Headlamp validation: https://github.com/proompteng/lab/actions/runs/28219234063 passed manifest rendering plus native image platform validation.
- Added cluster-hosted Attic Nix cache implementation plan at `docs/superpowers/plans/2026-06-26-nix-attic-cache.md` after researching Attic, Harmonia, and nix-serve-ng.
- Local `nix flake check` and `nix develop -c oci-doctor` could not be rerun from this desktop shell because host `nix` is absent; the Nix toolchain workflow above covers those checks in CI.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
