### PR TITLE
fix(torghut): update keeper for operator compatibility

### DIFF
--- a/argocd/applications/torghut/clickhouse/clickhouse-keeper.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-keeper.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
+  taskID: torghut-keeper-reconcile-20260703
   configuration:
     clusters:
       - name: default
@@ -25,7 +26,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: clickhouse-keeper
-              image: registry.ide-newton.ts.net/lab/clickhouse-keeper:24.3.5.46@sha256:23bc68f765052b59a19e56e5e18b2ecb7cfc23a51ef901b59cd78a0f759c200c
+              image: mirror.gcr.io/clickhouse/clickhouse-keeper:25.12.5.44@sha256:525b8b0f93ccb371131c46f22a066ea43d33d74aba314203e8044609945d8524
               resources:
                 requests:
                   cpu: 250m


### PR DESCRIPTION
## Summary

- Updates Torghut ClickHouse Keeper from the pinned `24.3.5.46` image to the same `25.12.5.44` Keeper line already healthy under the upgraded Altinity operator.
- Pins the multi-arch manifest digest and adds a `taskID` bump so the ClickHouse Keeper operator reconciles the StatefulSet.
- Fixes the Argo Degraded root cause: operator `0.27.1` renders `use_xid_64`, which the old `24.3.5.46` Keeper binary rejects at startup.

## Related Issues

None

## Testing

- `crane digest mirror.gcr.io/clickhouse/clickhouse-keeper:25.12.5.44`
- `crane manifest mirror.gcr.io/clickhouse/clickhouse-keeper:25.12.5.44 | jq '.manifests[]? | {platform, digest}'`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-render.yaml && rg -n 'ClickHouseKeeperInstallation|torghut-keeper-reconcile-20260703|clickhouse-keeper:25.12.5.44|525b8b0f' /tmp/torghut-render.yaml`
- `git diff --check`
- `bun run lint:argocd`
- Live root-cause readback:
  - `chk-torghut-keeper-default-0-0-0` is `CrashLoopBackOff`
  - previous Keeper logs show `Code: 115` and `Unknown setting 'use_xid_64': in Coordination settings config`
  - `use_xid_64` is present in operator-generated `ConfigMap/chk-torghut-keeper-common-configd`
  - Posthog Keeper is healthy with the same generated setting on `mirror.gcr.io/clickhouse/clickhouse-keeper:25.12.5.44`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
