### PR TITLE
chore(symphony): promote image 952ed74f

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T04:35:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T06:23:23Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2d9a0b5d"
-    digest: sha256:ce45dd6de7d8559341f0ea194dab7c946701b1e70fcddbdf2b28d96e906be1f4
+    newTag: "952ed74f"
+    digest: sha256:5a980ab38835aaa41926cf9d13db8ce5db286a23f0c25d9a366556d06112eaf5

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T04:35:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T06:23:23Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2d9a0b5d"
-    digest: sha256:ce45dd6de7d8559341f0ea194dab7c946701b1e70fcddbdf2b28d96e906be1f4
+    newTag: "952ed74f"
+    digest: sha256:5a980ab38835aaa41926cf9d13db8ce5db286a23f0c25d9a366556d06112eaf5

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T04:35:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T06:23:23Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2d9a0b5d"
-    digest: sha256:ce45dd6de7d8559341f0ea194dab7c946701b1e70fcddbdf2b28d96e906be1f4
+    newTag: "952ed74f"
+    digest: sha256:5a980ab38835aaa41926cf9d13db8ce5db286a23f0c25d9a366556d06112eaf5


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `952ed74f685247b5abc082e2960710967abe0aae`
- Image tag: `952ed74f`
- Image digest: `sha256:5a980ab38835aaa41926cf9d13db8ce5db286a23f0c25d9a366556d06112eaf5`