### PR TITLE
chore(symphony): promote image fc28d2c3

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T12:10:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T13:30:15Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "86e969e4"
-    digest: sha256:0f111bf128c294684d7231ad11af0d45f781f357f44108e3888e7a22895071a3
+    newTag: "fc28d2c3"
+    digest: sha256:03a144f0e6b093ec45a8e84af34bfdc8b1629a37c336e57b0bcf581952d378ed

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T12:10:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T13:30:15Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "86e969e4"
-    digest: sha256:0f111bf128c294684d7231ad11af0d45f781f357f44108e3888e7a22895071a3
+    newTag: "fc28d2c3"
+    digest: sha256:03a144f0e6b093ec45a8e84af34bfdc8b1629a37c336e57b0bcf581952d378ed

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T12:10:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T13:30:15Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "86e969e4"
-    digest: sha256:0f111bf128c294684d7231ad11af0d45f781f357f44108e3888e7a22895071a3
+    newTag: "fc28d2c3"
+    digest: sha256:03a144f0e6b093ec45a8e84af34bfdc8b1629a37c336e57b0bcf581952d378ed


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `fc28d2c365b84bbb77e360021b3c5de819b4c808`
- Image tag: `fc28d2c3`
- Image digest: `sha256:03a144f0e6b093ec45a8e84af34bfdc8b1629a37c336e57b0bcf581952d378ed`