### PR TITLE
fix(torghut): bound empirical retention cronjob

### DIFF
--- a/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
@@ -14,6 +14,8 @@ spec:
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 86400
+      backoffLimit: 0
+      activeDeadlineSeconds: 1800
       template:
         spec:
           restartPolicy: Never

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -127,6 +127,9 @@ describe('Torghut manifest scheduling', () => {
         const jobSpec = getAtPath(manifest, ['spec', 'jobTemplate', 'spec'])
         expect(spec.failedJobsHistoryLimit, path).toBe(2)
         expect(jobSpec.ttlSecondsAfterFinished, path).toBe(86400)
+        expect(typeof jobSpec.backoffLimit, path).toBe('number')
+        expect(jobSpec.backoffLimit, path).toBeGreaterThanOrEqual(0)
+        expect(jobSpec.activeDeadlineSeconds, path).toBeGreaterThan(0)
         checkedCronJobs += 1
       }
     }

--- a/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py
@@ -177,6 +177,25 @@ class TestProductApplicationsetRendersTorghutNamespaceSecurityMetadata(
             resources,
         )
 
+    def test_empirical_artifacts_retention_cronjob_is_bounded(self) -> None:
+        spec, container = _load_cronjob_container(
+            "argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml"
+        )
+
+        self.assertEqual(spec.get("schedule"), "17 4 * * *")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(spec.get("failedJobsHistoryLimit"), 2)
+        job_spec = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], spec.get("jobTemplate", {})).get("spec", {}),
+        )
+        self.assertEqual(job_spec.get("ttlSecondsAfterFinished"), 86400)
+        self.assertEqual(job_spec.get("backoffLimit"), 0)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 1800)
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn('mc find "empirical/${BUCKET_NAME}"', args)
+        self.assertIn('--older-than "${RETENTION_DAYS}d"', args)
+
     def test_generated_resource_retention_cronjob_prunes_only_stale_residue(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds `backoffLimit` and `activeDeadlineSeconds` to `torghut-empirical-artifacts-retention` so the daily MinIO cleanup cannot run unbounded.
- Strengthens the package manifest scheduling contract so Torghut scheduled jobs must carry finite retry and deadline policy.
- Adds a Torghut live-config contract test for the empirical artifact retention CronJob command and bounds.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `cd services/torghut && uv run --frozen ruff check tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py && uv run --frozen pytest tests/live_config_manifest_contract/test_product_applicationset_renders_torghut_namespace_security_metadata.py -k 'empirical_artifacts_retention_cronjob_is_bounded or stale_backfill_hooks_are_removed_from_gitops'`
- `kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-bound-retention.yaml`
- `git diff --check`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
