### PR TITLE
perf(rook-ceph): increase recovery concurrency

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -34,6 +34,8 @@ cephClusterSpec:
       bluestore_cache_autotune: "true"
       osd_mclock_profile: "high_recovery_ops"
       osd_memory_target: "6442450944"
+      osd_max_backfills: "16"
+      osd_recovery_max_active: "32"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Increase Ceph recovery concurrency for the Turin OSD maintenance window.
- Set `osd_max_backfills=16` and `osd_recovery_max_active=32` alongside `high_recovery_ops`.
- Keep the live recovery tuning durable so Argo does not revert it while OSD1 drains.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph`
- `git diff --check`
- `bun run lint:argocd`
- Live readback: backfilling PGs increased from `16` to `32` after setting the runtime values.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This intentionally favors recovery/backfill over client latency during OSD maintenance.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
