### PR TITLE
chore(sag): promote image sha-653ec53505daab568a5129d8de604502366900fd

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    digest: sha256:6b2849995b085aa42e820257d9c1e42d4d3b8d16aa46f09f8f0b9a23297cdc59
+    digest: sha256:04653d47cf30fd07c2c26854693a11e1a97a0bf9f1d15976fe766cc762d5d7dd


### PR DESCRIPTION
## Summary
Promote the Sag image into GitOps manifests.

- Source commit: `653ec53505daab568a5129d8de604502366900fd`
- Image tag: `sha-653ec53505daab568a5129d8de604502366900fd`
- Image digest: `sha256:04653d47cf30fd07c2c26854693a11e1a97a0bf9f1d15976fe766cc762d5d7dd`