### PR TITLE
fix(agents): finish process tools on child exit

### DIFF
--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -415,6 +415,60 @@ describe('agents-shell MCP tools', () => {
     await server.close()
   })
 
+  it('finishes process tools when a git descendant keeps stdio open after child exit', async () => {
+    const config = makeConfig()
+    mkdirSync(join(config.workspaceRoot, 'lab'), { recursive: true })
+    const bin = join(config.workspaceRoot, 'bin')
+    mkdirSync(bin, { recursive: true })
+    writeFileSync(
+      join(bin, 'git'),
+      `#!/bin/sh
+if [ "$1" = "fetch" ]; then
+  (sleep 3) &
+  printf '%s\\n' 'fetched origin main'
+  exit 0
+fi
+printf '%s\\n' "$@"
+`,
+    )
+    chmodSync(join(bin, 'git'), 0o755)
+
+    const previousPath = process.env.PATH
+    process.env.PATH = `${bin}:${previousPath ?? ''}`
+
+    const { client, server, clientTransport, serverTransport } = await connectServer(config)
+
+    try {
+      const startedAt = Date.now()
+      const result = await client.callTool({
+        name: 'git_write',
+        arguments: { args: ['fetch', 'origin', 'main'], cwd: 'lab', timeoutSeconds: 1 },
+      })
+      const elapsedMs = Date.now() - startedAt
+      expect(result.isError).not.toBe(true)
+      const content = result.structuredContent as {
+        exitCode?: number | null
+        stdout?: string
+        timedOut?: boolean
+      }
+      expect(content.exitCode).toBe(0)
+      expect(content.timedOut).toBe(false)
+      expect(content.stdout).toContain('fetched origin main')
+      expect(elapsedMs).toBeLessThan(2_000)
+    } finally {
+      await clientTransport.close()
+      await serverTransport.close()
+      await client.close()
+      await server.close()
+
+      if (previousPath == null) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = previousPath
+      }
+    }
+  })
+
   it('reads files and blocks apply_patch paths outside /workspace', async () => {
     const config = makeConfig()
     mkdirSync(join(config.workspaceRoot, 'lab'), { recursive: true })

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -856,11 +856,21 @@ export class AgentsShellRunner {
     }, timeoutSeconds * 1000)
 
     const result = await new Promise<{ exitCode: number | null; signal: string | null }>((resolvePromise, reject) => {
-      child.on('error', reject)
-      child.on('close', (exitCode, signal) => resolvePromise({ exitCode, signal }))
+      let settled = false
+      const finish = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+        if (settled) return
+        settled = true
+        child.stdout.destroy()
+        child.stderr.destroy()
+        resolvePromise({ exitCode, signal })
+      }
+
+      child.once('error', reject)
+      child.once('exit', (exitCode, signal) => setImmediate(() => finish(exitCode, signal)))
+      child.once('close', (exitCode, signal) => finish(exitCode, signal))
     }).finally(() => clearTimeout(timeout))
 
-    return toProcessResult(
+    const processResult = toProcessResult(
       commandLine,
       cwd,
       result.exitCode,
@@ -871,6 +881,14 @@ export class AgentsShellRunner {
       maxOutputBytes,
       new Set(options.okExitCodes ?? [0]),
     )
+    this.audit(`${options.auditEvent}_finished`, options.auth, {
+      command: commandLine,
+      cwd,
+      exitCode: result.exitCode,
+      signal: result.signal,
+      timedOut,
+    })
+    return processResult
   }
 
   shutdown() {


### PR DESCRIPTION
## Summary

- Resolve generic process tools from the child process exit event so inherited stdio from descendants cannot strand MCP requests.
- Destroy child output streams after process exit and write finished audit entries for process-backed tools.
- Add a git_write regression test for a fetch command whose descendant keeps stdio open longer than the tool timeout.

## Related Issues

None

## Testing

- bunx oxfmt --check services/agents/src/server/agents-shell-mcp.ts services/agents/src/server/agents-shell-mcp.test.ts
- bun run --filter @proompteng/agents test -- src/server/agents-shell-mcp.test.ts
- bun run --filter @proompteng/agents tsc

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
