### PR TITLE
fix(observability): set alertmanager external url

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -15,6 +15,8 @@ global:
 
 mimir:
   structuredConfig:
+    alertmanager:
+      external_url: https://mimir.ide-newton.ts.net/alertmanager
     limits:
       ingestion_rate: 20000
       ingestion_burst_size: 400000


### PR DESCRIPTION
## Summary

- Set the Mimir Alertmanager external URL to the Tailscale gateway path.
- Fix Alertmanager notification links that rendered without a host.
- Keep the UI reachable at `https://mimir.ide-newton.ts.net/alertmanager`.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applications/observability/mimir-values.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/observability | rg -n "external_url: https://mimir\.ide-newton\.ts\.net/alertmanager|name: observability-mimir-alertmanager|checksum/config" -C 2`
- `curl -skL --max-time 8 -o /tmp/mimir-alertmanager.html -w '%{http_code} %{url_effective}\n' 'https://mimir.ide-newton.ts.net/alertmanager/#/alerts?receiver=critical-email'`

## Screenshots (if applicable)

N/A - infrastructure configuration only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
