### PR TITLE
chore(agents): promote images e72bd097

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: d3f505a7
-  digest: sha256:5ff81a265e9a37dff98607ac86ec091aca0f09224dc834ee22ed9a95912ce347
+  tag: e72bd097
+  digest: sha256:27479b4260a55f6f3fd6ae05eb40e4b01a42d0cdbf1ddc5947119520a7debf1e
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,32 +14,32 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: d3f505a7
-    digest: sha256:a742697cc4a3a9c944241335fc26d2557988013c8d25b36beb4fc5157bdee8c0
+    tag: e72bd097
+    digest: sha256:1d1738bb2381ec4b1609b8b0779db65552c87f50bd9da1530500e0cf1270a6c7
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: d3f505a7307c390200f3683b6824d11ddf4e1599
-      AGENTS_GITOPS_REVISION: d3f505a7307c390200f3683b6824d11ddf4e1599
-      AGENTS_SOURCE_CI_RUN_ID: "28337058523"
+      AGENTS_SOURCE_HEAD_SHA: e72bd097dbfa784628fb4020e0d65f188a79a970
+      AGENTS_GITOPS_REVISION: e72bd097dbfa784628fb4020e0d65f188a79a970
+      AGENTS_SOURCE_CI_RUN_ID: "28339423216"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:a742697cc4a3a9c944241335fc26d2557988013c8d25b36beb4fc5157bdee8c0
-      AGENTS_SERVING_BUILD_COMMIT: d3f505a7307c390200f3683b6824d11ddf4e1599
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:a742697cc4a3a9c944241335fc26d2557988013c8d25b36beb4fc5157bdee8c0
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:1d1738bb2381ec4b1609b8b0779db65552c87f50bd9da1530500e0cf1270a6c7
+      AGENTS_SERVING_BUILD_COMMIT: e72bd097dbfa784628fb4020e0d65f188a79a970
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:1d1738bb2381ec4b1609b8b0779db65552c87f50bd9da1530500e0cf1270a6c7
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: d3f505a7
-    digest: sha256:b6b56c298886304433ba39ec53b35c1a0c14ee7130d646f0e1024ca2b316cd69
+    tag: e72bd097
+    digest: sha256:55891dc9f70050d85187bda7bf9be78b471b7ad9410dadc9441e1918c3688f7b
 agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: d3f505a7
-    digest: sha256:329e5c42f9d9ee9d7bc474db262138fef523b01c8203f4a0aa958f0f727e7c5c
+    tag: e72bd097
+    digest: sha256:a78bcc12409ae930dc7a41d4805395b184a5ce9fe44310ad29f8ba71a22e8469
     pullPolicy: IfNotPresent
   env:
     vars:
@@ -157,8 +157,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: d3f505a7
-    digest: sha256:5ff81a265e9a37dff98607ac86ec091aca0f09224dc834ee22ed9a95912ce347
+    tag: e72bd097
+    digest: sha256:27479b4260a55f6f3fd6ae05eb40e4b01a42d0cdbf1ddc5947119520a7debf1e
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `e72bd097dbfa784628fb4020e0d65f188a79a970`
- Image tag: `e72bd097`
- Agents build run: `28339423216`
- Promotion source: `manual_dispatch`