### PR TITLE
ci(nix): tighten enabled app build inventory

### DIFF
--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -8,6 +8,11 @@ The current inventory shape is:
 
 - 71 enabled ApplicationSet entries.
 - 1 direct root-managed Application in the same directory: `home-root`.
+- 11 migrated `nix-image` apps.
+- 25 Helm/chart apps.
+- 24 vendor/manifest apps, including manifest-only repo-image references where this checkout does not own the image build.
+- 2 external-source apps.
+- 10 deferred repo-image apps that need separate service-specific migration work or clean live health first.
 - Helm/chart-only and vendor-manifest apps are not image-build migration targets.
 - Repo-image apps are only migration candidates after source ownership and a build/deploy path are proven.
 
@@ -32,7 +37,7 @@ No Ceph, Rook, ObjectBucketClaim, PVC, or storage changes are in scope.
 2. PR 2: ARC runner toolchain speedup with pinned Nix, `skopeo`, `crane`, `cosign`, `jq`, `yq`, and `kustomize`. No storage changes.
 3. PR 3: migrate clean simple build-owning apps first: `oirat`, `bumba`, and `froussard`.
 4. PR 4: migrate enabled frontend/product build-owning apps: `docs`, `app`, `proompteng`, `olden`, and `synthesis`.
-5. PR 5+: migrate complex build-owning apps only after service-specific derivations are proven: `agents`, `jangar`, `symphony`, `bilig`, `sag`, `analysis`, and `autotrader`.
+5. PR 5+: migrate complex build-owning apps only after service-specific derivations are proven. Completed examples include `symphony` and `sag`; remaining complex candidates include `agents`, `jangar`, and `arc`. `analysis` and `bilig` are manifest-only in this checkout until their owning source/build path is present here, and `autotrader` is a vendor-manifest app without a repo image build.
 6. Defer Torghut-family image migration until live app health is clean.
 
 ## Test Plan

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -89,18 +89,20 @@ describe('enabled app inventory', () => {
   })
 
   it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
-    for (const name of [
-      'agents',
-      'jangar',
-      'symphony-jangar',
-      'symphony-torghut',
-      'bilig',
-      'analysis',
-      'torghut',
-      'torghut-options',
-    ]) {
+    for (const name of ['agents', 'jangar', 'symphony-jangar', 'symphony-torghut', 'torghut', 'torghut-options']) {
       expect(entry(name).class).toBe('deferred')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
+      expect(entry(name).deferredReason).toBeTruthy()
+    }
+  })
+
+  it('keeps repo-image apps without local build ownership out of Nix migration state', () => {
+    for (const name of ['analysis', 'bilig']) {
+      expect(entry(name).class).toBe('vendor-manifest')
+      expect(entry(name).repoImages.length).toBeGreaterThan(0)
+      expect(entry(name).buildScriptPath).toBeUndefined()
+      expect(entry(name).deployScriptPath).toBeUndefined()
+      expect(entry(name).nixImageAttr).toBeUndefined()
       expect(entry(name).deferredReason).toBeTruthy()
     }
   })

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -53,8 +53,6 @@ const earlyNixImageApps = new Set([
 
 const deferredApps = new Map<string, string>([
   ['agents', 'complex multi-image runtime; migrate after simple services prove the shared Nix contract'],
-  ['analysis', 'repo image is tracked by image updater, but no local build/deploy script is wired in this repo'],
-  ['bilig', 'complex application image; requires a dedicated derivation and rollout proof'],
   ['jangar', 'complex service plus OpenWebUI chart; requires a dedicated derivation and rollout proof'],
   ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
   ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
@@ -77,6 +75,11 @@ const appToNixAttr = new Map<string, string>([
   ['sag', 'sag-image'],
   ['symphony', 'symphony-image'],
   ['synthesis', 'synthesis-image'],
+])
+
+const manifestOnlyRepoImageApps = new Map<string, string>([
+  ['analysis', 'repo image is tracked by image updater, but no local source build/deploy path exists in this repo'],
+  ['bilig', 'repo image is produced outside this checkout; this app is GitOps/image-updater managed here'],
 ])
 
 const uniqueSorted = (values: Iterable<string>): string[] => [...new Set(values)].sort()
@@ -255,6 +258,11 @@ const inspectApplicationPath = (root: string, entry: EnabledAppInventoryEntry): 
 const classify = (entry: EnabledAppInventoryEntry): EnabledAppInventoryEntry => {
   if (entry.repoURL !== labRepoURL) {
     return { ...entry, class: 'external-source' }
+  }
+
+  const manifestOnlyReason = manifestOnlyRepoImageApps.get(entry.name)
+  if (manifestOnlyReason) {
+    return { ...entry, class: 'vendor-manifest', deferredReason: manifestOnlyReason }
   }
 
   const deferredReason = deferredApps.get(entry.name)


### PR DESCRIPTION
## Summary

- Reclassify enabled repo-image references without local source/build ownership as manifest-only instead of pending Nix migrations.
- Keep `analysis` and `bilig` out of Nix image rollout proof until this checkout owns a real build/deploy path for those images.
- Update the enabled-app rollout plan counts and add regression coverage for the no-fake-build guardrail.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `bun run packages/scripts/src/shared/enabled-apps.ts --assert`
- `bunx oxfmt --check packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
