### PR TITLE
feat(nix): deploy attic cache service

### DIFF
--- a/.github/workflows/attic-build-push.yaml
+++ b/.github/workflows/attic-build-push.yaml
@@ -1,0 +1,149 @@
+name: attic-build-push
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'docs/nix-cache.md'
+      - 'argocd/applications/attic/**'
+      - '.github/workflows/attic-build-push.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'docs/nix-cache.md'
+      - 'argocd/applications/attic/**'
+      - '.github/workflows/attic-build-push.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install xz for Nix installer
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y xz
+          elif ! command -v xz >/dev/null 2>&1; then
+            echo "xz is required to install Nix on this runner." >&2
+            exit 1
+          fi
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build Attic image
+        run: nix build .#atticd-image --print-build-logs
+
+      - name: Load and smoke image
+        run: |
+          set -euo pipefail
+          docker load < result
+          docker run --rm --platform '${{ matrix.platform }}' registry.ide-newton.ts.net/lab/attic:dev --version
+
+      - name: Resolve image tag
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: meta
+        run: echo "tag=sha-$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Push platform image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/attic
+          TAG: ${{ steps.meta.outputs.tag }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          docker tag "${IMAGE}:dev" "${IMAGE}:${TAG}-${ARCH}"
+          docker tag "${IMAGE}:dev" "${IMAGE}:latest-${ARCH}"
+          docker push "${IMAGE}:${TAG}-${ARCH}"
+          docker push "${IMAGE}:latest-${ARCH}"
+
+  publish-index:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-platform
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install xz for Nix installer
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y xz
+          elif ! command -v xz >/dev/null 2>&1; then
+            echo "xz is required to install Nix on this runner." >&2
+            exit 1
+          fi
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=sha-$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create OCI image index
+        id: oci
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/attic
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          nix run .#create-oci-index -- \
+            --image "${IMAGE}" \
+            --tag "${TAG}" \
+            --arch-tag "linux/amd64=${TAG}-amd64" \
+            --arch-tag "linux/arm64=${TAG}-arm64" \
+            --latest
+
+      - name: Verify OCI image index platforms
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/attic
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: nix run .#assert-oci-platforms -- "${IMAGE}:${TAG}" linux/amd64 linux/arm64

--- a/argocd/applications/attic/configmap.yaml
+++ b/argocd/applications/attic/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: attic-config
+  namespace: attic
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+data:
+  server.toml: |
+    listen = "[::]:8080"
+    allowed-hosts = [
+      "attic.attic.svc.cluster.local",
+      "attic.ide-newton.ts.net"
+    ]
+    api-endpoint = "https://attic.ide-newton.ts.net/"
+    substituter-endpoint = "https://attic.ide-newton.ts.net/"
+    soft-delete-caches = true
+    require-proof-of-possession = true
+
+    [database]
+    heartbeat = true
+
+    [storage]
+    type = "s3"
+    region = "us-east-1"
+    bucket = "attic-cache"
+    endpoint = "http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80"
+
+    [chunking]
+    nar-size-threshold = 65536
+    min-size = 16384
+    avg-size = 65536
+    max-size = 262144
+
+    [compression]
+    type = "zstd"
+
+    [garbage-collection]
+    interval = "0s"
+    default-retention-period = "6 months"

--- a/argocd/applications/attic/deployment.yaml
+++ b/argocd/applications/attic/deployment.yaml
@@ -1,0 +1,151 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: attic
+  namespace: attic
+  labels:
+    app.kubernetes.io/name: attic
+    app.kubernetes.io/component: nix-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: attic
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: attic
+        app.kubernetes.io/component: nix-cache
+    spec:
+      securityContext:
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: db-migrations
+          image: registry.ide-newton.ts.net/lab/attic:latest
+          imagePullPolicy: Always
+          command:
+            - atticd
+          args:
+            - --config
+            - /etc/attic/server.toml
+            - --mode
+            - db-migrations
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: ATTIC_SERVER_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: attic-db-app
+                  key: uri
+            - name: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+              valueFrom:
+                secretKeyRef:
+                  name: attic-secrets
+                  key: token-rs256-secret-base64
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_SECRET_ACCESS_KEY
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          volumeMounts:
+            - name: attic-config
+              mountPath: /etc/attic
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      containers:
+        - name: attic
+          image: registry.ide-newton.ts.net/lab/attic:latest
+          imagePullPolicy: Always
+          command:
+            - atticd
+          args:
+            - --config
+            - /etc/attic/server.toml
+            - --mode
+            - api-server
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: ATTIC_SERVER_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: attic-db-app
+                  key: uri
+            - name: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+              valueFrom:
+                secretKeyRef:
+                  name: attic-secrets
+                  key: token-rs256-secret-base64
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: attic-cache
+                  key: AWS_SECRET_ACCESS_KEY
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          volumeMounts:
+            - name: attic-config
+              mountPath: /etc/attic
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: attic-config
+          configMap:
+            name: attic-config
+        - name: tmp
+          emptyDir: {}

--- a/argocd/applications/attic/externalsecret.yaml
+++ b/argocd/applications/attic/externalsecret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: attic-secrets
+  namespace: attic
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+spec:
+  refreshPolicy: CreatedOnce
+  refreshInterval: 0s
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-infra
+  target:
+    name: attic-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token-rs256-secret-base64
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: attic-cache/token-rs256-secret-base64
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/argocd/applications/attic/gc-cronjob.yaml
+++ b/argocd/applications/attic/gc-cronjob.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: attic-gc
+  namespace: attic
+  labels:
+    app.kubernetes.io/name: attic
+    app.kubernetes.io/component: garbage-collector
+spec:
+  schedule: "17 9 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: attic
+            app.kubernetes.io/component: garbage-collector
+        spec:
+          restartPolicy: Never
+          securityContext:
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: attic-gc
+              image: registry.ide-newton.ts.net/lab/attic:latest
+              imagePullPolicy: Always
+              command:
+                - atticd
+              args:
+                - --config
+                - /etc/attic/server.toml
+                - --mode
+                - garbage-collector-once
+              env:
+                - name: RUST_LOG
+                  value: info
+                - name: ATTIC_SERVER_DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-db-app
+                      key: uri
+                - name: ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-secrets
+                      key: token-rs256-secret-base64
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-cache
+                      key: AWS_ACCESS_KEY_ID
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: attic-cache
+                      key: AWS_SECRET_ACCESS_KEY
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+              volumeMounts:
+                - name: attic-config
+                  mountPath: /etc/attic
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: attic-config
+              configMap:
+                name: attic-config
+            - name: tmp
+              emptyDir: {}

--- a/argocd/applications/attic/kustomization.yaml
+++ b/argocd/applications/attic/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: attic
+resources:
+  - objectbucketclaim.yaml
+  - postgres-cluster.yaml
+  - externalsecret.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - tailscale-ingress.yaml
+  - gc-cronjob.yaml

--- a/argocd/applications/attic/objectbucketclaim.yaml
+++ b/argocd/applications/attic/objectbucketclaim.yaml
@@ -1,0 +1,8 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: attic-cache
+  namespace: attic
+spec:
+  bucketName: attic-cache
+  storageClassName: rook-ceph-bucket

--- a/argocd/applications/attic/postgres-cluster.yaml
+++ b/argocd/applications/attic/postgres-cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: attic-db
+  namespace: attic
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  instances: 1
+  primaryUpdateStrategy: unsupervised
+  storage:
+    storageClass: rook-ceph-block
+    size: 20Gi
+  bootstrap:
+    initdb:
+      database: attic
+      owner: attic
+      encoding: "UTF8"
+      dataChecksums: true
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pgadmin"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pgadmin"
+  monitoring:
+    enablePodMonitor: true
+# CNPG emits app credentials in `attic-db-app`; Attic reads its `uri` key via ATTIC_SERVER_DATABASE_URL.

--- a/argocd/applications/attic/service.yaml
+++ b/argocd/applications/attic/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: attic
+  namespace: attic
+  labels:
+    app.kubernetes.io/name: attic
+    app.kubernetes.io/component: nix-cache
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: attic
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applications/attic/tailscale-ingress.yaml
+++ b/argocd/applications/attic/tailscale-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: attic-tailscale
+  namespace: attic
+  annotations:
+    tailscale.com/tags: tag:k8s
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - attic.ide-newton.ts.net
+  rules:
+    - host: attic.ide-newton.ts.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: attic
+                port:
+                  number: 80

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -334,6 +334,18 @@ spec:
                   argocd.argoproj.io/sync-wave: "3"
                 automation: manual
                 enabled: "true"
+              - name: attic
+                path: argocd/applications/attic
+                namespace: attic
+                annotations:
+                  argocd.argoproj.io/sync-wave: "3"
+                managedNamespaceMetadata:
+                  labels:
+                    external-secrets.proompteng.ai/enabled: "true"
+                  annotations:
+                    argocd.argoproj.io/sync-options: Prune=false
+                automation: auto
+                enabled: "true"
               - name: observability
                 path: argocd/applications/observability
                 namespace: observability

--- a/docs/nix-cache.md
+++ b/docs/nix-cache.md
@@ -1,0 +1,128 @@
+# Lab Nix Cache
+
+Attic is the lab Nix binary cache. It stores Nix store outputs so ARC CI and
+developer machines can reuse toolchain and helper derivations instead of
+rebuilding them.
+
+Supported endpoints:
+
+- In-cluster and ARC CI: `http://attic.attic.svc.cluster.local/lab`
+- Developer host over Tailscale: `https://attic.ide-newton.ts.net/lab`
+
+Only those endpoints are part of this rollout. Do not add a second DNS-backed
+ingress path in this phase.
+
+## Server
+
+The GitOps app is `argocd/applications/attic` in namespace `attic`.
+
+Backends:
+
+- database: `Cluster/attic-db`, app secret `attic-db-app`
+- object storage: `ObjectBucketClaim/attic-cache`
+- signing key: `ExternalSecret/attic-secrets`
+- image: `registry.ide-newton.ts.net/lab/attic:latest`
+
+The Attic config uses an explicit allowed-host list:
+
+- `attic.attic.svc.cluster.local`
+- `attic.ide-newton.ts.net`
+
+The API deployment runs database migrations in an init container, then starts
+`atticd --mode api-server`. Garbage collection runs separately through
+`CronJob/attic-gc`.
+
+## Secret Inputs
+
+Create the 1Password item in the `infra` vault before rollout:
+
+```text
+attic-cache/token-rs256-secret-base64
+```
+
+Generate the value with:
+
+```bash
+openssl genrsa -traditional 4096 | base64 | tr -d '\n'
+```
+
+Do not commit the generated value and do not paste it into PR text.
+
+The CI push token is not part of the service rollout. Add it only after the
+cache exists, public pull is verified, and main-only push wiring is ready.
+
+## Operator Checks
+
+Cluster health:
+
+```bash
+kubectl -n argocd get application attic -o json | jq '{sync:.status.sync.status, health:.status.health.status, revision:.status.sync.revision}'
+kubectl -n attic get deploy,pod,svc,ingress,externalsecret,objectbucketclaim
+kubectl -n attic get cluster attic-db
+```
+
+In-cluster endpoint:
+
+```bash
+kubectl -n attic run attic-cache-smoke \
+  --rm -i \
+  --restart=Never \
+  --image=curlimages/curl \
+  -- curl -fsSL http://attic.attic.svc.cluster.local/lab/nix-cache-info
+```
+
+Host endpoint:
+
+```bash
+curl -fsSL https://attic.ide-newton.ts.net/lab/nix-cache-info
+```
+
+Local doctor:
+
+```bash
+nix run .#cache-doctor
+ATTIC_CACHE_URL=http://attic.attic.svc.cluster.local/lab nix run .#cache-doctor
+```
+
+## Client Configuration
+
+For a developer host:
+
+```bash
+export ATTIC_PUBLIC_KEY='<public key from attic cache info lab>'
+export NIX_CONFIG=$'extra-substituters = https://attic.ide-newton.ts.net/lab\nextra-trusted-public-keys = '"${ATTIC_PUBLIC_KEY}"
+nix run .#cache-doctor
+```
+
+For ARC CI jobs:
+
+```text
+extra-substituters = http://attic.attic.svc.cluster.local/lab
+extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+```
+
+Use `extra-*` settings so the default `cache.nixos.org` fallback remains
+available.
+
+## Push Boundary
+
+Pushes require `ATTIC_TOKEN` and must be restricted to trusted `main` branch
+workflows.
+
+The helper refuses to run without a token:
+
+```bash
+export ATTIC_CACHE_ENDPOINT=http://attic.attic.svc.cluster.local
+export ATTIC_CACHE_NAME=lab
+# Set ATTIC_TOKEN in the shell environment before invoking the helper.
+nix run .#cache-push -- ./result
+```
+
+Pull request workflows must not receive `ATTIC_TOKEN`.
+
+## Container Build Boundary
+
+Attic caches Nix store paths. It does not directly cache Docker layers,
+`bun install`, `pip install`, image export, or registry push time. Container
+build acceleration remains a separate BuildKit and Dockerfile optimization
+phase.

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
             pkgs.skopeo
             pkgs.regclient
             pkgs.cosign
+            pkgs.attic-client
           ] ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
             pkgs.libiconv
           ];
@@ -128,6 +129,21 @@
             exec bash scripts/argo-lint.sh
           '';
 
+          cacheDoctor = mkShellScript "cache-doctor" [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.curl
+            pkgs.gawk
+            pkgs.gnugrep
+            pkgs.nixVersions.nix_2_28
+          ] (builtins.readFile ./nix/cache-doctor.sh);
+
+          cachePush = mkShellScript "cache-push" [
+            pkgs.attic-client
+            pkgs.bash
+            pkgs.coreutils
+          ] (builtins.readFile ./nix/cache-push.sh);
+
           createOciIndex = mkOciScript "create-oci-index" ''
             exec bun run packages/scripts/src/shared/oci.ts create-index "$@"
           '';
@@ -140,6 +156,33 @@
             exec bun run packages/scripts/src/shared/oci.ts assert "$@"
           '';
 
+          linuxPackages = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+            "atticd-image" = pkgs.dockerTools.buildLayeredImage {
+              name = "registry.ide-newton.ts.net/lab/attic";
+              tag = "dev";
+              contents = [
+                pkgs.attic-client
+                pkgs.attic-server
+                pkgs.cacert
+              ];
+              config = {
+                Entrypoint = [ "atticd" ];
+                Env = [
+                  "PATH=${lib.makeBinPath [
+                    pkgs.attic-client
+                    pkgs.attic-server
+                    pkgs.coreutils
+                  ]}"
+                  "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                ];
+                ExposedPorts = {
+                  "8080/tcp" = { };
+                };
+                User = "65532:65532";
+              };
+            };
+          };
+
           mkApp = drv: {
             type = "app";
             program = lib.getExe drv;
@@ -147,7 +190,7 @@
           };
         in
         {
-          packages = exact // {
+          packages = exact // linuxPackages // {
             default = toolchainDoctor;
             inherit
               toolchainDoctor
@@ -155,10 +198,14 @@
               lintArgocd
               renderHeadlamp
               lintArgoWorkflows
+              cacheDoctor
+              cachePush
               createOciIndex
               inspectOciImage
               assertOciPlatforms
               ;
+            atticClient = pkgs.attic-client;
+            atticServer = pkgs.attic-server;
           };
 
           apps = {
@@ -168,6 +215,8 @@
             lint-argocd = mkApp lintArgocd;
             render-headlamp = mkApp renderHeadlamp;
             lint-argo-workflows = mkApp lintArgoWorkflows;
+            cache-doctor = mkApp cacheDoctor;
+            cache-push = mkApp cachePush;
             create-oci-index = mkApp createOciIndex;
             inspect-oci-image = mkApp inspectOciImage;
             assert-oci-platforms = mkApp assertOciPlatforms;
@@ -177,6 +226,8 @@
             packages = shellPackages ++ [
               toolchainDoctor
               ociDoctor
+              cacheDoctor
+              cachePush
             ];
             shellHook = ''
               export LAB_NIX_TOOLCHAIN=1

--- a/nix/cache-doctor.sh
+++ b/nix/cache-doctor.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_url="${ATTIC_CACHE_URL:-${NIX_CACHE_URL:-https://attic.ide-newton.ts.net/lab}}"
+public_key="${ATTIC_PUBLIC_KEY:-}"
+
+if [[ "${cache_url}" != http://* && "${cache_url}" != https://* ]]; then
+  echo "ATTIC_CACHE_URL must be an http(s) URL, got: ${cache_url}" >&2
+  exit 2
+fi
+
+echo "Checking Nix cache endpoint: ${cache_url}"
+cache_info="$(curl -fsSL "${cache_url%/}/nix-cache-info")"
+printf '%s\n' "${cache_info}"
+
+if ! grep -Fq 'StoreDir: /nix/store' <<<"${cache_info}"; then
+  echo "Cache endpoint did not return a Nix cache-info document." >&2
+  exit 1
+fi
+
+if [[ -n "${public_key}" ]]; then
+  nix_config="$(nix show-config 2>/dev/null || true)"
+  nix_config="${nix_config}"$'\n'"${NIX_CONFIG:-}"
+
+  if ! grep -Fq "${cache_url}" <<<"${nix_config}"; then
+    echo "Nix config does not include substituter ${cache_url}." >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "${public_key}" <<<"${nix_config}"; then
+    echo "Nix config does not include ATTIC_PUBLIC_KEY." >&2
+    exit 1
+  fi
+else
+  echo "ATTIC_PUBLIC_KEY is unset; skipping local trusted-public-key verification."
+fi
+
+echo "Attic cache doctor passed."

--- a/nix/cache-push.sh
+++ b/nix/cache-push.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${ATTIC_TOKEN:-}" ]]; then
+  echo "ATTIC_TOKEN is required to push to Attic." >&2
+  exit 2
+fi
+
+cache_name="${ATTIC_CACHE_NAME:-lab}"
+cache_endpoint="${ATTIC_CACHE_ENDPOINT:-http://attic.attic.svc.cluster.local}"
+
+if [[ "$#" -eq 0 ]]; then
+  echo "Usage: cache-push <store-path> [<store-path> ...]" >&2
+  exit 2
+fi
+
+paths=()
+for path in "$@"; do
+  if [[ ! -e "${path}" ]]; then
+    echo "Store path does not exist: ${path}" >&2
+    exit 1
+  fi
+  paths+=("${path}")
+done
+
+echo "Logging in to Attic endpoint ${cache_endpoint} for cache ${cache_name}."
+attic login "${cache_name}" "${cache_endpoint}" "${ATTIC_TOKEN}" >/dev/null
+
+echo "Pushing ${#paths[@]} path(s) to Attic cache ${cache_name}."
+attic push "${cache_name}" "${paths[@]}"


### PR DESCRIPTION
## Summary

- Adds a GitOps-managed Attic Nix binary cache service backed by CNPG Postgres and a Rook/Ceph ObjectBucketClaim.
- Publishes a pinned Nix-built Attic image through a new multi-arch ARC workflow.
- Adds `cache-doctor` and `cache-push` Nix helper apps plus operator documentation for supported cluster and Tailscale endpoints.
- Keeps the rollout pull-only for now: no CI push token, no cache bootstrap job, and no extra DNS-backed ingress path.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/attic`
- `kustomize build argocd/applications/attic | kubeconform -strict -ignore-missing-schemas`
- `shellcheck nix/cache-doctor.sh nix/cache-push.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_stream(File.read(f)); puts f }' .github/workflows/attic-build-push.yaml argocd/applicationsets/platform.yaml argocd/applications/attic/*.yaml`
- `rg -n "attic\\.k8s\\.proompteng\\.ai|IngressRoute|traefik|external-dns|private-dns|private DNS" argocd/applications/attic docs/nix-cache.md .github nix`
- `git diff --name-only --diff-filter=ACM | xargs rg -n "ATTIC_TOKEN=|eyJ[A-Za-z0-9_-]+\\.|token-rs256-secret-base64:|BEGIN .*PRIVATE"`
- `docker run --rm -v /Users:/Users -w "$PWD" nixos/nix:2.28.4 sh -lc 'nix --extra-experimental-features "nix-command flakes" flake check --no-build --all-systems --print-build-logs'`
- `docker run --rm -v /Users:/Users -w "$PWD" nixos/nix:2.28.4 sh -lc 'nix --extra-experimental-features "nix-command flakes" build .#atticd-image --out-link /tmp/atticd-image --print-build-logs && ls -lh /tmp/atticd-image'`
- `bun run lint:argocd`

Note: local `actionlint .github/workflows/attic-build-push.yaml` was not used as a pass/fail gate because this repo does not configure actionlint custom labels and existing workflows already use `arc-amd64` / `arc-arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
