### PR TITLE
fix(nix): stabilize attic rollout dependencies

### DIFF
--- a/argocd/applications/attic/deployment.yaml
+++ b/argocd/applications/attic/deployment.yaml
@@ -111,6 +111,9 @@ spec:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+                - name: Host
+                  value: attic.attic.svc.cluster.local
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
@@ -118,6 +121,9 @@ spec:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+                - name: Host
+                  value: attic.attic.svc.cluster.local
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5

--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -30,6 +30,10 @@ pspEnable: false
 
 allowLoopDevices: false
 
+# RGW admin paths can exceed the chart default during HDD compaction/recovery.
+# Keep OBC provisioning fail-closed, but do not interrupt healthy admin lookups.
+cephCommandsTimeoutSeconds: "120"
+
 csi:
   rookUseCsiOperator: true
   enableRbdDriver: true


### PR DESCRIPTION
## Summary

- Add a Host header to Attic readiness and liveness probes so kubelet probes pass Attic allowed-host validation.
- Raise Rook Ceph command timeout from 15s to 120s so OBC/RGW admin operations do not get interrupted during normal HDD metadata latency.
- Matches the live rollout repair that allowed the Attic pod to become Ready after the bucket secret was created.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/attic | rg -n "httpHeaders|Host|attic.attic.svc.cluster.local|readinessProbe|livenessProbe" -C 2`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph | rg -n "ROOK_CEPH_COMMANDS_TIMEOUT_SECONDS|name: rook-ceph-operator-config|cephCommandsTimeout" -C 3`
- `git diff --check`
- `bun run lint:argocd`
- Live smoke: `kubectl -n attic run attic-http-smoke --rm -i --restart=Never --image=curlimages/curl -- curl -fsS http://attic.attic.svc.cluster.local/`
- Live smoke: `curl -fsS https://attic.ide-newton.ts.net/`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
