### PR TITLE
chore(symphony): promote image f35a503a

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T00:50:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:04:04Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b6083af0"
-    digest: sha256:f53cd2dec1d2d73888ebf915e93a912650712c887bcf444edd6ce306076270e7
+    newTag: "f35a503a"
+    digest: sha256:e8bfa19b5e23b202a26f10413a1d738da5d9be2329030213e0d5e5944958157c

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T00:50:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:04:04Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b6083af0"
-    digest: sha256:f53cd2dec1d2d73888ebf915e93a912650712c887bcf444edd6ce306076270e7
+    newTag: "f35a503a"
+    digest: sha256:e8bfa19b5e23b202a26f10413a1d738da5d9be2329030213e0d5e5944958157c

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T00:50:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:04:04Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b6083af0"
-    digest: sha256:f53cd2dec1d2d73888ebf915e93a912650712c887bcf444edd6ce306076270e7
+    newTag: "f35a503a"
+    digest: sha256:e8bfa19b5e23b202a26f10413a1d738da5d9be2329030213e0d5e5944958157c


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `f35a503a28473ee759ab3732ae49db7812d82001`
- Image tag: `f35a503a`
- Image digest: `sha256:e8bfa19b5e23b202a26f10413a1d738da5d9be2329030213e0d5e5944958157c`