### PR TITLE
fix(argocd): order temporal schema sync

### DIFF
--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -17,6 +17,9 @@ patches:
         path: /metadata/annotations/helm.sh~1hook-delete-policy
       - op: remove
         path: /metadata/annotations/helm.sh~1hook-weight
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-2"
   - target:
       kind: Secret
       name: temporal-visibility-store
@@ -27,6 +30,9 @@ patches:
         path: /metadata/annotations/helm.sh~1hook-delete-policy
       - op: remove
         path: /metadata/annotations/helm.sh~1hook-weight
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-2"
   - target:
       kind: Job
       name: temporal-schema
@@ -42,7 +48,7 @@ patches:
         value: Force=true,Replace=true
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1sync-wave
-        value: "1"
+        value: "-1"
 
 helmCharts:
   - name: cassandra


### PR DESCRIPTION
## Summary

- Put Temporal datastore Secrets in sync wave `-2`.
- Run the `temporal-schema` Job in sync wave `-1` so schema setup happens before the Temporal Deployments wait for health.
- Keep the schema Job on `Force=true,Replace=true` so Argo CD can recreate the previously stuck hook Job.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/temporal >/tmp/enabled-chart-renders/temporal.yaml`
- Temporal datastore Secret and schema Job render scan confirmed no remaining `helm.sh/hook` annotations.
- `rg -n "argocd.argoproj.io/sync-wave: \"-2\"|argocd.argoproj.io/sync-wave: \"-1\"|argocd.argoproj.io/sync-options: Force=true,Replace=true" /tmp/enabled-chart-renders/temporal-schema-and-secrets.yaml`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/enabled-chart-renders/temporal-nonschema.yaml`
- `kubectl create --dry-run=server -f /tmp/enabled-chart-renders/temporal-schema-job-validation.yaml`
- `bun packages/scripts/src/shared/enabled-apps.ts --json >/tmp/enabled-apps-temporal-waves.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This only fixes Argo CD sync ordering for Temporal schema setup.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
