### PR TITLE
fix(infra): allow codex auth external secrets namespaces

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -38,6 +38,9 @@ spec:
                 renderWithLovely: false
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
+                managedNamespaceMetadata:
+                  labels:
+                    external-secrets.proompteng.ai/enabled: "true"
                 automation: auto
                 enabled: "true"
               - name: autotrader
@@ -150,6 +153,9 @@ spec:
                 namespace: jangar
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
+                managedNamespaceMetadata:
+                  labels:
+                    external-secrets.proompteng.ai/enabled: "true"
                 automation: auto
                 enabled: "true"
               - name: agents
@@ -157,6 +163,9 @@ spec:
                 namespace: agents
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
+                managedNamespaceMetadata:
+                  labels:
+                    external-secrets.proompteng.ai/enabled: "true"
                 automation: auto
                 enabled: "true"
               - name: agents-ci
@@ -261,6 +270,9 @@ spec:
                 renderWithLovely: false
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
+                managedNamespaceMetadata:
+                  labels:
+                    external-secrets.proompteng.ai/enabled: "true"
                 automation: manual
                 enabled: "true"
               - name: torghut


### PR DESCRIPTION
## Summary

- Adds `external-secrets.proompteng.ai/enabled=true` to the ApplicationSet-managed namespace metadata for `synthesis`, `jangar`, `agents`, and `sag`.
- Makes the namespace authorization required by `ClusterSecretStore/onepassword-infra` durable in GitOps.
- Matches the live emergency labels applied during the Codex auth ExternalSecret rollout.

## Related Issues

None

## Testing

- `yq '.spec.generators[0].matrix.generators[1].list.elements[] | select(.name == "synthesis" or .name == "jangar" or .name == "agents" or .name == "sag") | [.name, .namespace, .managedNamespaceMetadata.labels."external-secrets.proompteng.ai/enabled"] | @tsv' argocd/applicationsets/product.yaml`
- `bun run lint:argocd`
- `git diff --check`
- Live check: `kubectl get externalsecret -n agents,synthesis,jangar,torghut,sag codex-auth` equivalent now reports `Ready=True` for all five namespaces after the live labels were applied.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
