### PR TITLE
fix(torghut): harden noisy post-sync hooks

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -60,7 +60,7 @@ spec:
             - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
               value: "5"
             - name: TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS
-              value: "10"
+              value: "30"
           resources:
             requests:
               cpu: 100m

--- a/argocd/applications/torghut/whitepapers-bucket-bootstrap-job.yaml
+++ b/argocd/applications/torghut/whitepapers-bucket-bootstrap-job.yaml
@@ -8,6 +8,7 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 2
+  activeDeadlineSeconds: 120
   ttlSecondsAfterFinished: 300
   template:
     spec:
@@ -62,21 +63,3 @@ spec:
             - |
               mc alias set ceph "http://${BUCKET_HOST}:${BUCKET_PORT}" "${AWS_ACCESS_KEY_ID}" "${AWS_SECRET_ACCESS_KEY}"
               mc stat "ceph/${BUCKET_NAME}" >/dev/null 2>&1 || mc mb "ceph/${BUCKET_NAME}"
-
-              for prefix in \
-                "raw/github" \
-                "raw/arxiv" \
-                "raw/ssrn" \
-                "normalized/pdf" \
-                "extracted/text" \
-                "extracted/sections" \
-                "metadata/documents" \
-                "metadata/processing" \
-                "synthesis" \
-                "verdicts" \
-                "design-prs" \
-                "index/manifests" \
-                "ops/failed" \
-                "ops/quarantine"; do
-                printf "" | mc pipe "ceph/${BUCKET_NAME}/${prefix}/.keep"
-              done

--- a/services/torghut/scripts/verify_tigerbeetle_ledger.py
+++ b/services/torghut/scripts/verify_tigerbeetle_ledger.py
@@ -47,43 +47,50 @@ def _smoke_accounts(settings: Settings) -> list[TigerBeetleAccountSpec]:
 
 def run_smoke(settings: Settings) -> dict[str, Any]:
     client = create_tigerbeetle_client(settings)
-    accounts = _smoke_accounts(settings)
-    transfer = TigerBeetleTransferSpec(
-        transfer_id=stable_u128(
-            "torghut.tigerbeetle.smoke.transfer",
-            f"{settings.tigerbeetle_cluster_id}:torghut-smoke",
-        ),
-        transfer_kind=TRANSFER_KIND_SMOKE,
-        debit_account_id=accounts[0].account_id,
-        credit_account_id=accounts[1].account_id,
-        amount=1,
-        ledger=LEDGER_USD_MICRO,
-        code=TRANSFER_CODE_SMOKE,
-    )
+    try:
+        accounts = _smoke_accounts(settings)
+        transfer = TigerBeetleTransferSpec(
+            transfer_id=stable_u128(
+                "torghut.tigerbeetle.smoke.transfer",
+                f"{settings.tigerbeetle_cluster_id}:torghut-smoke",
+            ),
+            transfer_kind=TRANSFER_KIND_SMOKE,
+            debit_account_id=accounts[0].account_id,
+            credit_account_id=accounts[1].account_id,
+            amount=1,
+            ledger=LEDGER_USD_MICRO,
+            code=TRANSFER_CODE_SMOKE,
+        )
 
-    client.nop()
-    print("protocol probe ok")
-    client.create_accounts(accounts)
-    client.create_accounts(accounts)
-    looked_up_accounts = client.lookup_accounts([item.account_id for item in accounts])
-    if len(looked_up_accounts) != len(accounts):
-        raise RuntimeError("create_accounts idempotent replay failed")
-    print("create_accounts idempotent ok")
-    client.create_transfers([transfer])
-    client.create_transfers([transfer])
-    looked_up_transfers = client.lookup_transfers([transfer.transfer_id])
-    if len(looked_up_transfers) != 1:
-        raise RuntimeError("lookup_transfers failed")
-    print("create_transfers idempotent ok")
-    print("lookup_transfers ok")
-    print("reconciliation ok")
-    return {
-        "schema_version": "torghut.tigerbeetle-smoke.v1",
-        "ok": True,
-        "cluster_id": settings.tigerbeetle_cluster_id,
-        "account_ids": [str(item.account_id) for item in accounts],
-        "transfer_id": str(transfer.transfer_id),
-    }
+        client.nop()
+        print("protocol probe ok")
+        client.create_accounts(accounts)
+        client.create_accounts(accounts)
+        looked_up_accounts = client.lookup_accounts(
+            [item.account_id for item in accounts]
+        )
+        if len(looked_up_accounts) != len(accounts):
+            raise RuntimeError("create_accounts idempotent replay failed")
+        print("create_accounts idempotent ok")
+        client.create_transfers([transfer])
+        client.create_transfers([transfer])
+        looked_up_transfers = client.lookup_transfers([transfer.transfer_id])
+        if len(looked_up_transfers) != 1:
+            raise RuntimeError("lookup_transfers failed")
+        print("create_transfers idempotent ok")
+        print("lookup_transfers ok")
+        print("reconciliation ok")
+        return {
+            "schema_version": "torghut.tigerbeetle-smoke.v1",
+            "ok": True,
+            "cluster_id": settings.tigerbeetle_cluster_id,
+            "account_ids": [str(item.account_id) for item in accounts],
+            "transfer_id": str(transfer.transfer_id),
+        }
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
 
 
 def main() -> int:

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -757,3 +757,19 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
             env.get("TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES"),
             "torghut-tigerbeetle.torghut.svc.cluster.local:3000",
         )
+        self.assertEqual(env.get("TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS"), "30")
+
+    def test_torghut_whitepaper_bootstrap_only_ensures_bucket(self) -> None:
+        spec, container = _load_job_container(
+            "argocd/applications/torghut/whitepapers-bucket-bootstrap-job.yaml"
+        )
+        args = container.get("command")
+        rendered_command = "\n".join(str(item) for item in args or [])
+
+        self.assertEqual(spec.get("backoffLimit"), 2)
+        self.assertEqual(spec.get("activeDeadlineSeconds"), 120)
+        self.assertEqual(spec.get("ttlSecondsAfterFinished"), 300)
+        self.assertIn("mc stat", rendered_command)
+        self.assertIn("mc mb", rendered_command)
+        self.assertNotIn("mc pipe", rendered_command)
+        self.assertNotIn(".keep", rendered_command)

--- a/services/torghut/tests/test_verify_tigerbeetle_ledger.py
+++ b/services/torghut/tests/test_verify_tigerbeetle_ledger.py
@@ -21,6 +21,15 @@ class MissingTransferLookupClient(FakeTigerBeetleClient):
         return []
 
 
+class ClosableFakeTigerBeetleClient(FakeTigerBeetleClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class TestVerifyTigerBeetleLedger(TestCase):
     def test_run_smoke_proves_protocol_probe_idempotent_writes_and_lookup(
         self,
@@ -44,6 +53,17 @@ class TestVerifyTigerBeetleLedger(TestCase):
         self.assertIn("create_transfers idempotent ok", output)
         self.assertIn("lookup_transfers ok", output)
         self.assertIn("reconciliation ok", output)
+
+    def test_run_smoke_closes_owned_client(self) -> None:
+        client = ClosableFakeTigerBeetleClient()
+
+        with patch(
+            "scripts.verify_tigerbeetle_ledger.create_tigerbeetle_client",
+            return_value=client,
+        ):
+            run_smoke(Settings(TORGHUT_TIGERBEETLE_ENABLED=True))
+
+        self.assertTrue(client.closed)
 
     def test_run_smoke_fails_when_account_lookup_is_missing(self) -> None:
         with patch(


### PR DESCRIPTION
## Summary

- Removes the whitepaper bootstrap `.keep` object loop and keeps the hook focused on bucket existence only.
- Adds an active deadline to the whitepaper bootstrap hook so Argo cannot wait indefinitely on object-store writes.
- Extends TigerBeetle smoke RPC timeout and closes the owned smoke client after proof execution.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_verify_tigerbeetle_ledger.py tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py -k 'tigerbeetle_smoke_job_runs_protocol_proof or whitepaper_bootstrap_only_ensures_bucket or run_smoke'`
- `uv run --frozen ruff check scripts/verify_tigerbeetle_ledger.py tests/test_verify_tigerbeetle_ledger.py tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-hook-cleanup-kustomize.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
