### PR TITLE
chore(jangar): promote image 86e969e4

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-30T09:29:04Z
+    deploy.knative.dev/rollout: 2026-06-30T12:12:46Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: cf4061c5bc057774d313abb88c30cfe988246d69
+              value: 86e969e4e9e85dfc6b03183bff7c8fbbd6b37072
             - name: JANGAR_GITOPS_REVISION
-              value: cf4061c5bc057774d313abb88c30cfe988246d69
+              value: 86e969e4e9e85dfc6b03183bff7c8fbbd6b37072
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28434260844"
+              value: "28442401754"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:87545650f25a415b5db7d0b7898fdf94b86749bfefe62f2250c2ca467287f8a6
+              value: sha256:6d7adcc132c38b2bbad0ba9219a2a45be348a161465bcd911f163588750a3a82
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: cf4061c5bc057774d313abb88c30cfe988246d69
+              value: 86e969e4e9e85dfc6b03183bff7c8fbbd6b37072
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:87545650f25a415b5db7d0b7898fdf94b86749bfefe62f2250c2ca467287f8a6
+              value: sha256:6d7adcc132c38b2bbad0ba9219a2a45be348a161465bcd911f163588750a3a82
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: cf4061c5
-    digest: sha256:87545650f25a415b5db7d0b7898fdf94b86749bfefe62f2250c2ca467287f8a6
+    newTag: 86e969e4
+    digest: sha256:6d7adcc132c38b2bbad0ba9219a2a45be348a161465bcd911f163588750a3a82


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `86e969e4e9e85dfc6b03183bff7c8fbbd6b37072`
- Image tag: `86e969e4`
- Image digest: `sha256:6d7adcc132c38b2bbad0ba9219a2a45be348a161465bcd911f163588750a3a82`
- Source CI run: `28442401754`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates