### PR TITLE
fix(agents): use generic shell file tool names

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -38,8 +38,8 @@ agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: c7892bda
-    digest: sha256:ef7434a3fff761eacdd79412520219afefde578512f61a6b90fb82c8c6957d59
+    tag: "458875108"
+    digest: sha256:e7cb9d3f1283ccecb088250d8374f3d645246ba98d137cf88c3fe57333c09501
     pullPolicy: IfNotPresent
   env:
     vars:

--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -276,8 +276,8 @@ describe('agents-shell MCP tools', () => {
     const tools = await client.listTools()
     expect(tools.tools.map((tool) => tool.name).sort()).toEqual(
       [
-        'workspace_search',
-        'workspace_read_file',
+        'search',
+        'read_file',
         'apply_patch',
         'agent_guide',
         'shell_run',
@@ -296,7 +296,7 @@ describe('agents-shell MCP tools', () => {
       ].sort(),
     )
 
-    const search = tools.tools.find((tool) => tool.name === 'workspace_search')
+    const search = tools.tools.find((tool) => tool.name === 'search')
     expect(search?.annotations?.readOnlyHint).toBe(true)
     expect(search?._meta).toMatchObject({
       securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
@@ -359,7 +359,7 @@ describe('agents-shell MCP tools', () => {
     await server.close()
 
     const rawTools = await listToolsOnWire(config)
-    const rawSearch = rawTools.find((tool) => tool.name === 'workspace_search')
+    const rawSearch = rawTools.find((tool) => tool.name === 'search')
     expect(rawSearch?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read'] }])
     expect(rawSearch?._meta).toMatchObject({
       securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
@@ -421,7 +421,7 @@ describe('agents-shell MCP tools', () => {
     const { client, server, clientTransport, serverTransport } = await connectServer(config)
 
     const read = await client.callTool({
-      name: 'workspace_read_file',
+      name: 'read_file',
       arguments: { path: 'hello.txt' },
     })
     expect((read.structuredContent as { content?: string } | undefined)?.content).toBe('hello from agents-shell\n')
@@ -575,7 +575,7 @@ fi
     }
   })
 
-  it('searches workspace files with ripgrep instead of empty piped stdin', async () => {
+  it('searches files with ripgrep instead of empty piped stdin', async () => {
     const config = makeConfig()
     mkdirSync(join(config.workspaceRoot, 'lab', 'src'), { recursive: true })
     writeFileSync(
@@ -597,7 +597,7 @@ fi
 
     try {
       const result = await client.callTool({
-        name: 'workspace_search',
+        name: 'search',
         arguments: { query: 'createAgentsShellServer', path: 'lab', fixedStrings: true },
       })
       const content = result.structuredContent as {

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -174,14 +174,14 @@ Operate like Codex:
 - Persist until the request is complete or an evidence-backed blocker remains.
 - Inspect before editing: read repo state, relevant files, tests, and applicable AGENTS.md instructions.
 - Respect dirty worktrees: do not revert, overwrite, or discard changes you did not make.
-- Use rg for search, workspace_read_file for reads, and apply_patch with Codex patch syntax for edits.
+- Use search for repo/file discovery, read_file for bounded file reads, and apply_patch with Codex patch syntax for edits.
 - Use destructive git, Kubernetes, or filesystem operations only when the user request clearly requires them.
 - Validate from focused tests to broader checks, then summarize exact commands and results.
 
 Default repo workflow:
 1. Confirm /workspace/lab is on a fresh origin/main base or preserve and report existing dirty work.
 2. Create a codex/... branch for the task.
-3. Search with workspace_search, inspect with workspace_read_file and git, and make scoped edits with apply_patch.
+3. Search with search, inspect with read_file and git, and make scoped edits with apply_patch.
 4. Run focused tests, lint, type checks, or smoke commands that prove the change.
 5. Commit as Greg Konush, push the branch, create a pull request with gh, and monitor CI.
 6. Fix failures and continue until the task is complete, CI status is checked, and the PR URL is available.
@@ -1179,11 +1179,11 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
   )
 
   server.registerTool(
-    'workspace_search',
+    'search',
     {
-      title: 'Search workspace',
+      title: 'Search files',
       description:
-        'Use this when searching text or file contents under /workspace. It runs ripgrep with bounded output, skips standard dependency/cache/generated directories, and never modifies files.',
+        'Use this when searching text or file contents under the private workspace root. It runs ripgrep with bounded output, skips standard dependency/cache/generated directories, and never modifies files.',
       inputSchema: {
         query: z.string().min(1),
         path: z.string().optional(),
@@ -1219,18 +1219,18 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
         maxOutputBytes: args.maxOutputBytes,
         okExitCodes: [0, 1],
         auth,
-        auditEvent: 'workspace_search',
+        auditEvent: 'search',
       })
       return jsonTextResult(result)
     }),
   )
 
   server.registerTool(
-    'workspace_read_file',
+    'read_file',
     {
-      title: 'Read workspace file',
+      title: 'Read file',
       description:
-        'Use this when reading a specific file under /workspace. It returns a bounded UTF-8 text prefix and never modifies files.',
+        'Use this when reading a specific file under the private workspace root. It returns a bounded UTF-8 text prefix and never modifies files.',
       inputSchema: {
         path: z.string().min(1),
         maxBytes: z.number().int().min(1).optional(),
@@ -1319,7 +1319,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
     {
       title: 'Run shell command',
       description:
-        'Use this for a short, user-requested terminal command inside the private agents-shell workspace container, such as diagnostics, tests, build scripts, Python scripts, or other workspace automation. It returns stdout, stderr, exit code, and job metadata. The tool does not publish messages or data; the server enforces /workspace cwd bounds, timeout caps, output caps, OAuth scopes, and audit logging. Prefer workspace_search, workspace_read_file, git, and kubectl for read-only inspection before running a terminal command.',
+        'Use this for a short, user-requested terminal command inside the private agents-shell workspace container, such as diagnostics, tests, build scripts, Python scripts, or other workspace automation. It returns stdout, stderr, exit code, and job metadata. The tool does not publish messages or data; the server enforces /workspace cwd bounds, timeout caps, output caps, OAuth scopes, and audit logging. Prefer search, read_file, git, and kubectl for read-only inspection before running a terminal command.',
       inputSchema: shellInputSchema,
       outputSchema: shellJobSchema,
       annotations: shellAnnotations,


### PR DESCRIPTION
## Summary

- Renames ChatGPT-facing agents-shell file tools from `workspace_search` and `workspace_read_file` to `search` and `read_file`.
- Keeps the `/workspace` boundary in server validation, descriptions, OAuth metadata, and audit logging.
- Pins the agents-shell GitOps image to the built `458875108` artifact containing the new tool names.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents test -- src/server/agents-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents tsc`
- `crane digest registry.ide-newton.ts.net/lab/agents-shell:458875108`
- `kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml && rg -n "image: registry.ide-newton.ts.net/lab/agents-shell|458875108|e7cb9d3f|AGENTS_SHELL_ALLOWED_USERNAMES" /tmp/agents-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

Renames two MCP tool names exposed to ChatGPT. Existing connector metadata must be refreshed after rollout.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
