### PR TITLE
fix(argocd): drop clickhouse chart hook resources

### DIFF
--- a/argocd/applications/clickhouse-operator/kustomization.yaml
+++ b/argocd/applications/clickhouse-operator/kustomization.yaml
@@ -9,5 +9,61 @@ helmCharts:
     namespace: clickhouse-operator
     includeCRDs: true
     valuesFile: ./values.yaml
+# CRDs are rendered directly; drop the Helm hook installer so Argo does not wait on non-Job hooks.
+patches:
+  - target:
+      kind: ServiceAccount
+      name: clickhouse-operator-altinity-clickhouse-operator-crd-install
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: clickhouse-operator-altinity-clickhouse-operator-crd-install
+  - target:
+      kind: ClusterRole
+      name: clickhouse-operator-altinity-clickhouse-operator-crd-install
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: clickhouse-operator-altinity-clickhouse-operator-crd-install
+  - target:
+      kind: ClusterRoleBinding
+      name: clickhouse-operator-altinity-clickhouse-operator-crd-install
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: clickhouse-operator-altinity-clickhouse-operator-crd-install
+  - target:
+      kind: ConfigMap
+      name: clickhouse-operator-altinity-clickhouse-operator-crds-1
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: clickhouse-operator-altinity-clickhouse-operator-crds-1
+  - target:
+      kind: ConfigMap
+      name: clickhouse-operator-altinity-clickhouse-operator-crds-2
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: clickhouse-operator-altinity-clickhouse-operator-crds-2
+  - target:
+      kind: Job
+      name: clickhouse-operator-altinity-clickhouse-operator-crd-install
+    patch: |-
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: clickhouse-operator-altinity-clickhouse-operator-crd-install
 commonAnnotations:
   argocd.argoproj.io/sync-options: ServerSideApply=true


### PR DESCRIPTION
## Summary

- Deletes the ClickHouse chart's rendered `crd-install` hook resources from the Kustomize output.
- Keeps the real ClickHouse CRDs rendered directly through `includeCRDs: true`.
- Unblocks Argo CD sync, which was waiting on non-Job Helm hook resources after the chart upgrade.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/clickhouse-operator >/tmp/enabled-chart-renders/clickhouse-operator.yaml`
- `rg -n "clickhouse-operator-altinity-clickhouse-operator-crd-install|clickhouse-operator-altinity-clickhouse-operator-crds-[12]|helm.sh/hook" /tmp/enabled-chart-renders/clickhouse-operator.yaml` returned no matches
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/enabled-chart-renders/clickhouse-operator.yaml`
- `bun packages/scripts/src/shared/enabled-apps.ts --json >/tmp/enabled-apps-followup.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This removes only redundant Helm hook installer resources; the CRDs remain part of the rendered chart output.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
