### PR TITLE
fix(torghut): pin options to ready cleanup image

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c2014dbf926afc33de70aa2890b01dc2ab06d7836fece344a5cc22ce56fbbc4
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1223-g70a976f56
+              value: v0.596.0-1247-gc1e630bf5
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
+              value: 8e1ae9a8c668c206afc6885ca817039da226810b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:6b48053a22d7bac71c594e8a942c9f127f9c457bcfcd4d0ff2959afb94ad75ec
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c2014dbf926afc33de70aa2890b01dc2ab06d7836fece344a5cc22ce56fbbc4
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1223-g70a976f56
+              value: v0.596.0-1247-gc1e630bf5
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 70a976f561dd0e453dd775fe9c9135d870104ed2
+              value: 8e1ae9a8c668c206afc6885ca817039da226810b
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Summary

- Pin `torghut-options-catalog` and `torghut-options-enricher` back to the cleanup image digest that is already Ready in live rollout.
- Keep the release workflow change from PR 11735 in place so future Torghut promotions do not automatically advance options deployments before the slow first-cycle write path is fixed.
- Restore GitOps desired state to match the healthy live options-enricher pod and let Argo finish the app health transition.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut-options >/tmp/torghut-options-ready-pin-render.yaml`
- `rg -n 'torghut-options-(catalog|enricher)|sha256:0c2014db|sha256:6b48053a|8e1ae9a8c668c206afc6885ca817039da226810b|70a976f561dd0e453dd775fe9c9135d870104ed2' /tmp/torghut-options-ready-pin-render.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
