### PR TITLE
fix(clickhouse): allow operator drain eviction

### DIFF
--- a/argocd/applications/clickhouse-operator/values.yaml
+++ b/argocd/applications/clickhouse-operator/values.yaml
@@ -178,7 +178,7 @@ additionalResources:
         app.kubernetes.io/component: controller
         app.kubernetes.io/part-of: data-platform
     spec:
-      maxUnavailable: 0
+      maxUnavailable: 1
       selector:
         matchLabels:
           app.kubernetes.io/name: altinity-clickhouse-operator


### PR DESCRIPTION
## Summary

- Change the ClickHouse operator PodDisruptionBudget from `maxUnavailable: 0` to `maxUnavailable: 1`.
- Keep the operator singleton deployment and chart configuration otherwise unchanged.
- Remove one preventable Altra drain blocker by allowing the operator pod to be evicted and rescheduled during planned node maintenance.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/clickhouse-operator >/tmp/kustomize-clickhouse-operator.yaml`
- `git diff --check`
- Rendered readback: `clickhouse-operator/clickhouse-operator maxUnavailable=1`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This allows voluntary eviction of the singleton ClickHouse operator pod during maintenance; managed ClickHouse data-plane resources remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
