### PR TITLE
chore(symphony): promote image 6fbe31cb

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T09:29:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:07:05Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1cf03a2d"
-    digest: sha256:faab29d30cf910cb7aece6c6c96740b56bf0904195b25dd49cbeb46ef6e4e8b8
+    newTag: "6fbe31cb"
+    digest: sha256:fc464aaae385ef61e65cedfd5b91e0b6223434356240f0f2850a81fbe8d94f79

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T09:29:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:07:05Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1cf03a2d"
-    digest: sha256:faab29d30cf910cb7aece6c6c96740b56bf0904195b25dd49cbeb46ef6e4e8b8
+    newTag: "6fbe31cb"
+    digest: sha256:fc464aaae385ef61e65cedfd5b91e0b6223434356240f0f2850a81fbe8d94f79

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T09:29:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:07:05Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1cf03a2d"
-    digest: sha256:faab29d30cf910cb7aece6c6c96740b56bf0904195b25dd49cbeb46ef6e4e8b8
+    newTag: "6fbe31cb"
+    digest: sha256:fc464aaae385ef61e65cedfd5b91e0b6223434356240f0f2850a81fbe8d94f79


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `6fbe31cbd51d08c04e7358f83eb4cbc4c2e3297f`
- Image tag: `6fbe31cb`
- Image digest: `sha256:fc464aaae385ef61e65cedfd5b91e0b6223434356240f0f2850a81fbe8d94f79`