### PR TITLE
chore(torghut): promote ta image 04b7c092

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f
   imagePullPolicy: IfNotPresent
-  restartNonce: 17
+  restartNonce: 16
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f
   imagePullPolicy: IfNotPresent
-  restartNonce: 16
+  restartNonce: 17
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f
   imagePullPolicy: IfNotPresent
-  restartNonce: 16
+  restartNonce: 17
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -88,9 +88,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: 04b7c092
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: 04b7c092e52ae68ffac7cb10466691b65cfbca8c
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f
   imagePullPolicy: IfNotPresent
-  restartNonce: 18
+  restartNonce: 19
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: 04b7c092
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: 04b7c092e52ae68ffac7cb10466691b65cfbca8c
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e3e8e0f82d44e5c963bc0111e9d23ef38ce73578c6a2483ab74db2313ee1c149
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f
   imagePullPolicy: IfNotPresent
-  restartNonce: 13
+  restartNonce: 14
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 72a1961c
+              value: 04b7c092
             - name: TORGHUT_TA_COMMIT
-              value: 72a1961c5773c805b99997b3b6e726d5e1df6cd5
+              value: 04b7c092e52ae68ffac7cb10466691b65cfbca8c
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `04b7c092e52ae68ffac7cb10466691b65cfbca8c`
- Image tag: `04b7c092`
- Image digest: `sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f`
- Manifests: live TA, sim TA, options TA