### PR TITLE
fix(flamingo): disable unsupported numa auto binding

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -35,7 +35,6 @@ model as an active fallback in GitOps, Pi, AnyPi, or OpenWebUI config.
 --enable-auto-tool-choice
 --tool-call-parser qwen3_coder
 --optimization-level 2
---numa-bind
 ```
 
 The production target is full 262K server context. If this profile fails,
@@ -43,8 +42,11 @@ reduce concurrency first by moving to `--max-num-seqs 8` and
 `--max-num-batched-tokens 8192`. Do not reduce context below 262K unless both
 vLLM KV/concurrency tuning and an SGLang validation path fail.
 
-NUMA auto-binding is part of the first 262K candidate. Keep it only if the live
-startup, smoke tests, and benchmark comparison beat the no-NUMA profile.
+NUMA auto-binding is intentionally disabled. Live rollout proved that vLLM
+0.23.0 cannot auto-detect Turin's GPU-to-NUMA topology and exits with
+`NUMA binding was requested, but vLLM could not detect the GPU-to-NUMA topology
+automatically`. Test NUMA only with explicit `--numa-bind-nodes` values after a
+separate topology readback.
 
 The active reasoning parser is `qwen3`, so reasoning text is returned through
 the OpenAI-compatible reasoning field instead of being mixed into normal

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -68,7 +68,6 @@ spec:
             - qwen3_coder
             - --optimization-level
             - "2"
-            - --numa-bind
           env:
             - name: HF_HOME
               value: /models/huggingface

--- a/argocd/applications/flamingo/docs/large-model-multigpu.md
+++ b/argocd/applications/flamingo/docs/large-model-multigpu.md
@@ -87,10 +87,13 @@ args:
   - qwen3_coder
   - --optimization-level
   - "2"
-  - --numa-bind
 ```
 
 Add the parallelism flags for the shape under test.
+
+Do not use bare `--numa-bind` on Turin. vLLM 0.23.0 fails startup when it cannot
+auto-detect the GPU-to-NUMA topology. Any NUMA experiment must first capture
+`nvidia-smi topo -m` and use explicit `--numa-bind-nodes` values.
 
 ## Two GPUs
 

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -9,7 +9,6 @@ export const requiredTerms = [
   '229376',
   '32768',
   'nvfp4',
-  'numa-bind',
 ]
 
 export const forbiddenTerms = [


### PR DESCRIPTION
## Summary

- Removes bare `--numa-bind` from Flamingo because live vLLM 0.23.0 startup fails when Turin GPU-to-NUMA topology cannot be auto-detected.
- Keeps the 262K Qwen3.6 NVFP4 serving profile, NVFP4 KV cache, and 229376/32768 Pi/AnyPi budget intact.
- Documents that NUMA must be tested later with explicit `--numa-bind-nodes` after topology readback.

## Related Issues

None

## Testing

- Live rollout log from `flamingo-56bdfd9bd7-tkdnn` showed: `RuntimeError: NUMA binding was requested, but vLLM could not detect the GPU-to-NUMA topology automatically`.
- `bun run lint:flamingo-hard-migration`
- `bun test scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-hotfix-render.yaml`
- `git diff --check`
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts argocd/applications/flamingo/README.md argocd/applications/flamingo/docs/large-model-multigpu.md`

## Breaking Changes

None. This is a startup hotfix for the already-merged 262K Flamingo profile.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
