### PR TITLE
fix(nix): align froussard knative last modifier

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     serving.knative.dev/revision-history-limit: "3"
     serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
-    serving.knative.dev/lastModifier: admin
+    serving.knative.dev/lastModifier: system:serviceaccount:argocd:argocd-application-controller
     argocd.argoproj.io/tracking-id: froussard:serving.knative.dev/Service:froussard/froussard
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -347,7 +347,9 @@ describe('native OCI build workflows', () => {
     expect(froussardKnativeService).toContain(
       'serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller',
     )
-    expect(froussardKnativeService).toContain('serving.knative.dev/lastModifier: admin')
+    expect(froussardKnativeService).toContain(
+      'serving.knative.dev/lastModifier: system:serviceaccount:argocd:argocd-application-controller',
+    )
   })
 
   it('promotes Attic by digest after a Nix OCI build contract', () => {


### PR DESCRIPTION
## Summary

- Align Froussard's GitOps `serving.knative.dev/lastModifier` annotation with the value Knative keeps after Argo applies the service.
- Keep the immutable `creator` annotation and Froussard Nix digest rollout contract intact.
- Update the OCI contract test so future Froussard rollouts do not reintroduce the stale `admin` annotation value.

## Related Issues

None

## Testing

```bash
bun test packages/scripts/src/shared/__tests__/oci.test.ts
kustomize build --enable-helm argocd/applications/froussard > /tmp/froussard-local-render.yaml
yq 'select(.apiVersion == "serving.knative.dev/v1" and .kind == "Service" and .metadata.name == "froussard")' /tmp/froussard-local-render.yaml > /tmp/froussard-local-ksvc.yaml
kubectl apply --server-side --field-manager=argocd-controller --dry-run=server -f /tmp/froussard-local-ksvc.yaml -o json | jq '{image:.spec.template.spec.containers[0].image, commit:(.spec.template.spec.containers[0].env[]? | select(.name=="FROUSSARD_COMMIT") | .value), creator:.metadata.annotations."serving.knative.dev/creator", lastModifier:.metadata.annotations."serving.knative.dev/lastModifier"}'
git diff --check
```

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
