### PR TITLE
fix(arc): run post deploy checks with kube rbacs

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -38,6 +38,7 @@ spec:
                 - name: listener
           template:
             spec:
+              serviceAccountName: arc-arm64-gha-rs-kube-mode
               nodeSelector:
                 kubernetes.io/arch: arm64
               dnsConfig:

--- a/argocd/applications/arc/kube-mode-serviceaccount.yaml
+++ b/argocd/applications/arc/kube-mode-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: arc-arm64-gha-rs-kube-mode
+  namespace: arc

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -10,6 +10,14 @@ const agentsCiClusterRbac = readFileSync(
   new URL('../../../../../argocd/applications/agents-ci/runner-rbac-cluster.yaml', import.meta.url),
   'utf8',
 )
+const arcApplication = readFileSync(
+  new URL('../../../../../argocd/applications/arc/application.yaml', import.meta.url),
+  'utf8',
+)
+const arcKubeModeServiceAccount = readFileSync(
+  new URL('../../../../../argocd/applications/arc/kube-mode-serviceaccount.yaml', import.meta.url),
+  'utf8',
+)
 
 describe('torghut post-deploy verifier workflow', () => {
   it('does not skip Knative Service readiness when the runner lacks RBAC', () => {
@@ -150,6 +158,14 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(agentsCiClusterRbac).toContain('serving.knative.dev')
     expect(agentsCiClusterRbac).toContain('resources:\n      - pods')
     expect(agentsCiClusterRbac).toContain('arc-arm64-gha-rs-kube-mode')
+  })
+
+  it('runs arm64 workflows with the kube-mode service account that receives post-deploy RBAC', () => {
+    expect(arcApplication).toContain('runnerScaleSetName: arc-arm64')
+    expect(arcApplication).toContain('serviceAccountName: arc-arm64-gha-rs-kube-mode')
+    expect(arcKubeModeServiceAccount).toContain('kind: ServiceAccount')
+    expect(arcKubeModeServiceAccount).toContain('name: arc-arm64-gha-rs-kube-mode')
+    expect(arcKubeModeServiceAccount).toContain('namespace: arc')
   })
 
   it('grants the ARC runner patch access for explicit Argo refreshes', () => {


### PR DESCRIPTION
## Summary

- Creates the `arc-arm64-gha-rs-kube-mode` service account that existing post-deploy RBAC already targets.
- Wires the `arc-arm64` runner scale set to use that kube-mode service account instead of the no-permission account.
- Adds a regression test so Torghut post-deploy verification cannot drift back to a runner without Argo patch/read access.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
