### PR TITLE
fix(torghut): restart failed flink deployments

### DIFF
--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
   imagePullPolicy: IfNotPresent
-  restartNonce: 20
+  restartNonce: 21
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
   imagePullPolicy: IfNotPresent
-  restartNonce: 15
+  restartNonce: 16
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:


### PR DESCRIPTION
## Summary

- Bump `restartNonce` on `FlinkDeployment/torghut-ta` from 15 to 16 to redeploy the failed primary TA job after Kafka recovery.
- Bump `restartNonce` on `FlinkDeployment/torghut-ta-sim` from 20 to 21 to redeploy the failed simulation TA job.
- Keep images, topics, checkpoint locations, and runtime config unchanged; this is a focused recovery redeploy.

## Related Issues

None

## Testing

- `mise exec helm -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-flink-restart-render.yaml`
- `rg -n 'name: torghut-ta0name: torghut-ta-sim0restartNonce: (16|21)' /tmp/torghut-flink-restart-render.yaml`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
