### PR TITLE
fix(arc): avoid duplicate runner work volume

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -29,14 +29,6 @@ spec:
             - arc-arm64
           minRunners: 1
           maxRunners: 3
-          containerMode:
-            type: "kubernetes"
-            kubernetesModeWorkVolumeClaim:
-              accessModes: ["ReadWriteOnce"]
-              storageClassName: "rook-ceph-block"
-              resources:
-                requests:
-                  storage: 20Gi
           listenerTemplate:
             spec:
               dnsConfig:
@@ -167,14 +159,6 @@ spec:
             - arc-amd64
           minRunners: 0
           maxRunners: 2
-          containerMode:
-            type: "kubernetes"
-            kubernetesModeWorkVolumeClaim:
-              accessModes: ["ReadWriteOnce"]
-              storageClassName: "rook-ceph-block"
-              resources:
-                requests:
-                  storage: 20Gi
           listenerTemplate:
             spec:
               dnsConfig:
@@ -302,14 +286,6 @@ spec:
             - arc-arm64
           minRunners: 0
           maxRunners: 2
-          containerMode:
-            type: "kubernetes"
-            kubernetesModeWorkVolumeClaim:
-              accessModes: ["ReadWriteOnce"]
-              storageClassName: "rook-ceph-block"
-              resources:
-                requests:
-                  storage: 20Gi
           listenerTemplate:
             spec:
               dnsConfig:


### PR DESCRIPTION
## Summary

- Remove `containerMode` from customized ARC runner scale-set values so the chart does not inject a second `work` volume type.
- Keep the explicit runner pod templates and ephemeral PVC-backed `work` volumes owned by the template.
- Fixes runner pod creation failures where `work` rendered with both `emptyDir` and `ephemeral` volume sources.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applications/arc/application.yaml`
- `ruby -ryaml -e 'YAML.load_file(ARGV[0]); puts "yaml ok"' argocd/applications/arc/application.yaml`
- Live mitigation applied: removed duplicate `emptyDir` from `arc-amd64` and `arc-arm64` AutoscalingRunnerSet `work` volumes; replacement runner pods reached `2/2 Running`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The runner templates still use ephemeral PVC-backed work volumes; this removes only the conflicting chart container-mode injection.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
