### PR TITLE
chore(jangar): promote image ae168a31

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-20T06:42:53Z
+    deploy.knative.dev/rollout: 2026-06-27T20:09:54Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 69ba69c6b9769d239ff76de8e2210532120f6618
+              value: ae168a31710243c2e78af3be988d6c70bb9d9ce8
             - name: JANGAR_GITOPS_REVISION
-              value: 69ba69c6b9769d239ff76de8e2210532120f6618
+              value: ae168a31710243c2e78af3be988d6c70bb9d9ce8
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "27863191686"
+              value: "28300385847"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:2d36d4c6d80befb2c19bcc1f620c424d908b2baa8160ed01a27508088f4d7e3a
+              value: sha256:4b29f731f5fe928bab79edfb968a97a55dadd55d318f78feb57e1ac16aadbedc
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 69ba69c6b9769d239ff76de8e2210532120f6618
+              value: ae168a31710243c2e78af3be988d6c70bb9d9ce8
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:2d36d4c6d80befb2c19bcc1f620c424d908b2baa8160ed01a27508088f4d7e3a
+              value: sha256:4b29f731f5fe928bab79edfb968a97a55dadd55d318f78feb57e1ac16aadbedc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 69ba69c6
-    digest: sha256:2d36d4c6d80befb2c19bcc1f620c424d908b2baa8160ed01a27508088f4d7e3a
+    newTag: ae168a31
+    digest: sha256:4b29f731f5fe928bab79edfb968a97a55dadd55d318f78feb57e1ac16aadbedc


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `ae168a31710243c2e78af3be988d6c70bb9d9ce8`
- Image tag: `ae168a31`
- Image digest: `sha256:4b29f731f5fe928bab79edfb968a97a55dadd55d318f78feb57e1ac16aadbedc`
- Source CI run: `28300385847`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates