### PR TITLE
chore(symphony): promote image cf4061c5

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:13:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:32:53Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c0082039"
-    digest: sha256:e0d819d886182f7ec144ef01ac33db4369d497eead82c5fd9af1b227c693d302
+    newTag: "cf4061c5"
+    digest: sha256:41c7f47e2159352536da6cbd850bc181ff36e35f4f40ba5e694f35cfb9af12d0

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:13:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:32:53Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c0082039"
-    digest: sha256:e0d819d886182f7ec144ef01ac33db4369d497eead82c5fd9af1b227c693d302
+    newTag: "cf4061c5"
+    digest: sha256:41c7f47e2159352536da6cbd850bc181ff36e35f4f40ba5e694f35cfb9af12d0

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:13:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:32:53Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c0082039"
-    digest: sha256:e0d819d886182f7ec144ef01ac33db4369d497eead82c5fd9af1b227c693d302
+    newTag: "cf4061c5"
+    digest: sha256:41c7f47e2159352536da6cbd850bc181ff36e35f4f40ba5e694f35cfb9af12d0


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `cf4061c5bc057774d313abb88c30cfe988246d69`
- Image tag: `cf4061c5`
- Image digest: `sha256:41c7f47e2159352536da6cbd850bc181ff36e35f4f40ba5e694f35cfb9af12d0`