### PR TITLE
chore(analysis): promote image 538e2e8d8a7f

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: bc75eed33d78f60023fbcb8847305bb0e2b2f29f
+    newTag: 538e2e8d8a7fe41d2eeed639426970ff1436f5f6


### PR DESCRIPTION
## Summary

- Promotes `argocd/applications/analysis` to `registry.ide-newton.ts.net/lab/analysis:538e2e8d8a7fe41d2eeed639426970ff1436f5f6`.
- Keeps rollout in lab GitOps by changing only the analysis kustomize image tag.
- Uses the self-hosted analysis image publish workflow output.

## Related Issues

None

## Testing

- `/Users/gregkonush/.codex/worktrees/385f/analysis/scripts/verify-analysis-image.sh 538e2e8d8a7fe41d2eeed639426970ff1436f5f6`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
