### PR TITLE
feat(agents): make agents-shell agentic

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -55,6 +55,23 @@ agentsShell:
       AGENTS_SHELL_MAX_OUTPUT_BYTES: "200000"
       AGENTS_SHELL_MAX_CONCURRENT_JOBS: "4"
       AGENTS_SHELL_ENABLE_K8S_APPLY: "true"
+      HOME: /workspace/.agents-shell/home
+      AGENTS_SHELL_GIT_USER_NAME: Greg Konush
+      AGENTS_SHELL_GIT_USER_EMAIL: greg@proompteng.ai
+      AGENTS_SHELL_AGENT_NAMESPACE: agents
+      AGENTS_SHELL_AGENT_NAME: codex-agent
+      AGENTS_SHELL_AGENT_REPOSITORY: proompteng/lab
+      AGENTS_SHELL_AGENT_BASE_BRANCH: main
+      AGENTS_SHELL_AGENT_VCS_REF: github
+      AGENTS_SHELL_AGENT_RUNTIME_SERVICE_ACCOUNT: agents-sa
+      AGENTS_SHELL_AGENT_SECRETS: github-token,codex-auth
+    secrets:
+      - name: GITHUB_TOKEN
+        secretName: github-token
+        key: token
+      - name: GH_TOKEN
+        secretName: github-token
+        key: token
   rbac:
     clusterAdmin: true
     extraReadNamespaces:
@@ -82,7 +99,7 @@ agentsShell:
       repository: https://github.com/proompteng/lab.git
       branch: main
       targetPath: /workspace/lab
-      depth: 1
+      depth: 0
       tokenSecret:
         name: github-token
         key: token

--- a/charts/agents/templates/agents-shell-deployment.yaml
+++ b/charts/agents/templates/agents-shell-deployment.yaml
@@ -98,9 +98,16 @@ spec:
                 git config --global credential.helper 'store --file=/tmp/git-credentials'
               fi
 
+              fetch_args=()
+              clone_args=()
+              if [[ "${GIT_DEPTH}" != "0" ]]; then
+                fetch_args=(--depth="${GIT_DEPTH}")
+                clone_args=(--depth="${GIT_DEPTH}")
+              fi
+
               if [[ -d "${GIT_TARGET_PATH}/.git" ]]; then
                 git -C "${GIT_TARGET_PATH}" remote set-url origin "${GIT_REPOSITORY}"
-                git -C "${GIT_TARGET_PATH}" fetch --depth="${GIT_DEPTH}" origin "${GIT_BRANCH}"
+                git -C "${GIT_TARGET_PATH}" fetch "${fetch_args[@]}" origin "${GIT_BRANCH}"
                 if git -C "${GIT_TARGET_PATH}" diff --quiet && git -C "${GIT_TARGET_PATH}" diff --cached --quiet; then
                   git -C "${GIT_TARGET_PATH}" checkout -B "${GIT_BRANCH}" FETCH_HEAD
                   git -C "${GIT_TARGET_PATH}" reset --hard FETCH_HEAD
@@ -112,10 +119,12 @@ spec:
                 exit 1
               else
                 rm -rf "${GIT_TARGET_PATH}"
-                git clone --depth="${GIT_DEPTH}" --branch="${GIT_BRANCH}" "${GIT_REPOSITORY}" "${GIT_TARGET_PATH}"
+                git clone "${clone_args[@]}" --branch="${GIT_BRANCH}" "${GIT_REPOSITORY}" "${GIT_TARGET_PATH}"
               fi
 
               git -C "${GIT_TARGET_PATH}" remote set-url origin "${GIT_REPOSITORY}"
+              git -C "${GIT_TARGET_PATH}" config user.name "Greg Konush"
+              git -C "${GIT_TARGET_PATH}" config user.email "greg@proompteng.ai"
               rm -f /tmp/git-credentials
           volumeMounts:
             - name: workspace

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -364,7 +364,7 @@
                 "repository": { "type": "string" },
                 "branch": { "type": "string" },
                 "targetPath": { "type": "string" },
-                "depth": { "type": "integer", "minimum": 1 },
+                "depth": { "type": "integer", "minimum": 0 },
                 "tokenSecret": {
                   "type": "object",
                   "properties": {

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -106,6 +106,16 @@ agentsShell:
       AGENTS_SHELL_WORKSPACE_ROOT: /workspace
       AGENTS_SHELL_AUDIT_LOG_PATH: /workspace/.agents-shell/audit.jsonl
       AGENTS_SHELL_ENABLE_K8S_APPLY: 'false'
+      HOME: /workspace/.agents-shell/home
+      AGENTS_SHELL_GIT_USER_NAME: Greg Konush
+      AGENTS_SHELL_GIT_USER_EMAIL: greg@proompteng.ai
+      AGENTS_SHELL_AGENT_NAMESPACE: agents
+      AGENTS_SHELL_AGENT_NAME: codex-agent
+      AGENTS_SHELL_AGENT_REPOSITORY: proompteng/lab
+      AGENTS_SHELL_AGENT_BASE_BRANCH: main
+      AGENTS_SHELL_AGENT_VCS_REF: github
+      AGENTS_SHELL_AGENT_RUNTIME_SERVICE_ACCOUNT: agents-sa
+      AGENTS_SHELL_AGENT_SECRETS: github-token,codex-auth
     secrets: []
     config: []
     extra: []
@@ -124,7 +134,7 @@ agentsShell:
       repository: https://github.com/proompteng/lab.git
       branch: main
       targetPath: /workspace/lab
-      depth: 1
+      depth: 0
       tokenSecret:
         name: ''
         key: token

--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -315,14 +315,33 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
   gh \
   git \
   jq \
+  openssh-client \
+  procps \
   python3 \
   ripgrep \
+  wget \
   yq; \
   ln -sf /usr/bin/python3 /usr/local/bin/python; \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app/services/agents
-RUN mkdir -p /workspace /workspace/.agents-shell
+RUN install -o root -g root -m 0755 ./scripts/apply_patch.py /usr/local/bin/apply_patch \
+  && chmod +x ./scripts/agents-shell-entrypoint.sh \
+  && mkdir -p /workspace /workspace/.agents-shell \
+  && command -v bash git gh rg curl jq yq python3 ps wget kubectl apply_patch \
+  && tmp="$(mktemp -d)" \
+  && cd "$tmp" \
+  && printf '%s\n' old > smoke.txt \
+  && printf '%s\n' \
+    '*** Begin Patch' \
+    '*** Update File: smoke.txt' \
+    '@@' \
+    '-old' \
+    '+new' \
+    '*** End Patch' \
+    | apply_patch \
+  && grep -qx new smoke.txt \
+  && rm -rf "$tmp"
 
 ENV AGENTS_SERVER_PROFILE=agents-shell \
   AGENTS_GRPC_ENABLED=0 \
@@ -334,4 +353,4 @@ ENV AGENTS_SERVER_PROFILE=agents-shell \
   AGENTS_SHELL_OAUTH_ISSUER=https://auth.proompteng.ai/realms/master \
   AGENTS_SHELL_ALLOWED_K8S_NAMESPACES=agents
 
-CMD ["bun", "run", "start:agents-shell"]
+CMD ["./scripts/agents-shell-entrypoint.sh"]

--- a/services/agents/scripts/agents-shell-entrypoint.sh
+++ b/services/agents/scripts/agents-shell-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME="${HOME:-/workspace/.agents-shell/home}"
+mkdir -p "${HOME}" /workspace/.agents-shell
+
+git config --global user.name "${AGENTS_SHELL_GIT_USER_NAME:-Greg Konush}"
+git config --global user.email "${AGENTS_SHELL_GIT_USER_EMAIL:-greg@proompteng.ai}"
+git config --global --add safe.directory /workspace/lab
+git config --global init.defaultBranch main
+
+if [[ -n "${GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
+  export GH_TOKEN="${GITHUB_TOKEN}"
+fi
+if [[ -n "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
+  export GITHUB_TOKEN="${GH_TOKEN}"
+fi
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  gh auth setup-git --hostname github.com
+fi
+
+exec bun run start:agents-shell

--- a/services/agents/scripts/apply-patch.test.ts
+++ b/services/agents/scripts/apply-patch.test.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const script = fileURLToPath(new URL('./apply_patch.py', import.meta.url))
+
+const tempRoots: string[] = []
+
+const tempWorkspace = () => {
+  const root = mkdtempSync(join(tmpdir(), 'agents-apply-patch-'))
+  tempRoots.push(root)
+  return root
+}
+
+const runPatch = (cwd: string, patch: string) =>
+  spawnSync('python3', [script], {
+    cwd,
+    input: patch,
+    encoding: 'utf8',
+  })
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop()
+    if (root) rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('apply_patch script', () => {
+  it('applies Codex add, update, and delete sections', () => {
+    const cwd = tempWorkspace()
+
+    const add = runPatch(
+      cwd,
+      ['*** Begin Patch', '*** Add File: src/example.txt', '+old', '*** End Patch', ''].join('\n'),
+    )
+    expect(add.status).toBe(0)
+    expect(readFileSync(join(cwd, 'src/example.txt'), 'utf8')).toBe('old\n')
+
+    const update = runPatch(
+      cwd,
+      ['*** Begin Patch', '*** Update File: src/example.txt', '@@', '-old', '+new', '*** End Patch', ''].join('\n'),
+    )
+    expect(update.status).toBe(0)
+    expect(readFileSync(join(cwd, 'src/example.txt'), 'utf8')).toBe('new\n')
+
+    const remove = runPatch(
+      cwd,
+      ['*** Begin Patch', '*** Delete File: src/example.txt', '*** End Patch', ''].join('\n'),
+    )
+    expect(remove.status).toBe(0)
+    expect(existsSync(join(cwd, 'src/example.txt'))).toBe(false)
+  })
+
+  it('keeps patch paths under the working directory', () => {
+    const cwd = tempWorkspace()
+    writeFileSync(join(cwd, 'safe.txt'), 'safe\n')
+
+    const result = runPatch(
+      cwd,
+      ['*** Begin Patch', '*** Add File: ../escape.txt', '+bad', '*** End Patch', ''].join('\n'),
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('patch path must stay under working directory')
+    expect(existsSync(join(cwd, '../escape.txt'))).toBe(false)
+  })
+
+  it('accepts the Codex end-of-file marker in update hunks', () => {
+    const cwd = tempWorkspace()
+    writeFileSync(join(cwd, 'example.txt'), 'old\n')
+
+    const result = runPatch(
+      cwd,
+      [
+        '*** Begin Patch',
+        '*** Update File: example.txt',
+        '@@',
+        '-old',
+        '+new',
+        '*** End of File',
+        '*** End Patch',
+        '',
+      ].join('\n'),
+    )
+
+    expect(result.status).toBe(0)
+    expect(readFileSync(join(cwd, 'example.txt'), 'utf8')).toBe('new\n')
+  })
+})

--- a/services/agents/scripts/apply_patch.py
+++ b/services/agents/scripts/apply_patch.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class PatchError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class AddFile:
+    path: str
+    lines: list[str]
+
+
+@dataclass(frozen=True)
+class DeleteFile:
+    path: str
+
+
+@dataclass(frozen=True)
+class UpdateFile:
+    path: str
+    hunks: list[list[tuple[str, str]]]
+    move_to: str | None = None
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def resolve_under_cwd(raw_path: str) -> Path:
+    if not raw_path or "\0" in raw_path:
+        raise PatchError("patch path is empty or invalid")
+    candidate = Path(raw_path)
+    if candidate.is_absolute():
+        raise PatchError(f"patch path must be relative: {raw_path}")
+
+    root = Path.cwd().resolve()
+    resolved = (root / candidate).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PatchError(f"patch path must stay under working directory: {raw_path}") from exc
+    return resolved
+
+
+def parse_section_path(line: str, marker: str) -> str:
+    if not line.startswith(marker):
+        raise PatchError(f"expected {marker}")
+    path = line[len(marker) :].strip()
+    if not path:
+        raise PatchError(f"missing path after {marker}")
+    return path
+
+
+def is_file_section(line: str) -> bool:
+    return line.startswith("*** Add File: ") or line.startswith("*** Update File: ") or line.startswith("*** Delete File: ")
+
+
+def parse_patch(patch: str) -> list[AddFile | DeleteFile | UpdateFile]:
+    normalized = patch.replace("\r\n", "\n").replace("\r", "\n")
+    if not normalized.strip():
+        raise PatchError("patch is empty")
+    if not normalized.lstrip().startswith("*** Begin Patch"):
+        raise PatchError("patch must start with *** Begin Patch")
+    if not normalized.rstrip().endswith("*** End Patch"):
+        raise PatchError("patch must end with *** End Patch")
+
+    lines = normalized.split("\n")
+    while lines and lines[-1] == "":
+        lines.pop()
+    if lines[0].strip() != "*** Begin Patch":
+        raise PatchError("patch must start with *** Begin Patch")
+    if lines[-1].strip() != "*** End Patch":
+        raise PatchError("patch must end with *** End Patch")
+
+    operations: list[AddFile | DeleteFile | UpdateFile] = []
+    index = 1
+    while index < len(lines) - 1:
+        line = lines[index]
+        if line.startswith("*** Add File: "):
+            path = parse_section_path(line, "*** Add File: ")
+            index += 1
+            added: list[str] = []
+            while index < len(lines) - 1 and not lines[index].startswith("*** "):
+                entry = lines[index]
+                if not entry.startswith("+"):
+                    raise PatchError(f"add-file lines must start with '+': {entry}")
+                added.append(entry[1:])
+                index += 1
+            operations.append(AddFile(path=path, lines=added))
+            continue
+
+        if line.startswith("*** Delete File: "):
+            path = parse_section_path(line, "*** Delete File: ")
+            operations.append(DeleteFile(path=path))
+            index += 1
+            continue
+
+        if line.startswith("*** Update File: "):
+            path = parse_section_path(line, "*** Update File: ")
+            index += 1
+            move_to: str | None = None
+            if index < len(lines) - 1 and lines[index].startswith("*** Move to: "):
+                move_to = parse_section_path(lines[index], "*** Move to: ")
+                index += 1
+
+            hunks: list[list[tuple[str, str]]] = []
+            while index < len(lines) - 1 and not is_file_section(lines[index]):
+                if lines[index] == "*** End of File":
+                    index += 1
+                    continue
+                if lines[index].startswith("@@"):
+                    index += 1
+
+                hunk: list[tuple[str, str]] = []
+                while index < len(lines) - 1 and not lines[index].startswith("@@") and not is_file_section(lines[index]):
+                    entry = lines[index]
+                    if entry == "*** End of File":
+                        index += 1
+                        break
+                    if not entry:
+                        raise PatchError("patch change lines must start with space, '+', or '-'")
+                    prefix = entry[0]
+                    if prefix not in {" ", "+", "-"}:
+                        raise PatchError(f"unknown patch line prefix {prefix!r}: {entry}")
+                    hunk.append((prefix, entry[1:]))
+                    index += 1
+
+                if hunk:
+                    hunks.append(hunk)
+
+            operations.append(UpdateFile(path=path, hunks=hunks, move_to=move_to))
+            continue
+
+        raise PatchError(f"unknown patch section: {line}")
+
+    if not operations:
+        raise PatchError("patch contains no file operations")
+    return operations
+
+
+def lines_to_text(lines: list[str]) -> str:
+    return "".join(f"{line}\n" for line in lines)
+
+
+def hunk_text(hunk: list[tuple[str, str]], prefixes: set[str]) -> str:
+    return "".join(f"{line}\n" for prefix, line in hunk if prefix in prefixes)
+
+
+def apply_update(path: Path, hunks: list[list[tuple[str, str]]]) -> str:
+    if not path.exists():
+        raise PatchError(f"file does not exist: {path}")
+    original = path.read_text()
+    updated = original
+    cursor = 0
+    for hunk in hunks:
+        old = hunk_text(hunk, {" ", "-"})
+        new = hunk_text(hunk, {" ", "+"})
+        if old:
+            location = updated.find(old, cursor)
+            if location == -1:
+                location = updated.find(old)
+            if location == -1:
+                raise PatchError(f"patch hunk did not match: {path}")
+            updated = f"{updated[:location]}{new}{updated[location + len(old):]}"
+            cursor = location + len(new)
+        else:
+            updated = f"{updated[:cursor]}{new}{updated[cursor:]}"
+            cursor += len(new)
+    return updated
+
+
+def apply_operations(operations: list[AddFile | DeleteFile | UpdateFile]) -> list[str]:
+    changed: list[str] = []
+    for operation in operations:
+        if isinstance(operation, AddFile):
+            path = resolve_under_cwd(operation.path)
+            if path.exists():
+                raise PatchError(f"file already exists: {operation.path}")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(lines_to_text(operation.lines))
+            changed.append(operation.path)
+            continue
+
+        if isinstance(operation, DeleteFile):
+            path = resolve_under_cwd(operation.path)
+            if not path.exists():
+                raise PatchError(f"file does not exist: {operation.path}")
+            path.unlink()
+            changed.append(operation.path)
+            continue
+
+        path = resolve_under_cwd(operation.path)
+        updated = apply_update(path, operation.hunks) if operation.hunks else path.read_text()
+        if operation.move_to:
+            target = resolve_under_cwd(operation.move_to)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(updated)
+            if target != path and path.exists():
+                path.unlink()
+            changed.append(operation.move_to)
+        else:
+            path.write_text(updated)
+            changed.append(operation.path)
+
+    return changed
+
+
+def main() -> int:
+    try:
+        patch = sys.stdin.read()
+        changed = apply_operations(parse_patch(patch))
+    except PatchError as exc:
+        return fail(str(exc))
+    except OSError as exc:
+        return fail(f"patch failed: {exc}")
+
+    for path in changed:
+        print(f"changed {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    os.umask(0o022)
+    raise SystemExit(main())

--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -210,11 +210,12 @@ describe('agents-shell MCP tools', () => {
     const { client, server, clientTransport, serverTransport } = await connectServer(config)
 
     const tools = await client.listTools()
-    expect(tools.tools.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining([
+    expect(tools.tools.map((tool) => tool.name).sort()).toEqual(
+      [
         'workspace_search',
         'workspace_read_file',
-        'workspace_apply_patch',
+        'apply_patch',
+        'agent_guide',
         'shell_run',
         'shell_start',
         'shell_read',
@@ -224,10 +225,11 @@ describe('agents-shell MCP tools', () => {
         'git_write',
         'kubectl',
         'kubectl_admin',
-      ]),
-    )
-    expect(tools.tools.map((tool) => tool.name)).not.toEqual(
-      expect.arrayContaining(['git_status', 'git_diff', 'k8s_get', 'k8s_apply']),
+        'agent_start',
+        'agent_status',
+        'agent_read',
+        'agent_cancel',
+      ].sort(),
     )
 
     const search = tools.tools.find((tool) => tool.name === 'workspace_search')
@@ -242,7 +244,14 @@ describe('agents-shell MCP tools', () => {
 
     const shellRun = tools.tools.find((tool) => tool.name === 'shell_run')
     expect(shellRun?.annotations?.destructiveHint).toBe(false)
-    expect(shellRun?.annotations?.openWorldHint).toBe(false)
+    expect(shellRun?.annotations?.openWorldHint).toBe(true)
+
+    const applyPatch = tools.tools.find((tool) => tool.name === 'apply_patch')
+    expect(applyPatch?.annotations?.readOnlyHint).toBe(false)
+    expect(applyPatch?.annotations?.destructiveHint).toBe(false)
+    expect(applyPatch?._meta).toMatchObject({
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write', 'offline_access'] }],
+    })
 
     const git = tools.tools.find((tool) => tool.name === 'git')
     expect(git?.annotations?.readOnlyHint).toBe(true)
@@ -272,6 +281,10 @@ describe('agents-shell MCP tools', () => {
       securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.admin', 'offline_access'] }],
     })
 
+    const agentStart = tools.tools.find((tool) => tool.name === 'agent_start')
+    expect(agentStart?.annotations?.destructiveHint).toBe(true)
+    expect(agentStart?.annotations?.openWorldHint).toBe(true)
+
     await clientTransport.close()
     await serverTransport.close()
     await client.close()
@@ -291,22 +304,14 @@ describe('agents-shell MCP tools', () => {
     expect(rawSearch?.inputSchema?.additionalProperties).toBe(false)
 
     const rawShellRun = rawTools.find((tool) => tool.name === 'shell_run')
-    expect(
-      (rawShellRun?.inputSchema?.properties as Record<string, Record<string, unknown>>).timeoutSeconds.maximum,
-    ).toBeUndefined()
-    expect(
-      (rawShellRun?.inputSchema?.properties as Record<string, Record<string, unknown>>).maxOutputBytes.maximum,
-    ).toBeUndefined()
-    expect(
-      (rawShellRun?.outputSchema?.properties as Record<string, Record<string, unknown>>).exitCode.minimum,
-    ).toBeUndefined()
-    expect(
-      (rawShellRun?.outputSchema?.properties as Record<string, Record<string, unknown>>).exitCode.anyOf,
-    ).toBeUndefined()
-    expect((rawShellRun?.outputSchema?.properties as Record<string, Record<string, unknown>>).exitCode.type).toEqual([
-      'integer',
-      'null',
-    ])
+    expect(rawShellRun).toBeDefined()
+    const rawShellRunInputProperties = rawShellRun?.inputSchema?.properties as Record<string, Record<string, unknown>>
+    const rawShellRunOutputProperties = rawShellRun?.outputSchema?.properties as Record<string, Record<string, unknown>>
+    expect(rawShellRunInputProperties.timeoutSeconds.maximum).toBeUndefined()
+    expect(rawShellRunInputProperties.maxOutputBytes.maximum).toBeUndefined()
+    expect(rawShellRunOutputProperties.exitCode.minimum).toBeUndefined()
+    expect(rawShellRunOutputProperties.exitCode.anyOf).toBeUndefined()
+    expect(rawShellRunOutputProperties.exitCode.type).toEqual(['integer', 'null'])
 
     const rawKubectl = rawTools.find((tool) => tool.name === 'kubectl')
     expect(rawKubectl?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }])
@@ -335,8 +340,9 @@ describe('agents-shell MCP tools', () => {
     await server.close()
   })
 
-  it('reads files and blocks patch paths outside /workspace', async () => {
+  it('reads files and blocks apply_patch paths outside /workspace', async () => {
     const config = makeConfig()
+    mkdirSync(join(config.workspaceRoot, 'lab'), { recursive: true })
     writeFileSync(join(config.workspaceRoot, 'hello.txt'), 'hello from agents-shell\n')
     const { client, server, clientTransport, serverTransport } = await connectServer(config)
 
@@ -347,10 +353,9 @@ describe('agents-shell MCP tools', () => {
     expect((read.structuredContent as { content?: string } | undefined)?.content).toBe('hello from agents-shell\n')
 
     const blocked = await client.callTool({
-      name: 'workspace_apply_patch',
+      name: 'apply_patch',
       arguments: {
-        patch:
-          'diff --git a/../escape.txt b/../escape.txt\n--- a/../escape.txt\n+++ b/../escape.txt\n@@ -0,0 +1 @@\n+nope\n',
+        patch: '*** Begin Patch\n*** Update File: ../../escape.txt\n@@\n-old\n+new\n*** End Patch\n',
       },
     })
     expect(blocked.isError).toBe(true)
@@ -362,6 +367,138 @@ describe('agents-shell MCP tools', () => {
     await serverTransport.close()
     await client.close()
     await server.close()
+  })
+
+  it('applies Codex patch syntax through the apply_patch executable', async () => {
+    const config = makeConfig()
+    mkdirSync(join(config.workspaceRoot, 'lab', 'src'), { recursive: true })
+    const bin = join(config.workspaceRoot, 'bin')
+    mkdirSync(bin, { recursive: true })
+    writeFileSync(
+      join(bin, 'apply_patch'),
+      '#!/bin/sh\ncat > .patch-input\nprintf "%s\\n" "Success. Updated the following files:" "M src/example.ts"\n',
+    )
+    chmodSync(join(bin, 'apply_patch'), 0o755)
+
+    const previousPath = process.env.PATH
+    process.env.PATH = `${bin}:${previousPath ?? ''}`
+
+    const { client, server, clientTransport, serverTransport } = await connectServer(config)
+
+    try {
+      const result = await client.callTool({
+        name: 'apply_patch',
+        arguments: {
+          cwd: 'lab',
+          patch: '*** Begin Patch\n*** Add File: src/example.ts\n+export const value = 1\n*** End Patch\n',
+        },
+      })
+      expect(result.isError).not.toBe(true)
+      const content = result.structuredContent as { command?: string; changedFiles?: string[]; stdout?: string }
+      expect(content.command).toBe('apply_patch')
+      expect(content.changedFiles).toEqual(['src/example.ts'])
+      expect(content.stdout).toContain('Success. Updated the following files')
+    } finally {
+      await clientTransport.close()
+      await serverTransport.close()
+      await client.close()
+      await server.close()
+
+      if (previousPath == null) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = previousPath
+      }
+    }
+  })
+
+  it('starts and observes delegated AgentRun lifecycle through generic kubectl', async () => {
+    const config = makeConfig()
+    const bin = join(config.workspaceRoot, 'bin')
+    mkdirSync(bin, { recursive: true })
+    writeFileSync(
+      join(bin, 'kubectl'),
+      `#!/bin/sh
+printf '%s\\n' "$@" >> "\${PWD}/kubectl-calls.txt"
+if [ "$1" = "apply" ]; then
+  cat > "\${PWD}/kubectl-stdin.json"
+  printf '%s\\n' 'agentrun.agents.proompteng.ai/created configured'
+elif [ "$1" = "get" ] && [ "$2" = "agentrun" ]; then
+  printf '%s\\n' '{"status":{"phase":"Running","vcs":{"headBranch":"codex/demo"}}}'
+elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  printf '%s\\n' '{"items":[{"metadata":{"name":"job-1"}}]}'
+elif [ "$1" = "logs" ]; then
+  printf '%s\\n' 'delegated log line'
+elif [ "$1" = "delete" ]; then
+  printf '%s\\n' 'agentrun deleted'
+fi
+`,
+    )
+    chmodSync(join(bin, 'kubectl'), 0o755)
+
+    const previousPath = process.env.PATH
+    process.env.PATH = `${bin}:${previousPath ?? ''}`
+
+    const { client, server, clientTransport, serverTransport } = await connectServer(
+      config,
+      makeAuth(['agents-shell.read', 'agents-shell.write', 'agents-shell.admin']),
+    )
+
+    try {
+      const start = await client.callTool({
+        name: 'agent_start',
+        arguments: {
+          task: 'Make a small repo change, test it, commit, push, create a PR, and monitor CI.',
+          headBranch: 'codex/demo',
+        },
+      })
+      expect(start.isError).not.toBe(true)
+      const startContent = start.structuredContent as {
+        agentRunName?: string
+        headBranch?: string
+        apply?: { stdout?: string }
+      }
+      expect(startContent.headBranch).toBe('codex/demo')
+      expect(startContent.apply?.stdout).toContain('agentrun.agents.proompteng.ai/created configured')
+
+      const manifest = JSON.parse(readFileSync(join(config.workspaceRoot, 'kubectl-stdin.json'), 'utf8')) as {
+        spec?: {
+          implementation?: { inline?: { text?: string } }
+          parameters?: { repository?: string; base?: string; head?: string }
+          vcsPolicy?: { mode?: string }
+        }
+      }
+      expect(manifest.spec?.implementation?.inline?.text).toContain('Make a small repo change')
+      expect(manifest.spec?.parameters).toMatchObject({
+        repository: 'proompteng/lab',
+        base: 'main',
+        head: 'codex/demo',
+      })
+      expect(manifest.spec?.vcsPolicy?.mode).toBe('read-write')
+
+      const agentRunName = startContent.agentRunName!
+      const status = await client.callTool({ name: 'agent_status', arguments: { agentRunName } })
+      expect((status.structuredContent as { agentRun?: { status?: { phase?: string } } }).agentRun?.status?.phase).toBe(
+        'Running',
+      )
+
+      const logs = await client.callTool({ name: 'agent_read', arguments: { agentRunName } })
+      expect((logs.structuredContent as { stdout?: string }).stdout).toContain('delegated log line')
+
+      const cancel = await client.callTool({ name: 'agent_cancel', arguments: { agentRunName } })
+      expect((cancel.structuredContent as { stdout?: string }).stdout).toContain('agentrun deleted')
+    } finally {
+      await clientTransport.close()
+      await serverTransport.close()
+      await client.close()
+      await server.close()
+
+      if (previousPath == null) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = previousPath
+      }
+    }
   })
 
   it('searches workspace files with ripgrep instead of empty piped stdin', async () => {

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -63,6 +63,19 @@ type ProcessResult = {
   stderrTruncated: boolean
 }
 
+type AgentStartInput = {
+  task: string
+  headBranch?: string
+  baseBranch?: string
+  repository?: string
+  agentName?: string
+  tokenBudget?: number
+  ttlSecondsAfterFinished?: number
+  acceptanceCriteria?: string[]
+  timeoutSeconds?: number
+  maxOutputBytes?: number
+}
+
 type OAuth2SecurityScheme = {
   type: 'oauth2'
   scopes: string[]
@@ -104,6 +117,15 @@ export type AgentsShellConfig = {
   auditLogPath: string | null
   allowedK8sNamespaces: Set<string>
   k8sApplyEnabled: boolean
+  agentNamespace: string
+  agentName: string
+  agentRepository: string
+  agentBaseBranch: string
+  agentVcsRef: string
+  agentRuntimeServiceAccount: string
+  agentSecrets: string[]
+  agentDefaultTokenBudget: number
+  agentDefaultTtlSecondsAfterFinished: number
   port: number
   host: string
 }
@@ -112,6 +134,30 @@ const AGENTS_SHELL_VERSION = '0.1.0'
 const DEFAULT_RESOURCE = 'https://agents-shell.proompteng.ai'
 const DEFAULT_ISSUER = 'https://auth.proompteng.ai/realms/master'
 const PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource'
+const DEFAULT_AGENT_NAMESPACE = 'agents'
+const DEFAULT_AGENT_NAME = 'codex-agent'
+const DEFAULT_AGENT_REPOSITORY = 'proompteng/lab'
+const DEFAULT_AGENT_BASE_BRANCH = 'main'
+const DEFAULT_AGENT_VCS_REF = 'github'
+const DEFAULT_AGENT_RUNTIME_SERVICE_ACCOUNT = 'agents-sa'
+const DEFAULT_AGENT_SECRETS = ['github-token', 'codex-auth']
+const DEFAULT_AGENT_TOKEN_BUDGET = 250_000
+const DEFAULT_AGENT_TTL_SECONDS_AFTER_FINISHED = 86_400
+
+const AGENT_GUIDE = `Use agents-shell as a production coding agent for /workspace/lab.
+
+Default repo workflow:
+1. Inspect state first with git status, rg, file reads, and targeted commands.
+2. Create a codex/... branch from fresh origin/main.
+3. Edit files with apply_patch using Codex patch syntax.
+4. Run focused tests, lint, type checks, or smoke commands that prove the change.
+5. Commit as Greg Konush, push the branch, create a pull request with gh, and monitor CI.
+6. Continue until the task is complete, CI status is checked, and the PR URL is available.
+
+Use shell_run for short commands, shell_start/read/status/kill for long commands, git and git_write for repository operations, kubectl and kubectl_admin for cluster operations, and agent_start/status/read/cancel for delegated long-running Codex AgentRun work. Report blockers only with exact tool calls, timestamps, logs, and the layer that failed.`
+
+const SERVER_INSTRUCTIONS =
+  'Agents-shell is a private tool-only ChatGPT app for end-to-end agentic work inside /workspace/lab. Inspect with rg/git/read tools, edit only with apply_patch, test, commit as Greg Konush, push, create PRs with gh, monitor CI, and use agent_start for non-trivial delegated work. Continue until completion or an evidence-backed blocker. Tools are bounded by OAuth scopes, audit logs, cwd, timeout, output caps, and Kubernetes RBAC.'
 
 const SCOPES = {
   read: 'agents-shell.read',
@@ -145,7 +191,7 @@ const writeAnnotations: ToolAnnotations = {
 const shellAnnotations: ToolAnnotations = {
   readOnlyHint: false,
   destructiveHint: false,
-  openWorldHint: false,
+  openWorldHint: true,
 }
 
 const destructiveAnnotations: ToolAnnotations = {
@@ -208,6 +254,11 @@ const parseList = (value: string | undefined) =>
       .map((item) => item.trim())
       .filter(Boolean),
   )
+
+const parseArray = (value: string | undefined, fallback: string[]) => {
+  const parsed = Array.from(parseList(value))
+  return parsed.length > 0 ? parsed : fallback
+}
 
 const parseListenPort = (env: NodeJS.ProcessEnv) => {
   const raw = env.PORT ?? env.AGENTS_SHELL_LISTEN_PORT ?? '8080'
@@ -313,6 +364,17 @@ export const defaultAgentsShellConfigFromEnv = (env: NodeJS.ProcessEnv = process
     auditLogPath: env.AGENTS_SHELL_AUDIT_LOG_PATH ?? '/workspace/.agents-shell/audit.jsonl',
     allowedK8sNamespaces: parseList(env.AGENTS_SHELL_ALLOWED_K8S_NAMESPACES ?? 'agents'),
     k8sApplyEnabled: env.AGENTS_SHELL_ENABLE_K8S_APPLY === 'true',
+    agentNamespace: env.AGENTS_SHELL_AGENT_NAMESPACE ?? DEFAULT_AGENT_NAMESPACE,
+    agentName: env.AGENTS_SHELL_AGENT_NAME ?? DEFAULT_AGENT_NAME,
+    agentRepository: env.AGENTS_SHELL_AGENT_REPOSITORY ?? DEFAULT_AGENT_REPOSITORY,
+    agentBaseBranch: env.AGENTS_SHELL_AGENT_BASE_BRANCH ?? DEFAULT_AGENT_BASE_BRANCH,
+    agentVcsRef: env.AGENTS_SHELL_AGENT_VCS_REF ?? DEFAULT_AGENT_VCS_REF,
+    agentRuntimeServiceAccount: env.AGENTS_SHELL_AGENT_RUNTIME_SERVICE_ACCOUNT ?? DEFAULT_AGENT_RUNTIME_SERVICE_ACCOUNT,
+    agentSecrets: parseArray(env.AGENTS_SHELL_AGENT_SECRETS, DEFAULT_AGENT_SECRETS),
+    agentDefaultTokenBudget: Number(env.AGENTS_SHELL_AGENT_DEFAULT_TOKEN_BUDGET ?? DEFAULT_AGENT_TOKEN_BUDGET),
+    agentDefaultTtlSecondsAfterFinished: Number(
+      env.AGENTS_SHELL_AGENT_DEFAULT_TTL_SECONDS_AFTER_FINISHED ?? DEFAULT_AGENT_TTL_SECONDS_AFTER_FINISHED,
+    ),
     port: parseListenPort(env),
     host: env.HOST ?? env.AGENTS_SHELL_HOST ?? '0.0.0.0',
   }
@@ -872,32 +934,123 @@ const withToolErrors =
     }
   }
 
-const extractPatchPaths = (patch: string) => {
+const extractCodexPatchPaths = (patch: string) => {
   const paths = new Set<string>()
   for (const line of patch.split('\n')) {
-    const diffMatch = line.match(/^diff --git a\/(.+) b\/(.+)$/)
-    if (diffMatch) {
-      paths.add(diffMatch[1])
-      paths.add(diffMatch[2])
-      continue
-    }
-    const fileMatch = line.match(/^(?:---|\+\+\+) (?:a\/|b\/)?(.+)$/)
-    if (fileMatch && fileMatch[1] !== '/dev/null') {
-      paths.add(fileMatch[1].split('\t')[0])
-      continue
-    }
+    const fileMatch = line.match(/^\*\*\* (?:Add File|Update File|Delete File|Move to): (.+)$/)
+    if (fileMatch) paths.add(fileMatch[1].trim())
   }
   return Array.from(paths)
 }
 
-const validatePatchPaths = (workspaceRoot: string, cwd: string, patch: string) => {
-  const paths = extractPatchPaths(patch)
-  if (paths.length === 0) throw new Error('patch does not contain recognizable file paths')
+const validateCodexPatch = (workspaceRoot: string, cwd: string, patch: string) => {
+  if (!patch.trimStart().startsWith('*** Begin Patch')) {
+    throw new Error("patch must start with '*** Begin Patch'")
+  }
+  if (!patch.trimEnd().endsWith('*** End Patch')) {
+    throw new Error("patch must end with '*** End Patch'")
+  }
+  const paths = extractCodexPatchPaths(patch)
+  if (paths.length === 0) throw new Error('patch does not contain recognizable Codex patch file paths')
   for (const path of paths) {
     const candidate = resolve(cwd, path)
     if (!isInsidePath(resolve(workspaceRoot), candidate)) {
       throw new Error(`patch path must stay under workspace: ${path}`)
     }
+  }
+  return paths
+}
+
+const slugifyKubernetesName = (value: string) => {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || 'task'
+}
+
+const boundedKubernetesName = (parts: string[]) => {
+  const suffix = randomUUID().slice(0, 8)
+  const prefix = parts.map(slugifyKubernetesName).filter(Boolean).join('-')
+  const maxPrefixLength = 63 - suffix.length - 1
+  return `${prefix.slice(0, maxPrefixLength).replace(/-+$/g, '')}-${suffix}`
+}
+
+const agentRunNameFromInput = (task: string) => boundedKubernetesName(['agents-shell', task])
+
+const buildAgentRunManifest = (config: AgentsShellConfig, args: AgentStartInput) => {
+  const agentRunName = agentRunNameFromInput(args.task)
+  const baseBranch = args.baseBranch ?? config.agentBaseBranch
+  const headBranch = args.headBranch ?? `codex/${agentRunName}`
+  const repository = args.repository ?? config.agentRepository
+  const agentName = args.agentName ?? config.agentName
+  const tokenBudget = asPositiveInteger(args.tokenBudget, 'tokenBudget', config.agentDefaultTokenBudget, 1_000_000, 1)
+  const ttlSecondsAfterFinished = asPositiveInteger(
+    args.ttlSecondsAfterFinished,
+    'ttlSecondsAfterFinished',
+    config.agentDefaultTtlSecondsAfterFinished,
+    604_800,
+    0,
+  )
+
+  return {
+    apiVersion: 'agents.proompteng.ai/v1alpha1',
+    kind: 'AgentRun',
+    metadata: {
+      name: agentRunName,
+      namespace: config.agentNamespace,
+      labels: {
+        'app.kubernetes.io/name': 'agents-shell',
+        'app.kubernetes.io/component': 'delegated-agent',
+      },
+    },
+    spec: {
+      agentRef: { name: agentName },
+      implementation: {
+        inline: {
+          summary: `agents-shell delegated work: ${args.task.slice(0, 200)}`,
+          text: args.task,
+          acceptanceCriteria: args.acceptanceCriteria,
+          source: {
+            provider: 'custom',
+            externalId: `${repository}:${headBranch}`,
+            url: config.resource,
+          },
+          vcsRef: { name: config.agentVcsRef },
+        },
+      },
+      goal: {
+        objective: args.task,
+        tokenBudget,
+      },
+      ttlSecondsAfterFinished,
+      parameters: {
+        repository,
+        base: baseBranch,
+        head: headBranch,
+        stage: 'implementation',
+      },
+      runtime: {
+        type: 'job',
+        config: {
+          serviceAccountName: config.agentRuntimeServiceAccount,
+        },
+      },
+      secrets: config.agentSecrets,
+      vcsRef: { name: config.agentVcsRef },
+      vcsPolicy: {
+        required: true,
+        mode: 'read-write',
+      },
+    },
+  }
+}
+
+const parseJsonOrNull = (value: string) => {
+  try {
+    return value.trim() ? (JSON.parse(value) as unknown) : null
+  } catch {
+    return null
   }
 }
 
@@ -908,8 +1061,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       version: config.version,
     },
     {
-      instructions:
-        'Agents-shell is a private tool-only ChatGPT app for bounded agentic work inside /workspace. Use workspace tools for file search/read/patch operations. Use shell_run for short user-requested commands and shell_start/shell_read/shell_kill for long-running scripts. Use git and kubectl for generic read-only argv-based repository and Kubernetes inspection. Use git_write or kubectl_admin only when the user explicitly asks for a mutation or admin operation. Always inspect state before mutating. The shell and CLI tools are bounded by OAuth scopes, audit logging, cwd, timeout, output caps, and the Kubernetes ServiceAccount RBAC.',
+      instructions: SERVER_INSTRUCTIONS,
       capabilities: {
         tools: {},
       },
@@ -994,18 +1146,20 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
   )
 
   server.registerTool(
-    'workspace_apply_patch',
+    'apply_patch',
     {
-      title: 'Apply workspace patch',
+      title: 'Apply Codex patch',
       description:
-        'Use this when applying a unified diff to files under /workspace. It validates paths, runs git apply --check, then applies the patch.',
+        'Use this when editing files under /workspace with Codex patch syntax. Pass the complete patch text beginning with *** Begin Patch and ending with *** End Patch. This is the default file-editing tool for repo work.',
       inputSchema: {
         patch: z.string().min(1),
-        cwd: z.string().optional(),
+        cwd: z.string().optional().describe('Working directory under /workspace. Defaults to /workspace/lab.'),
         timeoutSeconds: z.number().int().min(1).optional(),
         maxOutputBytes: z.number().int().min(1024).optional(),
       },
-      outputSchema: commandResultSchema,
+      outputSchema: commandResultSchema.extend({
+        changedFiles: z.array(z.string()),
+      }),
       annotations: writeAnnotations,
       ...toolSecurityMeta([SCOPES.write]),
     },
@@ -1015,31 +1169,36 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       timeoutSeconds?: number
       maxOutputBytes?: number
     }>(config, auth, WRITE_SCOPES, async (args) => {
-      const cwd = resolveExistingDirectory(config.workspaceRoot, args.cwd)
-      validatePatchPaths(config.workspaceRoot, cwd, args.patch)
-      const check = await runner.runProcess({
-        command: 'git',
-        args: ['apply', '--check', '-'],
-        cwd: relative(resolve(config.workspaceRoot), cwd) || '.',
-        stdin: args.patch,
-        timeoutSeconds: args.timeoutSeconds,
-        maxOutputBytes: args.maxOutputBytes,
-        auth,
-        auditEvent: 'workspace_apply_patch_check',
-      })
-      if (!check.ok) return jsonTextResult(check)
+      const cwd = resolveExistingDirectory(config.workspaceRoot, args.cwd ?? 'lab')
+      const changedFiles = validateCodexPatch(config.workspaceRoot, cwd, args.patch)
       const result = await runner.runProcess({
-        command: 'git',
-        args: ['apply', '-'],
+        command: 'apply_patch',
+        args: [],
         cwd: relative(resolve(config.workspaceRoot), cwd) || '.',
         stdin: args.patch,
         timeoutSeconds: args.timeoutSeconds,
         maxOutputBytes: args.maxOutputBytes,
         auth,
-        auditEvent: 'workspace_apply_patch',
+        auditEvent: 'apply_patch',
       })
-      return jsonTextResult(result)
+      return jsonTextResult({ ...result, changedFiles })
     }),
+  )
+
+  server.registerTool(
+    'agent_guide',
+    {
+      title: 'Read agent guide',
+      description:
+        'Use this when starting non-trivial repo work or when deciding whether to use direct tools or a delegated AgentRun. It returns the agents-shell operating guide.',
+      inputSchema: {},
+      outputSchema: z.object({ guide: z.string() }),
+      annotations: readOnlyAnnotations,
+      ...toolSecurityMeta([SCOPES.read]),
+    },
+    withToolErrors<Record<string, never>>(config, auth, READ_SCOPES, async () =>
+      jsonTextResult({ guide: AGENT_GUIDE }),
+    ),
   )
 
   server.registerTool(
@@ -1323,6 +1482,212 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
           }),
         )
       },
+    ),
+  )
+
+  server.registerTool(
+    'agent_start',
+    {
+      title: 'Start delegated agent',
+      description:
+        'Use this when a non-trivial repo task should continue server-side until it is complete. It creates a real AgentRun for proompteng/lab with read-write VCS, GitHub credentials, and Codex runtime defaults.',
+      inputSchema: {
+        task: z.string().min(1).describe('Complete task prompt for the delegated coding agent.'),
+        headBranch: z.string().min(1).optional().describe('Optional branch name. Defaults to codex/<generated-name>.'),
+        baseBranch: z.string().min(1).optional().describe('Base branch. Defaults to main.'),
+        repository: z.string().min(1).optional().describe('Repository in owner/name form. Defaults to proompteng/lab.'),
+        agentName: z.string().min(1).optional().describe('Agent resource name. Defaults to codex-agent.'),
+        tokenBudget: z.number().int().min(1).optional(),
+        ttlSecondsAfterFinished: z.number().int().min(0).optional(),
+        acceptanceCriteria: z.array(z.string().min(1)).max(50).optional(),
+        timeoutSeconds: z.number().int().min(1).optional(),
+        maxOutputBytes: z.number().int().min(1024).optional(),
+      },
+      outputSchema: z.object({
+        ok: z.boolean(),
+        agentRunName: z.string(),
+        namespace: z.string(),
+        repository: z.string(),
+        baseBranch: z.string(),
+        headBranch: z.string(),
+        apply: commandResultSchema,
+      }),
+      annotations: destructiveAnnotations,
+      ...toolSecurityMeta([SCOPES.admin]),
+    },
+    withToolErrors<AgentStartInput>(config, auth, [SCOPES.admin], async (args) => {
+      const manifest = buildAgentRunManifest(config, args)
+      const spec = manifest.spec as {
+        parameters: { repository: string; base: string; head: string }
+      }
+      const result = await runner.runProcess({
+        command: 'kubectl',
+        args: ['apply', '-n', config.agentNamespace, '-f', '-'],
+        stdin: JSON.stringify(manifest, null, 2),
+        timeoutSeconds: args.timeoutSeconds,
+        maxOutputBytes: args.maxOutputBytes,
+        auth,
+        auditEvent: 'agent_start',
+      })
+      return jsonTextResult({
+        ok: result.ok,
+        agentRunName: manifest.metadata.name,
+        namespace: config.agentNamespace,
+        repository: spec.parameters.repository,
+        baseBranch: spec.parameters.base,
+        headBranch: spec.parameters.head,
+        apply: result,
+      })
+    }),
+  )
+
+  server.registerTool(
+    'agent_status',
+    {
+      title: 'Read delegated agent status',
+      description:
+        'Use this when checking a delegated AgentRun. It returns the live AgentRun object and matching Jobs so ChatGPT can continue from exact runtime evidence.',
+      inputSchema: {
+        agentRunName: z.string().min(1),
+        namespace: z.string().min(1).optional(),
+        timeoutSeconds: z.number().int().min(1).optional(),
+        maxOutputBytes: z.number().int().min(1024).optional(),
+      },
+      outputSchema: z.object({
+        ok: z.boolean(),
+        agentRunName: z.string(),
+        namespace: z.string(),
+        agentRun: z.unknown().nullable(),
+        jobs: z.unknown().nullable(),
+        getAgentRun: commandResultSchema,
+        getJobs: commandResultSchema,
+      }),
+      annotations: openReadOnlyAnnotations,
+      ...toolSecurityMeta([SCOPES.read]),
+    },
+    withToolErrors<{
+      agentRunName: string
+      namespace?: string
+      timeoutSeconds?: number
+      maxOutputBytes?: number
+    }>(config, auth, READ_SCOPES, async (args) => {
+      const namespace = args.namespace ?? config.agentNamespace
+      const getAgentRun = await runner.runProcess({
+        command: 'kubectl',
+        args: ['get', 'agentrun', args.agentRunName, '-n', namespace, '-o', 'json'],
+        timeoutSeconds: args.timeoutSeconds,
+        maxOutputBytes: args.maxOutputBytes,
+        auth,
+        auditEvent: 'agent_status_get_agentrun',
+      })
+      const getJobs = await runner.runProcess({
+        command: 'kubectl',
+        args: [
+          'get',
+          'jobs',
+          '-n',
+          namespace,
+          '-l',
+          `agents.proompteng.ai/agent-run=${args.agentRunName}`,
+          '-o',
+          'json',
+        ],
+        timeoutSeconds: args.timeoutSeconds,
+        maxOutputBytes: args.maxOutputBytes,
+        auth,
+        auditEvent: 'agent_status_get_jobs',
+      })
+      return jsonTextResult({
+        ok: getAgentRun.ok,
+        agentRunName: args.agentRunName,
+        namespace,
+        agentRun: parseJsonOrNull(getAgentRun.stdout),
+        jobs: parseJsonOrNull(getJobs.stdout),
+        getAgentRun,
+        getJobs,
+      })
+    }),
+  )
+
+  server.registerTool(
+    'agent_read',
+    {
+      title: 'Read delegated agent logs',
+      description: 'Use this when reading retained logs from a delegated AgentRun job. It never starts a new AgentRun.',
+      inputSchema: {
+        agentRunName: z.string().min(1),
+        namespace: z.string().min(1).optional(),
+        tailLines: z.number().int().min(1).max(5000).optional(),
+        timeoutSeconds: z.number().int().min(1).optional(),
+        maxOutputBytes: z.number().int().min(1024).optional(),
+      },
+      outputSchema: commandResultSchema,
+      annotations: openReadOnlyAnnotations,
+      ...toolSecurityMeta([SCOPES.read]),
+    },
+    withToolErrors<{
+      agentRunName: string
+      namespace?: string
+      tailLines?: number
+      timeoutSeconds?: number
+      maxOutputBytes?: number
+    }>(config, auth, READ_SCOPES, async (args) => {
+      const namespace = args.namespace ?? config.agentNamespace
+      const tailLines = asPositiveInteger(args.tailLines, 'tailLines', 200, 5000, 1)
+      return jsonTextResult(
+        await runner.runProcess({
+          command: 'kubectl',
+          args: [
+            'logs',
+            '-n',
+            namespace,
+            '-l',
+            `agents.proompteng.ai/agent-run=${args.agentRunName}`,
+            '--all-containers=true',
+            '--tail',
+            String(tailLines),
+          ],
+          timeoutSeconds: args.timeoutSeconds,
+          maxOutputBytes: args.maxOutputBytes,
+          auth,
+          auditEvent: 'agent_read',
+        }),
+      )
+    }),
+  )
+
+  server.registerTool(
+    'agent_cancel',
+    {
+      title: 'Cancel delegated agent',
+      description:
+        'Use this when stopping a delegated AgentRun. It deletes the AgentRun resource so the controller can clean up owned runtime resources.',
+      inputSchema: {
+        agentRunName: z.string().min(1),
+        namespace: z.string().min(1).optional(),
+        timeoutSeconds: z.number().int().min(1).optional(),
+        maxOutputBytes: z.number().int().min(1024).optional(),
+      },
+      outputSchema: commandResultSchema,
+      annotations: destructiveAnnotations,
+      ...toolSecurityMeta([SCOPES.admin]),
+    },
+    withToolErrors<{
+      agentRunName: string
+      namespace?: string
+      timeoutSeconds?: number
+      maxOutputBytes?: number
+    }>(config, auth, [SCOPES.admin], async (args) =>
+      jsonTextResult(
+        await runner.runProcess({
+          command: 'kubectl',
+          args: ['delete', 'agentrun', args.agentRunName, '-n', args.namespace ?? config.agentNamespace],
+          timeoutSeconds: args.timeoutSeconds,
+          maxOutputBytes: args.maxOutputBytes,
+          auth,
+          auditEvent: 'agent_cancel',
+        }),
+      ),
     ),
   )
 


### PR DESCRIPTION
## Summary

- Adds generic `apply_patch`, `agent_guide`, and delegated AgentRun lifecycle MCP tools for `agents-shell`.
- Bakes durable repo-agent tooling into the `agents-shell` image, including `gh`, `rg`, `git`, `wget`, `procps`, and `/usr/local/bin/apply_patch`.
- Configures `agents-shell` workspace bootstrap for full-depth repo work, Greg Konush git identity, GitHub tokens, and PR-capable defaults for `proompteng/lab`.
- Replaces the old workspace patch tool with Codex patch syntax and coverage for tool metadata, path safety, delegated AgentRun creation, and the standalone patch executable.

## Related Issues

None

## Testing

- `bun run --cwd services/agents tsc && bun run --cwd services/agents test`
- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts packages/scripts/src/agents/__tests__/agentrun-ingestion-mitigation.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `mise exec go@1.24.13 -- bash scripts/agents/validate-agents.sh`
- `bun run --cwd services/agents lint`
- `bunx oxlint --deny-warnings services/agents/scripts/apply-patch.test.ts services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `python3 -m py_compile services/agents/scripts/apply_patch.py`
- `git diff --check`
- Pruned local image smoke: `docker build -f services/agents/Dockerfile --target agents-shell -t agents-shell:codex-agentic-local ...` with the same `json/` and `full/` context shape from `turbo prune`; the Dockerfile smoke reached `changed smoke.txt` through `/usr/local/bin/apply_patch`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
