### PR TITLE
fix(flamingo): use eager qwen36 safetensors loading

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -28,7 +28,7 @@ model as an active fallback in GitOps, Pi, AnyPi, or OpenWebUI config.
 --max-model-len 262144
 --gpu-memory-utilization 0.95
 --kv-cache-dtype fp8
---safetensors-load-strategy prefetch
+--safetensors-load-strategy eager
 --max-num-seqs 16
 --max-num-batched-tokens 16384
 --enable-prefix-caching
@@ -54,11 +54,12 @@ The model weights are NVFP4, but the KV cache uses FP8. Live rollout proved that
 `requires sm100f`; do not retry NVFP4 KV unless the vLLM/image/GPU capability
 combination changes and is proven in a separate smoke.
 
-Safetensors prefetch is forced because the model cache is RBD-backed but appears
-to vLLM as local EXT4, which disables automatic prefetching. Live rollout proved
-lazy checkpoint loading can block for minutes in disk I/O before the HTTP server
-starts; `--safetensors-load-strategy prefetch` makes the 23 GiB weight read
-explicit and repeatable.
+Safetensors eager loading is forced because the model cache is RBD-backed but
+appears to vLLM as local EXT4. Live rollout proved lazy checkpoint loading can
+block for about 12 minutes in disk I/O before the HTTP server starts, and
+`--safetensors-load-strategy prefetch` was slower than the lazy baseline on the
+single 23 GiB shard. `eager` uses a different vLLM loader path that reads the
+whole shard into RAM before yielding tensors.
 
 The active reasoning parser is `qwen3`, so reasoning text is returned through
 the OpenAI-compatible reasoning field instead of being mixed into normal

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - --kv-cache-dtype
             - fp8
             - --safetensors-load-strategy
-            - prefetch
+            - eager
             - --max-num-seqs
             - "16"
             - --max-num-batched-tokens

--- a/argocd/applications/flamingo/docs/large-model-multigpu.md
+++ b/argocd/applications/flamingo/docs/large-model-multigpu.md
@@ -76,7 +76,7 @@ args:
   - --kv-cache-dtype
   - fp8
   - --safetensors-load-strategy
-  - prefetch
+  - eager
   - --max-num-seqs
   - "16"
   - --max-num-batched-tokens

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -10,7 +10,7 @@ export const requiredTerms = [
   '32768',
   'fp8',
   'safetensors-load-strategy',
-  'prefetch',
+  'eager',
 ]
 
 export const forbiddenTerms = [


### PR DESCRIPTION
## Summary

- Switches the Qwen3.6 Flamingo safetensors load strategy from `prefetch` to `eager`.
- Documents the live rollout finding: prefetch was slower than the lazy baseline on the single RBD-backed 23 GiB shard.
- Keeps the hard-migration validator aligned with the promoted loader strategy.

## Related Issues

None

## Testing

- `bun test scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `bun run lint:flamingo-hard-migration`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml`
- `bunx oxfmt --check argocd/applications/flamingo/deployment.yaml argocd/applications/flamingo/README.md argocd/applications/flamingo/docs/large-model-multigpu.md scripts/jangar/validate-flamingo-hard-migration.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
