### PR TITLE
fix(argocd): clear service drift

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:939870b8e52c6d5c87b1ec59787f20724d6da9aefb05ae30ee89a529da450340
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:356a7e25488a0ddf8f901e77f6db970792c5cfaad15e0915d3a184a6dadf4578
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -73,7 +73,7 @@ spec:
             - name: FROUSSARD_VERSION
               value: v0.571.1-491-ga931fba9e
             - name: FROUSSARD_COMMIT
-              value: 67efb77c315182233a779b0cb6dfe41370f6f5d7
+              value: 653ec53505daab568a5129d8de604502366900fd
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT

--- a/argocd/applications/saigak/statefulset.yaml
+++ b/argocd/applications/saigak/statefulset.yaml
@@ -20,8 +20,8 @@ spec:
     spec:
       runtimeClassName: nvidia
       nodeSelector:
-        kubernetes.io/arch: arm64
-        kubernetes.io/hostname: talos-192-168-1-85
+        kubernetes.io/arch: amd64
+        kubernetes.io/hostname: turin
         nvidia.com/gpu.present: "true"
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -156,6 +156,28 @@ spec:
                 namespace: saigak
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
+                ignoreDifferences:
+                  - group: ""
+                    kind: PersistentVolumeClaim
+                    name: saigak-data
+                    jsonPointers:
+                      - /metadata/annotations
+                      - /spec/volumeMode
+                      - /spec/volumeName
+                  - group: apps
+                    kind: StatefulSet
+                    name: saigak
+                    jqPathExpressions:
+                      - .metadata.annotations
+                      - .spec.template.spec.containers[].livenessProbe.httpGet.scheme
+                      - .spec.template.spec.containers[].livenessProbe.successThreshold
+                      - .spec.template.spec.containers[].readinessProbe.httpGet.scheme
+                      - .spec.template.spec.containers[].readinessProbe.successThreshold
+                      - .spec.template.spec.containers[].startupProbe.httpGet.scheme
+                      - .spec.template.spec.containers[].startupProbe.successThreshold
+                      - .spec.template.spec.containers[].terminationMessagePath
+                      - .spec.template.spec.containers[].terminationMessagePolicy
+                      - .spec.template.spec.volumes[].configMap.defaultMode
                 automation: manual
                 enabled: "true"
                 managedNamespaceMetadata:


### PR DESCRIPTION
## Summary

- Align the Froussard Knative manifest with the currently healthy, Argo-rendered image digest and commit.
- Keep Saigak on the live Turin GPU node so GitOps sync does not move it back to an arm64 node with no allocatable GPUs.
- Add Saigak Argo ignore rules for bound PVC fields and Kubernetes-defaulted StatefulSet fields that were producing drift.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/froussard -o /tmp/drift-fix/froussard.yaml`
- `kustomize build --enable-helm argocd/applications/saigak -o /tmp/drift-fix/saigak.yaml`
- `bun packages/scripts/src/shared/enabled-apps.ts --json`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/drift-fix/froussard.yaml`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f /tmp/drift-fix/saigak.yaml`
- `kubectl apply --server-side --force-conflicts --field-manager=argocd-application-controller --dry-run=server -f argocd/applicationsets/platform.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
