### PR TITLE
chore(symphony): promote image 2d9a0b5d

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T03:51:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T04:35:19Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2c1b0d01"
-    digest: sha256:fbf4dedfd4fa02bddb371bcd476324944393f1f99f8ba8aef4cb4003ce37eb44
+    newTag: "2d9a0b5d"
+    digest: sha256:ce45dd6de7d8559341f0ea194dab7c946701b1e70fcddbdf2b28d96e906be1f4

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T03:51:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T04:35:19Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2c1b0d01"
-    digest: sha256:fbf4dedfd4fa02bddb371bcd476324944393f1f99f8ba8aef4cb4003ce37eb44
+    newTag: "2d9a0b5d"
+    digest: sha256:ce45dd6de7d8559341f0ea194dab7c946701b1e70fcddbdf2b28d96e906be1f4

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T03:51:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T04:35:19Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2c1b0d01"
-    digest: sha256:fbf4dedfd4fa02bddb371bcd476324944393f1f99f8ba8aef4cb4003ce37eb44
+    newTag: "2d9a0b5d"
+    digest: sha256:ce45dd6de7d8559341f0ea194dab7c946701b1e70fcddbdf2b28d96e906be1f4


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `2d9a0b5db98f57fdffaf41b296bae2cfb8eaac8e`
- Image tag: `2d9a0b5d`
- Image digest: `sha256:ce45dd6de7d8559341f0ea194dab7c946701b1e70fcddbdf2b28d96e906be1f4`