### PR TITLE
ci(nix): migrate sag image build

### DIFF
--- a/.github/workflows/auto-pr-release-branches.yml
+++ b/.github/workflows/auto-pr-release-branches.yml
@@ -6,6 +6,7 @@ on:
       - 'release/**'
     paths:
       - 'argocd/applications/*/kustomization.yaml'
+      - 'argocd/sag/kustomization.yaml'
   workflow_dispatch:
     inputs:
       head_branch:
@@ -106,6 +107,7 @@ jobs:
             "argocd/applications/oirat/kustomization.yaml"
             "argocd/applications/olden/kustomization.yaml"
             "argocd/applications/proompteng/kustomization.yaml"
+            "argocd/sag/kustomization.yaml"
             "argocd/applications/symphony/kustomization.yaml"
             "argocd/applications/symphony-jangar/kustomization.yaml"
             "argocd/applications/symphony-torghut/kustomization.yaml"

--- a/.github/workflows/sag-build-push.yaml
+++ b/.github/workflows/sag-build-push.yaml
@@ -1,4 +1,4 @@
-name: symphony-build-push
+name: sag-build-push
 
 permissions:
   contents: read
@@ -6,10 +6,9 @@ permissions:
 on:
   pull_request:
     paths:
-      - 'services/symphony/**'
+      - 'services/sag/**'
       - 'packages/codex/**'
-      - 'packages/otel/**'
-      - 'packages/scripts/src/symphony/**'
+      - 'packages/scripts/src/sag/**'
       - 'packages/scripts/src/shared/cli.ts'
       - 'packages/scripts/src/shared/git.ts'
       - 'packages/scripts/src/shared/nix-oci-deploy.ts'
@@ -18,7 +17,7 @@ on:
       - 'tsconfig.base.json'
       - 'flake.nix'
       - 'flake.lock'
-      - 'nix/images/symphony.nix'
+      - 'nix/images/sag.nix'
       - 'nix/images/openai-codex-cli.nix'
       - 'nix/images/bun-workspace-service.nix'
       - 'nix/packages.nix'
@@ -28,18 +27,18 @@ on:
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
       - 'nix/oci-release-contract.sh'
-      - '.github/workflows/symphony-build-push.yaml'
-      - '.github/workflows/symphony-release.yml'
+      - '.github/workflows/sag-build-push.yaml'
+      - '.github/workflows/sag-release.yml'
+      - '.github/workflows/sag-post-deploy-verify.yml'
       - '.github/workflows/nix-oci-build-common.yml'
       - '.github/actions/setup-nix-toolchain/**'
   push:
     branches:
       - main
     paths:
-      - 'services/symphony/**'
+      - 'services/sag/**'
       - 'packages/codex/**'
-      - 'packages/otel/**'
-      - 'packages/scripts/src/symphony/**'
+      - 'packages/scripts/src/sag/**'
       - 'packages/scripts/src/shared/cli.ts'
       - 'packages/scripts/src/shared/git.ts'
       - 'packages/scripts/src/shared/nix-oci-deploy.ts'
@@ -48,7 +47,7 @@ on:
       - 'tsconfig.base.json'
       - 'flake.nix'
       - 'flake.lock'
-      - 'nix/images/symphony.nix'
+      - 'nix/images/sag.nix'
       - 'nix/images/openai-codex-cli.nix'
       - 'nix/images/bun-workspace-service.nix'
       - 'nix/packages.nix'
@@ -58,8 +57,9 @@ on:
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
       - 'nix/oci-release-contract.sh'
-      - '.github/workflows/symphony-build-push.yaml'
-      - '.github/workflows/symphony-release.yml'
+      - '.github/workflows/sag-build-push.yaml'
+      - '.github/workflows/sag-release.yml'
+      - '.github/workflows/sag-post-deploy-verify.yml'
       - '.github/workflows/nix-oci-build-common.yml'
       - '.github/actions/setup-nix-toolchain/**'
   workflow_dispatch:
@@ -73,9 +73,9 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: ./.github/workflows/nix-oci-build-common.yml
     with:
-      image_name: symphony
-      package_attr: symphony-image
+      image_name: sag
+      package_attr: sag-image
       tag: sha-${{ github.sha }}
       latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'symphony-release-contract' || '' }}
+      release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'sag-release-contract' || '' }}
     secrets: inherit

--- a/.github/workflows/sag-post-deploy-verify.yml
+++ b/.github/workflows/sag-post-deploy-verify.yml
@@ -1,0 +1,127 @@
+name: sag-post-deploy-verify
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'argocd/sag/**'
+  workflow_dispatch:
+    inputs:
+      expected_revision:
+        description: Optional full commit SHA expected in Argo sync revision
+        required: false
+        type: string
+
+concurrency:
+  group: sag-post-deploy-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: arc-arm64
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.31.2
+
+      - name: Configure in-cluster kubeconfig when context is missing
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if kubectl config current-context >/dev/null 2>&1; then
+            echo "Kubectl context already configured"
+            exit 0
+          fi
+
+          if [ -z "${KUBERNETES_SERVICE_HOST:-}" ] || [ -z "${KUBERNETES_SERVICE_PORT:-}" ]; then
+            echo "KUBERNETES_SERVICE_HOST/PORT are not set and no kubectl context exists"
+            exit 1
+          fi
+          test -f /var/run/secrets/kubernetes.io/serviceaccount/token
+          test -f /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+          KUBECONFIG_PATH="${RUNNER_TEMP}/kubeconfig"
+          echo "KUBECONFIG=${KUBECONFIG_PATH}" >> "${GITHUB_ENV}"
+
+          kubectl config set-cluster in-cluster \
+            --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+            --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+            --embed-certs=true \
+            --kubeconfig="${KUBECONFIG_PATH}"
+
+          kubectl config set-credentials gha-runner \
+            --token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+            --kubeconfig="${KUBECONFIG_PATH}"
+
+          kubectl config set-context in-cluster \
+            --cluster=in-cluster \
+            --user=gha-runner \
+            --namespace=sag \
+            --kubeconfig="${KUBECONFIG_PATH}"
+
+          kubectl config use-context in-cluster --kubeconfig="${KUBECONFIG_PATH}"
+
+      - name: Verify Sag Argo health and deployment digest
+        shell: bash
+        env:
+          EXPECTED_REVISION_INPUT: ${{ inputs.expected_revision || '' }}
+        run: |
+          set -euo pipefail
+
+          expected_digest="$(
+            awk '
+              $0 ~ /name:[[:space:]]*registry\.ide-newton\.ts\.net\/lab\/sag/ { in_image = 1; next }
+              in_image && $1 == "digest:" {
+                print $2
+                exit
+              }
+            ' argocd/sag/kustomization.yaml
+          )"
+          if ! [[ "${expected_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Unable to resolve expected Sag digest from argocd/sag/kustomization.yaml" >&2
+            exit 2
+          fi
+
+          expected_revision="${EXPECTED_REVISION_INPUT:-${GITHUB_SHA}}"
+          for attempt in $(seq 1 90); do
+            app_json="$(kubectl -n argocd get application sag -o json)"
+            sync_status="$(jq -r '.status.sync.status // ""' <<< "${app_json}")"
+            health_status="$(jq -r '.status.health.status // ""' <<< "${app_json}")"
+            revision="$(jq -r '.status.sync.revision // ""' <<< "${app_json}")"
+
+            if [ "${sync_status}" = "Synced" ] && [ "${health_status}" = "Healthy" ] &&
+              { [ "${revision}" = "${expected_revision}" ] || git merge-base --is-ancestor "${expected_revision}" "${revision}" 2>/dev/null; }; then
+              break
+            fi
+
+            if [ "${attempt}" -eq 90 ]; then
+              echo "Sag Argo did not become Synced/Healthy at expected revision." >&2
+              echo "${app_json}" | jq '{sync:.status.sync.status, health:.status.health.status, revision:.status.sync.revision}'
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          kubectl -n sag rollout status deployment/sag --timeout=180s
+          live_image="$(kubectl -n sag get deployment sag -o json | jq -r '.spec.template.spec.containers[] | select(.name=="sag") | .image')"
+          echo "live_image=${live_image}"
+          if [[ "${live_image}" != *"@${expected_digest}"* ]]; then
+            echo "Sag deployment image does not contain expected digest ${expected_digest}" >&2
+            exit 1
+          fi
+
+          desired_replicas="$(kubectl -n sag get deployment sag -o json | jq -r '.spec.replicas // 1')"
+          available_replicas="$(kubectl -n sag get deployment sag -o json | jq -r '.status.availableReplicas // 0')"
+          echo "desired_replicas=${desired_replicas}"
+          echo "available_replicas=${available_replicas}"

--- a/.github/workflows/sag-release.yml
+++ b/.github/workflows/sag-release.yml
@@ -1,0 +1,215 @@
+name: sag-release
+
+on:
+  workflow_run:
+    workflows:
+      - sag-build-push
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to promote (defaults to current main HEAD)
+        required: false
+        type: string
+      image_tag:
+        description: Image tag to promote (defaults to sha-<commit_sha>)
+        required: false
+        type: string
+      image_digest:
+        description: Image digest override (sha256:...)
+        required: false
+        type: string
+
+concurrency:
+  group: sag-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+      }}
+    runs-on: arc-arm64
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+
+      - name: Download release contract artifact from triggering build
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: sag-release-contract
+          path: .artifacts/sag
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_SHA_INPUT: ${{ inputs.commit_sha }}
+          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+          DIGEST_INPUT: ${{ inputs.image_digest }}
+        run: |
+          set -euo pipefail
+
+          image="registry.ide-newton.ts.net/lab/sag"
+          main_head="$(git rev-parse origin/main)"
+          promote=true
+          contract_digest=""
+
+          if [ "${EVENT_NAME}" = "workflow_run" ]; then
+            contract_path=".artifacts/sag/release-contract.json"
+            test -f "${contract_path}"
+
+            service="$(jq -r '.service' "${contract_path}")"
+            package_attr="$(jq -r '.packageAttr' "${contract_path}")"
+            contract_image="$(jq -r '.image' "${contract_path}")"
+            source_sha="$(jq -r '.sourceSha' "${contract_path}")"
+            tag="$(jq -r '.tag' "${contract_path}")"
+            contract_digest="$(jq -r '.digest' "${contract_path}")"
+
+            test "${service}" = "sag"
+            test "${package_attr}" = "sag-image"
+            test "${contract_image}" = "${image}"
+            test "${source_sha}" = "${WORKFLOW_RUN_HEAD_SHA}"
+
+            input_paths=(
+              services/sag
+              packages/codex
+              packages/scripts/src/sag
+              packages/scripts/src/shared/cli.ts
+              packages/scripts/src/shared/git.ts
+              packages/scripts/src/shared/nix-oci-deploy.ts
+              nix/images/sag.nix
+              nix/images/openai-codex-cli.nix
+              nix/images/bun-workspace-service.nix
+              nix/packages.nix
+              flake.nix
+              flake.lock
+              bun.lock
+              package.json
+              tsconfig.base.json
+              .github/workflows/sag-build-push.yaml
+              .github/workflows/sag-release.yml
+              .github/workflows/nix-oci-build-common.yml
+              .github/actions/setup-nix-toolchain
+            )
+
+            if ! git merge-base --is-ancestor "${source_sha}" "${main_head}"; then
+              promote=false
+              reason="source-not-ancestor"
+            elif ! git diff --quiet "${source_sha}..${main_head}" -- "${input_paths[@]}"; then
+              promote=false
+              reason="newer-main-has-sag-build-inputs"
+            else
+              reason="eligible"
+            fi
+          else
+            source_sha="${COMMIT_SHA_INPUT:-${main_head}}"
+            tag="${IMAGE_TAG_INPUT:-sha-${source_sha}}"
+            reason="manual-or-dispatch"
+          fi
+
+          digest="${DIGEST_INPUT:-${contract_digest}}"
+          if [ "${promote}" = "true" ] && [ -z "${digest}" ]; then
+            digest="$(crane digest "${image}:${tag}")"
+          fi
+
+          {
+            echo "image=${image}"
+            echo "source_sha=${source_sha}"
+            echo "tag=${tag}"
+            echo "digest=${digest}"
+            echo "promote=${promote}"
+            echo "reason=${reason}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout source revision
+        if: steps.meta.outputs.promote == 'true'
+        run: git checkout --force "${{ steps.meta.outputs.source_sha }}"
+
+      - name: Verify image digest and platforms
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.meta.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if ! [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Invalid Sag digest: ${DIGEST}" >&2
+            exit 2
+          fi
+          nix run .#assert-oci-platforms -- "${IMAGE}@${DIGEST}" linux/amd64 linux/arm64
+
+      - name: Update Sag manifest
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        env:
+          SAG_DIGEST: ${{ steps.meta.outputs.digest }}
+        run: |
+          set -euo pipefail
+          perl -0pi -e 's#(-\s*name:\s+registry\.ide-newton\.ts\.net/lab/sag\s*\n\s*(?:newName:\s+registry\.ide-newton\.ts\.net/lab/sag\s*\n\s*)?)(?:newTag|digest):\s*.*#$1digest: '"${SAG_DIGEST}"'#g' argocd/sag/kustomization.yaml
+          grep -F "digest: ${SAG_DIGEST}" argocd/sag/kustomization.yaml
+
+      - name: Check for manifest changes
+        if: steps.meta.outputs.promote == 'true'
+        id: changes
+        run: |
+          if git diff --quiet -- argocd/sag/kustomization.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create deploy pull request
+        if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: codex/sag-release-${{ steps.meta.outputs.tag }}
+          base: main
+          title: 'chore(sag): promote image ${{ steps.meta.outputs.tag }}'
+          commit-message: 'chore(sag): promote image ${{ steps.meta.outputs.tag }}'
+          delete-branch: true
+          add-paths: |
+            argocd/sag/kustomization.yaml
+          body: |
+            ## Summary
+            Promote the Sag image into GitOps manifests.
+
+            - Source commit: `${{ steps.meta.outputs.source_sha }}`
+            - Image tag: `${{ steps.meta.outputs.tag }}`
+            - Image digest: `${{ steps.meta.outputs.digest }}`
+
+      - name: No manifest changes detected
+        if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'
+        run: echo 'No Sag manifest changes detected.'
+
+      - name: Promotion skipped
+        if: steps.meta.outputs.promote != 'true'
+        run: |
+          echo 'Skipping Sag promotion: ${{ steps.meta.outputs.reason }}'

--- a/flake.nix
+++ b/flake.nix
@@ -255,6 +255,11 @@
               repoRoot = ./.;
               bun = exact.bun;
             };
+            "sag-image" = import ./nix/images/sag.nix {
+              inherit pkgs lib nodejs;
+              repoRoot = ./.;
+              bun = exact.bun;
+            };
           };
 
           mkApp = drv: {

--- a/nix/images/openai-codex-cli.nix
+++ b/nix/images/openai-codex-cli.nix
@@ -1,0 +1,42 @@
+{ pkgs }:
+
+let
+  codexVersion = "0.142.4";
+  codexPlatform =
+    {
+      x86_64-linux = {
+        npmVersion = "${codexVersion}-linux-x64";
+        vendor = "x86_64-unknown-linux-musl";
+        hash = "sha256-PVplrOt1q7N8fo4DHbGgw00LpV1dJjxeb0MMIefebHw=";
+      };
+      aarch64-linux = {
+        npmVersion = "${codexVersion}-linux-arm64";
+        vendor = "aarch64-unknown-linux-musl";
+        hash = "sha256-ERM4csGF8zXPQI7dE5U7UngI39jmfZhEFyOu7N+wVD4=";
+      };
+    }
+    .${pkgs.stdenv.hostPlatform.system}
+      or (throw "Codex CLI is not packaged for ${pkgs.stdenv.hostPlatform.system}");
+in
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "openai-codex-cli";
+  version = codexVersion;
+
+  src = pkgs.fetchurl {
+    url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexPlatform.npmVersion}.tgz";
+    hash = codexPlatform.hash;
+  };
+  sourceRoot = "package/vendor/${codexPlatform.vendor}";
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin" "$out/libexec/openai-codex"
+    cp -R . "$out/libexec/openai-codex/"
+    ln -s "$out/libexec/openai-codex/bin/codex" "$out/bin/codex"
+    runHook postInstall
+  '';
+}

--- a/nix/images/sag.nix
+++ b/nix/images/sag.nix
@@ -14,8 +14,8 @@ import ./bun-workspace-service.nix {
   serviceName = "sag";
   packageName = "@proompteng/sag";
   depsHash = {
-    x86_64-linux = lib.fakeHash;
-    aarch64-linux = lib.fakeHash;
+    x86_64-linux = "sha256-h1IJHQ/dQ9h9186ey5F9qvPciftsqs5C0Pzf20+VJcs=";
+    aarch64-linux = "sha256-MKW2UdIImn3vKytf9R5IckUKfuTdjWchI2qSBv7Jh/Y=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/sag.nix
+++ b/nix/images/sag.nix
@@ -1,0 +1,69 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+  bun,
+  nodejs,
+}:
+
+let
+  codexCli = import ./openai-codex-cli.nix { inherit pkgs; };
+in
+import ./bun-workspace-service.nix {
+  inherit pkgs lib repoRoot bun nodejs;
+  serviceName = "sag";
+  packageName = "@proompteng/sag";
+  depsHash = {
+    x86_64-linux = lib.fakeHash;
+    aarch64-linux = lib.fakeHash;
+  };
+  dependencyClosure = "bunCache";
+  installFilters = [
+    "@proompteng/codex"
+    "@proompteng/sag"
+  ];
+  sourcePaths = [
+    "packages/codex"
+    "services/sag"
+  ];
+  buildCommands = [
+    "bun --cwd=packages/codex run build"
+    "bun run build:sag"
+  ];
+  runtimeInstallPhase = ''
+    mkdir -p "$out/app/services/sag"
+    cp -R "$TMPDIR/work/services/sag/.output" "$out/app/services/sag/.output"
+    if [ -d "$TMPDIR/work/services/sag/public" ]; then
+      cp -R "$TMPDIR/work/services/sag/public" "$out/app/services/sag/public"
+    fi
+    mkdir -p "$out/app/packages"
+    cp -R "$TMPDIR/work/packages/codex" "$out/app/packages/codex"
+    cp -R "$TMPDIR/work/node_modules" "$out/app/node_modules"
+    if [ -d "$TMPDIR/work/services/sag/node_modules" ]; then
+      cp -R "$TMPDIR/work/services/sag/node_modules" "$out/app/services/sag/node_modules"
+    fi
+    cp "$TMPDIR/work/services/sag/package.json" "$out/app/services/sag/package.json"
+  '';
+  command = [
+    "bun"
+    ".output/server/index.mjs"
+  ];
+  workingDir = "/app/services/sag";
+  env = [
+    "PORT=3000"
+    "HOSTNAME=0.0.0.0"
+    "NITRO_PORT=3000"
+    "CODEX_HOME=/home/bun/.codex"
+    "CODEX_AUTH=/home/bun/.codex/auth.json"
+    "SAG_CODEX_BINARY=codex"
+    "SAG_CODEX_CWD=/tmp"
+  ];
+  extraContents = [
+    codexCli
+    nodejs
+    pkgs.bash
+  ];
+  exposedPorts = {
+    "3000/tcp" = { };
+  };
+}

--- a/nix/images/symphony.nix
+++ b/nix/images/symphony.nix
@@ -7,45 +7,7 @@
 }:
 
 let
-  codexVersion = "0.142.4";
-  codexPlatform =
-    {
-      x86_64-linux = {
-        npmVersion = "${codexVersion}-linux-x64";
-        vendor = "x86_64-unknown-linux-musl";
-        hash = "sha256-PVplrOt1q7N8fo4DHbGgw00LpV1dJjxeb0MMIefebHw=";
-      };
-      aarch64-linux = {
-        npmVersion = "${codexVersion}-linux-arm64";
-        vendor = "aarch64-unknown-linux-musl";
-        hash = "sha256-ERM4csGF8zXPQI7dE5U7UngI39jmfZhEFyOu7N+wVD4=";
-      };
-    }
-    .${pkgs.stdenv.hostPlatform.system}
-      or (throw "Codex CLI is not packaged for ${pkgs.stdenv.hostPlatform.system}");
-
-  codexCli = pkgs.stdenvNoCC.mkDerivation {
-    pname = "openai-codex-cli";
-    version = codexVersion;
-
-    src = pkgs.fetchurl {
-      url = "https://registry.npmjs.org/@openai/codex/-/codex-${codexPlatform.npmVersion}.tgz";
-      hash = codexPlatform.hash;
-    };
-    sourceRoot = "package/vendor/${codexPlatform.vendor}";
-
-    dontConfigure = true;
-    dontBuild = true;
-    dontFixup = true;
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p "$out/bin" "$out/libexec/openai-codex"
-      cp -R . "$out/libexec/openai-codex/"
-      ln -s "$out/libexec/openai-codex/bin/codex" "$out/bin/codex"
-      runHook postInstall
-    '';
-  };
+  codexCli = import ./openai-codex-cli.nix { inherit pkgs; };
 in
 import ./bun-workspace-service.nix {
   inherit pkgs lib repoRoot bun nodejs;

--- a/packages/scripts/src/sag/build-image.ts
+++ b/packages/scripts/src/sag/build-image.ts
@@ -1,10 +1,7 @@
 #!/usr/bin/env bun
 
-import { resolve } from 'node:path'
-
-import { repoRoot } from '../shared/cli'
-import { buildAndPushDockerImage } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
 
 export type BuildImageOptions = {
   registry?: string
@@ -12,33 +9,35 @@ export type BuildImageOptions = {
   tag?: string
   context?: string
   dockerfile?: string
-  platforms?: string[]
   cacheRef?: string
+  dryRun?: boolean
 }
 
 export const buildImage = async (options: BuildImageOptions = {}) => {
   const registry = options.registry ?? process.env.SAG_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = options.repository ?? process.env.SAG_IMAGE_REPOSITORY ?? 'lab/sag'
   const tag = options.tag ?? process.env.SAG_IMAGE_TAG ?? execGit(['rev-parse', '--short', 'HEAD'])
-  const context = resolve(repoRoot, options.context ?? process.env.SAG_BUILD_CONTEXT ?? '.')
-  const dockerfile = resolve(repoRoot, options.dockerfile ?? process.env.SAG_DOCKERFILE ?? 'services/sag/Dockerfile')
-  const platforms = options.platforms ??
-    process.env.SAG_IMAGE_PLATFORMS?.split(',').map((platform) => platform.trim()) ?? ['linux/amd64']
-  const cacheRef = options.cacheRef ?? process.env.SAG_BUILD_CACHE_REF ?? `${registry}/${repository}:buildcache`
+  const commit = execGit(['rev-parse', 'HEAD'])
 
-  return buildAndPushDockerImage({
+  const result = await buildAndPushNixImage({
+    service: 'sag',
+    imageName: 'sag',
+    packageAttr: 'sag-image',
     registry,
     repository,
     tag,
-    context,
-    dockerfile,
-    platforms,
-    cacheRef,
+    sourceSha: commit,
+    latestTag: 'latest',
+    dryRun: options.dryRun,
   })
+
+  return { image: `${registry}/${repository}:${tag}`, digest: result.reference, commit }
 }
 
 if (import.meta.main) {
-  buildImage().catch((error) => {
+  const args = process.argv.slice(2)
+  const cliTag = args[0]?.trim() && !args[0]?.startsWith('-') ? args[0] : undefined
+  buildImage({ tag: cliTag, dryRun: args.includes('--dry-run') }).catch((error) => {
     console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
   })

--- a/packages/scripts/src/sag/deploy-service.ts
+++ b/packages/scripts/src/sag/deploy-service.ts
@@ -4,27 +4,37 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
 import { buildImage } from './build-image'
 
 export const main = async () => {
+  const args = new Set(process.argv.slice(2))
+  const dryRun = args.has('--dry-run')
+  const noApply = dryRun || args.has('--no-apply')
+
   ensureCli('kubectl')
 
   const registry = process.env.SAG_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = process.env.SAG_IMAGE_REPOSITORY ?? 'lab/sag'
   const defaultTag = execGit(['rev-parse', '--short', 'HEAD'])
   const tag = process.env.SAG_IMAGE_TAG ?? defaultTag
-  const image = `${registry}/${repository}:${tag}`
 
-  await buildImage({ registry, repository, tag })
-  const digest = inspectImageDigest(image)
-  console.log(`Image digest: ${digest}`)
+  const imageResult = await buildImage({ registry, repository, tag, dryRun })
+  console.log(`Image digest: ${imageResult.digest}`)
 
-  updateManifests({ tag })
+  if (dryRun) {
+    console.log('Dry run complete; manifests and cluster state were not changed.')
+    return
+  }
+
+  updateManifests({ imageDigest: imageResult.digest })
 
   await ensureNamespace()
   const kustomizePath = resolve(repoRoot, process.env.SAG_KUSTOMIZE_PATH ?? 'argocd/sag')
+  if (noApply) {
+    console.log('Skipping kubectl apply because --no-apply was requested.')
+    return
+  }
   await run('kubectl', ['apply', '-k', kustomizePath])
   await run('kubectl', ['rollout', 'status', 'deployment/sag', '-n', 'sag', '--timeout=180s'])
 }
@@ -33,12 +43,17 @@ if (import.meta.main) {
   main().catch((error) => fatal('Failed to build and deploy sag', error))
 }
 
-function updateManifests({ tag }: { tag: string }) {
+function updateManifests({ imageDigest }: { imageDigest: string }) {
+  const digest = imageDigest.split('@')[1]
+  if (!digest?.startsWith('sha256:')) {
+    throw new Error(`Expected sag image digest reference, got ${imageDigest}`)
+  }
+
   const kustomizationPath = resolve(repoRoot, 'argocd/sag/kustomization.yaml')
   const kustomization = readFileSync(kustomizationPath, 'utf8')
   const updated = kustomization.replace(
-    /(-\s*name:\s+registry\.ide-newton\.ts\.net\/lab\/sag\s*\n\s*newName:\s+registry\.ide-newton\.ts\.net\/lab\/sag\s*\n\s*newTag:\s*).*/,
-    (_, prefix) => `${prefix}"${tag}"`,
+    /(-\s*name:\s+registry\.ide-newton\.ts\.net\/lab\/sag\s*\n\s*(?:newName:\s+registry\.ide-newton\.ts\.net\/lab\/sag\s*\n\s*)?)(?:newTag|digest):\s*.*/,
+    (_, prefix) => `${prefix}digest: ${digest}`,
   )
 
   if (updated === kustomization) {
@@ -46,7 +61,7 @@ function updateManifests({ tag }: { tag: string }) {
   }
 
   writeFileSync(kustomizationPath, updated)
-  console.log(`Updated ${kustomizationPath} with tag ${tag}`)
+  console.log(`Updated ${kustomizationPath} with digest ${digest}`)
 }
 
 async function ensureNamespace() {

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -67,6 +67,7 @@ describe('enabled app inventory', () => {
       'olden',
       'synthesis',
       'attic',
+      'sag',
       'symphony',
     ]) {
       expect(entry(name).class).toBe('nix-image')
@@ -83,6 +84,7 @@ describe('enabled app inventory', () => {
     expect(entry('proompteng').nixImageAttr).toBe('proompteng-image')
     expect(entry('olden').nixImageAttr).toBe('olden-image')
     expect(entry('synthesis').nixImageAttr).toBe('synthesis-image')
+    expect(entry('sag').nixImageAttr).toBe('sag-image')
     expect(entry('symphony').nixImageAttr).toBe('symphony-image')
   })
 
@@ -90,7 +92,6 @@ describe('enabled app inventory', () => {
     for (const name of [
       'agents',
       'jangar',
-      'sag',
       'symphony-jangar',
       'symphony-torghut',
       'bilig',

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -28,6 +28,9 @@ const agentsBuildWorkflow = readRepoFile('.github/workflows/agents-build-push.ym
 const jangarBuildWorkflow = readRepoFile('.github/workflows/jangar-build-push.yaml')
 const symphonyBuildWorkflow = readRepoFile('.github/workflows/symphony-build-push.yaml')
 const symphonyReleaseWorkflow = readRepoFile('.github/workflows/symphony-release.yml')
+const sagBuildWorkflow = readRepoFile('.github/workflows/sag-build-push.yaml')
+const sagReleaseWorkflow = readRepoFile('.github/workflows/sag-release.yml')
+const sagPostDeployVerifyWorkflow = readRepoFile('.github/workflows/sag-post-deploy-verify.yml')
 const autoPrReleaseBranchesWorkflow = readRepoFile('.github/workflows/auto-pr-release-branches.yml')
 const releasePrAutomergeWorkflow = readRepoFile('.github/workflows/release-pr-automerge.yml')
 const oiratWorkflow = readRepoFile('.github/workflows/oirat-ci.yml')
@@ -43,11 +46,15 @@ const productImageModules = [
   readRepoFile('nix/images/synthesis.nix'),
 ]
 const symphonyImageModule = readRepoFile('nix/images/symphony.nix')
+const sagImageModule = readRepoFile('nix/images/sag.nix')
+const openaiCodexCliModule = readRepoFile('nix/images/openai-codex-cli.nix')
 const oiratBuildScript = readRepoFile('packages/scripts/src/oirat/build-image.ts')
 const bumbaBuildScript = readRepoFile('packages/scripts/src/bumba/build-image.ts')
 const froussardDeployScript = readRepoFile('packages/scripts/src/froussard/deploy-service.ts')
 const symphonyBuildScript = readRepoFile('packages/scripts/src/symphony/build-image.ts')
 const symphonyDeployScript = readRepoFile('packages/scripts/src/symphony/deploy-service.ts')
+const sagBuildScript = readRepoFile('packages/scripts/src/sag/build-image.ts')
+const sagDeployScript = readRepoFile('packages/scripts/src/sag/deploy-service.ts')
 const productBuildScripts = [
   readRepoFile('packages/scripts/src/app/build-image.ts'),
   readRepoFile('packages/scripts/src/docs/build-image.ts'),
@@ -269,7 +276,13 @@ describe('native OCI build workflows', () => {
   })
 
   it('does not fan out expensive image builds on unrelated shared script changes', () => {
-    for (const workflow of [agentsBuildWorkflow, jangarBuildWorkflow, symphonyBuildWorkflow, productNixWorkflow]) {
+    for (const workflow of [
+      agentsBuildWorkflow,
+      jangarBuildWorkflow,
+      symphonyBuildWorkflow,
+      sagBuildWorkflow,
+      productNixWorkflow,
+    ]) {
       expect(workflow).not.toContain("'packages/scripts/src/shared/**'")
       expect(workflow).not.toContain('- packages/scripts/src/shared/**')
     }
@@ -284,6 +297,10 @@ describe('native OCI build workflows', () => {
     expect(symphonyBuildWorkflow).toContain("'packages/scripts/src/shared/git.ts'")
     expect(symphonyBuildWorkflow).toContain("'packages/scripts/src/shared/nix-oci-deploy.ts'")
     expect(symphonyBuildWorkflow).not.toContain("'packages/scripts/src/shared/docker.ts'")
+    expect(sagBuildWorkflow).toContain("'packages/scripts/src/shared/cli.ts'")
+    expect(sagBuildWorkflow).toContain("'packages/scripts/src/shared/git.ts'")
+    expect(sagBuildWorkflow).toContain("'packages/scripts/src/shared/nix-oci-deploy.ts'")
+    expect(sagBuildWorkflow).not.toContain("'packages/scripts/src/shared/docker.ts'")
 
     expect(productNixWorkflow).toContain("'packages/scripts/src/shared/nix-oci-deploy.ts'")
     expect(enabledProductReleaseWorkflow).not.toContain('packages/scripts/src/shared nix/images')
@@ -319,6 +336,9 @@ describe('native OCI build workflows', () => {
       enabledProductReleaseWorkflow,
       symphonyBuildWorkflow,
       symphonyReleaseWorkflow,
+      sagBuildWorkflow,
+      sagReleaseWorkflow,
+      sagPostDeployVerifyWorkflow,
     ]
     for (const workflow of migratedWorkflows) {
       expect(workflow).not.toContain('docker/build-push-action')
@@ -367,8 +387,9 @@ describe('native OCI build workflows', () => {
   it('routes the enabled Symphony fleet image through a real Nix OCI attr', () => {
     expect(flake).toContain('"symphony-image"')
     expect(repoFileExists('nix/images/symphony.nix')).toBe(true)
-    expect(symphonyImageModule).toContain('pname = "openai-codex-cli"')
-    expect(symphonyImageModule).toContain('version = codexVersion')
+    expect(symphonyImageModule).toContain('import ./openai-codex-cli.nix')
+    expect(openaiCodexCliModule).toContain('pname = "openai-codex-cli"')
+    expect(openaiCodexCliModule).toContain('version = codexVersion')
     expect(symphonyImageModule).toContain('dependencyClosure = "bunCache";')
     expect(symphonyImageModule).toContain('"@proompteng/symphony"')
     expect(symphonyImageModule).toContain('pkgs.uv')
@@ -385,6 +406,30 @@ describe('native OCI build workflows', () => {
     expect(symphonyReleaseWorkflow).toContain('crane digest "${IMAGE_NAME}:${IMAGE_TAG}"')
     expect(symphonyReleaseWorkflow).not.toContain('docker buildx')
     expect(symphonyReleaseWorkflow).not.toContain('docker/setup-buildx-action')
+  })
+
+  it('routes the enabled Sag image through a real Nix OCI attr', () => {
+    expect(flake).toContain('"sag-image"')
+    expect(repoFileExists('nix/images/sag.nix')).toBe(true)
+    expect(sagImageModule).toContain('dependencyClosure = "bunCache";')
+    expect(sagImageModule).toContain('"@proompteng/codex"')
+    expect(sagImageModule).toContain('"@proompteng/sag"')
+    expect(sagImageModule).toContain('import ./openai-codex-cli.nix')
+
+    expect(sagBuildWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
+    expect(sagBuildWorkflow).toContain('image_name: sag')
+    expect(sagBuildWorkflow).toContain('package_attr: sag-image')
+    expect(sagBuildWorkflow).toContain('sag-release-contract')
+    expect(sagBuildWorkflow).toContain('tag: sha-${{ github.sha }}')
+    expect(sagBuildWorkflow).not.toContain('oven-sh/setup-bun')
+    expect(sagBuildWorkflow).not.toContain('docker/setup-buildx-action')
+
+    expect(sagReleaseWorkflow).toContain('argocd/sag/kustomization.yaml')
+    expect(sagReleaseWorkflow).toContain('nix run .#assert-oci-platforms -- "${IMAGE}@${DIGEST}"')
+    expect(sagReleaseWorkflow).toContain('test "${service}" = "sag"')
+    expect(sagReleaseWorkflow).not.toContain('docker buildx')
+    expect(sagPostDeployVerifyWorkflow).toContain('kubectl -n sag rollout status deployment/sag')
+    expect(sagPostDeployVerifyWorkflow).toContain('desired_replicas=')
   })
 
   it('routes enabled product app image builds through real Nix OCI attrs', () => {
@@ -440,6 +485,7 @@ describe('native OCI build workflows', () => {
       bumbaBuildScript,
       froussardDeployScript,
       symphonyBuildScript,
+      sagBuildScript,
       ...productBuildScripts,
     ]) {
       expect(script).toContain("from '../shared/nix-oci-deploy'")
@@ -459,6 +505,11 @@ describe('native OCI build workflows', () => {
     expect(symphonyDeployScript).toContain('dryRun')
     expect(symphonyDeployScript).toContain('noApply')
     expect(symphonyDeployScript).toContain('digest:')
+    expect(sagDeployScript).not.toContain("from '../shared/docker'")
+    expect(sagDeployScript).not.toContain('inspectImageDigest')
+    expect(sagDeployScript).toContain('dryRun')
+    expect(sagDeployScript).toContain('noApply')
+    expect(sagDeployScript).toContain('digest:')
 
     expect(nixOciDeployScript).toContain("await run('nix', ['build', `.#${packageAttr}`")
     expect(nixOciDeployScript).toContain("await run('nix', pushArgs")
@@ -505,6 +556,7 @@ describe('native OCI build workflows', () => {
       'argocd/applications/oirat/kustomization.yaml',
       'argocd/applications/olden/kustomization.yaml',
       'argocd/applications/proompteng/kustomization.yaml',
+      'argocd/sag/kustomization.yaml',
       'argocd/applications/symphony/kustomization.yaml',
       'argocd/applications/symphony-jangar/kustomization.yaml',
       'argocd/applications/symphony-torghut/kustomization.yaml',

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -46,6 +46,7 @@ const earlyNixImageApps = new Set([
   'oirat',
   'olden',
   'proompteng',
+  'sag',
   'symphony',
   'synthesis',
 ])
@@ -55,7 +56,6 @@ const deferredApps = new Map<string, string>([
   ['analysis', 'repo image is tracked by image updater, but no local build/deploy script is wired in this repo'],
   ['bilig', 'complex application image; requires a dedicated derivation and rollout proof'],
   ['jangar', 'complex service plus OpenWebUI chart; requires a dedicated derivation and rollout proof'],
-  ['sag', 'complex app; migrate after simple Bun/Node services'],
   ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
   ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
   ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
@@ -74,6 +74,7 @@ const appToNixAttr = new Map<string, string>([
   ['oirat', 'oirat-image'],
   ['olden', 'olden-image'],
   ['proompteng', 'proompteng-image'],
+  ['sag', 'sag-image'],
   ['symphony', 'symphony-image'],
   ['synthesis', 'synthesis-image'],
 ])


### PR DESCRIPTION
## Summary

- Migrates the enabled `sag` image build from Docker Buildx to the shared Nix OCI/Skopeo workflow.
- Adds a pinned shared OpenAI Codex CLI Nix package and reuses it from both Sag and Symphony images for better closure/cache reuse.
- Keeps Sag manual deploy parity by routing `bun run sag:deploy` through `buildAndPushNixImage`, digest-pinning `argocd/sag/kustomization.yaml`, and preserving `--dry-run`/`--no-apply`.
- Adds Sag build, release, and post-deploy verify workflows without changing Sag replicas, Postgres, PVCs, Ceph, Rook, OBCs, or storage resources.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag build`
- `bunx oxfmt --check packages/scripts/src/sag/build-image.ts packages/scripts/src/sag/deploy-service.ts packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/sag-build-push.yaml .github/workflows/sag-release.yml .github/workflows/sag-post-deploy-verify.yml .github/workflows/symphony-build-push.yaml .github/workflows/auto-pr-release-branches.yml`
- `git diff --cached --check`
- `bun run packages/scripts/src/shared/enabled-apps.ts --assert`
- Not run locally: `nix build .#sag-image`, because this workstation does not have `nix` installed. The ARC PR workflow is expected to run the real Nix build; the current fixed-output hash is intentionally bootstrapped through that CI surface.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
