### PR TITLE
docs(agents): document agents-shell ChatGPT workflow

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -13,6 +13,7 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Creating AgentRuns safely (prompt precedence): `agentrun-creation-guide.md`
 - Agents control-plane UI and schema-form rollout proof: `control-plane-ui.md`
 - Connecting Codex to Agents through MCP: `codex-mcp-agents.md`
+- ChatGPT-driven agents-shell repo work: start with `codex-mcp-agents.md` and the live `agent_guide` connector instructions.
 - Launching workflow loops correctly (state reuse + checks): `agentrun-workflow-loop-launch-guide.md`
 - Running Codex Spark review/fix PR cycles: `codex-spark-review-cycle.md`
 - How to validate changes in CI: `ci-validation-plan.md`


### PR DESCRIPTION
## Summary

- Added a concise Start Here bullet for ChatGPT-driven agents-shell repo work.
- Pointed readers to `codex-mcp-agents.md` for the MCP workflow context.
- Pointed readers to the live `agent_guide` connector instructions as the current operating source.

## Related Issues

None

## Testing

- `git diff --check`
- `rg --line-number --fixed-strings 'ChatGPT-driven agents-shell repo work: start with `codex-mcp-agents.md` and the live `agent_guide` connector instructions.' docs/agents/README.md`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
