### PR TITLE
chore(agents): promote images cd81cb7a

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: a74e2dde
-  digest: sha256:e173a8dc848ce9feedb047d01ee902a433546de8cb9c54a56405f2855f74cd53
+  tag: cd81cb7a
+  digest: sha256:97d9b9a06a020fd3b8c385bfb6387ecf0b9f38ee9dcaf8af6ba001ba4920c912
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,32 +14,32 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: a74e2dde
-    digest: sha256:cc2f2be115077e9d31be5bebcce97faf6bd3f01a3af1db781f8b52355f68219e
+    tag: cd81cb7a
+    digest: sha256:e148b2ec408cf4efaa7561f7768685e5bb8d133b1352128dfc2fdac2611dcaf2
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: a74e2ddef9117c420389c45274a8a982480b4514
-      AGENTS_GITOPS_REVISION: a74e2ddef9117c420389c45274a8a982480b4514
-      AGENTS_SOURCE_CI_RUN_ID: "28369393886"
+      AGENTS_SOURCE_HEAD_SHA: cd81cb7a6731e59bfcf6c929f262aa778d4e1e93
+      AGENTS_GITOPS_REVISION: cd81cb7a6731e59bfcf6c929f262aa778d4e1e93
+      AGENTS_SOURCE_CI_RUN_ID: "28415747082"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:cc2f2be115077e9d31be5bebcce97faf6bd3f01a3af1db781f8b52355f68219e
-      AGENTS_SERVING_BUILD_COMMIT: a74e2ddef9117c420389c45274a8a982480b4514
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:cc2f2be115077e9d31be5bebcce97faf6bd3f01a3af1db781f8b52355f68219e
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:e148b2ec408cf4efaa7561f7768685e5bb8d133b1352128dfc2fdac2611dcaf2
+      AGENTS_SERVING_BUILD_COMMIT: cd81cb7a6731e59bfcf6c929f262aa778d4e1e93
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:e148b2ec408cf4efaa7561f7768685e5bb8d133b1352128dfc2fdac2611dcaf2
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: a74e2dde
-    digest: sha256:4531efd1928e119b086de43ce9fd0d742eae19dcf5fb65b1cf281312409161b9
+    tag: cd81cb7a
+    digest: sha256:797777398e8e972d8aceabbecfd1c5698cbb2221aec6ddf88d1380ca3e6e007b
 agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: a74e2dde
-    digest: sha256:4a4bc1ce590f2b233428719ce08d67de86f909c971c7e1fdc1c8cc99255c4671
+    tag: cd81cb7a
+    digest: sha256:176924974c7e949494492c36b0931975d3a74bce60855f178c000091fac5438c
     pullPolicy: IfNotPresent
   env:
     vars:
@@ -158,8 +158,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: a74e2dde
-    digest: sha256:e173a8dc848ce9feedb047d01ee902a433546de8cb9c54a56405f2855f74cd53
+    tag: cd81cb7a
+    digest: sha256:97d9b9a06a020fd3b8c385bfb6387ecf0b9f38ee9dcaf8af6ba001ba4920c912
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `cd81cb7a6731e59bfcf6c929f262aa778d4e1e93`
- Image tag: `cd81cb7a`
- Agents build run: `28415747082`
- Promotion source: `workflow_run`