### PR TITLE
fix(agents): allow shell keycloak username identity

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -46,6 +46,7 @@ agentsShell:
       AGENTS_SHELL_RESOURCE: https://agents-shell.proompteng.ai
       AGENTS_SHELL_OAUTH_ISSUER: https://auth.proompteng.ai/realms/master
       AGENTS_SHELL_ALLOWED_EMAILS: greg@proompteng.ai,agents-shell-chatgpt@proompteng.ai
+      AGENTS_SHELL_ALLOWED_USERNAMES: admin,agents-shell-chatgpt
       AGENTS_SHELL_ALLOWED_K8S_NAMESPACES: ""
       AGENTS_SHELL_WORKSPACE_ROOT: /workspace
       AGENTS_SHELL_AUDIT_LOG_PATH: /workspace/.agents-shell/audit.jsonl

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -38,8 +38,8 @@ agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: adbb128c5
-    digest: sha256:fd406d8ed0b0faa8f2507c2cdd09a03ef5853e7b6d8c1cc6318e6013e344b306
+    tag: 58c7cf8cf
+    digest: sha256:e2e2dd0dff6dc316a6beb3e22e8a46d1d7d6af0a10b57b95e5cf8f31924b48c6
     pullPolicy: IfNotPresent
   env:
     vars:

--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -13,6 +13,7 @@ import {
   createAgentsShellServer,
   defaultAgentsShellConfigFromEnv,
   normalizeMcpAcceptHeader,
+  oauthIdentityAllowed,
   oauthProtectedResourceMetadata,
   resolveWorkspacePath,
   startAgentsShellServer,
@@ -40,10 +41,12 @@ const makeConfig = (): AgentsShellConfig => {
 const makeAuth = (scopes = ['agents-shell.read', 'agents-shell.write']): AuthContext => ({
   subject: 'user-1',
   email: 'greg@proompteng.ai',
+  username: 'greg',
   scopes: new Set(scopes),
   payload: {
     sub: 'user-1',
     email: 'greg@proompteng.ai',
+    preferred_username: 'greg',
     scope: scopes.join(' '),
   },
 })
@@ -143,6 +146,17 @@ describe('agents-shell MCP OAuth metadata', () => {
     expect(buildBearerChallenge(config)).toBe(
       'Bearer resource_metadata="https://agents-shell.example.test/.well-known/oauth-protected-resource"',
     )
+  })
+
+  it('allows a configured Keycloak username when the token has no email claim', () => {
+    const config = defaultAgentsShellConfigFromEnv({
+      AGENTS_SHELL_ALLOWED_EMAILS: 'greg@proompteng.ai',
+      AGENTS_SHELL_ALLOWED_USERNAMES: 'admin,agents-shell-chatgpt',
+    })
+
+    expect(oauthIdentityAllowed(config, { subject: 'user-1', email: 'greg@proompteng.ai', username: null })).toBe(true)
+    expect(oauthIdentityAllowed(config, { subject: 'user-2', email: null, username: 'admin' })).toBe(true)
+    expect(oauthIdentityAllowed(config, { subject: 'user-3', email: null, username: 'unknown' })).toBe(false)
   })
 
   it('normalizes MCP Accept headers for ChatGPT metadata clients', () => {

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -95,6 +95,7 @@ type RegisteredToolForList = {
 export type AuthContext = {
   subject: string
   email: string | null
+  username: string | null
   scopes: Set<string>
   payload: JWTPayload
   authError?: OAuthChallenge
@@ -113,6 +114,7 @@ export type AgentsShellConfig = {
   jwksUrl: string
   supportedScopes: string[]
   allowedEmails: Set<string>
+  allowedUsernames: Set<string>
   allowedSubjects: Set<string>
   workspaceRoot: string
   defaultTimeoutSeconds: number
@@ -383,6 +385,7 @@ export const defaultAgentsShellConfigFromEnv = (env: NodeJS.ProcessEnv = process
     jwksUrl: env.AGENTS_SHELL_JWKS_URL ?? `${issuer.replace(/\/$/, '')}/protocol/openid-connect/certs`,
     supportedScopes: ['openid', 'email', 'profile', SCOPES.offlineAccess, SCOPES.read, SCOPES.write, SCOPES.admin],
     allowedEmails: parseList(env.AGENTS_SHELL_ALLOWED_EMAILS),
+    allowedUsernames: parseList(env.AGENTS_SHELL_ALLOWED_USERNAMES),
     allowedSubjects: parseList(env.AGENTS_SHELL_ALLOWED_SUBJECTS),
     workspaceRoot: env.AGENTS_SHELL_WORKSPACE_ROOT ?? '/workspace',
     defaultTimeoutSeconds: Number(env.AGENTS_SHELL_DEFAULT_TIMEOUT_SECONDS ?? '60'),
@@ -417,6 +420,18 @@ export const oauthProtectedResourceMetadata = (config: AgentsShellConfig) => ({
 })
 
 const quoteAuthParam = (value: string) => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
+export const oauthIdentityAllowed = (
+  config: AgentsShellConfig,
+  identity: { subject: string; email: string | null; username: string | null },
+) => {
+  if (config.allowedSubjects.size > 0 && !config.allowedSubjects.has(identity.subject)) return false
+  if (config.allowedEmails.size === 0 && config.allowedUsernames.size === 0) return true
+  return (
+    (identity.email ? config.allowedEmails.has(identity.email) : false) ||
+    (identity.username ? config.allowedUsernames.has(identity.username) : false)
+  )
+}
 
 export const buildBearerChallenge = (config: AgentsShellConfig, error?: string, errorDescription?: string) => {
   const metadataUrl = `${config.resource.replace(/\/$/, '')}${PROTECTED_RESOURCE_PATH}`
@@ -532,12 +547,8 @@ class AuthVerifier {
     if (!subject) throw new Error('token is missing subject')
 
     const email = typeof payload.email === 'string' ? payload.email : null
-    if (this.config.allowedSubjects.size > 0 && !this.config.allowedSubjects.has(subject)) {
-      throw new Error('subject is not allowed')
-    }
-    if (this.config.allowedEmails.size > 0 && (!email || !this.config.allowedEmails.has(email))) {
-      throw new Error('email is not allowed')
-    }
+    const username = typeof payload.preferred_username === 'string' ? payload.preferred_username : null
+    if (!oauthIdentityAllowed(this.config, { subject, email, username })) throw new Error('identity is not allowed')
 
     const scopes = new Set(
       String(payload.scope ?? '')
@@ -545,7 +556,7 @@ class AuthVerifier {
         .map((scope) => scope.trim())
         .filter(Boolean),
     )
-    return { subject, email, scopes, payload }
+    return { subject, email, username, scopes, payload }
   }
 }
 
@@ -677,6 +688,7 @@ export class AgentsShellRunner {
       event,
       subject: auth?.subject ?? null,
       email: auth?.email ?? null,
+      username: auth?.username ?? null,
       ...payload,
     })
     try {
@@ -1800,6 +1812,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
 const anonymousAuthContext = (authError?: OAuthChallenge): AuthContext => ({
   subject: 'unauthenticated',
   email: null,
+  username: null,
   scopes: new Set(),
   payload: {},
   authError,


### PR DESCRIPTION
## Summary

- Allows the agents-shell MCP auth layer to accept a configured Keycloak username when access tokens do not carry an email claim.
- Adds focused tests for username-based identity allowlisting while preserving subject and email allowlist behavior.
- Pins the agents-shell GitOps image to the built `58c7cf8cf` artifact that contains the auth fix.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/agents test -- src/server/agents-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents tsc`
- `kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml && rg -n "AGENTS_SHELL_ALLOWED_USERNAMES|image: registry.ide-newton.ts.net/lab/agents-shell" /tmp/agents-render.yaml`
- `crane digest registry.ide-newton.ts.net/lab/agents-shell:58c7cf8cf`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
