### PR TITLE
fix(nix): let froussard digest rollouts apply

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -430,6 +430,14 @@ spec:
                 namespace: froussard
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
+                # Froussard's Knative Service has historical client-side apply ownership.
+                # Server-side apply reports a successful sync but preserves the old image/env.
+                syncOptions:
+                  - CreateNamespace=true
+                  - RespectIgnoreDifferences=true
+                  - ApplyOutOfSyncOnly=true
+                  - PruneLast=true
+                  - ClientSideApplyMigration=false
                 ignoreDifferences:
                   - group: serving.knative.dev
                     kind: Service

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -14,6 +14,7 @@ const atticReleaseWorkflow = readRepoFile('.github/workflows/attic-release.yml')
 const atticReleaseMetadataScript = readRepoFile('nix/attic-release-metadata.sh')
 const atticDeployment = readRepoFile('argocd/applications/attic/deployment.yaml')
 const atticGcCronJob = readRepoFile('argocd/applications/attic/gc-cronjob.yaml')
+const productApplicationSet = readRepoFile('argocd/applicationsets/product.yaml')
 const flake = readRepoFile('flake.nix')
 const inspectOciArchiveScript = readRepoFile('nix/oci-inspect-archive.sh')
 const ciRunTimedScript = readRepoFile('nix/ci-run-timed.sh')
@@ -332,6 +333,16 @@ describe('native OCI build workflows', () => {
     expect(autoPrReleaseBranchesWorkflow).toContain('reason="migrated-nix-image-app:${path}"')
     expect(releasePrAutomergeWorkflow).not.toContain("'argocd/applications/bumba/kustomization.yaml'")
     expect(releasePrAutomergeWorkflow).not.toContain('"argocd/applications/bumba/kustomization.yaml"')
+  })
+
+  it('keeps Froussard Knative digest rollouts on client-side apply', () => {
+    const match = productApplicationSet.match(/- name: froussard[\s\S]*?automation: manual/)
+    expect(match).not.toBeNull()
+    const froussardBlock = match?.[0] ?? ''
+    expect(froussardBlock).toContain('syncOptions:')
+    expect(froussardBlock).toContain('- RespectIgnoreDifferences=true')
+    expect(froussardBlock).toContain('- ApplyOutOfSyncOnly=true')
+    expect(froussardBlock).not.toContain('- ServerSideApply=true')
   })
 
   it('promotes Attic by digest after a Nix OCI build contract', () => {


### PR DESCRIPTION
## Summary

- Adds a Froussard-only product ApplicationSet sync option override that removes server-side apply for the Knative Service rollout path.
- Preserves the existing namespace, ignore-difference, apply-out-of-sync, prune-last, and client-side migration settings for Froussard.
- Adds a regression test proving Froussard digest rollouts stay on client-side apply so image/env changes actually reconcile.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/enabled-simple-nix-release.yml .github/workflows/froussard-ci.yml .github/workflows/nix-oci-build-common.yml`
- `yq -o=json '.spec.generators[0].matrix.generators[1].list.elements[] | select(.name == "froussard")' argocd/applicationsets/product.yaml | jq '{name, syncOptions, automation, enabled}'`
- `kustomize build --enable-helm argocd/applications/froussard | rg -n 'FROUSSARD_COMMIT|aa8ce247|froussard@sha256:0c62f776'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
