### PR TITLE
perf(nix): tag OCI latest refs without layer copy

### DIFF
--- a/nix/oci-push.sh
+++ b/nix/oci-push.sh
@@ -84,7 +84,7 @@ skopeo --policy "${policy_json}" copy --format oci "docker-archive:${resolved_ta
 if [[ -n "${latest_tag}" ]]; then
   latest_reference="${image}:${latest_tag}"
   echo "Tagging ${reference} as ${latest_reference}."
-  skopeo --policy "${policy_json}" copy --format oci "docker://${reference}" "docker://${latest_reference}"
+  crane tag "${reference}" "${latest_tag}"
 fi
 
 digest="$(crane digest "${reference}")"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -244,6 +244,11 @@ describe('native OCI build workflows', () => {
     expect(ociPushScript).toContain('skopeo --policy "${policy_json}" copy --format oci')
   })
 
+  it('tags platform latest refs without re-copying image layers', () => {
+    expect(ociPushScript).toContain('crane tag "${reference}" "${latest_tag}"')
+    expect(ociPushScript).not.toContain('skopeo --policy "${policy_json}" copy --format oci "docker://${reference}"')
+  })
+
   it('does not use Docker Buildx or docker daemon commands in migrated workflows', () => {
     const migratedWorkflows = [atticWorkflow, nixOciWorkflow, oiratWorkflow, bumbaWorkflow, froussardWorkflow]
     for (const workflow of migratedWorkflows) {


### PR DESCRIPTION
## Summary

- Change `nix/oci-push.sh` so platform latest tagging uses `crane tag` instead of a second `skopeo copy`.
- Keep the primary Nix image archive push on Skopeo and Docker-free.
- Add a regression test that rejects layer-copying for platform latest tags.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `shellcheck nix/oci-push.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
