### PR TITLE
fix(rook-ceph): preserve turin osd0 db lv path

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -132,6 +132,9 @@ cephClusterSpec:
               databaseSizeMB: "300000"
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0MZ1M
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0LVM9
+            config:
+              metadataDevice: /dev/ceph-10525ca6-66f7-48fd-a13a-7f7063dcc31b/osd-db-osd1
+              databaseSizeMB: "300000"
 
   disruptionManagement:
     managePodBudgets: true

--- a/docs/runbooks/rook-ceph-turin-bluestore-db-fast-migration.md
+++ b/docs/runbooks/rook-ceph-turin-bluestore-db-fast-migration.md
@@ -396,24 +396,29 @@ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd unset noout
 
 ## GitOps Follow-Up
 
-After `osd.0` and `osd.1` are migrated, update
-`argocd/applications/rook-ceph/cluster-values.yaml` so future OSD prepares use
-the same desired DB device. Use per-device config, not node-wide config:
+After each OSD is migrated, update
+`argocd/applications/rook-ceph/cluster-values.yaml` before Argo CD is allowed
+to reconcile again. Use per-device config, not node-wide config.
+
+For a fresh empty metadata NVMe, the raw by-id Kingston device is acceptable.
+After the Kingston NVMe already has BlueStore DB LVs, Rook may not inventory the
+parent NVMe as an available metadata device during later prepares. This matches
+the failure mode tracked in [rook/rook#13634](https://github.com/rook/rook/issues/13634).
+In that case, pre-create or reuse the target DB LV and point `metadataDevice`
+at the LV path directly.
+
+Live OSD0 example after the 2026-06-30 recreate:
 
 ```yaml
 - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0LVM9
   config:
-    metadataDevice: /dev/disk/by-id/nvme-KINGSTON_SNV3S1000G_50026B76878F0B27
-    databaseSizeMB: "300000"
-- name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0MZ1M
-  config:
-    metadataDevice: /dev/disk/by-id/nvme-KINGSTON_SNV3S1000G_50026B76878F0B27
-    databaseSizeMB: "300000"
-- name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0NL5D
-  config:
-    metadataDevice: /dev/disk/by-id/nvme-KINGSTON_SNV3S1000G_50026B76878F0B27
+    metadataDevice: /dev/ceph-10525ca6-66f7-48fd-a13a-7f7063dcc31b/osd-db-osd1
     databaseSizeMB: "300000"
 ```
+
+Repeat this for `osd.1` only after its target DB LV is known. Do not resume
+Argo with a raw Kingston parent path for the OSD currently being recreated if
+Rook has already failed inventory against that parent device.
 
 Validate:
 


### PR DESCRIPTION
## Summary

- Preserve Turin `osd.0` BlueStore DB placement by pointing Rook at the known-good Kingston DB LV path.
- Document the Rook metadata-device inventory failure mode when the shared Kingston NVMe already has DB LVs.
- Keep the next `osd.1` LV path explicit: update GitOps only after its target DB LV is known.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph`
- `git diff --check`
- `bun run lint:argocd`
- Live readback: `ceph osd metadata 0 --format json` reports `bluefs_dedicated_db=1`, `bluefs_single_shared_device=0`, `bluefs_db_devices=nvme2n1`, and `bluestore_bdev_devices=sdd`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Argo should remain paused until this PR is merged or the live CephCluster spec is otherwise kept aligned with the LV path.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
