### PR TITLE
chore(symphony): promote image 86e969e4

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:32:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T12:10:00Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cf4061c5"
-    digest: sha256:41c7f47e2159352536da6cbd850bc181ff36e35f4f40ba5e694f35cfb9af12d0
+    newTag: "86e969e4"
+    digest: sha256:0f111bf128c294684d7231ad11af0d45f781f357f44108e3888e7a22895071a3

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:32:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T12:10:00Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cf4061c5"
-    digest: sha256:41c7f47e2159352536da6cbd850bc181ff36e35f4f40ba5e694f35cfb9af12d0
+    newTag: "86e969e4"
+    digest: sha256:0f111bf128c294684d7231ad11af0d45f781f357f44108e3888e7a22895071a3

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T09:32:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T12:10:00Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cf4061c5"
-    digest: sha256:41c7f47e2159352536da6cbd850bc181ff36e35f4f40ba5e694f35cfb9af12d0
+    newTag: "86e969e4"
+    digest: sha256:0f111bf128c294684d7231ad11af0d45f781f357f44108e3888e7a22895071a3


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `86e969e4e9e85dfc6b03183bff7c8fbbd6b37072`
- Image tag: `86e969e4`
- Image digest: `sha256:0f111bf128c294684d7231ad11af0d45f781f357f44108e3888e7a22895071a3`