### PR TITLE
chore(symphony): promote image 352edeaa

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:30:43Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T01:19:01Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4948a728"
-    digest: sha256:443d1a7cbf72e7c72d170b03e7dae06480c883924f6948135aeca6b6bb866a1d
+    newTag: "352edeaa"
+    digest: sha256:17c9824e56a6737c3eb25e20fc8c524f3ef74343c237e76601734dba59503060

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:30:43Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T01:19:01Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4948a728"
-    digest: sha256:443d1a7cbf72e7c72d170b03e7dae06480c883924f6948135aeca6b6bb866a1d
+    newTag: "352edeaa"
+    digest: sha256:17c9824e56a6737c3eb25e20fc8c524f3ef74343c237e76601734dba59503060

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-29T05:30:43Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T01:19:01Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4948a728"
-    digest: sha256:443d1a7cbf72e7c72d170b03e7dae06480c883924f6948135aeca6b6bb866a1d
+    newTag: "352edeaa"
+    digest: sha256:17c9824e56a6737c3eb25e20fc8c524f3ef74343c237e76601734dba59503060


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `352edeaa6d2c0a4ce5659e1ff07e1b1755c31a13`
- Image tag: `352edeaa`
- Image digest: `sha256:17c9824e56a6737c3eb25e20fc8c524f3ef74343c237e76601734dba59503060`