### PR TITLE
ci(nix): fix attic oci index cache warming

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -93,12 +93,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${NIX_OCI_LOG_DIR}"
-          helper_attrs=(.#inspect-oci-archive)
+          helper_attrs=(.#inspectOciArchive)
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            helper_attrs+=(.#oci-push .#cache-push)
+            helper_attrs+=(.#ociPush .#cachePush)
           fi
           bash nix/ci-run-timed.sh "prime-build-platform-helpers-${ARCH}" "${NIX_OCI_LOG_DIR}/prime-helpers-${ARCH}.log" \
-            bash -lc 'nix build --print-build-logs --no-link --print-out-paths "$@" | tee "${NIX_OCI_LOG_DIR}/helper-paths-${ARCH}.txt"' \
+            bash -lc 'set -euo pipefail; output_file="${NIX_OCI_LOG_DIR}/helper-paths-${ARCH}.txt"; nix build --print-build-logs --no-link --print-out-paths "$@" | tee "${output_file}"; test -s "${output_file}"' \
             bash "${helper_attrs[@]}"
 
       - name: Build Nix image archive
@@ -161,6 +161,10 @@ jobs:
           set -euo pipefail
           test -n "${ATTIC_TOKEN}"
           mapfile -t helper_paths < "${NIX_OCI_LOG_DIR}/helper-paths-${ARCH}.txt"
+          if [[ "${#helper_paths[@]}" -eq 0 ]]; then
+            echo "No build-platform helper closure paths were captured." >&2
+            exit 2
+          fi
           bash nix/ci-run-timed.sh "push-build-platform-closures-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-${ARCH}.log" \
             nix run .#cache-push -- "${IMAGE_TAR}" "${helper_paths[@]}"
 
@@ -214,13 +218,13 @@ jobs:
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Prime OCI index helper closures
-        env:
-          HELPER_ATTRS: '.#create-oci-index .#assert-oci-platforms .#write-oci-release-contract .#cache-push'
         run: |
           set -euo pipefail
           mkdir -p "${NIX_OCI_LOG_DIR}"
+          helper_attrs=(.#createOciIndex .#assertOciPlatforms .#writeOciReleaseContract .#cachePush)
           bash nix/ci-run-timed.sh "prime-index-helpers" "${NIX_OCI_LOG_DIR}/prime-index-helpers.log" \
-            bash -lc 'nix build --print-build-logs --no-link --print-out-paths ${HELPER_ATTRS} | tee "${NIX_OCI_LOG_DIR}/index-helper-paths.txt"'
+            bash -lc 'set -euo pipefail; output_file="${NIX_OCI_LOG_DIR}/index-helper-paths.txt"; nix build --print-build-logs --no-link --print-out-paths "$@" | tee "${output_file}"; test -s "${output_file}"' \
+            bash "${helper_attrs[@]}"
 
       - name: Create OCI image index
         id: oci
@@ -271,6 +275,10 @@ jobs:
           set -euo pipefail
           test -n "${ATTIC_TOKEN}"
           mapfile -t helper_paths < "${NIX_OCI_LOG_DIR}/index-helper-paths.txt"
+          if [[ "${#helper_paths[@]}" -eq 0 ]]; then
+            echo "No index helper closure paths were captured." >&2
+            exit 2
+          fi
           bash nix/ci-run-timed.sh "push-index-helper-closures" "${NIX_OCI_LOG_DIR}/cache-push-index-helpers.log" \
             nix run .#cache-push -- "${helper_paths[@]}"
 

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -200,12 +200,15 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/')
     expect(nixOciWorkflow).not.toContain('extra-substituters = http://attic.attic.svc.cluster.local/lab')
     expect(nixOciWorkflow).toContain('nix build --print-build-logs --no-link --print-out-paths "$@"')
-    expect(nixOciWorkflow).toContain('helper_attrs=(.#inspect-oci-archive)')
-    expect(nixOciWorkflow).toContain('helper_attrs+=(.#oci-push .#cache-push)')
+    expect(nixOciWorkflow).toContain('helper_attrs=(.#inspectOciArchive)')
+    expect(nixOciWorkflow).toContain('helper_attrs+=(.#ociPush .#cachePush)')
+    expect(nixOciWorkflow).toContain('test -s "${output_file}"')
+    expect(nixOciWorkflow).toContain('No build-platform helper closure paths were captured.')
+    expect(nixOciWorkflow).toContain('No index helper closure paths were captured.')
     expect(nixOciWorkflow).toContain('nix/ci-run-timed.sh')
     expect(nixOciWorkflow).toContain('nix/ci-nix-oci-summary.sh')
     expect(nixOciWorkflow).toContain(
-      '.#create-oci-index .#assert-oci-platforms .#write-oci-release-contract .#cache-push',
+      'helper_attrs=(.#createOciIndex .#assertOciPlatforms .#writeOciReleaseContract .#cachePush)',
     )
     expect(nixOciWorkflow).not.toContain('nix develop -c')
   })


### PR DESCRIPTION
## Summary

- Fix Nix OCI helper closure priming to build package attrs instead of app attrs.
- Make helper-path capture fail closed with `pipefail` and nonempty path-file checks.
- Add workflow contract coverage for the Attic index helper cache-warm path.

## Related Issues

None

## Testing

- `shellcheck nix/ci-run-timed.sh nix/ci-nix-oci-summary.sh nix/cache-push.sh nix/oci-push.sh`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/attic-build-push.yaml .github/workflows/nix-oci-build-common.yml .github/workflows/attic-release.yml`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
