### PR TITLE
fix(agents): avoid spurious shell reconnect challenges

### DIFF
--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -51,6 +51,8 @@ const makeAuth = (scopes = ['agents-shell.read', 'agents-shell.write']): AuthCon
   },
 })
 
+const linkedOauthScheme = [{ type: 'oauth2', scopes: ['agents-shell.read', 'offline_access'] }]
+
 const randomListenPort = () => 30_000 + Math.floor(Math.random() * 20_000)
 
 const connectServer = async (config: AgentsShellConfig, auth = makeAuth()) => {
@@ -301,7 +303,7 @@ describe('agents-shell MCP tools', () => {
     const search = tools.tools.find((tool) => tool.name === 'search')
     expect(search?.annotations?.readOnlyHint).toBe(true)
     expect(search?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
       ui: { visibility: ['model'] },
       'openai/visibility': 'public',
       'openai/toolInvocation/invoking': 'Running tool',
@@ -316,7 +318,7 @@ describe('agents-shell MCP tools', () => {
     expect(applyPatch?.annotations?.readOnlyHint).toBe(false)
     expect(applyPatch?.annotations?.destructiveHint).toBe(false)
     expect(applyPatch?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
     })
 
     const git = tools.tools.find((tool) => tool.name === 'git')
@@ -324,13 +326,13 @@ describe('agents-shell MCP tools', () => {
     expect(git?.annotations?.destructiveHint).toBe(false)
     expect(git?.annotations?.openWorldHint).toBe(false)
     expect(git?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
     })
 
     const gitWrite = tools.tools.find((tool) => tool.name === 'git_write')
     expect(gitWrite?.annotations?.destructiveHint).toBe(true)
     expect(gitWrite?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
     })
 
     const kubectl = tools.tools.find((tool) => tool.name === 'kubectl')
@@ -338,21 +340,21 @@ describe('agents-shell MCP tools', () => {
     expect(kubectl?.annotations?.destructiveHint).toBe(false)
     expect(kubectl?.annotations?.openWorldHint).toBe(true)
     expect(kubectl?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
     })
 
     const kubectlAdmin = tools.tools.find((tool) => tool.name === 'kubectl_admin')
     expect(kubectlAdmin?.annotations?.destructiveHint).toBe(true)
     expect(kubectlAdmin?.annotations?.openWorldHint).toBe(true)
     expect(kubectlAdmin?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
     })
 
     const agentStart = tools.tools.find((tool) => tool.name === 'agent_start')
     expect(agentStart?.annotations?.destructiveHint).toBe(true)
     expect(agentStart?.annotations?.openWorldHint).toBe(true)
     expect(agentStart?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
     })
 
     await clientTransport.close()
@@ -364,9 +366,9 @@ describe('agents-shell MCP tools', () => {
     expect(Buffer.byteLength(JSON.stringify({ tools: rawTools }))).toBeLessThan(18_000)
 
     const rawSearch = rawTools.find((tool) => tool.name === 'search')
-    expect(rawSearch?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read'] }])
+    expect(rawSearch?.securitySchemes).toEqual(linkedOauthScheme)
     expect(rawSearch?._meta).toMatchObject({
-      securitySchemes: [{ type: 'oauth2', scopes: ['agents-shell.read'] }],
+      securitySchemes: linkedOauthScheme,
       ui: { visibility: ['model'] },
       'openai/visibility': 'public',
       'openai/toolInvocation/invoking': 'Running tool',
@@ -382,15 +384,18 @@ describe('agents-shell MCP tools', () => {
     expect(rawShellRunInputProperties.maxOutputBytes.maximum).toBeUndefined()
 
     const rawKubectl = rawTools.find((tool) => tool.name === 'kubectl')
-    expect(rawKubectl?.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read'] }])
+    expect(rawKubectl?.securitySchemes).toEqual(linkedOauthScheme)
     expect(rawKubectl?.inputSchema?.additionalProperties).toBe(false)
 
     for (const tool of rawTools) {
       expect(tool.description?.length ?? 0).toBeLessThanOrEqual(140)
       expect(tool.outputSchema).toBeUndefined()
-      expect(tool.securitySchemes).toEqual([{ type: 'oauth2', scopes: ['agents-shell.read'] }])
+      expect(tool.securitySchemes).toEqual(linkedOauthScheme)
       expect(tool.securitySchemes).not.toEqual(
         expect.arrayContaining([expect.objectContaining({ scopes: expect.arrayContaining(['agents-shell.admin']) })]),
+      )
+      expect(tool.securitySchemes).toEqual(
+        expect.arrayContaining([expect.objectContaining({ scopes: expect.arrayContaining(['offline_access']) })]),
       )
     }
   })
@@ -720,6 +725,25 @@ fi
     expect(result._meta?.['mcp/www_authenticate']).toEqual([
       'Bearer resource_metadata="https://agents-shell.example.test/.well-known/oauth-protected-resource", error="insufficient_scope", error_description="The requested agents-shell tool requires additional OAuth scopes."',
     ])
+
+    await clientTransport.close()
+    await serverTransport.close()
+    await client.close()
+    await server.close()
+  })
+
+  it('does not turn ordinary tool failures into OAuth reconnect challenges', async () => {
+    const config = makeConfig()
+    const { client, server, clientTransport, serverTransport } = await connectServer(config)
+
+    const result = await client.callTool({
+      name: 'shell_run',
+      arguments: { command: 'echo should-not-run', cwd: 'missing-worktree' },
+    })
+
+    expect(result.isError).toBe(true)
+    expect(JSON.stringify(result.content)).toContain('cwd does not exist')
+    expect(result._meta?.['mcp/www_authenticate']).toBeUndefined()
 
     await clientTransport.close()
     await serverTransport.close()

--- a/services/agents/src/server/agents-shell-mcp.ts
+++ b/services/agents/src/server/agents-shell-mcp.ts
@@ -205,6 +205,7 @@ const SCOPES = {
 } as const
 
 const READ_SCOPES = [SCOPES.read, SCOPES.write, SCOPES.admin]
+const CONNECTOR_LINK_SCOPES = [SCOPES.offlineAccess]
 // ChatGPT connector sessions are private and identity-allowlisted. Keep tool authorization on the stable
 // linked scope so long-running workflows do not re-enter OAuth when they move from read tools to write tools.
 const WRITE_SCOPES = READ_SCOPES
@@ -576,7 +577,10 @@ const requireScopes = (auth: AuthContext, acceptedScopes: string[]) => {
     throw new AuthChallengeError(auth.authError)
   }
   if (!scopesSatisfied(auth, acceptedScopes)) {
-    throw new Error(`missing required OAuth scope; one of ${acceptedScopes.join(', ')} is required`)
+    throw new AuthChallengeError({
+      error: 'insufficient_scope',
+      description: 'The requested agents-shell tool requires additional OAuth scopes.',
+    })
   }
 }
 
@@ -937,7 +941,7 @@ const summarizeJob = (
 }
 
 const toolSecurityMeta = (scopes: string[]) => {
-  const requestedScopes = Array.from(new Set(scopes))
+  const requestedScopes = Array.from(new Set([...scopes, ...CONNECTOR_LINK_SCOPES]))
   const securitySchemes = [
     {
       type: 'oauth2',
@@ -1061,12 +1065,10 @@ const withToolErrors =
       return await handler(args)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      const oauthError = error instanceof AuthChallengeError ? error.oauthError : 'insufficient_scope'
-      const oauthDescription =
-        error instanceof AuthChallengeError
-          ? error.oauthDescription
-          : 'The requested agents-shell tool requires additional OAuth scopes.'
-      return errorResult(message, buildBearerChallenge(config, oauthError, oauthDescription))
+      if (error instanceof AuthChallengeError) {
+        return errorResult(message, buildBearerChallenge(config, error.oauthError, error.oauthDescription))
+      }
+      return errorResult(message)
     }
   }
 


### PR DESCRIPTION
## Summary

- Prevent ordinary agents-shell tool failures from emitting MCP OAuth reconnect challenges.
- Keep real auth failures on the OAuth challenge path by making missing scopes an explicit AuthChallengeError.
- Advertise offline_access in every tool security scheme so ChatGPT requests a durable connector grant during linking.

## Related Issues

None

## Testing

- `bun test services/agents/src/server/agents-shell-mcp.test.ts`
- `bun run --filter @proompteng/agents lint`
- `bun run --filter @proompteng/agents tsc`
- `bun run --filter @proompteng/agents lint:oxlint` exits 0; it reports existing warnings outside this patch.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
