### PR TITLE
perf(rook-ceph): favor recovery during osd maintenance

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -32,7 +32,7 @@ cephClusterSpec:
       mon_data_avail_warn: "15"
     osd:
       bluestore_cache_autotune: "true"
-      osd_mclock_profile: "balanced"
+      osd_mclock_profile: "high_recovery_ops"
       osd_memory_target: "6442450944"
 
   dataDirHostPath: /var/lib/rook


### PR DESCRIPTION
## Summary

- Set Rook Ceph `osd_mclock_profile` to `high_recovery_ops` during Turin OSD maintenance.
- Keep the live recovery-priority override durable so Argo does not revert it to `balanced` mid-drain.
- Preserve existing BlueStore cache and OSD memory settings.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph`
- `git diff --check`
- `bun run lint:argocd`
- Live readback: `ceph config get osd osd_mclock_profile` returns `high_recovery_ops`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This intentionally favors recovery/backfill over client latency during OSD maintenance.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
