### PR TITLE
revert(torghut): rollback failed promotion c50fc84739fa02d6afbfbf1baf28e151e0612ff7

### DIFF
--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - codex-auth-externalsecret.yaml
   - postgres-cluster.yaml
   - cnpg-torghut-db-objectbucketclaim.yaml
   - postgres-scheduled-backup.yaml


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `c50fc84739fa02d6afbfbf1baf28e151e0612ff7`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28414739426`
- Rollback source: `HEAD^` manifests from the failed run checkout