### PR TITLE
revert(torghut): rollback failed promotion 843163f4fe6ae7783e1b161c1063774a41d18f3a

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -21,14 +21,28 @@ The empirical workflow depends on the namespace-local sealed secret
 `rook-ceph-rgw-argo-workflows` for Argo archive-log uploads. Keep that secret managed here so
 workflow submissions in `torghut` do not rely on manual secret copies from `argo-workflows`.
 
-Runtime-ledger proof packet assembly is no longer scheduled by a Torghut CronJob. Use the explicit operator/API repair
-paths and Argo workflow submissions for bounded proof collection; do not reintroduce a GitOps CronJob that silently
-promotes or imports runtime-window evidence on a timer.
+The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
+paper-route proof lane. It first repairs sim source-window lineage, refreshes sim execution TCA rows from `SIM_DB_DSN`,
+then runs `renew_latest_empirical_promotion_jobs.py` with the sim
+`/trading/proofs?kind=runtime_window&window=latest_closed&full_audit=true&limit=5` proof payload, and finally runs
+`assemble_runtime_ledger_proof_packet.py` in explicit
+`authority` mode and uploads the packet under `runtime-ledger-proof-packets/{run_id}`. The scheduled packet uses the
+final authority thresholds: 20 runtime-ledger trading days, $10,000 total post-cost net PnL, $500/day post-cost net PnL,
+3% max drawdown/equity, 25% best-day share, and 35% symbol concentration. When the paper-route window is import-ready,
+the packet now requires the live closed-window proof from `/trading/proofs` and carries
+source-activity blockers such as `paper_route_source_activity_missing`, `source_decisions_missing`,
+`source_executions_missing`, and `source_tca_missing` into the final verdict. Treat those as the next repair target
+before rerunning import; do not collapse them into a generic runtime-ledger-missing diagnosis.
+
+The renewal conductor also carries an explicit live H-PAIRS runtime-window target for account `PA3SX7FYNUTF`. That target
+uses `DB_DSN` for source and target reads/writes and is a separate scope from the sim paper-route target. It is expected
+to remain blocked until live execution-eligible decisions, executions, order events, TCA rows, and durable runtime-ledger
+buckets exist; the target makes those blockers visible in the scheduled proof packet without granting promotion.
 
 The `torghut-paper-account-flatten` CronJob runs at 09:05, 09:15, 09:20, and 09:25 America/New_York before the regular
 session, then repeats those minutes during the post-close 16:00 hour.
-The post-close run is part of the paper-route proof lane: it persists the flat account snapshot required before explicit
-operator proof collection turns a closed paper-route window into authority-checkable runtime-ledger evidence.
+The post-close run is part of the paper-route proof lane: it persists the flat account snapshot required before the
+21:23 UTC renewal/import conductor can turn a closed paper-route window into authority-checkable runtime-ledger evidence.
 
 The live TigerBeetle journal CronJob uses small supervised source slices. Keep the execution batch and order-event
 max-batch settings conservative enough to finish under the watchdog; failed slices do not grant accounting authority and

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -1,0 +1,197 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-empirical-promotion-renewal
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: empirical-promotion-renewal
+spec:
+  suspend: true
+  schedule: "23 8,21 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 900
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      backoffLimit: 2
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: torghut-runtime
+          containers:
+            - name: renew
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:441503b721325a24b7da86b000767f843a41c9a32b92c1d83ceac84f0fae798a
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                  ephemeral-storage: 2Gi
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json
+                  PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json
+                  HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT=/tmp/torghut-empirical-renewal/hpairs-source-proof-census.json
+                  mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")" "$(dirname "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}")"
+                  echo "stage=empirical_promotion_renewal started_at=$(date -Iseconds)"
+                  WINDOW_END="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  WINDOW_START="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+                  echo "stage=reconcile_cross_dsn_order_feed_links started_at=$(date -Iseconds) window_start=${WINDOW_START} window_end=${WINDOW_END}"
+                  /opt/venv/bin/python scripts/reconcile_cross_dsn_order_feed_links.py \
+                    --event-dsn-env DB_DSN \
+                    --canonical-dsn-env SIM_DB_DSN \
+                    --source-account-label PA3SX7FYNUTF \
+                    --canonical-account-label TORGHUT_SIM \
+                    --window-start "${WINDOW_START}" \
+                    --window-end "${WINDOW_END}" \
+                    --limit 5000 \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --batch-size 1000 \
+                    --max-batches 2 \
+                    --backfill-execution-events \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_REPLAY \
+                    --batch-size 1000 \
+                    --max-batches 2 \
+                    --backfill-execution-events \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --older-than-seconds 0 \
+                    --batch-size 1000 \
+                    --max-batches 5 \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/audit_hpairs_source_proof_census.py \
+                    --dsn "${SIM_DB_DSN}" \
+                    --hypothesis-id H-PAIRS-01 \
+                    --candidate-id c88421d619759b2cfaa6f4d0 \
+                    --runtime-strategy-name microbar-cross-sectional-pairs-v1 \
+                    --account-label TORGHUT_SIM \
+                    --source-account-label TORGHUT_SIM \
+                    --observed-stage paper \
+                    > "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}"
+                  /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
+                    --output-dir /tmp/torghut-empirical-renewal \
+                    --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
+                    --hpairs-source-proof-census-file "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}" \
+                    --runtime-window-import \
+                    --runtime-window-target-plan-url 'http://torghut-sim.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=latest_closed&full_audit=true&limit=5' \
+                    --runtime-window-target-plan-url 'http://torghut.torghut.svc.cluster.local/trading/status' \
+                    --runtime-window-target-plan-url-timeout-seconds 45 \
+                    --runtime-window-target-plan-url-attempts 3 \
+                    --runtime-window-target-plan-url-retry-backoff-seconds 5 \
+                    --runtime-window-target-plan-exclusive \
+                    --runtime-window-target-plan-settlement-seconds 3600 \
+                    --runtime-window-hypothesis-id H-PAIRS-01 \
+                    --runtime-window-candidate-id c88421d619759b2cfaa6f4d0 \
+                    --runtime-window-strategy-family microbar_cross_sectional_pairs \
+                    --runtime-window-strategy-name microbar-cross-sectional-pairs-v1 \
+                    --runtime-window-account-label TORGHUT_SIM \
+                    --runtime-window-observed-stage paper \
+                    --runtime-window-source-dsn-env SIM_DB_DSN \
+                    --runtime-window-target-dsn-env SIM_DB_DSN \
+                    --runtime-window-dataset-snapshot-ref portfolio-profit-autoresearch-500-v1 \
+                    --runtime-window-source-manifest-ref config/trading/hypotheses/h-pairs-01.json \
+                    --json \
+                    | tee "${RENEWAL_OUTPUT}"
+                  /opt/venv/bin/python scripts/assemble_runtime_ledger_proof_packet.py \
+                    --status-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
+                    --completion-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --timeout-seconds 30 \
+                    --proof-mode authority \
+                    --runtime-window-import-file "${RENEWAL_OUTPUT}" \
+                    --hpairs-source-proof-census-file "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}" \
+                    --min-runtime-ledger-net-pnl 10000 \
+                    --min-runtime-ledger-daily-net-pnl 500 \
+                    --min-runtime-ledger-trading-days 20 \
+                    --max-runtime-ledger-drawdown-pct-equity 0.03 \
+                    --max-runtime-ledger-best-day-share 0.25 \
+                    --max-runtime-ledger-symbol-concentration-share 0.35 \
+                    --output-file "${PROOF_PACKET_OUTPUT}" \
+                    --artifact-prefix 'runtime-ledger-proof-packets/{run_id}' \
+                    --require-artifact-upload \
+                    --allow-blocked-exit-zero
+                  echo "stage=empirical_promotion_renewal completed_at=$(date -Iseconds)"
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: DB_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: uri
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: TORGHUT_IMAGE_DIGEST
+                  value: sha256:441503b721325a24b7da86b000767f843a41c9a32b92c1d83ceac84f0fae798a
+                - name: TORGHUT_COMMIT
+                  value: 0beb34eb52fc5ebbe93e98d49dcee4d00430fcb5
+                - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: BUCKET_NAME
+                - name: TORGHUT_EMPIRICAL_CEPH_BUCKET_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: BUCKET_HOST
+                - name: TORGHUT_EMPIRICAL_CEPH_BUCKET_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: BUCKET_PORT
+                - name: TORGHUT_EMPIRICAL_CEPH_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: AWS_ACCESS_KEY_ID
+                - name: TORGHUT_EMPIRICAL_CEPH_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: AWS_SECRET_ACCESS_KEY

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-execution-tca-refresh
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: execution-tca-refresh
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      backoffLimit: 1
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: torghut-runtime
+          containers:
+            - name: refresh-execution-tca
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:441503b721325a24b7da86b000767f843a41c9a32b92c1d83ceac84f0fae798a
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
+                  ephemeral-storage: 512Mi
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: DB_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: uri
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: TORGHUT_EXECUTION_TCA_ACTIVITY_LOOKBACK_SECONDS
+                  value: "86400"
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  echo "stage=refresh_execution_tca_metrics dsn_env=SIM_DB_DSN account=TORGHUT_SIM started_at=$(date -Iseconds)"
+                  /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --older-than-seconds 900 \
+                    --batch-size 1000 \
+                    --max-batches 5 \
+                    --apply \
+                    --json
+                  echo "stage=refresh_execution_tca_metrics dsn_env=DB_DSN started_at=$(date -Iseconds)"
+                  /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
+                    --dsn-env DB_DSN \
+                    --older-than-seconds 900 \
+                    --batch-size 1000 \
+                    --max-batches 5 \
+                    --apply \
+                    --json

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -35,7 +35,10 @@ resources:
   - whitepaper-semantic-backfill-job.yaml
   - empirical-artifacts-objectbucketclaim.yaml
   - empirical-jobs-backfill-job.yaml
+  - empirical-promotion-renewal-cronjob.yaml
+  - order-feed-source-window-repair-cronjob.yaml
   - empirical-artifacts-retention-cronjob.yaml
+  - execution-tca-refresh-cronjob.yaml
   - zero-notional-drift-repair-cronjob.yaml
   - paper-account-flatten-cronjob.yaml
   - whitepaper-autoresearch-workflowtemplate.yaml

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -1,0 +1,115 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-order-feed-source-window-repair
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: order-feed-source-window-repair
+spec:
+  schedule: "13,43 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      backoffLimit: 1
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: torghut-runtime
+          containers:
+            - name: repair-source-windows
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:441503b721325a24b7da86b000767f843a41c9a32b92c1d83ceac84f0fae798a
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
+                  ephemeral-storage: 512Mi
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  echo "stage=repair_order_feed_source_windows started_at=$(date -Iseconds)"
+                  WINDOW_END="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  WINDOW_START="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+                  echo "stage=reconcile_cross_dsn_order_feed_links started_at=$(date -Iseconds) window_start=${WINDOW_START} window_end=${WINDOW_END}"
+                  /opt/venv/bin/python scripts/reconcile_cross_dsn_order_feed_links.py \
+                    --event-dsn-env DB_DSN \
+                    --canonical-dsn-env SIM_DB_DSN \
+                    --source-account-label PA3SX7FYNUTF \
+                    --canonical-account-label TORGHUT_SIM \
+                    --window-start "${WINDOW_START}" \
+                    --window-end "${WINDOW_END}" \
+                    --limit 5000 \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env DB_DSN \
+                    --account-label PA3SX7FYNUTF \
+                    --canonical-account-label TORGHUT_SIM \
+                    --batch-size 1000 \
+                    --max-batches 1 \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --batch-size 100 \
+                    --max-batches 4 \
+                    --backfill-execution-events \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_REPLAY \
+                    --batch-size 100 \
+                    --max-batches 4 \
+                    --backfill-execution-events \
+                    --apply \
+                    --json
+                  echo "stage=order_feed_source_window_repair completed_at=$(date -Iseconds)"
+              securityContext:
+                seccompProfile:
+                  type: Unconfined
+              env:
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: DB_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: uri
+                - name: PYTHONUNBUFFERED
+                  value: "1"


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `843163f4fe6ae7783e1b161c1063774a41d18f3a`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28431785174`
- Rollback source: `HEAD^` manifests from the failed run checkout