### PR TITLE
fix(nix): create writable tmp dirs in bun images

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,7 +11,10 @@ import ./bun-workspace-service.nix {
   inherit pkgs lib repoRoot bun nodejs;
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
-  depsHash = "sha256-H4lK2btS85onVqnGLIjpeM/hU/D5DGMlVPGdaS/GSUc=";
+  depsHash = {
+    x86_64-linux = "sha256-ndyiyuCI8lQmM6yPNDhY6q4VWtJohWJbZjrMwGObbe0=";
+    aarch64-linux = "sha256-ndyiyuCI8lQmM6yPNDhY6q4VWtJohWJbZjrMwGObbe0=";
+  };
   installFilters = [
     "@proompteng/bumba"
     "@proompteng/temporal-bun-sdk"

--- a/nix/images/bun-workspace-service.nix
+++ b/nix/images/bun-workspace-service.nix
@@ -260,6 +260,10 @@ pkgs.dockerTools.buildLayeredImage {
     pkgs.cacert
     pkgs.coreutils
   ] ++ extraContents;
+  extraCommands = ''
+    mkdir -p tmp var/tmp
+    chmod 1777 tmp var/tmp
+  '';
   config = {
     Entrypoint = command;
     WorkingDir = workingDir;

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-a3huVNnkJRiJQ52xFiM1R++61KmK/xTmy6YXlBWfblw=";
-    aarch64-linux = "sha256-Ss/1Vd6rXk80PPniTuZmdGEjSS9Kk2u9kp8rAc1mp70=";
+    x86_64-linux = "sha256-SHYomlo6kr3cok0PtFuNZCCW4thKJ7oTV7WAomgQ4uc=";
+    aarch64-linux = "sha256-mJ0C9aLQSRUzzeu78dPZIvk/EkHThbQdHGkyaMOGyg0=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-auT+p0n8yzouCdpXWpj9lqtz/PwB0184htYWWRw4xbw=";
-    aarch64-linux = "sha256-9MLDGvLPp/GNxZCuHeKLHzitmPA1KXJLfEyoHqoGCek=";
+    x86_64-linux = "sha256-VH/h1FsSjswTgn78p44G0VVOdd6IPQIvULghepxkn2o=";
+    aarch64-linux = "sha256-kSB3lX0Kv4aOztJdOtxnAk3gS+T1H1xu/gT5b1QOcig=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -283,6 +283,12 @@ describe('native OCI build workflows', () => {
     expect(bunWorkspaceServiceModule).toContain('inherit maxLayers;')
   })
 
+  it('creates writable temp directories in Bun workspace images for non-root runtime pods', () => {
+    expect(bunWorkspaceServiceModule).toContain('extraCommands =')
+    expect(bunWorkspaceServiceModule).toContain('mkdir -p tmp var/tmp')
+    expect(bunWorkspaceServiceModule).toContain('chmod 1777 tmp var/tmp')
+  })
+
   it('does not fan out expensive image builds on unrelated shared script changes', () => {
     for (const workflow of [
       agentsBuildWorkflow,


### PR DESCRIPTION
## Summary

- Add writable `tmp` and `var/tmp` directories to Bun workspace Nix images so non-root runtime pods can create `/tmp` paths.
- Refresh fixed-output Bun dependency hashes for Bumba, Oirat, and Froussard after the shared Bun workspace image change.
- Add a contract test so migrated Bun workspace images keep writable temp directories.

## Related Issues

N/A

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`
- `nix build .#agents-shell-image --print-build-logs` could not run locally because `nix` is not installed in this desktop environment; PR CI is building the real Nix image matrix on ARC.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
