### PR TITLE
chore(torghut): promote ta image 1cf03a2d

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:4eb3be1c3177da53237ea6715bd682969f180a76ceb7b9d914190eb96b0ca7e7
   imagePullPolicy: IfNotPresent
-  restartNonce: 16
+  restartNonce: 17
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -88,9 +88,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: 1cf03a2d
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: 1cf03a2de690110f5d289e93f87784a07480a4b6
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:4eb3be1c3177da53237ea6715bd682969f180a76ceb7b9d914190eb96b0ca7e7
   imagePullPolicy: IfNotPresent
-  restartNonce: 18
+  restartNonce: 19
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: 1cf03a2d
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: 1cf03a2de690110f5d289e93f87784a07480a4b6
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:4eb3be1c3177da53237ea6715bd682969f180a76ceb7b9d914190eb96b0ca7e7
   imagePullPolicy: IfNotPresent
-  restartNonce: 13
+  restartNonce: 14
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: 1cf03a2d
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: 1cf03a2de690110f5d289e93f87784a07480a4b6
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `1cf03a2de690110f5d289e93f87784a07480a4b6`
- Image tag: `1cf03a2d`
- Image digest: `sha256:4eb3be1c3177da53237ea6715bd682969f180a76ceb7b9d914190eb96b0ca7e7`
- Manifests: live TA, sim TA, options TA