### PR TITLE
test(torghut): allow options ta restart nonce bumps

### DIFF
--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -351,7 +351,7 @@ describe('Torghut manifest scheduling', () => {
     const deployment = parseManifest('argocd/applications/torghut-options/ta/flinkdeployment.yaml')
     const spec = getAtPath(deployment, ['spec'])
     const flinkConfiguration = getAtPath(spec, ['flinkConfiguration'])
-    expect(spec.restartNonce).toBe(16)
+    expect(spec.restartNonce).toBeGreaterThanOrEqual(16)
     expect(flinkConfiguration['restart-strategy.fixed-delay.attempts']).toBe('60')
     expect(flinkConfiguration['restart-strategy.fixed-delay.delay']).toBe('10 s')
   })


### PR DESCRIPTION
## Summary

- Relaxes the options TA restart nonce guard so legitimate GitOps image promotions can bump the nonce.
- Keeps the recovery baseline by requiring `restartNonce >= 16`.
- Leaves the Kafka offset reset and fixed-delay restart strategy assertions intact.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts -t "keeps options TA recoverable across transient Kafka source startup failures"`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
