### PR TITLE
chore(torghut): promote image 70a976f5

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -51,9 +51,9 @@ spec:
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: be03f05885ca748d732ebe8a28dd36689ad6ffe5
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+              value: sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: be03f05885ca748d732ebe8a28dd36689ad6ffe5
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+              value: sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1217-gbe03f0588
+              value: v0.596.0-1223-g70a976f56
             - name: TORGHUT_OPTIONS_COMMIT
-              value: be03f05885ca748d732ebe8a28dd36689ad6ffe5
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1217-gbe03f0588
+              value: v0.596.0-1223-g70a976f56
             - name: TORGHUT_OPTIONS_COMMIT
-              value: be03f05885ca748d732ebe8a28dd36689ad6ffe5
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -18,7 +18,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:441503b721325a24b7da86b000767f843a41c9a32b92c1d83ceac84f0fae798a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-30T19:35:33Z"
+        client.knative.dev/updateTimestamp: "2026-06-30T20:27:37Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           ports:
             - name: http1
               containerPort: 8181
@@ -539,11 +539,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1217-gbe03f0588
+              value: v0.596.0-1223-g70a976f56
             - name: TORGHUT_COMMIT
-              value: be03f05885ca748d732ebe8a28dd36689ad6ffe5
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+              value: sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-30T19:35:33Z"
+        client.knative.dev/updateTimestamp: "2026-06-30T20:27:37Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           ports:
             - name: http1
               containerPort: 8181
@@ -410,11 +410,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1217-gbe03f0588
+              value: v0.596.0-1223-g70a976f56
             - name: TORGHUT_COMMIT
-              value: be03f05885ca748d732ebe8a28dd36689ad6ffe5
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+              value: sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: be03f05885ca748d732ebe8a28dd36689ad6ffe5
+            value: 70a976f561dd0e453dd775fe9c9135d870104ed2
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+            value: sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9cb6635acb0e88a02d2036be32ebabd3e15625beb455a759b429f0e519892b59
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `70a976f561dd0e453dd775fe9c9135d870104ed2`
- Image tag: `70a976f5`
- Image digest: `sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher