### PR TITLE
fix(froussard): match digest image releases

### DIFF
--- a/.github/workflows/enabled-simple-nix-release.yml
+++ b/.github/workflows/enabled-simple-nix-release.yml
@@ -192,7 +192,7 @@ jobs:
             froussard)
               image_ref="${IMAGE}@${DIGEST}"
               path="argocd/applications/froussard/knative-service.yaml"
-              IMAGE_REF="${image_ref}" perl -0pi -e 's#image:\s+registry\.ide-newton\.ts\.net/lab/froussard(?::[A-Za-z0-9_.-]+|@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' "${path}"
+              IMAGE_REF="${image_ref}" perl -0pi -e 's#image:\s+registry\.ide-newton\.ts\.net/lab/froussard(?::[A-Za-z0-9_.-]+|\@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' "${path}"
               SOURCE_SHA="${SOURCE_SHA}" perl -0pi -e 's#(name:\s+FROUSSARD_COMMIT\s*\n\s*value:\s*).*#$1$ENV{SOURCE_SHA}#g' "${path}"
               grep -F "image: ${image_ref}" "${path}"
               ;;

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -319,6 +319,7 @@ describe('native OCI build workflows', () => {
     expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/oirat/kustomization.yaml')
     expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/bumba/kustomization.yaml')
     expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/froussard/knative-service.yaml')
+    expect(enabledSimpleReleaseWorkflow).toContain('\\@sha256:[0-9a-f]{64}')
     expect(enabledSimpleReleaseWorkflow).toContain('peter-evans/create-pull-request@v7')
     expect(enabledSimpleReleaseWorkflow).not.toContain('docker buildx')
   })


### PR DESCRIPTION
## Summary

- Escape the literal `@sha256` in the Froussard release workflow Perl regex.
- Keep digest-pinned Froussard Knative images promotable by the generated release workflow.
- Add a contract assertion for the escaped digest regex.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/enabled-simple-nix-release.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
