### PR TITLE
fix(rook-ceph): preserve turin osd1 db lv path

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -131,6 +131,9 @@ cephClusterSpec:
               metadataDevice: /dev/disk/by-id/nvme-KINGSTON_SNV3S1000G_50026B76878F0B27
               databaseSizeMB: "300000"
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0MZ1M
+            config:
+              metadataDevice: /dev/ceph-10525ca6-66f7-48fd-a13a-7f7063dcc31b/osd-db-zxa0mz1m
+              databaseSizeMB: "300000"
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0LVM9
             config:
               metadataDevice: /dev/ceph-10525ca6-66f7-48fd-a13a-7f7063dcc31b/osd-db-osd1

--- a/docs/runbooks/rook-ceph-turin-bluestore-db-fast-migration.md
+++ b/docs/runbooks/rook-ceph-turin-bluestore-db-fast-migration.md
@@ -407,18 +407,22 @@ the failure mode tracked in [rook/rook#13634](https://github.com/rook/rook/issue
 In that case, pre-create or reuse the target DB LV and point `metadataDevice`
 at the LV path directly.
 
-Live OSD0 example after the 2026-06-30 recreate:
+Live OSD0/OSD1 examples after the 2026-06-30 recreates:
 
 ```yaml
+- name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0MZ1M
+  config:
+    metadataDevice: /dev/ceph-10525ca6-66f7-48fd-a13a-7f7063dcc31b/osd-db-zxa0mz1m
+    databaseSizeMB: "300000"
 - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0LVM9
   config:
     metadataDevice: /dev/ceph-10525ca6-66f7-48fd-a13a-7f7063dcc31b/osd-db-osd1
     databaseSizeMB: "300000"
 ```
 
-Repeat this for `osd.1` only after its target DB LV is known. Do not resume
-Argo with a raw Kingston parent path for the OSD currently being recreated if
-Rook has already failed inventory against that parent device.
+Repeat this for any later OSD only after its target DB LV is known. Do not
+resume Argo with a raw Kingston parent path for the OSD currently being
+recreated if Rook has already failed inventory against that parent device.
 
 Validate:
 


### PR DESCRIPTION
## Summary

- Preserve Turin `osd.1` BlueStore DB placement by pointing Rook at the dedicated Kingston DB LV path.
- Document the live OSD0 and OSD1 LV mappings used by the Turin recreate procedure.
- Keep the Rook metadata-device workaround explicit so Argo does not revert OSD1 to HDD-only prepare behavior.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph`
- `git diff --check`
- `bun run lint:argocd`
- Live readback: CephCluster Turin device `ata-ST24000NM000C-3WD103_ZXA0MZ1M` now uses `metadataDevice=/dev/ceph-10525ca6-66f7-48fd-a13a-7f7063dcc31b/osd-db-zxa0mz1m`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. OSD1 is currently draining and must not be purged until `ceph osd safe-to-destroy osd.1` passes.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
