### PR TITLE
fix(nix): preserve agents runtime deps

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -134,6 +134,7 @@ jobs:
             echo "Nix image output is not a tar file: ${image_tar}" >&2
             exit 1
           fi
+          printf '%s\n' "${image_tar}" > "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"
           echo "image_tar=${image_tar}" >> "${GITHUB_OUTPUT}"
           echo "Built ${PACKAGE_ATTR} for ${{ matrix.platform }} at ${image_tar}."
 
@@ -168,7 +169,7 @@ jobs:
           fi
           bash nix/ci-run-timed.sh "push-platform-image-${ARCH}" "${NIX_OCI_LOG_DIR}/oci-push-${ARCH}.log" "${args[@]}"
 
-      - name: Push reusable helper closures to Attic
+      - name: Push build platform closures to Attic
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
@@ -182,8 +183,14 @@ jobs:
             echo "No build-platform helper closure paths were captured." >&2
             exit 2
           fi
+          mapfile -t image_paths < "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"
+          if [[ "${#image_paths[@]}" -eq 0 ]]; then
+            echo "No Nix image closure paths were captured." >&2
+            exit 2
+          fi
+          cache_paths=("${helper_paths[@]}" "${image_paths[@]}")
           bash nix/ci-run-timed.sh "push-build-platform-closures-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-${ARCH}.log" \
-            nix run .#cache-push -- "${helper_paths[@]}"
+            nix run .#cache-push -- "${cache_paths[@]}"
 
       - name: Summarize Nix OCI cache use
         if: always()

--- a/nix/images/agents.nix
+++ b/nix/images/agents.nix
@@ -83,18 +83,32 @@ let
   runtimeInstallPhase = ''
     mkdir -p "$out/app/packages" "$out/app/services/agents"
 
+    copyWorkspaceNodeModules() {
+      local source_path="$1"
+      local target_path="$2"
+
+      if [ -d "$source_path" ]; then
+        rm -rf "$target_path"
+        mkdir -p "$target_path"
+        cp -R "$source_path/." "$target_path/"
+      fi
+    }
+
     cp -R "$TMPDIR/work/node_modules" "$out/app/node_modules"
     for package in agent-contracts codex cx-tools otel temporal-bun-sdk; do
       cp -R "$TMPDIR/work/packages/$package" "$out/app/packages/$package"
+      copyWorkspaceNodeModules "$TMPDIR/work/packages/$package/node_modules" "$out/app/packages/$package/node_modules"
     done
 
     cp "$TMPDIR/work/services/agents/package.json" "$out/app/services/agents/package.json"
     cp -R "$TMPDIR/work/services/agents/src" "$out/app/services/agents/src"
     cp -R "$TMPDIR/work/services/agents/scripts" "$out/app/services/agents/scripts"
     cp -R "$TMPDIR/work/services/agents/.output" "$out/app/services/agents/.output"
+    copyWorkspaceNodeModules "$TMPDIR/work/services/agents/node_modules" "$out/app/services/agents/node_modules"
 
     chmod +x "$out/app/services/agents/scripts/agents-shell-entrypoint.sh"
     mkdir -p "$out/app/packages/agent-contracts/node_modules"
+    rm -rf "$out/app/packages/agent-contracts/node_modules/effect"
     ln -s /app/node_modules/effect "$out/app/packages/agent-contracts/node_modules/effect"
   '';
 

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -12,8 +12,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-KGHJgGVfesk5pNYzr/he+f8CK84kufdXkWWPrbnUpIg=";
-    aarch64-linux = "sha256-KGHJgGVfesk5pNYzr/he+f8CK84kufdXkWWPrbnUpIg=";
+    x86_64-linux = "sha256-r1MqBWNeGieUQque+vdJCPDGxMx3gOTmPOuTnzRQ+Pc=";
+    aarch64-linux = "sha256-r1MqBWNeGieUQque+vdJCPDGxMx3gOTmPOuTnzRQ+Pc=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-Ctm7jVWwS7aFROoHrwOb0r4vwilTWqpxo8z5+zdmSJU=";
-    aarch64-linux = "sha256-ko0nDKmqJdnsZNHVjU01sO8FBoZhwAtPx4XKqYGG3DE=";
+    x86_64-linux = "sha256-kJ3EYa/VBjZdlSwCYq/7suUohBFxxoghZoDalfTOiY8=";
+    aarch64-linux = "sha256-ft1Zcx/6ocKrRQbUs15r0d2Vu2aA7+leb6N7Qd/V28g=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-dsUT1jkChBLckFmQpXjqUlRj6nVTRs0wXjpfNM3Nq4Q=";
-    aarch64-linux = "sha256-sLwYDdj7SW6zt/F5jjNaH0BP7lKBR+AMueE3EvGFRso=";
+    x86_64-linux = "sha256-b7gVdCguIM7nTpTtFVCB5XtQa8gTlpYCbBXZirSxzRM=";
+    aarch64-linux = "sha256-QQZr97O1Ux7zqCrk3UaeMRL43ALxn+1I6AzgrpkL7Tc=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -252,8 +252,10 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('nix run .#oci-push --')
     expect(nixOciWorkflow).toContain('nix run .#create-oci-index --')
     expect(nixOciWorkflow).toContain('nix run .#assert-oci-platforms --')
-    expect(nixOciWorkflow).toContain('nix run .#cache-push -- "${helper_paths[@]}"')
-    expect(nixOciWorkflow).not.toContain('nix run .#cache-push -- "${IMAGE_TAR}"')
+    expect(nixOciWorkflow).toContain('printf \'%s\\n\' "${image_tar}" > "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
+    expect(nixOciWorkflow).toContain('mapfile -t image_paths < "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
+    expect(nixOciWorkflow).toContain('cache_paths=("${helper_paths[@]}" "${image_paths[@]}")')
+    expect(nixOciWorkflow).toContain('nix run .#cache-push -- "${cache_paths[@]}"')
     expect(nixOciWorkflow).toContain('nix run .#write-oci-release-contract --')
     expect(nixOciWorkflow).toContain('substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/')
     expect(nixOciWorkflow).not.toContain('extra-substituters = http://attic.attic.svc.cluster.local/lab')
@@ -262,6 +264,7 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('helper_attrs+=(.#ociPush .#cachePush)')
     expect(nixOciWorkflow).toContain('test -s "${output_file}"')
     expect(nixOciWorkflow).toContain('No build-platform helper closure paths were captured.')
+    expect(nixOciWorkflow).toContain('No Nix image closure paths were captured.')
     expect(nixOciWorkflow).toContain('No index helper closure paths were captured.')
     expect(nixOciWorkflow).toContain('Start checkout timer')
     expect(nixOciWorkflow).toContain('Record checkout timing')
@@ -547,6 +550,20 @@ describe('native OCI build workflows', () => {
     expect(agentsImageModule).toContain('"agents-controller-image"')
     expect(agentsImageModule).toContain('"agents-control-plane-image"')
     expect(agentsImageModule).toContain('"agents-shell-image"')
+  })
+
+  it('preserves isolated Bun workspace runtime dependencies in Agents images', () => {
+    expect(agentsImageModule).toContain('copyWorkspaceNodeModules()')
+    expect(agentsImageModule).toContain(
+      'copyWorkspaceNodeModules "$TMPDIR/work/packages/$package/node_modules" "$out/app/packages/$package/node_modules"',
+    )
+    expect(agentsImageModule).toContain(
+      'copyWorkspaceNodeModules "$TMPDIR/work/services/agents/node_modules" "$out/app/services/agents/node_modules"',
+    )
+    expect(agentsImageModule).toContain('rm -rf "$target_path"')
+    expect(agentsImageModule).toContain('cp -R "$source_path/." "$target_path/"')
+    expect(agentsImageModule).toContain('rm -rf "$out/app/packages/agent-contracts/node_modules/effect"')
+    expect(agentsImageModule).toContain('ln -s /app/node_modules/effect')
   })
 
   it('routes enabled product app image builds through real Nix OCI attrs', () => {


### PR DESCRIPTION
## Summary

- Preserve isolated Bun workspace `node_modules` directories in the Agents Nix runtime image layout.
- Copy package-local and `services/agents` runtime dependencies into the Nix image output so Agents services can resolve direct Bun dependencies at startup.
- Warm real Nix OCI image closures from trusted `main` runs by pushing the built image tar path to Attic along with reusable helper closures.
- Refresh Bumba, Oirat, and Froussard fixed-output Bun dependency hashes exposed by the shared Nix image fanout.
- Add OCI contract coverage for both the Agents runtime dependency layout and the real image-closure Attic push path.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `nix flake check --print-build-logs`
- `nix flake check --all-systems --print-build-logs`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
