### PR TITLE
chore(torghut): cap direct deployment history

### DIFF
--- a/argocd/applications/torghut/alloy-deployment.yaml
+++ b/argocd/applications/torghut/alloy-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut-alloy
     app.kubernetes.io/component: observability
 spec:
+  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
     app.kubernetes.io/part-of: torghut
 spec:
+  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:

--- a/argocd/applications/torghut/llm-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut-llm-guardrails-exporter
     app.kubernetes.io/part-of: torghut
 spec:
+  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:

--- a/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
@@ -110,6 +110,27 @@ class TestProductApplicationsetRendersTorghutNamespaceSecurityMetadata(
             {"name": "torghut-clickhouse-auth", "key": "torghut_password"},
         )
 
+    def test_direct_torghut_deployments_bound_replica_set_history(self) -> None:
+        deployment_paths = [
+            "argocd/applications/torghut/alloy-deployment.yaml",
+            "argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml",
+            "argocd/applications/torghut/llm-guardrails-exporter.yaml",
+            "argocd/applications/torghut/ws/deployment.yaml",
+            "argocd/applications/torghut-options/catalog/deployment.yaml",
+            "argocd/applications/torghut-options/enricher/deployment.yaml",
+            "argocd/applications/torghut-options/ws/deployment.yaml",
+        ]
+
+        for path in deployment_paths:
+            with self.subTest(path=path):
+                deployment = next(
+                    item
+                    for item in _load_yaml_mappings(path)
+                    if item.get("kind") == "Deployment"
+                )
+                spec = cast(Mapping[str, object], deployment.get("spec", {}))
+                self.assertEqual(spec.get("revisionHistoryLimit"), 2)
+
     def test_whitepaper_semantic_backfill_runs_on_arm_nodes(self) -> None:
         manifest = _load_yaml_mapping(
             "argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml"


### PR DESCRIPTION
## Summary

- Caps direct Torghut Deployment `revisionHistoryLimit` at 2 for Alloy and guardrails exporters.
- Adds a manifest contract test covering all direct Torghut/Torghut Options Deployment history limits.
- Leaves FlinkDeployment-owned TA history untouched because the live CRD schema does not expose a supported `revisionHistoryLimit` field.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py -k 'direct_torghut_deployments_bound_replica_set_history or generated_resource_retention'`
- `uv run --frozen ruff check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
