### PR TITLE
fix(argocd): run temporal schema job after secrets

### DIFF
--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -27,6 +27,22 @@ patches:
         path: /metadata/annotations/helm.sh~1hook-delete-policy
       - op: remove
         path: /metadata/annotations/helm.sh~1hook-weight
+  - target:
+      kind: Job
+      name: temporal-schema
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-delete-policy
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options
+        value: Force=true,Replace=true
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "1"
 
 helmCharts:
   - name: cassandra


### PR DESCRIPTION
## Summary

- Convert the Temporal `temporal-schema` Job from a Helm hook into a normal Argo-managed Job.
- Run the schema Job in sync wave `1` so the datastore Secrets are applied first.
- Add `Force=true,Replace=true` for the schema Job so Argo CD can replace the stuck hook Job during the rollout.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/temporal >/tmp/enabled-chart-renders/temporal.yaml`
- Temporal datastore Secret and schema Job render scan confirmed no remaining `helm.sh/hook` annotations.
- `rg -n "argocd.argoproj.io/sync-options: Force=true,Replace=true|argocd.argoproj.io/sync-wave: \"1\"" /tmp/enabled-chart-renders/temporal-schema-and-secrets.yaml`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/enabled-chart-renders/temporal-nonschema.yaml`
- `kubectl create --dry-run=server -f /tmp/enabled-chart-renders/temporal-schema-job-validation.yaml`
- `bun packages/scripts/src/shared/enabled-apps.ts --json >/tmp/enabled-apps-temporal-hook.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This preserves Temporal schema execution while making the ordering explicit for Argo CD.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
