### PR TITLE
fix(agents): stop requiring offline access on tools

### DIFF
--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -282,6 +282,7 @@ render_kustomize
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_agents.yaml" agents.proompteng.ai v1alpha1 Agent
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_agentruns.yaml" agents.proompteng.ai v1alpha1 AgentRun
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_agentproviders.yaml" agents.proompteng.ai v1alpha1 AgentProvider
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_versioncontrolproviders.yaml" agents.proompteng.ai v1alpha1 VersionControlProvider
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_implementationspecs.yaml" agents.proompteng.ai v1alpha1 ImplementationSpec
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_implementationsources.yaml" agents.proompteng.ai v1alpha1 ImplementationSource
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_memories.yaml" agents.proompteng.ai v1alpha1 Memory

--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -235,7 +235,7 @@ describe('agents-shell MCP tools', () => {
     const search = tools.tools.find((tool) => tool.name === 'workspace_search')
     expect(search?.annotations?.readOnlyHint).toBe(true)
     expect(search?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
       ui: { visibility: ['model'] },
       'openai/visibility': 'public',
       'openai/toolInvocation/invoking': 'Running tool',
@@ -250,20 +250,20 @@ describe('agents-shell MCP tools', () => {
     expect(applyPatch?.annotations?.readOnlyHint).toBe(false)
     expect(applyPatch?.annotations?.destructiveHint).toBe(false)
     expect(applyPatch?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write', 'offline_access'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write'] }],
     })
 
     const git = tools.tools.find((tool) => tool.name === 'git')
     expect(git?.annotations?.readOnlyHint).toBe(true)
     expect(git?.annotations?.destructiveHint).toBe(false)
     expect(git?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
     })
 
     const gitWrite = tools.tools.find((tool) => tool.name === 'git_write')
     expect(gitWrite?.annotations?.destructiveHint).toBe(true)
     expect(gitWrite?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write', 'offline_access'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write'] }],
     })
 
     const kubectl = tools.tools.find((tool) => tool.name === 'kubectl')
@@ -271,14 +271,14 @@ describe('agents-shell MCP tools', () => {
     expect(kubectl?.annotations?.destructiveHint).toBe(false)
     expect(kubectl?.annotations?.openWorldHint).toBe(true)
     expect(kubectl?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
     })
 
     const kubectlAdmin = tools.tools.find((tool) => tool.name === 'kubectl_admin')
     expect(kubectlAdmin?.annotations?.destructiveHint).toBe(true)
     expect(kubectlAdmin?.annotations?.openWorldHint).toBe(true)
     expect(kubectlAdmin?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.admin', 'offline_access'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.admin'] }],
     })
 
     const agentStart = tools.tools.find((tool) => tool.name === 'agent_start')
@@ -292,9 +292,9 @@ describe('agents-shell MCP tools', () => {
 
     const rawTools = await listToolsOnWire(config)
     const rawSearch = rawTools.find((tool) => tool.name === 'workspace_search')
-    expect(rawSearch?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }])
+    expect(rawSearch?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read'] }])
     expect(rawSearch?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
       ui: { visibility: ['model'] },
       'openai/visibility': 'public',
       'openai/toolInvocation/invoking': 'Running tool',
@@ -314,7 +314,7 @@ describe('agents-shell MCP tools', () => {
     expect(rawShellRunOutputProperties.exitCode.type).toEqual(['integer', 'null'])
 
     const rawKubectl = rawTools.find((tool) => tool.name === 'kubectl')
-    expect(rawKubectl?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }])
+    expect(rawKubectl?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read'] }])
     expect(rawKubectl?.inputSchema?.additionalProperties).toBe(false)
   })
 

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -168,7 +168,6 @@ const SCOPES = {
 
 const READ_SCOPES = [SCOPES.read, SCOPES.write, SCOPES.admin]
 const WRITE_SCOPES = [SCOPES.write, SCOPES.admin]
-const OAUTH_SESSION_SCOPES = [SCOPES.offlineAccess]
 
 const readOnlyAnnotations: ToolAnnotations = {
   readOnlyHint: true,
@@ -799,7 +798,7 @@ const summarizeJob = (
 }
 
 const toolSecurityMeta = (scopes: string[]) => {
-  const requestedScopes = Array.from(new Set([...scopes, ...OAUTH_SESSION_SCOPES]))
+  const requestedScopes = Array.from(new Set(scopes))
   const securitySchemes = [
     {
       type: 'oauth2',


### PR DESCRIPTION
## Summary

- Removes `offline_access` from per-tool OAuth security schemes for `agents-shell`.
- Keeps `offline_access` advertised in protected-resource metadata for OAuth session refresh.
- Adds the missing `VersionControlProvider` CRD schema generation to agents chart validation.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test src/server/agents-shell-mcp.test.ts`
- `bun run --cwd services/agents tsc`
- `bunx oxfmt --check services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `bunx oxlint --deny-warnings services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `mise exec go@1.24 -- scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
