### PR TITLE
chore(jangar): promote image f35a503a

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-29T00:53:40Z
+    deploy.knative.dev/rollout: 2026-06-29T05:02:17Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: b6083af08a7063a28742339c2a341331f11b21ad
+              value: f35a503a28473ee759ab3732ae49db7812d82001
             - name: JANGAR_GITOPS_REVISION
-              value: b6083af08a7063a28742339c2a341331f11b21ad
+              value: f35a503a28473ee759ab3732ae49db7812d82001
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28341830761"
+              value: "28349587389"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:218817490c1442260342b700628788c7f5f7d7408b790d28a9c75746a5f37215
+              value: sha256:8bd5544be27523d0167a640425a6cb7832ba6e3a0173c3139387d1dccd9b61c1
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: b6083af08a7063a28742339c2a341331f11b21ad
+              value: f35a503a28473ee759ab3732ae49db7812d82001
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:218817490c1442260342b700628788c7f5f7d7408b790d28a9c75746a5f37215
+              value: sha256:8bd5544be27523d0167a640425a6cb7832ba6e3a0173c3139387d1dccd9b61c1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: b6083af0
-    digest: sha256:218817490c1442260342b700628788c7f5f7d7408b790d28a9c75746a5f37215
+    newTag: f35a503a
+    digest: sha256:8bd5544be27523d0167a640425a6cb7832ba6e3a0173c3139387d1dccd9b61c1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `f35a503a28473ee759ab3732ae49db7812d82001`
- Image tag: `f35a503a`
- Image digest: `sha256:8bd5544be27523d0167a640425a6cb7832ba6e3a0173c3139387d1dccd9b61c1`
- Source CI run: `28349587389`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates