### PR TITLE
ci(agents): disable native build attestations

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -77,8 +77,8 @@ jobs:
           AGENTS_BUILD_SOURCEMAP: '0'
           AGENTS_BUILD_CI: 'true'
           AGENTS_BUILD_LOG_LEVEL: warn
-          DOCKER_BUILD_PROVENANCE: min
-          DOCKER_BUILD_SBOM: 'true'
+          DOCKER_BUILD_PROVENANCE: 'false'
+          DOCKER_BUILD_SBOM: 'false'
         run: bun run agents:deploy -- --no-apply
 
   publish-index:


### PR DESCRIPTION
## Summary

- Disabled BuildKit provenance and SBOM attestation export in the Agents native image promotion workflow.
- Kept the existing native multi-arch build, push, cache, and publish-index path unchanged.
- Avoids the observed registry export stall while preserving the normal GitOps promotion flow for `agents-shell`.

## Related Issues

None

## Testing

- `python3` YAML parse check for `.github/workflows/agents-build-push.yml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
