### PR TITLE
ci(agents): reduce native image cache export

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -72,12 +72,12 @@ jobs:
           AGENTS_IMAGE_PLATFORMS: ${{ matrix.platform }}
           AGENTS_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-buildcache:${{ matrix.arch }}
           AGENTS_RUNNER_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-codex-runner:buildcache-${{ matrix.arch }}
-          AGENTS_BUILD_CACHE_MODE: max
+          AGENTS_BUILD_CACHE_MODE: min
           AGENTS_BUILD_NODE_OPTIONS: --max-old-space-size=4096
           AGENTS_BUILD_SOURCEMAP: '0'
           AGENTS_BUILD_CI: 'true'
           AGENTS_BUILD_LOG_LEVEL: warn
-          DOCKER_BUILD_PROVENANCE: max
+          DOCKER_BUILD_PROVENANCE: min
           DOCKER_BUILD_SBOM: 'true'
         run: bun run agents:deploy -- --no-apply
 


### PR DESCRIPTION
## Summary

- Reduce `agents-build-push` BuildKit cache export from `max` to `min`.
- Reduce Docker provenance mode from `max` to `min` for native Agents image builds.
- Keep normal multi-arch image publishing intact while avoiding oversized registry cache/provenance exports.

## Related Issues

None

## Testing

- `git diff --check`
- `python3` YAML parse check for `.github/workflows/agents-build-push.yml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
