### PR TITLE
chore(symphony): promote image 4948a728

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:04:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:30:43Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f35a503a"
-    digest: sha256:e8bfa19b5e23b202a26f10413a1d738da5d9be2329030213e0d5e5944958157c
+    newTag: "4948a728"
+    digest: sha256:443d1a7cbf72e7c72d170b03e7dae06480c883924f6948135aeca6b6bb866a1d

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:04:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:30:43Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f35a503a"
-    digest: sha256:e8bfa19b5e23b202a26f10413a1d738da5d9be2329030213e0d5e5944958157c
+    newTag: "4948a728"
+    digest: sha256:443d1a7cbf72e7c72d170b03e7dae06480c883924f6948135aeca6b6bb866a1d

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:04:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:30:43Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f35a503a"
-    digest: sha256:e8bfa19b5e23b202a26f10413a1d738da5d9be2329030213e0d5e5944958157c
+    newTag: "4948a728"
+    digest: sha256:443d1a7cbf72e7c72d170b03e7dae06480c883924f6948135aeca6b6bb866a1d


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `4948a728580d48eb3bccbe24e0ab66d51491c551`
- Image tag: `4948a728`
- Image digest: `sha256:443d1a7cbf72e7c72d170b03e7dae06480c883924f6948135aeca6b6bb866a1d`