### PR TITLE
fix(argocd): unblock chart upgrade rollouts

### DIFF
--- a/argocd/applications/feature-flags/flipt-values.yaml
+++ b/argocd/applications/feature-flags/flipt-values.yaml
@@ -2,6 +2,9 @@ fullnameOverride: feature-flags
 
 replicaCount: 1
 
+strategy:
+  type: Recreate
+
 service:
   type: ClusterIP
   httpPort: 8013

--- a/argocd/applications/feature-flags/kustomization.yaml
+++ b/argocd/applications/feature-flags/kustomization.yaml
@@ -28,3 +28,13 @@ patches:
         path: /metadata/annotations/helm.sh~1hook
       - op: remove
         path: /metadata/annotations/helm.sh~1hook-weight
+  - target:
+      kind: Deployment
+      name: feature-flags
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: feature-flags
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true

--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -6,6 +6,28 @@ resources:
   - load-balancer-frontend.yaml
   - ingressroute-temporal-k8s-private.yaml
 
+patches:
+  - target:
+      kind: Secret
+      name: temporal-default-store
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-delete-policy
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight
+  - target:
+      kind: Secret
+      name: temporal-visibility-store
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-delete-policy
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight
+
 helmCharts:
   - name: cassandra
     repo: https://charts.helm.sh/incubator


### PR DESCRIPTION
## Summary

- Set the Feature Flags Flipt Deployment strategy to `Recreate` so the single RWO PVC is released before the upgraded pod starts.
- Annotate the Feature Flags Deployment with `argocd.argoproj.io/sync-options: Replace=true` so Argo CD removes the stale `rollingUpdate` strategy field through GitOps.
- Strip Helm hook annotations from Temporal datastore Secrets so the Temporal schema hook can resolve `temporal-default-store` and `temporal-visibility-store` during sync.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/feature-flags >/tmp/enabled-chart-renders/feature-flags.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/temporal >/tmp/enabled-chart-renders/temporal.yaml`
- `rg -n "type: Recreate|argocd.argoproj.io/sync-options: Replace=true" /tmp/enabled-chart-renders/feature-flags.yaml`
- `rg -n "rollingUpdate" /tmp/enabled-chart-renders/feature-flags.yaml` confirmed no matches.
- Temporal Secret render scan confirmed no remaining `helm.sh/hook` annotations on `temporal-default-store` or `temporal-visibility-store`.
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/enabled-chart-renders/feature-flags-nondeployment.yaml`
- `kubectl replace --dry-run=server -f /tmp/enabled-chart-renders/feature-flags-deployment.yaml`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/enabled-chart-renders/temporal.yaml`
- `bun packages/scripts/src/shared/enabled-apps.ts --json >/tmp/enabled-apps-followup2.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Feature Flags intentionally switches from rolling update to recreate rollout behavior because the app has one replica backed by a `ReadWriteOnce` PVC.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
