### PR TITLE
fix(torghut): pin options image during cleanup rollout

### DIFF
--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -254,6 +254,7 @@ jobs:
           TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           TORGHUT_IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
           TORGHUT_COMMIT: ${{ steps.meta.outputs.source_sha }}
+          TORGHUT_INCLUDE_OPTIONS_MANIFESTS: "false"
         run: |
           set -euo pipefail
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c2014dbf926afc33de70aa2890b01dc2ab06d7836fece344a5cc22ce56fbbc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1247-gc1e630bf5
+              value: v0.596.0-1223-g70a976f56
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8e1ae9a8c668c206afc6885ca817039da226810b
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c2014dbf926afc33de70aa2890b01dc2ab06d7836fece344a5cc22ce56fbbc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1247-gc1e630bf5
+              value: v0.596.0-1223-g70a976f56
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8e1ae9a8c668c206afc6885ca817039da226810b
+              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Summary

- Roll back `torghut-options-catalog` and `torghut-options-enricher` to the last known-good Torghut image digest after the promoted cleanup image left the enricher unready in live rollout.
- Keep Torghut release manifest promotion from advancing options deployments by setting `TORGHUT_INCLUDE_OPTIONS_MANIFESTS=false` in the release workflow.
- Preserve the promoted cleanup image for the core Torghut app, CronJobs, workflow templates, and Hyperliquid runtime.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut-options >/tmp/torghut-options-pin-render.yaml`
- `rg -n 'torghut-options-(catalog|enricher)|sha256:6b48053a|sha256:0c2014db|70a976f561dd0e453dd775fe9c9135d870104ed2|8e1ae9a8c668c206afc6885ca817039da226810b' /tmp/torghut-options-pin-render.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
