### PR TITLE
fix(flamingo): prefetch qwen36 safetensors

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -28,6 +28,7 @@ model as an active fallback in GitOps, Pi, AnyPi, or OpenWebUI config.
 --max-model-len 262144
 --gpu-memory-utilization 0.95
 --kv-cache-dtype fp8
+--safetensors-load-strategy prefetch
 --max-num-seqs 16
 --max-num-batched-tokens 16384
 --enable-prefix-caching
@@ -52,6 +53,12 @@ The model weights are NVFP4, but the KV cache uses FP8. Live rollout proved that
 `--kv-cache-dtype nvfp4` fails on this Blackwell Max-Q card with
 `requires sm100f`; do not retry NVFP4 KV unless the vLLM/image/GPU capability
 combination changes and is proven in a separate smoke.
+
+Safetensors prefetch is forced because the model cache is RBD-backed but appears
+to vLLM as local EXT4, which disables automatic prefetching. Live rollout proved
+lazy checkpoint loading can block for minutes in disk I/O before the HTTP server
+starts; `--safetensors-load-strategy prefetch` makes the 23 GiB weight read
+explicit and repeatable.
 
 The active reasoning parser is `qwen3`, so reasoning text is returned through
 the OpenAI-compatible reasoning field instead of being mixed into normal

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -56,6 +56,8 @@ spec:
             - "0.95"
             - --kv-cache-dtype
             - fp8
+            - --safetensors-load-strategy
+            - prefetch
             - --max-num-seqs
             - "16"
             - --max-num-batched-tokens

--- a/argocd/applications/flamingo/docs/large-model-multigpu.md
+++ b/argocd/applications/flamingo/docs/large-model-multigpu.md
@@ -75,6 +75,8 @@ args:
   - "0.95"
   - --kv-cache-dtype
   - fp8
+  - --safetensors-load-strategy
+  - prefetch
   - --max-num-seqs
   - "16"
   - --max-num-batched-tokens

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -9,6 +9,8 @@ export const requiredTerms = [
   '229376',
   '32768',
   'fp8',
+  'safetensors-load-strategy',
+  'prefetch',
 ]
 
 export const forbiddenTerms = [


### PR DESCRIPTION
## Summary

- Forces vLLM safetensors prefetch for the Qwen3.6 Flamingo pod.
- Documents why the model cache needs explicit prefetch on RBD-backed EXT4.
- Extends the Flamingo hard-migration guardrail so the production profile keeps the prefetch flag.

## Related Issues

None

## Testing

- `bun test scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `bun run lint:flamingo-hard-migration`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml`
- `bunx oxfmt --check argocd/applications/flamingo/deployment.yaml argocd/applications/flamingo/README.md argocd/applications/flamingo/docs/large-model-multigpu.md scripts/jangar/validate-flamingo-hard-migration.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
