### PR TITLE
feat(nix): guard enabled app image rollout

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -6,10 +6,18 @@ on:
       - main
     paths:
       - 'packages/scripts/**'
+      - 'argocd/root.yaml'
+      - 'argocd/applicationsets/**'
+      - 'argocd/applications/**'
+      - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
       - '.github/workflows/scripts-ci.yml'
   pull_request:
     paths:
       - 'packages/scripts/**'
+      - 'argocd/root.yaml'
+      - 'argocd/applicationsets/**'
+      - 'argocd/applications/**'
+      - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
       - '.github/workflows/scripts-ci.yml'
 
 concurrency:

--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -1,0 +1,53 @@
+# Enabled-App Nix Build Performance Rollout Plan
+
+## Summary
+
+This rollout treats Nix adoption as build performance and reproducibility work across the root-enabled Argo surface. The source of truth is `argocd/root.yaml`, which points Argo at `argocd/applicationsets`; only apps enabled through those files count as production rollout proof.
+
+The current inventory shape is:
+
+- 71 enabled ApplicationSet entries.
+- 1 direct root-managed Application in the same directory: `home-root`.
+- Helm/chart-only and vendor-manifest apps are not image-build migration targets.
+- Repo-image apps are only migration candidates after source ownership and a build/deploy path are proven.
+
+Both supported production paths must remain available for each migrated build-owning app:
+
+- GitHub Actions build/release workflows.
+- Existing manual deploy scripts such as `bun run <service>:deploy`.
+
+No Ceph, Rook, ObjectBucketClaim, PVC, or storage changes are in scope.
+
+## Key Changes
+
+- Add a root-enabled inventory guardrail that classifies apps as `nix-image`, `helm-chart`, `vendor-manifest`, `external-source`, or `deferred`.
+- Keep chart-only apps out of image migration. For Helm apps, optimize reproducible `kustomize build --enable-helm`, schema validation, chart/version pinning, and live smoke only.
+- Add a shared Nix OCI contract helper for future migrated services. The helper defines one contract for service name, Nix attr, source SHA, output path, image digest, platforms, cache provenance, timing, and tool versions.
+- Keep GitHub Actions and manual deploy scripts on the same contract so a service cannot have one image path in CI and another image path locally.
+- Keep Docker available only as an explicit transitional fallback for unmigrated services.
+
+## Rollout Sequence
+
+1. PR 1: inventory/classification, guardrails, timing/cache metrics foundation, contract helper, tests, and docs. No service image migration.
+2. PR 2: ARC runner toolchain speedup with pinned Nix, `skopeo`, `crane`, `cosign`, `jq`, `yq`, and `kustomize`. No storage changes.
+3. PR 3: migrate clean simple build-owning apps first: `oirat`, `bumba`, and `froussard`.
+4. PR 4: migrate enabled frontend/product build-owning apps: `docs`, `app`, `proompteng`, `olden`, and `synthesis`.
+5. PR 5+: migrate complex build-owning apps only after service-specific derivations are proven: `agents`, `jangar`, `symphony`, `bilig`, `sag`, `analysis`, and `autotrader`.
+6. Defer Torghut-family image migration until live app health is clean.
+
+## Test Plan
+
+- Inventory tests prove disabled apps are excluded, `home-root` is represented separately, Helm/chart apps do not receive image-build migration state, and repo-image references are not automatically counted as early proof.
+- Contract tests prove migrated services can share the same GitHub Actions and manual deploy metadata without Docker daemon assumptions.
+- Workflow tests prove migrated Nix OCI workflows avoid Docker Buildx, `docker load`, `docker run`, and `docker push`.
+- Performance proof records runner setup, Nix setup, dependency realization, app build, image assembly, image push, index creation, release PR, and rollout timing.
+- Reproducibility proof requires pinned inputs, digest-pinned releases, stable output paths for same inputs, and network-free builds except declared fixed-output fetches/substituters.
+
+## Acceptance
+
+- No build is added for chart-only or vendor-only apps.
+- Every migrated build-owning app works through both GitHub Actions and manual deploy script paths.
+- Migrated workflows and scripts publish the same OCI digest/platform contract.
+- Argo rollout proof is only counted for root-enabled live apps.
+- No mandatory workflow regresses by more than 10%; target is at least 25% less repeated setup/dependency time for migrated image builds.
+- No Ceph, Rook, ObjectBucketClaim, PVC, or storage changes are included.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test'
+
+import { assertEnabledAppBuildPolicy, loadEnabledAppInventory } from '../enabled-apps'
+
+const inventory = loadEnabledAppInventory()
+
+const entry = (name: string) => {
+  const found = inventory.entries.find((candidate) => candidate.name === name)
+  if (!found) throw new Error(`Missing enabled app inventory entry for ${name}`)
+  return found
+}
+
+describe('enabled app inventory', () => {
+  it('loads only root-enabled ApplicationSet entries plus direct root-managed Applications', () => {
+    expect(inventory.applicationSetEntryCount).toBe(71)
+    expect(inventory.directApplicationCount).toBe(1)
+    expect(inventory.entries).toHaveLength(72)
+    expect(inventory.entries.some((candidate) => candidate.name === 'facteur')).toBe(false)
+    expect(inventory.entries.some((candidate) => candidate.name === 'bonjour')).toBe(false)
+  })
+
+  it('does not inspect local lab manifests for external source applications', () => {
+    expect(entry('metrics-server')).toMatchObject({
+      class: 'external-source',
+      repoURL: 'https://github.com/kubernetes-sigs/metrics-server.git',
+      repoImages: [],
+      hasHelmChart: false,
+    })
+    expect(entry('home-root')).toMatchObject({
+      class: 'external-source',
+      repoURL: 'git@github.com:gregkonush/home.git',
+      sourceKind: 'direct-application',
+      repoImages: [],
+      hasHelmChart: false,
+    })
+  })
+
+  it('keeps chart-only apps out of Nix image migration state', () => {
+    for (const name of [
+      'headlamp',
+      'temporal',
+      'observability',
+      'nats',
+      'kafka',
+      'traefik',
+      'tailscale',
+      'cert-manager',
+    ]) {
+      expect(entry(name)).toMatchObject({
+        class: 'helm-chart',
+        hasHelmChart: true,
+        repoImages: [],
+      })
+      expect(entry(name).nixImageAttr).toBeUndefined()
+      expect(entry(name).buildScriptPath).toBeUndefined()
+    }
+  })
+
+  it('marks only approved early build-owning apps as Nix image candidates', () => {
+    for (const name of ['oirat', 'bumba', 'froussard', 'docs', 'app', 'proompteng', 'olden', 'synthesis', 'attic']) {
+      expect(entry(name).class).toBe('nix-image')
+      expect(entry(name).repoImages.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
+    for (const name of ['agents', 'jangar', 'sag', 'symphony', 'bilig', 'analysis', 'torghut', 'torghut-options']) {
+      expect(entry(name).class).toBe('deferred')
+      expect(entry(name).repoImages.length).toBeGreaterThan(0)
+      expect(entry(name).deferredReason).toBeTruthy()
+    }
+  })
+
+  it('passes the no-build-for-chart-and-vendor guardrail', () => {
+    expect(() => assertEnabledAppBuildPolicy(inventory)).not.toThrow()
+  })
+})

--- a/packages/scripts/src/shared/__tests__/nix-oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/nix-oci.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test'
+
+import { buildNixOciBuildPlan, buildNixOciReleaseContract } from '../nix-oci'
+
+describe('Nix OCI build contract', () => {
+  it('builds the shared GitHub Actions and manual deploy image plan', () => {
+    const plan = buildNixOciBuildPlan({
+      service: 'oirat',
+      imageName: 'oirat',
+      packageAttr: 'oirat-image',
+      tag: 'sha-abc1234',
+      sourceSha: 'abc123456789',
+    })
+
+    expect(plan.image).toBe('registry.ide-newton.ts.net/lab/oirat')
+    expect(plan.referenceTag).toBe('registry.ide-newton.ts.net/lab/oirat:sha-abc1234')
+    expect(plan.nixBuildArgs).toEqual(['nix', 'build', '.#oirat-image', '--print-build-logs'])
+    expect(plan.platformPushArgs['linux/amd64']).toContain('sha-abc1234-amd64')
+    expect(plan.platformPushArgs['linux/arm64']).toContain('sha-abc1234-arm64')
+    expect(plan.indexArgs).toContain('linux/amd64=sha-abc1234-amd64')
+    expect(plan.indexArgs).toContain('linux/arm64=sha-abc1234-arm64')
+  })
+
+  it('refuses pushes outside the lab registry namespace', () => {
+    expect(() =>
+      buildNixOciBuildPlan({
+        service: 'bad',
+        imageName: 'bad',
+        packageAttr: 'bad-image',
+        tag: 'sha-bad',
+        sourceSha: 'bad',
+        registry: 'ghcr.io',
+        repository: 'proompteng/bad',
+      }),
+    ).toThrow('Nix OCI image pushes must stay in registry.ide-newton.ts.net/lab')
+  })
+
+  it('serializes the same release contract shape for manual scripts and Actions', () => {
+    const plan = buildNixOciBuildPlan({
+      service: 'bumba',
+      imageName: 'bumba',
+      packageAttr: 'bumba-image',
+      tag: 'sha-feedbee',
+      sourceSha: 'feedbeefeedbeefeedbee',
+    })
+
+    expect(
+      buildNixOciReleaseContract({
+        plan,
+        digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        invocation: 'manual-script',
+      }),
+    ).toEqual({
+      service: 'bumba',
+      image: 'registry.ide-newton.ts.net/lab/bumba',
+      tag: 'sha-feedbee',
+      digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      reference:
+        'registry.ide-newton.ts.net/lab/bumba@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      sourceSha: 'feedbeefeedbeefeedbee',
+      packageAttr: 'bumba-image',
+      platforms: ['linux/amd64', 'linux/arm64'],
+      builder: 'nix-dockerTools-skopeo',
+      invocation: 'manual-script',
+    })
+  })
+})

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -1,0 +1,350 @@
+#!/usr/bin/env bun
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { basename, join, relative, resolve } from 'node:path'
+
+import YAML from 'yaml'
+
+import { fatal, repoRoot } from './cli'
+
+export type EnabledAppClass = 'nix-image' | 'helm-chart' | 'vendor-manifest' | 'external-source' | 'deferred'
+
+export type EnabledAppInventoryEntry = {
+  name: string
+  path: string
+  repoURL: string
+  sourceFile: string
+  sourceKind: 'applicationset-element' | 'direct-application'
+  class: EnabledAppClass
+  enabled: boolean
+  hasHelmChart: boolean
+  repoImages: string[]
+  buildScriptPath?: string
+  deployScriptPath?: string
+  workflowPaths: string[]
+  nixImageAttr?: string
+  deferredReason?: string
+}
+
+export type EnabledAppInventory = {
+  entries: EnabledAppInventoryEntry[]
+  applicationSetEntryCount: number
+  directApplicationCount: number
+}
+
+type JsonRecord = Record<string, unknown>
+
+const labRepoURL = 'https://github.com/proompteng/lab.git'
+const labImagePrefix = 'registry.ide-newton.ts.net/lab/'
+
+const earlyNixImageApps = new Set([
+  'app',
+  'attic',
+  'bumba',
+  'docs',
+  'froussard',
+  'oirat',
+  'olden',
+  'proompteng',
+  'synthesis',
+])
+
+const deferredApps = new Map<string, string>([
+  ['agents', 'complex multi-image runtime; migrate after simple services prove the shared Nix contract'],
+  ['analysis', 'repo image is tracked by image updater, but no local build/deploy script is wired in this repo'],
+  ['bilig', 'complex application image; requires a dedicated derivation and rollout proof'],
+  ['jangar', 'complex service plus OpenWebUI chart; requires a dedicated derivation and rollout proof'],
+  ['sag', 'complex app; migrate after simple Bun/Node services'],
+  ['symphony', 'complex service with multiple Argo apps sharing one image'],
+  ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
+  ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
+  ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
+  ['torghut', 'deferred until live GitOps/app health is clean'],
+  ['torghut-hyperliquid-feed', 'Torghut-family image; deferred until live app health is clean'],
+  ['torghut-hyperliquid-runtime', 'Torghut-family image; deferred until live app health is clean'],
+  ['torghut-options', 'Torghut-family image; deferred until live app health is clean'],
+])
+
+const appToNixAttr = new Map<string, string>([['attic', 'atticd-image']])
+
+const uniqueSorted = (values: Iterable<string>): string[] => [...new Set(values)].sort()
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined)
+
+const walk = (value: unknown, visit: (record: JsonRecord) => void): void => {
+  if (Array.isArray(value)) {
+    for (const entry of value) walk(entry, visit)
+    return
+  }
+  if (!isRecord(value)) return
+
+  visit(value)
+  for (const child of Object.values(value)) {
+    walk(child, visit)
+  }
+}
+
+const readYamlDocuments = (path: string): unknown[] => {
+  const raw = readFileSync(path, 'utf8')
+  return YAML.parseAllDocuments(raw)
+    .filter((document) => !document.errors.length)
+    .map((document) => document.toJSON())
+    .filter((document) => document !== null)
+}
+
+const listYamlFiles = (dir: string): string[] => {
+  if (!existsSync(dir)) return []
+
+  const entries: string[] = []
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    const stat = statSync(path)
+    if (stat.isDirectory()) {
+      entries.push(...listYamlFiles(path))
+    } else if (stat.isFile() && /\.(ya?ml)$/.test(name)) {
+      entries.push(path)
+    }
+  }
+  return entries.sort()
+}
+
+const isEnabledValue = (value: unknown): boolean => {
+  const normalized =
+    typeof value === 'string'
+      ? value.trim().toLowerCase()
+      : typeof value === 'boolean' || typeof value === 'number'
+        ? String(value).toLowerCase()
+        : 'true'
+  return normalized !== 'false' && normalized !== '0'
+}
+
+const collectApplicationSetElements = (document: unknown, sourceFile: string): EnabledAppInventoryEntry[] => {
+  const entries: EnabledAppInventoryEntry[] = []
+  walk(document, (record) => {
+    const elements = record.elements
+    if (!Array.isArray(elements)) return
+
+    for (const element of elements) {
+      if (!isRecord(element)) continue
+
+      const name = asString(element.name)
+      const path = asString(element.path)
+      if (!name || !path || !isEnabledValue(element.enabled)) continue
+
+      entries.push({
+        name,
+        path,
+        repoURL: asString(element.repoURL) ?? labRepoURL,
+        sourceFile,
+        sourceKind: 'applicationset-element',
+        class: 'vendor-manifest',
+        enabled: true,
+        hasHelmChart: false,
+        repoImages: [],
+        workflowPaths: [],
+      })
+    }
+  })
+  return entries
+}
+
+const collectDirectApplications = (document: unknown, sourceFile: string): EnabledAppInventoryEntry[] => {
+  if (!isRecord(document) || document.kind !== 'Application') return []
+  const metadata = isRecord(document.metadata) ? document.metadata : {}
+  const spec = isRecord(document.spec) ? document.spec : {}
+  const source = isRecord(spec.source) ? spec.source : {}
+  const name = asString(metadata.name)
+  const path = asString(source.path)
+  if (!name || !path || name === 'root') return []
+
+  return [
+    {
+      name,
+      path,
+      repoURL: asString(source.repoURL) ?? labRepoURL,
+      sourceFile,
+      sourceKind: 'direct-application',
+      class: 'vendor-manifest',
+      enabled: true,
+      hasHelmChart: false,
+      repoImages: [],
+      workflowPaths: [],
+    },
+  ]
+}
+
+const collectRepoImages = (yamlPath: string, document: unknown): string[] => {
+  const images = new Set<string>()
+  walk(document, (record) => {
+    const image = asString(record.image)
+    if (image?.startsWith(labImagePrefix)) images.add(image)
+
+    const repository = asString(record.repository)
+    if (repository?.startsWith(labImagePrefix)) images.add(repository)
+
+    if (basename(yamlPath) === 'kustomization.yaml' && Array.isArray(record.images)) {
+      for (const entry of record.images) {
+        if (!isRecord(entry)) continue
+        for (const key of ['name', 'newName']) {
+          const value = asString(entry[key])
+          if (value?.startsWith(labImagePrefix)) images.add(value)
+        }
+      }
+    }
+  })
+  return [...images]
+}
+
+const inspectApplicationPath = (root: string, entry: EnabledAppInventoryEntry): EnabledAppInventoryEntry => {
+  if (entry.repoURL !== labRepoURL) {
+    return entry
+  }
+
+  const absolutePath = resolve(root, entry.path)
+  const yamlFiles = listYamlFiles(absolutePath)
+  const repoImages = new Set<string>()
+  let hasHelmChart = false
+
+  for (const yamlPath of yamlFiles) {
+    for (const document of readYamlDocuments(yamlPath)) {
+      walk(document, (record) => {
+        if (Array.isArray(record.helmCharts) || record.kind === 'HelmRelease') {
+          hasHelmChart = true
+        }
+      })
+      for (const image of collectRepoImages(yamlPath, document)) repoImages.add(image)
+    }
+  }
+
+  const buildScriptPath = `packages/scripts/src/${entry.name}/build-image.ts`
+  const deployScriptPath = `packages/scripts/src/${entry.name}/deploy-service.ts`
+  const workflowPaths = listYamlFiles(resolve(root, '.github/workflows')).filter((path) => {
+    const workflow = readFileSync(path, 'utf8')
+    return (
+      workflow.includes(`image_name: ${entry.name}`) ||
+      workflow.includes(`registry.ide-newton.ts.net/lab/${entry.name}`)
+    )
+  })
+
+  return {
+    ...entry,
+    hasHelmChart,
+    repoImages: uniqueSorted(repoImages),
+    buildScriptPath: existsSync(resolve(root, buildScriptPath)) ? buildScriptPath : undefined,
+    deployScriptPath: existsSync(resolve(root, deployScriptPath)) ? deployScriptPath : undefined,
+    workflowPaths: workflowPaths.map((path) => relative(root, path)).sort(),
+    nixImageAttr: appToNixAttr.get(entry.name),
+  }
+}
+
+const classify = (entry: EnabledAppInventoryEntry): EnabledAppInventoryEntry => {
+  if (entry.repoURL !== labRepoURL) {
+    return { ...entry, class: 'external-source' }
+  }
+
+  const deferredReason = deferredApps.get(entry.name)
+  if (deferredReason) {
+    return { ...entry, class: 'deferred', deferredReason }
+  }
+
+  if (entry.repoImages.length > 0) {
+    if (earlyNixImageApps.has(entry.name)) {
+      return { ...entry, class: 'nix-image' }
+    }
+    return {
+      ...entry,
+      class: 'deferred',
+      deferredReason: 'repo image is present but this app is not in the approved early Nix migration wave',
+    }
+  }
+
+  if (entry.hasHelmChart) {
+    return { ...entry, class: 'helm-chart' }
+  }
+
+  return { ...entry, class: 'vendor-manifest' }
+}
+
+export const loadEnabledAppInventory = (root = repoRoot): EnabledAppInventory => {
+  const applicationsetsDir = resolve(root, 'argocd/applicationsets')
+  const sourceFiles = listYamlFiles(applicationsetsDir)
+  const rawEntries: EnabledAppInventoryEntry[] = []
+
+  for (const path of sourceFiles) {
+    const sourceFile = relative(root, path)
+    for (const document of readYamlDocuments(path)) {
+      rawEntries.push(...collectApplicationSetElements(document, sourceFile))
+      rawEntries.push(...collectDirectApplications(document, sourceFile))
+    }
+  }
+
+  const deduped = new Map<string, EnabledAppInventoryEntry>()
+  for (const entry of rawEntries) {
+    deduped.set(`${entry.sourceKind}:${entry.name}:${entry.path}:${entry.repoURL}`, entry)
+  }
+
+  const entries = [...deduped.values()]
+    .map((entry) => classify(inspectApplicationPath(root, entry)))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return {
+    entries,
+    applicationSetEntryCount: entries.filter((entry) => entry.sourceKind === 'applicationset-element').length,
+    directApplicationCount: entries.filter((entry) => entry.sourceKind === 'direct-application').length,
+  }
+}
+
+export const assertEnabledAppBuildPolicy = (inventory: EnabledAppInventory): void => {
+  const invalid = inventory.entries.filter(
+    (entry) =>
+      (entry.class === 'helm-chart' || entry.class === 'vendor-manifest' || entry.class === 'external-source') &&
+      (entry.nixImageAttr || entry.buildScriptPath),
+  )
+
+  if (invalid.length > 0) {
+    throw new Error(
+      `Non-build app(s) have image build state: ${invalid.map((entry) => `${entry.name}:${entry.class}`).join(', ')}`,
+    )
+  }
+
+  const chartBuilds = inventory.entries.filter((entry) => entry.class === 'helm-chart' && entry.repoImages.length > 0)
+  if (chartBuilds.length > 0) {
+    throw new Error(
+      `Helm-chart app(s) unexpectedly own lab images: ${chartBuilds.map((entry) => entry.name).join(', ')}`,
+    )
+  }
+}
+
+const printTable = (inventory: EnabledAppInventory): void => {
+  for (const entry of inventory.entries) {
+    console.log(
+      [entry.class, entry.name, entry.path, entry.repoURL, entry.repoImages.join(','), entry.deferredReason ?? ''].join(
+        '\t',
+      ),
+    )
+  }
+}
+
+const runCli = (): void => {
+  const args = process.argv.slice(2)
+  const inventory = loadEnabledAppInventory()
+  if (args.includes('--assert')) {
+    assertEnabledAppBuildPolicy(inventory)
+  }
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(inventory, null, 2))
+    return
+  }
+  printTable(inventory)
+}
+
+if (import.meta.main) {
+  try {
+    runCli()
+  } catch (error) {
+    fatal('Enabled app inventory check failed', error)
+  }
+}

--- a/packages/scripts/src/shared/nix-oci.ts
+++ b/packages/scripts/src/shared/nix-oci.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+
+import { fatal } from './cli'
+
+export type NixOciPlatform = 'linux/amd64' | 'linux/arm64'
+
+export type NixOciBuildPlanInput = {
+  service: string
+  imageName: string
+  packageAttr: string
+  sourceSha: string
+  tag: string
+  registry?: string
+  repository?: string
+  platforms?: NixOciPlatform[]
+}
+
+export type NixOciBuildPlan = Omit<Required<NixOciBuildPlanInput>, 'platforms'> & {
+  platforms: NixOciPlatform[]
+  image: string
+  referenceTag: string
+  nixBuildArgs: string[]
+  platformPushArgs: Partial<Record<NixOciPlatform, string[]>>
+  indexArgs: string[]
+}
+
+export type NixOciReleaseContract = {
+  service: string
+  image: string
+  tag: string
+  digest: string
+  reference: string
+  sourceSha: string
+  packageAttr: string
+  platforms: NixOciPlatform[]
+  builder: 'nix-dockerTools-skopeo'
+  invocation: 'github-actions' | 'manual-script'
+}
+
+const defaultRegistry = 'registry.ide-newton.ts.net'
+const defaultPlatforms: NixOciPlatform[] = ['linux/amd64', 'linux/arm64']
+
+const normalizeNonEmpty = (value: string, field: string): string => {
+  const normalized = value.trim()
+  if (!normalized) {
+    throw new Error(`${field} is required`)
+  }
+  return normalized
+}
+
+const assertLabRepository = (registry: string, repository: string): void => {
+  if (registry !== defaultRegistry || !repository.startsWith('lab/')) {
+    throw new Error(`Nix OCI image pushes must stay in ${defaultRegistry}/lab, got ${registry}/${repository}`)
+  }
+}
+
+export const buildNixOciBuildPlan = (input: NixOciBuildPlanInput): NixOciBuildPlan => {
+  const service = normalizeNonEmpty(input.service, 'service')
+  const imageName = normalizeNonEmpty(input.imageName, 'imageName')
+  const packageAttr = normalizeNonEmpty(input.packageAttr, 'packageAttr')
+  const sourceSha = normalizeNonEmpty(input.sourceSha, 'sourceSha')
+  const tag = normalizeNonEmpty(input.tag, 'tag')
+  const registry = normalizeNonEmpty(input.registry ?? defaultRegistry, 'registry')
+  const repository = normalizeNonEmpty(input.repository ?? `lab/${imageName}`, 'repository')
+  const platforms = input.platforms?.length ? input.platforms : defaultPlatforms
+
+  assertLabRepository(registry, repository)
+
+  const image = `${registry}/${repository}`
+  const archTags = platforms.flatMap((platform) => {
+    const arch = platform.replace('linux/', '') as 'amd64' | 'arm64'
+    return ['--arch-tag', `${platform}=${tag}-${arch}`]
+  })
+  const platformPushArgs = Object.fromEntries(
+    platforms.map((platform) => {
+      const arch = platform.replace('linux/', '') as 'amd64' | 'arm64'
+      return [
+        platform,
+        [
+          'nix',
+          'run',
+          '.#oci-push',
+          '--',
+          '--image',
+          image,
+          '--tag',
+          `${tag}-${arch}`,
+          '--tar',
+          `<${packageAttr}-tar>`,
+        ],
+      ]
+    }),
+  ) as Partial<Record<NixOciPlatform, string[]>>
+
+  return {
+    service,
+    imageName,
+    packageAttr,
+    sourceSha,
+    tag,
+    registry,
+    repository,
+    platforms,
+    image,
+    referenceTag: `${image}:${tag}`,
+    nixBuildArgs: ['nix', 'build', `.#${packageAttr}`, '--print-build-logs'],
+    platformPushArgs,
+    indexArgs: ['nix', 'run', '.#create-oci-index', '--', '--image', image, '--tag', tag, ...archTags],
+  }
+}
+
+export const buildNixOciReleaseContract = (input: {
+  plan: NixOciBuildPlan
+  digest: string
+  invocation: NixOciReleaseContract['invocation']
+}): NixOciReleaseContract => {
+  const digest = normalizeNonEmpty(input.digest, 'digest')
+  if (!digest.startsWith('sha256:')) {
+    throw new Error(`digest must be a sha256 digest, got ${digest}`)
+  }
+
+  return {
+    service: input.plan.service,
+    image: input.plan.image,
+    tag: input.plan.tag,
+    digest,
+    reference: `${input.plan.image}@${digest}`,
+    sourceSha: input.plan.sourceSha,
+    packageAttr: input.plan.packageAttr,
+    platforms: input.plan.platforms,
+    builder: 'nix-dockerTools-skopeo',
+    invocation: input.invocation,
+  }
+}
+
+const runCli = (): void => {
+  const [, , service, imageName, packageAttr, tag, sourceSha] = process.argv
+  const plan = buildNixOciBuildPlan({
+    service: service ?? '',
+    imageName: imageName ?? '',
+    packageAttr: packageAttr ?? '',
+    tag: tag ?? '',
+    sourceSha: sourceSha ?? '',
+  })
+  console.log(JSON.stringify(plan, null, 2))
+}
+
+if (import.meta.main) {
+  try {
+    runCli()
+  } catch (error) {
+    fatal('Failed to build Nix OCI plan', error)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the canonical enabled-app Nix rollout plan under `docs/`.
- Adds a root-enabled Argo inventory tool that classifies ApplicationSet/direct apps as `nix-image`, `helm-chart`, `vendor-manifest`, `external-source`, or `deferred`.
- Adds guardrail tests so chart-only/vendor/external apps do not receive image-build migration state.
- Adds a shared Nix OCI build/release contract helper for future GitHub Actions and manual deploy script parity.
- Expands `packages-scripts` CI triggers so root/ApplicationSet/app manifest changes rerun the guardrails.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/nix-oci.test.ts`
- `bun run packages/scripts/src/shared/enabled-apps.ts --assert --json >/tmp/enabled-apps-inventory.json && jq '{appset:.applicationSetEntryCount,direct:.directApplicationCount,counts:(.entries|group_by(.class)|map({key:.[0].class,value:length})|from_entries)}' /tmp/enabled-apps-inventory.json`
- `bun test packages/scripts/src/shared`
- `bun run --cwd packages/scripts lint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `bun test packages/scripts/src`
- `git diff --check`
- `nix flake check --print-build-logs` was not run locally because `nix` is not installed in this desktop shell; PR CI must provide the Nix runner proof.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
