### PR TITLE
revert(torghut): rollback failed promotion 365d36534876a9641509b872684b04671b5bc8c9

### DIFF
--- a/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
@@ -14,8 +14,6 @@ spec:
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 86400
-      backoffLimit: 0
-      activeDeadlineSeconds: 1800
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `365d36534876a9641509b872684b04671b5bc8c9`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28478522150`
- Rollback source: `HEAD^` manifests from the failed run checkout