### PR TITLE
feat(turin): add local nvme scratch storage

### DIFF
--- a/argocd/applications/local-path/kustomization.yaml
+++ b/argocd/applications/local-path/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: local-path-storage
 resources:
   - github.com/rancher/local-path-provisioner/deploy?ref=v0.0.35
+  - storageclasses-turin-nvme.yaml
 patches:
   - target:
       kind: Namespace

--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -20,6 +20,13 @@ data:
           "paths":["/var/mnt/local-path-provisioner"]
         },
         {
+          "node":"turin",
+          "paths":[
+            "/var/mnt/turin-nvme-intel",
+            "/var/mnt/turin-nvme-transcend"
+          ]
+        },
+        {
           "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
           "paths":["/var/local-path-provisioner"]
         }

--- a/argocd/applications/local-path/storageclasses-turin-nvme.yaml
+++ b/argocd/applications/local-path/storageclasses-turin-nvme.yaml
@@ -1,0 +1,41 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path-turin-nvme-intel
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+    storage.proompteng.ai/durability: rebuildable
+    storage.proompteng.ai/node: turin
+    storage.proompteng.ai/source-device: nvme-INTEL_SSDPEKKF256G8L_BTHH851313AU256B
+    storage.proompteng.ai/prohibited-use: ceph-registry-kafka-database-torghut-durable-state
+provisioner: rancher.io/local-path
+parameters:
+  nodePath: /var/mnt/turin-nvme-intel
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: kubernetes.io/hostname
+        values:
+          - turin
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path-turin-nvme-transcend
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+    storage.proompteng.ai/durability: rebuildable
+    storage.proompteng.ai/node: turin
+    storage.proompteng.ai/source-device: nvme-TS256GMTE652T2_I203860329
+    storage.proompteng.ai/prohibited-use: ceph-registry-kafka-database-torghut-durable-state
+provisioner: rancher.io/local-path
+parameters:
+  nodePath: /var/mnt/turin-nvme-transcend
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: kubernetes.io/hostname
+        values:
+          - turin

--- a/devices/turin/docs/local-nvme-scratch.md
+++ b/devices/turin/docs/local-nvme-scratch.md
@@ -9,29 +9,42 @@ failure domains.
 
 ## Live Disk Evidence
 
-Live host-device readback from the `rook-ceph-osd-0` pod on 2026-06-28 showed:
+Live Talos disk readback on 2026-06-29 showed:
 
 ```text
-/dev/disk/by-id/nvme-INTEL_SSDPEKKF256G8L_BTHH851313AU256B -> /dev/nvme0n1
-/dev/disk/by-id/nvme-TS256GMTE652T2_I203860329 -> /dev/nvme1n1
+/dev/disk/by-id/nvme-TS256GMTE652T2_I203860329 -> /dev/nvme0n1
+/dev/disk/by-id/nvme-INTEL_SSDPEKKF256G8L_BTHH851313AU256B -> /dev/nvme1n1
 ```
 
-Both devices already had partition tables. Treat them as local-only and
-destructive-to-local-state before provisioning scratch volumes.
+The Transcend device previously had old COS partitions; they were cleared with
+`talosctl wipe disk ... --drop-partition` on 2026-06-29. The Intel device was
+initially visible as a whole disk, then Talos created `u-turin-nvme-intel` as
+GPT partition 1. The kernel briefly exposed that partition as stale
+`/dev/nvme1n1p2`; this was corrected without reboot by running `partx -d --nr 2`
+and `partx -a --nr 1` from the privileged Turin OSD container. Treat both
+devices as local-only and destructive-to-local-state before provisioning scratch
+volumes.
 
-Current partition shape from the same live readback:
+Current disk shape from the same live readback:
 
 ```text
-nvme0n1 238.5G INTEL SSDPEKKF256G8L BTHH851313AU256B
-├─nvme0n1p1 238G
-└─nvme0n1p2 485M
+nvme0n1 256GB TS256GMTE652T2 I203860329
+nvme1n1 256GB INTEL SSDPEKKF256G8L BTHH851313AU256B
+nvme2n1 1.0TB KINGSTON SNV3S1000G 50026B76878F0B27
+nvme3n1 4.1TB ORICO 13CBMEK6HEW8CN2X9AKW
+```
 
-nvme1n1 238.5G TS256GMTE652T2 I203860329
-├─nvme1n1p1 64M
-├─nvme1n1p2 64M
-├─nvme1n1p3 4G
-├─nvme1n1p4 8G
-└─nvme1n1p5 226.3G
+The Kingston device is reserved for Ceph BlueStore DB/WAL. The ORICO device is
+the Talos OS/EPHEMERAL disk. Do not use either for local-path scratch.
+
+Previously cleared local-only Transcend partitions:
+
+```text
+nvme0n1p1 COS_GRUB
+nvme0n1p2 COS_OEM
+nvme0n1p3 COS_RECOVERY
+nvme0n1p4 COS_STATE
+nvme0n1p5 COS_PERSISTENT
 ```
 
 ## Talos User-Volume Manifests
@@ -41,8 +54,16 @@ nvme1n1 238.5G TS256GMTE652T2 I203860329
 
 These create Talos user volumes mounted by Talos under `/var/mnt/`:
 
-- `u-local-path-provisioner-turin-scratch-intel`
-- `u-local-path-provisioner-turin-scratch-transcend`
+- `/var/mnt/turin-nvme-intel`
+- `/var/mnt/turin-nvme-transcend`
+
+The selectors must use stable by-id symlinks, not `/dev/nvmeXn1`, because NVMe
+enumeration can change across boot:
+
+```yaml
+match: "'/dev/disk/by-id/nvme-INTEL_SSDPEKKF256G8L_BTHH851313AU256B' in disk.symlinks && !system_disk"
+match: "'/dev/disk/by-id/nvme-TS256GMTE652T2_I203860329' in disk.symlinks && !system_disk"
+```
 
 ## Preflight
 
@@ -57,8 +78,10 @@ kubectl get pv -A | rg 'local-path|turin'
 
 Confirm:
 
-1. `nvme0n1` is Intel `BTHH851313AU256B`.
-1. `nvme1n1` is Transcend `I203860329`.
+1. `nvme0n1` currently reports Transcend `I203860329`.
+1. `nvme1n1` currently reports Intel `BTHH851313AU256B`.
+1. The Talos user-volume selectors still match by stable `/dev/disk/by-id/*`
+   symlink, not by `/dev/nvmeXn1`.
 1. Neither disk backs Ceph, Talos install, Kafka, registry, Torghut, or another
    durable workload.
 1. You are in a maintenance window; applying or fixing user-volume layout may
@@ -75,6 +98,9 @@ talosctl -n <turin-ip> apply-config --mode no-reboot --file <machineconfig-with-
 If Talos reports existing partitions, stop and explicitly decide whether to wipe
 the local-only partitions. Do not wipe the Kingston NVMe
 `nvme-KINGSTON_SNV3S1000G_50026B76878F0B27` or the ORICO Talos install disk.
+For the current live mapping, the Transcend `TS256GMTE652T2_I203860329` stale
+COS partitions were already cleared on 2026-06-29 before enabling the scratch
+user volume.
 
 ## Kubernetes StorageClass Wiring
 
@@ -93,28 +119,54 @@ Example:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: local-path-turin-nvme-scratch
+  name: local-path-turin-nvme-intel
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
     storage.proompteng.ai/durability: rebuildable
     storage.proompteng.ai/node: turin
 provisioner: rancher.io/local-path
 parameters:
-  nodePath: /var/mnt/local-path-provisioner-turin-scratch-intel
+  nodePath: /var/mnt/turin-nvme-intel
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: kubernetes.io/hostname
+        values:
+          - turin
 ```
 
 Only add a `nodePath` after it exists in `nodePathMap`; the provisioner requires
 the selected path to be present in the configured path map.
 
+The GitOps storage classes are:
+
+- `local-path-turin-nvme-intel`
+- `local-path-turin-nvme-transcend`
+
+Both are non-default, `Delete` reclaim, `WaitForFirstConsumer`, and constrained
+to `kubernetes.io/hostname=turin`.
+
+If the local-path provisioner has already been running, restart only that
+Deployment after applying the ConfigMap so it reloads the new Turin node paths.
+This does not move or remount existing local-path PV data.
+
 ## Acceptance
 
 ```bash
 talosctl -n <turin-ip> get volumestatus -o yaml | rg -n 'turin-scratch|phase:|location:|prettySize:'
-kubectl get storageclass local-path-turin-nvme-scratch
+kubectl get storageclass local-path-turin-nvme-intel local-path-turin-nvme-transcend
 kubectl -n local-path-storage logs deploy/local-path-provisioner --tail=100
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd metadata -f json | jq -r '.[] | select(.hostname=="turin") | [.id,.bluefs_db_devices] | @tsv'
 ```
 
-Then create a tiny PVC/pod pinned to `turin`, write a test file, delete it, and
-confirm the PV node affinity is `kubernetes.io/hostname=turin`.
+Then create a tiny PVC/pod for each StorageClass, pin the pod to `turin`, write
+a test file, delete it, and confirm the PV node affinity is
+`kubernetes.io/hostname=turin`.
+
+## References
+
+- Talos disk selectors:
+  <https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common>
+- Local Path Provisioner:
+  <https://github.com/rancher/local-path-provisioner>

--- a/devices/turin/manifests/local-path-scratch-intel.patch.yaml
+++ b/devices/turin/manifests/local-path-scratch-intel.patch.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1alpha1
 kind: UserVolumeConfig
-name: local-path-provisioner-turin-scratch-intel
+name: turin-nvme-intel
 provisioning:
   # Turin-local scratch only. This disk is single-host and must not hold durable state.
-  # Live by-id proof on 2026-06-28:
-  # /dev/disk/by-id/nvme-INTEL_SSDPEKKF256G8L_BTHH851313AU256B -> /dev/nvme0n1
+  # Live by-id proof on 2026-06-29:
+  # /dev/disk/by-id/nvme-INTEL_SSDPEKKF256G8L_BTHH851313AU256B -> /dev/nvme1n1
   diskSelector:
-    match: disk.dev_path == '/dev/nvme0n1'
+    match: "'/dev/disk/by-id/nvme-INTEL_SSDPEKKF256G8L_BTHH851313AU256B' in disk.symlinks && !system_disk"
   minSize: 100GB
   grow: true

--- a/devices/turin/manifests/local-path-scratch-transcend.patch.yaml
+++ b/devices/turin/manifests/local-path-scratch-transcend.patch.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1alpha1
 kind: UserVolumeConfig
-name: local-path-provisioner-turin-scratch-transcend
+name: turin-nvme-transcend
 provisioning:
   # Turin-local scratch only. This disk is single-host and must not hold durable state.
-  # Live by-id proof on 2026-06-28:
-  # /dev/disk/by-id/nvme-TS256GMTE652T2_I203860329 -> /dev/nvme1n1
+  # Live by-id proof on 2026-06-29:
+  # /dev/disk/by-id/nvme-TS256GMTE652T2_I203860329 -> /dev/nvme0n1
   diskSelector:
-    match: disk.dev_path == '/dev/nvme1n1'
+    match: "'/dev/disk/by-id/nvme-TS256GMTE652T2_I203860329' in disk.symlinks && !system_disk"
   minSize: 100GB
   grow: true


### PR DESCRIPTION
## Summary

- Adds two explicit, non-default Turin-local NVMe scratch StorageClasses for Intel and Transcend 256GB disks.
- Wires local-path provisioner to `/var/mnt/turin-nvme-intel` and `/var/mnt/turin-nvme-transcend` with Turin-only topology.
- Updates Talos user-volume patches to use stable by-id disk selectors and documents the no-reboot live rollout path.

## Related Issues

None

## Testing

- `git diff --check`
- `kustomize build argocd/applications/local-path`
- `bun run lint:argocd`
- Live Talos validation: both `u-turin-nvme-intel` and `u-turin-nvme-transcend` are `ready`, XFS, mounted under `/var/mnt`.
- Live Kubernetes smoke: one PVC per new StorageClass bound on `turin`, write/read succeeded, and PVC deletion removed both PVs.
- Live Ceph check: Turin BlueStore DB remains on Kingston `nvme2n1`; Intel/Transcend are not used by Ceph.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
