### PR TITLE
fix(infra): server-side apply clickhouse operator configmaps

### DIFF
--- a/argocd/applications/clickhouse-operator/kustomization.yaml
+++ b/argocd/applications/clickhouse-operator/kustomization.yaml
@@ -9,3 +9,5 @@ helmCharts:
     namespace: clickhouse-operator
     includeCRDs: true
     valuesFile: ./values.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: ServerSideApply=true


### PR DESCRIPTION
## Summary

- Keep the Altinity ClickHouse Operator pinned at the known-good 0.26.3 release.
- Add Argo `ServerSideApply=true` to rendered clickhouse-operator resources so CRD ConfigMap hooks do not fail on oversized client-side apply annotations.
- Avoid the 0.27.1 Keeper reconciliation regression while making future sync operations succeed.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/clickhouse-operator >/tmp/clickhouse-operator-0263-ssa.yaml`
- `yq 'select(.kind == "ConfigMap" and .metadata.name == "clickhouse-operator-altinity-clickhouse-operator-crds") | .metadata.annotations' /tmp/clickhouse-operator-0263-ssa.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
