### PR TITLE
chore(symphony): promote image sha-67efb77c315182233a779b0cb6dfe41370f6f5d7

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-01T01:22:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-01T03:54:15Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-653ec53505daab568a5129d8de604502366900fd"
-    digest: sha256:b9bd867639de5cc4a6cf498f7dc560ae93ce243ed7bd5babfa593a67bc109a02
+    newTag: "sha-67efb77c315182233a779b0cb6dfe41370f6f5d7"
+    digest: sha256:6bc777ca66bd110e63f65e66713f335a1e416dc47de499b82b24f3ef6a2fc9b1

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-01T01:22:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-01T03:54:15Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-653ec53505daab568a5129d8de604502366900fd"
-    digest: sha256:b9bd867639de5cc4a6cf498f7dc560ae93ce243ed7bd5babfa593a67bc109a02
+    newTag: "sha-67efb77c315182233a779b0cb6dfe41370f6f5d7"
+    digest: sha256:6bc777ca66bd110e63f65e66713f335a1e416dc47de499b82b24f3ef6a2fc9b1

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-01T01:22:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-01T03:54:15Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-653ec53505daab568a5129d8de604502366900fd"
-    digest: sha256:b9bd867639de5cc4a6cf498f7dc560ae93ce243ed7bd5babfa593a67bc109a02
+    newTag: "sha-67efb77c315182233a779b0cb6dfe41370f6f5d7"
+    digest: sha256:6bc777ca66bd110e63f65e66713f335a1e416dc47de499b82b24f3ef6a2fc9b1


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `67efb77c315182233a779b0cb6dfe41370f6f5d7`
- Image tag: `sha-67efb77c315182233a779b0cb6dfe41370f6f5d7`
- Image digest: `sha256:6bc777ca66bd110e63f65e66713f335a1e416dc47de499b82b24f3ef6a2fc9b1`