### PR TITLE
feat(agents): add ChatGPT dev-shell MCP tunnel

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -34,6 +34,16 @@ runner:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
     tag: d26e313e
     digest: sha256:cbca5f4a2f8dd453b7dd1e36b28028661b23094b7624bb7b939f969a43df777c
+devShell:
+  enabled: true
+  image:
+    repository: registry.ide-newton.ts.net/lab/agents-dev-shell
+    tag: 6eed493f
+    digest: sha256:e6adc87f1d7c2210a841a7baf974cd2cfe0ed10bdea755cad2719a8e25a9d581
+  externalSecret:
+    enabled: true
+    remoteRef:
+      key: openai-tunnel-client/agents-control-plane-api-key
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -271,7 +271,34 @@ imagePolicy:
 ```
 
 `imagePolicy.requireDigest=true` rejects mutable chart-managed images at render time. It covers the control plane,
-runner image defaults, Argo CD hooks, Helm tests, and non-canonical runtime image env aliases.
+runner image defaults, the dev-shell MCP deployment, Argo CD hooks, Helm tests, and non-canonical runtime image env
+aliases.
+
+### Dev-Shell MCP Tunnel
+
+Set `devShell.enabled=true` to run a private ChatGPT-facing shell MCP server in the release namespace. The deployment
+uses a dedicated ServiceAccount, does not mount its service account token by default, runs the MCP server on
+`127.0.0.1:8090`, and forwards the configured OpenAI tunnel through a `tunnel-client` sidecar.
+
+```yaml
+devShell:
+  enabled: true
+  image:
+    repository: registry.example.com/platform/agents-dev-shell
+    tag: 2026-06-25
+    digest: sha256:...
+  tunnel:
+    id: tunnel_6a3e0c93576481919403b1ae9edeafd0
+    secretName: openai-tunnel-client
+    secretKey: api-key
+  externalSecret:
+    enabled: true
+    remoteRef:
+      key: openai-tunnel-client/agents-control-plane-api-key
+```
+
+When `externalSecret.enabled=false`, create `devShell.tunnel.secretName` out of band. The Secret must contain the
+OpenAI tunnel `CONTROL_PLANE_API_KEY` at `devShell.tunnel.secretKey`.
 
 ### Database
 
@@ -534,6 +561,7 @@ Frequent render failures:
 | `image.repository`, `image.tag`, `image.digest`                      | Default Agents image used by the control-plane and controllers.           |
 | `controlPlane.image.*`, `controllers.image.*`                        | Optional per-deployment overrides when those images differ.               |
 | `runner.image.repository`, `runner.image.tag`, `runner.image.digest` | Global fallback image for AgentRun Jobs.                                  |
+| `devShell.*`                                                         | Optional private shell MCP server forwarded through OpenAI Secure Tunnel. |
 | `imagePolicy.requireDigest`                                          | Require immutable image digests for chart-managed images.                 |
 | `database.secretRef.*`                                               | Existing database URL Secret.                                             |
 | `database.caSecret.*`                                                | Optional Postgres CA certificate Secret.                                  |

--- a/charts/agents/templates/_helpers.tpl
+++ b/charts/agents/templates/_helpers.tpl
@@ -112,6 +112,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "agents.devShellName" -}}
+{{- .Values.devShell.name | default (printf "%s-dev-shell" (include "agents.name" .)) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "agents.devShellSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "agents.devShellName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: dev-shell
+{{- end -}}
+
+{{- define "agents.devShellServiceAccountName" -}}
+{{- if .Values.devShell.serviceAccount.name -}}
+{{- .Values.devShell.serviceAccount.name -}}
+{{- else if .Values.devShell.serviceAccount.create -}}
+{{- include "agents.devShellName" . -}}
+{{- else -}}
+default
+{{- end -}}
+{{- end -}}
+
 {{- define "agents.databaseSecretName" -}}
 {{- if .Values.database.createSecret.enabled -}}
 {{- if .Values.database.createSecret.name -}}

--- a/charts/agents/templates/dev-shell-deployment.yaml
+++ b/charts/agents/templates/dev-shell-deployment.yaml
@@ -1,0 +1,177 @@
+{{- if .Values.devShell.enabled -}}
+{{- $image := .Values.devShell.image -}}
+{{- $namespace := .Values.namespaceOverride | default .Release.Namespace -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agents.devShellName" . }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dev-shell
+spec:
+  replicas: {{ .Values.devShell.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "agents.devShellSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "agents.devShellSelectorLabels" . | nindent 8 }}
+        {{- with .Values.devShell.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.devShell.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "agents.devShellServiceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- if $image.pullSecrets }}
+      imagePullSecrets:
+        {{- range $image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if hasKey .Values.devShell "nodeSelector" }}
+      nodeSelector:
+        {{- if .Values.devShell.nodeSelector }}
+        {{- toYaml .Values.devShell.nodeSelector | nindent 8 }}
+        {{- else }}
+        {}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.devShell.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.devShell.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.devShell.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: workspace
+          {{- if or .Values.devShell.workspace.medium .Values.devShell.workspace.sizeLimit }}
+          emptyDir:
+            {{- if .Values.devShell.workspace.medium }}
+            medium: {{ .Values.devShell.workspace.medium | quote }}
+            {{- end }}
+            {{- if .Values.devShell.workspace.sizeLimit }}
+            sizeLimit: {{ .Values.devShell.workspace.sizeLimit | quote }}
+            {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: openai-tunnel
+          secret:
+            secretName: {{ .Values.devShell.tunnel.secretName }}
+      containers:
+        - name: mcp-shell
+          image: "{{ $image.repository }}:{{ $image.tag }}{{- if $image.digest }}@{{ $image.digest }}{{ end }}"
+          imagePullPolicy: {{ $image.pullPolicy }}
+          {{- with .Values.devShell.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - bun
+            - run
+            - src/server/dev-shell-mcp.ts
+          env:
+            - name: AGENTS_DEV_SHELL_MCP_HOST
+              value: {{ .Values.devShell.mcp.host | quote }}
+            - name: AGENTS_DEV_SHELL_MCP_PORT
+              value: {{ .Values.devShell.mcp.port | quote }}
+            - name: AGENTS_DEV_SHELL_WORKSPACE_ROOT
+              value: /workspace
+            - name: AGENTS_DEV_SHELL_AUDIT_LOG_PATH
+              value: /workspace/.agents-dev-shell/audit.jsonl
+          ports:
+            - name: mcp
+              containerPort: {{ .Values.devShell.mcp.port }}
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -lc
+                - curl -fsS http://127.0.0.1:${AGENTS_DEV_SHELL_MCP_PORT}/readyz >/dev/null
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -lc
+                - curl -fsS http://127.0.0.1:${AGENTS_DEV_SHELL_MCP_PORT}/healthz >/dev/null
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.devShell.mcp.resources | nindent 12 }}
+        - name: tunnel-client
+          image: "{{ $image.repository }}:{{ $image.tag }}{{- if $image.digest }}@{{ $image.digest }}{{ end }}"
+          imagePullPolicy: {{ $image.pullPolicy }}
+          {{- with .Values.devShell.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - >-
+              exec tunnel-client run
+              --control-plane.tunnel-id "${CONTROL_PLANE_TUNNEL_ID}"
+              --control-plane.api-key "file:/var/run/secrets/openai-tunnel/${CONTROL_PLANE_API_KEY_FILE}"
+              --mcp.server-url "url=${MCP_SERVER_URL},channel=${MCP_CHANNEL}"
+              --health.listen-addr "0.0.0.0:${HEALTH_PORT}"
+              --log.format json
+          env:
+            - name: CONTROL_PLANE_TUNNEL_ID
+              value: {{ .Values.devShell.tunnel.id | quote }}
+            - name: CONTROL_PLANE_API_KEY_FILE
+              value: {{ .Values.devShell.tunnel.secretKey | quote }}
+            - name: MCP_SERVER_URL
+              value: {{ .Values.devShell.tunnel.mcpServerUrl | quote }}
+            - name: MCP_CHANNEL
+              value: {{ .Values.devShell.tunnel.channel | quote }}
+            - name: HEALTH_PORT
+              value: {{ .Values.devShell.tunnelClient.healthPort | quote }}
+          ports:
+            - name: tunnel-health
+              containerPort: {{ .Values.devShell.tunnelClient.healthPort }}
+          volumeMounts:
+            - name: openai-tunnel
+              mountPath: /var/run/secrets/openai-tunnel
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: tunnel-health
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: tunnel-health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.devShell.tunnelClient.resources | nindent 12 }}
+{{- end }}

--- a/charts/agents/templates/dev-shell-externalsecret.yaml
+++ b/charts/agents/templates/dev-shell-externalsecret.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.devShell.enabled .Values.devShell.externalSecret.enabled -}}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.devShell.tunnel.secretName }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dev-shell
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/ignore-healthcheck: "true"
+spec:
+  refreshPolicy: {{ .Values.devShell.externalSecret.refreshPolicy }}
+  refreshInterval: {{ .Values.devShell.externalSecret.refreshInterval }}
+  secretStoreRef:
+    kind: {{ .Values.devShell.externalSecret.secretStoreRef.kind }}
+    name: {{ .Values.devShell.externalSecret.secretStoreRef.name }}
+  target:
+    name: {{ .Values.devShell.tunnel.secretName }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: {{ .Values.devShell.tunnel.secretKey }}
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: {{ .Values.devShell.externalSecret.remoteRef.key }}
+        metadataPolicy: None
+        nullBytePolicy: Ignore
+{{- end }}

--- a/charts/agents/templates/dev-shell-serviceaccount.yaml
+++ b/charts/agents/templates/dev-shell-serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.devShell.enabled .Values.devShell.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agents.devShellServiceAccountName" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dev-shell
+  {{- with .Values.devShell.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agents/templates/validation.yaml
+++ b/charts/agents/templates/validation.yaml
@@ -23,6 +23,8 @@
 {{- $controlPlaneEnvVars := merge (deepCopy $globalEnvVars) (deepCopy $controlPlaneExplicitEnvVars) -}}
 {{- $controllersEnvVars := merge (deepCopy $globalEnvVars) (deepCopy $controllersExplicitEnvVars) -}}
 {{- $controllersEnabled := .Values.controllers.enabled | default false -}}
+{{- $devShell := .Values.devShell | default dict -}}
+{{- $devShellEnabled := $devShell.enabled | default false -}}
 {{- $envFromSecretRefs := .Values.envFromSecretRefs | default (list) -}}
 {{- $envFromConfigMapRefs := .Values.envFromConfigMapRefs | default (list) -}}
 {{- $reservedEnvKeysEnforced := .Values.validation.reservedEnvKeysEnforced | default false -}}
@@ -130,6 +132,12 @@
 {{- else if $runnerImage.repository -}}
 {{- if not (regexMatch $sha256DigestPattern (toString ($runnerImage.digest | default ""))) -}}
 {{- $errors = append $errors "imagePolicy.requireDigest=true requires runner.image.digest to be a sha256 digest when runner.image.repository is used for Deployment/agents." -}}
+{{- end -}}
+{{- end -}}
+{{- if $devShellEnabled -}}
+{{- $devShellImage := $devShell.image | default dict -}}
+{{- if not (regexMatch $sha256DigestPattern (toString ($devShellImage.digest | default ""))) -}}
+{{- $errors = append $errors "imagePolicy.requireDigest=true requires devShell.image.digest to be a sha256 digest when devShell.enabled=true." -}}
 {{- end -}}
 {{- end -}}
 {{- if $controllersEnabled -}}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -301,6 +301,128 @@
       },
       "additionalProperties": false
     },
+    "devShell": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+        },
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "digest": { "type": "string" },
+            "pullPolicy": { "type": "string" },
+            "pullSecrets": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": false
+        },
+        "tunnel": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "secretName": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$"
+            },
+            "secretKey": { "type": "string", "minLength": 1 },
+            "mcpServerUrl": { "type": "string", "minLength": 1 },
+            "channel": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false
+        },
+        "externalSecret": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "refreshPolicy": { "type": "string" },
+            "refreshInterval": { "type": "string" },
+            "secretStoreRef": {
+              "type": "object",
+              "properties": {
+                "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"] },
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "remoteRef": {
+              "type": "object",
+              "properties": {
+                "key": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean" },
+            "name": { "type": "string" },
+            "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+          },
+          "additionalProperties": false
+        },
+        "workspace": {
+          "type": "object",
+          "properties": {
+            "medium": { "type": "string" },
+            "sizeLimit": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "mcp": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "host": { "type": "string", "minLength": 1 },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": { "type": "object", "additionalProperties": { "type": "string" } },
+                "limits": { "type": "object", "additionalProperties": { "type": "string" } }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "tunnelClient": {
+          "type": "object",
+          "properties": {
+            "healthPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": { "type": "object", "additionalProperties": { "type": "string" } },
+                "limits": { "type": "object", "additionalProperties": { "type": "string" } }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "podSecurityContext": { "type": "object" },
+        "containerSecurityContext": { "type": "object" },
+        "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
+        "affinity": { "type": "object" },
+        "tolerations": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false
+    },
     "serviceAccount": {
       "type": "object",
       "properties": {

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -79,6 +79,73 @@ runner:
     pullPolicy: IfNotPresent
     pullSecrets: []
 
+devShell:
+  enabled: false
+  name: agents-dev-shell
+  replicaCount: 1
+  image:
+    repository: ghcr.io/proompteng/agents-dev-shell
+    tag: latest
+    digest: ''
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  tunnel:
+    id: tunnel_6a3e0c93576481919403b1ae9edeafd0
+    secretName: openai-tunnel-client
+    secretKey: api-key
+    mcpServerUrl: http://127.0.0.1:8090/mcp
+    channel: main
+  externalSecret:
+    enabled: false
+    refreshPolicy: CreatedOnce
+    refreshInterval: 0s
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: onepassword-infra
+    remoteRef:
+      key: openai-tunnel-client/agents-control-plane-api-key
+  serviceAccount:
+    create: true
+    name: ''
+    annotations: {}
+  workspace:
+    medium: ''
+    sizeLimit: ''
+  mcp:
+    port: 8090
+    host: 127.0.0.1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 2Gi
+  tunnelClient:
+    healthPort: 8081
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 serviceAccount:
   create: true
   name: ''

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -13,6 +13,7 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Creating AgentRuns safely (prompt precedence): `agentrun-creation-guide.md`
 - Agents control-plane UI and schema-form rollout proof: `control-plane-ui.md`
 - Connecting Codex to Agents through MCP: `codex-mcp-agents.md`
+- Connecting ChatGPT to a private dev-shell through OpenAI Secure MCP Tunnel: `chatgpt-dev-shell-mcp.md`
 - Launching workflow loops correctly (state reuse + checks): `agentrun-workflow-loop-launch-guide.md`
 - Running Codex Spark review/fix PR cycles: `codex-spark-review-cycle.md`
 - How to validate changes in CI: `ci-validation-plan.md`

--- a/docs/agents/chatgpt-dev-shell-mcp.md
+++ b/docs/agents/chatgpt-dev-shell-mcp.md
@@ -1,0 +1,79 @@
+# ChatGPT Dev-Shell MCP Tunnel
+
+This runbook connects ChatGPT to a private shell MCP server in the Kubernetes `agents` namespace through an OpenAI
+Secure MCP Tunnel. It intentionally does not expose public ingress and does not grant Kubernetes `pods/exec`.
+
+## Tunnel
+
+- Tunnel name: `agents`
+- Tunnel ID: `tunnel_6a3e0c93576481919403b1ae9edeafd0`
+- Binary: `openai/tunnel-client` release `v0.0.9--context-conduit-topaz`
+- Linux assets: `linux-amd64.zip` or `linux-arm64.zip`
+- Build verification: `SHA256SUMS.txt` is checked in `services/agents/Dockerfile`
+
+The tunnel sidecar runs:
+
+```bash
+tunnel-client run \
+  --control-plane.tunnel-id tunnel_6a3e0c93576481919403b1ae9edeafd0 \
+  --control-plane.api-key file:/var/run/secrets/openai-tunnel/api-key \
+  --mcp.server-url url=http://127.0.0.1:8090/mcp,channel=main \
+  --health.listen-addr 0.0.0.0:8081 \
+  --log.format json
+```
+
+## Kubernetes
+
+Enable `devShell` in `argocd/applications/agents/values.yaml` only with an immutable image digest:
+
+```yaml
+devShell:
+  enabled: true
+  image:
+    repository: registry.ide-newton.ts.net/lab/agents-dev-shell
+    tag: <git-sha>
+    digest: sha256:<digest>
+  externalSecret:
+    enabled: true
+    remoteRef:
+      key: openai-tunnel-client/agents-control-plane-api-key
+```
+
+Store the OpenAI tunnel `CONTROL_PLANE_API_KEY` in 1Password at the configured ExternalSecret key, or create a Secret
+named `openai-tunnel-client` with key `api-key`. Do not place the key in Helm values.
+
+## ChatGPT
+
+1. In Platform tunnel settings, associate the `agents` tunnel with the target ChatGPT workspace.
+2. In ChatGPT, create a connector with connection type `Tunnel` and select `agents`.
+3. Name: `Agents Dev Shell`.
+4. Description: `Executes commands inside a private Kubernetes dev-shell container through an OpenAI Secure MCP Tunnel.`
+5. For private single-user use, no OAuth is acceptable if ChatGPT allows it. For shared use, add OAuth before enabling
+   arbitrary shell tools.
+
+## Validation
+
+```bash
+kubectl -n agents get pod -l app.kubernetes.io/component=dev-shell
+kubectl -n agents port-forward deploy/agents-dev-shell 8090:8090 8081:8081
+curl -fsS http://127.0.0.1:8081/readyz
+curl -fsS http://127.0.0.1:8090/readyz
+```
+
+MCP smoke request:
+
+```bash
+curl -fsS http://127.0.0.1:8090/mcp \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shell_run","arguments":{"command":"pwd && python3 --version"}}}'
+```
+
+Tunnel diagnostic from inside the pod:
+
+```bash
+tunnel-client doctor \
+  --control-plane.tunnel-id tunnel_6a3e0c93576481919403b1ae9edeafd0 \
+  --control-plane.api-key file:/var/run/secrets/openai-tunnel/api-key \
+  --mcp.server-url url=http://127.0.0.1:8090/mcp,channel=main \
+  --explain
+```

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -27,6 +27,7 @@ describe('agents deploy-service helpers', () => {
         registry: 'registry.example',
         repository: 'lab/agents-controller',
         controlPlaneRepository: 'lab/agents-control-plane',
+        devShellRepository: 'lab/agents-dev-shell',
         tag: 'abc1234',
         platforms: ['linux/arm64'],
       }),
@@ -43,6 +44,13 @@ describe('agents deploy-service helpers', () => {
         repository: 'lab/agents-control-plane',
         tag: 'abc1234',
         target: 'control-plane',
+        platforms: ['linux/arm64'],
+      },
+      {
+        registry: 'registry.example',
+        repository: 'lab/agents-dev-shell',
+        tag: 'abc1234',
+        target: 'dev-shell',
         platforms: ['linux/arm64'],
       },
     ])
@@ -160,6 +168,11 @@ runner:
     repository: old/runner
     tag: old
     digest: sha256:old-runner
+devShell:
+  image:
+    repository: old/dev-shell
+    tag: old
+    digest: sha256:old-dev-shell
 `,
     )
 
@@ -183,6 +196,11 @@ runner:
         servingBuildCommit: 'abcdef1234567890',
         servingImageDigest: 'sha256:control-plane',
       },
+      {
+        repository: 'registry.example/lab/agents-dev-shell',
+        tag: 'abc123',
+        digest: 'sha256:dev-shell',
+      },
     )
 
     const updated = readFileSync(valuesPath, 'utf8')
@@ -190,8 +208,10 @@ runner:
     expect(updated).not.toContain('old/controllers-override')
     expect(updated).toContain('repository: registry.example/lab/agents-control-plane')
     expect(updated).toContain('repository: registry.example/lab/agents-codex-runner')
+    expect(updated).toContain('repository: registry.example/lab/agents-dev-shell')
     expect(updated).toContain('digest: sha256:controller')
     expect(updated).toContain('digest: sha256:runner')
+    expect(updated).toContain('digest: sha256:dev-shell')
     expect(updated).toContain('AGENTS_SOURCE_HEAD_SHA: abcdef1234567890')
     expect(updated).toContain('AGENTS_SOURCE_CI_RUN_ID: "12345"')
     expect(updated).toContain('AGENTS_SERVING_IMAGE_DIGEST: sha256:control-plane')

--- a/packages/scripts/src/agents/__tests__/update-values.test.ts
+++ b/packages/scripts/src/agents/__tests__/update-values.test.ts
@@ -9,6 +9,7 @@ const sha = 'a'.repeat(40)
 const controllerDigest = `sha256:${'1'.repeat(64)}`
 const controlPlaneDigest = `sha256:${'2'.repeat(64)}`
 const runnerDigest = `sha256:${'3'.repeat(64)}`
+const devShellDigest = `sha256:${'4'.repeat(64)}`
 
 describe('agents update-values helper', () => {
   it('writes promoted controller, control-plane, and runner multi-arch digests', () => {
@@ -31,6 +32,11 @@ runner:
     repository: old/runner
     tag: old
     digest: sha256:old-runner
+devShell:
+  image:
+    repository: old/dev-shell
+    tag: old
+    digest: sha256:old-dev-shell
 controllers:
   image:
     repository: old/controller
@@ -46,6 +52,8 @@ controllers:
         controllerDigest,
         controlPlaneRepository: 'registry.example/lab/agents-control-plane',
         controlPlaneDigest,
+        devShellRepository: 'registry.example/lab/agents-dev-shell',
+        devShellDigest,
         runnerRepository: 'registry.example/lab/agents-codex-runner',
         runnerDigest,
         sourceSha: sha,
@@ -57,10 +65,12 @@ controllers:
       expect(updated).toContain('repository: registry.example/lab/agents-controller')
       expect(updated).toContain('repository: registry.example/lab/agents-control-plane')
       expect(updated).toContain('repository: registry.example/lab/agents-codex-runner')
+      expect(updated).toContain('repository: registry.example/lab/agents-dev-shell')
       expect(updated).toContain('tag: abc12345')
       expect(updated).toContain(`digest: ${controllerDigest}`)
       expect(updated).toContain(`digest: ${controlPlaneDigest}`)
       expect(updated).toContain(`digest: ${runnerDigest}`)
+      expect(updated).toContain(`digest: ${devShellDigest}`)
       expect(updated).toContain(`AGENTS_SOURCE_HEAD_SHA: ${sha}`)
       expect(updated).toContain('AGENTS_SOURCE_CI_RUN_ID: "123456"')
     } finally {
@@ -78,6 +88,8 @@ controllers:
         controllerDigest: 'sha256:not-valid',
         controlPlaneRepository: 'registry.example/lab/agents-control-plane',
         controlPlaneDigest,
+        devShellRepository: 'registry.example/lab/agents-dev-shell',
+        devShellDigest,
         runnerRepository: 'registry.example/lab/agents-codex-runner',
         runnerDigest,
         sourceSha: sha,

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -23,6 +23,7 @@ type Options = {
   registry: string
   repository: string
   controlPlaneRepository: string
+  devShellRepository: string
   runnerRepository: string
   runnerDockerfile: string
   codexAuthPath?: string
@@ -55,9 +56,13 @@ type DatabaseSecretRequirement = {
 
 const CONTROLLER_DOCKER_TARGET = 'controller'
 const CONTROL_PLANE_DOCKER_TARGET = 'control-plane'
+const DEV_SHELL_DOCKER_TARGET = 'dev-shell'
 
 const buildAgentsServiceImagePlans = (
-  options: Pick<Options, 'registry' | 'repository' | 'controlPlaneRepository' | 'tag' | 'platforms'>,
+  options: Pick<
+    Options,
+    'registry' | 'repository' | 'controlPlaneRepository' | 'devShellRepository' | 'tag' | 'platforms'
+  >,
 ): BuildImageOptions[] => [
   {
     registry: options.registry,
@@ -71,6 +76,13 @@ const buildAgentsServiceImagePlans = (
     repository: options.controlPlaneRepository,
     tag: options.tag,
     target: CONTROL_PLANE_DOCKER_TARGET,
+    platforms: options.platforms,
+  },
+  {
+    registry: options.registry,
+    repository: options.devShellRepository,
+    tag: options.tag,
+    target: DEV_SHELL_DOCKER_TARGET,
     platforms: options.platforms,
   },
 ]
@@ -154,6 +166,15 @@ const parseArgs = (argv: string[]): Partial<Options> => {
       options.controlPlaneRepository = arg.slice('--control-plane-repository='.length)
       continue
     }
+    if (arg === '--dev-shell-repository') {
+      options.devShellRepository = argv[i + 1]
+      i += 1
+      continue
+    }
+    if (arg.startsWith('--dev-shell-repository=')) {
+      options.devShellRepository = arg.slice('--dev-shell-repository='.length)
+      continue
+    }
     if (arg === '--runner-repository') {
       options.runnerRepository = argv[i + 1]
       i += 1
@@ -211,6 +232,8 @@ const resolveOptions = (): Options => {
     'lab/agents-controller'
   const controlPlaneRepository =
     args.controlPlaneRepository ?? process.env.AGENTS_CONTROL_PLANE_IMAGE_REPOSITORY ?? 'lab/agents-control-plane'
+  const devShellRepository =
+    args.devShellRepository ?? process.env.AGENTS_DEV_SHELL_IMAGE_REPOSITORY ?? 'lab/agents-dev-shell'
   const runnerRepository =
     args.runnerRepository ??
     process.env.AGENTS_RUNNER_IMAGE_REPOSITORY ??
@@ -234,6 +257,7 @@ const resolveOptions = (): Options => {
     registry,
     repository,
     controlPlaneRepository,
+    devShellRepository,
     runnerRepository,
     runnerDockerfile: resolve(repoRoot, runnerDockerfile),
     codexAuthPath,
@@ -380,6 +404,7 @@ const updateValuesFile = (
   runnerTag: string,
   runnerDigest: string,
   releaseMetadata?: ReleaseMetadata,
+  devShellImage?: ImagePin | null,
 ) => {
   const raw = readFileSync(valuesPath, 'utf8')
   const doc = YAML.parse(raw) ?? {}
@@ -407,6 +432,14 @@ const updateValuesFile = (
   doc.runner.image.tag = runnerTag
   doc.runner.image.digest = runnerDigest
 
+  if (devShellImage) {
+    doc.devShell ??= {}
+    doc.devShell.image ??= {}
+    doc.devShell.image.repository = devShellImage.repository
+    doc.devShell.image.tag = devShellImage.tag
+    doc.devShell.image.digest = devShellImage.digest
+  }
+
   if (releaseMetadata) {
     doc.controlPlane.env ??= {}
     doc.controlPlane.env.vars ??= {}
@@ -422,7 +455,7 @@ const updateValuesFile = (
 
   writeFileSync(valuesPath, YAML.stringify(doc, { lineWidth: 120 }))
   console.log(
-    `Updated ${valuesPath} with ${imageRepository}:${tag}@${digest}, ${controlPlaneImageRepository}:${controlPlaneTag}@${controlPlaneDigest}, and ${runnerImageRepository}:${runnerTag}@${runnerDigest}`,
+    `Updated ${valuesPath} with ${imageRepository}:${tag}@${digest}, ${controlPlaneImageRepository}:${controlPlaneTag}@${controlPlaneDigest}, ${runnerImageRepository}:${runnerTag}@${runnerDigest}${devShellImage ? `, and ${devShellImage.repository}:${devShellImage.tag}@${devShellImage.digest}` : ''}`,
   )
 }
 
@@ -535,6 +568,8 @@ const main = async () => {
   const image = `${imageName}:${options.tag}`
   const controlPlaneImageName = `${options.registry}/${options.controlPlaneRepository}`
   const controlPlaneImage = `${controlPlaneImageName}:${options.tag}`
+  const devShellImageName = `${options.registry}/${options.devShellRepository}`
+  const devShellImage = `${devShellImageName}:${options.tag}`
   const runnerImageName = `${options.registry}/${options.runnerRepository}`
   const runnerImage = `${runnerImageName}:${options.tag}`
 
@@ -564,6 +599,8 @@ const main = async () => {
   const controlPlaneDigest = controlPlaneRepoDigest.includes('@')
     ? controlPlaneRepoDigest.split('@')[1]
     : controlPlaneRepoDigest
+  const devShellRepoDigest = inspectImageDigest(devShellImage)
+  const devShellDigest = devShellRepoDigest.includes('@') ? devShellRepoDigest.split('@')[1] : devShellRepoDigest
   const runnerRepoDigest = options.buildRunner ? inspectImageDigest(runnerImage) : runnerPin?.digest
   const runnerDigest =
     (runnerRepoDigest?.includes('@') ? runnerRepoDigest.split('@')[1] : runnerRepoDigest) ??
@@ -588,6 +625,11 @@ const main = async () => {
       manifestImageDigest: controlPlaneDigest,
       servingBuildCommit: execGit(['rev-parse', 'HEAD']),
       servingImageDigest: controlPlaneDigest,
+    },
+    {
+      repository: devShellImageName,
+      tag: options.tag,
+      digest: devShellDigest,
     },
   )
 

--- a/packages/scripts/src/agents/update-values.ts
+++ b/packages/scripts/src/agents/update-values.ts
@@ -14,6 +14,8 @@ type Options = {
   controllerDigest?: string
   controlPlaneRepository?: string
   controlPlaneDigest?: string
+  devShellRepository?: string
+  devShellDigest?: string
   runnerRepository?: string
   runnerDigest?: string
   sourceSha?: string
@@ -53,6 +55,12 @@ const parseArgs = (argv: string[]): Options => {
         break
       case '--control-plane-digest':
         options.controlPlaneDigest = normalizeDigest(value)
+        break
+      case '--dev-shell-repository':
+        options.devShellRepository = value
+        break
+      case '--dev-shell-digest':
+        options.devShellDigest = normalizeDigest(value)
         break
       case '--runner-repository':
         options.runnerRepository = value
@@ -124,6 +132,13 @@ export const updateAgentsValuesFromCliOptions = (options: Options) => {
       servingBuildCommit: sourceSha,
       servingImageDigest: controlPlaneDigest,
     },
+    options.devShellRepository || options.devShellDigest
+      ? {
+          repository: requireValue(options, 'devShellRepository'),
+          tag,
+          digest: requireDigest(options, 'devShellDigest'),
+        }
+      : null,
   )
 }
 

--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -9,6 +9,7 @@ ARG BUN_BASE_IMAGE=mirror.gcr.io/oven/bun
 ARG NODE24_VERSION=24.11.1
 ARG KUBECTL_VERSION=1.34.3
 ARG NATSCLI_VERSION=v0.4.0
+ARG TUNNEL_CLIENT_VERSION=v0.0.9--context-conduit-topaz
 
 FROM --platform=$BUILDPLATFORM ${BUN_BASE_IMAGE}:${BUN_VERSION} AS agents-build-tools
 ARG BUILDARCH
@@ -23,6 +24,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
   export DEBIAN_FRONTEND=noninteractive; \
   apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
   apt-get install -y --no-install-recommends \
+  bash \
   build-essential \
   ca-certificates \
   curl \
@@ -68,6 +70,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
   export DEBIAN_FRONTEND=noninteractive; \
   apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
   apt-get install -y --no-install-recommends \
+  bash \
   build-essential \
   ca-certificates \
   curl \
@@ -134,6 +137,27 @@ RUN set -eux; \
   install -o root -g root -m 0755 "/tmp/nats-${NATS_VERSION}-linux-${NATS_ARCH}/nats" /usr/local/bin/nats; \
   rm -rf "${NATS_ARCHIVE}" "/tmp/nats-${NATS_VERSION}-linux-${NATS_ARCH}"; \
   nats --version
+
+FROM agents-tools AS tunnel-client
+ARG TUNNEL_CLIENT_VERSION
+WORKDIR /tmp/tunnel-client
+
+RUN set -eux; \
+  ARCH="${TARGETARCH:-$(uname -m)}"; \
+  case "$ARCH" in \
+  amd64|x86_64) TUNNEL_ARCH=amd64 ;; \
+  arm64|aarch64) TUNNEL_ARCH=arm64 ;; \
+  *) echo "Unsupported arch for tunnel-client: $ARCH" >&2; exit 1 ;; \
+  esac; \
+  ASSET="tunnel-client-${TUNNEL_CLIENT_VERSION}-linux-${TUNNEL_ARCH}.zip"; \
+  BASE_URL="https://github.com/openai/tunnel-client/releases/download/${TUNNEL_CLIENT_VERSION}"; \
+  curl -fsSLO "${BASE_URL}/${ASSET}"; \
+  curl -fsSLO "${BASE_URL}/SHA256SUMS.txt"; \
+  grep " ${ASSET}$" SHA256SUMS.txt | sha256sum -c -; \
+  unzip -q "${ASSET}"; \
+  install -o root -g root -m 0755 tunnel-client /usr/local/bin/tunnel-client; \
+  rm -rf /tmp/tunnel-client; \
+  tunnel-client --version
 
 FROM agents-build-tools AS agents-workspace-deps
 WORKDIR /app
@@ -295,3 +319,31 @@ ENV AGENTS_VERSION=${AGENTS_VERSION} \
   AGENTS_COMMIT=${AGENTS_COMMIT}
 
 CMD ["bun", "run", "src/server/controller-entrypoint.ts"]
+
+FROM agents-tools AS dev-shell
+ARG AGENTS_VERSION=""
+ARG AGENTS_COMMIT=""
+
+COPY --from=tunnel-client /usr/local/bin/tunnel-client /usr/local/bin/tunnel-client
+
+WORKDIR /app/services/agents
+COPY --from=agents-build /app/services/agents/package.json ./package.json
+COPY --from=agents-build /app/services/agents/src ./src
+RUN mkdir -p /workspace/.agents-dev-shell \
+  && tunnel-client --version \
+  && python3 --version \
+  && git --version \
+  && kubectl version --client=true
+
+ENV NODE_ENV=production \
+  AGENTS_SERVER_PROFILE=agents-dev-shell \
+  AGENTS_DEV_SHELL_WORKSPACE_ROOT=/workspace \
+  AGENTS_DEV_SHELL_MCP_HOST=127.0.0.1 \
+  AGENTS_DEV_SHELL_MCP_PORT=8090 \
+  AGENTS_DEV_SHELL_AUDIT_LOG_PATH=/workspace/.agents-dev-shell/audit.jsonl
+ENV AGENTS_VERSION=${AGENTS_VERSION} \
+  AGENTS_COMMIT=${AGENTS_COMMIT}
+
+EXPOSE 8090
+
+CMD ["bun", "run", "src/server/dev-shell-mcp.ts"]

--- a/services/agents/src/server/dev-shell-mcp.test.ts
+++ b/services/agents/src/server/dev-shell-mcp.test.ts
@@ -1,0 +1,204 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { DevShellRunner, handleDevShellMcpRequest } from './dev-shell-mcp'
+
+const runners: DevShellRunner[] = []
+const tempDirs: string[] = []
+
+const makeRunner = () => {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), 'agents-dev-shell-'))
+  tempDirs.push(workspaceRoot)
+  const runner = new DevShellRunner({
+    workspaceRoot,
+    defaultTimeoutSeconds: 2,
+    maxTimeoutSeconds: 5,
+    defaultOutputBytes: 4096,
+    maxOutputBytes: 8192,
+    maxConcurrentJobs: 2,
+    auditLogPath: null,
+  })
+  runners.push(runner)
+  return runner
+}
+
+const post = async (runner: DevShellRunner, body: unknown) => {
+  const response = await handleDevShellMcpRequest(
+    new Request('http://127.0.0.1:8090/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    runner,
+  )
+  const json = response.status === 202 || response.status === 204 ? null : await response.json()
+  return { response, json }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const readUntilStdoutIncludes = async (runner: DevShellRunner, jobId: string, expected: string) => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const read = await post(runner, {
+      jsonrpc: '2.0',
+      id: `read-${attempt}`,
+      method: 'tools/call',
+      params: { name: 'shell_read', arguments: { jobId } },
+    })
+    if (String(read.json?.result?.structuredContent?.stdout ?? '').includes(expected)) return read
+    await sleep(50)
+  }
+  return post(runner, {
+    jsonrpc: '2.0',
+    id: 'read-final',
+    method: 'tools/call',
+    params: { name: 'shell_read', arguments: { jobId } },
+  })
+}
+
+afterEach(() => {
+  for (const runner of runners.splice(0)) {
+    runner.shutdown()
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('Agents dev-shell MCP handler', () => {
+  it('supports initialize and advertises destructive shell tools', async () => {
+    const runner = makeRunner()
+
+    const init = await post(runner, { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    expect(init.response.status).toBe(200)
+    expect(init.json?.result?.serverInfo?.name).toBe('agents-dev-shell')
+
+    const list = await post(runner, { jsonrpc: '2.0', id: 2, method: 'tools/list' })
+    expect(list.response.status).toBe(200)
+    const tools = list.json?.result?.tools as Array<{ name: string; annotations?: Record<string, unknown> }>
+    expect(tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(['shell_run', 'shell_start', 'shell_read', 'shell_kill', 'shell_status']),
+    )
+
+    const runTool = tools.find((tool) => tool.name === 'shell_run')
+    expect(runTool?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    })
+  })
+
+  it('runs a short shell command and returns stdout, stderr, and exit code', async () => {
+    const runner = makeRunner()
+
+    const result = await post(runner, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'shell_run',
+        arguments: {
+          command: 'printf "hello"; printf "problem" >&2; exit 7',
+        },
+      },
+    })
+
+    expect(result.response.status).toBe(200)
+    expect(result.json?.result?.structuredContent).toMatchObject({
+      command: 'printf "hello"; printf "problem" >&2; exit 7',
+      status: 'exited',
+      exitCode: 7,
+      stdout: 'hello',
+      stderr: 'problem',
+      timedOut: false,
+    })
+  })
+
+  it('rejects working directories outside the workspace root', async () => {
+    const runner = makeRunner()
+
+    const result = await post(runner, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'shell_run',
+        arguments: {
+          command: 'pwd',
+          cwd: '../../',
+        },
+      },
+    })
+
+    expect(result.response.status).toBe(200)
+    expect(result.json?.error?.code).toBe(-32602)
+    expect(result.json?.error?.message).toContain('cwd must stay under')
+  })
+
+  it('starts, reads, lists, and kills a long-running shell job', async () => {
+    const runner = makeRunner()
+
+    const start = await post(runner, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'shell_start',
+        arguments: {
+          command: 'while true; do echo tick; sleep 0.1; done',
+          timeoutSeconds: 5,
+        },
+      },
+    })
+    const jobId = start.json?.result?.structuredContent?.jobId as string
+    expect(jobId).toBeTruthy()
+
+    const read = await readUntilStdoutIncludes(runner, jobId, 'tick')
+    expect(read.json?.result?.structuredContent?.status).toBe('running')
+    expect(read.json?.result?.structuredContent?.stdout).toContain('tick')
+
+    const status = await post(runner, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'shell_status', arguments: { limit: 10 } },
+    })
+    expect(status.json?.result?.structuredContent?.jobs?.some((job: { jobId: string }) => job.jobId === jobId)).toBe(
+      true,
+    )
+
+    const killed = await post(runner, {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: { name: 'shell_kill', arguments: { jobId } },
+    })
+    expect(killed.json?.result?.structuredContent?.status).toBe('killed')
+  })
+
+  it('times out shell_run commands', async () => {
+    const runner = makeRunner()
+
+    const result = await post(runner, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'shell_run',
+        arguments: {
+          command: 'sleep 2',
+          timeoutSeconds: 1,
+        },
+      },
+    })
+
+    expect(result.response.status).toBe(200)
+    expect(result.json?.result?.structuredContent).toMatchObject({
+      status: 'timed_out',
+      timedOut: true,
+    })
+  })
+})

--- a/services/agents/src/server/dev-shell-mcp.ts
+++ b/services/agents/src/server/dev-shell-mcp.ts
@@ -1,0 +1,739 @@
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, isAbsolute, relative, resolve } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type { Readable } from 'node:stream'
+
+type JsonRpcId = string | number | null
+
+type JsonRpcRequest = {
+  jsonrpc?: string
+  id?: JsonRpcId
+  method: string
+  params?: unknown
+}
+
+type JsonRpcError = {
+  code: number
+  message: string
+  data?: unknown
+}
+
+type JsonRpcResponse = {
+  jsonrpc: '2.0'
+  id: JsonRpcId
+  result?: unknown
+  error?: JsonRpcError
+}
+
+type ShellJobStatus = 'running' | 'exited' | 'killed' | 'timed_out'
+
+type ShellJob = {
+  id: string
+  command: string
+  cwd: string
+  process: ChildProcessByStdio<null, Readable, Readable>
+  startedAt: string
+  finishedAt: string | null
+  status: ShellJobStatus
+  exitCode: number | null
+  signal: string | null
+  timedOut: boolean
+  timeout: ReturnType<typeof setTimeout> | null
+  stdout: OutputTail
+  stderr: OutputTail
+}
+
+type OutputTail = {
+  totalBytes: number
+  truncated: boolean
+  buffer: Buffer
+}
+
+export type DevShellMcpConfig = {
+  workspaceRoot: string
+  defaultTimeoutSeconds: number
+  maxTimeoutSeconds: number
+  defaultOutputBytes: number
+  maxOutputBytes: number
+  maxConcurrentJobs: number
+  auditLogPath: string | null
+}
+
+type CommandInput = {
+  command: string
+  cwd: string
+  timeoutSeconds: number
+  maxOutputBytes: number
+}
+
+const MCP_SESSION_HEADER = 'Mcp-Session-Id'
+const MCP_PROTOCOL_VERSION = '2024-11-05'
+const MCP_SERVER_INFO = { name: 'agents-dev-shell', version: '0.1.0' } as const
+const MCP_CONFIG_RESOURCE_URI = 'agents-dev-shell://config'
+const TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: true,
+} as const
+
+const DEFAULT_CONFIG: DevShellMcpConfig = {
+  workspaceRoot: process.env.AGENTS_DEV_SHELL_WORKSPACE_ROOT ?? '/workspace',
+  defaultTimeoutSeconds: Number(process.env.AGENTS_DEV_SHELL_DEFAULT_TIMEOUT_SECONDS ?? '60'),
+  maxTimeoutSeconds: Number(process.env.AGENTS_DEV_SHELL_MAX_TIMEOUT_SECONDS ?? '1800'),
+  defaultOutputBytes: Number(process.env.AGENTS_DEV_SHELL_DEFAULT_OUTPUT_BYTES ?? '20000'),
+  maxOutputBytes: Number(process.env.AGENTS_DEV_SHELL_MAX_OUTPUT_BYTES ?? '200000'),
+  maxConcurrentJobs: Number(process.env.AGENTS_DEV_SHELL_MAX_CONCURRENT_JOBS ?? '4'),
+  auditLogPath: process.env.AGENTS_DEV_SHELL_AUDIT_LOG_PATH ?? '/workspace/.agents-dev-shell/audit.jsonl',
+}
+
+const commandInputSchema = {
+  type: 'object',
+  properties: {
+    command: {
+      type: 'string',
+      description: 'Required shell command executed as /bin/bash -lc inside the dev-shell container.',
+    },
+    cwd: {
+      type: 'string',
+      description: 'Optional working directory under /workspace. Defaults to /workspace.',
+    },
+    timeoutSeconds: {
+      type: 'integer',
+      minimum: 1,
+      maximum: 1800,
+      description: 'Optional timeout. Defaults to 60 seconds and is capped by server policy.',
+    },
+    maxOutputBytes: {
+      type: 'integer',
+      minimum: 1024,
+      maximum: 200000,
+      description: 'Optional per-stream output tail cap. Defaults to server policy.',
+    },
+  },
+  required: ['command'],
+  additionalProperties: false,
+} as const
+
+const shellOutputSchema = {
+  type: 'object',
+  properties: {
+    jobId: { type: 'string' },
+    command: { type: 'string' },
+    cwd: { type: 'string' },
+    status: { type: 'string' },
+    exitCode: { type: ['integer', 'null'] },
+    signal: { type: ['string', 'null'] },
+    timedOut: { type: 'boolean' },
+    startedAt: { type: 'string' },
+    finishedAt: { type: ['string', 'null'] },
+    stdout: { type: 'string' },
+    stderr: { type: 'string' },
+    stdoutBytes: { type: 'integer' },
+    stderrBytes: { type: 'integer' },
+    stdoutRetentionStartByte: { type: 'integer' },
+    stderrRetentionStartByte: { type: 'integer' },
+    stdoutNextOffset: { type: 'integer' },
+    stderrNextOffset: { type: 'integer' },
+    stdoutTruncated: { type: 'boolean' },
+    stderrTruncated: { type: 'boolean' },
+  },
+  additionalProperties: false,
+} as const
+
+const toolsListResult = {
+  tools: [
+    {
+      name: 'shell_run',
+      title: 'Run shell command',
+      description:
+        'Use this when the user explicitly wants to execute a short shell command or script inside the private agents dev-shell container. This can modify files, call networks, or destroy data inside the container.',
+      inputSchema: commandInputSchema,
+      outputSchema: shellOutputSchema,
+      annotations: TOOL_ANNOTATIONS,
+    },
+    {
+      name: 'shell_start',
+      title: 'Start long-running shell command',
+      description:
+        'Use this when the user explicitly wants to start a long-running shell command or script inside the private agents dev-shell container and poll it later with shell_read.',
+      inputSchema: commandInputSchema,
+      outputSchema: shellOutputSchema,
+      annotations: TOOL_ANNOTATIONS,
+    },
+    {
+      name: 'shell_read',
+      title: 'Read shell job output',
+      description: 'Use this when reading status and retained stdout/stderr output for a shell_start job.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          jobId: { type: 'string', description: 'Required shell_start job id.' },
+          stdoutOffset: { type: 'integer', minimum: 0, description: 'Optional stdout byte offset to read from.' },
+          stderrOffset: { type: 'integer', minimum: 0, description: 'Optional stderr byte offset to read from.' },
+          maxOutputBytes: { type: 'integer', minimum: 1024, maximum: 200000 },
+        },
+        required: ['jobId'],
+        additionalProperties: false,
+      },
+      outputSchema: shellOutputSchema,
+      annotations: { readOnlyHint: true },
+    },
+    {
+      name: 'shell_kill',
+      title: 'Kill shell job',
+      description: 'Use this when the user explicitly wants to terminate a running shell_start job.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          jobId: { type: 'string', description: 'Required shell_start job id.' },
+          signal: {
+            type: 'string',
+            description: 'Optional POSIX signal. Defaults to SIGTERM.',
+          },
+        },
+        required: ['jobId'],
+        additionalProperties: false,
+      },
+      outputSchema: shellOutputSchema,
+      annotations: TOOL_ANNOTATIONS,
+    },
+    {
+      name: 'shell_status',
+      title: 'List shell jobs',
+      description: 'Use this when inspecting recent shell job status in the private agents dev-shell container.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          jobId: { type: 'string', description: 'Optional job id. Omit to list recent jobs.' },
+          limit: { type: 'integer', minimum: 1, maximum: 100, description: 'Optional list limit.' },
+        },
+        additionalProperties: false,
+      },
+      outputSchema: {
+        type: 'object',
+        properties: {
+          jobs: { type: 'array', items: shellOutputSchema },
+        },
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: true },
+    },
+  ],
+} as const
+
+const resourcesListResult = {
+  resources: [
+    {
+      uri: MCP_CONFIG_RESOURCE_URI,
+      name: 'Agents dev-shell MCP config',
+      description: 'Server metadata and bounded command execution defaults for the Agents dev-shell MCP server.',
+      mimeType: 'application/json',
+    },
+  ],
+} as const
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const jsonResponse = (payload: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(payload), {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      ...init.headers,
+    },
+  })
+
+const asJsonRpcResponse = (id: JsonRpcId, result: unknown): JsonRpcResponse => ({ jsonrpc: '2.0', id, result })
+const asJsonRpcError = (id: JsonRpcId, error: JsonRpcError): JsonRpcResponse => ({ jsonrpc: '2.0', id, error })
+
+const withMcpSessionHeaders = (request: Request, init: ResponseInit = {}): ResponseInit => {
+  const sessionId = request.headers.get(MCP_SESSION_HEADER)
+  if (!sessionId) return init
+  return {
+    ...init,
+    headers: {
+      ...init.headers,
+      [MCP_SESSION_HEADER]: sessionId,
+    },
+  }
+}
+
+const asPositiveInteger = (args: Record<string, unknown>, key: string, fallback: number, max: number, min = 1) => {
+  const value = args[key]
+  if (value == null) return fallback
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < min) {
+    throw new Error(`${key} must be a positive number`)
+  }
+  return Math.min(Math.floor(value), max)
+}
+
+const asOptionalString = (args: Record<string, unknown>, key: string) => {
+  const value = args[key]
+  if (value == null) return null
+  if (typeof value !== 'string') throw new Error(`${key} must be a string`)
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const asRequiredString = (args: Record<string, unknown>, key: string) => {
+  const value = asOptionalString(args, key)
+  if (!value) throw new Error(`${key} is required`)
+  return value
+}
+
+const appendTail = (tail: OutputTail, chunk: Buffer, maxBytes: number) => {
+  tail.totalBytes += chunk.length
+  const merged = Buffer.concat([tail.buffer, chunk])
+  if (merged.length > maxBytes) {
+    tail.buffer = merged.subarray(merged.length - maxBytes)
+    tail.truncated = true
+    return
+  }
+  tail.buffer = merged
+}
+
+const newTail = (): OutputTail => ({ totalBytes: 0, truncated: false, buffer: Buffer.alloc(0) })
+
+const outputFromOffset = (tail: OutputTail, offset: number | null, maxBytes: number) => {
+  const retentionStart = Math.max(0, tail.totalBytes - tail.buffer.length)
+  const safeOffset = offset ?? retentionStart
+  const start = Math.max(0, safeOffset - retentionStart)
+  let buffer = tail.buffer.subarray(Math.min(start, tail.buffer.length))
+  let truncatedBeforeOffset = safeOffset < retentionStart
+  if (buffer.length > maxBytes) {
+    buffer = buffer.subarray(buffer.length - maxBytes)
+    truncatedBeforeOffset = true
+  }
+  return {
+    text: buffer.toString('utf8'),
+    retentionStartByte: retentionStart,
+    nextOffset: tail.totalBytes,
+    truncatedBeforeOffset,
+  }
+}
+
+const isInside = (root: string, path: string) => {
+  const rel = relative(root, path)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+const resolveCwd = (workspaceRoot: string, cwd: string | null) => {
+  const root = resolve(workspaceRoot)
+  const candidate = cwd ? resolve(root, cwd) : root
+  if (!isInside(root, candidate)) {
+    throw new Error(`cwd must stay under ${root}`)
+  }
+  if (!existsSync(candidate)) {
+    throw new Error(`cwd does not exist: ${candidate}`)
+  }
+  return candidate
+}
+
+const buildConfigResource = (config: DevShellMcpConfig) => ({
+  uri: MCP_CONFIG_RESOURCE_URI,
+  mimeType: 'application/json',
+  text: JSON.stringify(
+    {
+      serverInfo: MCP_SERVER_INFO,
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      workspaceRoot: resolve(config.workspaceRoot),
+      defaultTimeoutSeconds: config.defaultTimeoutSeconds,
+      maxTimeoutSeconds: config.maxTimeoutSeconds,
+      defaultOutputBytes: config.defaultOutputBytes,
+      maxOutputBytes: config.maxOutputBytes,
+      maxConcurrentJobs: config.maxConcurrentJobs,
+      tools: toolsListResult.tools.map((tool) => tool.name),
+    },
+    null,
+    2,
+  ),
+})
+
+const parseToolCall = (params: unknown): { name: string; args: Record<string, unknown> } | JsonRpcError => {
+  if (!isRecord(params)) return { code: -32602, message: 'Invalid params' }
+  const name = params.name
+  if (typeof name !== 'string' || name.length === 0) {
+    return { code: -32602, message: 'Invalid params: missing tool name' }
+  }
+  const args = params.arguments
+  if (args == null) return { name, args: {} }
+  if (!isRecord(args)) return { code: -32602, message: 'Invalid params: arguments must be an object' }
+  return { name, args: args as Record<string, unknown> }
+}
+
+const parseResourceReadParams = (params: unknown): { uri: string } | JsonRpcError => {
+  if (!isRecord(params)) return { code: -32602, message: 'Invalid params' }
+  const uri = params.uri
+  if (typeof uri !== 'string' || uri.length === 0) {
+    return { code: -32602, message: 'Invalid params: missing resource uri' }
+  }
+  return { uri }
+}
+
+const summarizeJob = (
+  job: ShellJob,
+  maxOutputBytes: number,
+  offsets: { stdoutOffset?: number | null; stderrOffset?: number | null } = {},
+) => {
+  const stdout = outputFromOffset(job.stdout, offsets.stdoutOffset ?? null, maxOutputBytes)
+  const stderr = outputFromOffset(job.stderr, offsets.stderrOffset ?? null, maxOutputBytes)
+  return {
+    jobId: job.id,
+    command: job.command,
+    cwd: job.cwd,
+    status: job.status,
+    exitCode: job.exitCode,
+    signal: job.signal,
+    timedOut: job.timedOut,
+    startedAt: job.startedAt,
+    finishedAt: job.finishedAt,
+    stdout: stdout.text,
+    stderr: stderr.text,
+    stdoutBytes: job.stdout.totalBytes,
+    stderrBytes: job.stderr.totalBytes,
+    stdoutRetentionStartByte: stdout.retentionStartByte,
+    stderrRetentionStartByte: stderr.retentionStartByte,
+    stdoutNextOffset: stdout.nextOffset,
+    stderrNextOffset: stderr.nextOffset,
+    stdoutTruncated: job.stdout.truncated || stdout.truncatedBeforeOffset,
+    stderrTruncated: job.stderr.truncated || stderr.truncatedBeforeOffset,
+  }
+}
+
+const toolResult = (structuredContent: unknown) => ({
+  structuredContent,
+  content: [{ type: 'text', text: JSON.stringify(structuredContent, null, 2) }],
+})
+
+export class DevShellRunner {
+  readonly config: DevShellMcpConfig
+  readonly jobs = new Map<string, ShellJob>()
+
+  constructor(config: Partial<DevShellMcpConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+    mkdirSync(resolve(this.config.workspaceRoot), { recursive: true })
+  }
+
+  runningJobs() {
+    return Array.from(this.jobs.values()).filter((job) => job.status === 'running')
+  }
+
+  parseCommandInput(args: Record<string, unknown>): CommandInput {
+    return {
+      command: asRequiredString(args, 'command'),
+      cwd: resolveCwd(this.config.workspaceRoot, asOptionalString(args, 'cwd')),
+      timeoutSeconds: asPositiveInteger(
+        args,
+        'timeoutSeconds',
+        this.config.defaultTimeoutSeconds,
+        this.config.maxTimeoutSeconds,
+      ),
+      maxOutputBytes: asPositiveInteger(
+        args,
+        'maxOutputBytes',
+        this.config.defaultOutputBytes,
+        this.config.maxOutputBytes,
+        1024,
+      ),
+    }
+  }
+
+  audit(event: string, payload: Record<string, unknown>) {
+    if (!this.config.auditLogPath) return
+    const line = JSON.stringify({ ts: new Date().toISOString(), event, ...payload })
+    try {
+      mkdirSync(dirname(this.config.auditLogPath), { recursive: true })
+      appendFileSync(this.config.auditLogPath, `${line}\n`)
+    } catch (error) {
+      console.warn('[agents-dev-shell] failed to write audit log', error)
+    }
+  }
+
+  start(input: CommandInput): ShellJob {
+    if (this.runningJobs().length >= this.config.maxConcurrentJobs) {
+      throw new Error(`max concurrent jobs reached: ${this.config.maxConcurrentJobs}`)
+    }
+
+    const child = spawn('/bin/bash', ['-lc', input.command], {
+      cwd: input.cwd,
+      env: { ...process.env, TERM: process.env.TERM ?? 'dumb' },
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const now = new Date().toISOString()
+    const job: ShellJob = {
+      id: randomUUID(),
+      command: input.command,
+      cwd: input.cwd,
+      process: child,
+      startedAt: now,
+      finishedAt: null,
+      status: 'running',
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      timeout: null,
+      stdout: newTail(),
+      stderr: newTail(),
+    }
+
+    child.stdout.on('data', (chunk: Buffer) => appendTail(job.stdout, Buffer.from(chunk), input.maxOutputBytes))
+    child.stderr.on('data', (chunk: Buffer) => appendTail(job.stderr, Buffer.from(chunk), input.maxOutputBytes))
+    child.on('close', (code, signal) => {
+      if (job.timeout) {
+        clearTimeout(job.timeout)
+        job.timeout = null
+      }
+      if (job.status === 'running') job.status = 'exited'
+      job.exitCode = code
+      job.signal = signal
+      job.finishedAt = new Date().toISOString()
+      this.audit('shell_job_finished', {
+        jobId: job.id,
+        status: job.status,
+        exitCode: code,
+        signal,
+        timedOut: job.timedOut,
+      })
+    })
+    child.on('error', (error) => {
+      appendTail(job.stderr, Buffer.from(String(error)), input.maxOutputBytes)
+    })
+    job.timeout = setTimeout(() => {
+      if (job.status !== 'running') return
+      job.timedOut = true
+      job.status = 'timed_out'
+      this.killProcessGroup(job, 'SIGTERM')
+    }, input.timeoutSeconds * 1000)
+
+    this.jobs.set(job.id, job)
+    this.audit('shell_job_started', {
+      jobId: job.id,
+      command: input.command,
+      cwd: input.cwd,
+      timeoutSeconds: input.timeoutSeconds,
+    })
+    return job
+  }
+
+  async run(input: CommandInput) {
+    const job = this.start(input)
+    await new Promise<void>((resolvePromise) => job.process.once('close', () => resolvePromise()))
+    return job
+  }
+
+  killProcessGroup(job: ShellJob, signal = 'SIGTERM') {
+    const pid = job.process.pid
+    if (!pid) return false
+    try {
+      process.kill(-pid, signal as NodeJS.Signals)
+      return true
+    } catch {
+      return job.process.kill(signal as NodeJS.Signals)
+    }
+  }
+
+  kill(jobId: string, signal = 'SIGTERM') {
+    const job = this.requireJob(jobId)
+    if (job.status !== 'running') return job
+    const killed = this.killProcessGroup(job, signal)
+    if (killed) {
+      job.status = 'killed'
+      job.signal = signal
+      this.audit('shell_job_killed', { jobId: job.id, signal })
+    }
+    return job
+  }
+
+  requireJob(jobId: string) {
+    const job = this.jobs.get(jobId)
+    if (!job) throw new Error(`unknown jobId: ${jobId}`)
+    return job
+  }
+
+  shutdown() {
+    for (const job of this.runningJobs()) {
+      job.status = 'killed'
+      this.killProcessGroup(job, 'SIGTERM')
+    }
+  }
+}
+
+let defaultRunner: DevShellRunner | null = null
+
+const getDefaultRunner = () => {
+  defaultRunner ??= new DevShellRunner()
+  return defaultRunner
+}
+
+const handleToolCall = async (
+  id: JsonRpcId,
+  runner: DevShellRunner,
+  toolName: string,
+  args: Record<string, unknown>,
+) => {
+  try {
+    if (toolName === 'shell_run') {
+      const input = runner.parseCommandInput(args)
+      const job = await runner.run(input)
+      return asJsonRpcResponse(id, toolResult(summarizeJob(job, input.maxOutputBytes)))
+    }
+
+    if (toolName === 'shell_start') {
+      const input = runner.parseCommandInput(args)
+      const job = runner.start(input)
+      return asJsonRpcResponse(id, toolResult(summarizeJob(job, input.maxOutputBytes)))
+    }
+
+    if (toolName === 'shell_read') {
+      const job = runner.requireJob(asRequiredString(args, 'jobId'))
+      const maxOutputBytes = asPositiveInteger(
+        args,
+        'maxOutputBytes',
+        runner.config.defaultOutputBytes,
+        runner.config.maxOutputBytes,
+        1024,
+      )
+      const stdoutOffset = asPositiveInteger(args, 'stdoutOffset', 0, Number.MAX_SAFE_INTEGER, 0)
+      const stderrOffset = asPositiveInteger(args, 'stderrOffset', 0, Number.MAX_SAFE_INTEGER, 0)
+      return asJsonRpcResponse(
+        id,
+        toolResult(
+          summarizeJob(job, maxOutputBytes, {
+            stdoutOffset: args.stdoutOffset == null ? null : stdoutOffset,
+            stderrOffset: args.stderrOffset == null ? null : stderrOffset,
+          }),
+        ),
+      )
+    }
+
+    if (toolName === 'shell_kill') {
+      const job = runner.kill(asRequiredString(args, 'jobId'), asOptionalString(args, 'signal') ?? 'SIGTERM')
+      return asJsonRpcResponse(id, toolResult(summarizeJob(job, runner.config.defaultOutputBytes)))
+    }
+
+    if (toolName === 'shell_status') {
+      const jobId = asOptionalString(args, 'jobId')
+      const limit = asPositiveInteger(args, 'limit', 20, 100)
+      const jobs = jobId
+        ? [runner.requireJob(jobId)]
+        : Array.from(runner.jobs.values())
+            .sort((left, right) => right.startedAt.localeCompare(left.startedAt))
+            .slice(0, limit)
+      return asJsonRpcResponse(id, toolResult({ jobs: jobs.map((job) => summarizeJob(job, 4096)) }))
+    }
+
+    return asJsonRpcError(id, { code: -32601, message: `Unknown tool: ${toolName}` })
+  } catch (error) {
+    return asJsonRpcError(id, {
+      code: -32602,
+      message: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+const handleJsonRpcMessage = async (request: Request, runner: DevShellRunner, raw: unknown) => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return asJsonRpcError(null, { code: -32600, message: 'Invalid Request' })
+  }
+
+  const msg = raw as JsonRpcRequest
+  const id: JsonRpcId = typeof msg.id === 'string' || typeof msg.id === 'number' || msg.id === null ? msg.id : null
+  const method = msg.method
+  if (typeof method !== 'string' || method.length === 0) {
+    return asJsonRpcError(id, { code: -32600, message: 'Invalid Request: missing method' })
+  }
+  const isNotification = !('id' in msg)
+
+  switch (method) {
+    case 'initialize':
+      if (isNotification) return null
+      return asJsonRpcResponse(id, {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: {}, resources: {} },
+        serverInfo: MCP_SERVER_INFO,
+      })
+    case 'notifications/initialized':
+      return null
+    case 'tools/list':
+      if (isNotification) return null
+      return asJsonRpcResponse(id, toolsListResult)
+    case 'resources/list':
+      if (isNotification) return null
+      return asJsonRpcResponse(id, resourcesListResult)
+    case 'resources/read': {
+      const parsed = parseResourceReadParams(msg.params)
+      if ('code' in parsed) return isNotification ? null : asJsonRpcError(id, parsed)
+      if (parsed.uri !== MCP_CONFIG_RESOURCE_URI) {
+        return isNotification
+          ? null
+          : asJsonRpcError(id, { code: -32602, message: 'Invalid params: unknown resource uri' })
+      }
+      return isNotification ? null : asJsonRpcResponse(id, { contents: [buildConfigResource(runner.config)] })
+    }
+    case 'resources/templates/list':
+      if (isNotification) return null
+      return asJsonRpcResponse(id, { resourceTemplates: [] })
+    case 'tools/call': {
+      const parsed = parseToolCall(msg.params)
+      if ('code' in parsed) return isNotification ? null : asJsonRpcError(id, parsed)
+      return isNotification ? null : handleToolCall(id, runner, parsed.name, parsed.args)
+    }
+    default:
+      return isNotification ? null : asJsonRpcError(id, { code: -32601, message: `Method not found: ${method}` })
+  }
+}
+
+export const handleDevShellMcpRequest = async (request: Request, runner = getDefaultRunner()) => {
+  const url = new URL(request.url)
+  if (request.method === 'GET' && (url.pathname === '/healthz' || url.pathname === '/readyz')) {
+    return jsonResponse({ ok: true, server: MCP_SERVER_INFO.name })
+  }
+  if (request.method !== 'POST' || url.pathname !== '/mcp') {
+    return new Response('Not Found', { status: 404 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return jsonResponse(
+      asJsonRpcError(null, { code: -32700, message: 'Parse error' }),
+      withMcpSessionHeaders(request, { status: 400 }),
+    )
+  }
+
+  if (Array.isArray(body)) {
+    const responses: JsonRpcResponse[] = []
+    for (const item of body) {
+      const response = await handleJsonRpcMessage(request, runner, item)
+      if (response) responses.push(response)
+    }
+    if (responses.length === 0) return new Response(null, withMcpSessionHeaders(request, { status: 202 }))
+    return jsonResponse(responses, withMcpSessionHeaders(request))
+  }
+
+  const response = await handleJsonRpcMessage(request, runner, body)
+  if (!response) return new Response(null, withMcpSessionHeaders(request, { status: 202 }))
+  return jsonResponse(response, withMcpSessionHeaders(request))
+}
+
+if (import.meta.main) {
+  const port = Number(process.env.AGENTS_DEV_SHELL_MCP_PORT ?? process.env.PORT ?? '8090')
+  const hostname = process.env.AGENTS_DEV_SHELL_MCP_HOST ?? '127.0.0.1'
+  const server = Bun.serve({
+    hostname,
+    port,
+    fetch: (request) => handleDevShellMcpRequest(request),
+  })
+  const shutdown = () => {
+    defaultRunner?.shutdown()
+    server.stop(true)
+    process.exit(0)
+  }
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+  console.log(`[agents-dev-shell] MCP server listening on http://${hostname}:${port}/mcp`)
+}


### PR DESCRIPTION
## Summary

- Adds a standalone Agents dev-shell MCP server with bounded shell_run/shell_start/shell_read/shell_kill/shell_status tools, cwd allowlisting, output caps, timeouts, audit logging, and shutdown cleanup.
- Adds an agents-dev-shell Docker target that installs bash, Python, git, kubectl, and SHA256-verified OpenAI tunnel-client v0.0.9.
- Adds Helm/GitOps support for the dev-shell deployment, dedicated ServiceAccount, ExternalSecret-backed tunnel API key, digest enforcement, and non-root Pod Security defaults.
- Enables the agents dev-shell in Argo values with pushed multi-arch image registry.ide-newton.ts.net/lab/agents-dev-shell:6eed493f@sha256:e6adc87f1d7c2210a841a7baf974cd2cfe0ed10bdea755cad2719a8e25a9d581.
- Documents the ChatGPT connector setup and validation flow.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/update-values.test.ts`
- `bun run --filter @proompteng/agents test -- src/server/dev-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents tsc`
- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- kubectl kustomize argocd/applications/agents --enable-helm >/tmp/agents-argocd-render.yaml`
- `mise exec helm@3 -- kubectl kustomize argocd/applications/agents --enable-helm | kubectl apply --dry-run=server -n agents -f -`
- Local MCP smoke with `bun run services/agents/src/server/dev-shell-mcp.ts`, `tools/list`, and `shell_run` for `pwd && python3 --version`.
- Built and pushed `registry.ide-newton.ts.net/lab/agents-dev-shell:6eed493f`; verified the pushed OCI index digest and linux/amd64 plus linux/arm64 manifests.
- Ran the pushed image locally as UID 1000 with `/workspace` mounted and verified `shell_run` returns UID, workspace path, Python version, and tunnel-client version.

## Breaking Changes

None. Runtime rollout still requires the ExternalSecret remote key `openai-tunnel-client/agents-control-plane-api-key` to exist and the OpenAI tunnel to be associated with the target ChatGPT workspace.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
