### PR TITLE
ci(nix): migrate symphony image build

### DIFF
--- a/.github/workflows/auto-pr-release-branches.yml
+++ b/.github/workflows/auto-pr-release-branches.yml
@@ -106,6 +106,9 @@ jobs:
             "argocd/applications/oirat/kustomization.yaml"
             "argocd/applications/olden/kustomization.yaml"
             "argocd/applications/proompteng/kustomization.yaml"
+            "argocd/applications/symphony/kustomization.yaml"
+            "argocd/applications/symphony-jangar/kustomization.yaml"
+            "argocd/applications/symphony-torghut/kustomization.yaml"
             "argocd/applications/synthesis/kustomization.yaml"
           )
 

--- a/.github/workflows/symphony-build-push.yaml
+++ b/.github/workflows/symphony-build-push.yaml
@@ -4,107 +4,76 @@ permissions:
   contents: read
 
 on:
+  pull_request:
+    paths:
+      - 'services/symphony/**'
+      - 'packages/codex/**'
+      - 'packages/otel/**'
+      - 'packages/scripts/src/symphony/**'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig.base.json'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/images/symphony.nix'
+      - 'nix/images/bun-workspace-service.nix'
+      - 'nix/packages.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - '.github/workflows/symphony-build-push.yaml'
+      - '.github/workflows/symphony-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   push:
     branches:
       - main
     paths:
       - 'services/symphony/**'
       - 'packages/codex/**'
+      - 'packages/otel/**'
       - 'packages/scripts/src/symphony/**'
       - 'packages/scripts/src/shared/cli.ts'
-      - 'packages/scripts/src/shared/docker.ts'
       - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
       - 'package.json'
       - 'bun.lock'
       - 'tsconfig.base.json'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/images/symphony.nix'
+      - 'nix/images/bun-workspace-service.nix'
+      - 'nix/packages.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
       - '.github/workflows/symphony-build-push.yaml'
+      - '.github/workflows/symphony-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   workflow_dispatch:
 
 concurrency:
-  group: symphony-build-${{ github.ref }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: arc-arm64
-    timeout-minutes: 60
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Resolve image tag
-        id: meta
-        shell: bash
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Install dependencies
-        shell: bash
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts --filter @proompteng/codex --filter @proompteng/symphony
-
-      - name: Build and push Symphony image
-        env:
-          SYMPHONY_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
-          SYMPHONY_BUILD_CONTEXT: .
-          SYMPHONY_DOCKERFILE: services/symphony/Dockerfile
-        run: bun run packages/scripts/src/symphony/build-image.ts
-
-      - name: Resolve pushed image digest
-        id: digest
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/symphony'
-          TAG='${{ steps.meta.outputs.tag }}'
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
-          if [ -z "${DIGEST}" ]; then
-            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-      - name: Write release contract artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          bun run packages/scripts/src/symphony/release-contract.ts write \
-            --path symphony-release-contract.json \
-            --source-sha "${GITHUB_SHA}" \
-            --tag "${{ steps.meta.outputs.tag }}" \
-            --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/symphony'
-
-      - name: Upload release contract artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: symphony-release-contract
-          path: symphony-release-contract.json
-          if-no-files-found: error
-          retention-days: 3
-
-      - name: Update latest tag (best effort)
-        id: latest_tag
-        continue-on-error: true
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/symphony'
-          TAG='${{ steps.meta.outputs.tag }}'
-          docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${TAG}"
-          docker buildx imagetools inspect "${IMAGE}:${TAG}"
-          docker buildx imagetools inspect "${IMAGE}:latest"
-
-      - name: Warn on latest tag update failure
-        if: steps.latest_tag.outcome == 'failure'
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/symphony'
-          echo "::warning::Non-blocking failure updating ${IMAGE}:latest; digest-tagged image and release artifact are still valid."
+  nix-image:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: symphony
+      package_attr: symphony-image
+      tag: sha-${{ github.sha }}
+      latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'symphony-release-contract' || '' }}
+    secrets: inherit

--- a/.github/workflows/symphony-ci.yml
+++ b/.github/workflows/symphony-ci.yml
@@ -22,9 +22,16 @@ on:
       - '.github/workflows/symphony-post-deploy-verify.yml'
       - '.github/workflows/symphony-deploy-automerge.yml'
       - '.github/workflows/torghut-post-deploy-verify.yml'
-      - '.github/workflows/docker-build-common.yaml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
+      - 'nix/images/symphony.nix'
+      - 'nix/images/bun-workspace-service.nix'
+      - 'nix/packages.nix'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
       - 'package.json'
       - 'bun.lock'
+      - 'flake.nix'
+      - 'flake.lock'
       - 'tsconfig.base.json'
   workflow_dispatch:
 

--- a/.github/workflows/symphony-release.yml
+++ b/.github/workflows/symphony-release.yml
@@ -44,13 +44,15 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          bun-version: 1.3.14
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
@@ -102,7 +104,7 @@ jobs:
           elif [ -n "${CONTRACT_DIGEST}" ]; then
             DIGEST="${CONTRACT_DIGEST}"
           else
-            DIGEST="$(docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_TAG}" | awk '/^Digest:/ { print $2; exit }')"
+            DIGEST="$(crane digest "${IMAGE_NAME}:${IMAGE_TAG}")"
           fi
 
           DIGEST="${DIGEST#*@}"

--- a/flake.nix
+++ b/flake.nix
@@ -250,6 +250,11 @@
               repoRoot = ./.;
               bun = exact.bun;
             };
+            "symphony-image" = import ./nix/images/symphony.nix {
+              inherit pkgs lib nodejs;
+              repoRoot = ./.;
+              bun = exact.bun;
+            };
           };
 
           mkApp = drv: {

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -90,6 +90,7 @@ let
       pkgs.bash
       pkgs.coreutils
       pkgs.findutils
+      pkgs.gnugrep
     ];
 
     dontConfigure = true;
@@ -105,16 +106,48 @@ let
       mkdir -p "$HOME" "$BUN_INSTALL_CACHE_DIR" "$out"
       cp -R . "$out/"
       cd "$out"
-      bun install \
-        --cache-dir "$BUN_INSTALL_CACHE_DIR" \
-        --frozen-lockfile \
-        --ignore-scripts \
-        --backend=copyfile \
-        --linker=isolated \
-        --network-concurrency=1 \
-        --no-progress \
-        --no-summary \
-        ${installFilterArgs}
+
+      run_bun_install() {
+        local attempt
+        local log
+        local status
+
+        for attempt in 1 2 3; do
+          log="$TMPDIR/bun-install-attempt-$attempt.log"
+          rm -f "$log"
+
+          set +e
+          bun install \
+            --cache-dir "$BUN_INSTALL_CACHE_DIR" \
+            --frozen-lockfile \
+            --ignore-scripts \
+            --backend=copyfile \
+            --linker=isolated \
+            --network-concurrency=1 \
+            --no-progress \
+            --no-summary \
+            ${installFilterArgs} 2>&1 | tee "$log"
+          status=''${PIPESTATUS[0]}
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            return 0
+          fi
+
+          if ! grep -Eq "IntegrityCheckFailed|Integrity check failed" "$log"; then
+            return "$status"
+          fi
+
+          echo "bun install failed an integrity check on attempt $attempt; clearing Bun cache before retry" >&2
+          rm -rf "$BUN_INSTALL_CACHE_DIR"
+          mkdir -p "$BUN_INSTALL_CACHE_DIR"
+          find . -path '*/node_modules' -prune -exec rm -rf {} +
+        done
+
+        return "$status"
+      }
+
+      run_bun_install
 
       if [ "${dependencyClosure}" = "bunCache" ]; then
         cd "$TMPDIR"

--- a/nix/images/symphony.nix
+++ b/nix/images/symphony.nix
@@ -52,8 +52,8 @@ import ./bun-workspace-service.nix {
   serviceName = "symphony";
   packageName = "@proompteng/symphony";
   depsHash = {
-    x86_64-linux = lib.fakeHash;
-    aarch64-linux = lib.fakeHash;
+    x86_64-linux = "sha256-pxcAU1QozI2hE9tp9L2+D3ByfVXMsf1xgGsA0TpogUA=";
+    aarch64-linux = "sha256-p2f5eokISWywtx4Ut8Exad0wXIwK8bD3Ninh7WcboH8=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/symphony.nix
+++ b/nix/images/symphony.nix
@@ -1,0 +1,99 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+  bun,
+  nodejs,
+}:
+
+let
+  codexVersion = "0.142.4";
+  codexPlatform =
+    {
+      x86_64-linux = {
+        npmVersion = "${codexVersion}-linux-x64";
+        vendor = "x86_64-unknown-linux-musl";
+        hash = "sha256-PVplrOt1q7N8fo4DHbGgw00LpV1dJjxeb0MMIefebHw=";
+      };
+      aarch64-linux = {
+        npmVersion = "${codexVersion}-linux-arm64";
+        vendor = "aarch64-unknown-linux-musl";
+        hash = "sha256-ERM4csGF8zXPQI7dE5U7UngI39jmfZhEFyOu7N+wVD4=";
+      };
+    }
+    .${pkgs.stdenv.hostPlatform.system}
+      or (throw "Codex CLI is not packaged for ${pkgs.stdenv.hostPlatform.system}");
+
+  codexCli = pkgs.stdenvNoCC.mkDerivation {
+    pname = "openai-codex-cli";
+    version = codexVersion;
+
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexPlatform.npmVersion}.tgz";
+      hash = codexPlatform.hash;
+    };
+    sourceRoot = "package/vendor/${codexPlatform.vendor}";
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/bin" "$out/libexec/openai-codex"
+      cp -R . "$out/libexec/openai-codex/"
+      ln -s "$out/libexec/openai-codex/bin/codex" "$out/bin/codex"
+      runHook postInstall
+    '';
+  };
+in
+import ./bun-workspace-service.nix {
+  inherit pkgs lib repoRoot bun nodejs;
+  serviceName = "symphony";
+  packageName = "@proompteng/symphony";
+  depsHash = {
+    x86_64-linux = lib.fakeHash;
+    aarch64-linux = lib.fakeHash;
+  };
+  dependencyClosure = "bunCache";
+  installFilters = [
+    "@proompteng/codex"
+    "@proompteng/otel"
+    "@proompteng/symphony"
+  ];
+  sourcePaths = [
+    "packages/codex"
+    "packages/otel"
+    "services/symphony"
+  ];
+  buildCommands = [
+    "bun --cwd=packages/codex run build"
+    "bun --cwd=packages/otel run build"
+    "bun --cwd=services/symphony run tsc"
+  ];
+  command = [
+    "bun"
+    "src/index.ts"
+    "./WORKFLOW.md"
+  ];
+  workingDir = "/app/services/symphony";
+  env = [
+    "PORT=8080"
+  ];
+  extraContents = [
+    codexCli
+    nodejs
+    pkgs.bash
+    pkgs.curl
+    pkgs.gh
+    pkgs.git
+    pkgs.jq
+    pkgs.python3
+    pkgs.ripgrep
+    pkgs.uv
+    pkgs.xz
+  ];
+  exposedPorts = {
+    "8080/tcp" = { };
+  };
+}

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -57,7 +57,18 @@ describe('enabled app inventory', () => {
   })
 
   it('marks only approved early build-owning apps as Nix image candidates', () => {
-    for (const name of ['oirat', 'bumba', 'froussard', 'docs', 'app', 'proompteng', 'olden', 'synthesis', 'attic']) {
+    for (const name of [
+      'oirat',
+      'bumba',
+      'froussard',
+      'docs',
+      'app',
+      'proompteng',
+      'olden',
+      'synthesis',
+      'attic',
+      'symphony',
+    ]) {
       expect(entry(name).class).toBe('nix-image')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
     }
@@ -72,10 +83,21 @@ describe('enabled app inventory', () => {
     expect(entry('proompteng').nixImageAttr).toBe('proompteng-image')
     expect(entry('olden').nixImageAttr).toBe('olden-image')
     expect(entry('synthesis').nixImageAttr).toBe('synthesis-image')
+    expect(entry('symphony').nixImageAttr).toBe('symphony-image')
   })
 
   it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
-    for (const name of ['agents', 'jangar', 'sag', 'symphony', 'bilig', 'analysis', 'torghut', 'torghut-options']) {
+    for (const name of [
+      'agents',
+      'jangar',
+      'sag',
+      'symphony-jangar',
+      'symphony-torghut',
+      'bilig',
+      'analysis',
+      'torghut',
+      'torghut-options',
+    ]) {
       expect(entry(name).class).toBe('deferred')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
       expect(entry(name).deferredReason).toBeTruthy()

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -418,6 +418,10 @@ describe('native OCI build workflows', () => {
     }
     expect(bunWorkspaceServiceModule).toContain('cp -R ${depsSource}/. "$TMPDIR/work/"')
     expect(bunWorkspaceServiceModule).toContain('--cache-dir "$BUN_INSTALL_CACHE_DIR"')
+    expect(bunWorkspaceServiceModule).toContain('for attempt in 1 2 3')
+    expect(bunWorkspaceServiceModule).toContain('IntegrityCheckFailed|Integrity check failed')
+    expect(bunWorkspaceServiceModule).toContain('rm -rf "$BUN_INSTALL_CACHE_DIR"')
+    expect(bunWorkspaceServiceModule).toContain("find . -path '*/node_modules' -prune -exec rm -rf {} +")
   })
 
   it('does not rebuild migrated simple app images for GitOps-only manifest changes', () => {

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -27,6 +27,7 @@ const enabledProductReleaseWorkflow = readRepoFile('.github/workflows/enabled-pr
 const agentsBuildWorkflow = readRepoFile('.github/workflows/agents-build-push.yml')
 const jangarBuildWorkflow = readRepoFile('.github/workflows/jangar-build-push.yaml')
 const symphonyBuildWorkflow = readRepoFile('.github/workflows/symphony-build-push.yaml')
+const symphonyReleaseWorkflow = readRepoFile('.github/workflows/symphony-release.yml')
 const autoPrReleaseBranchesWorkflow = readRepoFile('.github/workflows/auto-pr-release-branches.yml')
 const releasePrAutomergeWorkflow = readRepoFile('.github/workflows/release-pr-automerge.yml')
 const oiratWorkflow = readRepoFile('.github/workflows/oirat-ci.yml')
@@ -41,9 +42,12 @@ const productImageModules = [
   readRepoFile('nix/images/proompteng.nix'),
   readRepoFile('nix/images/synthesis.nix'),
 ]
+const symphonyImageModule = readRepoFile('nix/images/symphony.nix')
 const oiratBuildScript = readRepoFile('packages/scripts/src/oirat/build-image.ts')
 const bumbaBuildScript = readRepoFile('packages/scripts/src/bumba/build-image.ts')
 const froussardDeployScript = readRepoFile('packages/scripts/src/froussard/deploy-service.ts')
+const symphonyBuildScript = readRepoFile('packages/scripts/src/symphony/build-image.ts')
+const symphonyDeployScript = readRepoFile('packages/scripts/src/symphony/deploy-service.ts')
 const productBuildScripts = [
   readRepoFile('packages/scripts/src/app/build-image.ts'),
   readRepoFile('packages/scripts/src/docs/build-image.ts'),
@@ -271,11 +275,15 @@ describe('native OCI build workflows', () => {
     }
 
     expect(productNixWorkflow).not.toContain("'nix/**'")
-    for (const workflow of [agentsBuildWorkflow, jangarBuildWorkflow, symphonyBuildWorkflow]) {
+    for (const workflow of [agentsBuildWorkflow, jangarBuildWorkflow]) {
       expect(workflow).toContain("'packages/scripts/src/shared/cli.ts'")
       expect(workflow).toContain("'packages/scripts/src/shared/docker.ts'")
       expect(workflow).toContain("'packages/scripts/src/shared/git.ts'")
     }
+    expect(symphonyBuildWorkflow).toContain("'packages/scripts/src/shared/cli.ts'")
+    expect(symphonyBuildWorkflow).toContain("'packages/scripts/src/shared/git.ts'")
+    expect(symphonyBuildWorkflow).toContain("'packages/scripts/src/shared/nix-oci-deploy.ts'")
+    expect(symphonyBuildWorkflow).not.toContain("'packages/scripts/src/shared/docker.ts'")
 
     expect(productNixWorkflow).toContain("'packages/scripts/src/shared/nix-oci-deploy.ts'")
     expect(enabledProductReleaseWorkflow).not.toContain('packages/scripts/src/shared nix/images')
@@ -309,6 +317,8 @@ describe('native OCI build workflows', () => {
       froussardWorkflow,
       productNixWorkflow,
       enabledProductReleaseWorkflow,
+      symphonyBuildWorkflow,
+      symphonyReleaseWorkflow,
     ]
     for (const workflow of migratedWorkflows) {
       expect(workflow).not.toContain('docker/build-push-action')
@@ -352,6 +362,29 @@ describe('native OCI build workflows', () => {
       expect(workflow).toContain('tag: sha-${{ github.sha }}')
       expect(workflow).not.toContain('uses: ./.github/workflows/docker-build-common.yaml')
     }
+  })
+
+  it('routes the enabled Symphony fleet image through a real Nix OCI attr', () => {
+    expect(flake).toContain('"symphony-image"')
+    expect(repoFileExists('nix/images/symphony.nix')).toBe(true)
+    expect(symphonyImageModule).toContain('pname = "openai-codex-cli"')
+    expect(symphonyImageModule).toContain('version = codexVersion')
+    expect(symphonyImageModule).toContain('dependencyClosure = "bunCache";')
+    expect(symphonyImageModule).toContain('"@proompteng/symphony"')
+    expect(symphonyImageModule).toContain('pkgs.uv')
+
+    expect(symphonyBuildWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
+    expect(symphonyBuildWorkflow).toContain('image_name: symphony')
+    expect(symphonyBuildWorkflow).toContain('package_attr: symphony-image')
+    expect(symphonyBuildWorkflow).toContain('symphony-release-contract')
+    expect(symphonyBuildWorkflow).toContain('tag: sha-${{ github.sha }}')
+    expect(symphonyBuildWorkflow).not.toContain('oven-sh/setup-bun')
+    expect(symphonyBuildWorkflow).not.toContain('docker/setup-buildx-action')
+
+    expect(symphonyReleaseWorkflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+    expect(symphonyReleaseWorkflow).toContain('crane digest "${IMAGE_NAME}:${IMAGE_TAG}"')
+    expect(symphonyReleaseWorkflow).not.toContain('docker buildx')
+    expect(symphonyReleaseWorkflow).not.toContain('docker/setup-buildx-action')
   })
 
   it('routes enabled product app image builds through real Nix OCI attrs', () => {
@@ -398,7 +431,13 @@ describe('native OCI build workflows', () => {
   })
 
   it('keeps manual migrated app deploy scripts on the shared Nix image helper', () => {
-    for (const script of [oiratBuildScript, bumbaBuildScript, froussardDeployScript, ...productBuildScripts]) {
+    for (const script of [
+      oiratBuildScript,
+      bumbaBuildScript,
+      froussardDeployScript,
+      symphonyBuildScript,
+      ...productBuildScripts,
+    ]) {
       expect(script).toContain("from '../shared/nix-oci-deploy'")
       expect(script).not.toContain("from '../shared/docker'")
       expect(script).not.toContain('buildAndPushDockerImage')
@@ -411,6 +450,11 @@ describe('native OCI build workflows', () => {
       expect(script).toContain('noApply')
       expect(script).toContain('digest:')
     }
+    expect(symphonyDeployScript).not.toContain("from '../shared/docker'")
+    expect(symphonyDeployScript).not.toContain('inspectImageDigest')
+    expect(symphonyDeployScript).toContain('dryRun')
+    expect(symphonyDeployScript).toContain('noApply')
+    expect(symphonyDeployScript).toContain('digest:')
 
     expect(nixOciDeployScript).toContain("await run('nix', ['build', `.#${packageAttr}`")
     expect(nixOciDeployScript).toContain("await run('nix', pushArgs")
@@ -457,6 +501,9 @@ describe('native OCI build workflows', () => {
       'argocd/applications/oirat/kustomization.yaml',
       'argocd/applications/olden/kustomization.yaml',
       'argocd/applications/proompteng/kustomization.yaml',
+      'argocd/applications/symphony/kustomization.yaml',
+      'argocd/applications/symphony-jangar/kustomization.yaml',
+      'argocd/applications/symphony-torghut/kustomization.yaml',
       'argocd/applications/synthesis/kustomization.yaml',
     ]) {
       expect(autoPrReleaseBranchesWorkflow).toContain(`"${path}"`)

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -46,6 +46,7 @@ const earlyNixImageApps = new Set([
   'oirat',
   'olden',
   'proompteng',
+  'symphony',
   'synthesis',
 ])
 
@@ -55,7 +56,6 @@ const deferredApps = new Map<string, string>([
   ['bilig', 'complex application image; requires a dedicated derivation and rollout proof'],
   ['jangar', 'complex service plus OpenWebUI chart; requires a dedicated derivation and rollout proof'],
   ['sag', 'complex app; migrate after simple Bun/Node services'],
-  ['symphony', 'complex service with multiple Argo apps sharing one image'],
   ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
   ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
   ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
@@ -74,6 +74,7 @@ const appToNixAttr = new Map<string, string>([
   ['oirat', 'oirat-image'],
   ['olden', 'olden-image'],
   ['proompteng', 'proompteng-image'],
+  ['symphony', 'symphony-image'],
   ['synthesis', 'synthesis-image'],
 ])
 

--- a/packages/scripts/src/symphony/build-image.ts
+++ b/packages/scripts/src/symphony/build-image.ts
@@ -1,9 +1,6 @@
 #!/usr/bin/env bun
 
-import { resolve } from 'node:path'
-
-import { repoRoot } from '../shared/cli'
-import { buildAndPushDockerImage } from '../shared/docker'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
 import { execGit } from '../shared/git'
 
 export type BuildImageOptions = {
@@ -13,31 +10,34 @@ export type BuildImageOptions = {
   context?: string
   dockerfile?: string
   cacheRef?: string
+  dryRun?: boolean
 }
 
 export const buildImage = async (options: BuildImageOptions = {}) => {
   const registry = options.registry ?? process.env.SYMPHONY_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = options.repository ?? process.env.SYMPHONY_IMAGE_REPOSITORY ?? 'lab/symphony'
   const tag = options.tag ?? process.env.SYMPHONY_IMAGE_TAG ?? execGit(['rev-parse', '--short', 'HEAD'])
-  const context = resolve(repoRoot, options.context ?? process.env.SYMPHONY_BUILD_CONTEXT ?? '.')
-  const dockerfile = resolve(
-    repoRoot,
-    options.dockerfile ?? process.env.SYMPHONY_DOCKERFILE ?? 'services/symphony/Dockerfile',
-  )
-  const cacheRef = options.cacheRef ?? process.env.SYMPHONY_BUILD_CACHE_REF ?? `${registry}/${repository}:buildcache`
+  const commit = execGit(['rev-parse', 'HEAD'])
 
-  return buildAndPushDockerImage({
+  const result = await buildAndPushNixImage({
+    service: 'symphony',
+    imageName: 'symphony',
+    packageAttr: 'symphony-image',
     registry,
     repository,
     tag,
-    context,
-    dockerfile,
-    cacheRef,
+    sourceSha: commit,
+    latestTag: 'latest',
+    dryRun: options.dryRun,
   })
+
+  return { image: `${registry}/${repository}:${tag}`, digest: result.reference, commit }
 }
 
 if (import.meta.main) {
-  buildImage().catch((error) => {
+  const args = process.argv.slice(2)
+  const cliTag = args[0]?.trim() && !args[0]?.startsWith('-') ? args[0] : undefined
+  buildImage({ tag: cliTag, dryRun: args.includes('--dry-run') }).catch((error) => {
     console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
   })

--- a/packages/scripts/src/symphony/deploy-service.ts
+++ b/packages/scripts/src/symphony/deploy-service.ts
@@ -4,7 +4,6 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
 import { buildImage } from './build-image'
 import { updateSymphonyManifests } from './update-manifests'
@@ -69,25 +68,36 @@ const resolveDeployTargets = () => {
 }
 
 export const main = async () => {
+  const args = new Set(process.argv.slice(2))
+  const dryRun = args.has('--dry-run')
+  const noApply = dryRun || args.has('--no-apply')
+
   ensureCli('kubectl')
 
   const registry = process.env.SYMPHONY_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = process.env.SYMPHONY_IMAGE_REPOSITORY ?? 'lab/symphony'
   const defaultTag = execGit(['rev-parse', '--short', 'HEAD'])
   const tag = process.env.SYMPHONY_IMAGE_TAG ?? defaultTag
-  const image = `${registry}/${repository}:${tag}`
 
-  await buildImage({ registry, repository, tag })
+  const imageResult = await buildImage({ registry, repository, tag, dryRun })
+  console.log(`Image digest: ${imageResult.digest}`)
 
-  const repoDigest = inspectImageDigest(image)
-  console.log(`Image digest: ${repoDigest}`)
+  if (dryRun) {
+    console.log('Dry run complete; manifests and cluster state were not changed.')
+    return
+  }
 
   updateSymphonyManifests({
     imageName: 'registry.ide-newton.ts.net/lab/symphony',
     tag,
-    digest: repoDigest,
+    digest: imageResult.digest,
     rolloutTimestamp: new Date().toISOString(),
   })
+
+  if (noApply) {
+    console.log('Skipping kubectl apply because --no-apply was requested.')
+    return
+  }
 
   for (const target of resolveDeployTargets()) {
     const kustomizePath = resolve(repoRoot, target.kustomizePath)

--- a/packages/scripts/src/symphony/release-contract.test.ts
+++ b/packages/scripts/src/symphony/release-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
 
@@ -30,6 +30,40 @@ describe('symphony release contract', () => {
         digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         image: 'registry.ide-newton.ts.net/lab/symphony',
         createdAt: '2026-03-14T21:00:00.000Z',
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts generic Nix OCI release contracts without a Symphony createdAt field', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'symphony-generic-release-contract-'))
+    const path = join(dir, 'contract.json')
+
+    try {
+      writeFileSync(
+        path,
+        `${JSON.stringify(
+          {
+            service: 'symphony',
+            sourceSha: '1234567890abcdef1234567890abcdef12345678',
+            tag: 'sha-1234567890abcdef1234567890abcdef12345678',
+            digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            image: 'registry.ide-newton.ts.net/lab/symphony',
+            packageAttr: 'symphony-image',
+            builder: 'nix-dockerTools-skopeo',
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      )
+
+      expect(readReleaseContract(relative(repoRoot, path))).toEqual({
+        sourceSha: '1234567890abcdef1234567890abcdef12345678',
+        tag: 'sha-1234567890abcdef1234567890abcdef12345678',
+        digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        image: 'registry.ide-newton.ts.net/lab/symphony',
       })
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/packages/scripts/src/symphony/release-contract.ts
+++ b/packages/scripts/src/symphony/release-contract.ts
@@ -17,7 +17,7 @@ export type SymphonyReleaseContract = {
   tag: string
   digest: string
   image: string
-  createdAt: string
+  createdAt?: string
 }
 
 type ContractField = keyof SymphonyReleaseContract
@@ -125,10 +125,10 @@ const assertValidContract = (contract: SymphonyReleaseContract) => {
   if (!contract.image.trim()) {
     throw new Error('image cannot be empty')
   }
-  if (!contract.createdAt.trim()) {
-    throw new Error('createdAt cannot be empty')
+  if (contract.createdAt !== undefined && !contract.createdAt.trim()) {
+    throw new Error('createdAt cannot be empty when set')
   }
-  if (Number.isNaN(Date.parse(contract.createdAt))) {
+  if (contract.createdAt !== undefined && Number.isNaN(Date.parse(contract.createdAt))) {
     throw new Error(`Invalid createdAt '${contract.createdAt}'`)
   }
 }
@@ -150,7 +150,7 @@ export const readReleaseContract = (path: string): SymphonyReleaseContract => {
     tag: parsed.tag ?? '',
     digest: normalizeDigest(parsed.digest ?? ''),
     image: parsed.image ?? '',
-    createdAt: parsed.createdAt ?? '',
+    ...(parsed.createdAt === undefined ? {} : { createdAt: parsed.createdAt }),
   }
   assertValidContract(contract)
   return contract

--- a/packages/scripts/src/symphony/resolve-release-metadata.ts
+++ b/packages/scripts/src/symphony/resolve-release-metadata.ts
@@ -12,7 +12,7 @@ const defaultContractPath = '.artifacts/symphony/symphony-release-contract.json'
 const defaultImage = 'registry.ide-newton.ts.net/lab/symphony'
 
 const buildTriggerPathRegex =
-  /^(services\/symphony\/|packages\/scripts\/src\/symphony\/|packages\/scripts\/src\/shared\/|packages\/codex\/|package\.json$|bun\.lock$|tsconfig\.base\.json$|\.github\/workflows\/symphony(?:-build-push|-release|-post-deploy-verify|-deploy-automerge|-ci)\.ya?ml$)/
+  /^(services\/symphony\/|packages\/scripts\/src\/symphony\/|packages\/scripts\/src\/shared\/|packages\/codex\/|packages\/otel\/|nix\/images\/symphony\.nix$|nix\/images\/bun-workspace-service\.nix$|nix\/packages\.nix$|nix\/oci-release-contract\.sh$|flake\.nix$|flake\.lock$|package\.json$|bun\.lock$|tsconfig\.base\.json$|\.github\/workflows\/nix-oci-build-common\.yml$|\.github\/actions\/setup-nix-toolchain\/|\.github\/workflows\/symphony(?:-build-push|-release|-post-deploy-verify|-deploy-automerge|-ci)\.ya?ml$)/
 
 type CliOptions = {
   eventName?: string

--- a/packages/scripts/src/symphony/verify-deployment.ts
+++ b/packages/scripts/src/symphony/verify-deployment.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
 
-import { parseArgoApplicationStatus, type ArgoApplicationStatus as ArgoStatus } from '../shared/argo'
+import { parseArgoApplicationStatus } from '../shared/argo'
 import { ensureCli, fatal, repoRoot } from '../shared/cli'
 
 type CliOptions = {


### PR DESCRIPTION
## Summary

- Migrates the root-enabled Symphony fleet image build from Docker Buildx to the shared Nix OCI image workflow.
- Adds `.#symphony-image` with pinned Bun workspace dependencies and a pinned Linux Codex CLI package instead of `@openai/codex@latest` during image build.
- Routes `bun run build:symphony` and `bun run symphony:deploy` through the shared Nix image helper, preserving digest manifest updates plus `--dry-run` and `--no-apply` behavior.
- Adds bounded Bun fixed-output dependency retry logic for registry tarball integrity failures, clearing corrupted cache state before retry while failing closed on other errors.
- Updates Symphony release and guardrail workflows so promotion consumes Nix OCI release contracts, resolves digests with `crane`, and blocks stale generic release branches for migrated Symfony manifests.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/symphony/build-image.ts packages/scripts/src/symphony/deploy-service.ts packages/scripts/src/symphony/release-contract.ts packages/scripts/src/symphony/release-contract.test.ts packages/scripts/src/symphony/resolve-release-metadata.ts packages/scripts/src/symphony/verify-deployment.ts`
- `bunx oxlint packages/scripts/src/symphony packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/symphony/release-contract.test.ts packages/scripts/src/symphony/deploy-service.test.ts`
- `bun run --cwd services/symphony tsc && bun run --cwd services/symphony test`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/symphony-build-push.yaml .github/workflows/symphony-release.yml .github/workflows/symphony-ci.yml .github/workflows/auto-pr-release-branches.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
