### PR TITLE
fix(agents): preserve stale shell checkouts

### DIFF
--- a/charts/agents/templates/agents-shell-deployment.yaml
+++ b/charts/agents/templates/agents-shell-deployment.yaml
@@ -109,21 +109,44 @@ spec:
                 clone_args=(--depth="${GIT_DEPTH}")
               fi
 
+              clone_checkout() {
+                rm -rf "${GIT_TARGET_PATH}"
+                git clone "${clone_args[@]}" --branch="${GIT_BRANCH}" "${GIT_REPOSITORY}" "${GIT_TARGET_PATH}"
+              }
+
+              preserve_checkout() {
+                local reason="$1"
+                local backup_root="/workspace/.agents-shell/checkouts"
+                local backup_path="${backup_root}/$(basename "${GIT_TARGET_PATH}")-$(date -u +%Y%m%dT%H%M%SZ)"
+
+                mkdir -p "${backup_root}"
+                if [[ -e "${backup_path}" ]]; then
+                  backup_path="${backup_path}-${RANDOM}"
+                fi
+
+                echo "preserving existing workspace checkout at ${backup_path}: ${reason}" >&2
+                mv "${GIT_TARGET_PATH}" "${backup_path}"
+              }
+
               if [[ -d "${GIT_TARGET_PATH}/.git" ]]; then
                 git -C "${GIT_TARGET_PATH}" remote set-url origin "${GIT_REPOSITORY}"
-                git -C "${GIT_TARGET_PATH}" fetch "${fetch_args[@]}" origin "${GIT_BRANCH}"
-                if git -C "${GIT_TARGET_PATH}" diff --quiet && git -C "${GIT_TARGET_PATH}" diff --cached --quiet; then
+                if [[ "${GIT_DEPTH}" == "0" ]] && [[ "$(git -C "${GIT_TARGET_PATH}" rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]]; then
+                  git -C "${GIT_TARGET_PATH}" fetch --unshallow origin "${GIT_BRANCH}" || git -C "${GIT_TARGET_PATH}" fetch origin "${GIT_BRANCH}"
+                else
+                  git -C "${GIT_TARGET_PATH}" fetch "${fetch_args[@]}" origin "${GIT_BRANCH}"
+                fi
+                if timeout 60s git -C "${GIT_TARGET_PATH}" diff --quiet && timeout 60s git -C "${GIT_TARGET_PATH}" diff --cached --quiet; then
                   git -C "${GIT_TARGET_PATH}" checkout -B "${GIT_BRANCH}" FETCH_HEAD
                   git -C "${GIT_TARGET_PATH}" reset --hard FETCH_HEAD
                 else
-                  echo "workspace repository has local changes; leaving checkout unchanged"
+                  preserve_checkout "local changes or git dirty-check timeout"
+                  clone_checkout
                 fi
               elif [[ -e "${GIT_TARGET_PATH}" && -n "$(find "${GIT_TARGET_PATH}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
-                echo "workspace target exists and is not an empty git checkout: ${GIT_TARGET_PATH}" >&2
-                exit 1
+                preserve_checkout "target exists and is not an empty git checkout"
+                clone_checkout
               else
-                rm -rf "${GIT_TARGET_PATH}"
-                git clone "${clone_args[@]}" --branch="${GIT_BRANCH}" "${GIT_REPOSITORY}" "${GIT_TARGET_PATH}"
+                clone_checkout
               fi
 
               git -C "${GIT_TARGET_PATH}" remote set-url origin "${GIT_REPOSITORY}"

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -488,6 +488,11 @@ describe('scheduled AgentRun templates', () => {
     expect(deploymentTemplate).toContain('hasKey $workspaceBootstrap "depth"')
     expect(deploymentTemplate).toContain('value: {{ $workspaceBootstrap.depth | quote }}')
     expect(deploymentTemplate).not.toContain('default 1 $workspaceBootstrap.depth')
+    expect(deploymentTemplate).toContain('git -C "${GIT_TARGET_PATH}" fetch --unshallow origin "${GIT_BRANCH}"')
+    expect(deploymentTemplate).toContain('timeout 60s git -C "${GIT_TARGET_PATH}" diff --quiet')
+    expect(deploymentTemplate).toContain('/workspace/.agents-shell/checkouts')
+    expect(deploymentTemplate).toContain('preserve_checkout "local changes or git dirty-check timeout"')
+    expect(deploymentTemplate).toContain('preserve_checkout "target exists and is not an empty git checkout"')
   })
 
   it('keeps checked-in workflow AgentRuns runnable with explicit steps', () => {


### PR DESCRIPTION
## Summary

- Makes agents-shell workspace bootstrap preserve stale or dirty existing checkouts under `/workspace/.agents-shell/checkouts`.
- Recreates `/workspace/lab` from the configured branch when the existing checkout is dirty, not a git checkout, or the dirty check times out.
- Handles full-depth bootstrap for existing shallow repositories with `git fetch --unshallow`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "preserves the agents-shell full-depth workspace bootstrap value"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxlint --deny-warnings packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml --show-only templates/agents-shell-deployment.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
