### PR TITLE
revert(torghut): rollback failed promotion d78a2cb94003a22122e80f966a3e5b713c8622be

### DIFF
--- a/argocd/applications/torghut/clickhouse/clickhouse-pdb.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-pdb.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: torghut-clickhouse
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-clickhouse
+    app.kubernetes.io/part-of: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      clickhouse.altinity.com/chi: torghut-clickhouse
+      clickhouse.altinity.com/cluster: default
+

--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - clickhouse-guardrails-exporter-configmap.yaml
   - clickhouse-guardrails-exporter.yaml
   - clickhouse-cluster.yaml
+  - clickhouse-pdb.yaml
   - clickhouse-service.yaml


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `d78a2cb94003a22122e80f966a3e5b713c8622be`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28301059122`
- Rollback source: `HEAD^` manifests from the failed run checkout