### PR TITLE
revert(torghut): rollback failed promotion 70a976f561dd0e453dd775fe9c9135d870104ed2

### DIFF
--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -7,9 +7,6 @@ metadata:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
-  ttlSecondsAfterFinished: 600
-  backoffLimit: 2
-  activeDeadlineSeconds: 600
   template:
     spec:
       restartPolicy: OnFailure

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -38,9 +38,8 @@ resources:
   - empirical-artifacts-retention-cronjob.yaml
   - zero-notional-drift-repair-cronjob.yaml
   - paper-account-flatten-cronjob.yaml
-  - generated-resource-retention-rbac.yaml
-  - generated-resource-retention-cronjob.yaml
   - whitepaper-autoresearch-workflowtemplate.yaml
+  - whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
   - empirical-promotion-workflowtemplate.yaml
   - historical-simulation-workflowtemplate.yaml
   - analysis-template-runtime-ready.yaml

--- a/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
@@ -1,0 +1,69 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: torghut-replay-source-materialization
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: replay-materialization
+    app.kubernetes.io/part-of: lab
+spec:
+  schedules:
+    - "5 5 * * 2-6"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
+  startingDeadlineSeconds: 900
+  workflowSpec:
+    workflowTemplateRef:
+      name: torghut-whitepaper-autoresearch-profit-target
+    arguments:
+      parameters:
+        - name: fullWindowStartDate
+          value: "2026-05-18"
+        - name: fullWindowEndDate
+          value: "2026-05-29"
+        - name: expectedLastTradingDay
+          value: "2026-05-29"
+        - name: trainDays
+          value: "3"
+        - name: holdoutDays
+          value: "2"
+        - name: secondOosDays
+          value: "0"
+        - name: replayTapePreviewTopK
+          value: "8"
+        - name: replayTapePreviewMinRows
+          value: "2"
+        - name: latestCompleteWindowMinDays
+          value: "5"
+        - name: minExecutableRowsPerSymbolDay
+          value: "1"
+        - name: minQuoteValidRatio
+          value: "0"
+        - name: maxCoverageSpreadBps
+          value: "1000000000"
+        - name: maxExecutableGapSeconds
+          value: "999999"
+        - name: maxCandidates
+          value: "16"
+        - name: topK
+          value: "8"
+        - name: explorationSlots
+          value: "2"
+        - name: feedbackBlockReauditSlots
+          value: "2"
+        - name: maxFrontierCandidatesPerSpec
+          value: "1"
+        - name: maxTotalFrontierCandidates
+          value: "6"
+        - name: realReplayTimeoutSeconds
+          value: "1800"
+        - name: realReplayShardSize
+          value: "1"
+        - name: realReplayShardTimeoutSeconds
+          value: "900"
+        - name: realReplayShardWorkers
+          value: "2"
+        - name: persistResults
+          value: "true"

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: torghut-ws
 spec:
   replicas: 1
-  revisionHistoryLimit: 2
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `70a976f561dd0e453dd775fe9c9135d870104ed2`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28472004482`
- Rollback source: `HEAD^` manifests from the failed run checkout