### PR TITLE
chore(jangar): promote image e72bd097

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-28T23:14:54Z
+    deploy.knative.dev/rollout: 2026-06-28T23:50:08Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 6fbe31cbd51d08c04e7358f83eb4cbc4c2e3297f
+              value: e72bd097dbfa784628fb4020e0d65f188a79a970
             - name: JANGAR_GITOPS_REVISION
-              value: 6fbe31cbd51d08c04e7358f83eb4cbc4c2e3297f
+              value: e72bd097dbfa784628fb4020e0d65f188a79a970
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28338973709"
+              value: "28339834392"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:bdd5dd66a8eb8b310b72ec5bbe4dce9f312f5d2e42ad03b000aebd56a53c13f6
+              value: sha256:a9297caf3a4c10796b8a07ebfee0faabc6a68d8c299070b5d0c0c3290c42f9cd
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 6fbe31cbd51d08c04e7358f83eb4cbc4c2e3297f
+              value: e72bd097dbfa784628fb4020e0d65f188a79a970
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:bdd5dd66a8eb8b310b72ec5bbe4dce9f312f5d2e42ad03b000aebd56a53c13f6
+              value: sha256:a9297caf3a4c10796b8a07ebfee0faabc6a68d8c299070b5d0c0c3290c42f9cd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 6fbe31cb
-    digest: sha256:bdd5dd66a8eb8b310b72ec5bbe4dce9f312f5d2e42ad03b000aebd56a53c13f6
+    newTag: e72bd097
+    digest: sha256:a9297caf3a4c10796b8a07ebfee0faabc6a68d8c299070b5d0c0c3290c42f9cd


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `e72bd097dbfa784628fb4020e0d65f188a79a970`
- Image tag: `e72bd097`
- Image digest: `sha256:a9297caf3a4c10796b8a07ebfee0faabc6a68d8c299070b5d0c0c3290c42f9cd`
- Source CI run: `28339834392`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates