### PR TITLE
fix(torghut): use zero surge options enricher rollout

### DIFF
--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -9,7 +9,10 @@ spec:
   replicas: 1
   revisionHistoryLimit: 2
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: torghut-options-enricher

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -83,7 +83,11 @@ describe('Torghut manifest scheduling', () => {
   it('rolls the options enricher without overlapping side-effecting workers', () => {
     const deployment = parseManifest('argocd/applications/torghut-options/enricher/deployment.yaml')
     expect(getAtPath(deployment, ['spec']).strategy).toMatchObject({
-      type: 'Recreate',
+      type: 'RollingUpdate',
+      rollingUpdate: {
+        maxSurge: 0,
+        maxUnavailable: 1,
+      },
     })
   })
 


### PR DESCRIPTION
## Summary

- Replace the invalid `Recreate` strategy attempt with a valid zero-surge rolling update for the one-replica `torghut-options-enricher`.
- Keep rollout behavior non-overlapping by setting `maxSurge: 0` and `maxUnavailable: 1`.
- Update the manifest regression test to assert the server-side-apply-compatible rollout strategy.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut-options`
- `kubectl apply --server-side --dry-run=server -f /tmp/torghut-options-zero-surge-render.yaml`
- `git diff --check`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
