### PR TITLE
chore(agents): pin fixed anypi runner image

### DIFF
--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:85953dd7a@sha256:362b1416b62d6e5461b1ea4214d156edef7e425066c3f886c268650863c7a764
+    image: registry.ide-newton.ts.net/lab/anypi:053454b56@sha256:cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c
   adapter:
     type: exec
   envTemplate:

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:85953dd7a@sha256:362b1416b62d6e5461b1ea4214d156edef7e425066c3f886c268650863c7a764
+    image: registry.ide-newton.ts.net/lab/anypi:053454b56@sha256:cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c
   adapter:
     type: exec
   envTemplate:

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ harness against the self-hosted Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:85953dd7a@sha256:362b1416b62d6e5461b1ea4214d156edef7e425066c3f886c268650863c7a764`
+- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:053454b56@sha256:cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen36-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`


### PR DESCRIPTION
## Summary

- Pin `AgentProvider/anypi` to `registry.ide-newton.ts.net/lab/anypi:053454b56@sha256:cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c`.
- Pin `AgentProvider/anypi-eval` to the same fixed multi-arch image so eval and production providers run identical harness code.
- Update the AnyPi operator README default image reference.

## Related Issues

None

## Testing

- `crane digest registry.ide-newton.ts.net/lab/anypi:053454b56`
- `crane manifest registry.ide-newton.ts.net/lab/anypi:053454b56 | jq -e '[.manifests[] | select(.platform.os=="linux") | .platform.architecture] | sort == ["amd64","arm64"]'`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml && rg -n "053454b56|cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c" /tmp/agents-render.yaml`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
