### PR TITLE
fix(nix): prevent stale bumba release downgrades

### DIFF
--- a/.github/workflows/auto-pr-release-branches.yml
+++ b/.github/workflows/auto-pr-release-branches.yml
@@ -94,9 +94,29 @@ jobs:
             gh api "repos/$GH_REPO/contents/$path?ref=$ref" --jq '.content' | tr -d '\n' | base64 -d
           }
 
+          changed_files=()
+          mapfile -t changed_files < <(
+            gh api "repos/$GH_REPO/compare/main...$HEAD_BRANCH" --jq '.files[].filename'
+          )
+
+          migrated_nix_image_paths=(
+            "argocd/applications/bumba/kustomization.yaml"
+          )
+
+          for path in "${changed_files[@]}"; do
+            for migrated_path in "${migrated_nix_image_paths[@]}"; do
+              if [[ "$path" == "$migrated_path" ]]; then
+                create_pr="false"
+                reason="migrated-nix-image-app:${path}"
+                break 2
+              fi
+            done
+          done
+
           base_file=""
           head_file=""
-          if base_file="$(read_repo_file_at_ref "argocd/applications/synthesis/kustomization.yaml" "main")" &&
+          if [[ "$create_pr" == "true" ]] &&
+            base_file="$(read_repo_file_at_ref "argocd/applications/synthesis/kustomization.yaml" "main")" &&
             head_file="$(read_repo_file_at_ref "argocd/applications/synthesis/kustomization.yaml" "$HEAD_BRANCH")"; then
             base_tag="$(extract_synthesis_image_tag <<< "$base_file")"
             head_tag="$(extract_synthesis_image_tag <<< "$head_file")"

--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -12,7 +12,6 @@ on:
     paths:
       - 'argocd/applications/proompteng/kustomization.yaml'
       - 'argocd/applications/synthesis/kustomization.yaml'
-      - 'argocd/applications/bumba/kustomization.yaml'
       - 'argocd/applications/khoshut/kustomization.yaml'
       - 'argocd/applications/analysis/kustomization.yaml'
       - 'argocd/applications/bilig/kustomization.yaml'
@@ -71,7 +70,6 @@ jobs:
           allowed_paths=(
             "argocd/applications/proompteng/kustomization.yaml"
             "argocd/applications/synthesis/kustomization.yaml"
-            "argocd/applications/bumba/kustomization.yaml"
             "argocd/applications/khoshut/kustomization.yaml"
             "argocd/applications/analysis/kustomization.yaml"
             "argocd/applications/bilig/kustomization.yaml"

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
+    digest: sha256:d81a5c2b515524a50c02ffc839ee9ea3aa4205133259f5d6a781e710a8a68a79
     newName: registry.ide-newton.ts.net/lab/bumba
-    newTag: sha-cf447cd

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -20,6 +20,8 @@ const ciRunTimedScript = readRepoFile('nix/ci-run-timed.sh')
 const ciNixOciSummaryScript = readRepoFile('nix/ci-nix-oci-summary.sh')
 const nixOciWorkflow = readRepoFile('.github/workflows/nix-oci-build-common.yml')
 const enabledSimpleReleaseWorkflow = readRepoFile('.github/workflows/enabled-simple-nix-release.yml')
+const autoPrReleaseBranchesWorkflow = readRepoFile('.github/workflows/auto-pr-release-branches.yml')
+const releasePrAutomergeWorkflow = readRepoFile('.github/workflows/release-pr-automerge.yml')
 const oiratWorkflow = readRepoFile('.github/workflows/oirat-ci.yml')
 const bumbaWorkflow = readRepoFile('.github/workflows/bumba-ci.yml')
 const froussardWorkflow = readRepoFile('.github/workflows/froussard-ci.yml')
@@ -322,6 +324,14 @@ describe('native OCI build workflows', () => {
     expect(enabledSimpleReleaseWorkflow).toContain('\\@sha256:[0-9a-f]{64}')
     expect(enabledSimpleReleaseWorkflow).toContain('peter-evans/create-pull-request@v7')
     expect(enabledSimpleReleaseWorkflow).not.toContain('docker buildx')
+  })
+
+  it('blocks stale Docker-era release PRs for migrated simple Nix image apps', () => {
+    expect(autoPrReleaseBranchesWorkflow).toContain('migrated_nix_image_paths=(')
+    expect(autoPrReleaseBranchesWorkflow).toContain('"argocd/applications/bumba/kustomization.yaml"')
+    expect(autoPrReleaseBranchesWorkflow).toContain('reason="migrated-nix-image-app:${path}"')
+    expect(releasePrAutomergeWorkflow).not.toContain("'argocd/applications/bumba/kustomization.yaml'")
+    expect(releasePrAutomergeWorkflow).not.toContain('"argocd/applications/bumba/kustomization.yaml"')
   })
 
   it('promotes Attic by digest after a Nix OCI build contract', () => {


### PR DESCRIPTION
## Summary

- Restores the Bumba GitOps image pin to the Nix-built digest after the stale Docker-era release PR downgraded it to `sha-cf447cd`.
- Removes Bumba from the generic release-branch automerge allowlist now that Bumba uses the enabled simple Nix image release workflow.
- Adds an auto-PR guard and regression test so future image-updater Bumba branches are skipped instead of opened or auto-merged.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/auto-pr-release-branches.yml .github/workflows/release-pr-automerge.yml .github/workflows/enabled-simple-nix-release.yml .github/workflows/bumba-ci.yml`
- `kustomize build --enable-helm argocd/applications/bumba | rg -n 'bumba@sha256:d81a5c2b515524a50c02ffc839ee9ea3aa4205133259f5d6a781e710a8a68a79|image:'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
