### PR TITLE
fix(agents): reduce ChatGPT tool safety friction

### DIFF
--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -256,6 +256,7 @@ describe('agents-shell MCP tools', () => {
     const git = tools.tools.find((tool) => tool.name === 'git')
     expect(git?.annotations?.readOnlyHint).toBe(true)
     expect(git?.annotations?.destructiveHint).toBe(false)
+    expect(git?.annotations?.openWorldHint).toBe(false)
     expect(git?._meta).toMatchObject({
       securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
     })
@@ -540,9 +541,11 @@ fi
         exitCode?: number
         stdout?: string
       }
-      expect(content.command).toBe(
-        'rg --line-number --no-heading --color=never --hidden -g !.git --fixed-strings createAgentsShellServer .',
-      )
+      expect(content.command).toContain('rg --line-number --no-heading --color=never --hidden')
+      expect(content.command).toContain('-g !.git/**')
+      expect(content.command).toContain('-g !node_modules/**')
+      expect(content.command).toContain('-g !schemas/custom/**')
+      expect(content.command).toContain('--fixed-strings createAgentsShellServer .')
       expect(content.exitCode).toBe(0)
       expect(content.stdout).toContain('src/agents-shell.ts:1:export const createAgentsShellServer = true')
     } finally {

--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -562,6 +562,27 @@ fi
     }
   })
 
+  it('returns Codex-style operating guidance for the current ChatGPT model', async () => {
+    const config = makeConfig()
+    const { client, server, clientTransport, serverTransport } = await connectServer(config)
+
+    try {
+      const result = await client.callTool({ name: 'agent_guide', arguments: {} })
+      const content = result.structuredContent as { guide?: string }
+      expect(content.guide).toContain('current ChatGPT model')
+      expect(content.guide).toContain('AGENTS.md')
+      expect(content.guide).toContain('Respect dirty worktrees')
+      expect(content.guide).toContain('apply_patch')
+      expect(content.guide).toContain('Commit as Greg Konush')
+      expect(content.guide).toContain('create a pull request with gh')
+    } finally {
+      await clientTransport.close()
+      await serverTransport.close()
+      await client.close()
+      await server.close()
+    }
+  })
+
   it('returns an OAuth challenge when a tool lacks required scope', async () => {
     const config = makeConfig()
     const { client, server, clientTransport, serverTransport } = await connectServer(

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -161,18 +161,27 @@ const DEFAULT_WORKSPACE_SEARCH_EXCLUDES = [
 
 const AGENT_GUIDE = `Use agents-shell as a production coding agent for /workspace/lab.
 
+Operate like Codex:
+- Apply these instructions to the current ChatGPT model in this chat; do not rely on stale model-specific prompt text.
+- Persist until the request is complete or an evidence-backed blocker remains.
+- Inspect before editing: read repo state, relevant files, tests, and applicable AGENTS.md instructions.
+- Respect dirty worktrees: do not revert, overwrite, or discard changes you did not make.
+- Use rg for search, workspace_read_file for reads, and apply_patch with Codex patch syntax for edits.
+- Use destructive git, Kubernetes, or filesystem operations only when the user request clearly requires them.
+- Validate from focused tests to broader checks, then summarize exact commands and results.
+
 Default repo workflow:
-1. Inspect state first with git status, rg, file reads, and targeted commands.
-2. Create a codex/... branch from fresh origin/main.
-3. Edit files with apply_patch using Codex patch syntax.
+1. Confirm /workspace/lab is on a fresh origin/main base or preserve and report existing dirty work.
+2. Create a codex/... branch for the task.
+3. Search with workspace_search, inspect with workspace_read_file and git, and make scoped edits with apply_patch.
 4. Run focused tests, lint, type checks, or smoke commands that prove the change.
 5. Commit as Greg Konush, push the branch, create a pull request with gh, and monitor CI.
-6. Continue until the task is complete, CI status is checked, and the PR URL is available.
+6. Fix failures and continue until the task is complete, CI status is checked, and the PR URL is available.
 
-Use shell_run for short commands, shell_start/read/status/kill for long commands, git and git_write for repository operations, kubectl and kubectl_admin for cluster operations, and agent_start/status/read/cancel for delegated long-running Codex AgentRun work. Report blockers only with exact tool calls, timestamps, logs, and the layer that failed.`
+Use shell_run for short commands, shell_start/read/status/kill for long commands, git and git_write for repository operations, kubectl and kubectl_admin for cluster operations, and agent_start/status/read/cancel for delegated long-running Codex AgentRun work. Report blockers only with exact tool calls, arguments, timestamps, server logs, audit entries, live environment state, and the layer that failed.`
 
 const SERVER_INSTRUCTIONS =
-  'Agents-shell is a private tool-only ChatGPT app for end-to-end agentic work inside /workspace/lab. Inspect with rg/git/read tools, edit only with apply_patch, test, commit as Greg Konush, push, create PRs with gh, monitor CI, and use agent_start for non-trivial delegated work. Continue until completion or an evidence-backed blocker. Tools are bounded by OAuth scopes, audit logs, cwd, timeout, output caps, and Kubernetes RBAC.'
+  'Agents-shell is a private tool-only ChatGPT app for end-to-end Codex-style repo work inside /workspace/lab. Apply these instructions to the current ChatGPT model in this chat; do not rely on stale model-specific prompt text. Persist until completion or an evidence-backed blocker. Inspect repo state and applicable AGENTS.md instructions before editing. Respect dirty worktrees and never discard user changes. Search with rg, read files directly, edit with apply_patch, validate with focused tests before broader checks, commit as Greg Konush, push branches, create PRs with gh, and monitor CI. Use shell tools for terminal work, git tools for repo work, kubectl tools for cluster work, and agent_start for delegated long-running Codex AgentRun work. Tools are bounded by OAuth scopes, audit logs, cwd, timeout, output caps, and Kubernetes RBAC.'
 
 const SCOPES = {
   read: 'agents-shell.read',

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -143,6 +143,21 @@ const DEFAULT_AGENT_RUNTIME_SERVICE_ACCOUNT = 'agents-sa'
 const DEFAULT_AGENT_SECRETS = ['github-token', 'codex-auth']
 const DEFAULT_AGENT_TOKEN_BUDGET = 250_000
 const DEFAULT_AGENT_TTL_SECONDS_AFTER_FINISHED = 86_400
+const DEFAULT_WORKSPACE_SEARCH_EXCLUDES = [
+  '.git',
+  'node_modules',
+  '.next',
+  '.turbo',
+  '.cache',
+  'dist',
+  'build',
+  'coverage',
+  'target',
+  'vendor',
+  '.venv',
+  'venv',
+  'schemas/custom',
+]
 
 const AGENT_GUIDE = `Use agents-shell as a production coding agent for /workspace/lab.
 
@@ -1072,7 +1087,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
     {
       title: 'Search workspace',
       description:
-        'Use this when searching text or file contents under /workspace. It runs ripgrep with bounded output and never modifies files.',
+        'Use this when searching text or file contents under /workspace. It runs ripgrep with bounded output, skips standard dependency/cache/generated directories, and never modifies files.',
       inputSchema: {
         query: z.string().min(1),
         path: z.string().optional(),
@@ -1092,7 +1107,10 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       maxOutputBytes?: number
     }>(config, auth, READ_SCOPES, async (args) => {
       const cwd = resolveExistingDirectory(config.workspaceRoot, args.path)
-      const rgArgs = ['--line-number', '--no-heading', '--color=never', '--hidden', '-g', '!.git']
+      const rgArgs = ['--line-number', '--no-heading', '--color=never', '--hidden']
+      for (const exclude of DEFAULT_WORKSPACE_SEARCH_EXCLUDES) {
+        rgArgs.push('-g', `!${exclude}/**`)
+      }
       if (args.fixedStrings) rgArgs.push('--fixed-strings')
       if (args.caseSensitive === false) rgArgs.push('--ignore-case')
       rgArgs.push(args.query)
@@ -1331,7 +1349,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
     {
       title: 'Inspect git repository',
       description:
-        'Use this when running read-only git inspection inside /workspace. Pass args exactly as argv after git, for example ["status","--short","--branch"], ["diff","--","path"], ["log","--oneline","-5"], or ["show","HEAD:path"]. This is a generic argv wrapper for repository inspection; use git_write only for commits, checkout, reset, merge, or other repository mutations.',
+        'Use this for read-only repository inspection inside /workspace. Pass args exactly as argv after git. The server accepts only read-only subcommands and returns stdout, stderr, exit code, and timeout status.',
       inputSchema: {
         args: z.array(z.string().min(1)).min(1).describe('Arguments passed to git, excluding the git executable.'),
         cwd: z.string().optional(),
@@ -1339,7 +1357,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
         maxOutputBytes: z.number().int().min(1024).optional(),
       },
       outputSchema: commandResultSchema,
-      annotations: openReadOnlyAnnotations,
+      annotations: readOnlyAnnotations,
       ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{ args: string[]; cwd?: string; timeoutSeconds?: number; maxOutputBytes?: number }>(


### PR DESCRIPTION
## Summary

- Mark the read-only `git` MCP tool as closed-world inspection and remove mutation-heavy wording from its descriptor.
- Add default ripgrep excludes for dependency, cache, and generated directories in `workspace_search`.
- Align `agent_guide` and server instructions with current model-neutral Codex workflow rules.
- Extend agents-shell MCP tests for git metadata, workspace search, and published agent guidance.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test src/server/agents-shell-mcp.test.ts`
- `bun run --cwd services/agents tsc`
- `bunx oxfmt --check services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `bunx oxlint --deny-warnings services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `mise exec go@1.24 -- scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
