### PR TITLE
chore(symphony): promote image 1ce06117

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T06:23:23Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:34:12Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "952ed74f"
-    digest: sha256:5a980ab38835aaa41926cf9d13db8ce5db286a23f0c25d9a366556d06112eaf5
+    newTag: "1ce06117"
+    digest: sha256:b6a2819756b6e1ca92c433d0b9b6dd3aedd986f3f0475feb2a5f3f5a831edc28

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T06:23:23Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:34:12Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "952ed74f"
-    digest: sha256:5a980ab38835aaa41926cf9d13db8ce5db286a23f0c25d9a366556d06112eaf5
+    newTag: "1ce06117"
+    digest: sha256:b6a2819756b6e1ca92c433d0b9b6dd3aedd986f3f0475feb2a5f3f5a831edc28

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T06:23:23Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:34:12Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "952ed74f"
-    digest: sha256:5a980ab38835aaa41926cf9d13db8ce5db286a23f0c25d9a366556d06112eaf5
+    newTag: "1ce06117"
+    digest: sha256:b6a2819756b6e1ca92c433d0b9b6dd3aedd986f3f0475feb2a5f3f5a831edc28


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `1ce061175672fb1812b37fdb4ff5f1f5ee359be1`
- Image tag: `1ce06117`
- Image digest: `sha256:b6a2819756b6e1ca92c433d0b9b6dd3aedd986f3f0475feb2a5f3f5a831edc28`