### PR TITLE
fix(torghut): prevent overlapping options enricher rollouts

### DIFF
--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 2
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: torghut-options-enricher

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -80,6 +80,13 @@ describe('Torghut manifest scheduling', () => {
     }
   })
 
+  it('rolls the options enricher without overlapping side-effecting workers', () => {
+    const deployment = parseManifest('argocd/applications/torghut-options/enricher/deployment.yaml')
+    expect(getAtPath(deployment, ['spec']).strategy).toMatchObject({
+      type: 'Recreate',
+    })
+  })
+
   it('pins arm64-only Torghut image consumers to arm64 nodes', () => {
     for (const check of torghutArm64ImageChecks) {
       const manifest = parseManifest(check.path)


### PR DESCRIPTION
## Summary

- Set `torghut-options-enricher` Deployment strategy to `Recreate` so image rollouts do not run old and new side-effecting workers concurrently.
- Keep the options catalog rollout unchanged; only the DB/Kafka-mutating enricher gets non-overlap semantics.
- Add a manifest regression test for the enricher rollout strategy.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut-options`
- `git diff --check`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
