### PR TITLE
chore(jangar): promote image 1cf03a2d

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-28T07:09:14Z
+    deploy.knative.dev/rollout: 2026-06-28T09:45:20Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: cf447cdc03e958be278fd4a35962a7cd50770bd2
+              value: 1cf03a2de690110f5d289e93f87784a07480a4b6
             - name: JANGAR_GITOPS_REVISION
-              value: cf447cdc03e958be278fd4a35962a7cd50770bd2
+              value: 1cf03a2de690110f5d289e93f87784a07480a4b6
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28313926674"
+              value: "28318252263"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:5885fe23196d4f4aef9b1de95f64728f92f69711abda1c474ce0762ba93b806f
+              value: sha256:5746c7351dade0c94ee0baa16b0526729fcad01767d9d8e9ea1760103f9e1766
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: cf447cdc03e958be278fd4a35962a7cd50770bd2
+              value: 1cf03a2de690110f5d289e93f87784a07480a4b6
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:5885fe23196d4f4aef9b1de95f64728f92f69711abda1c474ce0762ba93b806f
+              value: sha256:5746c7351dade0c94ee0baa16b0526729fcad01767d9d8e9ea1760103f9e1766
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: cf447cdc
-    digest: sha256:5885fe23196d4f4aef9b1de95f64728f92f69711abda1c474ce0762ba93b806f
+    newTag: 1cf03a2d
+    digest: sha256:5746c7351dade0c94ee0baa16b0526729fcad01767d9d8e9ea1760103f9e1766


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `1cf03a2de690110f5d289e93f87784a07480a4b6`
- Image tag: `1cf03a2d`
- Image digest: `sha256:5746c7351dade0c94ee0baa16b0526729fcad01767d9d8e9ea1760103f9e1766`
- Source CI run: `28318252263`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates