### PR TITLE
ci(agents): disable registry build cache

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -70,8 +70,8 @@ jobs:
           AGENTS_DOCKERFILE: services/agents/Dockerfile
           AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
           AGENTS_IMAGE_PLATFORMS: ${{ matrix.platform }}
-          AGENTS_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-buildcache:${{ matrix.arch }}
-          AGENTS_RUNNER_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-codex-runner:buildcache-${{ matrix.arch }}
+          AGENTS_BUILD_CACHE_REF: 'false'
+          AGENTS_RUNNER_BUILD_CACHE_REF: 'false'
           AGENTS_BUILD_CACHE_MODE: min
           AGENTS_BUILD_NODE_OPTIONS: --max-old-space-size=4096
           AGENTS_BUILD_SOURCEMAP: '0'

--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -78,6 +78,23 @@ describe('agents build-image helpers', () => {
     )
   })
 
+  it('allows CI to disable registry cache refs explicitly', () => {
+    process.env.AGENTS_BUILD_CACHE_REF = 'false'
+
+    expect(
+      __private.resolveBuildConfiguration({
+        registry: 'registry.example',
+        repository: 'lab/agents-controller',
+        tag: 'abc123',
+        commit: 'abcdef',
+      }).cacheRef,
+    ).toBeUndefined()
+    expect(__private.resolveCacheRef(undefined, 'off', 'registry.example/cache:latest')).toBeUndefined()
+    expect(__private.resolveCacheRef(undefined, undefined, 'registry.example/cache:latest')).toBe(
+      'registry.example/cache:latest',
+    )
+  })
+
   it('uses the Agents workspace as the default control-plane prune scope', () => {
     expect(__private.parsePruneScopes(undefined, 'control-plane')).toEqual([
       '@proompteng/agents',

--- a/packages/scripts/src/agents/build-image.ts
+++ b/packages/scripts/src/agents/build-image.ts
@@ -33,7 +33,7 @@ type BuildConfiguration = {
   version: string
   commit: string
   codexAuthPath: string
-  cacheRef: string
+  cacheRef?: string
   cacheMode?: DockerCacheMode
   platforms?: string[]
   buildArgs: Record<string, string>
@@ -47,6 +47,18 @@ const parsePlatforms = (value: string | undefined): string[] | undefined => {
     .filter(Boolean)
 
   return platforms.length > 0 ? platforms : undefined
+}
+
+const disabledCacheRefValues = new Set(['', '0', 'false', 'none', 'off', 'disabled'])
+
+export const resolveCacheRef = (optionValue: string | undefined, envValue: string | undefined, fallback: string) => {
+  const raw = optionValue ?? envValue
+  if (raw === undefined) return fallback
+
+  const normalized = raw.trim()
+  if (disabledCacheRefValues.has(normalized.toLowerCase())) return undefined
+
+  return normalized
 }
 
 const defaultPruneScopesForTarget = (_target: string | undefined): string[] => [
@@ -183,7 +195,11 @@ const resolveBuildConfiguration = (options: BuildImageOptions = {}): BuildConfig
   const commit = options.commit ?? process.env.AGENTS_COMMIT ?? execGit(['rev-parse', 'HEAD'])
   const codexAuthPath =
     options.codexAuthPath ?? process.env.CODEX_AUTH_PATH ?? resolve(process.env.HOME ?? '', '.codex/auth.json')
-  const cacheRef = options.cacheRef ?? process.env.AGENTS_BUILD_CACHE_REF ?? `${registry}/${repository}:buildcache`
+  const cacheRef = resolveCacheRef(
+    options.cacheRef,
+    process.env.AGENTS_BUILD_CACHE_REF,
+    `${registry}/${repository}:buildcache`,
+  )
   const cacheMode = options.cacheMode ?? parseCacheMode(process.env.AGENTS_BUILD_CACHE_MODE)
   const platforms =
     options.platforms ??
@@ -289,7 +305,7 @@ export const buildImages = async (options: BuildImageOptions[]) => {
         target: config.target,
         buildArgs: config.buildArgs,
         codexAuthPath: codexAuthPathForDocker,
-        cacheRef: cacheRefForBatchTarget(config.cacheRef, targetName, hasSharedCacheRef),
+        cacheRef: config.cacheRef ? cacheRefForBatchTarget(config.cacheRef, targetName, hasSharedCacheRef) : undefined,
         cacheMode: config.cacheMode,
         platforms: config.platforms,
       }
@@ -323,6 +339,7 @@ export const __private = {
   execGit,
   parsePlatforms,
   parsePruneScopes,
+  resolveCacheRef,
   resolveBuildConfiguration,
   removeNestedNodeModules,
 }

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
 import YAML from 'yaml'
-import { buildImages, type BuildImageOptions } from './build-image'
+import { buildImages, resolveCacheRef, type BuildImageOptions } from './build-image'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
 import { buildAndPushDockerImage, inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
@@ -576,8 +576,11 @@ const main = async () => {
       context: repoRoot,
       dockerfile: options.runnerDockerfile,
       codexAuthPath: options.codexAuthPath,
-      cacheRef:
-        process.env.AGENTS_RUNNER_BUILD_CACHE_REF ?? `${options.registry}/${options.runnerRepository}:buildcache`,
+      cacheRef: resolveCacheRef(
+        undefined,
+        process.env.AGENTS_RUNNER_BUILD_CACHE_REF,
+        `${options.registry}/${options.runnerRepository}:buildcache`,
+      ),
       platforms: options.platforms,
     })
   }


### PR DESCRIPTION
## Summary

- Allows Agents image builds to disable registry cache refs with explicit `false`/`off` values.
- Disables registry cache import/export in `agents-build-push` for service and runner images.
- Adds regression coverage for disabled Agents build cache ref resolution.

## Related Issues

None

## Testing

- `bunx oxfmt --check .github/workflows/agents-build-push.yml packages/scripts/src/agents/build-image.ts packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/build-image.test.ts`
- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
