### PR TITLE
fix(anypi): avoid ci repair on unavailable checks

### DIFF
--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -47,6 +47,7 @@ import {
   hasWorktreeProgress,
   normalizeConventionalSummary,
   renderPullRequestBody,
+  shouldRunCiRepair,
 } from './run'
 
 describe('Anypi config', () => {
@@ -392,6 +393,44 @@ describe('Anypi prompt contract', () => {
     })
   })
 
+  test('only treats failed or cancelled GitHub checks as CI-repairable', () => {
+    expect(
+      shouldRunCiRepair({
+        ok: false,
+        status: 'failed',
+        requiredOnly: false,
+        attempts: 1,
+        durationMs: 100,
+        checks: [{ name: 'scripts', workflow: 'CI', bucket: 'fail' }],
+        summary: '0 passed/skipped, 0 pending, 1 failed/cancelled',
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldRunCiRepair({
+        ok: false,
+        status: 'failed',
+        requiredOnly: false,
+        attempts: 1,
+        durationMs: 100,
+        checks: [{ name: 'scripts', workflow: 'CI', bucket: 'pending' }],
+        summary: '0 passed/skipped, 1 pending, 0 failed/cancelled',
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldRunCiRepair({
+        ok: false,
+        status: 'unavailable',
+        requiredOnly: true,
+        attempts: 1,
+        durationMs: 100,
+        checks: [],
+        summary: "gh pr checks failed (1): no required checks reported on the 'codex/example' branch",
+      }),
+    ).toBe(false)
+  })
+
   test('rejects generated artifact and lockfile drift before commit', async () => {
     expect(classifyRestrictedChangedFile('bun.lock')).toBe('lockfile')
     expect(classifyRestrictedChangedFile('services/anypi/dist/index.js')).toBe('generated-artifact')
@@ -464,7 +503,7 @@ describe('Anypi prompt contract', () => {
         args: ['pr', 'checks', 'branch', '--required', '--json', 'name,workflow,state,bucket,link'],
         exitCode: 1,
         stdout: '',
-        stderr: "no checks reported on the 'codex/example' branch",
+        stderr: "no required checks reported on the 'codex/example' branch",
         durationMs: 12,
       }),
     ).toBe(true)

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -415,7 +415,7 @@ export const parseCiChecksResult = (result: CommandResult): CiCheck[] => {
 
 export const isNoChecksReportedResult = (result: CommandResult) => {
   if (result.exitCode === 0) return false
-  return /no checks reported/i.test(`${result.stderr}\n${result.stdout}`)
+  return /no (?:required )?checks reported/i.test(`${result.stderr}\n${result.stdout}`)
 }
 
 export const isNoRequiredChecksResult = isNoChecksReportedResult

--- a/services/anypi/src/run.ts
+++ b/services/anypi/src/run.ts
@@ -209,6 +209,9 @@ const formatValidationError = (result: ValidationResult) =>
 
 const formatCiError = (ci: CiWaitResult) => `ci checks ${ci.status}: ${ci.summary}`
 
+export const shouldRunCiRepair = (ci: CiWaitResult) =>
+  ci.status === 'failed' && ci.checks.some((check) => ['fail', 'cancel'].includes(check.bucket ?? ''))
+
 const formatCiRepairSummary = (ci: CiWaitResult) => {
   const checks = ci.checks
     .map(
@@ -402,6 +405,7 @@ export const runAnypi = async (env: NodeJS.ProcessEnv = process.env): Promise<An
           status.ci = ci
           await writeStatus(config.statusPath, status)
           if (ci.ok) break
+          if (!shouldRunCiRepair(ci)) throw new Error(formatCiError(ci))
           if (attempt >= config.ciRepairAttempts) throw new Error(formatCiError(ci))
 
           await logger.error(`${formatCiError(ci)}; starting ci repair ${attempt + 1}/${config.ciRepairAttempts}`)


### PR DESCRIPTION
## Summary

- Recognizes GitHub CLI output that says `no required checks reported` and falls back to all PR checks instead of treating it as unavailable.
- Starts CI repair only for actionable failed or cancelled checks, not unavailable or timed-out check discovery.
- Adds regression coverage for no-required-check wording and CI-repairability classification.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/anypi test`
- `bun run --filter @proompteng/anypi tsc`
- `bunx oxfmt --check services/anypi/src/git.ts services/anypi/src/run.ts services/anypi/src/config.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
