### PR TITLE
ci(nix): preinstall arc runner toolchain

### DIFF
--- a/.github/actions/setup-nix-toolchain/action.yml
+++ b/.github/actions/setup-nix-toolchain/action.yml
@@ -1,0 +1,95 @@
+name: setup-nix-toolchain
+description: Validate the ARC preinstalled Nix toolchain and fall back to installing Nix when needed.
+
+inputs:
+  github-token:
+    description: GitHub token passed to the fallback Nix installer.
+    required: false
+    default: ''
+  extra-nix-config:
+    description: Nix configuration written for the current runner.
+    required: false
+    default: |
+      experimental-features = nix-command flakes
+  install-ci-toolchain:
+    description: Install and validate the repo CI toolchain when the runner image does not already provide it.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Detect preinstalled Nix
+      id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v nix >/dev/null 2>&1; then
+          echo "nix_available=true" >> "${GITHUB_OUTPUT}"
+          nix --version
+        else
+          echo "nix_available=false" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Install xz for fallback Nix installer
+      if: steps.detect.outputs.nix_available != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v apt-get >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y xz-utils
+        elif command -v apk >/dev/null 2>&1; then
+          sudo apk add --no-cache xz
+        elif command -v dnf >/dev/null 2>&1; then
+          sudo dnf install -y xz
+        elif ! command -v xz >/dev/null 2>&1; then
+          echo "xz is required to install Nix on this runner." >&2
+          exit 1
+        fi
+
+    - name: Install fallback Nix
+      if: steps.detect.outputs.nix_available != 'true'
+      uses: cachix/install-nix-action@v31
+      with:
+        github_access_token: ${{ inputs.github-token }}
+        extra_nix_config: ${{ inputs.extra-nix-config }}
+
+    - name: Configure Nix
+      shell: bash
+      env:
+        EXTRA_NIX_CONFIG: ${{ inputs.extra-nix-config }}
+      run: |
+        set -euo pipefail
+        mkdir -p "${HOME}/.config/nix"
+        printf '%s\n' "${EXTRA_NIX_CONFIG}" > "${HOME}/.config/nix/nix.conf"
+        {
+          echo 'NIX_CONFIG<<__LAB_NIX_CONFIG__'
+          printf '%s\n' "${EXTRA_NIX_CONFIG}"
+          echo '__LAB_NIX_CONFIG__'
+        } >> "${GITHUB_ENV}"
+        {
+          echo "${HOME}/.nix-profile/bin"
+          echo "/nix/var/nix/profiles/default/bin"
+        } >> "${GITHUB_PATH}"
+        export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+        nix --version
+
+    - name: Ensure repo CI toolchain
+      if: inputs.install-ci-toolchain == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+        missing=0
+        for cmd in nix skopeo crane cosign jq yq kustomize docker docker-buildx; do
+          if ! command -v "${cmd}" >/dev/null 2>&1; then
+            missing=1
+            break
+          fi
+        done
+        if [ "${missing}" -eq 1 ]; then
+          nix profile install .#ciToolchain --priority 4
+        fi
+        toolchain-doctor
+        oci-doctor

--- a/.github/workflows/arc-runner-build-push.yml
+++ b/.github/workflows/arc-runner-build-push.yml
@@ -58,6 +58,11 @@ jobs:
         id: meta
         run: echo "tag=sha-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
 
+      - name: Require Attic public key
+        env:
+          ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
+        run: test -n "${ATTIC_PUBLIC_KEY}"
+
       - name: Prepare minimal runner image context
         run: |
           set -euo pipefail
@@ -72,13 +77,16 @@ jobs:
           ARCH: ${{ matrix.arch }}
           TAG: ${{ steps.meta.outputs.tag }}
           IMAGE: registry.ide-newton.ts.net/lab/arc-runner
+          ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           args=(
             docker buildx build
             --platform "${PLATFORM}"
             --file images/arc-runner/Dockerfile
-              --build-arg "LAB_GIT_SHA=${GITHUB_SHA}"
+            --build-arg "LAB_GIT_SHA=${GITHUB_SHA}"
+            --build-arg "LAB_NIX_EXTRA_SUBSTITUTERS=http://attic.attic.svc.cluster.local/lab"
+            --build-arg "LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS=${ATTIC_PUBLIC_KEY}"
             )
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
             args+=(

--- a/.github/workflows/arc-runner-build-push.yml
+++ b/.github/workflows/arc-runner-build-push.yml
@@ -1,0 +1,194 @@
+name: arc-runner-build-push
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'images/arc-runner/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - '.github/actions/setup-nix-toolchain/**'
+      - '.github/workflows/arc-runner-build-push.yml'
+      - '.github/workflows/arc-runner-release.yml'
+      - 'packages/scripts/src/shared/__tests__/arc-runner.test.ts'
+  push:
+    branches:
+      - main
+    paths:
+      - 'images/arc-runner/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - '.github/actions/setup-nix-toolchain/**'
+      - '.github/workflows/arc-runner-build-push.yml'
+      - '.github/workflows/arc-runner-release.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: arc-amd64
+          - platform: linux/arm64
+            arch: arm64
+            runner: arc-arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          cache-binary: false
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=sha-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Prepare minimal runner image context
+        run: |
+          set -euo pipefail
+          rm -rf .artifacts/arc-runner-context
+          mkdir -p .artifacts/arc-runner-context
+          cp flake.nix flake.lock .artifacts/arc-runner-context/
+          cp -R nix .artifacts/arc-runner-context/nix
+
+      - name: Build ARC runner image
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          ARCH: ${{ matrix.arch }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          IMAGE: registry.ide-newton.ts.net/lab/arc-runner
+        run: |
+          set -euo pipefail
+          args=(
+            docker buildx build
+            --platform "${PLATFORM}"
+            --file images/arc-runner/Dockerfile
+              --build-arg "LAB_GIT_SHA=${GITHUB_SHA}"
+            )
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            args+=(
+              --push
+              --tag "${IMAGE}:${TAG}-${ARCH}"
+              --tag "${IMAGE}:latest-${ARCH}"
+            )
+          else
+            args+=(
+              --load
+              --tag "lab-arc-runner:test-${ARCH}"
+            )
+          fi
+          args+=(.artifacts/arc-runner-context)
+          "${args[@]}"
+
+      - name: Smoke PR runner image toolchain
+        if: github.event_name == 'pull_request'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          docker run --rm "lab-arc-runner:test-${ARCH}" bash -lc '
+            set -euo pipefail
+            nix --version
+            command -v skopeo
+            command -v crane
+            command -v cosign
+            command -v jq
+            command -v yq
+            command -v kustomize
+            test -d /home/runner/externals
+          '
+
+  publish-index:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-platform
+    runs-on: arc-arm64
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          cache-binary: false
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=sha-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish ARC runner multi-arch index
+        id: image
+        env:
+          IMAGE: registry.ide-newton.ts.net/lab/arc-runner
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}" \
+            -t "${IMAGE}:latest" \
+            "${IMAGE}:${TAG}-amd64" \
+            "${IMAGE}:${TAG}-arm64"
+
+          manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
+          digest="$(jq -r '.manifest.digest // empty' <<< "${manifest_json}")"
+          if ! printf '%s' "${digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+            echo "Failed to resolve digest for ${IMAGE}:${TAG}" >&2
+            docker buildx imagetools inspect "${IMAGE}:${TAG}" >&2
+            exit 1
+          fi
+
+          for platform in linux/amd64 linux/arm64; do
+            platform_digest="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${manifest_json}" | head -n 1
+            )"
+            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}" >&2
+              docker buildx imagetools inspect "${IMAGE}:${TAG}" >&2
+              exit 1
+            fi
+          done
+
+          mkdir -p .artifacts/arc-runner
+          jq -n \
+            --arg image "${IMAGE}" \
+            --arg tag "${TAG}" \
+            --arg digest "${digest}" \
+            --arg sourceSha "${GITHUB_SHA}" \
+            --arg workflowRunId "${GITHUB_RUN_ID}" \
+            '{
+              image: $image,
+              tag: $tag,
+              digest: $digest,
+              reference: "\($image)@\($digest)",
+              sourceSha: $sourceSha,
+              workflowRunId: $workflowRunId,
+              platforms: ["linux/amd64", "linux/arm64"],
+              builder: "dockerfile-arc-runner-nix-toolchain"
+            }' > .artifacts/arc-runner/release-contract.json
+
+      - name: Upload ARC runner release contract
+        uses: actions/upload-artifact@v4
+        with:
+          name: arc-runner-release-contract
+          path: .artifacts/arc-runner/release-contract.json
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -1,0 +1,180 @@
+name: arc-runner-release
+
+on:
+  workflow_run:
+    workflows:
+      - arc-runner-build-push
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to promote.
+        required: false
+        type: string
+      image_tag:
+        description: Image tag to promote.
+        required: false
+        type: string
+      image_digest:
+        description: Image digest override (sha256:...).
+        required: false
+        type: string
+
+concurrency:
+  group: arc-runner-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+      }}
+    runs-on: arc-arm64
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Download release contract
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: arc-runner-release-contract
+          path: .artifacts/arc-runner
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          cache-binary: false
+
+      - name: Resolve release metadata
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_SHA_INPUT: ${{ inputs.commit_sha }}
+          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+          IMAGE_DIGEST_INPUT: ${{ inputs.image_digest }}
+        run: |
+          set -euo pipefail
+          image='registry.ide-newton.ts.net/lab/arc-runner'
+          contract='.artifacts/arc-runner/release-contract.json'
+
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            source_sha="$(jq -r '.sourceSha' "${contract}")"
+            tag="$(jq -r '.tag' "${contract}")"
+            digest="$(jq -r '.digest' "${contract}")"
+          else
+            source_sha="${COMMIT_SHA_INPUT:-$(git rev-parse HEAD)}"
+            tag="${IMAGE_TAG_INPUT:-sha-${source_sha}}"
+            digest="${IMAGE_DIGEST_INPUT:-}"
+            if [[ -z "${digest}" ]]; then
+              manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image}:${tag}")"
+              digest="$(jq -r '.manifest.digest // empty' <<< "${manifest_json}")"
+            fi
+          fi
+
+          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Invalid ARC runner digest: ${digest}" >&2
+            exit 1
+          fi
+          if [[ "${source_sha}" != "$(git rev-parse HEAD)" ]]; then
+            echo "promote=false" >> "${GITHUB_OUTPUT}"
+            echo "Stale ARC runner build ${source_sha}; current main is $(git rev-parse HEAD)." >&2
+            exit 0
+          fi
+
+          {
+            echo "promote=true"
+            echo "image=${image}"
+            echo "tag=${tag}"
+            echo "digest=${digest}"
+            echo "source_sha=${source_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Verify promoted ARC runner index
+        if: steps.meta.outputs.promote == 'true'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.meta.outputs.digest }}
+        run: |
+          set -euo pipefail
+          manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}@${DIGEST}")"
+          for platform in linux/amd64 linux/arm64; do
+            found="$(
+              jq -r --arg platform "${platform}" \
+                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
+                <<< "${manifest_json}" | head -n 1
+            )"
+            test -n "${found}"
+          done
+
+      - name: Update ARC runner images
+        if: steps.meta.outputs.promote == 'true'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.meta.outputs.digest }}
+        run: |
+          set -euo pipefail
+          export IMAGE_REF="${IMAGE}@${DIGEST}"
+          perl -0pi -e 's#image:\s+(?:ghcr\.io/actions/actions-runner:latest|registry\.ide-newton\.ts\.net/lab/arc-runner@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' argocd/applications/arc/application.yaml
+          test "$(grep -cF "image: ${IMAGE_REF}" argocd/applications/arc/application.yaml)" -eq 6
+          grep -F 'image: docker:dind' argocd/applications/arc/application.yaml >/dev/null
+          grep -F 'storageClassName: "rook-ceph-block"' argocd/applications/arc/application.yaml >/dev/null
+
+      - name: Create ARC runner release pull request
+        if: steps.meta.outputs.promote == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: codex/arc-runner-release-${{ steps.meta.outputs.tag }}
+          title: 'chore(arc): promote runner image ${{ steps.meta.outputs.tag }}'
+          commit-message: 'chore(arc): promote runner image ${{ steps.meta.outputs.tag }}'
+          body: |
+            ## Summary
+
+            - Promote ARC runner containers to `${{ steps.meta.outputs.image }}@${{ steps.meta.outputs.digest }}`.
+            - Source commit: `${{ steps.meta.outputs.source_sha }}`.
+            - Keep `docker:dind`, runner PVC settings, and storage classes unchanged.
+
+            ## Related Issues
+
+            N/A
+
+            ## Testing
+
+            - `docker buildx imagetools inspect "${{ steps.meta.outputs.image }}@${{ steps.meta.outputs.digest }}"`
+            - Verified `linux/amd64` and `linux/arm64` manifest entries.
+
+            ## Screenshots (if applicable)
+
+            N/A
+
+            ## Breaking Changes
+
+            None
+
+            ## Checklist
+
+            - [x] Testing section documents the exact validation performed (or `N/A` with justification).
+            - [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
+            - [x] Documentation, release notes, and follow-ups are updated or tracked.
+          labels: |
+            automated-pr
+            arc
+          add-paths: |
+            argocd/applications/arc/application.yaml
+
+      - name: Promotion skipped
+        if: steps.meta.outputs.promote != 'true'
+        run: echo 'Skipping stale ARC runner promotion because source SHA is not current for runner build inputs.'

--- a/.github/workflows/argo-lint.yml
+++ b/.github/workflows/argo-lint.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-nix-config: |
             experimental-features = nix-command flakes
 
       - name: Lint Argo workflow manifests

--- a/.github/workflows/attic-release.yml
+++ b/.github/workflows/attic-release.yml
@@ -53,26 +53,12 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install xz for Nix installer
-        run: |
-          set -euo pipefail
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y xz-utils
-          elif command -v apk >/dev/null 2>&1; then
-            sudo apk add --no-cache xz
-          elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y xz
-          elif ! command -v xz >/dev/null 2>&1; then
-            echo "xz is required to install Nix on this runner." >&2
-            exit 1
-          fi
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
             experimental-features = nix-command flakes
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}

--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -36,26 +36,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Install xz for Nix installer
-        run: |
-          set -euo pipefail
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y xz-utils
-          elif command -v apk >/dev/null 2>&1; then
-            sudo apk add --no-cache xz
-          elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y xz
-          elif ! command -v xz >/dev/null 2>&1; then
-            echo "xz is required to install Nix on this runner." >&2
-            exit 1
-          fi
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-nix-config: |
             experimental-features = nix-command flakes
 
       - name: Render Headlamp manifests

--- a/.github/workflows/khoshut-ci.yml
+++ b/.github/workflows/khoshut-ci.yml
@@ -53,11 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-nix-config: |
             experimental-features = nix-command flakes
 
       - name: Validate Argo CD manifests

--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-nix-config: |
             experimental-features = nix-command flakes
 
       - name: Validate manifests

--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -63,26 +63,12 @@ jobs:
       - name: Require Attic public key
         run: test -n "${ATTIC_PUBLIC_KEY}"
 
-      - name: Install xz for Nix installer
-        run: |
-          set -euo pipefail
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y xz-utils
-          elif command -v apk >/dev/null 2>&1; then
-            sudo apk add --no-cache xz
-          elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y xz
-          elif ! command -v xz >/dev/null 2>&1; then
-            echo "xz is required to install Nix on this runner." >&2
-            exit 1
-          fi
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
             experimental-features = nix-command flakes
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
@@ -193,26 +179,12 @@ jobs:
       - name: Require Attic public key
         run: test -n "${ATTIC_PUBLIC_KEY}"
 
-      - name: Install xz for Nix installer
-        run: |
-          set -euo pipefail
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y xz-utils
-          elif command -v apk >/dev/null 2>&1; then
-            sudo apk add --no-cache xz
-          elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y xz
-          elif ! command -v xz >/dev/null 2>&1; then
-            echo "xz is required to install Nix on this runner." >&2
-            exit 1
-          fi
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
             experimental-features = nix-command flakes
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
           ruby = assertVersion "ruby_3_4" "3.4.7" pkgs.ruby_3_4;
 
           shellPackages = [
+            pkgs.nixVersions.nix_2_28
             nodejs
             exact.bun
             go
@@ -188,6 +189,25 @@
             exec bun run packages/scripts/src/shared/oci.ts assert "$@"
           '';
 
+          ciToolchain = pkgs.buildEnv {
+            name = "lab-ci-toolchain";
+            paths = shellPackages ++ [
+              toolchainDoctor
+              ociDoctor
+              cacheDoctor
+              cachePush
+              ociPush
+              inspectOciArchive
+              writeOciReleaseContract
+              resolveAtticReleaseMetadata
+              createOciIndex
+              inspectOciImage
+              assertOciPlatforms
+            ];
+            pathsToLink = [ "/bin" ];
+            ignoreCollisions = true;
+          };
+
           linuxPackages = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
             "atticd-image" = import ./nix/images/attic.nix { inherit pkgs lib; };
           };
@@ -216,6 +236,7 @@
               createOciIndex
               inspectOciImage
               assertOciPlatforms
+              ciToolchain
               ;
             atticClient = pkgs.attic-client;
             atticServer = pkgs.attic-server;

--- a/images/arc-runner/Dockerfile
+++ b/images/arc-runner/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ACTIONS_RUNNER_BASE=ghcr.io/actions/actions-runner@sha256:08c30b0a7105f64bddfc485d2487a22aa03932a791402393352fdf674bda2c29
+FROM ${ACTIONS_RUNNER_BASE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LAB_GIT_SHA=unknown
+ARG NIX_INSTALL_URL=https://releases.nixos.org/nix/nix-2.28.5/install
+
+LABEL org.opencontainers.image.title="lab-arc-runner"
+LABEL org.opencontainers.image.description="GitHub Actions ARC runner with the Lab Nix CI toolchain preinstalled"
+LABEL org.opencontainers.image.source="https://github.com/proompteng/lab"
+LABEL org.opencontainers.image.revision="${LAB_GIT_SHA}"
+
+USER root
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl git jq xz-utils \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -m 0755 /nix \
+  && chown runner:runner /nix
+
+USER runner
+ENV USER=runner
+ENV NIX_CONFIG="experimental-features = nix-command flakes"
+ENV PATH="/home/runner/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+
+WORKDIR /tmp/lab-nix-toolchain
+COPY --chown=runner:runner flake.nix flake.lock ./
+COPY --chown=runner:runner nix ./nix
+
+RUN curl --proto '=https' --tlsv1.2 -fsSL "${NIX_INSTALL_URL}" -o /tmp/install-nix.sh \
+  && sh /tmp/install-nix.sh --no-daemon --yes --no-channel-add --no-modify-profile \
+  && rm /tmp/install-nix.sh \
+  && nix profile install .#ciToolchain --priority 4 \
+  && toolchain-doctor \
+  && oci-doctor \
+  && nix store gc
+
+WORKDIR /home/runner

--- a/images/arc-runner/Dockerfile
+++ b/images/arc-runner/Dockerfile
@@ -5,6 +5,8 @@ FROM ${ACTIONS_RUNNER_BASE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LAB_GIT_SHA=unknown
+ARG LAB_NIX_EXTRA_SUBSTITUTERS=
+ARG LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS=
 ARG NIX_INSTALL_URL=https://releases.nixos.org/nix/nix-2.28.5/install
 
 LABEL org.opencontainers.image.title="lab-arc-runner"
@@ -23,7 +25,6 @@ RUN apt-get update \
 
 USER runner
 ENV USER=runner
-ENV NIX_CONFIG="experimental-features = nix-command flakes"
 ENV PATH="/home/runner/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
 
 WORKDIR /tmp/lab-nix-toolchain
@@ -33,6 +34,13 @@ COPY --chown=runner:runner nix ./nix
 RUN curl --proto '=https' --tlsv1.2 -fsSL "${NIX_INSTALL_URL}" -o /tmp/install-nix.sh \
   && sh /tmp/install-nix.sh --no-daemon --yes --no-channel-add --no-modify-profile \
   && rm /tmp/install-nix.sh \
+  && mkdir -p "${HOME}/.config/nix" \
+  && { \
+    echo "experimental-features = nix-command flakes"; \
+    if [ -n "${LAB_NIX_EXTRA_SUBSTITUTERS}" ]; then echo "extra-substituters = ${LAB_NIX_EXTRA_SUBSTITUTERS}"; fi; \
+    if [ -n "${LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS}" ]; then echo "extra-trusted-public-keys = ${LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS}"; fi; \
+  } > "${HOME}/.config/nix/nix.conf" \
+  && export NIX_CONFIG="$(cat "${HOME}/.config/nix/nix.conf")" \
   && nix profile install .#ciToolchain --priority 4 \
   && toolchain-doctor \
   && oci-doctor \

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -89,28 +89,40 @@ let
     x86_64-linux = {
       archiveRoot = "linux-amd64";
       src = fetchurl {
-        url = "https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz";
+        urls = [
+          "https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz"
+          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-amd64.tar.gz"
+        ];
         hash = "sha256-pYRO8sOO9t3ztaj32R5+Do68OaOLs/yAE9Ypwe8pwlk=";
       };
     };
     aarch64-linux = {
       archiveRoot = "linux-arm64";
       src = fetchurl {
-        url = "https://get.helm.sh/helm-v${helmVersion}-linux-arm64.tar.gz";
+        urls = [
+          "https://get.helm.sh/helm-v${helmVersion}-linux-arm64.tar.gz"
+          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-arm64.tar.gz"
+        ];
         hash = "sha256-ETzMU7fFfCq6DNCqVgtVAIQbGLUhDXhkGs/dxT2sirI=";
       };
     };
     x86_64-darwin = {
       archiveRoot = "darwin-amd64";
       src = fetchurl {
-        url = "https://get.helm.sh/helm-v${helmVersion}-darwin-amd64.tar.gz";
+        urls = [
+          "https://get.helm.sh/helm-v${helmVersion}-darwin-amd64.tar.gz"
+          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-darwin-amd64.tar.gz"
+        ];
         hash = "sha256-c0NK6sNq0GjOLlWCuIUaKG3GKOrhZJSibirQskpxmfk=";
       };
     };
     aarch64-darwin = {
       archiveRoot = "darwin-arm64";
       src = fetchurl {
-        url = "https://get.helm.sh/helm-v${helmVersion}-darwin-arm64.tar.gz";
+        urls = [
+          "https://get.helm.sh/helm-v${helmVersion}-darwin-arm64.tar.gz"
+          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-darwin-arm64.tar.gz"
+        ];
         hash = "sha256-YenFRV8Gsq0KEoCXW/ZYkucHrcGddmsM9OkAbjt7S2w=";
       };
     };

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -84,50 +84,6 @@ let
       '';
     };
 
-  helmVersion = "3.14.4";
-  helmSource = sourceFor "helm" {
-    x86_64-linux = {
-      archiveRoot = "linux-amd64";
-      src = fetchurl {
-        urls = [
-          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-amd64.tar.gz"
-          "https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz"
-        ];
-        hash = "sha256-pYRO8sOO9t3ztaj32R5+Do68OaOLs/yAE9Ypwe8pwlk=";
-      };
-    };
-    aarch64-linux = {
-      archiveRoot = "linux-arm64";
-      src = fetchurl {
-        urls = [
-          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-arm64.tar.gz"
-          "https://get.helm.sh/helm-v${helmVersion}-linux-arm64.tar.gz"
-        ];
-        hash = "sha256-ETzMU7fFfCq6DNCqVgtVAIQbGLUhDXhkGs/dxT2sirI=";
-      };
-    };
-    x86_64-darwin = {
-      archiveRoot = "darwin-amd64";
-      src = fetchurl {
-        urls = [
-          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-darwin-amd64.tar.gz"
-          "https://get.helm.sh/helm-v${helmVersion}-darwin-amd64.tar.gz"
-        ];
-        hash = "sha256-c0NK6sNq0GjOLlWCuIUaKG3GKOrhZJSibirQskpxmfk=";
-      };
-    };
-    aarch64-darwin = {
-      archiveRoot = "darwin-arm64";
-      src = fetchurl {
-        urls = [
-          "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-darwin-arm64.tar.gz"
-          "https://get.helm.sh/helm-v${helmVersion}-darwin-arm64.tar.gz"
-        ];
-        hash = "sha256-YenFRV8Gsq0KEoCXW/ZYkucHrcGddmsM9OkAbjt7S2w=";
-      };
-    };
-  };
-
   kustomizeVersion = "5.8.0";
   kustomizeSource = sourceFor "kustomize" {
     x86_64-linux = {
@@ -367,12 +323,15 @@ in
 {
   inherit bun;
 
-  helm = mkTarballBin {
-    pname = "helm";
-    version = helmVersion;
-    source = helmSource;
-    installPath = "helm";
-  };
+  helm =
+    let
+      helm = pkgs.kubernetes-helm;
+      major = lib.versions.major (lib.getVersion helm);
+    in
+    if major == "3" then
+      helm
+    else
+      throw "kubernetes-helm must stay on Helm 3, got ${lib.getVersion helm}";
 
   kustomize = mkTarballBin {
     pname = "kustomize";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -90,8 +90,8 @@ let
       archiveRoot = "linux-amd64";
       src = fetchurl {
         urls = [
-          "https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz"
           "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-amd64.tar.gz"
+          "https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz"
         ];
         hash = "sha256-pYRO8sOO9t3ztaj32R5+Do68OaOLs/yAE9Ypwe8pwlk=";
       };
@@ -100,8 +100,8 @@ let
       archiveRoot = "linux-arm64";
       src = fetchurl {
         urls = [
-          "https://get.helm.sh/helm-v${helmVersion}-linux-arm64.tar.gz"
           "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-arm64.tar.gz"
+          "https://get.helm.sh/helm-v${helmVersion}-linux-arm64.tar.gz"
         ];
         hash = "sha256-ETzMU7fFfCq6DNCqVgtVAIQbGLUhDXhkGs/dxT2sirI=";
       };
@@ -110,8 +110,8 @@ let
       archiveRoot = "darwin-amd64";
       src = fetchurl {
         urls = [
-          "https://get.helm.sh/helm-v${helmVersion}-darwin-amd64.tar.gz"
           "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-darwin-amd64.tar.gz"
+          "https://get.helm.sh/helm-v${helmVersion}-darwin-amd64.tar.gz"
         ];
         hash = "sha256-c0NK6sNq0GjOLlWCuIUaKG3GKOrhZJSibirQskpxmfk=";
       };
@@ -120,8 +120,8 @@ let
       archiveRoot = "darwin-arm64";
       src = fetchurl {
         urls = [
-          "https://get.helm.sh/helm-v${helmVersion}-darwin-arm64.tar.gz"
           "https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-darwin-arm64.tar.gz"
+          "https://get.helm.sh/helm-v${helmVersion}-darwin-arm64.tar.gz"
         ];
         hash = "sha256-YenFRV8Gsq0KEoCXW/ZYkucHrcGddmsM9OkAbjt7S2w=";
       };

--- a/nix/toolchain-doctor.sh
+++ b/nix/toolchain-doctor.sh
@@ -29,6 +29,16 @@ expect_contains() {
   esac
 }
 
+expect_prefix() {
+  name="$1"
+  expected="$2"
+  actual="$3"
+  case "$actual" in
+    "$expected"*) printf '%-18s %s\n' "$name" "$actual" ;;
+    *) fail "$name expected output starting with $expected, got $actual" ;;
+  esac
+}
+
 for cmd in nix node bun go ruby python3.11 python3.12 uv tofu helm kustomize kubeconform kubectl argo argocd buf gh shellcheck jq yq rg fd fzf; do
   have "$cmd"
 done
@@ -42,7 +52,7 @@ expect_contains python3.11 "Python 3.11." "$(python3.11 --version)"
 expect_contains python3.12 "Python 3.12." "$(python3.12 --version)"
 printf '%-18s %s\n' uv "$(uv --version | head -n 1)"
 printf '%-18s %s\n' tofu "$(tofu version | head -n 1)"
-expect_eq helm v3.14.4 "$(helm version --template '{{ .Version }}')"
+expect_prefix helm v3. "$(helm version --template '{{ .Version }}')"
 expect_contains kustomize "v5.8.0" "$(kustomize version)"
 expect_contains kubeconform "v0.7.0" "$(kubeconform -v)"
 expect_contains kubectl "v1.29.4" "$(kubectl version --client=true --output=yaml | awk '/gitVersion:/ {print $2; exit}')"

--- a/nix/toolchain-doctor.sh
+++ b/nix/toolchain-doctor.sh
@@ -29,10 +29,11 @@ expect_contains() {
   esac
 }
 
-for cmd in node bun go ruby python3.11 python3.12 uv tofu helm kustomize kubeconform kubectl argo argocd buf gh shellcheck jq yq rg fd fzf; do
+for cmd in nix node bun go ruby python3.11 python3.12 uv tofu helm kustomize kubeconform kubectl argo argocd buf gh shellcheck jq yq rg fd fzf; do
   have "$cmd"
 done
 
+expect_contains nix "nix (Nix) 2.28." "$(nix --version)"
 expect_eq node v24.11.1 "$(node --version)"
 expect_eq bun 1.3.14 "$(bun --version)"
 expect_eq go go1.25.5 "$(go version | awk '{print $3}')"

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'bun:test'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
+
+const setupAction = readRepoFile('.github/actions/setup-nix-toolchain/action.yml')
+const arcApplication = readRepoFile('argocd/applications/arc/application.yaml')
+const arcRunnerDockerfile = readRepoFile('images/arc-runner/Dockerfile')
+const arcRunnerBuildWorkflow = readRepoFile('.github/workflows/arc-runner-build-push.yml')
+const arcRunnerReleaseWorkflow = readRepoFile('.github/workflows/arc-runner-release.yml')
+const nixOciWorkflow = readRepoFile('.github/workflows/nix-oci-build-common.yml')
+const atticReleaseWorkflow = readRepoFile('.github/workflows/attic-release.yml')
+const argoLintWorkflow = readRepoFile('.github/workflows/argo-lint.yml')
+const kubeconformWorkflow = readRepoFile('.github/workflows/kubeconform.yml')
+const khoshutWorkflow = readRepoFile('.github/workflows/khoshut-ci.yml')
+const headlampWorkflow = readRepoFile('.github/workflows/headlamp-ci.yml')
+const flake = readRepoFile('flake.nix')
+
+describe('ARC Nix runner toolchain', () => {
+  it('keeps ARC storage and Docker sidecar unchanged while making runner images releasable by digest', () => {
+    expect(arcApplication).toContain('runnerScaleSetName: arc-arm64')
+    expect(arcApplication).toContain('runnerScaleSetName: arc-amd64')
+    expect(arcApplication).toContain('runnerScaleSetName: analysis-arm64')
+    expect(arcApplication).toContain('image: docker:dind')
+    expect(arcApplication).toContain('storageClassName: "rook-ceph-block"')
+    expect(arcApplication).toContain('volumeClaimTemplate:')
+    expect(arcRunnerReleaseWorkflow).toContain('registry.ide-newton.ts.net/lab/arc-runner')
+    expect(arcRunnerReleaseWorkflow).toContain('test "$(grep -cF "image: ${IMAGE_REF}"')
+    expect(arcRunnerReleaseWorkflow).toContain("grep -F 'image: docker:dind'")
+    expect(arcRunnerReleaseWorkflow).toContain('grep -F \'storageClassName: "rook-ceph-block"\'')
+    expect(arcRunnerReleaseWorkflow).not.toContain('ObjectBucketClaim')
+    expect(arcRunnerReleaseWorkflow).not.toContain('PersistentVolumeClaim')
+  })
+
+  it('builds a custom actions runner image with pinned Nix CI tools preinstalled', () => {
+    expect(arcRunnerDockerfile).toContain('FROM ${ACTIONS_RUNNER_BASE}')
+    expect(arcRunnerDockerfile).toContain(
+      'ghcr.io/actions/actions-runner@sha256:08c30b0a7105f64bddfc485d2487a22aa03932a791402393352fdf674bda2c29',
+    )
+    expect(arcRunnerDockerfile).not.toContain('ghcr.io/actions/actions-runner:latest')
+    expect(arcRunnerDockerfile).toContain('https://releases.nixos.org/nix/nix-2.28.5/install')
+    expect(arcRunnerDockerfile).toContain('COPY --chown=runner:runner flake.nix flake.lock ./')
+    expect(arcRunnerDockerfile).toContain('COPY --chown=runner:runner nix ./nix')
+    expect(arcRunnerDockerfile).toContain(
+      'sh /tmp/install-nix.sh --no-daemon --yes --no-channel-add --no-modify-profile',
+    )
+    expect(arcRunnerDockerfile).toContain('nix profile install .#ciToolchain --priority 4')
+    expect(arcRunnerDockerfile).toContain('toolchain-doctor')
+    expect(arcRunnerDockerfile).toContain('oci-doctor')
+    expect(flake).toContain('ciToolchain = pkgs.buildEnv')
+    expect(flake).toContain('name = "lab-ci-toolchain"')
+    expect(flake).toContain('pathsToLink = [ "/bin" ]')
+    expect(flake).toContain('ignoreCollisions = true')
+  })
+
+  it('publishes multi-arch ARC runner images and opens a digest-pinning release PR', () => {
+    expect(arcRunnerBuildWorkflow).toContain('runner: arc-amd64')
+    expect(arcRunnerBuildWorkflow).toContain('runner: arc-arm64')
+    expect(arcRunnerBuildWorkflow).toContain('Prepare minimal runner image context')
+    expect(arcRunnerBuildWorkflow).toContain('cp flake.nix flake.lock .artifacts/arc-runner-context/')
+    expect(arcRunnerBuildWorkflow).toContain('docker buildx build')
+    expect(arcRunnerBuildWorkflow).toContain('--platform "${PLATFORM}"')
+    expect(arcRunnerBuildWorkflow).toContain('--push')
+    expect(arcRunnerBuildWorkflow).toContain('docker buildx imagetools create')
+    expect(arcRunnerBuildWorkflow).toContain('linux/amd64')
+    expect(arcRunnerBuildWorkflow).toContain('linux/arm64')
+    expect(arcRunnerBuildWorkflow).toContain('arc-runner-release-contract')
+    expect(arcRunnerReleaseWorkflow).toContain('workflows:')
+    expect(arcRunnerReleaseWorkflow).toContain('arc-runner-build-push')
+    expect(arcRunnerReleaseWorkflow).toContain('peter-evans/create-pull-request@v7')
+    expect(arcRunnerReleaseWorkflow).toContain('argocd/applications/arc/application.yaml')
+  })
+
+  it('uses a shared setup action so Nix jobs validate preinstalled tools before falling back', () => {
+    expect(setupAction).toContain('Detect preinstalled Nix')
+    expect(setupAction).toContain("steps.detect.outputs.nix_available != 'true'")
+    expect(setupAction).toContain('uses: cachix/install-nix-action@v31')
+    expect(setupAction).toContain('extra_nix_config: ${{ inputs.extra-nix-config }}')
+    expect(setupAction).toContain('NIX_CONFIG<<__LAB_NIX_CONFIG__')
+    expect(setupAction).toContain('nix profile install .#ciToolchain --priority 4')
+    expect(setupAction).toContain('toolchain-doctor')
+    expect(setupAction).toContain('oci-doctor')
+
+    for (const workflow of [
+      nixOciWorkflow,
+      atticReleaseWorkflow,
+      argoLintWorkflow,
+      kubeconformWorkflow,
+      khoshutWorkflow,
+      headlampWorkflow,
+    ]) {
+      expect(workflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+    }
+
+    expect(nixOciWorkflow).not.toContain('Install xz for Nix installer')
+    expect(nixOciWorkflow).not.toContain('uses: cachix/install-nix-action@v31')
+    expect(atticReleaseWorkflow).not.toContain('Install xz for Nix installer')
+    expect(atticReleaseWorkflow).not.toContain('uses: cachix/install-nix-action@v31')
+  })
+})

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -18,6 +18,7 @@ const khoshutWorkflow = readRepoFile('.github/workflows/khoshut-ci.yml')
 const headlampWorkflow = readRepoFile('.github/workflows/headlamp-ci.yml')
 const flake = readRepoFile('flake.nix')
 const nixPackages = readRepoFile('nix/packages.nix')
+const toolchainDoctor = readRepoFile('nix/toolchain-doctor.sh')
 
 describe('ARC Nix runner toolchain', () => {
   it('keeps ARC storage and Docker sidecar unchanged while making runner images releasable by digest', () => {
@@ -63,6 +64,8 @@ describe('ARC Nix runner toolchain', () => {
     expect(nixPackages).toContain('kubernetes-helm must stay on Helm 3')
     expect(nixPackages).not.toContain('https://github.com/helm/helm/releases/download/v${helmVersion}/')
     expect(nixPackages).not.toContain('https://get.helm.sh/helm-v${helmVersion}-')
+    expect(toolchainDoctor).toContain('expect_prefix helm v3.')
+    expect(toolchainDoctor).not.toContain('expect_eq helm v3.14.4')
   })
 
   it('publishes multi-arch ARC runner images and opens a digest-pinning release PR', () => {

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -58,9 +58,8 @@ describe('ARC Nix runner toolchain', () => {
     expect(flake).toContain('name = "lab-ci-toolchain"')
     expect(flake).toContain('pathsToLink = [ "/bin" ]')
     expect(flake).toContain('ignoreCollisions = true')
-    expect(nixPackages).toContain('https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz')
-    expect(nixPackages).toContain(
-      'https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-amd64.tar.gz',
+    expect(nixPackages.indexOf('https://github.com/helm/helm/releases/download/v${helmVersion}/')).toBeLessThan(
+      nixPackages.indexOf('https://get.helm.sh/helm-v${helmVersion}-'),
     )
   })
 

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -17,6 +17,7 @@ const kubeconformWorkflow = readRepoFile('.github/workflows/kubeconform.yml')
 const khoshutWorkflow = readRepoFile('.github/workflows/khoshut-ci.yml')
 const headlampWorkflow = readRepoFile('.github/workflows/headlamp-ci.yml')
 const flake = readRepoFile('flake.nix')
+const nixPackages = readRepoFile('nix/packages.nix')
 
 describe('ARC Nix runner toolchain', () => {
   it('keeps ARC storage and Docker sidecar unchanged while making runner images releasable by digest', () => {
@@ -41,6 +42,10 @@ describe('ARC Nix runner toolchain', () => {
     )
     expect(arcRunnerDockerfile).not.toContain('ghcr.io/actions/actions-runner:latest')
     expect(arcRunnerDockerfile).toContain('https://releases.nixos.org/nix/nix-2.28.5/install')
+    expect(arcRunnerDockerfile).toContain('ARG LAB_NIX_EXTRA_SUBSTITUTERS=')
+    expect(arcRunnerDockerfile).toContain('ARG LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS=')
+    expect(arcRunnerDockerfile).toContain('extra-substituters = ${LAB_NIX_EXTRA_SUBSTITUTERS}')
+    expect(arcRunnerDockerfile).toContain('extra-trusted-public-keys = ${LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS}')
     expect(arcRunnerDockerfile).toContain('COPY --chown=runner:runner flake.nix flake.lock ./')
     expect(arcRunnerDockerfile).toContain('COPY --chown=runner:runner nix ./nix')
     expect(arcRunnerDockerfile).toContain(
@@ -53,6 +58,10 @@ describe('ARC Nix runner toolchain', () => {
     expect(flake).toContain('name = "lab-ci-toolchain"')
     expect(flake).toContain('pathsToLink = [ "/bin" ]')
     expect(flake).toContain('ignoreCollisions = true')
+    expect(nixPackages).toContain('https://get.helm.sh/helm-v${helmVersion}-linux-amd64.tar.gz')
+    expect(nixPackages).toContain(
+      'https://github.com/helm/helm/releases/download/v${helmVersion}/helm-v${helmVersion}-linux-amd64.tar.gz',
+    )
   })
 
   it('publishes multi-arch ARC runner images and opens a digest-pinning release PR', () => {
@@ -60,6 +69,12 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerBuildWorkflow).toContain('runner: arc-arm64')
     expect(arcRunnerBuildWorkflow).toContain('Prepare minimal runner image context')
     expect(arcRunnerBuildWorkflow).toContain('cp flake.nix flake.lock .artifacts/arc-runner-context/')
+    expect(arcRunnerBuildWorkflow).toContain('Require Attic public key')
+    expect(arcRunnerBuildWorkflow).toContain('ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}')
+    expect(arcRunnerBuildWorkflow).toContain(
+      '--build-arg "LAB_NIX_EXTRA_SUBSTITUTERS=http://attic.attic.svc.cluster.local/lab"',
+    )
+    expect(arcRunnerBuildWorkflow).toContain('--build-arg "LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS=${ATTIC_PUBLIC_KEY}"')
     expect(arcRunnerBuildWorkflow).toContain('docker buildx build')
     expect(arcRunnerBuildWorkflow).toContain('--platform "${PLATFORM}"')
     expect(arcRunnerBuildWorkflow).toContain('--push')

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -58,9 +58,11 @@ describe('ARC Nix runner toolchain', () => {
     expect(flake).toContain('name = "lab-ci-toolchain"')
     expect(flake).toContain('pathsToLink = [ "/bin" ]')
     expect(flake).toContain('ignoreCollisions = true')
-    expect(nixPackages.indexOf('https://github.com/helm/helm/releases/download/v${helmVersion}/')).toBeLessThan(
-      nixPackages.indexOf('https://get.helm.sh/helm-v${helmVersion}-'),
-    )
+    expect(nixPackages).toContain('pkgs.kubernetes-helm')
+    expect(nixPackages).toContain('lib.versions.major')
+    expect(nixPackages).toContain('kubernetes-helm must stay on Helm 3')
+    expect(nixPackages).not.toContain('https://github.com/helm/helm/releases/download/v${helmVersion}/')
+    expect(nixPackages).not.toContain('https://get.helm.sh/helm-v${helmVersion}-')
   })
 
   it('publishes multi-arch ARC runner images and opens a digest-pinning release PR', () => {


### PR DESCRIPTION
## Summary

- Add a digest-pinned custom ARC runner image that bakes in the pinned Nix CI toolchain and validates `toolchain-doctor` plus OCI tooling during image build.
- Add build/publish and digest-release workflows for the ARC runner image across `linux/amd64` and `linux/arm64`, with release PR promotion into `argocd/applications/arc/application.yaml`.
- Replace repeated Nix installer boilerplate in real Nix workflows with a shared setup action that validates preinstalled tools and falls back only when needed.
- Add contract tests proving ARC storage and DinD settings remain unchanged and that migrated workflows use the shared setup path.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/nix-oci.test.ts`
- `bun test packages/scripts/src`
- `bun run --cwd packages/scripts lint` (passes with existing warnings in unrelated files)
- `bun run --cwd packages/scripts lint:oxlint:type` (passes with existing warnings in unrelated files)
- `shellcheck nix/toolchain-doctor.sh nix/oci-doctor.sh`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/arc-runner-build-push.yml .github/workflows/arc-runner-release.yml .github/workflows/nix-oci-build-common.yml .github/workflows/attic-release.yml .github/workflows/argo-lint.yml .github/workflows/kubeconform.yml .github/workflows/khoshut-ci.yml .github/workflows/headlamp-ci.yml`
- `git diff --check`
- `docker buildx build --progress=plain --platform linux/arm64 --load -f images/arc-runner/Dockerfile -t lab-arc-runner:local-pr2 /tmp/lab-arc-runner-context`
- `docker run --rm --platform linux/arm64 lab-arc-runner:local-pr2 bash -lc 'set -euo pipefail; nix --version; toolchain-doctor >/tmp/toolchain.out; tail -n 1 /tmp/toolchain.out; oci-doctor >/tmp/oci.out; tail -n 1 /tmp/oci.out; test -d /home/runner/externals'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
