### PR TITLE
perf(nix): bound bun image layer count

### DIFF
--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -19,6 +19,7 @@
   extraContents ? [ ],
   exposedPorts ? { },
   workingDir ? "/app",
+  maxLayers ? 24,
 }:
 
 let
@@ -251,6 +252,7 @@ in
 pkgs.dockerTools.buildLayeredImage {
   name = "registry.ide-newton.ts.net/lab/${imageName}";
   tag = "nix";
+  inherit maxLayers;
   contents = [
     appRoot
     bun

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -278,6 +278,11 @@ describe('native OCI build workflows', () => {
     expect(ciNixOciSummaryScript).toContain('GITHUB_STEP_SUMMARY')
   })
 
+  it('caps Bun workspace image layers to keep registry publishes bounded', () => {
+    expect(bunWorkspaceServiceModule).toContain('maxLayers ? 24')
+    expect(bunWorkspaceServiceModule).toContain('inherit maxLayers;')
+  })
+
   it('does not fan out expensive image builds on unrelated shared script changes', () => {
     for (const workflow of [
       agentsBuildWorkflow,


### PR DESCRIPTION
## Summary

- Caps shared Bun workspace Nix image layering at 24 layers to reduce registry blob fanout during platform image publishes.
- Keeps the value configurable for service-specific overrides while applying the bounded default to migrated Bun/Agents images.
- Adds a static OCI contract test so the layer cap stays in place.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`
- `nix eval --raw .#agents-control-plane-image.drvPath` could not run locally because `nix` is not installed on this host PATH; CI ARC runners provide the Nix toolchain.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
