### PR TITLE
chore(symphony): promote image c0082039

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:51:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:13:52Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "8c47ea3c"
-    digest: sha256:85a6f43aa307c67f5ced9b2459120353c42ff64a89e67ae9904c6382c92e0ecd
+    newTag: "c0082039"
+    digest: sha256:e0d819d886182f7ec144ef01ac33db4369d497eead82c5fd9af1b227c693d302

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:51:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:13:52Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "8c47ea3c"
-    digest: sha256:85a6f43aa307c67f5ced9b2459120353c42ff64a89e67ae9904c6382c92e0ecd
+    newTag: "c0082039"
+    digest: sha256:e0d819d886182f7ec144ef01ac33db4369d497eead82c5fd9af1b227c693d302

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T08:51:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:13:52Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "8c47ea3c"
-    digest: sha256:85a6f43aa307c67f5ced9b2459120353c42ff64a89e67ae9904c6382c92e0ecd
+    newTag: "c0082039"
+    digest: sha256:e0d819d886182f7ec144ef01ac33db4369d497eead82c5fd9af1b227c693d302


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `c00820396ebd217b6514642237b0ac98d50f423e`
- Image tag: `c0082039`
- Image digest: `sha256:e0d819d886182f7ec144ef01ac33db4369d497eead82c5fd9af1b227c693d302`