### PR TITLE
chore(symphony): promote image 2c1b0d01

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T01:19:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T03:51:17Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "352edeaa"
-    digest: sha256:17c9824e56a6737c3eb25e20fc8c524f3ef74343c237e76601734dba59503060
+    newTag: "2c1b0d01"
+    digest: sha256:fbf4dedfd4fa02bddb371bcd476324944393f1f99f8ba8aef4cb4003ce37eb44

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T01:19:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T03:51:17Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "352edeaa"
-    digest: sha256:17c9824e56a6737c3eb25e20fc8c524f3ef74343c237e76601734dba59503060
+    newTag: "2c1b0d01"
+    digest: sha256:fbf4dedfd4fa02bddb371bcd476324944393f1f99f8ba8aef4cb4003ce37eb44

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T01:19:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T03:51:17Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "352edeaa"
-    digest: sha256:17c9824e56a6737c3eb25e20fc8c524f3ef74343c237e76601734dba59503060
+    newTag: "2c1b0d01"
+    digest: sha256:fbf4dedfd4fa02bddb371bcd476324944393f1f99f8ba8aef4cb4003ce37eb44


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `2c1b0d01ca0445a24e604a5376e483063b1227ac`
- Image tag: `2c1b0d01`
- Image digest: `sha256:fbf4dedfd4fa02bddb371bcd476324944393f1f99f8ba8aef4cb4003ce37eb44`