### PR TITLE
fix(infra): restore agents and flamingo runtime health

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: sha-67efb77c315182233a779b0cb6dfe41370f6f5d7
-  digest: sha256:b9c048dc6a06757eb987fbc4aa80ca3abe65af100c04ed9aac601995976d7432
+  tag: 86e969e4
+  digest: sha256:0004d24e7c47554776c3ed2728cf197756c53e4feb8d8dd8f0cea61489684bb4
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -38,8 +38,8 @@ agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: sha-67efb77c315182233a779b0cb6dfe41370f6f5d7
-    digest: sha256:993273ab0aa6c643ef85696a0607180498687449cab48c213cb7ec0d1e3bbe74
+    tag: 86e969e4
+    digest: sha256:b9db608abcb967ab4e9148909a0e3158ef74b1b0ea9c70e53aac79929ebd5b1e
     pullPolicy: IfNotPresent
   env:
     vars:
@@ -94,6 +94,7 @@ agentsShell:
   nodeSelector:
     kubernetes.io/arch: amd64
   workspace:
+    volumeMode: emptyDir
     size: 20Gi
     bootstrap:
       enabled: true

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -53,11 +53,9 @@ spec:
             - --max-model-len
             - "262144"
             - --gpu-memory-utilization
-            - "0.95"
+            - "0.85"
             - --kv-cache-dtype
             - fp8
-            - --safetensors-load-strategy
-            - eager
             - --max-num-seqs
             - "16"
             - --max-num-batched-tokens

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -156,6 +156,9 @@ spec:
                 managedNamespaceMetadata:
                   labels:
                     external-secrets.proompteng.ai/enabled: "true"
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
                 automation: auto
                 enabled: "true"
               - name: agents
@@ -166,7 +169,7 @@ spec:
                 managedNamespaceMetadata:
                   labels:
                     external-secrets.proompteng.ai/enabled: "true"
-                automation: auto
+                automation: manual
                 enabled: "true"
               - name: agents-ci
                 path: argocd/applications/agents-ci

--- a/charts/agents/templates/agents-shell-deployment.yaml
+++ b/charts/agents/templates/agents-shell-deployment.yaml
@@ -2,6 +2,7 @@
 {{- $namespace := .Values.namespaceOverride | default .Release.Namespace -}}
 {{- $image := .Values.agentsShell.image | default dict -}}
 {{- $workspaceBootstrap := .Values.agentsShell.workspace.bootstrap | default dict -}}
+{{- $workspaceVolumeMode := .Values.agentsShell.workspace.volumeMode | default "persistentVolumeClaim" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -223,10 +224,15 @@ spec:
               mountPath: /workspace
       volumes:
         - name: workspace
-          {{- if .Values.agentsShell.workspace.enabled }}
+          {{- if eq $workspaceVolumeMode "emptyDir" }}
+          emptyDir: {}
+          {{- else if eq $workspaceVolumeMode "persistentVolumeClaim" }}
+          {{- if not .Values.agentsShell.workspace.enabled }}
+          {{- fail "agentsShell.workspace.enabled must be true when agentsShell.workspace.volumeMode is persistentVolumeClaim" }}
+          {{- end }}
           persistentVolumeClaim:
             claimName: {{ include "agents.agentsShellWorkspaceClaimName" . }}
           {{- else }}
-          emptyDir: {}
+          {{- fail "agentsShell.workspace.volumeMode must be either persistentVolumeClaim or emptyDir" }}
           {{- end }}
 {{- end }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -350,6 +350,11 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
+            "volumeMode": {
+              "type": "string",
+              "enum": ["persistentVolumeClaim", "emptyDir"],
+              "description": "Volume source mounted by the agents-shell pod. Leave persistentVolumeClaim for durable workspaces; use emptyDir for stateless emergency restore while keeping the PVC object managed separately."
+            },
             "existingClaim": { "type": "string" },
             "claimName": { "type": "string" },
             "accessModes": { "type": "array", "items": { "type": "string" } },

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -121,6 +121,7 @@ agentsShell:
     extra: []
   workspace:
     enabled: true
+    volumeMode: persistentVolumeClaim
     existingClaim: ''
     claimName: ''
     accessModes:


### PR DESCRIPTION
## Summary

- Roll back Agents controller and shell images to the last live-verified digest that boots cleanly.
- Add `agentsShell.workspace.volumeMode` so the shell pod can use `emptyDir` while the existing workspace PVC remains managed.
- Make the live Jangar privileged namespace labels and Agents manual sync setting durable in the product ApplicationSet.
- Reduce Flamingo GPU memory utilization to `0.85` and remove eager safetensors loading so vLLM reaches readiness on Turin.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/agents >/tmp/agents-validated.yaml`
- `kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-validated.yaml`
- `yq '.' argocd/applicationsets/product.yaml >/dev/null`
- `helm lint charts/agents -f argocd/applications/agents/values.yaml`
- `git diff --check`
- Live smoke already performed before this GitOps PR: Kafka ready, Attic cache endpoint, Posthog web health, Jangar health/OpenWebUI, Agents shell health/ready, Flamingo `/v1/models`.

## Breaking Changes

None. Agents shell workspace persistence is temporarily disabled at the pod mount layer with `emptyDir`, but the PVC object remains managed and retained.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
