### PR TITLE
perf(rook-ceph): maximize recovery concurrency

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -34,8 +34,8 @@ cephClusterSpec:
       bluestore_cache_autotune: "true"
       osd_mclock_profile: "high_recovery_ops"
       osd_memory_target: "6442450944"
-      osd_max_backfills: "16"
-      osd_recovery_max_active: "32"
+      osd_max_backfills: "32"
+      osd_recovery_max_active: "64"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Raise Ceph recovery concurrency to keep more remapped PGs active during Turin OSD maintenance.
- Set `osd_max_backfills=32` and `osd_recovery_max_active=64` while `high_recovery_ops` is active.
- Keep the live recovery tuning durable so Argo does not revert it mid-drain.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph`
- `git diff --check`
- `bun run lint:argocd`
- Live readback: backfilling PGs increased to `64` and `backfill_wait` dropped to `10` after applying the runtime values.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This intentionally favors recovery/backfill over client latency during OSD maintenance.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
