### PR TITLE
perf(nix): skip image builds for manifest-only changes

### DIFF
--- a/.github/workflows/bumba-ci.yml
+++ b/.github/workflows/bumba-ci.yml
@@ -27,8 +27,6 @@ on:
     paths:
       - 'services/bumba/**'
       - 'packages/scripts/src/bumba/**'
-      - 'argocd/applications/bumba/**'
-      - 'argocd/applicationsets/product.yaml'
       - '.github/workflows/bumba-ci.yml'
       - '.github/workflows/nix-oci-build-common.yml'
       - '.github/workflows/enabled-simple-nix-release.yml'

--- a/.github/workflows/enabled-simple-nix-release.yml
+++ b/.github/workflows/enabled-simple-nix-release.yml
@@ -135,13 +135,13 @@ jobs:
 
           case "${SERVICE}" in
             oirat)
-              paths=(services/oirat packages/discord packages/scripts/src/oirat argocd/applications/oirat nix/images flake.nix flake.lock bun.lock package.json .github/workflows/oirat-ci.yml .github/workflows/nix-oci-build-common.yml)
+              paths=(services/oirat packages/discord packages/scripts/src/oirat nix/images flake.nix flake.lock bun.lock package.json .github/workflows/oirat-ci.yml .github/workflows/nix-oci-build-common.yml)
               ;;
             bumba)
-              paths=(services/bumba packages/temporal-bun-sdk packages/scripts/src/bumba argocd/applications/bumba nix/images flake.nix flake.lock bun.lock package.json .github/workflows/bumba-ci.yml .github/workflows/nix-oci-build-common.yml)
+              paths=(services/bumba packages/temporal-bun-sdk packages/scripts/src/bumba nix/images flake.nix flake.lock bun.lock package.json .github/workflows/bumba-ci.yml .github/workflows/nix-oci-build-common.yml)
               ;;
             froussard)
-              paths=(apps/froussard packages/agent-contracts packages/codex packages/discord packages/otel packages/scripts/src/froussard argocd/applications/froussard nix/images flake.nix flake.lock bun.lock package.json .github/workflows/froussard-ci.yml .github/workflows/nix-oci-build-common.yml)
+              paths=(apps/froussard packages/agent-contracts packages/codex packages/discord packages/otel packages/scripts/src/froussard nix/images flake.nix flake.lock bun.lock package.json .github/workflows/froussard-ci.yml .github/workflows/nix-oci-build-common.yml)
               ;;
           esac
 

--- a/.github/workflows/froussard-ci.yml
+++ b/.github/workflows/froussard-ci.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'apps/froussard/**'
       - 'packages/scripts/src/froussard/**'
-      - 'argocd/applications/froussard/**'
       - '.github/workflows/froussard-ci.yml'
       - '.github/workflows/nix-oci-build-common.yml'
       - '.github/workflows/enabled-simple-nix-release.yml'
@@ -28,7 +27,6 @@ on:
     paths:
       - 'apps/froussard/**'
       - 'packages/scripts/src/froussard/**'
-      - 'argocd/applications/froussard/**'
       - '.github/workflows/froussard-ci.yml'
       - '.github/workflows/nix-oci-build-common.yml'
       - '.github/workflows/enabled-simple-nix-release.yml'

--- a/.github/workflows/oirat-ci.yml
+++ b/.github/workflows/oirat-ci.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'services/oirat/**'
       - 'packages/scripts/src/oirat/**'
-      - 'argocd/applications/oirat/**'
       - '.github/workflows/oirat-ci.yml'
       - '.github/workflows/nix-oci-build-common.yml'
       - '.github/workflows/enabled-simple-nix-release.yml'
@@ -28,7 +27,6 @@ on:
     paths:
       - 'services/oirat/**'
       - 'packages/scripts/src/oirat/**'
-      - 'argocd/applications/oirat/**'
       - '.github/workflows/oirat-ci.yml'
       - '.github/workflows/nix-oci-build-common.yml'
       - '.github/workflows/enabled-simple-nix-release.yml'

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -299,6 +299,16 @@ describe('native OCI build workflows', () => {
     }
   })
 
+  it('does not rebuild migrated simple app images for GitOps-only manifest changes', () => {
+    expect(oiratWorkflow).not.toContain("'argocd/applications/oirat/**'")
+    expect(bumbaWorkflow).not.toContain("'argocd/applications/bumba/**'")
+    expect(bumbaWorkflow).not.toContain("'argocd/applicationsets/product.yaml'")
+    expect(froussardWorkflow).not.toContain("'argocd/applications/froussard/**'")
+    expect(enabledSimpleReleaseWorkflow).not.toContain('packages/scripts/src/oirat argocd/applications/oirat')
+    expect(enabledSimpleReleaseWorkflow).not.toContain('packages/scripts/src/bumba argocd/applications/bumba')
+    expect(enabledSimpleReleaseWorkflow).not.toContain('packages/scripts/src/froussard argocd/applications/froussard')
+  })
+
   it('keeps manual migrated app deploy scripts on the shared Nix image helper', () => {
     for (const script of [oiratBuildScript, bumbaBuildScript, froussardDeployScript]) {
       expect(script).toContain("from '../shared/nix-oci-deploy'")


### PR DESCRIPTION
## Summary

- Stop migrated simple-app Nix image workflows from running on GitOps manifest-only changes.
- Keep release PR manifest updates intact while removing manifests from the release workflow's image build-input drift check.
- Add OCI workflow contract coverage so Oirat, Bumba, and Froussard do not regress into manifest-triggered image rebuilds.

## Related Issues

None

## Testing

```bash
bun test packages/scripts/src/shared/__tests__/oci.test.ts
actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/oirat-ci.yml .github/workflows/bumba-ci.yml .github/workflows/froussard-ci.yml .github/workflows/enabled-simple-nix-release.yml
git diff --check
```

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
