### PR TITLE
chore(symphony): promote image b6083af0

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:46:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T00:50:55Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e72bd097"
-    digest: sha256:6738201eb3ca4d1f9169e29f53fb1dc93e659f46265ff207eaca50c90019a705
+    newTag: "b6083af0"
+    digest: sha256:f53cd2dec1d2d73888ebf915e93a912650712c887bcf444edd6ce306076270e7

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:46:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T00:50:55Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e72bd097"
-    digest: sha256:6738201eb3ca4d1f9169e29f53fb1dc93e659f46265ff207eaca50c90019a705
+    newTag: "b6083af0"
+    digest: sha256:f53cd2dec1d2d73888ebf915e93a912650712c887bcf444edd6ce306076270e7

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-28T23:46:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T00:50:55Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e72bd097"
-    digest: sha256:6738201eb3ca4d1f9169e29f53fb1dc93e659f46265ff207eaca50c90019a705
+    newTag: "b6083af0"
+    digest: sha256:f53cd2dec1d2d73888ebf915e93a912650712c887bcf444edd6ce306076270e7


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `b6083af08a7063a28742339c2a341331f11b21ad`
- Image tag: `b6083af0`
- Image digest: `sha256:f53cd2dec1d2d73888ebf915e93a912650712c887bcf444edd6ce306076270e7`