### PR TITLE
fix(nix): provide skopeo policy for oci push

### DIFF
--- a/nix/oci-push.sh
+++ b/nix/oci-push.sh
@@ -65,14 +65,26 @@ if [[ "${image}" != registry.ide-newton.ts.net/lab/* ]]; then
   exit 1
 fi
 
+policy_json="$(mktemp)"
+trap 'rm -f "${policy_json}"' EXIT
+cat > "${policy_json}" <<'EOF'
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ]
+}
+EOF
+
 reference="${image}:${tag}"
 echo "Pushing Nix-built OCI image tar to ${reference}."
-skopeo copy --format oci "docker-archive:${resolved_tar_path}" "docker://${reference}"
+skopeo --policy "${policy_json}" copy --format oci "docker-archive:${resolved_tar_path}" "docker://${reference}"
 
 if [[ -n "${latest_tag}" ]]; then
   latest_reference="${image}:${latest_tag}"
   echo "Tagging ${reference} as ${latest_reference}."
-  skopeo copy --format oci "docker://${reference}" "docker://${latest_reference}"
+  skopeo --policy "${policy_json}" copy --format oci "docker://${reference}" "docker://${latest_reference}"
 fi
 
 digest="$(crane digest "${reference}")"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -15,6 +15,7 @@ const atticReleaseMetadataScript = readRepoFile('nix/attic-release-metadata.sh')
 const flake = readRepoFile('flake.nix')
 const inspectOciArchiveScript = readRepoFile('nix/oci-inspect-archive.sh')
 const nixOciWorkflow = readRepoFile('.github/workflows/nix-oci-build-common.yml')
+const ociPushScript = readRepoFile('nix/oci-push.sh')
 
 afterEach(() => {
   __private.setSpawnSync()
@@ -199,6 +200,12 @@ describe('native OCI build workflows', () => {
     expect(inspectOciArchiveScript).toContain('(.Architecture | type == "string" and length > 0)')
     expect(inspectOciArchiveScript).toContain('(.Os | type == "string" and length > 0)')
     expect(inspectOciArchiveScript).not.toContain('(.RepoTags | length >= 1)')
+  })
+
+  it('gives Skopeo an explicit containers policy on ARC runners', () => {
+    expect(ociPushScript).toContain('policy_json="$(mktemp)"')
+    expect(ociPushScript).toContain('"type": "insecureAcceptAnything"')
+    expect(ociPushScript).toContain('skopeo --policy "${policy_json}" copy --format oci')
   })
 
   it('does not use Docker Buildx or docker daemon commands in migrated workflows', () => {


### PR DESCRIPTION
## Summary

- Add an explicit temporary containers policy file to `nix/oci-push.sh` so Skopeo can push on ARC runners without relying on host policy files.
- Use that policy for both platform image pushes and latest-tag copies.
- Add a contract test for the ARC Skopeo policy requirement.

## Related Issues

None

## Testing

- `shellcheck nix/oci-push.sh`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`
- `docker run --rm nixos/nix:2.28.3 ... skopeo --policy /tmp/policy.json copy --help`

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
