### PR TITLE
chore(symphony): promote image b7213469

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-20T21:12:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:08:39Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "7613d3da"
-    digest: sha256:41ec3af5a425b7fbfe1f1dfb532399f2250ea517d680a3dd4f9c1d8fab73623d
+    newTag: "b7213469"
+    digest: sha256:de8506f18cc9af496bb4355c9dfbec6798b3a1238429f671981e4f52ce3b14bd

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-20T21:12:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:08:39Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "7613d3da"
-    digest: sha256:41ec3af5a425b7fbfe1f1dfb532399f2250ea517d680a3dd4f9c1d8fab73623d
+    newTag: "b7213469"
+    digest: sha256:de8506f18cc9af496bb4355c9dfbec6798b3a1238429f671981e4f52ce3b14bd

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-20T21:12:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:08:39Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "7613d3da"
-    digest: sha256:41ec3af5a425b7fbfe1f1dfb532399f2250ea517d680a3dd4f9c1d8fab73623d
+    newTag: "b7213469"
+    digest: sha256:de8506f18cc9af496bb4355c9dfbec6798b3a1238429f671981e4f52ce3b14bd


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `b721346940c339bd6bd0175d8480506287697ccf`
- Image tag: `b7213469`
- Image digest: `sha256:de8506f18cc9af496bb4355c9dfbec6798b3a1238429f671981e4f52ce3b14bd`