### PR TITLE
chore(symphony): promote image e72bd097

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:07:05Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:46:15Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "6fbe31cb"
-    digest: sha256:fc464aaae385ef61e65cedfd5b91e0b6223434356240f0f2850a81fbe8d94f79
+    newTag: "e72bd097"
+    digest: sha256:6738201eb3ca4d1f9169e29f53fb1dc93e659f46265ff207eaca50c90019a705

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:07:05Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:46:15Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "6fbe31cb"
-    digest: sha256:fc464aaae385ef61e65cedfd5b91e0b6223434356240f0f2850a81fbe8d94f79
+    newTag: "e72bd097"
+    digest: sha256:6738201eb3ca4d1f9169e29f53fb1dc93e659f46265ff207eaca50c90019a705

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:07:05Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:46:15Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "6fbe31cb"
-    digest: sha256:fc464aaae385ef61e65cedfd5b91e0b6223434356240f0f2850a81fbe8d94f79
+    newTag: "e72bd097"
+    digest: sha256:6738201eb3ca4d1f9169e29f53fb1dc93e659f46265ff207eaca50c90019a705


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `e72bd097dbfa784628fb4020e0d65f188a79a970`
- Image tag: `e72bd097`
- Image digest: `sha256:6738201eb3ca4d1f9169e29f53fb1dc93e659f46265ff207eaca50c90019a705`