### PR TITLE
ci(nix): decouple attic warm cache push

### DIFF
--- a/.github/workflows/nix-cache-warm.yml
+++ b/.github/workflows/nix-cache-warm.yml
@@ -1,0 +1,89 @@
+name: nix-cache-warm
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'docs/nix-cache.md'
+      - '.github/workflows/nix-cache-warm.yml'
+      - '.github/workflows/nix-toolchain.yml'
+      - '.github/workflows/nix-cache-smoke.yml'
+      - '.github/workflows/oci-native-build-common.yml'
+      - 'packages/scripts/src/shared/oci.ts'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    runs-on: arc-arm64
+    timeout-minutes: 120
+    env:
+      ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
+      ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
+      ATTIC_PUSH_BATCH_SIZE: '1'
+      ATTIC_PUSH_JOBS: '1'
+      ATTIC_PUSH_NO_CLOSURE: 'true'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Ensure Attic public key is configured
+        run: test -n "${ATTIC_PUBLIC_KEY}"
+
+      - name: Install xz for Nix installer
+        run: |
+          if command -v xz >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache xz
+          elif command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y xz-utils
+          else
+            echo "No supported package manager found to install xz." >&2
+            exit 1
+          fi
+
+      - name: Install Nix with Attic pull substituter
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            extra-substituters = http://attic.attic.svc.cluster.local/lab
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+
+      - name: Resolve selected warm cache store paths
+        run: |
+          nix build --no-link --print-out-paths \
+            .#cacheSmoke \
+            .#toolchainDoctor \
+            .#ociDoctor \
+            .#lintArgocd \
+            .#renderHeadlamp \
+            .#lintArgoWorkflows \
+            .#cachePush \
+            .#createOciIndex \
+            .#inspectOciImage \
+            .#assertOciPlatforms \
+            > /tmp/attic-warm-cache-paths
+          echo "Resolved $(wc -l < /tmp/attic-warm-cache-paths) store path(s)."
+
+      - name: Push selected warm cache closures
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+        run: |
+          mapfile -t paths < /tmp/attic-warm-cache-paths
+          nix run .#cache-push -- "${paths[@]}"

--- a/.github/workflows/nix-toolchain.yml
+++ b/.github/workflows/nix-toolchain.yml
@@ -20,6 +20,7 @@ on:
       - 'argocd/**/*.yaml'
       - '.github/workflows/nix-toolchain.yml'
       - '.github/workflows/nix-cache-smoke.yml'
+      - '.github/workflows/nix-cache-warm.yml'
       - '.github/workflows/oci-native-build-common.yml'
       - '.github/workflows/oci-builder-benchmark.yml'
       - '.github/workflows/kubeconform.yml'
@@ -45,6 +46,7 @@ on:
       - 'argocd/**/*.yaml'
       - '.github/workflows/nix-toolchain.yml'
       - '.github/workflows/nix-cache-smoke.yml'
+      - '.github/workflows/nix-cache-warm.yml'
       - '.github/workflows/oci-native-build-common.yml'
       - '.github/workflows/oci-builder-benchmark.yml'
       - '.github/workflows/kubeconform.yml'
@@ -113,28 +115,3 @@ jobs:
 
       - name: Lint Argo Workflow manifests
         run: nix run .#lint-argo-workflows
-
-      - name: Resolve warm cache store paths
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          nix build --no-link --print-out-paths \
-            .#cacheSmoke \
-            .#toolchainDoctor \
-            .#ociDoctor \
-            .#lintArgocd \
-            .#renderHeadlamp \
-            .#lintArgoWorkflows \
-            .#cachePush \
-            .#createOciIndex \
-            .#inspectOciImage \
-            .#assertOciPlatforms \
-            > /tmp/attic-warm-cache-paths
-          echo "Resolved $(wc -l < /tmp/attic-warm-cache-paths) store path(s)."
-
-      - name: Push warm cache closures
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
-        run: |
-          mapfile -t paths < /tmp/attic-warm-cache-paths
-          nix run .#cache-push -- "${paths[@]}"

--- a/docs/nix-cache.md
+++ b/docs/nix-cache.md
@@ -181,6 +181,20 @@ available.
 Pushes require `ATTIC_TOKEN` and must be restricted to trusted `main` branch
 workflows.
 
+Cache correctness is proven by `.github/workflows/nix-cache-smoke.yml`:
+
+- pull requests consume the public Attic cache without `ATTIC_TOKEN`
+- `main` pushes publish only the repo-local `cacheSmoke` closure
+- `main` then runs a fresh substitute-only proof with `max-jobs = 0`
+
+Selected helper closure warming runs separately in
+`.github/workflows/nix-cache-warm.yml`. That workflow is main-only, uses the
+in-cluster endpoint, pushes selected helper outputs with `--no-closure`, and has
+an explicit timeout so large first-warm uploads cannot pin the required
+`nix-toolchain` check. The default `cache.nixos.org` fallback remains available
+for Nixpkgs dependencies, so the warm workflow should not duplicate the upstream
+Nixpkgs closure into Attic.
+
 The helper refuses to run without a token:
 
 ```bash

--- a/nix/cache-push.sh
+++ b/nix/cache-push.sh
@@ -11,6 +11,7 @@ cache_endpoint="${ATTIC_CACHE_ENDPOINT:-http://attic.attic.svc.cluster.local}"
 server_name="${ATTIC_SERVER_NAME:-lab-ci}"
 batch_size="${ATTIC_PUSH_BATCH_SIZE:-1}"
 push_jobs="${ATTIC_PUSH_JOBS:-1}"
+push_no_closure="${ATTIC_PUSH_NO_CLOSURE:-false}"
 
 if [[ "$#" -eq 0 ]]; then
   echo "Usage: cache-push <store-path> [<store-path> ...]" >&2
@@ -27,6 +28,21 @@ if ! [[ "${push_jobs}" =~ ^[1-9][0-9]*$ ]]; then
   exit 2
 fi
 
+case "${push_no_closure}" in
+  1 | true | TRUE | yes | YES)
+    push_no_closure_enabled=true
+    push_mode="specified paths only"
+    ;;
+  0 | false | FALSE | no | NO)
+    push_no_closure_enabled=false
+    push_mode="closures"
+    ;;
+  *)
+    echo "ATTIC_PUSH_NO_CLOSURE must be true or false, got: ${push_no_closure}" >&2
+    exit 2
+    ;;
+esac
+
 paths=()
 for path in "$@"; do
   if [[ ! -e "${path}" ]]; then
@@ -39,9 +55,14 @@ done
 echo "Logging in to Attic endpoint ${cache_endpoint} for cache ${cache_name}."
 attic login --set-default "${server_name}" "${cache_endpoint}" "${ATTIC_TOKEN}" >/dev/null
 
-echo "Pushing ${#paths[@]} path(s) to Attic cache ${cache_name} in batches of ${batch_size} with ${push_jobs} upload job(s)."
+echo "Pushing ${#paths[@]} path(s) to Attic cache ${cache_name} in batches of ${batch_size} with ${push_jobs} upload job(s), mode: ${push_mode}."
 for ((start = 0; start < ${#paths[@]}; start += batch_size)); do
   batch=("${paths[@]:start:batch_size}")
   echo "Pushing batch $((start / batch_size + 1)) with ${#batch[@]} path(s)."
-  attic push --jobs "${push_jobs}" "${server_name}:${cache_name}" "${batch[@]}"
+  push_args=(push --jobs "${push_jobs}")
+  if [[ "${push_no_closure_enabled}" == true ]]; then
+    push_args+=(--no-closure)
+  fi
+  push_args+=("${server_name}:${cache_name}" "${batch[@]}")
+  attic "${push_args[@]}"
 done


### PR DESCRIPTION
## Summary

- Removes the selected-closure Attic warm push from required `nix-toolchain`, so the required toolchain check cannot hang on a large first-warm upload.
- Adds a separate main-only `nix-cache-warm` workflow for selected helper outputs, using ARC, the in-cluster Attic endpoint, serial uploads, and `--no-closure`.
- Adds `ATTIC_PUSH_NO_CLOSURE` support to `nix/cache-push.sh` and documents the split between fail-closed cache correctness proof and best-scoped cache warming.

## Related Issues

None

## Testing

- `shellcheck nix/cache-push.sh`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/nix-toolchain.yml .github/workflows/nix-cache-smoke.yml .github/workflows/nix-cache-warm.yml`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/nix-toolchain.yml .github/workflows/nix-cache-smoke.yml .github/workflows/nix-cache-warm.yml`
- `git diff --check`
- `rg -n "attic\\.k8s\\.proompteng\\.ai|IngressRoute|traefik|external-dns|private-dns|ATTIC_TOKEN=|eyJ[A-Za-z0-9_-]+\\.|BEGIN .*PRIVATE" .github/workflows/nix-toolchain.yml .github/workflows/nix-cache-smoke.yml .github/workflows/nix-cache-warm.yml docs/nix-cache.md nix || true`
- Fake `attic` harness verified `ATTIC_PUSH_NO_CLOSURE=true` emits `attic push --jobs 1 --no-closure`, default mode omits `--no-closure`, and invalid values fail closed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
