### PR TITLE
fix(symphony): grant arc verify readback rbac

### DIFF
--- a/argocd/applications/agents-ci/runner-rbac-cluster.yaml
+++ b/argocd/applications/agents-ci/runner-rbac-cluster.yaml
@@ -59,6 +59,12 @@ subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
     namespace: arc
+  - kind: ServiceAccount
+    name: arc-arm64-gha-rs-no-permission
+    namespace: arc
+  - kind: ServiceAccount
+    name: arc-amd64-gha-rs-no-permission
+    namespace: arc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -111,6 +117,12 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
+    namespace: arc
+  - kind: ServiceAccount
+    name: arc-arm64-gha-rs-no-permission
+    namespace: arc
+  - kind: ServiceAccount
+    name: arc-amd64-gha-rs-no-permission
     namespace: arc
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

- Adds the live ARC `no-permission` runner service accounts to existing read-only Argo Application verification RBAC.
- Adds the same live runner service accounts to existing read-only Deployment/ReplicaSet rollout RBAC.
- Keeps the fix scoped to post-deploy readback for Symphony verification; no storage, Ceph, PVC, OBC, or runner volume changes.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/agents-ci` with rendered output saved to `/tmp/agents-ci-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/agents-ci-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
