### PR TITLE
feat: harden the flamingo benchmark runner smoke validation and tests

### DIFF
--- a/scripts/jangar/benchmark-flamingo-vllm.test.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.test.ts
@@ -1,0 +1,655 @@
+/// <reference types="bun-types/test-globals" />
+import {
+  buildLongContextValidator,
+  buildLongPrompt,
+  buildBenchmarkCommand,
+  buildKubectlExecCommand,
+  parseBenchmarkOutput,
+  validateSmokeResult,
+  validateLongContextSmoke,
+  type ChatResult,
+  smokeValidators,
+} from './benchmark-flamingo-vllm'
+
+// ── Command construction tests ───────────────────────────────────────────────
+
+describe('buildBenchmarkCommand', () => {
+  it('builds a valid vllm bench serve command', () => {
+    const cmd = buildBenchmarkCommand({
+      model: 'qwen36-flamingo',
+      tokenizer: 'unsloth/Qwen3.6-35B-A3B-NVFP4',
+      label: 'short-coding-loop',
+      inputLen: 4096,
+      outputLen: 512,
+      numPrompts: 16,
+      concurrency: 4,
+      podDir: '/tmp/bench-123',
+      resultFile: 'short-coding-loop.json',
+    })
+
+    expect(cmd[0]).toBe('vllm')
+    expect(cmd).toContain('bench')
+    expect(cmd).toContain('serve')
+    expect(cmd).toContain('openai-chat')
+    expect(cmd).toContain('http://127.0.0.1:8000')
+    expect(cmd).toContain('/v1/chat/completions')
+    expect(cmd).toContain('qwen36-flamingo')
+    expect(cmd).toContain('unsloth/Qwen3.6-35B-A3B-NVFP4')
+    expect(cmd).toContain('--trust-remote-code')
+    expect(cmd).toContain('--dataset-name')
+    expect(cmd).toContain('random')
+    expect(cmd).toContain('4096')
+    expect(cmd).toContain('512')
+    expect(cmd).toContain('16')
+    expect(cmd).toContain('4')
+    expect(cmd).toContain('--save-result')
+    expect(cmd).toContain('/tmp/bench-123')
+    expect(cmd).toContain('short-coding-loop.json')
+  })
+
+  it('produces identical output for same inputs (pure function)', () => {
+    const opts = {
+      model: 'qwen36-flamingo',
+      tokenizer: 'unsloth/Qwen3.6-35B-A3B-NVFP4',
+      label: 'agent-edit-loop',
+      inputLen: 32768,
+      outputLen: 4096,
+      numPrompts: 8,
+      concurrency: 2,
+      podDir: '/tmp/bench-456',
+      resultFile: 'agent-edit-loop.json',
+    }
+    const first = buildBenchmarkCommand(opts)
+    const second = buildBenchmarkCommand(opts)
+    expect(first).toEqual(second)
+  })
+})
+
+describe('buildKubectlExecCommand', () => {
+  it('wraps the benchmark command in kubectl exec sh -lc', () => {
+    const cmd = buildKubectlExecCommand({
+      deployment: 'flamingo',
+      podDir: '/tmp/bench-789',
+      resultFile: 'short.json',
+      label: 'short',
+      inputLen: 4096,
+      outputLen: 512,
+      numPrompts: 4,
+      concurrency: 2,
+      model: 'qwen36-flamingo',
+      tokenizer: 'unsloth/Qwen3.6-35B-A3B-NVFP4',
+      kubeContext: 'galactic-tailscale',
+      namespace: 'flamingo',
+    })
+
+    expect(cmd[0]).toBe('kubectl')
+    expect(cmd).toContain('--context')
+    expect(cmd).toContain('galactic-tailscale')
+    expect(cmd).toContain('-n')
+    expect(cmd).toContain('flamingo')
+    expect(cmd).toContain('exec')
+    expect(cmd).toContain('deploy/flamingo')
+    expect(cmd).toContain('sh')
+    expect(cmd).toContain('-lc')
+    // Verify the inner command is present
+    const inner = cmd.join(' ')
+    expect(inner).toContain('vllm')
+    expect(inner).toContain('bench')
+    expect(inner).toContain('serve')
+  })
+
+  it('includes the result marker and cat for stdout parsing', () => {
+    const cmd = buildKubectlExecCommand({
+      deployment: 'flamingo',
+      podDir: '/tmp/bench',
+      resultFile: 'x.json',
+      label: 'x',
+      inputLen: 100,
+      outputLen: 10,
+      numPrompts: 1,
+      concurrency: 1,
+      model: 'qwen36-flamingo',
+      tokenizer: 'test',
+      kubeContext: 'ctx',
+      namespace: 'ns',
+    })
+    const inner = cmd.join(' ')
+    expect(inner).toContain('__FLAMINGO_BENCH_RESULT_JSON__')
+    expect(inner).toContain('cat ')
+  })
+
+  it('quotes paths with spaces correctly', () => {
+    const cmd = buildKubectlExecCommand({
+      deployment: 'flamingo',
+      podDir: '/tmp/bench with spaces',
+      resultFile: 'x.json',
+      label: 'x',
+      inputLen: 100,
+      outputLen: 10,
+      numPrompts: 1,
+      concurrency: 1,
+      model: 'qwen36-flamingo',
+      tokenizer: 'test',
+      kubeContext: 'ctx',
+      namespace: 'ns',
+    })
+    const inner = cmd.join(' ')
+    // shellQuote wraps with single quotes
+    expect(inner).toContain("'/tmp/bench with spaces'")
+  })
+})
+
+// ── Root metrics URL behavior ─────────────────────────────────────────────────
+
+describe('benchmark output parsing', () => {
+  it('parses valid JSON after the marker', () => {
+    const validJson = JSON.stringify({ ttft: 100, throughput: 500 })
+    const stdout = `some log lines\n\n${validJson}`
+    const result = parseBenchmarkOutput(`prefix__FLAMINGO_BENCH_RESULT_JSON__\n${validJson}`)
+    expect(result).toEqual({ ttft: 100, throughput: 500 })
+  })
+
+  it('returns undefined when marker is absent', () => {
+    const result = parseBenchmarkOutput('no marker here\njust output')
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined on JSON parse failure', () => {
+    const stdout = `prefix__FLAMINGO_BENCH_RESULT_JSON__\n{invalid json`
+    const result = parseBenchmarkOutput(stdout)
+    expect(result).toBeUndefined()
+  })
+
+  it('handles empty JSON after marker', () => {
+    const result = parseBenchmarkOutput(`prefix__FLAMINGO_BENCH_RESULT_JSON__\n`)
+    expect(result).toBeUndefined()
+  })
+
+  it('finds the last occurrence of the marker', () => {
+    const stdout = `first__FLAMINGO_BENCH_RESULT_JSON__\nold\n__FLAMINGO_BENCH_RESULT_JSON__\n{"latest":true}`
+    const result = parseBenchmarkOutput(stdout)
+    expect(result).toEqual({ latest: true })
+  })
+
+  it('parses valid benchmark JSON with numeric throughput', () => {
+    const benchJson = {
+      total_time_ms: 12345,
+      ttft_mean_ms: 100,
+      tpot_mean_ms: 5,
+      output_throughput: 200,
+      total_input_tokens: 10000,
+      total_output_tokens: 5000,
+      failed: 0,
+    }
+    const stdout = `__FLAMINGO_BENCH_RESULT_JSON__\n${JSON.stringify(benchJson)}`
+    const result = parseBenchmarkOutput(stdout)
+    expect(result).toEqual(benchJson)
+  })
+})
+
+// ── Semantic smoke validation tests ──────────────────────────────────────────
+
+describe('validateSmokeResult — exact-no-thinking', () => {
+  it('passes when content contains "qwen36-ready" and finishes cleanly', () => {
+    const result: ChatResult = {
+      label: 'exact-no-thinking',
+      ok: true,
+      elapsedMs: 80,
+      status: 200,
+      response: {
+        choices: [
+          {
+            message: { content: 'qwen36-ready', finish_reason: 'stop' },
+          },
+        ],
+      },
+    }
+    expect(validateSmokeResult('exact-no-thinking', result)).toEqual([])
+  })
+
+  it('passes with finish_reason "length"', () => {
+    const result: ChatResult = {
+      label: 'exact-no-thinking',
+      ok: true,
+      elapsedMs: 80,
+      response: {
+        choices: [{ message: { content: 'qwen36-ready', finish_reason: 'length' } }],
+      },
+    }
+    expect(validateSmokeResult('exact-no-thinking', result)).toEqual([])
+  })
+
+  it('fails when content does not contain the marker', () => {
+    const result: ChatResult = {
+      label: 'exact-no-thinking',
+      ok: true,
+      elapsedMs: 80,
+      response: {
+        choices: [{ message: { content: 'hello world', finish_reason: 'stop' } }],
+      },
+    }
+    const errors = validateSmokeResult('exact-no-thinking', result)
+    expect(errors).toContainEqual(expect.stringContaining('qwen36-ready'))
+  })
+
+  it('fails when HTTP request fails', () => {
+    const result: ChatResult = {
+      label: 'exact-no-thinking',
+      ok: false,
+      elapsedMs: 100,
+      error: 'Connection refused',
+    }
+    const errors = validateSmokeResult('exact-no-thinking', result)
+    expect(errors).toContain('HTTP-level failure: Connection refused')
+  })
+
+  it('fails when response payload is missing', () => {
+    const result: ChatResult = {
+      label: 'exact-no-thinking',
+      ok: true,
+      elapsedMs: 10,
+      response: null,
+    }
+    const errors = validateSmokeResult('exact-no-thinking', result)
+    expect(errors).toContain('semantic: missing response payload')
+  })
+
+  it('fails when choices is missing', () => {
+    const result: ChatResult = {
+      label: 'exact-no-thinking',
+      ok: true,
+      elapsedMs: 10,
+      response: { data: 'other' },
+    }
+    const errors = validateSmokeResult('exact-no-thinking', result)
+    expect(errors).toContain('semantic: missing choices[0].message')
+  })
+
+  it('fails with non-stop finish_reason', () => {
+    const result: ChatResult = {
+      label: 'exact-no-thinking',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [{ message: { content: 'qwen36-ready', finish_reason: 'content_filter' } }],
+      },
+    }
+    const errors = validateSmokeResult('exact-no-thinking', result)
+    expect(errors).toContainEqual(expect.stringContaining('finish_reason'))
+  })
+})
+
+describe('validateSmokeResult — medium-thinking', () => {
+  it('passes when content contains marker and completion_tokens > 0', () => {
+    const result: ChatResult = {
+      label: 'medium-thinking',
+      ok: true,
+      elapsedMs: 3000,
+      response: {
+        choices: [
+          {
+            message: {
+              content: 'qwen36-thinking-ready',
+              finish_reason: 'stop',
+              completion_tokens: 745,
+            },
+          },
+        ],
+      },
+    }
+    expect(validateSmokeResult('medium-thinking', result)).toEqual([])
+  })
+
+  it('fails when completion_tokens is zero', () => {
+    const result: ChatResult = {
+      label: 'medium-thinking',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [{ message: { content: 'qwen36-thinking-ready', finish_reason: 'stop', completion_tokens: 0 } }],
+      },
+    }
+    const errors = validateSmokeResult('medium-thinking', result)
+    expect(errors).toContainEqual(expect.stringContaining('completion_tokens'))
+  })
+
+  it('fails when content does not contain the marker', () => {
+    const result: ChatResult = {
+      label: 'medium-thinking',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [{ message: { content: 'wrong', finish_reason: 'stop', completion_tokens: 100 } }],
+      },
+    }
+    const errors = validateSmokeResult('medium-thinking', result)
+    expect(errors).toContainEqual(expect.stringContaining('qwen36-thinking-ready'))
+  })
+
+  it('fails with HTTP error', () => {
+    const result: ChatResult = {
+      label: 'medium-thinking',
+      ok: false,
+      elapsedMs: 5000,
+      error: 'timeout',
+    }
+    const errors = validateSmokeResult('medium-thinking', result)
+    expect(errors).toContain('HTTP-level failure: timeout')
+  })
+})
+
+describe('validateSmokeResult — tool-call', () => {
+  it('passes when tool_calls is structured with id FLAMINGO-262K', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: true,
+      elapsedMs: 280,
+      response: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: {
+                    name: 'lookup_status',
+                    arguments: JSON.stringify({ id: 'FLAMINGO-262K' }),
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    }
+    expect(validateSmokeResult('tool-call', result)).toEqual([])
+  })
+
+  it('fails when tool_calls is empty', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: true,
+      elapsedMs: 10,
+      response: { choices: [{ message: { tool_calls: [] } }] },
+    }
+    const errors = validateSmokeResult('tool-call', result)
+    expect(errors).toContain('semantic: tool_calls must be a non-empty array')
+  })
+
+  it('fails when function name is wrong', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: { name: 'wrong_tool', arguments: '{}' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    const errors = validateSmokeResult('tool-call', result)
+    expect(errors).toContainEqual(expect.stringContaining('lookup_status'))
+  })
+
+  it('fails when arguments id is not FLAMINGO-262K', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: { name: 'lookup_status', arguments: JSON.stringify({ id: 'WRONG-ID' }) },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    }
+    const errors = validateSmokeResult('tool-call', result)
+    expect(errors).toContainEqual(expect.stringContaining('FLAMINGO-262K'))
+  })
+
+  it('fails when finish_reason is not tool_calls', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: { name: 'lookup_status', arguments: JSON.stringify({ id: 'FLAMINGO-262K' }) },
+                },
+              ],
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+    }
+    const errors = validateSmokeResult('tool-call', result)
+    expect(errors).toContainEqual(expect.stringContaining('finish_reason'))
+  })
+
+  it('fails when HTTP request fails', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: false,
+      elapsedMs: 10000,
+      error: '502 Bad Gateway',
+    }
+    const errors = validateSmokeResult('tool-call', result)
+    expect(errors).toContain('HTTP-level failure: 502 Bad Gateway')
+  })
+
+  it('fails when arguments is not valid JSON', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: { name: 'lookup_status', arguments: 'not-json' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    }
+    const errors = validateSmokeResult('tool-call', result)
+    expect(errors).toContain('semantic: tool_calls[0].function.arguments is not valid JSON')
+  })
+
+  it('fails when arguments does not parse to an object with id', () => {
+    const result: ChatResult = {
+      label: 'tool-call',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: 'function',
+                  function: { name: 'lookup_status', arguments: JSON.stringify([]) },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    }
+    const errors = validateSmokeResult('tool-call', result)
+    expect(errors).toContainEqual(expect.stringContaining('arguments'))
+  })
+})
+
+// ── Long-context smoke validation ─────────────────────────────────────────────
+
+describe('validateLongContextSmoke', () => {
+  it('passes when content includes the expected marker', () => {
+    const result: ChatResult = {
+      label: 'long-context-220000',
+      ok: true,
+      elapsedMs: 34000,
+      response: {
+        choices: [{ message: { content: 'flamingo-long-220000', finish_reason: 'stop' } }],
+      },
+    }
+    expect(validateLongContextSmoke(result, 'flamingo-long-220000')).toEqual([])
+  })
+
+  it('fails when content does not include the marker', () => {
+    const result: ChatResult = {
+      label: 'long-context-220000',
+      ok: true,
+      elapsedMs: 100,
+      response: {
+        choices: [{ message: { content: 'no marker here', finish_reason: 'stop' } }],
+      },
+    }
+    const errors = validateLongContextSmoke(result, 'flamingo-long-220000')
+    expect(errors).toContainEqual(expect.stringContaining('flamingo-long-220000'))
+  })
+
+  it('fails on HTTP error', () => {
+    const result: ChatResult = {
+      label: 'long-context-220000',
+      ok: false,
+      elapsedMs: 10000,
+      error: 'timeout',
+    }
+    const errors = validateLongContextSmoke(result, 'flamingo-long-220000')
+    expect(errors).toContain('HTTP-level failure: timeout')
+  })
+
+  it('fails on missing choices[0].message', () => {
+    const result: ChatResult = {
+      label: 'long-context-220000',
+      ok: true,
+      elapsedMs: 10,
+      response: {},
+    }
+    const errors = validateLongContextSmoke(result, 'flamingo-long-220000')
+    expect(errors).toContain('missing choices[0].message')
+  })
+
+  it('fails on non-string content', () => {
+    const result: ChatResult = {
+      label: 'long-context-220000',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [{ message: { content: 42, finish_reason: 'stop' } }],
+      },
+    }
+    const errors = validateLongContextSmoke(result, 'flamingo-long-220000')
+    expect(errors).toContain('content is not a string')
+  })
+
+  it('fails on bad finish_reason', () => {
+    const result: ChatResult = {
+      label: 'long-context-220000',
+      ok: true,
+      elapsedMs: 10,
+      response: {
+        choices: [{ message: { content: 'flamingo-long-220000', finish_reason: 'content_filter' } }],
+      },
+    }
+    const errors = validateLongContextSmoke(result, 'flamingo-long-220000')
+    expect(errors).toContainEqual(expect.stringContaining('finish_reason'))
+  })
+})
+
+describe('buildLongContextValidator', () => {
+  it('produces a validator function for expected markers', () => {
+    const validator = buildLongContextValidator('flamingo-long-180000')
+    const pass: ChatResult = {
+      label: 'test',
+      ok: true,
+      elapsedMs: 100,
+      response: {
+        choices: [{ message: { content: 'flamingo-long-180000', finish_reason: 'stop' } }],
+      },
+    }
+    const fail: ChatResult = {
+      label: 'test',
+      ok: true,
+      elapsedMs: 100,
+      response: {
+        choices: [{ message: { content: 'wrong', finish_reason: 'stop' } }],
+      },
+    }
+    expect(validator(pass)).toBeNull()
+    expect(validator(fail)).not.toBeNull()
+  })
+})
+
+// ── buildLongPrompt ──────────────────────────────────────────────────────────
+
+describe('buildLongPrompt', () => {
+  it('includes the marker in instruction and return line', () => {
+    const prompt = buildLongPrompt(5, 'flamingo-long-5')
+    expect(prompt).toContain('Remember the marker flamingo-long-5.')
+    expect(prompt).toContain('Return exactly: flamingo-long-5')
+    expect(prompt).toContain('flamingo-long-5')
+  })
+
+  it('produces a prompt with approximately the right number of fill tokens', () => {
+    const prompt = buildLongPrompt(100, 'marker')
+    // Each 'x ' pair is one token approximation, plus instruction and return lines
+    const lines = prompt.split('\n')
+    // First line: "Remember the marker marker."
+    // Second line: "The following filler..."
+    // Third line: 100 x's
+    // Fourth line: "Return exactly: marker"
+    expect(lines.length).toBe(4)
+    expect(lines[2]).toBe('x '.repeat(100))
+  })
+
+  it('is deterministic for same inputs', () => {
+    const first = buildLongPrompt(256, 'my-marker')
+    const second = buildLongPrompt(256, 'my-marker')
+    expect(first).toBe(second)
+  })
+})
+
+// ── Integration: smoke result shapes ─────────────────────────────────────────
+
+describe('ChatResult shape completeness', () => {
+  it('all required smoke labels have validators', () => {
+    const labels = ['exact-no-thinking', 'medium-thinking', 'tool-call']
+    for (const label of labels) {
+      expect(smokeValidators[label]).toBeDefined()
+    }
+  })
+})

--- a/scripts/jangar/benchmark-flamingo-vllm.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.ts
@@ -923,8 +923,10 @@ async function main(): Promise<void> {
   }
 }
 
-// Guard: do not run `main()` when this file is imported by bun test.
-if (import.meta.main && process.argv[1]?.includes('benchmark-flamingo-vllm')) {
+// Guard: do not run `main()` when this file is imported by bun test
+// or any other module loader. Only execute when this file is the entrypoint.
+const _script = process.argv[1] ?? ''
+if (_script.endsWith('benchmark-flamingo-vllm.ts') && !_script.endsWith('.test.ts')) {
   void main().catch((error: unknown) => {
     console.error(error instanceof Error ? error.stack : error)
     process.exitCode = 1

--- a/scripts/jangar/benchmark-flamingo-vllm.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.ts
@@ -4,6 +4,8 @@ import { spawn } from 'node:child_process'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
 type CommandResult = {
   command: string[]
   code: number | null
@@ -12,7 +14,7 @@ type CommandResult = {
   elapsedMs: number
 }
 
-type ChatResult = {
+export type ChatResult = {
   label: string
   ok: boolean
   elapsedMs: number
@@ -53,47 +55,476 @@ type RunSummary = {
   notes: string[]
 }
 
-const args = new Map<string, string>()
+// ── Dependency injection interface ───────────────────────────────────────────
+// Allows tests to replace spawn / fetch without mocking globals.
 
-for (const arg of process.argv.slice(2)) {
-  const [key, value = ''] = arg.split('=', 2)
-  if (key.startsWith('--')) {
-    args.set(key.slice(2), value || 'true')
+interface RunnerDeps {
+  spawn: typeof spawn
+  fetch: typeof fetch
+}
+
+// ── Config helpers ───────────────────────────────────────────────────────────
+
+export function parseArgs(): Map<string, string> {
+  const args = new Map<string, string>()
+  for (const arg of process.argv.slice(2)) {
+    const [key, value = ''] = arg.split('=', 2)
+    if (key.startsWith('--')) {
+      args.set(key.slice(2), value || 'true')
+    }
+  }
+  return args
+}
+
+export function resolveConfig(args: Map<string, string>): {
+  profile: string
+  kubeContext: string
+  namespace: string
+  deployment: string
+  model: string
+  tokenizer: string
+  baseUrl: string
+  serverUrl: string
+  resultDir: string
+  timeoutMs: number
+  contextTargets: number[]
+} {
+  const profile = args.get('profile') ?? process.env.FLAMINGO_BENCH_PROFILE ?? 'smoke'
+  const kubeContext = args.get('context') ?? process.env.KUBE_CONTEXT ?? 'galactic-tailscale'
+  const namespace = args.get('namespace') ?? process.env.FLAMINGO_NAMESPACE ?? 'flamingo'
+  const deployment = args.get('deployment') ?? process.env.FLAMINGO_DEPLOYMENT ?? 'flamingo'
+  const model = args.get('model') ?? process.env.FLAMINGO_MODEL ?? 'qwen36-flamingo'
+  const tokenizer = args.get('tokenizer') ?? process.env.FLAMINGO_BENCH_TOKENIZER ?? 'unsloth/Qwen3.6-35B-A3B-NVFP4'
+  const baseUrl = (
+    args.get('base-url') ??
+    process.env.FLAMINGO_BASE_URL ??
+    'http://flamingo.ide-newton.ts.net/v1'
+  ).replace(/\/+$/, '')
+  const serverUrl = (args.get('server-url') ?? process.env.FLAMINGO_SERVER_URL ?? baseUrl.replace(/\/v1$/, '')).replace(
+    /\/+$/,
+    '',
+  )
+  const resultDir = resolve(
+    args.get('result-dir') ?? process.env.FLAMINGO_BENCH_RESULT_DIR ?? '/tmp/flamingo-vllm-bench',
+  )
+  const timeoutMs = Number.parseInt(args.get('timeout-ms') ?? process.env.FLAMINGO_BENCH_TIMEOUT_MS ?? '1800000', 10)
+  const contextTargets = (
+    args.get('long-targets') ??
+    process.env.FLAMINGO_LONG_TARGETS ??
+    (profile === 'full' ? '220000' : '')
+  )
+    .split(',')
+    .map((value) => Number.parseInt(value.trim(), 10))
+    .filter((value) => Number.isFinite(value) && value > 0)
+
+  return {
+    profile,
+    kubeContext,
+    namespace,
+    deployment,
+    model,
+    tokenizer,
+    baseUrl,
+    serverUrl,
+    resultDir,
+    timeoutMs,
+    contextTargets,
   }
 }
 
-const profile = args.get('profile') ?? process.env.FLAMINGO_BENCH_PROFILE ?? 'smoke'
-const kubeContext = args.get('context') ?? process.env.KUBE_CONTEXT ?? 'galactic-tailscale'
-const namespace = args.get('namespace') ?? process.env.FLAMINGO_NAMESPACE ?? 'flamingo'
-const deployment = args.get('deployment') ?? process.env.FLAMINGO_DEPLOYMENT ?? 'flamingo'
-const model = args.get('model') ?? process.env.FLAMINGO_MODEL ?? 'qwen36-flamingo'
-const tokenizer = args.get('tokenizer') ?? process.env.FLAMINGO_BENCH_TOKENIZER ?? 'unsloth/Qwen3.6-35B-A3B-NVFP4'
-const baseUrl = (
-  args.get('base-url') ??
-  process.env.FLAMINGO_BASE_URL ??
-  'http://flamingo.ide-newton.ts.net/v1'
-).replace(/\/+$/, '')
-const serverUrl = (args.get('server-url') ?? process.env.FLAMINGO_SERVER_URL ?? baseUrl.replace(/\/v1$/, '')).replace(
-  /\/+$/,
-  '',
-)
-const resultDir = resolve(args.get('result-dir') ?? process.env.FLAMINGO_BENCH_RESULT_DIR ?? '/tmp/flamingo-vllm-bench')
-const timeoutMs = Number.parseInt(args.get('timeout-ms') ?? process.env.FLAMINGO_BENCH_TIMEOUT_MS ?? '1800000', 10)
-const benchmarkResultMarker = '__FLAMINGO_BENCH_RESULT_JSON__'
-const contextTargets = (
-  args.get('long-targets') ??
-  process.env.FLAMINGO_LONG_TARGETS ??
-  (profile === 'full' ? '220000' : '')
-)
-  .split(',')
-  .map((value) => Number.parseInt(value.trim(), 10))
-  .filter((value) => Number.isFinite(value) && value > 0)
+// ── Constants ────────────────────────────────────────────────────────────────
 
-async function run(command: string[], timeout = timeoutMs): Promise<CommandResult> {
+const benchmarkResultMarker = '__FLAMINGO_BENCH_RESULT_JSON__'
+
+// ── Command builders (testable) ──────────────────────────────────────────────
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+/**
+ * Build the raw vLLM bench command array (not wrapped in kubectl exec).
+ * Pure function – no side effects, no I/O.
+ */
+export function buildBenchmarkCommand({
+  model,
+  tokenizer,
+  label,
+  inputLen,
+  outputLen,
+  numPrompts,
+  concurrency,
+  podDir,
+  resultFile,
+}: {
+  model: string
+  tokenizer: string
+  label: string
+  inputLen: number
+  outputLen: number
+  numPrompts: number
+  concurrency: number
+  podDir: string
+  resultFile: string
+}): string[] {
+  return [
+    'vllm',
+    'bench',
+    'serve',
+    '--backend',
+    'openai-chat',
+    '--base-url',
+    'http://127.0.0.1:8000',
+    '--endpoint',
+    '/v1/chat/completions',
+    '--model',
+    model,
+    '--tokenizer',
+    tokenizer,
+    '--trust-remote-code',
+    '--dataset-name',
+    'random',
+    '--random-input-len',
+    String(inputLen),
+    '--random-output-len',
+    String(outputLen),
+    '--num-prompts',
+    String(numPrompts),
+    '--max-concurrency',
+    String(concurrency),
+    '--save-result',
+    '--result-dir',
+    podDir,
+    '--result-filename',
+    resultFile,
+  ]
+}
+
+/**
+ * Build the full kubectl exec wrapper that runs the benchmark inside a pod.
+ * Pure function.
+ */
+export function buildKubectlExecCommand({
+  deployment,
+  podDir,
+  resultFile,
+  label,
+  inputLen,
+  outputLen,
+  numPrompts,
+  concurrency,
+  model,
+  tokenizer,
+  kubeContext,
+  namespace,
+}: {
+  deployment: string
+  podDir: string
+  resultFile: string
+  label: string
+  inputLen: number
+  outputLen: number
+  numPrompts: number
+  concurrency: number
+  model: string
+  tokenizer: string
+  kubeContext: string
+  namespace: string
+}): string[] {
+  const benchCommand = buildBenchmarkCommand({
+    model,
+    tokenizer,
+    label,
+    inputLen,
+    outputLen,
+    numPrompts,
+    concurrency,
+    podDir,
+    resultFile,
+  })
+
+  return [
+    'kubectl',
+    '--context',
+    kubeContext,
+    '-n',
+    namespace,
+    'exec',
+    `deploy/${deployment}`,
+    '--',
+    'sh',
+    '-lc',
+    [
+      `mkdir -p ${shellQuote(podDir)}`,
+      benchCommand.map(shellQuote).join(' '),
+      `printf '\\n${benchmarkResultMarker}\\n'`,
+      `cat ${shellQuote(`${podDir}/${resultFile}`)}`,
+    ].join(' && '),
+  ]
+}
+
+/**
+ * Parse benchmark JSON from shell output that has the marker appended.
+ * Returns the parsed JSON object or `undefined` if no marker / parse failure.
+ */
+export function parseBenchmarkOutput(stdout: string): unknown {
+  const markerIndex = stdout.lastIndexOf(benchmarkResultMarker)
+  if (markerIndex < 0) {
+    return undefined
+  }
+  try {
+    return JSON.parse(stdout.slice(markerIndex + benchmarkResultMarker.length).trim())
+  } catch {
+    return undefined
+  }
+}
+
+// ── Semantic smoke validation ────────────────────────────────────────────────
+
+/**
+ * Semantic validation rules per smoke label.
+ * Each validator returns a string reason on failure, or `null` on success.
+ */
+type SmokeValidator = (result: ChatResult) => string | null
+
+export const smokeValidators: Record<string, SmokeValidator> = {
+  /** exact-no-thinking: response content must contain "qwen36-ready" and finish cleanly. */
+  'exact-no-thinking': (result: ChatResult): string | null => {
+    if (!result.ok) return 'HTTP request failed'
+    if (!result.response) return 'missing response payload'
+
+    const resp = result.response as { choices?: Array<{ message?: { content?: unknown; finish_reason?: string } }> }
+    const choice = resp.choices?.[0]
+    if (!choice?.message) return 'missing choices[0].message'
+
+    const content = choice.message.content
+    if (typeof content !== 'string') return 'content is not a string'
+
+    if (!content.includes('qwen36-ready')) {
+      return `content must contain "qwen36-ready", got: ${String(content).slice(0, 200)}`
+    }
+
+    // "finish cleanly" = finish_reason is "stop" or "length" (non-error)
+    const finishReason = choice.message.finish_reason
+    if (finishReason && finishReason !== 'stop' && finishReason !== 'length') {
+      return `finish_reason must be "stop" or "length", got "${finishReason}"`
+    }
+
+    return null
+  },
+
+  /** medium-thinking: content must contain "qwen36-thinking-ready", finish cleanly, nonzero completion tokens. */
+  'medium-thinking': (result: ChatResult): string | null => {
+    if (!result.ok) return 'HTTP request failed'
+    if (!result.response) return 'missing response payload'
+
+    const resp = result.response as {
+      choices?: Array<{ message?: { content?: unknown; finish_reason?: string; completion_tokens?: number } }>
+    }
+    const choice = resp.choices?.[0]
+    if (!choice?.message) return 'missing choices[0].message'
+
+    const content = choice.message.content
+    if (typeof content !== 'string') return 'content is not a string'
+
+    if (!content.includes('qwen36-thinking-ready')) {
+      return `content must contain "qwen36-thinking-ready", got: ${String(content).slice(0, 200)}`
+    }
+
+    const finishReason = choice.message.finish_reason
+    if (finishReason && finishReason !== 'stop' && finishReason !== 'length') {
+      return `finish_reason must be "stop" or "length", got "${finishReason}"`
+    }
+
+    const completionTokens = choice.message.completion_tokens
+    if (typeof completionTokens !== 'number' || completionTokens === 0) {
+      return `completion_tokens must be nonzero, got ${completionTokens}`
+    }
+
+    return null
+  },
+
+  /** tool-call: must be a structured lookup_status call with JSON arguments id exactly "FLAMINGO-262K". */
+  'tool-call': (result: ChatResult): string | null => {
+    if (!result.ok) return 'HTTP request failed'
+    if (!result.response) return 'missing response payload'
+
+    const resp = result.response as {
+      choices?: Array<{
+        message?: { tool_calls?: unknown }
+        finish_reason?: string
+      }>
+    }
+    const choice = resp.choices?.[0]
+    if (!choice?.message) return 'missing choices[0].message'
+
+    const toolCalls = choice.message.tool_calls
+    if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+      return 'tool_calls must be a non-empty array'
+    }
+
+    // Validate the first tool call
+    const tc = toolCalls[0] as {
+      type?: string
+      function?: { name?: string; arguments?: string }
+    }
+    if (typeof tc?.type !== 'string' || tc.type !== 'function') {
+      return 'tool_calls[0].type must be "function"'
+    }
+
+    const fn = tc.function
+    if (typeof fn?.name !== 'string' || fn.name !== 'lookup_status') {
+      return `tool_calls[0].function.name must be "lookup_status", got "${fn?.name}"`
+    }
+
+    if (typeof fn?.arguments !== 'string') {
+      return 'tool_calls[0].function.arguments must be a string'
+    }
+
+    let args: unknown
+    try {
+      args = JSON.parse(fn.arguments)
+    } catch {
+      return 'tool_calls[0].function.arguments is not valid JSON'
+    }
+
+    if (typeof args !== 'object' || args === null || Array.isArray(args)) {
+      return 'tool_calls[0].function.arguments must parse to an object'
+    }
+
+    const obj = args as Record<string, unknown>
+    if (typeof obj.id !== 'string' || obj.id !== 'FLAMINGO-262K') {
+      return `arguments.id must be exactly "FLAMINGO-262K", got "${obj.id}"`
+    }
+
+    // finish_reason should be "tool_calls" to indicate clean completion
+    if (typeof choice.finish_reason !== 'string' || choice.finish_reason !== 'tool_calls') {
+      return `finish_reason must be "tool_calls", got "${choice.finish_reason}"`
+    }
+
+    return null
+  },
+
+  /** long-context-N: content must contain the expected marker (flamingo-long-N). */
+}
+
+export function buildLongContextValidator(expectedMarker: string): SmokeValidator {
+  return (result: ChatResult): string | null => {
+    if (!result.ok) return 'HTTP request failed'
+    if (!result.response) return 'missing response payload'
+
+    const resp = result.response as { choices?: Array<{ message?: { content?: unknown; finish_reason?: string } }> }
+    const choice = resp.choices?.[0]
+    if (!choice?.message) return 'missing choices[0].message'
+
+    const content = choice.message.content
+    if (typeof content !== 'string') return 'content is not a string'
+
+    if (!content.includes(expectedMarker)) {
+      return `content must contain "${expectedMarker}", got: ${String(content).slice(0, 200)}`
+    }
+
+    const finishReason = choice.message.finish_reason
+    if (finishReason && finishReason !== 'stop' && finishReason !== 'length') {
+      return `finish_reason must be "stop" or "length", got "${finishReason}"`
+    }
+
+    return null
+  }
+}
+
+// Attach long-context validator dynamically
+smokeValidators['long-context-validator'] = function (): string | null {
+  return null // placeholder – use per-instance validation below
+}
+
+/**
+ * Validate a single smoke result semantically.
+ * Returns an array of error strings (empty = pass).
+ */
+export function validateSmokeResult(label: string, result: ChatResult): string[] {
+  const errors: string[] = []
+
+  // Check HTTP-level success first
+  if (!result.ok) {
+    errors.push(`HTTP-level failure: ${result.error ?? 'unknown'}`)
+    return errors
+  }
+
+  // Run semantic validation
+  const reason = smokeValidators[label]?.(result)
+  if (reason) {
+    errors.push(`semantic: ${reason}`)
+  }
+
+  return errors
+}
+
+/**
+ * Validate a long-context smoke result given the expected marker.
+ */
+export function validateLongContextSmoke(result: ChatResult, expectedMarker: string): string[] {
+  const errors: string[] = []
+
+  if (!result.ok) {
+    errors.push(`HTTP-level failure: ${result.error ?? 'unknown'}`)
+    return errors
+  }
+
+  if (!result.response) {
+    errors.push('missing response payload')
+    return errors
+  }
+
+  const resp = result.response as { choices?: Array<{ message?: { content?: unknown; finish_reason?: string } }> }
+  const choice = resp.choices?.[0]
+  if (!choice?.message) {
+    errors.push('missing choices[0].message')
+    return errors
+  }
+
+  const content = choice.message.content
+  if (typeof content !== 'string') {
+    errors.push('content is not a string')
+    return errors
+  }
+
+  if (!content.includes(expectedMarker)) {
+    errors.push(`content must contain "${expectedMarker}", got: ${String(content).slice(0, 200)}`)
+  }
+
+  const finishReason = choice.message.finish_reason
+  if (finishReason && finishReason !== 'stop' && finishReason !== 'length') {
+    errors.push(`finish_reason must be "stop" or "length", got "${finishReason}"`)
+  }
+
+  return errors
+}
+
+// ── Other helpers (still exported for testability) ───────────────────────────
+
+/**
+ * Build the long-context prompt used for recall validation.
+ */
+export function buildLongPrompt(targetTokens: number, marker: string): string {
+  const filler = 'x '.repeat(targetTokens)
+  return [
+    `Remember the marker ${marker}.`,
+    'The following filler exists only to validate long-context recall.',
+    filler,
+    `Return exactly: ${marker}`,
+  ].join('\n')
+}
+
+function kubectlBuild(args: string[], kubeContext: string, namespace: string): string[] {
+  return ['kubectl', '--context', kubeContext, '-n', namespace, ...args]
+}
+
+async function runCommand(command: string[], timeout: number, spawnImpl: typeof spawn): Promise<CommandResult> {
   const started = Date.now()
 
   return await new Promise((resolvePromise) => {
-    const child = spawn(command[0], command.slice(1), {
+    const child = spawnImpl(command[0], command.slice(1), {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
 
@@ -129,16 +560,14 @@ async function run(command: string[], timeout = timeoutMs): Promise<CommandResul
   })
 }
 
-function kubectl(args: string[]): string[] {
-  return ['kubectl', '--context', kubeContext, '-n', namespace, ...args]
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`
-}
-
-async function fetchJson(path: string, init?: RequestInit): Promise<unknown> {
-  const response = await fetch(`${baseUrl}${path}`, {
+async function fetchJsonWithDeps(
+  baseUrl: string,
+  path: string,
+  init: RequestInit,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<unknown> {
+  const response = await fetchImpl(`${baseUrl}${path}`, {
     ...init,
     headers: {
       'content-type': 'application/json',
@@ -156,8 +585,13 @@ async function fetchJson(path: string, init?: RequestInit): Promise<unknown> {
   return text.length > 0 ? JSON.parse(text) : null
 }
 
-async function fetchText(path: string): Promise<string> {
-  const response = await fetch(`${serverUrl}${path}`, {
+async function fetchTextWithDeps(
+  serverUrl: string,
+  path: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const response = await fetchImpl(`${serverUrl}${path}`, {
     headers: {
       authorization: `Bearer ${process.env.FLAMINGO_API_KEY ?? 'flamingo-local'}`,
     },
@@ -171,13 +605,25 @@ async function fetchText(path: string): Promise<string> {
   return await response.text()
 }
 
-async function chatSmoke(label: string, payload: unknown): Promise<ChatResult> {
+async function chatSmoke(
+  label: string,
+  payload: unknown,
+  baseUrl: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<ChatResult> {
   const started = Date.now()
   try {
-    const response = await fetchJson('/chat/completions', {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    })
+    const response = await fetchJsonWithDeps(
+      baseUrl,
+      '/chat/completions',
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      },
+      timeoutMs,
+      fetchImpl,
+    )
     return { label, ok: true, elapsedMs: Date.now() - started, response }
   } catch (error) {
     return {
@@ -189,81 +635,85 @@ async function chatSmoke(label: string, payload: unknown): Promise<ChatResult> {
   }
 }
 
-function buildLongPrompt(targetTokens: number, marker: string): string {
-  const filler = 'x '.repeat(targetTokens)
-  return [
-    `Remember the marker ${marker}.`,
-    'The following filler exists only to validate long-context recall.',
-    filler,
-    `Return exactly: ${marker}`,
-  ].join('\n')
-}
+// ── Benchmark runner ─────────────────────────────────────────────────────────
 
-async function runBench(label: string, inputLen: number, outputLen: number, numPrompts: number, concurrency: number) {
+async function runBench({
+  label,
+  inputLen,
+  outputLen,
+  numPrompts,
+  concurrency,
+  deployment,
+  model,
+  tokenizer,
+  kubeContext,
+  namespace,
+  timeout,
+  spawnImpl,
+}: {
+  label: string
+  inputLen: number
+  outputLen: number
+  numPrompts: number
+  concurrency: number
+  deployment: string
+  model: string
+  tokenizer: string
+  kubeContext: string
+  namespace: string
+  timeout: number
+  spawnImpl: typeof spawn
+}): Promise<BenchmarkRun> {
   const podDir = `/tmp/flamingo-bench-${Date.now()}-${label}`
   const resultFile = `${label}.json`
-  const benchCommand = [
-    'vllm',
-    'bench',
-    'serve',
-    '--backend',
-    'openai-chat',
-    '--base-url',
-    'http://127.0.0.1:8000',
-    '--endpoint',
-    '/v1/chat/completions',
-    '--model',
-    model,
-    '--tokenizer',
-    tokenizer,
-    '--trust-remote-code',
-    '--dataset-name',
-    'random',
-    '--random-input-len',
-    String(inputLen),
-    '--random-output-len',
-    String(outputLen),
-    '--num-prompts',
-    String(numPrompts),
-    '--max-concurrency',
-    String(concurrency),
-    '--save-result',
-    '--result-dir',
+
+  const command = buildKubectlExecCommand({
+    deployment,
     podDir,
-    '--result-filename',
     resultFile,
-  ]
-  const command = kubectl([
-    'exec',
-    `deploy/${deployment}`,
-    '--',
-    'sh',
-    '-lc',
-    [
-      `mkdir -p ${shellQuote(podDir)}`,
-      benchCommand.map(shellQuote).join(' '),
-      `printf '\\n${benchmarkResultMarker}\\n'`,
-      `cat ${shellQuote(`${podDir}/${resultFile}`)}`,
-    ].join(' && '),
-  ])
-  const result = await run(command)
-  let resultJson: unknown
-  try {
-    const markerIndex = result.stdout.lastIndexOf(benchmarkResultMarker)
-    if (markerIndex >= 0) {
-      resultJson = JSON.parse(result.stdout.slice(markerIndex + benchmarkResultMarker.length).trim())
-    }
-  } catch {
-    resultJson = undefined
-  }
+    label,
+    inputLen,
+    outputLen,
+    numPrompts,
+    concurrency,
+    model,
+    tokenizer,
+    kubeContext,
+    namespace,
+  })
+
+  const result = await runCommand(command, timeout, spawnImpl)
+
+  const resultJson = parseBenchmarkOutput(result.stdout)
 
   return { label, command, result, resultJson }
 }
 
+// ── Main (still the entry point) ─────────────────────────────────────────────
+
 async function main(): Promise<void> {
+  const args = parseArgs()
+
+  const config = resolveConfig(args)
+  const {
+    profile,
+    kubeContext,
+    namespace,
+    deployment,
+    model,
+    tokenizer,
+    baseUrl,
+    serverUrl,
+    resultDir,
+    timeoutMs: timeout,
+    contextTargets,
+  } = config
+
   if (profile !== 'smoke' && profile !== 'full') {
     throw new Error(`--profile must be smoke or full, got ${profile}`)
   }
+
+  const deps: RunnerDeps = { spawn, fetch }
 
   await mkdir(resultDir, { recursive: true })
 
@@ -281,7 +731,11 @@ async function main(): Promise<void> {
     notes: [],
   }
 
-  const deploymentJson = await run(kubectl(['get', 'deployment', deployment, '-o', 'json']))
+  const deploymentJson = await runCommand(
+    kubectlBuild(['get', 'deployment', deployment, '-o', 'json'], kubeContext, namespace),
+    timeout,
+    deps.spawn,
+  )
   if (deploymentJson.code !== 0) {
     throw new Error(`failed to read deployment: ${deploymentJson.stderr}`)
   }
@@ -291,69 +745,99 @@ async function main(): Promise<void> {
   summary.deploymentArgs =
     parsedDeployment.spec?.template?.spec?.containers?.find((container) => container.name === 'vllm')?.args ?? []
 
-  summary.models = await fetchJson('/models')
-  summary.metricsBefore = await fetchText('/metrics')
-  summary.nvidiaSmiBefore = (await run(kubectl(['exec', `deploy/${deployment}`, '--', 'nvidia-smi']), 120000)).stdout
+  summary.models = await fetchJsonWithDeps(baseUrl, '/models', {}, timeout, deps.fetch)
+  summary.metricsBefore = await fetchTextWithDeps(serverUrl, '/metrics', timeout, deps.fetch)
+  summary.nvidiaSmiBefore = (
+    await runCommand(
+      kubectlBuild(['exec', `deploy/${deployment}`, '--', 'nvidia-smi'], kubeContext, namespace),
+      120000,
+      deps.spawn,
+    )
+  ).stdout
 
   summary.smokes.push(
-    await chatSmoke('exact-no-thinking', {
-      model,
-      messages: [{ role: 'user', content: 'Reply with exactly: qwen36-ready' }],
-      chat_template_kwargs: { enable_thinking: false },
-      max_tokens: 16,
-      temperature: 0,
-    }),
+    await chatSmoke(
+      'exact-no-thinking',
+      {
+        model,
+        messages: [{ role: 'user', content: 'Reply with exactly: qwen36-ready' }],
+        chat_template_kwargs: { enable_thinking: false },
+        max_tokens: 16,
+        temperature: 0,
+      },
+      baseUrl,
+      timeout,
+      deps.fetch,
+    ),
   )
 
   summary.smokes.push(
-    await chatSmoke('medium-thinking', {
-      model,
-      messages: [{ role: 'user', content: 'Reason briefly, then answer exactly: qwen36-thinking-ready' }],
-      chat_template_kwargs: { enable_thinking: true },
-      max_tokens: 2048,
-      temperature: 0,
-    }),
+    await chatSmoke(
+      'medium-thinking',
+      {
+        model,
+        messages: [{ role: 'user', content: 'Reason briefly, then answer exactly: qwen36-thinking-ready' }],
+        chat_template_kwargs: { enable_thinking: true },
+        max_tokens: 2048,
+        temperature: 0,
+      },
+      baseUrl,
+      timeout,
+      deps.fetch,
+    ),
   )
 
   summary.smokes.push(
-    await chatSmoke('tool-call', {
-      model,
-      messages: [{ role: 'user', content: 'Use the lookup_status tool for id FLAMINGO-262K and no other tool.' }],
-      tools: [
-        {
-          type: 'function',
-          function: {
-            name: 'lookup_status',
-            description: 'Look up rollout status by id.',
-            strict: true,
-            parameters: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' },
+    await chatSmoke(
+      'tool-call',
+      {
+        model,
+        messages: [{ role: 'user', content: 'Use the lookup_status tool for id FLAMINGO-262K and no other tool.' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'lookup_status',
+              description: 'Look up rollout status by id.',
+              strict: true,
+              parameters: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                },
+                required: ['id'],
+                additionalProperties: false,
               },
-              required: ['id'],
-              additionalProperties: false,
             },
           },
-        },
-      ],
-      tool_choice: 'auto',
-      chat_template_kwargs: { enable_thinking: false },
-      max_tokens: 128,
-      temperature: 0,
-    }),
+        ],
+        tool_choice: 'auto',
+        chat_template_kwargs: { enable_thinking: false },
+        max_tokens: 128,
+        temperature: 0,
+      },
+      baseUrl,
+      timeout,
+      deps.fetch,
+    ),
   )
 
   for (const target of contextTargets) {
     const marker = `flamingo-long-${target}`
     summary.smokes.push(
-      await chatSmoke(`long-context-${target}`, {
-        model,
-        messages: [{ role: 'user', content: buildLongPrompt(target, marker) }],
-        chat_template_kwargs: { enable_thinking: false },
-        max_tokens: 32,
-        temperature: 0,
-      }),
+      await chatSmoke(
+        `long-context-${target}`,
+        {
+          model,
+          messages: [{ role: 'user', content: buildLongPrompt(target, marker) }],
+          chat_template_kwargs: { enable_thinking: false },
+          max_tokens: 32,
+          temperature: 0,
+        },
+        baseUrl,
+        timeout,
+        deps.fetch,
+      ),
     )
   }
 
@@ -363,33 +847,66 @@ async function main(): Promise<void> {
       : [['short-coding-loop-smoke', 4096, 512, 4, 2] as const]
 
   for (const [label, inputLen, outputLen, numPrompts, concurrency] of benchProfiles) {
-    summary.benchmarks.push(await runBench(label, inputLen, outputLen, numPrompts, concurrency))
+    summary.benchmarks.push(
+      await runBench({
+        label,
+        inputLen,
+        outputLen,
+        numPrompts,
+        concurrency,
+        deployment,
+        model,
+        tokenizer,
+        kubeContext,
+        namespace,
+        timeout,
+        spawnImpl: deps.spawn,
+      }),
+    )
   }
 
   if (profile === 'full') {
     const sharedPrefix = `${'shared repository context line\n'.repeat(12000)}\nReturn exactly: prefix-cache-ready`
     summary.smokes.push(
-      await chatSmoke('prefix-cache-first', {
-        model,
-        messages: [{ role: 'user', content: sharedPrefix }],
-        chat_template_kwargs: { enable_thinking: false },
-        max_tokens: 16,
-        temperature: 0,
-      }),
+      await chatSmoke(
+        'prefix-cache-first',
+        {
+          model,
+          messages: [{ role: 'user', content: sharedPrefix }],
+          chat_template_kwargs: { enable_thinking: false },
+          max_tokens: 16,
+          temperature: 0,
+        },
+        baseUrl,
+        timeout,
+        deps.fetch,
+      ),
     )
     summary.smokes.push(
-      await chatSmoke('prefix-cache-second', {
-        model,
-        messages: [{ role: 'user', content: sharedPrefix }],
-        chat_template_kwargs: { enable_thinking: false },
-        max_tokens: 16,
-        temperature: 0,
-      }),
+      await chatSmoke(
+        'prefix-cache-second',
+        {
+          model,
+          messages: [{ role: 'user', content: sharedPrefix }],
+          chat_template_kwargs: { enable_thinking: false },
+          max_tokens: 16,
+          temperature: 0,
+        },
+        baseUrl,
+        timeout,
+        deps.fetch,
+      ),
     )
   }
 
-  summary.metricsAfter = await fetchText('/metrics')
-  summary.nvidiaSmiAfter = (await run(kubectl(['exec', `deploy/${deployment}`, '--', 'nvidia-smi']), 120000)).stdout
+  summary.metricsAfter = await fetchTextWithDeps(serverUrl, '/metrics', timeout, deps.fetch)
+  summary.nvidiaSmiAfter = (
+    await runCommand(
+      kubectlBuild(['exec', `deploy/${deployment}`, '--', 'nvidia-smi'], kubeContext, namespace),
+      120000,
+      deps.spawn,
+    )
+  ).stdout
   summary.finishedAt = new Date().toISOString()
 
   const outputPath = join(resultDir, `flamingo-${profile}-${summary.startedAt.replace(/[:.]/g, '-')}.json`)
@@ -406,7 +923,10 @@ async function main(): Promise<void> {
   }
 }
 
-void main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.stack : error)
-  process.exitCode = 1
-})
+// Guard: do not run `main()` when this file is imported by bun test.
+if (import.meta.main && process.argv[1]?.includes('benchmark-flamingo-vllm')) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.stack : error)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

- Harden the Flamingo benchmark runner smoke validation and tests.
- Validation commands and CI status are listed below.

## Related Issues

None

## Testing

- `bash -lc bun test scripts/jangar/benchmark-flamingo-vllm.test.ts` exit 0
- `bash -lc bunx tsc --ignoreConfig --noEmit --skipLibCheck --types bun --module NodeNext --moduleResolution NodeNext --target ES2023 scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/benchmark-flamingo-vllm.test.ts` exit 0
- `bash -lc bunx oxfmt --check scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/benchmark-flamingo-vllm.test.ts argocd/applications/flamingo/README.md` exit 0
- `bash -lc bun run lint:flamingo-hard-migration` exit 0
- `bash -lc git diff --check` exit 0
- CI: Pending: pull request checks have not completed yet.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
