### PR TITLE
chore(agents): promote images f7c78455

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: df2b9c13
-  digest: sha256:b5a488331e25bbf17aff2684e115904d997b6224a8e849617cc26c95ae5aec5c
+  tag: f7c78455
+  digest: sha256:03bf01064fc6fa42d53c09cc2fc51eb347e1226a8cc291d2105f719c872ecf7b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,32 +14,32 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: df2b9c13
-    digest: sha256:ba0b45e483d8e7ec2dae291906335be5b32c7e4008baae0b17b930dbeb185cd9
+    tag: f7c78455
+    digest: sha256:29cc082555d020535b6a9c10e76e6a778b1186fc2cb6cd5ddf8bcb00310ba90f
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: df2b9c13bbf6a6d4f56ef8ae27506e7d1fdc61c2
-      AGENTS_GITOPS_REVISION: df2b9c13bbf6a6d4f56ef8ae27506e7d1fdc61c2
-      AGENTS_SOURCE_CI_RUN_ID: "28323222775"
+      AGENTS_SOURCE_HEAD_SHA: f7c78455f35c9e973b12f399b02e862518b11373
+      AGENTS_GITOPS_REVISION: f7c78455f35c9e973b12f399b02e862518b11373
+      AGENTS_SOURCE_CI_RUN_ID: "28331925168"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:ba0b45e483d8e7ec2dae291906335be5b32c7e4008baae0b17b930dbeb185cd9
-      AGENTS_SERVING_BUILD_COMMIT: df2b9c13bbf6a6d4f56ef8ae27506e7d1fdc61c2
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:ba0b45e483d8e7ec2dae291906335be5b32c7e4008baae0b17b930dbeb185cd9
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:29cc082555d020535b6a9c10e76e6a778b1186fc2cb6cd5ddf8bcb00310ba90f
+      AGENTS_SERVING_BUILD_COMMIT: f7c78455f35c9e973b12f399b02e862518b11373
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:29cc082555d020535b6a9c10e76e6a778b1186fc2cb6cd5ddf8bcb00310ba90f
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: df2b9c13
-    digest: sha256:2c4b3d11339c350e79d086bec16e8c526fb086c7108c544d20077af2347dc564
+    tag: f7c78455
+    digest: sha256:0051b52c9d0a36e659be9d6e4130dd72665b4fef3fac566b98ca15b70a1f660a
 agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: df2b9c13
-    digest: sha256:1f1860f748ad1ceda3495a101a56cae0efc440146b41e7c7d7e07e8ff860217f
+    tag: f7c78455
+    digest: sha256:9e7e239f2f701bbe55b257c4112cc2859ff84d43ec20ecf5c058e995d8bdd9b3
     pullPolicy: IfNotPresent
   env:
     vars:
@@ -157,8 +157,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: df2b9c13
-    digest: sha256:b5a488331e25bbf17aff2684e115904d997b6224a8e849617cc26c95ae5aec5c
+    tag: f7c78455
+    digest: sha256:03bf01064fc6fa42d53c09cc2fc51eb347e1226a8cc291d2105f719c872ecf7b
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `f7c78455f35c9e973b12f399b02e862518b11373`
- Image tag: `f7c78455`
- Agents build run: `28331925168`
- Promotion source: `manual_dispatch`