### PR TITLE
ci(agents): force native platform image builds

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -67,6 +67,7 @@ jobs:
           AGENTS_BUILD_RUNNER: 'true'
           AGENTS_DOCKERFILE: services/agents/Dockerfile
           AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
+          AGENTS_IMAGE_PLATFORMS: native
           AGENTS_BUILD_CACHE_REF: 'false'
           AGENTS_RUNNER_BUILD_CACHE_REF: 'false'
           AGENTS_BUILD_CACHE_MODE: min

--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -230,20 +230,32 @@ describe('agents build-image helpers', () => {
           repository: 'lab/agents-controller',
           tag: 'abc123-amd64',
           target: 'controller',
+          platforms: [],
         },
         {
           registry: 'registry.example',
           repository: 'lab/agents-control-plane',
           tag: 'abc123-amd64',
           target: 'control-plane',
+          platforms: [],
+        },
+        {
+          registry: 'registry.example',
+          repository: 'lab/agents-shell',
+          tag: 'abc123-amd64',
+          target: 'agents-shell',
+          platforms: [],
         },
       ])
 
       expect(results.map((result) => result.image)).toEqual([
         'registry.example/lab/agents-controller:abc123-amd64',
         'registry.example/lab/agents-control-plane:abc123-amd64',
+        'registry.example/lab/agents-shell:abc123-amd64',
       ])
       expect(commands.map((command) => command.slice(0, 2))).toEqual([
+        ['docker', 'build'],
+        ['docker', 'push'],
         ['docker', 'build'],
         ['docker', 'push'],
         ['docker', 'build'],

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -56,6 +56,38 @@ describe('agents deploy-service helpers', () => {
     ])
   })
 
+  it('uses native image plans when per-arch CI disables explicit platforms', () => {
+    process.env.AGENTS_IMAGE_TAG = 'abc123-amd64'
+    process.env.AGENTS_IMAGE_PLATFORMS = 'native'
+
+    const options = __private.resolveOptions()
+
+    expect(options.platforms).toEqual([])
+    expect(__private.buildAgentsServiceImagePlans(options)).toEqual([
+      {
+        registry: 'registry.ide-newton.ts.net',
+        repository: 'lab/agents-controller',
+        tag: 'abc123-amd64',
+        target: 'controller',
+        platforms: [],
+      },
+      {
+        registry: 'registry.ide-newton.ts.net',
+        repository: 'lab/agents-control-plane',
+        tag: 'abc123-amd64',
+        target: 'control-plane',
+        platforms: [],
+      },
+      {
+        registry: 'registry.ide-newton.ts.net',
+        repository: 'lab/agents-shell',
+        tag: 'abc123-amd64',
+        target: 'agents-shell',
+        platforms: [],
+      },
+    ])
+  })
+
   it('treats local Codex auth as optional for runner image builds', () => {
     const previousHome = process.env.HOME
     const dir = mkdtempSync(join(tmpdir(), 'agents-codex-auth-'))

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -249,6 +249,7 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).not.toContain('platform: linux/')
     expect(workflow).not.toContain('AGENTS_IMAGE_PLATFORMS: ${{ matrix.platform }}')
     expect(workflow).not.toContain('AGENTS_IMAGE_PLATFORMS: linux/amd64,linux/arm64')
+    expect(workflow).toContain('AGENTS_IMAGE_PLATFORMS: native')
     expect(workflow).toContain("AGENTS_BUILD_CACHE_REF: 'false'")
     expect(workflow).toContain("AGENTS_RUNNER_BUILD_CACHE_REF: 'false'")
     expect(workflow).toContain("BUILDX_NO_DEFAULT_ATTESTATIONS: '1'")

--- a/packages/scripts/src/agents/build-image.ts
+++ b/packages/scripts/src/agents/build-image.ts
@@ -39,8 +39,13 @@ type BuildConfiguration = {
   buildArgs: Record<string, string>
 }
 
+const nativePlatformValues = new Set(['0', 'false', 'host', 'local', 'native', 'none', 'off'])
+
 const parsePlatforms = (value: string | undefined): string[] | undefined => {
   if (!value) return undefined
+  const normalized = value.trim().toLowerCase()
+  if (nativePlatformValues.has(normalized)) return []
+
   const platforms = value
     .split(',')
     .map((platform) => platform.trim())

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -95,8 +95,13 @@ const parseBoolean = (value: string | undefined, fallback: boolean): boolean => 
   return fallback
 }
 
+const nativePlatformValues = new Set(['0', 'false', 'host', 'local', 'native', 'none', 'off'])
+
 const parsePlatforms = (value: string | undefined): string[] | undefined => {
   if (!value) return undefined
+  const normalized = value.trim().toLowerCase()
+  if (nativePlatformValues.has(normalized)) return []
+
   const platforms = value
     .split(',')
     .map((platform) => platform.trim())


### PR DESCRIPTION
## Summary

- Add an explicit `AGENTS_IMAGE_PLATFORMS: native` setting to the per-architecture Agents image publication workflow.
- Teach the Agents build/deploy platform parsers to treat `native`/disabled platform values as host-native Docker builds instead of multi-platform Buildx builds.
- Add regression coverage for the native controller, control-plane, and agents-shell batch image path.

## Related Issues

None

## Testing

- `bunx oxfmt --check .github/workflows/agents-build-push.yml packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/build-image.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bun test packages/scripts/src`
- `bun run --filter @proompteng/scripts lint`
- `bun run --cwd packages/scripts lint:oxlint`
- `bun run --cwd packages/scripts lint:oxlint:type`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
