### PR TITLE
ci(agents): disable default build attestations

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -77,6 +77,7 @@ jobs:
           AGENTS_BUILD_SOURCEMAP: '0'
           AGENTS_BUILD_CI: 'true'
           AGENTS_BUILD_LOG_LEVEL: warn
+          BUILDX_NO_DEFAULT_ATTESTATIONS: '1'
           DOCKER_BUILD_PROVENANCE: 'false'
           DOCKER_BUILD_SBOM: 'false'
         run: bun run agents:deploy -- --no-apply


### PR DESCRIPTION
## Summary

- Disabled Buildx default provenance attestations in `agents-build-push`.
- Keeps explicit provenance and SBOM env disabled for the same workflow.
- Targets the observed BuildKit export stall that continued after removing explicit `--attest` flags.

## Related Issues

None

## Testing

- `python3` YAML parse check for `.github/workflows/agents-build-push.yml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
