### PR TITLE
chore(symphony): promote image sha-d6babaa3afaca9756b4453c518e01ca685e390c9

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T17:12:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T19:32:31Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-38d10301c4bb3e0e5c3f3c65072b80795a84b730"
+    newTag: "sha-d6babaa3afaca9756b4453c518e01ca685e390c9"
     digest: sha256:874024fcbaf18c0bdc0f67436dffd1aa1bce0732a890a00adcbdf6fd1b936316

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T17:12:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T19:32:31Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-38d10301c4bb3e0e5c3f3c65072b80795a84b730"
+    newTag: "sha-d6babaa3afaca9756b4453c518e01ca685e390c9"
     digest: sha256:874024fcbaf18c0bdc0f67436dffd1aa1bce0732a890a00adcbdf6fd1b936316

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T17:12:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-30T19:32:31Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-38d10301c4bb3e0e5c3f3c65072b80795a84b730"
+    newTag: "sha-d6babaa3afaca9756b4453c518e01ca685e390c9"
     digest: sha256:874024fcbaf18c0bdc0f67436dffd1aa1bce0732a890a00adcbdf6fd1b936316


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `d6babaa3afaca9756b4453c518e01ca685e390c9`
- Image tag: `sha-d6babaa3afaca9756b4453c518e01ca685e390c9`
- Image digest: `sha256:874024fcbaf18c0bdc0f67436dffd1aa1bce0732a890a00adcbdf6fd1b936316`