### PR TITLE
perf(flamingo): tune qwen36 serving benchmarks

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -6,7 +6,7 @@ agents. It is a normal Kubernetes Deployment, not a KubeVirt VM.
 ## Production Target
 
 - Node: `turin`
-- GPU: `NVIDIA RTX PRO 6000 Blackwell Max-Q`, advertised as `nvidia.com/gpu: 1`
+- GPU: one physical `NVIDIA RTX PRO 6000 Blackwell Max-Q`; the device plugin may expose time-sliced `nvidia.com/gpu` replicas.
 - RuntimeClass: `nvidia`
 - Server: `vllm/vllm-openai:v0.23.0-x86_64-cu129`
 - Image digest: `sha256:871762282db5bc464b5a3f0a59e41207ef25c2d95edf5f701e57a6bfc27b9496`
@@ -26,11 +26,17 @@ model as an active fallback in GitOps, Pi, AnyPi, or OpenWebUI config.
 --trust-remote-code
 --dtype bfloat16
 --max-model-len 262144
---gpu-memory-utilization 0.95
+--gpu-memory-utilization 0.85
 --kv-cache-dtype fp8
 --safetensors-load-strategy eager
 --max-num-seqs 16
 --max-num-batched-tokens 16384
+--max-num-partial-prefills 2
+--max-long-partial-prefills 1
+--long-prefill-token-threshold 8192
+--enable-dbo
+--dbo-decode-token-threshold 32
+--dbo-prefill-token-threshold 512
 --enable-prefix-caching
 --reasoning-parser qwen3
 --enable-auto-tool-choice
@@ -80,8 +86,11 @@ kubectl -n flamingo exec deploy/flamingo -- df -h /models || true
 
 Expected:
 
-- `nvidia.com/gpu` allocatable is `1`.
-- No non-Flamingo workload consumes the GPU.
+- `nvidia.com/gpu` allocatable is non-zero.
+- `flamingo` and the approved Plex transcode workload are the only expected
+  Blackwell GPU consumers before tuning.
+- `saigak` is not consuming a Turin/Blackwell GPU slot; it must remain the
+  separate embeddings path.
 - The model-cache PVC has enough free space for the Qwen3.6 NVFP4 artifact.
 
 Render before sync:
@@ -200,8 +209,9 @@ turns with `preserve_thinking=true`.
 ## Optimization Matrix
 
 Record each run with the vLLM image digest, model revision, flags, concurrency,
-prompt/output token counts, TTFT, output tokens per second, peak GPU memory, GPU
-power draw, temperature, preemption count, and any OOM or parser failure.
+prompt/output token counts, TTFT, TPOT, output tokens per second, KV-cache usage,
+prefix-cache hits, request wait/running gauges, GPU memory, GPU power draw,
+temperature, and any OOM, parser, HTTP, or preemption failure.
 
 Use the repo runner so output is comparable:
 
@@ -213,11 +223,36 @@ bun run flamingo:benchmark --profile=full --long-targets=180000,220000,229000
 | Profile | Context | `gpu_memory_utilization` | `max_num_seqs` | `max_num_batched_tokens` | Notes |
 | --- | ---: | ---: | ---: | ---: | --- |
 | `baseline-131k` | `131072` | `0.94` | `128` | `16384` | Pre-optimization baseline only |
-| `context-262k-fp8-eager` | `262144` | `0.95` | `16` | `16384` | Promoted production profile |
-| `context-262k-lowseq` | `262144` | `0.95` | `8` | `8192` | Startup fallback if the initial candidate OOMs |
-| `kv-262k-auto` | `262144` | `0.95` | `16` | `16384` | Compare only after FP8 smokes pass |
-| `batch-262k-32k` | `262144` | `0.95` | `16` | `32768` | Promote only if TTFT and preemption stay acceptable |
-| `mem-262k-097` | `262144` | `0.97` | `16` | `16384` | Promote only if no OOM or sustained preemption |
+| `context-262k-fp8-eager` | `262144` | `0.85` | `16` | `16384` | Current production baseline |
+| `prefill-dbo-262k` | `262144` | `0.85` | `16` | `16384` | Explicit partial-prefill + DBO profile |
+| `batch-262k-24k` | `262144` | `0.88` | `24` | `24576` | Test only after Saigak leaves Turin |
+| `batch-262k-32k` | `262144` | `0.90` | `32` | `32768` | Promote only if TTFT, KV usage, and Plex remain acceptable |
+| `mtp-262k-n1..4` | `262144` | `0.85` | `16` | `16384` | One MTP value per rollout; compare real acceptance length |
+
+The default `full` benchmark profile now covers the InferenceX-inspired
+serving shapes:
+
+- warmups at concurrency `1/2/4/8/16` plus a long-prefill warmup;
+- scheduler profile `4K` input / `512` output;
+- scheduler profile `32K` input / `4K` output;
+- scheduler profile `128K` input / `512` output;
+- long-context recall at `180K`, `220K`, and `229K` when the default full
+  target set is used.
+
+### InferenceX Methodology Adaptation
+
+InferenceX Qwen3.5 work is not copied flag-for-flag because it benchmarks a
+different model scale and hardware topology. The reusable parts are:
+
+- Qwen-specific reasoning and tool parsers stay active during every benchmark.
+- Thinking mode is controlled through Qwen chat-template kwargs, not generic
+  prose prompts.
+- Throughput is judged on coding-agent-like prompt/output shapes, not only tiny
+  random-token requests.
+- Speculative decoding is measured by accepted-token and draft counters:
+  `AL = 1 + accepted_draft_tokens / verification_drafts`.
+- Synthetic acceptance is benchmark-only and must not be used as a production
+  quality shortcut.
 
 ### Recorded Production Run
 
@@ -271,12 +306,23 @@ Short coding-loop smoke benchmark:
 | Mean TPOT | `6.38 ms` |
 | Failed requests | `0` |
 
-MTP candidate flags:
+MTP candidate flags, tested one value at a time:
 
 ```text
---moe-backend marlin
---speculative-config {"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}
+--speculative-config {"method":"mtp","num_speculative_tokens":1}
+--speculative-config {"method":"mtp","num_speculative_tokens":2}
+--speculative-config {"method":"mtp","num_speculative_tokens":3}
+--speculative-config {"method":"mtp","num_speculative_tokens":4}
 ```
+
+Promote MTP only when all of these hold in the benchmark artifact:
+
+- exact no-thinking, medium thinking, structured tool call, prefix-cache repeat,
+  and long-context recall pass;
+- `speculativeDecode.metricDelta.speculativeAcceptanceLength` is present;
+- output throughput improves by at least `15%` against the same non-MTP profile;
+- p99 TTFT regresses by no more than `10%`;
+- a real AnyPi-style repo task still completes with a code/test diff.
 
 KV-cache candidates must be checked against the pinned vLLM image before use:
 

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -56,10 +56,23 @@ spec:
             - "0.85"
             - --kv-cache-dtype
             - fp8
+            - --safetensors-load-strategy
+            - eager
             - --max-num-seqs
             - "16"
             - --max-num-batched-tokens
             - "16384"
+            - --max-num-partial-prefills
+            - "2"
+            - --max-long-partial-prefills
+            - "1"
+            - --long-prefill-token-threshold
+            - "8192"
+            - --enable-dbo
+            - --dbo-decode-token-threshold
+            - "32"
+            - --dbo-prefill-token-threshold
+            - "512"
             - --enable-prefix-caching
             - --reasoning-parser
             - qwen3

--- a/scripts/jangar/benchmark-flamingo-vllm.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.ts
@@ -26,6 +26,66 @@ type BenchmarkRun = {
   command: string[]
   result: CommandResult
   resultJson?: unknown
+  resultSummary?: BenchmarkResultSummary
+}
+
+type BenchmarkResultSummary = {
+  completed?: number
+  failed?: number
+  totalInputTokens?: number
+  totalOutputTokens?: number
+  requestThroughput?: number
+  outputThroughput?: number
+  totalTokenThroughput?: number
+  meanTtftMs?: number
+  medianTtftMs?: number
+  p99TtftMs?: number
+  meanTpotMs?: number
+  medianTpotMs?: number
+  p99TpotMs?: number
+}
+
+type MetricSnapshot = {
+  capturedAt: string
+  promptTokens: number
+  generationTokens: number
+  prefixCacheQueries: number
+  prefixCacheHits: number
+  promptTokensCached: number
+  requestSuccess: number
+  requestErrors: number
+  requestAborts: number
+  kvCacheUsagePerc: number
+  numRequestsRunning: number
+  numRequestsWaiting: number
+  specAcceptedTokens: number
+  specDrafts: number
+}
+
+type MetricDelta = {
+  elapsedMs: number
+  promptTokens: number
+  generationTokens: number
+  promptTokensPerSecond: number
+  generationTokensPerSecond: number
+  prefixCacheQueries: number
+  prefixCacheHits: number
+  prefixCacheHitRate?: number
+  promptTokensCached: number
+  requestSuccess: number
+  requestErrors: number
+  requestAborts: number
+  peakKvCacheUsagePerc: number
+  specAcceptedTokens: number
+  specDrafts: number
+  speculativeAcceptanceLength?: number
+}
+
+type SpeculativeDecodeSummary = {
+  requestedCandidates: number[]
+  deployedConfig?: unknown
+  metricDelta: Pick<MetricDelta, 'specAcceptedTokens' | 'specDrafts' | 'speculativeAcceptanceLength'>
+  note: string
 }
 
 type RunSummary = {
@@ -45,11 +105,19 @@ type RunSummary = {
   deploymentArgs?: string[]
   models?: unknown
   metricsBefore?: string
+  metricsAfterWarmup?: string
   metricsAfter?: string
+  metricsBeforeSummary?: MetricSnapshot
+  metricsAfterWarmupSummary?: MetricSnapshot
+  metricsAfterSummary?: MetricSnapshot
+  warmupMetricDelta?: MetricDelta
+  measuredMetricDelta?: MetricDelta
   nvidiaSmiBefore?: string
   nvidiaSmiAfter?: string
+  warmups: BenchmarkRun[]
   smokes: ChatResult[]
   benchmarks: BenchmarkRun[]
+  speculativeDecode?: SpeculativeDecodeSummary
   notes: string[]
 }
 
@@ -80,11 +148,16 @@ const serverUrl = (args.get('server-url') ?? process.env.FLAMINGO_SERVER_URL ?? 
 const resultDir = resolve(args.get('result-dir') ?? process.env.FLAMINGO_BENCH_RESULT_DIR ?? '/tmp/flamingo-vllm-bench')
 const timeoutMs = Number.parseInt(args.get('timeout-ms') ?? process.env.FLAMINGO_BENCH_TIMEOUT_MS ?? '1800000', 10)
 const benchmarkResultMarker = '__FLAMINGO_BENCH_RESULT_JSON__'
+const enableWarmup = (args.get('warmup') ?? process.env.FLAMINGO_BENCH_WARMUP ?? 'true') !== 'false'
 const contextTargets = (
   args.get('long-targets') ??
   process.env.FLAMINGO_LONG_TARGETS ??
-  (profile === 'full' ? '220000' : '')
+  (profile === 'full' ? '180000,220000,229000' : '')
 )
+  .split(',')
+  .map((value) => Number.parseInt(value.trim(), 10))
+  .filter((value) => Number.isFinite(value) && value > 0)
+const mtpCandidates = (args.get('mtp-candidates') ?? process.env.FLAMINGO_MTP_CANDIDATES ?? '1,2,3,4')
   .split(',')
   .map((value) => Number.parseInt(value.trim(), 10))
   .filter((value) => Number.isFinite(value) && value > 0)
@@ -143,7 +216,7 @@ async function fetchJson(path: string, init?: RequestInit): Promise<unknown> {
     headers: {
       'content-type': 'application/json',
       authorization: `Bearer ${process.env.FLAMINGO_API_KEY ?? 'flamingo-local'}`,
-      ...(init?.headers ?? {}),
+      ...init?.headers,
     },
     signal: AbortSignal.timeout(timeoutMs),
   })
@@ -169,6 +242,150 @@ async function fetchText(path: string): Promise<string> {
   }
 
   return await response.text()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function firstNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function numberField(record: Record<string, unknown>, fields: string[]): number | undefined {
+  for (const field of fields) {
+    const value = firstNumber(record[field])
+    if (value !== undefined) return value
+  }
+  return undefined
+}
+
+function parseMetric(text: string, metricName: string, requiredLabel?: string): number {
+  let total = 0
+  let found = false
+
+  for (const line of text.split('\n')) {
+    if (line.startsWith('#')) continue
+    if (!line.startsWith(`${metricName}{`) && !line.startsWith(`${metricName} `)) continue
+    if (requiredLabel && !line.includes(requiredLabel)) continue
+
+    const value = Number.parseFloat(line.trim().split(/\s+/).at(-1) ?? '')
+    if (!Number.isFinite(value)) continue
+    total += value
+    found = true
+  }
+
+  return found ? total : 0
+}
+
+function buildMetricSnapshot(text: string): MetricSnapshot {
+  return {
+    capturedAt: new Date().toISOString(),
+    promptTokens: parseMetric(text, 'vllm:prompt_tokens_total'),
+    generationTokens: parseMetric(text, 'vllm:generation_tokens_total'),
+    prefixCacheQueries: parseMetric(text, 'vllm:prefix_cache_queries_total'),
+    prefixCacheHits: parseMetric(text, 'vllm:prefix_cache_hits_total'),
+    promptTokensCached: parseMetric(text, 'vllm:prompt_tokens_cached_total'),
+    requestSuccess: parseMetric(text, 'vllm:request_success_total'),
+    requestErrors: parseMetric(text, 'vllm:request_success_total', 'finished_reason="error"'),
+    requestAborts: parseMetric(text, 'vllm:request_success_total', 'finished_reason="abort"'),
+    kvCacheUsagePerc: parseMetric(text, 'vllm:kv_cache_usage_perc'),
+    numRequestsRunning: parseMetric(text, 'vllm:num_requests_running'),
+    numRequestsWaiting: parseMetric(text, 'vllm:num_requests_waiting'),
+    specAcceptedTokens: parseMetric(text, 'vllm:spec_decode_num_accepted_tokens_total'),
+    specDrafts: parseMetric(text, 'vllm:spec_decode_num_drafts_total'),
+  }
+}
+
+function diffMetricSnapshots(before: MetricSnapshot, after: MetricSnapshot): MetricDelta {
+  const elapsedMs = Math.max(1, Date.parse(after.capturedAt) - Date.parse(before.capturedAt))
+  const elapsedSeconds = elapsedMs / 1000
+  const promptTokens = after.promptTokens - before.promptTokens
+  const generationTokens = after.generationTokens - before.generationTokens
+  const prefixCacheQueries = after.prefixCacheQueries - before.prefixCacheQueries
+  const prefixCacheHits = after.prefixCacheHits - before.prefixCacheHits
+  const specDrafts = after.specDrafts - before.specDrafts
+  const specAcceptedTokens = after.specAcceptedTokens - before.specAcceptedTokens
+
+  return {
+    elapsedMs,
+    promptTokens,
+    generationTokens,
+    promptTokensPerSecond: promptTokens / elapsedSeconds,
+    generationTokensPerSecond: generationTokens / elapsedSeconds,
+    prefixCacheQueries,
+    prefixCacheHits,
+    prefixCacheHitRate: prefixCacheQueries > 0 ? prefixCacheHits / prefixCacheQueries : undefined,
+    promptTokensCached: after.promptTokensCached - before.promptTokensCached,
+    requestSuccess: after.requestSuccess - before.requestSuccess,
+    requestErrors: after.requestErrors - before.requestErrors,
+    requestAborts: after.requestAborts - before.requestAborts,
+    peakKvCacheUsagePerc: Math.max(before.kvCacheUsagePerc, after.kvCacheUsagePerc),
+    specAcceptedTokens,
+    specDrafts,
+    speculativeAcceptanceLength: specDrafts > 0 ? 1 + specAcceptedTokens / specDrafts : undefined,
+  }
+}
+
+function summarizeBenchmarkResult(resultJson: unknown): BenchmarkResultSummary | undefined {
+  if (!isRecord(resultJson)) return undefined
+
+  return {
+    completed: numberField(resultJson, ['completed']),
+    failed: numberField(resultJson, ['failed']),
+    totalInputTokens: numberField(resultJson, ['total_input_tokens', 'totalInputTokens']),
+    totalOutputTokens: numberField(resultJson, ['total_output_tokens', 'totalOutputTokens']),
+    requestThroughput: numberField(resultJson, ['request_throughput', 'requestThroughput']),
+    outputThroughput: numberField(resultJson, ['output_throughput', 'outputThroughput']),
+    totalTokenThroughput: numberField(resultJson, ['total_token_throughput', 'totalTokenThroughput']),
+    meanTtftMs: numberField(resultJson, ['mean_ttft_ms', 'meanTtftMs']),
+    medianTtftMs: numberField(resultJson, ['median_ttft_ms', 'medianTtftMs']),
+    p99TtftMs: numberField(resultJson, ['p99_ttft_ms', 'p99TtftMs']),
+    meanTpotMs: numberField(resultJson, ['mean_tpot_ms', 'meanTpotMs']),
+    medianTpotMs: numberField(resultJson, ['median_tpot_ms', 'medianTpotMs']),
+    p99TpotMs: numberField(resultJson, ['p99_tpot_ms', 'p99TpotMs']),
+  }
+}
+
+function readFlagValue(argv: string[], flag: string): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === flag) return argv[i + 1]
+    if (argv[i].startsWith(`${flag}=`)) return argv[i].slice(flag.length + 1)
+  }
+  return undefined
+}
+
+function parseJsonFlag(argv: string[], flag: string): unknown {
+  const value = readFlagValue(argv, flag)
+  if (!value) return undefined
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+function buildSpeculativeDecodeSummary(
+  deploymentArgs: string[],
+  measuredMetricDelta: MetricDelta,
+): SpeculativeDecodeSummary {
+  const deployedConfig = parseJsonFlag(deploymentArgs, '--speculative-config')
+  const metricDelta = {
+    specAcceptedTokens: measuredMetricDelta.specAcceptedTokens,
+    specDrafts: measuredMetricDelta.specDrafts,
+    speculativeAcceptanceLength: measuredMetricDelta.speculativeAcceptanceLength,
+  }
+  const note =
+    deployedConfig === undefined
+      ? 'No deployed --speculative-config detected; run one MTP candidate at a time and compare this acceptance-length readback.'
+      : 'Measured real vLLM speculative accepted-token and draft counters for the deployed speculative configuration.'
+
+  return {
+    requestedCandidates: mtpCandidates,
+    deployedConfig,
+    metricDelta,
+    note,
+  }
 }
 
 async function chatSmoke(label: string, payload: unknown): Promise<ChatResult> {
@@ -257,7 +474,7 @@ async function runBench(label: string, inputLen: number, outputLen: number, numP
     resultJson = undefined
   }
 
-  return { label, command, result, resultJson }
+  return { label, command, result, resultJson, resultSummary: summarizeBenchmarkResult(resultJson) }
 }
 
 async function main(): Promise<void> {
@@ -276,6 +493,7 @@ async function main(): Promise<void> {
     baseUrl,
     serverUrl,
     kubernetes: { context: kubeContext, namespace, deployment },
+    warmups: [],
     smokes: [],
     benchmarks: [],
     notes: [],
@@ -293,7 +511,34 @@ async function main(): Promise<void> {
 
   summary.models = await fetchJson('/models')
   summary.metricsBefore = await fetchText('/metrics')
+  const metricsBeforeSummary = buildMetricSnapshot(summary.metricsBefore)
+  summary.metricsBeforeSummary = metricsBeforeSummary
   summary.nvidiaSmiBefore = (await run(kubectl(['exec', `deploy/${deployment}`, '--', 'nvidia-smi']), 120000)).stdout
+
+  if (enableWarmup) {
+    const warmupProfiles =
+      profile === 'full'
+        ? [
+            ['warmup-c1', 1024, 16, 1, 1] as const,
+            ['warmup-c2', 2048, 16, 2, 2] as const,
+            ['warmup-c4', 4096, 16, 4, 4] as const,
+            ['warmup-c8', 4096, 16, 8, 8] as const,
+            ['warmup-c16', 4096, 16, 16, 16] as const,
+            ['warmup-long-prefill', 32768, 16, 2, 2] as const,
+          ]
+        : [['warmup-c1', 1024, 16, 1, 1] as const, ['warmup-c2', 2048, 16, 2, 2] as const]
+
+    for (const [label, inputLen, outputLen, numPrompts, concurrency] of warmupProfiles) {
+      summary.warmups.push(await runBench(label, inputLen, outputLen, numPrompts, concurrency))
+    }
+  } else {
+    summary.notes.push('warmup disabled by --warmup=false or FLAMINGO_BENCH_WARMUP=false')
+  }
+
+  summary.metricsAfterWarmup = await fetchText('/metrics')
+  const metricsAfterWarmupSummary = buildMetricSnapshot(summary.metricsAfterWarmup)
+  summary.metricsAfterWarmupSummary = metricsAfterWarmupSummary
+  summary.warmupMetricDelta = diffMetricSnapshots(metricsBeforeSummary, metricsAfterWarmupSummary)
 
   summary.smokes.push(
     await chatSmoke('exact-no-thinking', {
@@ -359,7 +604,11 @@ async function main(): Promise<void> {
 
   const benchProfiles =
     profile === 'full'
-      ? [['short-coding-loop', 4096, 512, 16, 4] as const, ['agent-edit-loop', 32768, 4096, 8, 2] as const]
+      ? [
+          ['scheduler-4k512', 4096, 512, 16, 4] as const,
+          ['scheduler-32k4k', 32768, 4096, 8, 2] as const,
+          ['scheduler-128k512', 131072, 512, 4, 2] as const,
+        ]
       : [['short-coding-loop-smoke', 4096, 512, 4, 2] as const]
 
   for (const [label, inputLen, outputLen, numPrompts, concurrency] of benchProfiles) {
@@ -389,6 +638,10 @@ async function main(): Promise<void> {
   }
 
   summary.metricsAfter = await fetchText('/metrics')
+  const metricsAfterSummary = buildMetricSnapshot(summary.metricsAfter)
+  summary.metricsAfterSummary = metricsAfterSummary
+  summary.measuredMetricDelta = diffMetricSnapshots(metricsAfterWarmupSummary, metricsAfterSummary)
+  summary.speculativeDecode = buildSpeculativeDecodeSummary(summary.deploymentArgs, summary.measuredMetricDelta)
   summary.nvidiaSmiAfter = (await run(kubectl(['exec', `deploy/${deployment}`, '--', 'nvidia-smi']), 120000)).stdout
   summary.finishedAt = new Date().toISOString()
 
@@ -396,12 +649,20 @@ async function main(): Promise<void> {
   await writeFile(outputPath, `${JSON.stringify(summary, null, 2)}\n`)
 
   const failedSmokes = summary.smokes.filter((smoke) => !smoke.ok)
+  const failedWarmups = summary.warmups.filter((warmup) => warmup.result.code !== 0)
   const failedBenchmarks = summary.benchmarks.filter((benchmark) => benchmark.result.code !== 0)
   console.log(
-    JSON.stringify({ outputPath, failedSmokes: failedSmokes.length, failedBenchmarks: failedBenchmarks.length }),
+    JSON.stringify({
+      outputPath,
+      failedSmokes: failedSmokes.length,
+      failedWarmups: failedWarmups.length,
+      failedBenchmarks: failedBenchmarks.length,
+      measuredMetricDelta: summary.measuredMetricDelta,
+      speculativeDecode: summary.speculativeDecode,
+    }),
   )
 
-  if (failedSmokes.length > 0 || failedBenchmarks.length > 0) {
+  if (failedSmokes.length > 0 || failedWarmups.length > 0 || failedBenchmarks.length > 0) {
     process.exitCode = 1
   }
 }

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -11,6 +11,13 @@ export const requiredTerms = [
   'fp8',
   'safetensors-load-strategy',
   'eager',
+  'max-num-partial-prefills',
+  'max-long-partial-prefills',
+  'long-prefill-token-threshold',
+  'enable-dbo',
+  'dbo-decode-token-threshold',
+  'dbo-prefill-token-threshold',
+  'speculativeAcceptanceLength',
 ]
 
 export const forbiddenTerms = [


### PR DESCRIPTION
## Summary

- Adds safe vLLM scheduler tuning for `qwen36-flamingo`: eager safetensors loading, explicit partial-prefill bounds, and dual batch overlap thresholds while preserving the current Qwen3.6 NVFP4 model and memory baseline.
- Extends `scripts/jangar/benchmark-flamingo-vllm.ts` with warmups, InferenceX-style scheduler profiles, metrics snapshots/deltas, prefix-cache/request-error counters, and real MTP accepted-token/draft readback.
- Updates the Flamingo runbook with Saigak/Plex GPU guardrails, full-profile benchmark shapes, InferenceX methodology adaptation, and MTP promotion gates.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo >/tmp/flamingo-render.yaml && rg -n -- '--enable-dbo|--max-num-partial-prefills|--safetensors-load-strategy|qwen36-flamingo' /tmp/flamingo-render.yaml`
- `kustomize build argocd/applications/flamingo >/tmp/flamingo-render-nohelm.yaml && rg -n -- '--enable-dbo|--max-num-partial-prefills|--safetensors-load-strategy|qwen36-flamingo' /tmp/flamingo-render-nohelm.yaml`
- `bunx oxfmt --check argocd/applications/flamingo/README.md argocd/applications/flamingo/deployment.yaml scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/validate-flamingo-hard-migration.ts`
- `bunx oxlint --config .oxlintrc.json scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/validate-flamingo-hard-migration.ts`
- `bunx tsc --ignoreConfig --noEmit --target ES2023 --module ESNext --moduleResolution Bundler --types bun --skipLibCheck scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/validate-flamingo-hard-migration.ts`
- `bun run lint:flamingo-hard-migration && bun test scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `bun run lint:argocd`
- `bun run flamingo:benchmark --profile=smoke --result-dir=/tmp/flamingo-vllm-bench-pr`
  - Output: `/tmp/flamingo-vllm-bench-pr/flamingo-smoke-2026-07-03T07-08-48-428Z.json`
  - Result: `failedSmokes=0`, `failedWarmups=0`, `failedBenchmarks=0`, `requestErrors=0`
  - `/v1/models` reported `qwen36-flamingo`, root `unsloth/Qwen3.6-35B-A3B-NVFP4`, `max_model_len=262144`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
