### PR TITLE
fix(infra): roll back clickhouse operator keeper regression

### DIFF
--- a/argocd/applications/clickhouse-operator/kustomization.yaml
+++ b/argocd/applications/clickhouse-operator/kustomization.yaml
@@ -4,10 +4,8 @@ namespace: clickhouse-operator
 helmCharts:
   - name: altinity-clickhouse-operator
     repo: https://helm.altinity.com
-    version: 0.27.1
+    version: 0.26.3
     releaseName: clickhouse-operator
     namespace: clickhouse-operator
     includeCRDs: true
     valuesFile: ./values.yaml
-commonAnnotations:
-  argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/docs/runbooks/clickhouse-operator.md
+++ b/docs/runbooks/clickhouse-operator.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Altinity ClickHouse Operator implements a Kubernetes-native control plane for ClickHouse workloads. We deploy version 0.27.1 through Argo CD using the upstream Helm chart (`altinity/altinity-clickhouse-operator`). The GitOps application lives at `argocd/applications/clickhouse-operator/`, and Helm overrides are centralized in `argocd/applications/clickhouse-operator/values.yaml`.
+The Altinity ClickHouse Operator implements a Kubernetes-native control plane for ClickHouse workloads. We deploy version 0.26.3 through Argo CD using the upstream Helm chart (`altinity/altinity-clickhouse-operator`). The GitOps application lives at `argocd/applications/clickhouse-operator/`, and Helm overrides are centralized in `argocd/applications/clickhouse-operator/values.yaml`.
 
 ## Namespace & Access
 
@@ -223,7 +223,7 @@ This is an emergency-only path, but it is now a known one. Waiting for the clust
 
 - Helm chart rollback: `argocd app rollback clickhouse-operator <ID>` reverts to a previous revision while keeping the namespace intact.
 - Namespace recovery: if a change introduces broken CRDs or controllers, disable auto-sync, delete the `clickhouse-operator` namespace, and re-sync the application after values are corrected.
-- Keeper & cluster CRDs: versioned CRDs are pinned to chart v0.27.1. Regenerate schemas via `scripts/download_crd_schema.py` before upgrading to maintain kubeconform coverage.
+- Keeper & cluster CRDs: versioned CRDs are pinned to chart v0.26.3. Regenerate schemas via `scripts/download_crd_schema.py` before upgrading to maintain kubeconform coverage.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Roll back the Altinity ClickHouse Operator chart from 0.27.1 to the known-good 0.26.3 release.
- Remove the 0.27.1-specific server-side apply workaround.
- Correct the runbook to document the actual deployed 0.26.3 operator version.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/clickhouse-operator >/tmp/clickhouse-operator-rollback.yaml`
- `rg -n "clickhouse-operator:|0\\.27\\.1|0\\.26\\.3" /tmp/clickhouse-operator-rollback.yaml | head -80`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
