### PR TITLE
fix(forgejo-runners): stabilize action polling config

### DIFF
--- a/argocd/applications/forgejo-runners/configmap-runner.yaml
+++ b/argocd/applications/forgejo-runners/configmap-runner.yaml
@@ -10,30 +10,30 @@ data:
 
     runner:
       file: /data/.runner
-      capacity: 2
+      capacity: 1
       timeout: 3h
       shutdown_timeout: 5m
       insecure: false
-      fetch_timeout: 5s
-      fetch_interval: 2s
-      report_interval: 1s
+      fetch_timeout: 30s
+      fetch_interval: 10s
+      report_interval: 10s
 
     cache:
       enabled: true
       dir: /data/cache
-      host: ''
-      external_server: ''
-      secret: ''
-      actions_cache_url_override: ''
+      host: ""
+      external_server: ""
+      secret: ""
+      actions_cache_url_override: ""
 
     container:
-      network: ''
+      network: ""
       enable_ipv6: false
       privileged: false
-      options: ''
+      options: ""
       workdir_parent: /data/workspace
       valid_volumes:
-        - '**'
+        - "**"
       docker_host: unix:///var/run/docker.sock
       force_pull: false
       force_rebuild: false


### PR DESCRIPTION
## Summary

- Reduce Forgejo runner concurrency to one job per runner to stop action DB heartbeat pressure.
- Lengthen runner fetch/report intervals to avoid hammering Forgejo when Bilig pushes fan out CI and image jobs.
- Quote empty runner config strings with double quotes so live patches cannot degrade into malformed Docker network names.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Live validation: patched `forgejo-runners-config`, restarted both runner statefulsets, and confirmed `container.network: ""` in the live ConfigMap.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
