### PR TITLE
fix(agents-shell): mark shell tools private

### DIFF
--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -242,7 +242,7 @@ describe('agents-shell MCP tools', () => {
 
     const shellRun = tools.tools.find((tool) => tool.name === 'shell_run')
     expect(shellRun?.annotations?.destructiveHint).toBe(false)
-    expect(shellRun?.annotations?.openWorldHint).toBe(true)
+    expect(shellRun?.annotations?.openWorldHint).toBe(false)
 
     const git = tools.tools.find((tool) => tool.name === 'git')
     expect(git?.annotations?.readOnlyHint).toBe(true)

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -145,7 +145,7 @@ const writeAnnotations: ToolAnnotations = {
 const shellAnnotations: ToolAnnotations = {
   readOnlyHint: false,
   destructiveHint: false,
-  openWorldHint: true,
+  openWorldHint: false,
 }
 
 const destructiveAnnotations: ToolAnnotations = {
@@ -185,7 +185,7 @@ const shellInputSchema = {
     .string()
     .min(1)
     .describe(
-      'Short user-requested bash command executed with /bin/bash -lc inside the private agents-shell container.',
+      'User-requested terminal command line executed inside the private agents-shell workspace container. The tool returns output only and does not publish messages or data.',
     ),
   cwd: z.string().optional().describe('Working directory under /workspace. Defaults to /workspace.'),
   timeoutSeconds: z.number().int().min(1).optional().describe('Timeout in seconds, capped by server policy.'),
@@ -1046,7 +1046,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
     {
       title: 'Run shell command',
       description:
-        'Use this for a short, user-requested bash command inside the private agents-shell container, such as diagnostics, tests, build scripts, Python scripts, or other workspace automation. It returns stdout, stderr, exit code, and job metadata. The server enforces /workspace cwd bounds, timeout caps, output caps, OAuth scopes, and audit logging. Prefer workspace_search, workspace_read_file, git, and kubectl for read-only inspection before running a shell command.',
+        'Use this for a short, user-requested terminal command inside the private agents-shell workspace container, such as diagnostics, tests, build scripts, Python scripts, or other workspace automation. It returns stdout, stderr, exit code, and job metadata. The tool does not publish messages or data; the server enforces /workspace cwd bounds, timeout caps, output caps, OAuth scopes, and audit logging. Prefer workspace_search, workspace_read_file, git, and kubectl for read-only inspection before running a terminal command.',
       inputSchema: shellInputSchema,
       outputSchema: shellJobSchema,
       annotations: shellAnnotations,
@@ -1069,7 +1069,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
     {
       title: 'Start shell job',
       description:
-        'Use this for a long-running, user-requested bash command inside agents-shell, such as a dev server, test suite, or script. Poll the job with shell_read and stop it with shell_kill. The server enforces /workspace cwd bounds, timeout caps, output caps, OAuth scopes, and audit logging.',
+        'Use this for a long-running, user-requested terminal command inside the private agents-shell workspace container, such as a dev server, test suite, or script. Poll the job with shell_read and stop it with shell_kill. The tool does not publish messages or data; the server enforces /workspace cwd bounds, timeout caps, output caps, OAuth scopes, and audit logging.',
       inputSchema: shellInputSchema,
       outputSchema: shellJobSchema,
       annotations: shellAnnotations,


### PR DESCRIPTION
## Summary

- Mark `shell_run` and `shell_start` as private-container tools with `openWorldHint: false`.
- Clarify shell command schema/descriptions so ChatGPT treats harmless workspace terminal commands separately from external/admin actions.
- Keep `kubectl_admin` and `git_write` as the explicit destructive/admin surfaces.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `bun test services/agents/src/server/agents-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents lint`
- `bun run --filter @proompteng/agents tsc`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
