### PR TITLE
ci(arc): publish runner image on main dispatch

### DIFF
--- a/.github/workflows/arc-runner-build-push.yml
+++ b/.github/workflows/arc-runner-build-push.yml
@@ -80,6 +80,11 @@ jobs:
           ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
         run: |
           set -euo pipefail
+          should_publish=false
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]] && [[ "${GITHUB_EVENT_NAME}" == "push" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            should_publish=true
+          fi
+
           args=(
             docker buildx build
             --platform "${PLATFORM}"
@@ -88,7 +93,7 @@ jobs:
             --build-arg "LAB_NIX_EXTRA_SUBSTITUTERS=http://attic.attic.svc.cluster.local/lab"
             --build-arg "LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS=${ATTIC_PUBLIC_KEY}"
             )
-          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+          if [[ "${should_publish}" == "true" ]]; then
             args+=(
               --push
               --tag "${IMAGE}:${TAG}-${ARCH}"
@@ -122,7 +127,11 @@ jobs:
           '
 
   publish-index:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      ${{
+        github.ref == 'refs/heads/main' &&
+        (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      }}
     needs: build-platform
     runs-on: arc-arm64
     timeout-minutes: 20

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -81,8 +81,13 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerBuildWorkflow).toContain('--build-arg "LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS=${ATTIC_PUBLIC_KEY}"')
     expect(arcRunnerBuildWorkflow).toContain('docker buildx build')
     expect(arcRunnerBuildWorkflow).toContain('--platform "${PLATFORM}"')
+    expect(arcRunnerBuildWorkflow).toContain(
+      '[[ "${GITHUB_EVENT_NAME}" == "push" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]',
+    )
+    expect(arcRunnerBuildWorkflow).toContain('if [[ "${should_publish}" == "true" ]]; then')
     expect(arcRunnerBuildWorkflow).toContain('--push')
     expect(arcRunnerBuildWorkflow).toContain('docker buildx imagetools create')
+    expect(arcRunnerBuildWorkflow).toContain("github.event_name == 'workflow_dispatch'")
     expect(arcRunnerBuildWorkflow).toContain('linux/amd64')
     expect(arcRunnerBuildWorkflow).toContain('linux/arm64')
     expect(arcRunnerBuildWorkflow).toContain('arc-runner-release-contract')


### PR DESCRIPTION
## Summary

- Let `arc-runner-build-push` publish platform images and the multi-arch release contract when manually dispatched on `main`.
- Preserve PR and branch dispatch behavior as non-publishing validation.
- Add a contract test so the manual current-main publish path cannot silently regress.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/shared/__tests__/nix-oci.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/arc-runner-build-push.yml .github/workflows/arc-runner-release.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
