### PR TITLE
chore(symphony): promote image 1cf03a2d

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T07:21:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T09:29:56Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cf447cdc"
-    digest: sha256:f3c80b34a170e0832379d1cb105a15abbc4ac977e65a4cb5f42e38dcbba04c38
+    newTag: "1cf03a2d"
+    digest: sha256:faab29d30cf910cb7aece6c6c96740b56bf0904195b25dd49cbeb46ef6e4e8b8

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T07:21:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T09:29:56Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cf447cdc"
-    digest: sha256:f3c80b34a170e0832379d1cb105a15abbc4ac977e65a4cb5f42e38dcbba04c38
+    newTag: "1cf03a2d"
+    digest: sha256:faab29d30cf910cb7aece6c6c96740b56bf0904195b25dd49cbeb46ef6e4e8b8

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T07:21:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T09:29:56Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cf447cdc"
-    digest: sha256:f3c80b34a170e0832379d1cb105a15abbc4ac977e65a4cb5f42e38dcbba04c38
+    newTag: "1cf03a2d"
+    digest: sha256:faab29d30cf910cb7aece6c6c96740b56bf0904195b25dd49cbeb46ef6e4e8b8


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `1cf03a2de690110f5d289e93f87784a07480a4b6`
- Image tag: `1cf03a2d`
- Image digest: `sha256:faab29d30cf910cb7aece6c6c96740b56bf0904195b25dd49cbeb46ef6e4e8b8`