### PR TITLE
fix(agents): bump agents chart version

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.26
+version: 0.9.27
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.26
+version: 0.9.27
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Bump the agents Helm chart metadata version from 0.9.26 to 0.9.27.
- Keep Chart.yaml and Artifact Hub package metadata aligned so chart publishing does not collide with an existing immutable version.
- Unblocks the main agents-sync rollout after PR #11529 merged.

## Related Issues

None

## Testing

- mise exec helm@3 -- helm lint charts/agents
- git diff --check

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
