### PR TITLE
revert(torghut): rollback failed promotion be03f05885ca748d732ebe8a28dd36689ad6ffe5

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -128,6 +128,8 @@ spec:
               value: simple
             - name: TRADING_SIMPLE_SUBMIT_ENABLED
               value: "true"
+            - name: TRADING_LIVE_SUBMIT_ACTIVATION_EXPIRES_AT
+              value: "2026-06-22T20:05:00Z"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
@@ -239,13 +241,14 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TRADING_ORDER_FEED_TOPIC
-              value: torghut.trade-updates.v2
             - name: TRADING_ORDER_FEED_GROUP_ID
               value: torghut-order-feed-live-default
             - name: TRADING_ORDER_FEED_ASSIGNMENT_MODE
               value: manual
             - name: TRADING_ORDER_FEED_AUTO_OFFSET_RESET
-              value: earliest
+              value: latest
+            - name: TRADING_ORDER_FEED_TOPIC_V2
+              value: torghut.trade-updates.v2
             - name: TRADING_EXECUTION_PREFER_LIMIT
               value: "true"
             - name: TRADING_EXECUTION_ADVISOR_LIVE_APPLY_ENABLED


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `be03f05885ca748d732ebe8a28dd36689ad6ffe5`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28469296239`
- Rollback source: `HEAD^` manifests from the failed run checkout