### PR TITLE
revert(torghut): rollback failed promotion 2e2d98c31373742745974c85f06a5ae590ef428a

### DIFF
--- a/argocd/applications/torghut/alloy-deployment.yaml
+++ b/argocd/applications/torghut/alloy-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/name: torghut-alloy
     app.kubernetes.io/component: observability
 spec:
-  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
     app.kubernetes.io/part-of: torghut
 spec:
-  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:

--- a/argocd/applications/torghut/llm-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/name: torghut-llm-guardrails-exporter
     app.kubernetes.io/part-of: torghut
 spec:
-  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `2e2d98c31373742745974c85f06a5ae590ef428a`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28475921581`
- Rollback source: `HEAD^` manifests from the failed run checkout