### PR TITLE
fix(flamingo): harden qwen36 benchmark runner

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -141,33 +141,33 @@ curl -fsS http://flamingo.ide-newton.ts.net/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "qwen36-flamingo",
-    "messages": [{"role": "user", "content": "Use the provided tool to add 7 and 35. Do not answer directly."}],
+    "messages": [{"role": "user", "content": "Use the lookup_status tool for id FLAMINGO-262K and no other tool."}],
     "tools": [{
       "type": "function",
       "function": {
-        "name": "add",
-        "description": "Add two integers.",
+        "name": "lookup_status",
+        "description": "Look up rollout status by id.",
         "strict": true,
         "parameters": {
           "type": "object",
           "properties": {
-            "a": {"type": "integer"},
-            "b": {"type": "integer"}
+            "id": {"type": "string"}
           },
-          "required": ["a", "b"],
+          "required": ["id"],
           "additionalProperties": false
         }
       }
     }],
     "tool_choice": "auto",
+    "chat_template_kwargs": {"enable_thinking": false},
     "max_tokens": 128,
     "temperature": 0
   }' | jq '.choices[0].message.tool_calls'
 ```
 
-Expected: `tool_calls` is a non-empty array and arguments include `7` and `35`.
-If this returns only prose or raw XML, do not accept the rollout; fix the
-generic vLLM serving flags or image first.
+Expected: `tool_calls` is a non-empty array and arguments include
+`{"id":"FLAMINGO-262K"}`. If this returns only prose or raw XML, do not accept
+the rollout; fix the generic vLLM serving flags or image first.
 
 ## Pi And AnyPi Contract
 
@@ -213,11 +213,63 @@ bun run flamingo:benchmark --profile=full --long-targets=180000,220000,229000
 | Profile | Context | `gpu_memory_utilization` | `max_num_seqs` | `max_num_batched_tokens` | Notes |
 | --- | ---: | ---: | ---: | ---: | --- |
 | `baseline-131k` | `131072` | `0.94` | `128` | `16384` | Pre-optimization baseline only |
-| `context-262k-fp8` | `262144` | `0.95` | `16` | `16384` | Initial production candidate |
+| `context-262k-fp8-eager` | `262144` | `0.95` | `16` | `16384` | Promoted production profile |
 | `context-262k-lowseq` | `262144` | `0.95` | `8` | `8192` | Startup fallback if the initial candidate OOMs |
 | `kv-262k-auto` | `262144` | `0.95` | `16` | `16384` | Compare only after FP8 smokes pass |
 | `batch-262k-32k` | `262144` | `0.95` | `16` | `32768` | Promote only if TTFT and preemption stay acceptable |
 | `mem-262k-097` | `262144` | `0.97` | `16` | `16384` | Promote only if no OOM or sustained preemption |
+
+### Recorded Production Run
+
+Run timestamp: `2026-06-27T22:37:01Z`.
+
+Result artifact:
+`/tmp/flamingo-vllm-long-20260627T223701Z/flamingo-smoke-2026-06-27T22-37-01-725Z.json`.
+
+Launch profile:
+
+```text
+--max-model-len 262144
+--gpu-memory-utilization 0.95
+--kv-cache-dtype fp8
+--safetensors-load-strategy eager
+--max-num-seqs 16
+--max-num-batched-tokens 16384
+```
+
+Observed startup:
+
+- Lazy baseline loaded the single 23 GiB safetensors shard in `718.30s`.
+- Forced prefetch did not complete the same shard after more than `16m`.
+- Eager loading completed the shard in `26.08s` and full server startup in about
+  `3m16s`.
+- vLLM reported `65.38 GiB` available KV cache and `24.77x` maximum concurrency
+  for 262,144-token requests.
+
+Acceptance smokes:
+
+| Check | Result |
+| --- | --- |
+| `/v1/models` | `qwen36-flamingo`, `max_model_len=262144` |
+| Exact no-thinking chat | `qwen36-ready`, `80ms` |
+| Medium thinking chat | `qwen36-thinking-ready`, `3973ms`, `745` completion tokens |
+| Structured tool call | `lookup_status({"id":"FLAMINGO-262K"})`, `280ms` |
+| Long-context recall | `220053` prompt tokens, `flamingo-long-220000`, `34389ms` |
+
+Short coding-loop smoke benchmark:
+
+| Metric | Value |
+| --- | ---: |
+| Prompts | `4` |
+| Max concurrency | `2` |
+| Total input tokens | `16427` |
+| Total output tokens | `2048` |
+| Mean TTFT | `220.86 ms` |
+| p99 TTFT | `240.96 ms` |
+| Output throughput | `294.09 tok/s` |
+| Total token throughput | `2652.96 tok/s` |
+| Mean TPOT | `6.38 ms` |
+| Failed requests | `0` |
 
 MTP candidate flags:
 

--- a/scripts/jangar/benchmark-flamingo-vllm.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.ts
@@ -34,7 +34,9 @@ type RunSummary = {
   profile: string
   contextTargets: number[]
   model: string
+  tokenizer: string
   baseUrl: string
+  serverUrl: string
   kubernetes: {
     context: string
     namespace: string
@@ -65,13 +67,19 @@ const kubeContext = args.get('context') ?? process.env.KUBE_CONTEXT ?? 'galactic
 const namespace = args.get('namespace') ?? process.env.FLAMINGO_NAMESPACE ?? 'flamingo'
 const deployment = args.get('deployment') ?? process.env.FLAMINGO_DEPLOYMENT ?? 'flamingo'
 const model = args.get('model') ?? process.env.FLAMINGO_MODEL ?? 'qwen36-flamingo'
+const tokenizer = args.get('tokenizer') ?? process.env.FLAMINGO_BENCH_TOKENIZER ?? 'unsloth/Qwen3.6-35B-A3B-NVFP4'
 const baseUrl = (
   args.get('base-url') ??
   process.env.FLAMINGO_BASE_URL ??
   'http://flamingo.ide-newton.ts.net/v1'
 ).replace(/\/+$/, '')
+const serverUrl = (args.get('server-url') ?? process.env.FLAMINGO_SERVER_URL ?? baseUrl.replace(/\/v1$/, '')).replace(
+  /\/+$/,
+  '',
+)
 const resultDir = resolve(args.get('result-dir') ?? process.env.FLAMINGO_BENCH_RESULT_DIR ?? '/tmp/flamingo-vllm-bench')
 const timeoutMs = Number.parseInt(args.get('timeout-ms') ?? process.env.FLAMINGO_BENCH_TIMEOUT_MS ?? '1800000', 10)
+const benchmarkResultMarker = '__FLAMINGO_BENCH_RESULT_JSON__'
 const contextTargets = (
   args.get('long-targets') ??
   process.env.FLAMINGO_LONG_TARGETS ??
@@ -125,6 +133,10 @@ function kubectl(args: string[]): string[] {
   return ['kubectl', '--context', kubeContext, '-n', namespace, ...args]
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
 async function fetchJson(path: string, init?: RequestInit): Promise<unknown> {
   const response = await fetch(`${baseUrl}${path}`, {
     ...init,
@@ -145,7 +157,7 @@ async function fetchJson(path: string, init?: RequestInit): Promise<unknown> {
 }
 
 async function fetchText(path: string): Promise<string> {
-  const response = await fetch(`${baseUrl}${path}`, {
+  const response = await fetch(`${serverUrl}${path}`, {
     headers: {
       authorization: `Bearer ${process.env.FLAMINGO_API_KEY ?? 'flamingo-local'}`,
     },
@@ -190,6 +202,37 @@ function buildLongPrompt(targetTokens: number, marker: string): string {
 async function runBench(label: string, inputLen: number, outputLen: number, numPrompts: number, concurrency: number) {
   const podDir = `/tmp/flamingo-bench-${Date.now()}-${label}`
   const resultFile = `${label}.json`
+  const benchCommand = [
+    'vllm',
+    'bench',
+    'serve',
+    '--backend',
+    'openai-chat',
+    '--base-url',
+    'http://127.0.0.1:8000',
+    '--endpoint',
+    '/v1/chat/completions',
+    '--model',
+    model,
+    '--tokenizer',
+    tokenizer,
+    '--trust-remote-code',
+    '--dataset-name',
+    'random',
+    '--random-input-len',
+    String(inputLen),
+    '--random-output-len',
+    String(outputLen),
+    '--num-prompts',
+    String(numPrompts),
+    '--max-concurrency',
+    String(concurrency),
+    '--save-result',
+    '--result-dir',
+    podDir,
+    '--result-filename',
+    resultFile,
+  ]
   const command = kubectl([
     'exec',
     `deploy/${deployment}`,
@@ -197,29 +240,18 @@ async function runBench(label: string, inputLen: number, outputLen: number, numP
     'sh',
     '-lc',
     [
-      `mkdir -p ${podDir}`,
-      'vllm bench serve',
-      '--backend openai-chat',
-      '--base-url http://127.0.0.1:8000',
-      '--endpoint /v1/chat/completions',
-      `--model ${model}`,
-      '--dataset-name random',
-      `--random-input-len ${inputLen}`,
-      `--random-output-len ${outputLen}`,
-      `--num-prompts ${numPrompts}`,
-      `--max-concurrency ${concurrency}`,
-      '--save-result',
-      `--result-dir ${podDir}`,
-      `--result-filename ${resultFile}`,
-      `cat ${podDir}/${resultFile}`,
+      `mkdir -p ${shellQuote(podDir)}`,
+      benchCommand.map(shellQuote).join(' '),
+      `printf '\\n${benchmarkResultMarker}\\n'`,
+      `cat ${shellQuote(`${podDir}/${resultFile}`)}`,
     ].join(' && '),
   ])
   const result = await run(command)
   let resultJson: unknown
   try {
-    const jsonStart = result.stdout.lastIndexOf('{')
-    if (jsonStart >= 0) {
-      resultJson = JSON.parse(result.stdout.slice(jsonStart))
+    const markerIndex = result.stdout.lastIndexOf(benchmarkResultMarker)
+    if (markerIndex >= 0) {
+      resultJson = JSON.parse(result.stdout.slice(markerIndex + benchmarkResultMarker.length).trim())
     }
   } catch {
     resultJson = undefined
@@ -240,7 +272,9 @@ async function main(): Promise<void> {
     profile,
     contextTargets,
     model,
+    tokenizer,
     baseUrl,
+    serverUrl,
     kubernetes: { context: kubeContext, namespace, deployment },
     smokes: [],
     benchmarks: [],
@@ -276,7 +310,7 @@ async function main(): Promise<void> {
       model,
       messages: [{ role: 'user', content: 'Reason briefly, then answer exactly: qwen36-thinking-ready' }],
       chat_template_kwargs: { enable_thinking: true },
-      max_tokens: 256,
+      max_tokens: 2048,
       temperature: 0,
     }),
   )
@@ -284,27 +318,27 @@ async function main(): Promise<void> {
   summary.smokes.push(
     await chatSmoke('tool-call', {
       model,
-      messages: [{ role: 'user', content: 'Use the provided tool to add 7 and 35. Do not answer directly.' }],
+      messages: [{ role: 'user', content: 'Use the lookup_status tool for id FLAMINGO-262K and no other tool.' }],
       tools: [
         {
           type: 'function',
           function: {
-            name: 'add',
-            description: 'Add two integers.',
+            name: 'lookup_status',
+            description: 'Look up rollout status by id.',
             strict: true,
             parameters: {
               type: 'object',
               properties: {
-                a: { type: 'integer' },
-                b: { type: 'integer' },
+                id: { type: 'string' },
               },
-              required: ['a', 'b'],
+              required: ['id'],
               additionalProperties: false,
             },
           },
         },
       ],
       tool_choice: 'auto',
+      chat_template_kwargs: { enable_thinking: false },
       max_tokens: 128,
       temperature: 0,
     }),


### PR DESCRIPTION
## Summary

- Fixes the Flamingo benchmark runner so `/metrics` is read from the vLLM server root instead of `/v1/metrics`.
- Passes the real Qwen3.6 tokenizer source to `vllm bench serve` while keeping the served API model as `qwen36-flamingo`.
- Records the promoted 262K eager-load production run, 220K recall result, and smoke benchmark metrics.

## Related Issues

None

## Testing

- `bunx tsc --ignoreConfig --noEmit --skipLibCheck --types bun --module NodeNext --moduleResolution NodeNext --target ES2023 scripts/jangar/benchmark-flamingo-vllm.ts`
- `bunx oxfmt --check scripts/jangar/benchmark-flamingo-vllm.ts argocd/applications/flamingo/README.md`
- `bun run lint:flamingo-hard-migration`
- `bun run lint:argocd`
- `bun run flamingo:benchmark --profile=smoke --result-dir=/tmp/flamingo-vllm-bench-20260627T223613Z`
- `bun run flamingo:benchmark --profile=smoke --long-targets=220000 --result-dir=/tmp/flamingo-vllm-long-20260627T223701Z`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
