### PR TITLE
revert(torghut): rollback failed promotion b949691942a7388d5b4d196a6add78f8c448e45e

### DIFF
--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f
   imagePullPolicy: IfNotPresent
-  restartNonce: 20
+  restartNonce: 19
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 9ad8d81d
+              value: 04b7c092
             - name: TORGHUT_TA_COMMIT
-              value: 9ad8d81dba03fa4e4ca38d3e898676ceed3261e5
+              value: 04b7c092e52ae68ffac7cb10466691b65cfbca8c
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:d30b5d14a9db25f7a91338c676c4655f43804ccee83f3d107f575243bb90b99f
   imagePullPolicy: IfNotPresent
-  restartNonce: 15
+  restartNonce: 14
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 9ad8d81d
+              value: 04b7c092
             - name: TORGHUT_TA_COMMIT
-              value: 9ad8d81dba03fa4e4ca38d3e898676ceed3261e5
+              value: 04b7c092e52ae68ffac7cb10466691b65cfbca8c
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `b949691942a7388d5b4d196a6add78f8c448e45e`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28471824798`
- Rollback source: `HEAD^` manifests from the failed run checkout