### PR TITLE
fix(agents): grant offline access to chatgpt connector

### DIFF
--- a/argocd/applications/keycloak/agents-shell-client-bootstrap-job.yaml
+++ b/argocd/applications/keycloak/agents-shell-client-bootstrap-job.yaml
@@ -265,6 +265,25 @@ spec:
                 expected=(204,),
               )
 
+              offline_access_role = request(
+                'GET',
+                f'/admin/realms/{realm_path}/roles/offline_access',
+                token=token,
+              )
+              assigned_realm_roles = request(
+                'GET',
+                f'{users_path}/{urllib.parse.quote(user_resource_id, safe="")}/role-mappings/realm',
+                token=token,
+              )
+              if not any(role.get('name') == 'offline_access' for role in assigned_realm_roles):
+                request(
+                  'POST',
+                  f'{users_path}/{urllib.parse.quote(user_resource_id, safe="")}/role-mappings/realm',
+                  token=token,
+                  data=[{'id': offline_access_role['id'], 'name': offline_access_role['name']}],
+                  expected=(204,),
+                )
+
               print(f'Configured Keycloak client {client_id} and user {chatgpt_username} in realm {realm}')
               PY
           securityContext:

--- a/docs/keycloak-oidc.md
+++ b/docs/keycloak-oidc.md
@@ -14,12 +14,43 @@ This runbook covers the in-cluster Keycloak deployment used for OIDC, plus the i
 
 For Headlamp-specific wiring (OIDC secret, RBAC, control-plane OIDC args), see `docs/headlamp-setup.md`.
 
+## OIDC client for ChatGPT agents-shell
+
+The ChatGPT MCP connector uses the confidential `agents-shell` OIDC client bootstrapped by
+`argocd/applications/keycloak/agents-shell-client-bootstrap-job.yaml`.
+
+Capabilities:
+
+- Client authentication: On
+- Standard flow: On
+- Direct access grants: Off
+- Implicit flow: Off
+- Service accounts roles: Off
+- PKCE: `S256`
+- Valid redirect URI: `https://chatgpt.com/connector/oauth/*`
+- Web origin: `https://chatgpt.com`
+
+Required scopes and role mapping:
+
+- Default client scopes: `agents-shell.read`, `agents-shell.write`, `offline_access`
+- Optional client scope: `agents-shell.admin`
+- User: `agents-shell-chatgpt`
+- Realm role: `offline_access`
+
+The `offline_access` client scope alone is not enough for durable ChatGPT connector sessions. The ChatGPT user must
+also have the realm `offline_access` role, otherwise Keycloak can issue ordinary access/refresh tokens but will not
+issue offline refresh tokens for long-lived reconnect-free sessions.
+
 ## Operations model
 
 - Keycloak itself is GitOps-managed from `argocd/applications/keycloak`.
 - The `kubernetes` OIDC client used by Headlamp and the kube-apiserver is GitOps-managed by:
   - `argocd/applications/keycloak/headlamp-client-sealedsecret.yaml`
   - `argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml`
+- The ChatGPT agents-shell OIDC client is GitOps-managed by:
+  - `argocd/applications/keycloak/agents-shell-client-sealedsecret.yaml`
+  - `argocd/applications/keycloak/agents-shell-user-sealedsecret.yaml`
+  - `argocd/applications/keycloak/agents-shell-client-bootstrap-job.yaml`
 - That bootstrap job also enforces the realm session defaults Headlamp depends on:
   - Access token lifespan `300`
   - SSO session idle `28800`


### PR DESCRIPTION
## Summary

- Assigns the Keycloak realm `offline_access` role to the `agents-shell-chatgpt` user in the agents-shell client bootstrap job.
- Keeps the existing agents-shell client scopes and audience mapper intact while making offline refresh-token issuance possible.
- Documents the ChatGPT agents-shell OIDC client requirements and the scope-vs-role distinction in the Keycloak runbook.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/keycloak >/tmp/keycloak-render.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
