### PR TITLE
fix(jangar): remove duplicate openwebui env

### DIFF
--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -60,8 +60,6 @@ extraEnvVars:
   # Forward chat/user identifiers to the upstream OpenAI-compatible backend
   - name: ENABLE_FORWARD_USER_INFO_HEADERS
     value: "true"
-  - name: ENABLE_OLLAMA_API
-    value: "false"
 
 volumes:
   - name: jangar-db-ca


### PR DESCRIPTION
## Summary

- Remove the duplicate OpenWebUI ENABLE_OLLAMA_API env override from Jangar values.
- Let the OpenWebUI chart emit its built-in ENABLE_OLLAMA_API value once.
- Unblock Argo structured-merge diff so Jangar can reconcile to the merged Flamingo routing revision.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/jangar >/tmp/jangar-render.yaml`
- `yq . | select(.kind == "StatefulSet" and .metadata.name == "open-webui") | .spec.template.spec.containers[] | select(.name == "open-webui") | .env[].name /tmp/jangar-render.yaml | sort | uniq -d`
- `yq . | select(.kind == "StatefulSet" and .metadata.name == "open-webui") | .spec.template.spec.containers[] | select(.name == "open-webui") | .env[] | select(.name == "ENABLE_OLLAMA_API") /tmp/jangar-render.yaml`
- `kubeconform -strict -ignore-missing-schemas /tmp/jangar-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation change is needed for this render-only env duplication fix.
