### PR TITLE
chore(argocd): upgrade enabled helm charts

### DIFF
--- a/argocd/applications/arc/README.md
+++ b/argocd/applications/arc/README.md
@@ -2,7 +2,7 @@
 
 These runners are not pinned to any specific node by default.
 
-- Chart version pinned in `application.yaml` is `0.14.1` for both the controller and the runner scale set.
+- Chart version pinned in `application.yaml` is `0.14.2` for both the controller and the runner scale set.
 - Upgrading from ≤0.9.x requires deleting the legacy `actions.github.com` CRDs and reinstalling the controller/runner charts before letting Argo CD reconcile.
 - Keep the custom template (init container + privileged `docker:dind` sidecar with `DOCKER_HOST=unix:///var/run/docker.sock`) when reapplying so Docker builds continue to work under Kubernetes mode.
 - The runner container intentionally waits for `docker version` before starting `run.sh`; without this guard, ARC can register a runner before the dind socket is ready.

--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -8,13 +8,13 @@ spec:
   sources:
     - repoURL: ghcr.io
       chart: actions/actions-runner-controller-charts/gha-runner-scale-set-controller
-      targetRevision: 0.14.1
+      targetRevision: 0.14.2
       helm:
         releaseName: arc-controller
         skipCrds: false
     - repoURL: ghcr.io
       chart: actions/actions-runner-controller-charts/gha-runner-scale-set
-      targetRevision: 0.14.1
+      targetRevision: 0.14.2
       helm:
         releaseName: arc-runner-set
         skipCrds: false
@@ -145,7 +145,7 @@ spec:
                   emptyDir: {}
     - repoURL: ghcr.io
       chart: actions/actions-runner-controller-charts/gha-runner-scale-set
-      targetRevision: 0.14.1
+      targetRevision: 0.14.2
       helm:
         releaseName: arc-runner-set-amd64
         skipCrds: false
@@ -272,7 +272,7 @@ spec:
                   emptyDir: {}
     - repoURL: ghcr.io
       chart: actions/actions-runner-controller-charts/gha-runner-scale-set
-      targetRevision: 0.14.1
+      targetRevision: 0.14.2
       helm:
         releaseName: arc-runner-set-analysis
         skipCrds: false

--- a/argocd/applications/argo-rollouts/kustomization.yaml
+++ b/argocd/applications/argo-rollouts/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 helmCharts:
   - name: argo-rollouts
     repo: https://argoproj.github.io/argo-helm
-    version: 2.40.9
+    version: 2.41.0
     releaseName: argo-rollouts
     namespace: argo-rollouts
     valuesInline:

--- a/argocd/applications/argo-workflows/kustomization.yaml
+++ b/argocd/applications/argo-workflows/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 helmCharts:
   - name: argo-workflows
     repo: https://argoproj.github.io/argo-helm
-    version: 1.0.13
+    version: 1.0.18
     releaseName: argo-workflows
     namespace: argo-workflows
     valuesInline:

--- a/argocd/applications/cert-manager/kustomization.yaml
+++ b/argocd/applications/cert-manager/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io
-    version: v1.20.2
+    version: v1.20.3
     releaseName: cert-manager
     namespace: cert-manager
     includeCRDs: true

--- a/argocd/applications/clickhouse-operator/kustomization.yaml
+++ b/argocd/applications/clickhouse-operator/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: clickhouse-operator
 helmCharts:
   - name: altinity-clickhouse-operator
     repo: https://helm.altinity.com
-    version: 0.26.3
+    version: 0.27.1
     releaseName: clickhouse-operator
     namespace: clickhouse-operator
     includeCRDs: true

--- a/argocd/applications/cloudnative-pg/kustomization.yaml
+++ b/argocd/applications/cloudnative-pg/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: cloudnative-pg
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.io/charts
-    version: 0.28.0
+    version: 0.29.0
     releaseName: cloudnative-pg
     namespace: cloudnative-pg
     includeCRDs: true

--- a/argocd/applications/external-secrets/kustomization.yaml
+++ b/argocd/applications/external-secrets/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 helmCharts:
   - name: external-secrets
     repo: https://charts.external-secrets.io
-    version: 2.6.0
+    version: 2.7.0
     releaseName: external-secrets
     namespace: external-secrets
     includeCRDs: true

--- a/argocd/applications/feature-flags/kustomization.yaml
+++ b/argocd/applications/feature-flags/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 helmCharts:
   - name: flipt-v2
     repo: https://helm.flipt.io
-    version: 2.9.0
+    version: 2.10.0
     releaseName: feature-flags
     namespace: feature-flags
     valuesFile: flipt-values.yaml
@@ -17,7 +17,7 @@ helmCharts:
 images:
   - name: docker.flipt.io/flipt/flipt
     newName: mirror.gcr.io/flipt/flipt
-    newTag: v2.9.0
+    newTag: v2.10.0
 
 patches:
   - target:

--- a/argocd/applications/flink/base/operator/kustomization.yaml
+++ b/argocd/applications/flink/base/operator/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 namespace: flink
 helmCharts:
   - name: flink-kubernetes-operator
-    repo: https://downloads.apache.org/flink/flink-kubernetes-operator-1.14.0/
-    version: 1.14.0
+    repo: https://downloads.apache.org/flink/flink-kubernetes-operator-1.15.0/
+    version: 1.15.0
     releaseName: flink-kubernetes-operator
     namespace: flink
     includeCRDs: true

--- a/argocd/applications/forgejo/README.md
+++ b/argocd/applications/forgejo/README.md
@@ -3,8 +3,8 @@
 This app deploys [Forgejo](https://forgejo.org/) using the official OCI Helm chart:
 
 - Chart: `oci://code.forgejo.org/forgejo-helm/forgejo`
-- Chart version: `17.0.1`
-- App version: `15.0.1`
+- Chart version: `17.1.1`
+- App version: `15.0.3`
 
 ## Current profile
 

--- a/argocd/applications/forgejo/kustomization.yaml
+++ b/argocd/applications/forgejo/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 helmCharts:
   - name: forgejo
     repo: oci://code.forgejo.org/forgejo-helm
-    version: 17.0.1
+    version: 17.1.1
     releaseName: forgejo
     namespace: forgejo
     valuesFile: values.yaml

--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp
-    version: 0.41.0
+    version: 0.43.0
     releaseName: headlamp
     namespace: headlamp
     valuesFile: values.yaml

--- a/argocd/applications/istio-ingress/kustomization.yaml
+++ b/argocd/applications/istio-ingress/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 helmCharts:
   - name: gateway
     repo: https://istio-release.storage.googleapis.com/charts
-    version: 1.29.2
+    version: 1.30.2
     releaseName: gateway
     namespace: istio-ingress
     valuesInline:

--- a/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
+++ b/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: istio-proxy
-          image: docker.io/istio/proxyv2:1.29.2
+          image: docker.io/istio/proxyv2:1.30.2
           imagePullPolicy: Always
           args:
             - proxy

--- a/argocd/applications/istio-system/kustomization.yaml
+++ b/argocd/applications/istio-system/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 helmCharts:
   - name: base
     repo: https://istio-release.storage.googleapis.com/charts
-    version: 1.29.2
+    version: 1.30.2
     releaseName: istio-base
     namespace: istio-system
     includeCRDs: true
@@ -17,12 +17,12 @@ helmCharts:
       defaultRevision: default
   - name: istiod
     repo: https://istio-release.storage.googleapis.com/charts
-    version: 1.29.2
+    version: 1.30.2
     releaseName: istiod
     namespace: istio-system
   - name: cni
     repo: https://istio-release.storage.googleapis.com/charts
-    version: 1.29.2
+    version: 1.30.2
     releaseName: istio-cni
     namespace: istio-system
 patches:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -31,7 +31,7 @@ resources:
 helmCharts:
   - name: open-webui
     repo: https://helm.openwebui.com
-    version: 14.8.0
+    version: 15.2.0
     releaseName: jangar-openwebui
     namespace: jangar
     valuesFile: openwebui-values.yaml

--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -17,7 +17,7 @@ websocket:
     enabled: false
 
 image:
-  tag: v0.9.6
+  tag: v0.10.2
 
 openaiApiKey: ""
 

--- a/argocd/applications/kubernetes-reflector/kustomization.yaml
+++ b/argocd/applications/kubernetes-reflector/kustomization.yaml
@@ -4,11 +4,11 @@ namespace: kubernetes-reflector
 helmCharts:
   - name: reflector
     repo: https://emberstack.github.io/helm-charts
-    version: 10.0.40
+    version: 10.0.55
     releaseName: kubernetes-reflector
     namespace: kubernetes-reflector
 
 images:
   - name: docker.io/emberstack/kubernetes-reflector
     newName: mirror.gcr.io/emberstack/kubernetes-reflector
-    newTag: 10.0.40
+    newTag: 10.0.55

--- a/argocd/applications/nack/kustomization.yaml
+++ b/argocd/applications/nack/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: nack
 helmCharts:
   - name: nack
     repo: https://nats-io.github.io/k8s/helm/charts
-    version: 0.33.2
+    version: 0.34.0
     releaseName: nack
     namespace: nack
     includeCRDs: true
@@ -13,4 +13,4 @@ helmCharts:
 images:
   - name: natsio/jetstream-controller
     newName: mirror.gcr.io/natsio/jetstream-controller
-    newTag: 0.22.2
+    newTag: 0.23.0

--- a/argocd/applications/nats/kustomization.yaml
+++ b/argocd/applications/nats/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 helmCharts:
   - name: nats
     repo: https://nats-io.github.io/k8s/helm/charts
-    version: 2.12.6
+    version: 2.14.2
     releaseName: nats
     namespace: nats
     valuesFile: ./values.yaml
@@ -20,7 +20,7 @@ helmCharts:
 images:
   - name: nats
     newName: mirror.gcr.io/library/nats
-    newTag: 2.12.6-alpine
+    newTag: 2.14.2-alpine
   - name: natsio/nats-server-config-reloader
     newName: mirror.gcr.io/natsio/nats-server-config-reloader
     newTag: 0.21.1

--- a/argocd/applications/nvidia-gpu-operator/kustomization.yaml
+++ b/argocd/applications/nvidia-gpu-operator/kustomization.yaml
@@ -9,13 +9,49 @@ resources:
 helmCharts:
   - name: gpu-operator
     repo: https://nvidia.github.io/gpu-operator
-    version: v26.3.1
+    version: v26.3.3
     releaseName: gpu-operator
     namespace: gpu-operator
     includeCRDs: true
     valuesFile: values.yaml
 
 patches:
+  - target:
+      kind: ServiceAccount
+      name: gpu-operator-node-feature-discovery-prune
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: gpu-operator-node-feature-discovery-prune
+  - target:
+      kind: ClusterRole
+      name: gpu-operator-node-feature-discovery-prune
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: gpu-operator-node-feature-discovery-prune
+  - target:
+      kind: ClusterRoleBinding
+      name: gpu-operator-node-feature-discovery-prune
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: gpu-operator-node-feature-discovery-prune
+  - target:
+      kind: Job
+      name: gpu-operator-node-feature-discovery-prune
+    patch: |-
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: gpu-operator-node-feature-discovery-prune
   - target:
       kind: Job
       name: gpu-operator-upgrade-crd
@@ -24,17 +60,6 @@ patches:
       kind: Job
       metadata:
         name: gpu-operator-upgrade-crd
-        namespace: gpu-operator
-        annotations:
-          argocd.argoproj.io/sync-options: Replace=true
-  - target:
-      kind: Job
-      name: gpu-operator-node-feature-discovery-prune
-    patch: |-
-      apiVersion: batch/v1
-      kind: Job
-      metadata:
-        name: gpu-operator-node-feature-discovery-prune
         namespace: gpu-operator
         annotations:
           argocd.argoproj.io/sync-options: Replace=true

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -17,7 +17,7 @@ resources:
 helmCharts:
   - name: mimir-distributed
     repo: https://grafana.github.io/helm-charts
-    version: 6.0.6
+    version: 6.1.0
     releaseName: observability-mimir
     namespace: observability
     includeCRDs: true
@@ -122,6 +122,15 @@ patches:
         name: observability-loki-loki-distributed-querier
         annotations:
           argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: Job
+      name: observability-mimir-smoke-test
+    patch: |-
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: observability-mimir-smoke-test
   - target:
       kind: StatefulSet
       name: observability-mimir-alertmanager

--- a/argocd/applications/pgadmin/kustomization.yaml
+++ b/argocd/applications/pgadmin/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 helmCharts:
   - name: pgadmin4
     repo: https://helm.runix.net
-    version: 1.62.0
+    version: 1.65.0
     releaseName: pgadmin
     namespace: pgadmin
     valuesFile: values.yaml

--- a/argocd/applications/pgadmin/values.yaml
+++ b/argocd/applications/pgadmin/values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: pgadmin
 
 image:
-  tag: "9.12"
+  tag: "9.16"
 
 service:
   type: ClusterIP

--- a/argocd/applications/redis-operator/README.md
+++ b/argocd/applications/redis-operator/README.md
@@ -1,7 +1,7 @@
 # Redis Operator
 
 - Managed via the platform `ApplicationSet` (`argocd/applicationsets/platform.yaml`) which generates the Argo CD `Application` for this path.
-- This directory now exposes a `kustomization.yaml` that renders the [OT-Container-Kit Redis Operator](https://github.com/OT-CONTAINER-KIT/redis-operator) Helm chart (v0.24.0) via the Kustomize `helmCharts` plugin.
+- This directory now exposes a `kustomization.yaml` that renders the [OT-Container-Kit Redis Operator](https://github.com/OT-CONTAINER-KIT/redis-operator) Helm chart (v0.25.0) via the Kustomize `helmCharts` plugin.
 - Do **not** add nested `Application` manifests here; let the `ApplicationSet` continue owning the Argo CD `Application` resource.
 - Controller namespace: `redis-operator` (auto-created by Argo CD sync).
 

--- a/argocd/applications/redis-operator/kustomization.yaml
+++ b/argocd/applications/redis-operator/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: redis-operator
 helmCharts:
   - name: redis-operator
     repo: https://ot-container-kit.github.io/helm-charts
-    version: 0.24.0
+    version: 0.25.0
     releaseName: redis-operator
     namespace: redis-operator
     includeCRDs: true

--- a/argocd/applications/sealed-secrets/kustomization.yaml
+++ b/argocd/applications/sealed-secrets/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 helmCharts:
   - name: sealed-secrets
     repo: https://bitnami.github.io/sealed-secrets
-    version: 2.18.5
+    version: 2.19.0
     releaseName: sealed-secrets
     namespace: sealed-secrets
     includeCRDs: true
@@ -34,7 +34,7 @@ helmCharts:
 images:
   - name: docker.io/bitnami/sealed-secrets-controller
     newName: mirror.gcr.io/bitnami/sealed-secrets-controller
-    newTag: 0.36.6
+    newTag: 0.38.1
   - name: ghcr.io/bakito/sealed-secrets-web
     newName: ghcr.io/bakito/sealed-secrets-web
     newTag: v3.1.9

--- a/argocd/applications/tailscale/kustomization.yaml
+++ b/argocd/applications/tailscale/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: tailscale-operator
     repo: https://pkgs.tailscale.com/helmcharts
-    version: 1.96.5
+    version: 1.98.4
     releaseName: tailscale-operator
     namespace: tailscale
     valuesFile: values.yaml

--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -55,7 +55,7 @@ helmCharts:
         storageClassName: rook-ceph-block
   - name: temporal
     repo: https://go.temporal.io/helm-charts
-    version: 1.2.0
+    version: 1.5.0
     releaseName: temporal
     namespace: temporal
     includeCRDs: true
@@ -105,3 +105,6 @@ helmCharts:
       admintools:
         image:
           repository: mirror.gcr.io/temporalio/admin-tools
+      shims:
+        dockerize: false
+        elasticsearchTool: false

--- a/argocd/applications/traefik/kustomization.yaml
+++ b/argocd/applications/traefik/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 helmCharts:
   - name: traefik
     repo: https://traefik.github.io/charts
-    version: 39.0.9
+    version: 41.0.1
     releaseName: traefik
     namespace: traefik
     includeCRDs: true
@@ -16,4 +16,4 @@ helmCharts:
 images:
   - name: docker.io/traefik
     newName: mirror.gcr.io/library/traefik
-    newTag: v3.6.15
+    newTag: v3.7.5


### PR DESCRIPTION
## Summary

- Upgrades every root-enabled rendered Helm chart target in the requested set, excluding `rook-ceph` and `rook-ceph-cluster`.
- Carries the release-note-required follow-ups for Istio, Open WebUI, Flink, Temporal shims, and mirrored image tags.
- Drops GitOps-incompatible rendered Helm hook resources for the NVIDIA NFD prune job and Mimir smoke test job so server-side Argo apply remains clean.
- Leaves Rook/Ceph charts, Ceph cluster values, storage classes, object buckets, PVCs, and storage runbooks untouched.

## Related Issues

None

## Testing

- `bun packages/scripts/src/shared/enabled-apps.ts --json >/tmp/enabled-apps.json`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/{argo-rollouts,argo-workflows,cert-manager,clickhouse-operator,cloudnative-pg,external-secrets,feature-flags,forgejo,headlamp,istio-ingress,istio-system,jangar,kubernetes-reflector,nack,nats,nvidia-gpu-operator,observability,pgadmin,redis-operator,sealed-secrets,tailscale,temporal,traefik} >/tmp/enabled-chart-renders/app-name.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flink/base/operator >/tmp/enabled-chart-renders/flink.yaml`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/enabled-chart-renders/app-name.yaml` for every touched rendered app against Kubernetes server `v1.35.0`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f argocd/applications/arc/application.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None for repository consumers. Release-note handling included in this PR: Istio local gateway proxy image is bumped to `1.30.2`; Temporal disables the 1.29 shim defaults while preserving the existing persistence shape; Open WebUI image tag is bumped to `v0.10.2`; Flink uses the `flink-kubernetes-operator-1.15.0` repo URL.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
