### PR TITLE
chore(jangar): promote image 2c392bf9

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-30T13:49:59Z
+    deploy.knative.dev/rollout: 2026-06-30T15:18:56Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: fc28d2c365b84bbb77e360021b3c5de819b4c808
+              value: 2c392bf93edd4004a8e917d26079b136da283e96
             - name: JANGAR_GITOPS_REVISION
-              value: fc28d2c365b84bbb77e360021b3c5de819b4c808
+              value: 2c392bf93edd4004a8e917d26079b136da283e96
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28448099866"
+              value: "28454358302"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:b5e54308c251a51cf2dd72eb378ce7109c3f37fabc7e97fff9a0ab50b18361e1
+              value: sha256:1c50c47d76bc1ec7fa086b1f59c768db2a619481829f81c29d5ef46a2c421631
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: fc28d2c365b84bbb77e360021b3c5de819b4c808
+              value: 2c392bf93edd4004a8e917d26079b136da283e96
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:b5e54308c251a51cf2dd72eb378ce7109c3f37fabc7e97fff9a0ab50b18361e1
+              value: sha256:1c50c47d76bc1ec7fa086b1f59c768db2a619481829f81c29d5ef46a2c421631
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: fc28d2c3
-    digest: sha256:b5e54308c251a51cf2dd72eb378ce7109c3f37fabc7e97fff9a0ab50b18361e1
+    newTag: 2c392bf9
+    digest: sha256:1c50c47d76bc1ec7fa086b1f59c768db2a619481829f81c29d5ef46a2c421631


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `2c392bf93edd4004a8e917d26079b136da283e96`
- Image tag: `2c392bf9`
- Image digest: `sha256:1c50c47d76bc1ec7fa086b1f59c768db2a619481829f81c29d5ef46a2c421631`
- Source CI run: `28454358302`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates