### PR TITLE
chore(symphony): promote image 8c47ea3c

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:34:12Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:51:53Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1ce06117"
-    digest: sha256:b6a2819756b6e1ca92c433d0b9b6dd3aedd986f3f0475feb2a5f3f5a831edc28
+    newTag: "8c47ea3c"
+    digest: sha256:85a6f43aa307c67f5ced9b2459120353c42ff64a89e67ae9904c6382c92e0ecd

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:34:12Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:51:53Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1ce06117"
-    digest: sha256:b6a2819756b6e1ca92c433d0b9b6dd3aedd986f3f0475feb2a5f3f5a831edc28
+    newTag: "8c47ea3c"
+    digest: sha256:85a6f43aa307c67f5ced9b2459120353c42ff64a89e67ae9904c6382c92e0ecd

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:34:12Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:51:53Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1ce06117"
-    digest: sha256:b6a2819756b6e1ca92c433d0b9b6dd3aedd986f3f0475feb2a5f3f5a831edc28
+    newTag: "8c47ea3c"
+    digest: sha256:85a6f43aa307c67f5ced9b2459120353c42ff64a89e67ae9904c6382c92e0ecd


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `8c47ea3c9bb40ab9f25e8278a0b23127363742c4`
- Image tag: `8c47ea3c`
- Image digest: `sha256:85a6f43aa307c67f5ced9b2459120353c42ff64a89e67ae9904c6382c92e0ecd`