### PR TITLE
fix(torghut-ta): compile finite signal guard

### DIFF
--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
@@ -617,8 +617,7 @@ private fun setNullableTimestamp(
   index: Int,
   value: Instant?,
 ) {
-  val finite = value?.takeIf { it.isFinite() }
-  if (finite == null) {
+  if (value == null) {
     statement.setNull(index, Types.TIMESTAMP)
   } else {
     statement.setTimestamp(index, Timestamp.from(value))
@@ -642,7 +641,7 @@ private fun setNullableDouble(
   index: Int,
   value: Double?,
 ) {
-  val finite = value?.takeIf { it.isFinite() }
+  val finite = value?.takeIf { !it.isNaN() && !it.isInfinite() }
   if (finite == null) {
     statement.setNull(index, Types.DOUBLE)
   } else {


### PR DESCRIPTION
## Summary

- Fixes the Torghut TA finite-value ClickHouse guard so timestamp binding remains unchanged.
- Replaces Kotlin `isFinite()` usage with explicit `isNaN` / `isInfinite` checks for compatibility with the TA build toolchain.
- Unblocks `torghut-ta-build-push` after the evidence-loop rollout merge.

## Related Issues

Unblocks rollout after #11657.

## Testing

- `git diff --check`
- Local Gradle remains unavailable in agents-shell because Java is not installed; this PR is intended to validate through the same CI build that reported the compile error.

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
