### PR TITLE
fix(nix): repair release workflow contracts

### DIFF
--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           set -euo pipefail
           export IMAGE_REF="${IMAGE}@${DIGEST}"
-          perl -0pi -e 's#image:\s+(?:ghcr\.io/actions/actions-runner:latest|registry\.ide-newton\.ts\.net/lab/arc-runner@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' argocd/applications/arc/application.yaml
+          perl -0pi -e 's#image:\s+(?:ghcr\.io/actions/actions-runner:latest|registry\.ide-newton\.ts\.net/lab/arc-runner\@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' argocd/applications/arc/application.yaml
           test "$(grep -cF "image: ${IMAGE_REF}" argocd/applications/arc/application.yaml)" -eq 6
           grep -F 'image: docker:dind' argocd/applications/arc/application.yaml >/dev/null
           grep -F 'storageClassName: "rook-ceph-block"' argocd/applications/arc/application.yaml >/dev/null

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -29,6 +29,7 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcApplication).toContain('storageClassName: "rook-ceph-block"')
     expect(arcApplication).toContain('volumeClaimTemplate:')
     expect(arcRunnerReleaseWorkflow).toContain('registry.ide-newton.ts.net/lab/arc-runner')
+    expect(arcRunnerReleaseWorkflow).toContain('arc-runner\\@sha256')
     expect(arcRunnerReleaseWorkflow).toContain('test "$(grep -cF "image: ${IMAGE_REF}"')
     expect(arcRunnerReleaseWorkflow).toContain("grep -F 'image: docker:dind'")
     expect(arcRunnerReleaseWorkflow).toContain('grep -F \'storageClassName: "rook-ceph-block"\'')

--- a/packages/scripts/src/symphony/release-contract.test.ts
+++ b/packages/scripts/src/symphony/release-contract.test.ts
@@ -7,6 +7,13 @@ import { repoRoot } from '../shared/cli'
 import { readReleaseContract, writeReleaseContract } from './release-contract'
 
 describe('symphony release contract', () => {
+  it('uses the generic Nix OCI artifact filename for release metadata', () => {
+    const resolver = readFileSync(join(repoRoot, 'packages/scripts/src/symphony/resolve-release-metadata.ts'), 'utf8')
+
+    expect(resolver).toContain("const defaultContractPath = '.artifacts/symphony/release-contract.json'")
+    expect(resolver).not.toContain('.artifacts/symphony/symphony-release-contract.json')
+  })
+
   it('round-trips normalized contract data', () => {
     const dir = mkdtempSync(join(tmpdir(), 'symphony-release-contract-'))
     const path = join(dir, 'contract.json')

--- a/packages/scripts/src/symphony/resolve-release-metadata.ts
+++ b/packages/scripts/src/symphony/resolve-release-metadata.ts
@@ -8,7 +8,7 @@ import { fatal, repoRoot } from '../shared/cli'
 import { execGit } from '../shared/git'
 import { readReleaseContract } from './release-contract'
 
-const defaultContractPath = '.artifacts/symphony/symphony-release-contract.json'
+const defaultContractPath = '.artifacts/symphony/release-contract.json'
 const defaultImage = 'registry.ide-newton.ts.net/lab/symphony'
 
 const buildTriggerPathRegex =


### PR DESCRIPTION
## Summary

- Fixes the ARC runner release workflow image matcher so `@sha256` is escaped in the Perl regex instead of being interpreted as a Perl array.
- Keeps the existing six-runner-image replacement guard, Docker sidecar guard, and `rook-ceph-block` guard unchanged.
- Fixes the Symphony release resolver to read the shared Nix OCI artifact filename `.artifacts/symphony/release-contract.json`.
- Adds contract assertions for both release workflow regressions.

## Related Issues

None

## Testing

- Exact local reproduction of the release workflow replacement against `argocd/applications/arc/application.yaml`, confirming 6 runner image refs, 3 `docker:dind` refs, and 3 `rook-ceph-block` refs after replacement.
- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/symphony/release-contract.test.ts packages/scripts/src/symphony/deploy-service.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/symphony/release-contract.test.ts packages/scripts/src/symphony/resolve-release-metadata.ts`
- `bunx oxlint packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/symphony/release-contract.test.ts packages/scripts/src/symphony/resolve-release-metadata.ts`
- `actionlint -ignore 'label "arc-(amd64|arm64)" is unknown' .github/workflows/arc-runner-release.yml .github/workflows/symphony-release.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
