### PR TITLE
chore(agents): pin anypi pr body validator image

### DIFF
--- a/argocd/applications/agents/anypi-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:053454b56@sha256:cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c
+    image: registry.ide-newton.ts.net/lab/anypi:a5796fc2b@sha256:4e4e7ac9f646c061baaa7478ae42bf3acefc2ab46b2640ffa52b677cb8ed86ca
   adapter:
     type: exec
   envTemplate:

--- a/argocd/applications/agents/anypi-eval-agentprovider.yaml
+++ b/argocd/applications/agents/anypi-eval-agentprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   binary: /usr/local/bin/anypi-runner
   workload:
-    image: registry.ide-newton.ts.net/lab/anypi:053454b56@sha256:cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c
+    image: registry.ide-newton.ts.net/lab/anypi:a5796fc2b@sha256:4e4e7ac9f646c061baaa7478ae42bf3acefc2ab46b2640ffa52b677cb8ed86ca
   adapter:
     type: exec
   envTemplate:

--- a/docs/agents/anypi.md
+++ b/docs/agents/anypi.md
@@ -9,7 +9,7 @@ harness against the self-hosted Flamingo model.
 - Agent: `anypi-agent`
 - Binary: `/usr/local/bin/anypi-runner`
 - Runtime type: `job`
-- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:053454b56@sha256:cc475b6315d5e37773b9b86f5108926f0adbbad5d5dba8748be70048dbce5f2c`
+- Default provider workload image: `registry.ide-newton.ts.net/lab/anypi:a5796fc2b@sha256:4e4e7ac9f646c061baaa7478ae42bf3acefc2ab46b2640ffa52b677cb8ed86ca`
 - Default model endpoint: `http://flamingo.flamingo.svc.cluster.local/v1`
 - Default model: `qwen36-flamingo`
 - Supported workload image platforms: `linux/amd64`, `linux/arm64`

--- a/services/agents/src/server/v1/agent-runs.test.ts
+++ b/services/agents/src/server/v1/agent-runs.test.ts
@@ -227,7 +227,7 @@ describe('AgentRun v1 API', () => {
           binary: '/usr/local/bin/anypi-runner',
           workload: {
             image:
-              'registry.ide-newton.ts.net/lab/anypi:9cd6ed580@sha256:b6f90e286832458ee228472a066ba1249536bef2d53618014164f70b85e01990',
+              'registry.ide-newton.ts.net/lab/anypi:a5796fc2b@sha256:4e4e7ac9f646c061baaa7478ae42bf3acefc2ab46b2640ffa52b677cb8ed86ca',
           },
         },
       })
@@ -258,7 +258,7 @@ describe('AgentRun v1 API', () => {
       dryRun: true,
       providerName: 'anypi',
       resolvedWorkloadImage:
-        'registry.ide-newton.ts.net/lab/anypi:9cd6ed580@sha256:b6f90e286832458ee228472a066ba1249536bef2d53618014164f70b85e01990',
+        'registry.ide-newton.ts.net/lab/anypi:a5796fc2b@sha256:4e4e7ac9f646c061baaa7478ae42bf3acefc2ab46b2640ffa52b677cb8ed86ca',
       resolvedWorkloadImageSource: 'provider',
     })
     expect(kube.apply).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- Pin `AgentProvider/anypi` and `AgentProvider/anypi-eval` to the AnyPi image built from merged PR #11518.
- Update the AnyPi operator README default image reference to the same digest.
- Refresh the Agents v1 API dry-run test fixture so provider image resolution matches the current AnyPi image.

## Related Issues

None

## Testing

- `docker run --rm --platform linux/amd64 --entrypoint sh registry.ide-newton.ts.net/lab/anypi:a5796fc2b -lc 'cat /app/services/anypi/build-sha.txt && test -f /app/services/anypi/src/pr-body-validator.ts && test -x /usr/local/bin/anypi-runner && echo ok-amd64'`
- `docker run --rm --platform linux/arm64 --entrypoint sh registry.ide-newton.ts.net/lab/anypi:a5796fc2b -lc 'cat /app/services/anypi/build-sha.txt && test -f /app/services/anypi/src/pr-body-validator.ts && test -x /usr/local/bin/anypi-runner && echo ok-arm64'`
- `crane digest registry.ide-newton.ts.net/lab/anypi:a5796fc2b`
- `crane manifest registry.ide-newton.ts.net/lab/anypi:a5796fc2b | jq '[.manifests[] | {platform:.platform,digest:.digest}]'`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render-a5796fc2b.yaml && rg -n "a5796fc2b|4e4e7ac9f646c061baaa7478ae42bf3acefc2ab46b2640ffa52b677cb8ed86ca" /tmp/agents-render-a5796fc2b.yaml`
- `bun run lint:argocd`
- `bun run --filter @proompteng/agents test -- src/server/v1/agent-runs.test.ts`
- `bun run --filter @proompteng/anypi test -- services/anypi/src/config.test.ts`
- `bunx oxfmt --check argocd/applications/agents/anypi-agentprovider.yaml argocd/applications/agents/anypi-eval-agentprovider.yaml docs/agents/anypi.md services/agents/src/server/v1/agent-runs.test.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
