### PR TITLE
chore(symphony): promote image 2c392bf9

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T13:30:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T15:15:49Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "fc28d2c3"
-    digest: sha256:03a144f0e6b093ec45a8e84af34bfdc8b1629a37c336e57b0bcf581952d378ed
+    newTag: "2c392bf9"
+    digest: sha256:cf0159f36cc78ffc52ee69b6feecae0214fb098e4623a77e70a7538232e879c0

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T13:30:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T15:15:49Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "fc28d2c3"
-    digest: sha256:03a144f0e6b093ec45a8e84af34bfdc8b1629a37c336e57b0bcf581952d378ed
+    newTag: "2c392bf9"
+    digest: sha256:cf0159f36cc78ffc52ee69b6feecae0214fb098e4623a77e70a7538232e879c0

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T13:30:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T15:15:49Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "fc28d2c3"
-    digest: sha256:03a144f0e6b093ec45a8e84af34bfdc8b1629a37c336e57b0bcf581952d378ed
+    newTag: "2c392bf9"
+    digest: sha256:cf0159f36cc78ffc52ee69b6feecae0214fb098e4623a77e70a7538232e879c0


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `2c392bf93edd4004a8e917d26079b136da283e96`
- Image tag: `2c392bf9`
- Image digest: `sha256:cf0159f36cc78ffc52ee69b6feecae0214fb098e4623a77e70a7538232e879c0`