### PR TITLE
fix(nix): keep froussard ssa from preserving stale annotations

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -430,11 +430,11 @@ spec:
                 namespace: froussard
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
-                # Froussard's Knative Service has historical client-side apply ownership.
-                # Server-side apply reports a successful sync but preserves the old image/env.
+                # RespectIgnoreDifferences can preserve stale Knative metadata annotations
+                # during apply and block image/env digest rollouts from reconciling.
                 syncOptions:
                   - CreateNamespace=true
-                  - RespectIgnoreDifferences=true
+                  - ServerSideApply=true
                   - ApplyOutOfSyncOnly=true
                   - PruneLast=true
                   - ClientSideApplyMigration=false

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -335,14 +335,14 @@ describe('native OCI build workflows', () => {
     expect(releasePrAutomergeWorkflow).not.toContain('"argocd/applications/bumba/kustomization.yaml"')
   })
 
-  it('keeps Froussard Knative digest rollouts on client-side apply', () => {
+  it('keeps Froussard Knative digest rollouts from respecting ignored live annotations during apply', () => {
     const match = productApplicationSet.match(/- name: froussard[\s\S]*?automation: manual/)
     expect(match).not.toBeNull()
     const froussardBlock = match?.[0] ?? ''
     expect(froussardBlock).toContain('syncOptions:')
-    expect(froussardBlock).toContain('- RespectIgnoreDifferences=true')
+    expect(froussardBlock).toContain('- ServerSideApply=true')
     expect(froussardBlock).toContain('- ApplyOutOfSyncOnly=true')
-    expect(froussardBlock).not.toContain('- ServerSideApply=true')
+    expect(froussardBlock).not.toContain('- RespectIgnoreDifferences=true')
   })
 
   it('promotes Attic by digest after a Nix OCI build contract', () => {


### PR DESCRIPTION
## Summary

- Corrects the Froussard ApplicationSet sync override to keep server-side apply enabled while removing `RespectIgnoreDifferences=true`.
- Prevents Argo from preserving stale live Knative annotations that contain the old image/env during apply.
- Updates the regression test to lock the intended Froussard sync contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `yq -o=json '.spec.generators[0].matrix.generators[1].list.elements[] | select(.name == "froussard")' argocd/applicationsets/product.yaml | jq '{name, syncOptions, automation, enabled}'`
- `kubectl apply --server-side --dry-run=server -f /tmp/froussard-desired.yaml -o json | jq '{name:.metadata.name,image:.spec.template.spec.containers[0].image,commit:([.spec.template.spec.containers[0].env[]? | select(.name=="FROUSSARD_COMMIT") | .value][0])}'`
- `kustomize build --enable-helm argocd/applications/froussard | rg -n 'FROUSSARD_COMMIT|aa8ce247|froussard@sha256:0c62f776'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
