### PR TITLE
revert(torghut): rollback failed promotion e3f6cece458998e0d99052bc9182bbce7fb892bf

### DIFF
--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:1103c3a67207b5b41b8bb1bfd1bc775f82c00ffbdbdfb20ea7957227042d8127
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:0a2da31325b6096effe0c95ff9400d57763c3bac528a9428842f6923b9621726
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-56167552
+              value: main-70a976f5
             - name: TORGHUT_WS_COMMIT
-              value: 561675522428e44625744dc04646c30d9490d99f
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `e3f6cece458998e0d99052bc9182bbce7fb892bf`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28478825952`
- Rollback source: `HEAD^` manifests from the failed run checkout