### PR TITLE
fix(agents): pin controllers to restored image

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -159,8 +159,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: sha-67efb77c315182233a779b0cb6dfe41370f6f5d7
-    digest: sha256:b9c048dc6a06757eb987fbc4aa80ca3abe65af100c04ed9aac601995976d7432
+    tag: 86e969e4
+    digest: sha256:0004d24e7c47554776c3ed2728cf197756c53e4feb8d8dd8f0cea61489684bb4
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary

- Pin `controllers.image` to the same restored Agents controller digest used by the live recovery.
- Keeps the previously merged shell `emptyDir` restore and controller rollback source-consistent.
- Prevents Argo from rolling `agents-controllers` back to the crashlooping `sha-67ef...` image during sync.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/agents >/tmp/agents-followup-render.yaml`
- Render inspection confirmed `agents-controllers` uses `registry.ide-newton.ts.net/lab/agents-controller:86e969e4@sha256:0004d24e7c47554776c3ed2728cf197756c53e4feb8d8dd8f0cea61489684bb4`.
- Render inspection confirmed `agents-shell` still uses `emptyDir` and the restored shell digest.
- `helm lint charts/agents -f argocd/applications/agents/values.yaml`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
