### PR TITLE
ci(nix): consume attic cache from arc runners

### DIFF
--- a/.github/workflows/nix-cache-smoke.yml
+++ b/.github/workflows/nix-cache-smoke.yml
@@ -1,0 +1,61 @@
+name: nix-cache-smoke
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'docs/nix-cache.md'
+      - '.github/workflows/nix-cache-smoke.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'docs/nix-cache.md'
+      - '.github/workflows/nix-cache-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pull-only:
+    runs-on: arc-arm64
+    env:
+      ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
+      ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Ensure Attic public key is configured
+        run: test -n "${ATTIC_PUBLIC_KEY}"
+
+      - name: Install xz for Nix installer
+        run: |
+          if command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          fi
+
+      - name: Install Nix with Attic pull substituter
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            extra-substituters = http://attic.attic.svc.cluster.local/lab
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+
+      - name: Check Attic cache endpoint
+        run: nix run .#cache-doctor
+
+      - name: Build cache smoke derivation
+        run: nix build .#cacheSmoke --print-build-logs

--- a/.github/workflows/nix-cache-smoke.yml
+++ b/.github/workflows/nix-cache-smoke.yml
@@ -41,8 +41,18 @@ jobs:
 
       - name: Install xz for Nix installer
         run: |
+          if command -v xz >/dev/null 2>&1; then
+            exit 0
+          fi
+
           if command -v apk >/dev/null 2>&1; then
             sudo apk add --no-cache xz
+          elif command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          else
+            echo "No supported package manager found to install xz." >&2
+            exit 1
           fi
 
       - name: Install Nix with Attic pull substituter

--- a/.github/workflows/nix-toolchain.yml
+++ b/.github/workflows/nix-toolchain.yml
@@ -19,6 +19,7 @@ on:
       - 'packages/scripts/src/shared/__tests__/oci.test.ts'
       - 'argocd/**/*.yaml'
       - '.github/workflows/nix-toolchain.yml'
+      - '.github/workflows/nix-cache-smoke.yml'
       - '.github/workflows/oci-native-build-common.yml'
       - '.github/workflows/oci-builder-benchmark.yml'
       - '.github/workflows/kubeconform.yml'
@@ -43,6 +44,7 @@ on:
       - 'packages/scripts/src/shared/__tests__/oci.test.ts'
       - 'argocd/**/*.yaml'
       - '.github/workflows/nix-toolchain.yml'
+      - '.github/workflows/nix-cache-smoke.yml'
       - '.github/workflows/oci-native-build-common.yml'
       - '.github/workflows/oci-builder-benchmark.yml'
       - '.github/workflows/kubeconform.yml'
@@ -58,10 +60,32 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
+    env:
+      ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
+      ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+
+      - name: Ensure Attic public key is configured
+        run: test -n "${ATTIC_PUBLIC_KEY}"
+
+      - name: Install xz for Nix installer
+        run: |
+          if command -v xz >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          else
+            echo "No supported package manager found to install xz." >&2
+            exit 1
+          fi
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -69,6 +93,8 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = http://attic.attic.svc.cluster.local/lab
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Check flake
         run: nix flake check --print-build-logs

--- a/docs/nix-cache.md
+++ b/docs/nix-cache.md
@@ -102,7 +102,8 @@ BOOTSTRAP_TOKEN="$(kubectl -n attic exec deploy/attic -- \
     --pull lab \
     --push lab \
     --create-cache lab \
-    --configure-cache lab)"
+    --configure-cache lab \
+    --configure-cache-retention lab)"
 ```
 
 Create and publish the cache from the route available to the operator shell:


### PR DESCRIPTION
## Summary

- Adds a dedicated `nix-cache-smoke` workflow on `arc-arm64` that configures the in-cluster Attic substituter and builds `.#cacheSmoke` without any push token.
- Moves `nix-toolchain` from GitHub-hosted runners to `arc-arm64` so mandatory Nix checks can use `http://attic.attic.svc.cluster.local/lab` with `vars.ATTIC_PUBLIC_KEY`.
- Keeps PR cache use pull-only: no `ATTIC_TOKEN`, no push step, and no GitHub-hosted runner pointed at the in-cluster URL.
- Corrects the bootstrap runbook to include `--configure-cache-retention lab`, which the stock Attic CLI requires when running `attic cache configure --public`.

## Related Issues

None.

## Testing

- `ruby -e 'require "yaml"; %w[.github/workflows/nix-cache-smoke.yml .github/workflows/nix-toolchain.yml].each { |p| YAML.load_file(p) }; puts "ok"'`
- `git diff --check`
- `rg -n "ATTIC_TOKEN|attic\\.ide-newton\\.ts\\.net/lab|attic\\.attic\\.svc\\.cluster\\.local/lab" .github/workflows/nix-cache-smoke.yml .github/workflows/nix-toolchain.yml` showed only the in-cluster pull substituter and no token usage.
- GitHub check `nix-cache-smoke / pull-only` passed once before enabling the `nix-toolchain` ARC cache configuration.
- Live bootstrap proof before this PR: `ATTIC_PUBLIC_KEY` exists as a GitHub variable, `ATTIC_TOKEN` is not present as a secret, and cluster-side `nix build github:proompteng/lab/cb39973eb4c0b771f7ac5b20ee4ffaab8d87de63#cacheSmoke --print-build-logs` succeeded with `http://attic.attic.svc.cluster.local/lab` configured.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
