### PR TITLE
feat: add generic pr body placeholder validation to anypi with tests

### DIFF
--- a/services/anypi/src/config.test.ts
+++ b/services/anypi/src/config.test.ts
@@ -49,6 +49,7 @@ import {
   renderPullRequestBody,
   shouldRunCiRepair,
 } from './run'
+import { validatePullRequestBody, validationErrorToMessage } from './pr-body-validator'
 
 describe('Anypi config', () => {
   test('defaults to Flamingo and all Pi coding tools', () => {
@@ -740,6 +741,186 @@ describe('Anypi prompt contract', () => {
 
       expect(plan.sources).toEqual(['run-spec'])
       expect(plan.commands).toEqual(['run-spec command 1', 'run-spec command 2'])
+    })
+  })
+
+  // ------------------------------------------------------------------------
+  // PR body validation
+  // ------------------------------------------------------------------------
+
+  describe('PR body validation', () => {
+    test('valid rendered body passes without errors', () => {
+      const body = [
+        '## Summary',
+        '',
+        '- Improved the feature',
+        '- Fixed edge cases',
+        '',
+        '## Testing',
+        '',
+        '- ran bun test',
+        '',
+        '## Checklist',
+        '',
+        '- [x] All tests pass.',
+        '- [x] Documentation updated.',
+      ].join('\n')
+      expect(validatePullRequestBody(body)).toBeNull()
+    })
+
+    test('renders from template produce a clean body that passes validation', () => {
+      const body = renderPullRequestBody({
+        runSpec: { implementation: { summary: 'Fix PR body validation' } },
+        status: {
+          provider: 'anypi',
+          status: 'running' as const,
+          startedAt: '2026-06-16T00:00:00.000Z',
+          runName: 'anypi-foo',
+          namespace: 'agents',
+          model: 'qwen36-flamingo',
+          providerModel: 'flamingo/qwen36-flamingo',
+          thinkingLevel: 'medium' as const,
+          contextWindow: 229376,
+          maxTokens: 32768,
+          piPromptTimeoutSeconds: 1800,
+          promptVariant: 'minimal',
+          promptHash: '0123456789abcdef',
+          tools: [],
+          requiredTools: [],
+          validations: [],
+          validationPlan: { policy: 'append', sources: [], commands: [] },
+          agentAttempts: 1,
+          validationAttempts: 1,
+          ciAttempts: 1,
+          promptChars: 0,
+          ci: {
+            ok: true,
+            status: 'passed' as const,
+            requiredOnly: true,
+            attempts: 1,
+            durationMs: 100,
+            checks: [],
+            summary: '0 passed/skipped, 0 pending, 0 failed/cancelled',
+          },
+        },
+        git: {
+          repository: 'proompteng/lab',
+          baseBranch: 'main',
+          headBranch: 'codex/test',
+          cloneUrl: 'https://github.com/proompteng/lab.git',
+          webUrl: 'https://github.com/proompteng/lab',
+          worktree: '/tmp/lab',
+          env: {},
+          writeEnabled: true,
+          pullRequestsEnabled: true,
+        },
+        piText: 'done',
+        template: [
+          '## Summary',
+          '',
+          '## Related Issues',
+          '',
+          '## Testing',
+          '',
+          '## Screenshots (if applicable)',
+          '',
+          '## Breaking Changes',
+          '',
+          '## Checklist',
+          '',
+          '- [ ] Testing section documents the exact validation performed.',
+          '- [ ] Screenshots and Breaking Changes sections are handled appropriately.',
+          '- [ ] Documentation updated.',
+        ].join('\n'),
+      })
+      expect(validatePullRequestBody(body)).toBeNull()
+    })
+
+    test('rejects HTML comments from template scaffolding', () => {
+      const body = [
+        '## Summary',
+        '',
+        '<!-- 3-5 concise bullets describing what changed. -->',
+        '',
+        '- Did the thing.',
+      ].join('\n')
+      const err = validatePullRequestBody(body)
+      expect(err).not.toBeNull()
+      expect(err!.issues).toContain('html-comment')
+      expect(validationErrorToMessage(err!)).toContain('html-comment')
+    })
+
+    test('rejects bare TODO and TBD keywords', () => {
+      const body = ['## Summary', '', '- Improve this TODO section before merge.', '- TBD: finalize the changes.'].join(
+        '\n',
+      )
+      const err = validatePullRequestBody(body)
+      expect(err).not.toBeNull()
+      expect(err!.issues).toContain('TODO/TBD placeholder')
+    })
+
+    test('rejects angle-bracket placeholders', () => {
+      const body = ['## Summary', '', '- Improved <feature name>.', '- Updated <component> to handle edge cases.'].join(
+        '\n',
+      )
+      const err = validatePullRequestBody(body)
+      expect(err).not.toBeNull()
+      expect(err!.issues.some((issue) => issue.includes('angle-bracket'))).toBe(true)
+    })
+
+    test('rejects unchecked checklist items', () => {
+      const body = [
+        '## Summary',
+        '',
+        '- Fixed the bug.',
+        '',
+        '## Checklist',
+        '',
+        '- [ ] Testing section documents validation.',
+        '- [x] Screenshots handled.',
+      ].join('\n')
+      const err = validatePullRequestBody(body)
+      expect(err).not.toBeNull()
+      expect(err!.issues.some((issue) => issue.includes('unchecked checklist'))).toBe(true)
+    })
+
+    test('rejects bare-dash placeholders used as bullet scaffolding', () => {
+      const body = ['## Summary', '', '- Fixed things.', '', '- ', '- '].join('\n')
+      const err = validatePullRequestBody(body)
+      expect(err).not.toBeNull()
+      expect(err!.issues.some((issue) => issue.includes('bare-dash'))).toBe(true)
+    })
+
+    test('rejects combined scaffolding in one pass', () => {
+      const body = [
+        '## Summary',
+        '',
+        '<!-- TODO: write summary -->',
+        '',
+        '- <feature name>',
+        '',
+        '- ',
+        '- ',
+        '',
+        '## Checklist',
+        '',
+        '- [ ] Testing done.',
+      ].join('\n')
+      const err = validatePullRequestBody(body)
+      expect(err).not.toBeNull()
+      expect(err!.issues).toContain('html-comment')
+      expect(err!.issues).toContain('TODO/TBD placeholder')
+      expect(err!.issues.some((issue) => issue.includes('angle-bracket'))).toBe(true)
+      expect(err!.issues.some((issue) => issue.includes('bare-dash'))).toBe(true)
+      expect(err!.issues.some((issue) => issue.includes('unchecked checklist'))).toBe(true)
+    })
+
+    test('validation error message is human readable', () => {
+      const err = validatePullRequestBody('<!-- placeholder -->')
+      const msg = validationErrorToMessage(err!)
+      expect(msg).toContain('PR body validation failed')
+      expect(msg).toContain('html-comment')
+      expect(msg).toContain('remove all HTML comments')
     })
   })
 })

--- a/services/anypi/src/git.ts
+++ b/services/anypi/src/git.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path'
 
 import { runCommand, runShell } from './command'
 import type { AnypiConfig } from './config'
+import { validatePullRequestBody, validationErrorToMessage } from './pr-body-validator'
 import type {
   AgentRunSpecPayload,
   CiCheck,
@@ -333,6 +334,12 @@ export const createOrUpdatePullRequest = async (
   },
 ): Promise<PullRequestResult> => {
   if (!git.pullRequestsEnabled) return { enabled: false }
+
+  // Validate the PR body before any GitHub mutation.
+  const validation = validatePullRequestBody(input.body)
+  if (validation) {
+    throw new Error(validationErrorToMessage(validation))
+  }
   const owner = repositoryOwner(git.repository)
   const endpoint = `repos/${git.repository}/pulls`
   const view = await runCommand(

--- a/services/anypi/src/pr-body-validator.ts
+++ b/services/anypi/src/pr-body-validator.ts
@@ -1,0 +1,78 @@
+/**
+ * PR body validator — rejects rendered pull-request bodies that still contain
+ * template scaffolding (HTML comments, placeholder tokens, unchecked
+ * checkboxes, etc.).  Pure, synchronous, unit-testable.
+ */
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Inspect a rendered PR body and return a structured error when the body
+ * contains unresolved template scaffolding.
+ *
+ * Returns `null` when the body is clean.
+ */
+export const validatePullRequestBody = (body: string): ValidationError | null => {
+  const issues: string[] = []
+
+  // 1. HTML comments (e.g. `<!-- 3-5 concise bullets -->`)
+  if (/<!--[\s\S]*?-->/.test(body)) {
+    issues.push('html-comment')
+  }
+
+  // 2. Unchecked checklist items (e.g. `- [ ]`)
+  const lines = body.split('\n')
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (/^- \[\s*\] /.test(trimmed)) {
+      issues.push(`unchecked checklist: "${trimmed}"`)
+      break
+    }
+  }
+
+  // 3. TODO / TBD keywords (case-insensitive, word boundary)
+  if (/\bTODO\b|\bTBD\b/i.test(body)) {
+    issues.push('TODO/TBD placeholder')
+  }
+
+  // 4. Angle-bracket placeholders like `<...>` or `<feature name>`
+  const bracketMatches = body.match(/<[^>]+>/g)
+  if (bracketMatches) {
+    issues.push(`angle-bracket placeholder: "${bracketMatches[0]}"`)
+  }
+
+  // 5. Ellipsis-in-angle or bracket placeholders: `...` used as placeholder
+  //    in contexts like `[...]` or `<...>`
+  if (/(\[.*?\.\.\..*?\])|(<.*?\.\.\..*?>)/g.test(body)) {
+    issues.push('ellipsis placeholder')
+  }
+
+  // 6. Single-line bare dash placeholders (e.g. `-` on its own line)
+  const bareDashLines = body.split('\n').filter((line) => line.trim() === '-')
+  if (bareDashLines.length > 0) {
+    issues.push(`bare-dash placeholder (${bareDashLines.length} lines)`)
+  }
+
+  return issues.length > 0 ? { body, issues } : null
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ValidationError = {
+  body: string
+  issues: string[]
+}
+
+/**
+ * Human-readable error message suitable for throwing or logging.
+ */
+export const validationErrorToMessage = (error: ValidationError): string =>
+  [
+    `PR body validation failed: unresolved template scaffolding detected.`,
+    ...error.issues.map((issue) => `  - ${issue}`),
+    `Hint: remove all HTML comments, placeholders, and unchecked checklist items from the rendered PR body before sending to GitHub.`,
+  ].join('\n')


### PR DESCRIPTION
## Summary

- Add generic PR body placeholder validation to AnyPi with tests.
- Validation commands and CI status are listed below.

## Related Issues

None

## Testing

- `bash -lc bun run --filter @proompteng/anypi test -- services/anypi/src/config.test.ts` exit 0
- `bash -lc bun run --filter @proompteng/anypi tsc` exit 0
- `bash -lc bunx oxfmt --check services/anypi/src/git.ts services/anypi/src/run.ts services/anypi/src/config.test.ts services/anypi/src/types.ts` exit 0
- `bash -lc git diff --check` exit 0
- CI: passed: 14 passed/skipped, 0 pending, 0 failed/cancelled

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
