### PR TITLE
fix(agents): use single linked scope for agents-shell tools

### DIFF
--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -314,7 +314,7 @@ describe('agents-shell MCP tools', () => {
     expect(applyPatch?.annotations?.readOnlyHint).toBe(false)
     expect(applyPatch?.annotations?.destructiveHint).toBe(false)
     expect(applyPatch?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
     })
 
     const git = tools.tools.find((tool) => tool.name === 'git')
@@ -328,7 +328,7 @@ describe('agents-shell MCP tools', () => {
     const gitWrite = tools.tools.find((tool) => tool.name === 'git_write')
     expect(gitWrite?.annotations?.destructiveHint).toBe(true)
     expect(gitWrite?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
     })
 
     const kubectl = tools.tools.find((tool) => tool.name === 'kubectl')
@@ -343,14 +343,14 @@ describe('agents-shell MCP tools', () => {
     expect(kubectlAdmin?.annotations?.destructiveHint).toBe(true)
     expect(kubectlAdmin?.annotations?.openWorldHint).toBe(true)
     expect(kubectlAdmin?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
     })
 
     const agentStart = tools.tools.find((tool) => tool.name === 'agent_start')
     expect(agentStart?.annotations?.destructiveHint).toBe(true)
     expect(agentStart?.annotations?.openWorldHint).toBe(true)
     expect(agentStart?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.write'] }],
+      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
     })
 
     await clientTransport.close()
@@ -386,6 +386,7 @@ describe('agents-shell MCP tools', () => {
     expect(rawKubectl?.inputSchema?.additionalProperties).toBe(false)
 
     for (const tool of rawTools) {
+      expect(tool.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read'] }])
       expect(tool.securitySchemes).not.toEqual(
         expect.arrayContaining([expect.objectContaining({ scopes: expect.arrayContaining(['agents-shell.admin']) })]),
       )
@@ -647,12 +648,9 @@ fi
     }
   })
 
-  it('returns an OAuth challenge when a tool lacks required scope', async () => {
+  it('returns an OAuth challenge when auth lacks the linked agents-shell scope', async () => {
     const config = makeConfig()
-    const { client, server, clientTransport, serverTransport } = await connectServer(
-      config,
-      makeAuth(['agents-shell.read']),
-    )
+    const { client, server, clientTransport, serverTransport } = await connectServer(config, makeAuth(['openid']))
 
     const result = await client.callTool({
       name: 'shell_run',

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -199,7 +199,9 @@ const SCOPES = {
 } as const
 
 const READ_SCOPES = [SCOPES.read, SCOPES.write, SCOPES.admin]
-const WRITE_SCOPES = [SCOPES.write, SCOPES.admin]
+// ChatGPT connector sessions are private and identity-allowlisted. Keep tool authorization on the stable
+// linked scope so long-running workflows do not re-enter OAuth when they move from read tools to write tools.
+const WRITE_SCOPES = READ_SCOPES
 
 const readOnlyAnnotations: ToolAnnotations = {
   readOnlyHint: true,
@@ -1274,7 +1276,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
         changedFiles: z.array(z.string()),
       }),
       annotations: writeAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{
       patch: string
@@ -1323,7 +1325,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       inputSchema: shellInputSchema,
       outputSchema: shellJobSchema,
       annotations: shellAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{ command: string; cwd?: string; timeoutSeconds?: number; maxOutputBytes?: number }>(
       config,
@@ -1346,7 +1348,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       inputSchema: shellInputSchema,
       outputSchema: shellJobSchema,
       annotations: shellAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{ command: string; cwd?: string; timeoutSeconds?: number; maxOutputBytes?: number }>(
       config,
@@ -1409,7 +1411,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       },
       outputSchema: shellJobSchema,
       annotations: destructiveAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{ jobId: string; signal?: string }>(config, auth, WRITE_SCOPES, async (args) => {
       const job = runner.kill(args.jobId, auth, args.signal ?? 'SIGTERM')
@@ -1492,7 +1494,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       },
       outputSchema: commandResultSchema,
       annotations: destructiveAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{ args: string[]; cwd?: string; timeoutSeconds?: number; maxOutputBytes?: number }>(
       config,
@@ -1574,7 +1576,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       },
       outputSchema: commandResultSchema,
       annotations: destructiveAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{ args: string[]; cwd?: string; timeoutSeconds?: number; maxOutputBytes?: number }>(
       config,
@@ -1626,7 +1628,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
         apply: commandResultSchema,
       }),
       annotations: destructiveAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<AgentStartInput>(config, auth, WRITE_SCOPES, async (args) => {
       const manifest = buildAgentRunManifest(config, args)
@@ -1783,7 +1785,7 @@ export const createAgentsShellServer = (config: AgentsShellConfig, runner: Agent
       },
       outputSchema: commandResultSchema,
       annotations: destructiveAnnotations,
-      ...toolSecurityMeta([SCOPES.write]),
+      ...toolSecurityMeta([SCOPES.read]),
     },
     withToolErrors<{
       agentRunName: string


### PR DESCRIPTION
## Summary

- Use the stable linked `agents-shell.read` OAuth scope for every agents-shell tool advertised to ChatGPT.
- Keep identity allowlisting, tool annotations, destructive hints, and audit logging as the enforcement boundary for this private connector.
- Add regression coverage that every listed tool advertises the single linked scope and unauthenticated calls still receive an OAuth challenge.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents test -- src/server/agents-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents tsc`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
