### PR TITLE
fix(infra): server-side apply clickhouse operator resources

### DIFF
--- a/argocd/applications/clickhouse-operator/kustomization.yaml
+++ b/argocd/applications/clickhouse-operator/kustomization.yaml
@@ -9,3 +9,5 @@ helmCharts:
     namespace: clickhouse-operator
     includeCRDs: true
     valuesFile: ./values.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: ServerSideApply=true


### PR DESCRIPTION
## Summary

- Add Argo `ServerSideApply=true` sync options to rendered clickhouse-operator resources.
- Fix the 0.27.1 operator sync failure caused by oversized CRD ConfigMap client-side apply annotations.
- Keep the operator upgrade path GitOps-only; no direct manifest apply.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/clickhouse-operator >/tmp/clickhouse-operator-ssa.yaml`
- `yq 'select(.kind == "ConfigMap" and .metadata.name == "clickhouse-operator-altinity-clickhouse-operator-crds-1") | .metadata.annotations' /tmp/clickhouse-operator-ssa.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
