### PR TITLE
fix(torghut): avoid transient options subscription cap breaches

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -556,22 +556,21 @@ class ForwarderApp(
             while (isActive) {
               delay(config.symbolsPollIntervalMs)
               val desired = desiredSymbols().symbols
-              val (toAdd, toRemove) =
-                subscribedLock.withLock {
-                  val add = desired.filter { !subscribedSymbols.contains(it) }
-                  val remove = subscribedSymbols.filter { !desired.contains(it) }
-                  add to remove
-                }
+              val updates = subscribedLock.withLock { subscriptionUpdates(desired, subscribedSymbols) }
 
-              if (toAdd.isNotEmpty()) {
-                logger.info { "subscribing ${toAdd.size} symbols symbols=$toAdd" }
-                applySubscribe(toAdd)
+              updates.forEach { update ->
+                when (update.action) {
+                  SubscriptionAction.Unsubscribe -> {
+                    logger.info { "unsubscribing ${update.symbols.size} symbols symbols=${update.symbols}" }
+                    applyUnsubscribe(update.symbols)
+                  }
+                  SubscriptionAction.Subscribe -> {
+                    logger.info { "subscribing ${update.symbols.size} symbols symbols=${update.symbols}" }
+                    applySubscribe(update.symbols)
+                  }
+                }
               }
-              if (toRemove.isNotEmpty()) {
-                logger.info { "unsubscribing ${toRemove.size} symbols symbols=$toRemove" }
-                applyUnsubscribe(toRemove)
-              }
-              if (config.alpacaMarketType == AlpacaMarketType.OPTIONS && (toAdd.isNotEmpty() || toRemove.isNotEmpty())) {
+              if (config.alpacaMarketType == AlpacaMarketType.OPTIONS && updates.isNotEmpty()) {
                 publishOptionsWsStatus(
                   producer = producer,
                   seq = seq,
@@ -1476,6 +1475,32 @@ internal fun missingDesiredSymbols(
 ): List<String> {
   val normalizedSubscribed = subscribed.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.toSet()
   return desired.map { it.trim().uppercase() }.filter { it.isNotEmpty() && it !in normalizedSubscribed }.distinct()
+}
+
+internal enum class SubscriptionAction {
+  Unsubscribe,
+  Subscribe,
+}
+
+internal data class SubscriptionUpdate(
+  val action: SubscriptionAction,
+  val symbols: List<String>,
+)
+
+internal fun subscriptionUpdates(
+  desired: Collection<String>,
+  subscribed: Collection<String>,
+): List<SubscriptionUpdate> {
+  val normalizedDesired = desired.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.distinct()
+  val normalizedSubscribed = subscribed.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.distinct()
+  val desiredSet = normalizedDesired.toSet()
+  val subscribedSet = normalizedSubscribed.toSet()
+  val toRemove = normalizedSubscribed.filter { it !in desiredSet }
+  val toAdd = normalizedDesired.filter { it !in subscribedSet }
+  return buildList {
+    if (toRemove.isNotEmpty()) add(SubscriptionUpdate(SubscriptionAction.Unsubscribe, toRemove))
+    if (toAdd.isNotEmpty()) add(SubscriptionUpdate(SubscriptionAction.Subscribe, toAdd))
+  }
 }
 
 internal fun optionsEventStarved(

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
@@ -43,6 +43,40 @@ class ForwarderSubscriptionTest {
   }
 
   @Test
+  fun `subscription updates unsubscribe before subscribing to avoid transient provider cap breaches`() {
+    val updates =
+      subscriptionUpdates(
+        desired = listOf("AAPL", "MSFT", "GOOGL"),
+        subscribed = listOf("NVDA", "AMD", "AAPL"),
+      )
+
+    assertEquals(
+      listOf(
+        SubscriptionUpdate(SubscriptionAction.Unsubscribe, listOf("NVDA", "AMD")),
+        SubscriptionUpdate(SubscriptionAction.Subscribe, listOf("MSFT", "GOOGL")),
+      ),
+      updates,
+    )
+  }
+
+  @Test
+  fun `subscription updates normalize symbols and preserve desired add order`() {
+    val updates =
+      subscriptionUpdates(
+        desired = listOf(" aapl ", "msft", "MSFT", "googl"),
+        subscribed = listOf("AAPL", " nvda "),
+      )
+
+    assertEquals(
+      listOf(
+        SubscriptionUpdate(SubscriptionAction.Unsubscribe, listOf("NVDA")),
+        SubscriptionUpdate(SubscriptionAction.Subscribe, listOf("MSFT", "GOOGL")),
+      ),
+      updates,
+    )
+  }
+
+  @Test
   fun `options event starvation requires options subscriptions during regular market hours`() {
     val now = Instant.parse("2026-06-18T15:00:00Z")
     val stale = now.minusSeconds(120)


### PR DESCRIPTION
## Summary

- Change websocket symbol rotations to unsubscribe stale symbols before subscribing replacements.
- Add a pure subscription-update helper so provider-cap-safe ordering is covered by unit tests.
- Preserve symbol normalization and desired add ordering for deterministic subscription batches.

## Related Issues

None

## Testing

- `./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.ForwarderSubscriptionTest'`
- `./gradlew :websockets:test`
- `./gradlew :websockets:check`
- Live check: `torghut-ws-options` stayed Ready with `restartCount=0` after the previous rollout.
- Live log check: no `503 Service Unavailable`, `alpaca error code=405`, or `readiness changed to not_ready` matches in the last 5 minutes before this PR.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
