### PR TITLE
chore(sag): promote image sha-d6babaa3afaca9756b4453c518e01ca685e390c9

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260514082919"
+    digest: sha256:6b2849995b085aa42e820257d9c1e42d4d3b8d16aa46f09f8f0b9a23297cdc59


### PR DESCRIPTION
## Summary
Promote the Sag image into GitOps manifests.

- Source commit: `d6babaa3afaca9756b4453c518e01ca685e390c9`
- Image tag: `sha-d6babaa3afaca9756b4453c518e01ca685e390c9`
- Image digest: `sha256:6b2849995b085aa42e820257d9c1e42d4d3b8d16aa46f09f8f0b9a23297cdc59`