### PR TITLE
chore(symphony): promote image cf447cdc

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:52:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T07:21:28Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "fd5460d7"
-    digest: sha256:cbb48845efc4bc480f79957a8df28e09386cca311cfc282ba68887607279d15a
+    newTag: "cf447cdc"
+    digest: sha256:f3c80b34a170e0832379d1cb105a15abbc4ac977e65a4cb5f42e38dcbba04c38

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:52:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T07:21:28Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "fd5460d7"
-    digest: sha256:cbb48845efc4bc480f79957a8df28e09386cca311cfc282ba68887607279d15a
+    newTag: "cf447cdc"
+    digest: sha256:f3c80b34a170e0832379d1cb105a15abbc4ac977e65a4cb5f42e38dcbba04c38

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-27T21:52:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T07:21:28Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "fd5460d7"
-    digest: sha256:cbb48845efc4bc480f79957a8df28e09386cca311cfc282ba68887607279d15a
+    newTag: "cf447cdc"
+    digest: sha256:f3c80b34a170e0832379d1cb105a15abbc4ac977e65a4cb5f42e38dcbba04c38


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `cf447cdc03e958be278fd4a35962a7cd50770bd2`
- Image tag: `cf447cdc`
- Image digest: `sha256:f3c80b34a170e0832379d1cb105a15abbc4ac977e65a4cb5f42e38dcbba04c38`