### PR TITLE
fix(agents): preserve full-depth shell bootstrap

### DIFF
--- a/charts/agents/templates/agents-shell-deployment.yaml
+++ b/charts/agents/templates/agents-shell-deployment.yaml
@@ -72,7 +72,11 @@ spec:
             - name: GIT_TARGET_PATH
               value: {{ required "agentsShell.workspace.bootstrap.targetPath is required when bootstrap is enabled" $workspaceBootstrap.targetPath | quote }}
             - name: GIT_DEPTH
-              value: {{ default 1 $workspaceBootstrap.depth | quote }}
+              {{- if hasKey $workspaceBootstrap "depth" }}
+              value: {{ $workspaceBootstrap.depth | quote }}
+              {{- else }}
+              value: "1"
+              {{- end }}
             {{- with $workspaceBootstrap.tokenSecret }}
             {{- if .name }}
             - name: GIT_TOKEN

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -473,6 +473,23 @@ describe('scheduled AgentRun templates', () => {
     expect(objectAt(smokeRunSpec, 'secrets')).toEqual(['codex-auth'])
   })
 
+  it('preserves the agents-shell full-depth workspace bootstrap value', () => {
+    const values = readYamlObjects('argocd/applications/agents/values.yaml')[0]
+    const agentsShell = objectAt(values, 'agentsShell')
+    const workspace = objectAt(agentsShell, 'workspace')
+    const bootstrap = objectAt(workspace, 'bootstrap')
+    const deploymentTemplate = readFileSync(
+      resolve(process.cwd(), 'charts/agents/templates/agents-shell-deployment.yaml'),
+      'utf8',
+    )
+
+    expect(objectAt(bootstrap, 'enabled')).toBe(true)
+    expect(objectAt(bootstrap, 'depth')).toBe(0)
+    expect(deploymentTemplate).toContain('hasKey $workspaceBootstrap "depth"')
+    expect(deploymentTemplate).toContain('value: {{ $workspaceBootstrap.depth | quote }}')
+    expect(deploymentTemplate).not.toContain('default 1 $workspaceBootstrap.depth')
+  })
+
   it('keeps checked-in workflow AgentRuns runnable with explicit steps', () => {
     const provider = readYamlObjects('argocd/applications/agents/agents-primitives-agentprovider.yaml').find(
       (manifest) => objectAt(manifest, 'kind') === 'AgentProvider',


### PR DESCRIPTION
## Summary

- Fixes the agents-shell Helm template so an explicit workspace bootstrap depth of `0` is preserved.
- Keeps the live GitOps values on a full-depth `/workspace/lab` checkout for PR-capable agent workflows.
- Adds a regression test covering the GitOps value and template guard.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "preserves the agents-shell full-depth workspace bootstrap value"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxlint --deny-warnings packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml --show-only templates/agents-shell-deployment.yaml`
- `mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml --show-only templates/agents-shell-deployment.yaml | yq '.spec.template.spec.initContainers[] | select(.name == "bootstrap-workspace").env[] | select(.name == "GIT_DEPTH")'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
