### PR TITLE
fix(argocd): manage argo workflows crd installer

### DIFF
--- a/argocd/applications/argo-workflows/kustomization.yaml
+++ b/argocd/applications/argo-workflows/kustomization.yaml
@@ -11,6 +11,66 @@ resources:
   - alloy-rbac.yaml
   - alloy-configmap.yaml
   - alloy-deployment.yaml
+
+patches:
+  - target:
+      kind: ServiceAccount
+      name: argo-workflows-crd-install
+      namespace: argo-workflows
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-delete-policy
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-2"
+  - target:
+      kind: ClusterRole
+      name: argo-workflows-crd-install
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-delete-policy
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-2"
+  - target:
+      kind: ClusterRoleBinding
+      name: argo-workflows-crd-install
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-delete-policy
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-2"
+  - target:
+      kind: Job
+      name: argo-workflows-crd-install
+      namespace: argo-workflows
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-delete-policy
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options
+        value: Force=true,Replace=true
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-1"
+
 helmCharts:
   - name: argo-workflows
     repo: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
## Summary

- Convert the Argo Workflows `argo-workflows-crd-install` helper resources from Helm hooks into Argo-managed resources.
- Put the installer RBAC and service account in sync wave `-2`.
- Run the CRD installer Job in sync wave `-1` with `Force=true,Replace=true` so chart upgrades can recreate it before normal workloads.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argo-workflows >/tmp/enabled-chart-renders/argo-workflows.yaml`
- Argo Workflows CRD installer render scan confirmed no remaining `helm.sh/hook` annotations.
- `rg -n "argocd.argoproj.io/sync-wave: \"-2\"|argocd.argoproj.io/sync-wave: \"-1\"|argocd.argoproj.io/sync-options: Force=true,Replace=true" /tmp/enabled-chart-renders/argo-workflows-crd-install.yaml`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/enabled-chart-renders/argo-workflows-noninstalljob.yaml`
- `kubectl create --dry-run=server -f /tmp/enabled-chart-renders/argo-workflows-crd-install-job-validation.yaml`
- `bun packages/scripts/src/shared/enabled-apps.ts --json >/tmp/enabled-apps-argo-workflows-hook.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Server dry-run emitted existing PodSecurity restricted warnings for the Argo Workflows pods, but validation succeeded.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
