### PR TITLE
fix(nix): repair attic external secret reference

### DIFF
--- a/argocd/applications/attic/externalsecret.yaml
+++ b/argocd/applications/attic/externalsecret.yaml
@@ -20,6 +20,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
-        key: attic-cache/token-rs256-secret-base64
+        key: attic-cache
+        property: token-rs256-secret-base64
         metadataPolicy: None
         nullBytePolicy: Ignore

--- a/docs/nix-cache.md
+++ b/docs/nix-cache.md
@@ -34,10 +34,11 @@ The API deployment runs database migrations in an init container, then starts
 
 ## Secret Inputs
 
-Create the 1Password item in the `infra` vault before rollout:
+Create this 1Password item and field in the `infra` vault before rollout:
 
 ```text
-attic-cache/token-rs256-secret-base64
+item: attic-cache
+field: token-rs256-secret-base64
 ```
 
 Generate the value with:


### PR DESCRIPTION
## Summary

- Fixes `ExternalSecret/attic-secrets` to use the onepassword-sdk item-plus-property lookup contract.
- Updates the Nix cache runbook to document the actual `infra/attic-cache` item and `token-rs256-secret-base64` field.
- Keeps the Attic signing key in 1Password; no secret values are committed.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/attic | kubeconform -strict -ignore-missing-schemas`
- Rendered `argocd/applications/attic` and verified the output includes `key: attic-cache` plus `property: token-rs256-secret-base64` and no combined secret path.
- `bun run lint:argocd`
- Confirmed `infra/attic-cache` exists in 1Password with concealed field `token-rs256-secret-base64` populated.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
