### PR TITLE
ci(nix): stabilize attic warm cache push

### DIFF
--- a/argocd/applications/attic/deployment.yaml
+++ b/argocd/applications/attic/deployment.yaml
@@ -129,11 +129,11 @@ spec:
             timeoutSeconds: 5
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: "1"
+              cpu: 500m
               memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/nix/cache-push.sh
+++ b/nix/cache-push.sh
@@ -9,9 +9,21 @@ fi
 cache_name="${ATTIC_CACHE_NAME:-lab}"
 cache_endpoint="${ATTIC_CACHE_ENDPOINT:-http://attic.attic.svc.cluster.local}"
 server_name="${ATTIC_SERVER_NAME:-lab-ci}"
+batch_size="${ATTIC_PUSH_BATCH_SIZE:-1}"
+push_jobs="${ATTIC_PUSH_JOBS:-1}"
 
 if [[ "$#" -eq 0 ]]; then
   echo "Usage: cache-push <store-path> [<store-path> ...]" >&2
+  exit 2
+fi
+
+if ! [[ "${batch_size}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ATTIC_PUSH_BATCH_SIZE must be a positive integer, got: ${batch_size}" >&2
+  exit 2
+fi
+
+if ! [[ "${push_jobs}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ATTIC_PUSH_JOBS must be a positive integer, got: ${push_jobs}" >&2
   exit 2
 fi
 
@@ -27,5 +39,9 @@ done
 echo "Logging in to Attic endpoint ${cache_endpoint} for cache ${cache_name}."
 attic login --set-default "${server_name}" "${cache_endpoint}" "${ATTIC_TOKEN}" >/dev/null
 
-echo "Pushing ${#paths[@]} path(s) to Attic cache ${cache_name}."
-attic push "${server_name}:${cache_name}" "${paths[@]}"
+echo "Pushing ${#paths[@]} path(s) to Attic cache ${cache_name} in batches of ${batch_size} with ${push_jobs} upload job(s)."
+for ((start = 0; start < ${#paths[@]}; start += batch_size)); do
+  batch=("${paths[@]:start:batch_size}")
+  echo "Pushing batch $((start / batch_size + 1)) with ${#batch[@]} path(s)."
+  attic push --jobs "${push_jobs}" "${server_name}:${cache_name}" "${batch[@]}"
+done


### PR DESCRIPTION
## Summary

- Raise the Attic API deployment from `100m/256Mi` requests and `1 CPU/1Gi` limits to `500m/1Gi` requests and `2 CPU/4Gi` limits after the main warm-cache push OOMKilled the pod.
- Batch `nix/cache-push.sh` by explicit input path, defaulting to one path per `attic push`, so the single-replica cache API is not hit with the full warm set in one request.
- Force conservative Attic upload concurrency with `--jobs 1` by default while keeping `ATTIC_PUSH_JOBS` available for explicit future tuning.
- Preserve fail-closed behavior: missing tokens, invalid batch or job counts, missing store paths, or any failed batch still fail the CI step.

## Related Issues

None

## Testing

- `shellcheck nix/cache-push.sh`
- `kustomize build argocd/applications/attic >/tmp/attic-kustomize.yaml`
- `kubeconform -strict -ignore-missing-schemas /tmp/attic-kustomize.yaml`
- `git diff --check`
- `rg -n "ATTIC_TOKEN=|eyJ[A-Za-z0-9_-]+\\.|attic\\.k8s\\.proompteng\\.ai|IngressRoute|traefik|external-dns|private-dns" argocd/applications/attic nix/cache-push.sh .github docs || true`
- Fake `attic` harness confirmed three input paths with `ATTIC_PUSH_BATCH_SIZE=2` and `ATTIC_PUSH_JOBS=1` produce two `attic push --jobs 1` batches.
- Fake `attic` harness confirmed `ATTIC_PUSH_BATCH_SIZE=0` and `ATTIC_PUSH_JOBS=0` fail closed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
