### PR TITLE
fix(posthog): trigger keeper reconcile task

### DIFF
--- a/argocd/applications/posthog/clickhouse-keeper.yaml
+++ b/argocd/applications/posthog/clickhouse-keeper.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: posthog-clickhouse
     app.kubernetes.io/part-of: posthog
 spec:
+  taskID: posthog-keeper-reconcile-20260703
   configuration:
     clusters:
       - name: default


### PR DESCRIPTION
## Summary

- Add an explicit `spec.taskID` to `ClickHouseKeeperInstallation/posthog-keeper`.
- Trigger a real Altinity operator reconcile task for the stuck Posthog Keeper health state.
- Avoid Argo health overrides, status patches, or storage changes.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/posthog >/tmp/posthog-keeper-taskid.yaml`
- `yq 'select(.kind == "ClickHouseKeeperInstallation" and .metadata.name == "posthog-keeper") | .spec.taskID' /tmp/posthog-keeper-taskid.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
