### PR TITLE
ci(nix): fix substitute-only attic smoke

### DIFF
--- a/.github/workflows/nix-cache-smoke.yml
+++ b/.github/workflows/nix-cache-smoke.yml
@@ -117,7 +117,11 @@ jobs:
             experimental-features = nix-command flakes
             extra-substituters = http://attic.attic.svc.cluster.local/lab
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
-            max-jobs = 0
 
       - name: Prove cache smoke substitutes without local build
+        env:
+          NIX_CONFIG: |
+            extra-substituters = http://attic.attic.svc.cluster.local/lab
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+            max-jobs = 0
         run: nix build .#cacheSmoke --no-link --print-build-logs


### PR DESCRIPTION
## Summary

- Move `max-jobs = 0` out of the Nix installer configuration for the substitute-only Attic smoke job.
- Apply `max-jobs = 0` only to the final `nix build .#cacheSmoke` proof command so the runner cannot fall back to local builds during the cache substitution check.
- Keep the existing ARC runner, in-cluster Attic endpoint, public key, and main-only push behavior unchanged.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nix-cache-smoke.yml"); puts "yaml ok"'`
- `git diff --check`
- `rg -n "ATTIC_TOKEN=|eyJ[A-Za-z0-9_-]+\\.|attic\\.k8s\\.proompteng\\.ai|IngressRoute|traefik|external-dns|private-dns" .github/workflows/nix-cache-smoke.yml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
