### PR TITLE
chore(symphony): promote image fd5460d7

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:08:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:52:03Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b7213469"
-    digest: sha256:de8506f18cc9af496bb4355c9dfbec6798b3a1238429f671981e4f52ce3b14bd
+    newTag: "fd5460d7"
+    digest: sha256:cbb48845efc4bc480f79957a8df28e09386cca311cfc282ba68887607279d15a

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:08:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:52:03Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b7213469"
-    digest: sha256:de8506f18cc9af496bb4355c9dfbec6798b3a1238429f671981e4f52ce3b14bd
+    newTag: "fd5460d7"
+    digest: sha256:cbb48845efc4bc480f79957a8df28e09386cca311cfc282ba68887607279d15a

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:08:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:52:03Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b7213469"
-    digest: sha256:de8506f18cc9af496bb4355c9dfbec6798b3a1238429f671981e4f52ce3b14bd
+    newTag: "fd5460d7"
+    digest: sha256:cbb48845efc4bc480f79957a8df28e09386cca311cfc282ba68887607279d15a


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `fd5460d723554752871b00a72c4728e78430bbe9`
- Image tag: `fd5460d7`
- Image digest: `sha256:cbb48845efc4bc480f79957a8df28e09386cca311cfc282ba68887607279d15a`