### PR TITLE
fix(nix): preserve froussard knative immutable annotations

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: froussard
   annotations:
     serving.knative.dev/revision-history-limit: "3"
+    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
+    serving.knative.dev/lastModifier: admin
     argocd.argoproj.io/tracking-id: froussard:serving.knative.dev/Service:froussard/froussard
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -26,6 +26,7 @@ const releasePrAutomergeWorkflow = readRepoFile('.github/workflows/release-pr-au
 const oiratWorkflow = readRepoFile('.github/workflows/oirat-ci.yml')
 const bumbaWorkflow = readRepoFile('.github/workflows/bumba-ci.yml')
 const froussardWorkflow = readRepoFile('.github/workflows/froussard-ci.yml')
+const froussardKnativeService = readRepoFile('argocd/applications/froussard/knative-service.yaml')
 const oiratBuildScript = readRepoFile('packages/scripts/src/oirat/build-image.ts')
 const bumbaBuildScript = readRepoFile('packages/scripts/src/bumba/build-image.ts')
 const froussardDeployScript = readRepoFile('packages/scripts/src/froussard/deploy-service.ts')
@@ -343,6 +344,10 @@ describe('native OCI build workflows', () => {
     expect(froussardBlock).toContain('- ServerSideApply=true')
     expect(froussardBlock).toContain('- ApplyOutOfSyncOnly=true')
     expect(froussardBlock).not.toContain('- RespectIgnoreDifferences=true')
+    expect(froussardKnativeService).toContain(
+      'serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller',
+    )
+    expect(froussardKnativeService).toContain('serving.knative.dev/lastModifier: admin')
   })
 
   it('promotes Attic by digest after a Nix OCI build contract', () => {


### PR DESCRIPTION
## Summary

- Preserve Froussard's live Knative immutable service annotations in GitOps so Argo server-side apply stops trying to remove them.
- Keep the existing Froussard Nix digest rollout path on server-side apply without `RespectIgnoreDifferences`.
- Add a regression assertion to the Nix OCI contract test for the required Knative annotations.

## Related Issues

None

## Testing

```bash
bun test packages/scripts/src/shared/__tests__/oci.test.ts
kustomize build --enable-helm argocd/applications/froussard > /tmp/froussard-local-render.yaml
yq 'select(.apiVersion == "serving.knative.dev/v1" and .kind == "Service" and .metadata.name == "froussard")' /tmp/froussard-local-render.yaml > /tmp/froussard-local-ksvc.yaml
kubectl apply --server-side --dry-run=server -f /tmp/froussard-local-ksvc.yaml -o json | jq '{image:.spec.template.spec.containers[0].image, commit:(.spec.template.spec.containers[0].env[]? | select(.name=="FROUSSARD_COMMIT") | .value), creator:.metadata.annotations."serving.knative.dev/creator", lastModifier:.metadata.annotations."serving.knative.dev/lastModifier"}'
git diff --check
```

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
