### PR TITLE
fix(nix): stabilize product bun cache builds

### DIFF
--- a/nix/images/app.nix
+++ b/nix/images/app.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "app";
   packageName = "app";
   depsHash = {
-    x86_64-linux = lib.fakeHash;
-    aarch64-linux = lib.fakeHash;
+    x86_64-linux = "sha256-W6Tspd2SfITjEm0qjdGfgk906koL/z/OHTHXwzq2aAk=";
+    aarch64-linux = "sha256-Ril7Ipw+AMxMNdkRhwom9Nm26cGdGYykfshxlxPVAqg=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/app.nix
+++ b/nix/images/app.nix
@@ -11,9 +11,10 @@ import ./bun-workspace-service.nix {
   serviceName = "app";
   packageName = "app";
   depsHash = {
-    x86_64-linux = "sha256-gH/vkUNGcDRNhqbmnmklTadBxVkwBcJI94+rok3RZXs=";
-    aarch64-linux = "sha256-CbGk8vcCegTydIkJzAJzjmCUNSBOOphjcAvvlNDAyHQ=";
+    x86_64-linux = lib.fakeHash;
+    aarch64-linux = lib.fakeHash;
   };
+  dependencyClosure = "bunCache";
   installFilters = [
     "@proompteng/source"
     "@proompteng/design"

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -101,10 +101,12 @@ let
 
       export HOME="$TMPDIR/home"
       export BUN_INSTALL_CACHE_DIR="$TMPDIR/bun-cache"
+      export BUN_CONFIG_CACHE_DIR="$BUN_INSTALL_CACHE_DIR"
       mkdir -p "$HOME" "$BUN_INSTALL_CACHE_DIR" "$out"
       cp -R . "$out/"
       cd "$out"
       bun install \
+        --cache-dir "$BUN_INSTALL_CACHE_DIR" \
         --frozen-lockfile \
         --ignore-scripts \
         --backend=copyfile \
@@ -145,11 +147,14 @@ let
 
       export HOME="$TMPDIR/home"
       export BUN_INSTALL_CACHE_DIR="$TMPDIR/bun-cache"
+      export BUN_CONFIG_CACHE_DIR="$BUN_INSTALL_CACHE_DIR"
       mkdir -p "$HOME" "$BUN_INSTALL_CACHE_DIR" "$TMPDIR/work"
       ${
         if useBunCacheClosure then
           ''
             cp -R ${deps}/. "$BUN_INSTALL_CACHE_DIR/"
+            cp -R ${depsSource}/. "$TMPDIR/work/"
+            chmod -R u+w "$TMPDIR/work"
             cp -R . "$TMPDIR/work/"
             chmod -R u+w "$BUN_INSTALL_CACHE_DIR" "$TMPDIR/work"
           ''
@@ -165,6 +170,7 @@ let
         if useBunCacheClosure then
           ''
             bun install \
+              --cache-dir "$BUN_INSTALL_CACHE_DIR" \
               --offline \
               --frozen-lockfile \
               --ignore-scripts \

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -12,6 +12,7 @@
   sourcePaths,
   buildCommands ? [ ],
   runtimeInstallPhase ? null,
+  dependencyClosure ? "nodeModules",
   command,
   env ? [ ],
   extraContents ? [ ],
@@ -68,6 +69,7 @@ let
 
   installFilterArgs = lib.concatMapStringsSep " " (filter: "--filter ${lib.escapeShellArg filter}") installFilters;
   buildScript = lib.concatStringsSep "\n" buildCommands;
+  useBunCacheClosure = dependencyClosure == "bunCache";
   resolvedDepsHash =
     if builtins.isAttrs depsHash then
       depsHash.${pkgs.stdenv.hostPlatform.system}
@@ -112,6 +114,13 @@ let
         --no-summary \
         ${installFilterArgs}
 
+      if [ "${dependencyClosure}" = "bunCache" ]; then
+        cd "$TMPDIR"
+        rm -rf "$out"
+        mkdir -p "$out"
+        cp -R "$BUN_INSTALL_CACHE_DIR/." "$out/"
+      fi
+
       runHook postInstall
     '';
   };
@@ -137,10 +146,38 @@ let
       export HOME="$TMPDIR/home"
       export BUN_INSTALL_CACHE_DIR="$TMPDIR/bun-cache"
       mkdir -p "$HOME" "$BUN_INSTALL_CACHE_DIR" "$TMPDIR/work"
-      cp -R ${deps}/. "$TMPDIR/work/"
-      chmod -R u+w "$TMPDIR/work"
-      cp -R . "$TMPDIR/work/"
+      ${
+        if useBunCacheClosure then
+          ''
+            cp -R ${deps}/. "$BUN_INSTALL_CACHE_DIR/"
+            cp -R . "$TMPDIR/work/"
+            chmod -R u+w "$BUN_INSTALL_CACHE_DIR" "$TMPDIR/work"
+          ''
+        else
+          ''
+            cp -R ${deps}/. "$TMPDIR/work/"
+            chmod -R u+w "$TMPDIR/work"
+            cp -R . "$TMPDIR/work/"
+          ''
+      }
       cd "$TMPDIR/work"
+      ${
+        if useBunCacheClosure then
+          ''
+            bun install \
+              --offline \
+              --frozen-lockfile \
+              --ignore-scripts \
+              --backend=copyfile \
+              --linker=isolated \
+              --network-concurrency=1 \
+              --no-progress \
+              --no-summary \
+              ${installFilterArgs}
+          ''
+        else
+          ""
+      }
       ${buildScript}
 
       runHook postBuild

--- a/nix/images/docs.nix
+++ b/nix/images/docs.nix
@@ -11,9 +11,10 @@ import ./bun-workspace-service.nix {
   serviceName = "docs";
   packageName = "docs";
   depsHash = {
-    x86_64-linux = "sha256-CZuf9swJwaP8Ah4k+/ooMspdAbMwzom5Wmk4SaUMrFw=";
-    aarch64-linux = "sha256-5FSjGRFeyrZGzmthjvubv1bFUBj8DXf6uYA7l6pws8k=";
+    x86_64-linux = lib.fakeHash;
+    aarch64-linux = lib.fakeHash;
   };
+  dependencyClosure = "bunCache";
   installFilters = [
     "@proompteng/design"
     "docs"

--- a/nix/images/docs.nix
+++ b/nix/images/docs.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "docs";
   packageName = "docs";
   depsHash = {
-    x86_64-linux = lib.fakeHash;
-    aarch64-linux = lib.fakeHash;
+    x86_64-linux = "sha256-2855KavT7rqbLHIDedBlgyUBlsZ5TOJvtel3/kKomQ0=";
+    aarch64-linux = "sha256-0ICmO5A6gqtaODeOlXdVQBlUYyUp/hvdqnwIwQhfZyw=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/olden.nix
+++ b/nix/images/olden.nix
@@ -11,9 +11,10 @@ import ./bun-workspace-service.nix {
   serviceName = "olden";
   packageName = "olden";
   depsHash = {
-    x86_64-linux = "sha256-Pe1PrO+FBr+ZClvxp9pVGzVwMEaISpH3MizBywngFG8=";
-    aarch64-linux = "sha256-e2rM9XEgmgAt6YZZxPQR4w4jrL4jCFqkRiGVI2z1OGE=";
+    x86_64-linux = lib.fakeHash;
+    aarch64-linux = lib.fakeHash;
   };
+  dependencyClosure = "bunCache";
   installFilters = [
     "@proompteng/design"
     "olden"

--- a/nix/images/olden.nix
+++ b/nix/images/olden.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "olden";
   packageName = "olden";
   depsHash = {
-    x86_64-linux = lib.fakeHash;
-    aarch64-linux = lib.fakeHash;
+    x86_64-linux = "sha256-mVmJHnibB0eBjNCWLHwiPqZ1wcE4A590r0Le/pYckwo=";
+    aarch64-linux = "sha256-ObYDWyqG74ftNnBXZCu60JktViNYrMTrD9cMig4xUjA=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/proompteng.nix
+++ b/nix/images/proompteng.nix
@@ -11,9 +11,10 @@ import ./bun-workspace-service.nix {
   serviceName = "proompteng";
   packageName = "landing";
   depsHash = {
-    x86_64-linux = "sha256-29d7xZjrijoenLtveh+HhW9VJtFg7RFoliIWF5KXlGk=";
-    aarch64-linux = "sha256-tfZ1/HTqly1TRO52RIMIgnYvCMPnST7E3h8u5tahOsg=";
+    x86_64-linux = lib.fakeHash;
+    aarch64-linux = lib.fakeHash;
   };
+  dependencyClosure = "bunCache";
   installFilters = [
     "@proompteng/backend"
     "@proompteng/design"

--- a/nix/images/proompteng.nix
+++ b/nix/images/proompteng.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "proompteng";
   packageName = "landing";
   depsHash = {
-    x86_64-linux = lib.fakeHash;
-    aarch64-linux = lib.fakeHash;
+    x86_64-linux = "sha256-j20DZtVjkaOqdd4e1Aso3yIOLUbjC35+QereHDB+1Os=";
+    aarch64-linux = "sha256-zv7qtnx717wldtXk6vnBiCb3G8qmRPdceTysY29DUYc=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/synthesis.nix
+++ b/nix/images/synthesis.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "synthesis";
   packageName = "synthesis";
   depsHash = {
-    x86_64-linux = lib.fakeHash;
-    aarch64-linux = lib.fakeHash;
+    x86_64-linux = "sha256-k5BKKn+qtBwK0+3KonYbZk0GLO5vuy9Ld02VvTv/nPU=";
+    aarch64-linux = "sha256-Jl5kq+kFfrZxFEPxNU6PymTuNv96qdiryHeH9oYSZN4=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/synthesis.nix
+++ b/nix/images/synthesis.nix
@@ -11,9 +11,10 @@ import ./bun-workspace-service.nix {
   serviceName = "synthesis";
   packageName = "synthesis";
   depsHash = {
-    x86_64-linux = "sha256-vGwrOet63H8vdbGcvgJG6i/NZFfFXLXEfZJeIow8Ixg=";
-    aarch64-linux = "sha256-Bxjkj44xeUZIak/1tlfgrVMiav76NTWfVNxlwyT/FIA=";
+    x86_64-linux = lib.fakeHash;
+    aarch64-linux = lib.fakeHash;
   };
+  dependencyClosure = "bunCache";
   installFilters = [
     "@proompteng/design"
     "synthesis"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -22,6 +22,7 @@ const ciNixOciSummaryScript = readRepoFile('nix/ci-nix-oci-summary.sh')
 const nixOciWorkflow = readRepoFile('.github/workflows/nix-oci-build-common.yml')
 const enabledSimpleReleaseWorkflow = readRepoFile('.github/workflows/enabled-simple-nix-release.yml')
 const productNixWorkflow = readRepoFile('.github/workflows/product-nix-images.yml')
+const bunWorkspaceServiceModule = readRepoFile('nix/images/bun-workspace-service.nix')
 const enabledProductReleaseWorkflow = readRepoFile('.github/workflows/enabled-product-nix-release.yml')
 const autoPrReleaseBranchesWorkflow = readRepoFile('.github/workflows/auto-pr-release-branches.yml')
 const releasePrAutomergeWorkflow = readRepoFile('.github/workflows/release-pr-automerge.yml')
@@ -361,6 +362,8 @@ describe('native OCI build workflows', () => {
     for (const imageModule of productImageModules) {
       expect(imageModule).toContain('dependencyClosure = "bunCache";')
     }
+    expect(bunWorkspaceServiceModule).toContain('cp -R ${depsSource}/. "$TMPDIR/work/"')
+    expect(bunWorkspaceServiceModule).toContain('--cache-dir "$BUN_INSTALL_CACHE_DIR"')
   })
 
   it('does not rebuild migrated simple app images for GitOps-only manifest changes', () => {

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -30,6 +30,13 @@ const bumbaWorkflow = readRepoFile('.github/workflows/bumba-ci.yml')
 const froussardWorkflow = readRepoFile('.github/workflows/froussard-ci.yml')
 const froussardKnativeService = readRepoFile('argocd/applications/froussard/knative-service.yaml')
 const appImageModule = readRepoFile('nix/images/app.nix')
+const productImageModules = [
+  appImageModule,
+  readRepoFile('nix/images/docs.nix'),
+  readRepoFile('nix/images/olden.nix'),
+  readRepoFile('nix/images/proompteng.nix'),
+  readRepoFile('nix/images/synthesis.nix'),
+]
 const oiratBuildScript = readRepoFile('packages/scripts/src/oirat/build-image.ts')
 const bumbaBuildScript = readRepoFile('packages/scripts/src/bumba/build-image.ts')
 const froussardDeployScript = readRepoFile('packages/scripts/src/froussard/deploy-service.ts')
@@ -351,6 +358,9 @@ describe('native OCI build workflows', () => {
     expect(productNixWorkflow).not.toContain("'argocd/applications/olden/**'")
     expect(productNixWorkflow).not.toContain("'argocd/applications/synthesis/**'")
     expect(appImageModule).toContain('"@proompteng/source"')
+    for (const imageModule of productImageModules) {
+      expect(imageModule).toContain('dependencyClosure = "bunCache";')
+    }
   })
 
   it('does not rebuild migrated simple app images for GitOps-only manifest changes', () => {


### PR DESCRIPTION
## Summary

- Changes product Nix image dependency realization from fixed-output `node_modules` trees to fixed-output Bun cache closures plus offline installs in the normal build derivation.
- Applies the cache-mode path only to product app images: app, docs, olden, proompteng, and synthesis.
- Adds a workflow contract test that keeps product images on the Bun-cache closure mode while leaving simple service images unchanged.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxlint packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
