### PR TITLE
ci(nix): warm attic cache from main

### DIFF
--- a/.github/workflows/nix-cache-smoke.yml
+++ b/.github/workflows/nix-cache-smoke.yml
@@ -68,4 +68,56 @@ jobs:
         run: nix run .#cache-doctor
 
       - name: Build cache smoke derivation
-        run: nix build .#cacheSmoke --print-build-logs
+        id: cache-smoke
+        run: |
+          path="$(nix build .#cacheSmoke --no-link --print-out-paths --print-build-logs)"
+          echo "path=${path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Push cache smoke closure
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: nix run .#cache-push -- "${{ steps.cache-smoke.outputs.path }}"
+
+  substitute-only:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - pull-only
+    runs-on: arc-arm64
+    env:
+      ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Ensure Attic public key is configured
+        run: test -n "${ATTIC_PUBLIC_KEY}"
+
+      - name: Install xz for Nix installer
+        run: |
+          if command -v xz >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          else
+            echo "No supported package manager found to install xz." >&2
+            exit 1
+          fi
+
+      - name: Install Nix with Attic pull substituter
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            extra-substituters = http://attic.attic.svc.cluster.local/lab
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+            max-jobs = 0
+
+      - name: Prove cache smoke substitutes without local build
+        run: nix build .#cacheSmoke --no-link --print-build-logs

--- a/.github/workflows/nix-toolchain.yml
+++ b/.github/workflows/nix-toolchain.yml
@@ -113,3 +113,28 @@ jobs:
 
       - name: Lint Argo Workflow manifests
         run: nix run .#lint-argo-workflows
+
+      - name: Resolve warm cache store paths
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          nix build --no-link --print-out-paths \
+            .#cacheSmoke \
+            .#toolchainDoctor \
+            .#ociDoctor \
+            .#lintArgocd \
+            .#renderHeadlamp \
+            .#lintArgoWorkflows \
+            .#cachePush \
+            .#createOciIndex \
+            .#inspectOciImage \
+            .#assertOciPlatforms \
+            > /tmp/attic-warm-cache-paths
+          echo "Resolved $(wc -l < /tmp/attic-warm-cache-paths) store path(s)."
+
+      - name: Push warm cache closures
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          mapfile -t paths < /tmp/attic-warm-cache-paths
+          nix run .#cache-push -- "${paths[@]}"

--- a/nix/cache-push.sh
+++ b/nix/cache-push.sh
@@ -8,6 +8,7 @@ fi
 
 cache_name="${ATTIC_CACHE_NAME:-lab}"
 cache_endpoint="${ATTIC_CACHE_ENDPOINT:-http://attic.attic.svc.cluster.local}"
+server_name="${ATTIC_SERVER_NAME:-lab-ci}"
 
 if [[ "$#" -eq 0 ]]; then
   echo "Usage: cache-push <store-path> [<store-path> ...]" >&2
@@ -24,7 +25,7 @@ for path in "$@"; do
 done
 
 echo "Logging in to Attic endpoint ${cache_endpoint} for cache ${cache_name}."
-attic login "${cache_name}" "${cache_endpoint}" "${ATTIC_TOKEN}" >/dev/null
+attic login --set-default "${server_name}" "${cache_endpoint}" "${ATTIC_TOKEN}" >/dev/null
 
 echo "Pushing ${#paths[@]} path(s) to Attic cache ${cache_name}."
-attic push "${cache_name}" "${paths[@]}"
+attic push "${server_name}:${cache_name}" "${paths[@]}"


### PR DESCRIPTION
## Summary

- Adds main-only Attic push steps to `nix-cache-smoke` and `nix-toolchain`, guarded by `github.event_name == 'push' && github.ref == 'refs/heads/main'`.
- Pushes only explicit Nix store paths through `nix/cache-push.sh`; PR workflows remain pull-only and do not receive `ATTIC_TOKEN`.
- Adds a fresh-run substitute-only `.#cacheSmoke` proof job with `max-jobs = 0` after the main push path.
- Updates `cache-push.sh` to log in with an explicit default server alias and push to `server:cache`.

## Related Issues

None.

## Testing

- `shellcheck nix/cache-push.sh nix/cache-doctor.sh`
- `ruby -e 'require "yaml"; %w[.github/workflows/nix-cache-smoke.yml .github/workflows/nix-toolchain.yml].each { |p| YAML.load_file(p) }; puts "ok"'`
- `git diff --check`
- `env -u ATTIC_TOKEN bash nix/cache-push.sh /tmp` exits `2` with `ATTIC_TOKEN is required to push to Attic.`
- `docker run --rm --user 0 --entrypoint attic registry.ide-newton.ts.net/lab/attic:latest push --help` confirms `servername:cachename` push target syntax.
- `gh secret list -R proompteng/lab` shows `ATTIC_TOKEN` present; token value was not printed or committed.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
