### PR TITLE
chore(symphony): promote image sha-653ec53505daab568a5129d8de604502366900fd

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T19:32:31Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-01T01:22:52Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-d6babaa3afaca9756b4453c518e01ca685e390c9"
-    digest: sha256:874024fcbaf18c0bdc0f67436dffd1aa1bce0732a890a00adcbdf6fd1b936316
+    newTag: "sha-653ec53505daab568a5129d8de604502366900fd"
+    digest: sha256:b9bd867639de5cc4a6cf498f7dc560ae93ce243ed7bd5babfa593a67bc109a02

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T19:32:31Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-01T01:22:52Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-d6babaa3afaca9756b4453c518e01ca685e390c9"
-    digest: sha256:874024fcbaf18c0bdc0f67436dffd1aa1bce0732a890a00adcbdf6fd1b936316
+    newTag: "sha-653ec53505daab568a5129d8de604502366900fd"
+    digest: sha256:b9bd867639de5cc4a6cf498f7dc560ae93ce243ed7bd5babfa593a67bc109a02

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-30T19:32:31Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-01T01:22:52Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-d6babaa3afaca9756b4453c518e01ca685e390c9"
-    digest: sha256:874024fcbaf18c0bdc0f67436dffd1aa1bce0732a890a00adcbdf6fd1b936316
+    newTag: "sha-653ec53505daab568a5129d8de604502366900fd"
+    digest: sha256:b9bd867639de5cc4a6cf498f7dc560ae93ce243ed7bd5babfa593a67bc109a02


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `653ec53505daab568a5129d8de604502366900fd`
- Image tag: `sha-653ec53505daab568a5129d8de604502366900fd`
- Image digest: `sha256:b9bd867639de5cc4a6cf498f7dc560ae93ce243ed7bd5babfa593a67bc109a02`