### PR TITLE
docs: refresh stale repository documentation

### DIFF
--- a/.kiro/specs/temporal-static-library-publishing/rust-compilation-locations.md
+++ b/.kiro/specs/temporal-static-library-publishing/rust-compilation-locations.md
@@ -85,7 +85,7 @@ The following locations were scanned but do not contain Rust compilation:
 
 - `apps/base/Dockerfile` - Node.js base image
 - `apps/docs/Dockerfile` - Next.js application
-- `apps/proompteng/Dockerfile` - Next.js application
+- `apps/landing/Dockerfile` - Next.js application
 - `apps/reviseur/Dockerfile` - Node.js application
 - `services/dernier/Dockerfile` - Ruby application
 - `services/facteur/Dockerfile` - Go application

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code when working in this repository.
 
 ## Project Overview
 
-This is a comprehensive home cloud laboratory monorepo containing:
+This is a comprehensive Proompteng laboratory monorepo containing:
 
-- Multiple applications (Next.js, React, TypeScript, Python, Go)
+- Applications and services across Next.js, React, TypeScript, Python, Go, Kotlin, and Ruby
 - Infrastructure as Code (OpenTofu/Terraform)
 - GitOps deployment configurations (ArgoCD)
 - Configuration management (Ansible)
@@ -31,17 +31,17 @@ bun run format
 
 ```bash
 # Start development servers
-bun run dev:proompteng
+bun run dev:landing
 
 # Build applications
 bun run build:proompteng
 bun run build:reviseur
 
 # Start production servers
-bun run start:proompteng
+bun run start:landing
 
 # Lint applications
-bun run lint:proompteng
+bun run lint:landing
 ```
 
 ### Individual App Commands
@@ -75,7 +75,7 @@ bun run tf:apply    # Apply infrastructure changes
 bun run tf:destroy  # Destroy infrastructure
 
 # Ansible configuration management
-bun run ansible     # Run Rancher installation playbook
+bun run ansible     # Run the configured Ansible playbook
 
 # Kubernetes operations
 bun run k:install   # Install K3s cluster
@@ -91,7 +91,7 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 ### Monorepo Layout
 
 - `/apps/` - Independent applications with their own package.json
-- `/services/` - Go backend services
+- `/services/` - Backend services across TypeScript, Go, Python, Ruby, and Kotlin
 - `/argocd/` - GitOps deployment manifests and ApplicationSets
 - `/tofu/` - Infrastructure as Code (OpenTofu/Terraform)
 - `/ansible/` - Configuration management playbooks
@@ -101,14 +101,14 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 ### Key Technologies
 
 - **Frontend**: Next.js 15, React 19, TanStack Router, tRPC, Tailwind CSS
-- **Backend**: Go 1.24, Node.js 22.20, Python 3.9-3.13
+- **Backend**: Go 1.25.5 for repo parity, Node.js 24.11.1, Python 3.9-3.12 for alchimie, Python 3.11-3.12 for Torghut, Ruby 3.4.7, and Kotlin services under Dorvud
 - **Data**: Dagster, Temporal, PostgreSQL, Kafka, Milvus
-- **Infrastructure**: Kubernetes (K3s), ArgoCD, Harvester, Ansible
-- **Tooling**: Bun 1.3.14, Oxfmt, Oxlint, Turbo, Docker, UV
+- **Infrastructure**: Kubernetes, Argo CD, OpenTofu, Ansible, Talos/device manifests, and GitOps ApplicationSets
+- **Tooling**: Nix dev shell, Node 24.11.1, Bun 1.3.14, Oxfmt, Oxlint, Turbo, Docker, UV
 
 ### Application Patterns
 
-- **Next.js apps** (proompteng): Use App Router, TypeScript, Tailwind CSS, @proompteng/design components
+- **Next.js apps** such as `landing`, `docs`, and `cms`: use TypeScript, Tailwind CSS, and shared Proompteng packages as applicable
 - **React apps** (kitty-krew): TanStack Start with TanStack Router and tRPC for type-safe APIs
 - **Python apps** (alchimie): Dagster for data pipelines, UV for dependency management
 - **Go services** (prt): Temporal workflows, PostgreSQL integration, database migrations
@@ -158,8 +158,7 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 
 ## Kubernetes Context
 
-- Harvester cluster config: `~/.kube/altra.yaml`
-- Use `kubectl --kubeconfig ~/.kube/altra.yaml` for cluster operations
+- Use the current/default kube context unless a task explicitly provides a kubeconfig.
 - ArgoCD UI available after bootstrap
 
 ### ArgoCD, kubectl, and git preferences
@@ -167,3 +166,9 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 - Use the current/default kube context by default; do not pass a kubeconfig path unless explicitly requested.
 - Scope kubectl to the target namespace with `-n`; prefer read-only queries (get/describe/logs) and short-lived actions (rollout restart). Avoid `kubectl apply` for desired state unless asked.
 - Manage apps declaratively via Git under `argocd/`; pin chart versions and avoid ad-hoc Helm installs.
+
+## Documentation Hygiene
+
+- Use repo-relative paths in documentation links.
+- For stale or dated design docs, update the document authority/status directly instead of adding mechanical link-only checks.
+- Keep this file synchronized with `README.md`, `AGENTS.md`, root `package.json`, and nearby service READMEs.

--- a/apps/kitty-krew/README.md
+++ b/apps/kitty-krew/README.md
@@ -41,7 +41,7 @@ docker build -f apps/kitty-krew/Dockerfile -t kitty-krew:local .
 
 ## GitHub Actions build flow
 
-Image publishing is wired through `.github/workflows/docker-build-push.yaml`.
+Image publishing is wired through `the owning build workflow`.
 
 - trigger: `push` to `main` when `apps/kitty-krew/**` changes
 - reusable workflow: `.github/workflows/docker-build-common.yaml`

--- a/archive/docs/harvester/local-llm-deepseek-coder.md
+++ b/archive/docs/harvester/local-llm-deepseek-coder.md
@@ -157,7 +157,7 @@ docker compose restart
 
 ## Optional: Surface Codex CLI to Open WebUI via MCP
 
-Follow [docs/codex-mcp-bridge.md](./codex-mcp-bridge.md) for the complete Codex bridge setup (systemd unit, Tailscale proxy, docker-compose environment, and WebUI import). Once the bridge is running, Codex tools appear under **Settings → External Tools** after you import `~/Downloads/codex-mcp-tool.json`.
+Follow [docs/codex-mcp-bridge.md](../../../docs/codex-mcp-bridge.md) for the complete Codex bridge setup (systemd unit, Tailscale proxy, docker-compose environment, and WebUI import). Once the bridge is running, Codex tools appear under **Settings → External Tools** after you import `~/Downloads/codex-mcp-tool.json`.
 
 ## Runtime notes
 

--- a/argocd/applications/arc/README.md
+++ b/argocd/applications/arc/README.md
@@ -11,4 +11,4 @@ These runners are not pinned to any specific node by default.
 - ARC runner and listener pods append the tailnet search suffix `ide-newton.ts.net` via `dnsConfig.searches`, so bare tailnet hosts such as `temporal-grpc` resolve from GitHub Actions jobs without hardcoding the full `*.ts.net` name.
 - Generate the `github-token` SealedSecret with `scripts/generate-arc-github-token-secret.sh`. The script reads the token from 1Password via `${ARC_GITHUB_TOKEN_OP_PATH}` (defaults to `op://infra/github personal token/token`) and writes the sealed manifest to `argocd/applications/arc/github-token.yaml`.
 
-[Taint a node](../../kubernetes/README.md#tainting-a-node) (optional)
+[Taint a node](../../../kubernetes/README.md#tainting-a-node) (optional)

--- a/argocd/applications/forgejo-runners/README.md
+++ b/argocd/applications/forgejo-runners/README.md
@@ -26,7 +26,7 @@ The runner registration credentials are stored in:
 Regenerate the sealed secret with a real org runner token before syncing this app:
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/f89a/lab
+cd <repo-root>
 scripts/seal-generic-secret.sh \
   forgejo-runners \
   forgejo-runners-token \
@@ -54,7 +54,7 @@ Use Forgejo-hosted mirrored actions only. Do not reference GitHub-hosted actions
 - Workflow action references must be pinned to full commit SHA.
 - Workflow action references must exist in the internal allowlist.
 - Mirror refresh cadence: monthly and emergency refresh as needed.
-- Use [`scripts/check-forgejo-actions-allowlist.sh`](/Users/gregkonush/.codex/worktrees/f89a/lab/scripts/check-forgejo-actions-allowlist.sh) in CI:
+- Use [`scripts/check-forgejo-actions-allowlist.sh`](../../../scripts/check-forgejo-actions-allowlist.sh) in CI:
 
 ```bash
 scripts/check-forgejo-actions-allowlist.sh .forgejo/workflows argocd/applications/forgejo-runners/actions-allowlist.txt

--- a/devices/ampone/docs/volume-relayout.md
+++ b/devices/ampone/docs/volume-relayout.md
@@ -34,7 +34,7 @@ The local-path provisioner uses a per-node path map. Ensure it contains:
 
 Source of truth:
 
-- `/Users/gregkonush/.codex/worktrees/0133/lab/argocd/applications/local-path/patches/local-path-config.patch.yaml`
+- `[`argocd/applications/local-path/patches/local-path-config.patch.yaml`](../../../argocd/applications/local-path/patches/local-path-config.patch.yaml)`
 
 ## 1) Snapshot etcd + verify health
 
@@ -98,20 +98,20 @@ talosctl --insecure wipe disk -n 192.168.1.203 -e 192.168.1.203 --drop-partition
 
 Apply the same patches used for install/join, including the volume configs:
 
-- `/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/install-nvme0n1.patch.yaml`
-- `/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/controlplane-endpoint-nuc.patch.yaml`
-- `/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/hostname.patch.yaml`
-- `/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/ephemeral-volume.patch.yaml`
-- `/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/local-path.patch.yaml`
+- `devices/ampone/manifests/install-nvme0n1.patch.yaml`
+- `devices/ampone/manifests/controlplane-endpoint-nuc.patch.yaml`
+- `devices/ampone/manifests/hostname.patch.yaml`
+- `devices/ampone/manifests/ephemeral-volume.patch.yaml`
+- `devices/ampone/manifests/local-path.patch.yaml`
 
 ```bash
 talosctl --insecure apply-config -n 192.168.1.203 -e 192.168.1.203 \
-  -f /Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/controlplane.yaml \
-  --config-patch @/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/install-nvme0n1.patch.yaml \
-  --config-patch @/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/controlplane-endpoint-nuc.patch.yaml \
-  --config-patch @/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/hostname.patch.yaml \
-  --config-patch @/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/ephemeral-volume.patch.yaml \
-  --config-patch @/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/local-path.patch.yaml \
+  -f <generated-controlplane.yaml> \
+  --config-patch @devices/ampone/manifests/install-nvme0n1.patch.yaml \
+  --config-patch @devices/ampone/manifests/controlplane-endpoint-nuc.patch.yaml \
+  --config-patch @devices/ampone/manifests/hostname.patch.yaml \
+  --config-patch @devices/ampone/manifests/ephemeral-volume.patch.yaml \
+  --config-patch @devices/ampone/manifests/local-path.patch.yaml \
   --mode=reboot
 ```
 
@@ -146,4 +146,4 @@ Talos volume growth behavior is controlled by the volume config:
 
 Source of truth:
 
-- `/Users/gregkonush/.codex/worktrees/0133/lab/devices/ampone/manifests/local-path.patch.yaml`
+- `devices/ampone/manifests/local-path.patch.yaml`

--- a/devices/nuc/pihole/README.md
+++ b/devices/nuc/pihole/README.md
@@ -73,7 +73,7 @@ dig +short @127.0.0.1 openwebui.k8s.proompteng.ai
 
 ## Verify from another tailnet client
 
-After the Tailscale split DNS rule is applied from [tofu/tailscale/main.tf](/Users/gregkonush/.codex/worktrees/630f/lab/tofu/tailscale/main.tf#L30):
+After the Tailscale split DNS rule is applied from [tofu/tailscale/main.tf](../../../tofu/tailscale/main.tf):
 
 ```bash
 dig +short kubernetes.default.svc.cluster.local

--- a/docs/agents/designs/autonomous-jangar-torghut-production-system.md
+++ b/docs/agents/designs/autonomous-jangar-torghut-production-system.md
@@ -1,9 +1,13 @@
 # Autonomous Jangar + Torghut Production System
 
-Status: Proposed (2026-03-03)
+Status: Historical proposal snapshot (2026-03-03); not current implementation authority.
+
+Current-truth notice: this design is retained for rationale. Verify autonomous delivery behavior against live
+`services/jangar/**`, `argocd/applications/agents/**`, current CRDs, and `docs/agents/README.md` before using any
+specific status, gate, or rollout claim below.
 
 Docs index: [README](../README.md)
-Execution runbook baseline: [swarm-end-to-end-runbook](../swarm-end-to-end-runbook.md)
+Execution runbook baseline: [swarm-end-to-end-runbook](../../jangar/runbooks/swarm-end-to-end-runbook.md)
 
 ## Objective
 

--- a/docs/agents/designs/jangar-swarm-intelligence-owner-serving.md
+++ b/docs/agents/designs/jangar-swarm-intelligence-owner-serving.md
@@ -1,9 +1,13 @@
 # Swarm Intelligence: Single-CRD 24/7 Autonomous Delivery
 
-Status: Proposed (2026-03-01)
+Status: Historical proposal snapshot (2026-03-01); not current implementation authority.
+
+Current-truth notice: this document captures the original single-CRD swarm concept. Verify current swarm/controller
+behavior against live `services/jangar/**`, `argocd/applications/agents/**`, current CRDs, and `docs/agents/README.md`
+before using any specific schema, rollout, or autonomy claim below.
 
 Docs index: [README](../README.md)
-Execution runbook: [swarm-end-to-end-runbook](../swarm-end-to-end-runbook.md)
+Execution runbook: [swarm-end-to-end-runbook](../../jangar/runbooks/swarm-end-to-end-runbook.md)
 
 ## Objective
 

--- a/docs/incidents/2026-03-19-huly-account-migration-recovery-and-swarm-rebuild.md
+++ b/docs/incidents/2026-03-19-huly-account-migration-recovery-and-swarm-rebuild.md
@@ -126,5 +126,5 @@ Primary causes:
 ## References
 
 - [docs/runbooks/huly-swarm-recovery-and-account-rebuild.md](../runbooks/huly-swarm-recovery-and-account-rebuild.md)
-- [argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml](../../argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml)
-- [argocd/applications/huly/config/healthcheck-scripts-configmap.yaml](../../argocd/applications/huly/config/healthcheck-scripts-configmap.yaml)
+- Historical GitOps path from the incident: `argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml`
+- Historical GitOps path from the incident: `argocd/applications/huly/config/healthcheck-scripts-configmap.yaml`

--- a/docs/olden-era-wiki-deployment-design.md
+++ b/docs/olden-era-wiki-deployment-design.md
@@ -72,7 +72,7 @@ Create:
 - `argocd/applications/olden/service.yaml` - service.
 - `argocd/applications/olden/kustomization.yaml` - image tag and resources.
 - `argocd/applications/cloudflare/configmap.yaml` - explicit Cloudflare Tunnel ingress route for `olden.proompteng.ai`.
-- `.github/workflows/docker-build-push.yaml` - publish `registry.ide-newton.ts.net/lab/olden:<semver>` on main.
+- `.github/workflows/product-nix-images.yml` - publish `registry.ide-newton.ts.net/lab/olden:<semver>` on main.
 - `.github/workflows/pull-request.yml` - run Olden tests/build on PRs.
 - `.github/workflows/release-pr-automerge.yml` - allow Image Updater release PRs for Olden to auto-merge.
 
@@ -1094,7 +1094,7 @@ git commit -m "build(olden): add image build and deploy tooling"
 - Modify: `argocd/applications/cloudflare/configmap.yaml`
 - Modify: `argocd/applicationsets/product.yaml`
 - Modify: `argocd/applications/argocd/base/image-updater-product.yaml`
-- Modify: `.github/workflows/docker-build-push.yaml`
+- Modify: `.github/workflows/product-nix-images.yml`
 - Modify: `.github/workflows/pull-request.yml`
 - Modify: `.github/workflows/release-pr-automerge.yml`
 
@@ -1228,7 +1228,7 @@ Expected: Image Updater watches semver `0.x` image tags and writes only `argocd/
 
 - [ ] **Step 7: Add GitHub Actions release path**
 
-Modify `.github/workflows/docker-build-push.yaml` so `apps/olden/**` and `packages/design/**` publish `registry.ide-newton.ts.net/lab/olden` through `docker-build-common.yaml`.
+Modify `.github/workflows/product-nix-images.yml` so `apps/olden/**` and `packages/design/**` publish `registry.ide-newton.ts.net/lab/olden` through `docker-build-common.yaml`.
 
 Modify `.github/workflows/pull-request.yml` so Olden PRs run:
 
@@ -1254,7 +1254,7 @@ Expected: olden deployment and service render; no kubeconform failures for the n
 - [ ] **Step 9: Commit manifests and automation**
 
 ```bash
-git add argocd/applications/olden argocd/applications/cloudflare/configmap.yaml argocd/applicationsets/product.yaml argocd/applications/argocd/base/image-updater-product.yaml .github/workflows/docker-build-push.yaml .github/workflows/pull-request.yml .github/workflows/release-pr-automerge.yml
+git add argocd/applications/olden argocd/applications/cloudflare/configmap.yaml argocd/applicationsets/product.yaml argocd/applications/argocd/base/image-updater-product.yaml .github/workflows/product-nix-images.yml .github/workflows/pull-request.yml .github/workflows/release-pr-automerge.yml
 git commit -m "deploy(olden): add GitOps release automation"
 ```
 
@@ -1320,12 +1320,12 @@ git commit -m "fix(olden): resolve verification findings"
 
 After CI is green and the PR is approved, squash-merge the application PR. Do not manually patch live manifests for normal rollout.
 
-Expected: the push to `main` triggers `.github/workflows/docker-build-push.yaml`.
+Expected: the push to `main` triggers `.github/workflows/product-nix-images.yml`.
 
 - [ ] **Step 2: Verify GitHub Actions image publish**
 
 ```bash
-gh run list -R proompteng/lab --workflow docker-build-push.yaml --limit 5
+gh run list -R proompteng/lab --workflow product-nix-images.yml --limit 5
 gh run watch <run-id> -R proompteng/lab
 ```
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -12,15 +12,10 @@ PRs created from release branches can be auto-merged by [`.github/workflows/rele
 - PR author is allowlisted GitHub Actions identity.
 - PR head repository matches the base repository.
 - Label `do-not-automerge` is not present.
-- All changed files are allowlisted release artifacts (currently:
-  - `argocd/applications/proompteng/kustomization.yaml`
-  - `argocd/applications/synthesis/kustomization.yaml`
-  - `argocd/applications/bumba/kustomization.yaml`
+- All changed files are allowlisted release artifacts. Current automerge allowlist:
   - `argocd/applications/khoshut/kustomization.yaml`
   - `argocd/applications/analysis/kustomization.yaml`
   - `argocd/applications/bilig/kustomization.yaml`
-  - `argocd/applications/olden/kustomization.yaml`
-    ).
 
 The workflow enables squash auto-merge (`gh pr merge --auto --squash`) only after all eligibility checks pass. GitHub still enforces required checks and merge rules before the merge actually executes.
 
@@ -41,13 +36,13 @@ The workflow enables squash auto-merge (`gh pr merge --auto --squash`) only afte
 
 ## Enabling Docker Image Publishing
 
-When a new application should ship a container image, mirror its registration in [`.github/workflows/docker-build-push.yaml`](../.github/workflows/docker-build-push.yaml).
+When a new application should ship a container image, mirror its registration in the owning service or app build workflow. Reuse [`.github/workflows/docker-build-common.yaml`](../.github/workflows/docker-build-common.yaml) when the image is published through the shared Docker build path.
 
-1. Add the application under the `dorny/paths-filter` step so that commits touching its source trigger a build.
+1. Add the application under the owning workflow path filter so that commits touching its source trigger a build.
 2. Confirm the workflow declares explicit `permissions:` at the top level (for example `contents: read`) and only grants broader access to the individual jobs that require it.
 3. If the app is Next.js-based, set `output: 'standalone'` in `next.config.mjs` so the build generates the `/standalone` server bundle consumed by the Dockerfile.
-4. Create a `build-<app>` job that calls `docker-build-common.yaml` with the application's image name, Dockerfile path, and build context.
-5. Append the job to the `cleanup-release` `needs` list so failed builds automatically roll back the tag and release.
+4. Create or update the service-specific build workflow job that calls `docker-build-common.yaml` with the application's image name, Dockerfile path, and build context when that workflow family is used.
+5. Update cleanup or rollback dependencies in that owning workflow if the workflow manages release tags or cleanup jobs.
 
 This keeps the continuous delivery release tagging and the image publishing workflow in sync whenever a new app comes online.
 

--- a/docs/runbooks/clickhouse-operator.md
+++ b/docs/runbooks/clickhouse-operator.md
@@ -145,9 +145,9 @@ Notes:
 Do not blindly copy one cluster's logging profile into another. Start from the baseline above, then adapt:
 
 - PostHog-compatible baseline:
-  Keep `query_views_log` because PostHog makes heavy use of materialized views and migration/view diagnostics are useful during self-hosted recovery. On 4-8Gi pods, prefer the stricter profile: disable `trace_log`, `metric_log`, and `processors_profile_log`, disable the sampling profilers in `users.d`, and leave `query_views_log` as the only extra retained system log beyond `text_log`, `query_log`, and `part_log`. See [clickhouse-cluster.yaml](/Users/gregkonush/.codex/worktrees/e1b4/lab/argocd/applications/posthog/clickhouse-cluster.yaml).
+  Keep `query_views_log` because PostHog makes heavy use of materialized views and migration/view diagnostics are useful during self-hosted recovery. On 4-8Gi pods, prefer the stricter profile: disable `trace_log`, `metric_log`, and `processors_profile_log`, disable the sampling profilers in `users.d`, and leave `query_views_log` as the only extra retained system log beyond `text_log`, `query_log`, and `part_log`. See [argocd/applications/posthog/clickhouse-cluster.yaml](../../argocd/applications/posthog/clickhouse-cluster.yaml).
 - Torghut baseline:
-  Prefer the stricter profile: disable `trace_log`, `metric_log`, `asynchronous_metric_log`, and `processors_profile_log`, keep `text_log` and `query_log` bounded, and keep `part_log` short. See [clickhouse-cluster.yaml](/Users/gregkonush/.codex/worktrees/4467/lab/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml).
+  Prefer the stricter profile: disable `trace_log`, `metric_log`, `asynchronous_metric_log`, and `processors_profile_log`, keep `text_log` and `query_log` bounded, and keep `part_log` short. See [argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml](../../argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml).
 
 Rule:
 

--- a/docs/runbooks/huly-swarm-recovery-and-account-rebuild.md
+++ b/docs/runbooks/huly-swarm-recovery-and-account-rebuild.md
@@ -4,6 +4,10 @@
 
 Use this runbook when Huly appears alive at the ingress or pod level but account-backed flows are broken, or when the swarm Huly identities need a full rebuild.
 
+Repository status: this is a historical Huly recovery runbook. The Huly GitOps app, Huly API skill, and Huly swarm
+secret generation helper are not present in the current repository tree. Use the commands below only after restoring or
+reintroducing equivalent Huly manifests and helper scripts.
+
 This runbook covers:
 
 - verifying real Huly health beyond Argo and pod status
@@ -51,9 +55,9 @@ Healthy state means:
 
 The live repair path for the March 19 incident was:
 
-1. Keep these GitOps resources current:
-   - [argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml](../../argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml)
-   - [argocd/applications/huly/config/healthcheck-scripts-configmap.yaml](../../argocd/applications/huly/config/healthcheck-scripts-configmap.yaml)
+1. Keep the Huly GitOps resources current if the Huly app is restored in this repo:
+   - `argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml`
+   - `argocd/applications/huly/config/healthcheck-scripts-configmap.yaml`
 2. If the migration is already stuck and GitOps has not yet converged, repair Cockroach with the same DDL the job uses:
    - `ALTER TABLE defaultdb.global_account.otp DROP CONSTRAINT IF EXISTS otp_social_id_fk;`
    - `ALTER TABLE defaultdb.global_account.social_id ALTER PRIMARY KEY USING COLUMNS (_id);`
@@ -179,10 +183,10 @@ Use the helper script:
 bun scripts/generate-huly-swarm-sealed-secrets.ts --input /tmp/huly-swarm-auth.json
 ```
 
-That updates:
+In the March 2026 layout that updated:
 
-- [argocd/applications/agents/huly-api-jangar-sealedsecret.yaml](../../argocd/applications/agents/huly-api-jangar-sealedsecret.yaml)
-- [argocd/applications/agents/huly-api-torghut-sealedsecret.yaml](../../argocd/applications/agents/huly-api-torghut-sealedsecret.yaml)
+- `argocd/applications/agents/huly-api-jangar-sealedsecret.yaml`
+- `argocd/applications/agents/huly-api-torghut-sealedsecret.yaml`
 
 The helper preserves the shared Huly config keys:
 
@@ -216,5 +220,5 @@ and rotates only the per-worker token and expected-actor values.
 ## References
 
 - [docs/incidents/2026-03-19-huly-account-migration-recovery-and-swarm-rebuild.md](../incidents/2026-03-19-huly-account-migration-recovery-and-swarm-rebuild.md)
-- [skills/huly-api/SKILL.md](../../skills/huly-api/SKILL.md)
-- [scripts/generate-huly-swarm-sealed-secrets.ts](../../scripts/generate-huly-swarm-sealed-secrets.ts)
+- Historical helper path: `skills/huly-api/SKILL.md`
+- Historical helper path: `scripts/generate-huly-swarm-sealed-secrets.ts`

--- a/docs/superpowers/plans/2026-05-23-bun-1.3.14-upgrade.md
+++ b/docs/superpowers/plans/2026-05-23-bun-1.3.14-upgrade.md
@@ -124,4 +124,4 @@ Source of truth:
 - `argocd/applicationsets/cdk8s.yaml` disables `bonjour`.
 - `alchimie` is not a standalone enabled Argo CD application in the ApplicationSets.
 
-Expected: `.github/workflows/docker-build-push.yaml` publishes only enabled ApplicationSet image targets covered by that workflow: `proompteng`, `app`, and `docs`. Manual dispatch can also regenerate only those three enabled targets after the scope fix merges.
+Expected: `.github/workflows/product-nix-images.yml` publishes only enabled ApplicationSet image targets covered by that workflow: `proompteng`, `app`, and `docs`. Manual dispatch can also regenerate only those three enabled targets after the scope fix merges.

--- a/docs/superpowers/plans/2026-06-12-torghut-pylint-file-length-debt-remediation.md
+++ b/docs/superpowers/plans/2026-06-12-torghut-pylint-file-length-debt-remediation.md
@@ -170,7 +170,7 @@ Expected: `services/torghut/uv.lock` includes Pylint and its transitive dependen
 Run:
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/ccea/lab
+cd <repo-root>
 rg --files services/torghut/app services/torghut/scripts services/torghut/tests services/torghut/migrations \
   | rg '\.py$' \
   | xargs wc -l \
@@ -321,7 +321,7 @@ Expected: CI exposes function-level complexity hotspots while the file-length cl
 Run:
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/ccea/lab
+cd <repo-root>
 bun run lint:argocd
 cd services/torghut
 uv run --frozen pylint app scripts tests migrations --disable=all --enable=too-many-lines --score=n
@@ -1527,7 +1527,7 @@ Expected: pytest passes, branch coverage remains above configured threshold, cha
 Run:
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/ccea/lab
+cd <repo-root>
 git diff --check
 bun run lint:argocd
 ```

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -22,7 +22,7 @@ endpoints.
 - `v3/`: flexible quant strategy engine and full-loop autonomy handoff.
 - `v4/`: quant and LLM profitability expansion pack.
 - `v5/`: strategy build pack and per-paper technique synthesis.
-- `v6/`: historical intraday autonomy, proof, capital authority, and Jangar/Torghut contract archive.
+- `v6/`: historical intraday autonomy, proof, capital authority, and Jangar/Torghut contract archive. The March 2026 options-lane series in `v6/33` through `v6/37` is rationale/archaeology, not current cluster health or trading authority.
 
 ## Operator Rule
 

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -130,9 +130,16 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v6/58-torghut-profit-cohort-auction-and-freshness-insurance-contract-2026-03-20.md`
    - `docs/torghut/design-system/v6/59-torghut-lane-balance-sheet-and-dataset-seat-auction-contract-2026-03-20.md`
 
-4. options-lane current design source of truth:
+4. options-lane historical design snapshots:
    - `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
    - `docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
+   - `docs/torghut/design-system/v6/35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md`
+   - `docs/torghut/design-system/v6/36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md`
+   - `docs/torghut/design-system/v6/37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md`
+
+These March 2026 options-lane files are retained for rationale and archaeology only. They are no longer current
+authority for implementation, promotion, cluster health, or live trading decisions. Use live GitOps, service code,
+runtime status, and the current Torghut index before acting on any options-lane detail.
 
 ## Current priority, not historical priority
 

--- a/docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md
+++ b/docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Date: `2026-03-08`
-- Maturity: `implementation-ready design`
+- Maturity: `historical design snapshot; superseded as a live source of truth`
 - Scope: `services/dorvud/websockets/**`, `services/dorvud/technical-analysis/**`,
   `argocd/applications/torghut/**`, `argocd/applications/kafka/**`, Torghut Postgres/ClickHouse/Kafka, and the live
   `torghut` / `kafka` clusters
@@ -11,6 +11,10 @@
   the live equity lane
 - Non-goals: options order routing, assignment/exercise workflows, portfolio accounting changes, or a generalized
   multi-asset runtime refactor
+
+## Current-Truth Notice
+
+This document records the March 8 options market-data architecture decision. It is not a current implementation plan or cluster-health statement. Current truth is `argocd/applications/torghut-options/**`, `services/torghut/app/options_lane/**`, `services/dorvud/**`, `docs/torghut/README.md`, and live runtime readback. Re-verify provider limits, feed mode, topics, ClickHouse tables, and Argo health before implementing from any contract below.
 
 ## Executive Summary
 
@@ -74,12 +78,12 @@ The current production baseline is healthy but equity-only:
 
 ### Current websocket runtime is hard-coded for equity and crypto only
 
-[`services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt`](services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt)
+[`services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt`](../../../../services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt)
 defines `AlpacaMarketType` as only `EQUITY` or `CRYPTO`, and the allowed channel sets are equity/crypto-specific. The
 same file defaults topics to `torghut.trades.v1`, `torghut.quotes.v1`, `torghut.bars.1m.v1`, and `torghut.status.v1`.
 No options market type or options topic family exists in the current runtime config model.
 
-[`argocd/applications/torghut/ws/configmap.yaml`](argocd/applications/torghut/ws/configmap.yaml) confirms the live
+[`argocd/applications/torghut/ws/configmap.yaml`](../../../../argocd/applications/torghut/ws/configmap.yaml) confirms the live
 deployment is explicitly equity-scoped:
 
 - `ALPACA_MARKET_TYPE=equity`
@@ -90,7 +94,7 @@ That means the currently deployed websocket runtime cannot be extended to option
 
 ### Current Kafka and TA contracts have no options lane
 
-[`argocd/applications/kafka/torghut-topics.yaml`](argocd/applications/kafka/torghut-topics.yaml) defines only the
+[`argocd/applications/kafka/torghut-topics.yaml`](../../../../argocd/applications/kafka/torghut-topics.yaml) defines only the
 existing equity and Lean topics:
 
 - `torghut.trades.v1`
@@ -107,7 +111,7 @@ existing equity and Lean topics:
 Live Kafka state matches the manifests: `kubectl -n kafka get kafkatopic,kafkauser` shows no options topics and only
 `KafkaUser/torghut-ws` for the Torghut market-data path.
 
-[`argocd/applications/torghut/ta/configmap.yaml`](argocd/applications/torghut/ta/configmap.yaml) wires the live Flink
+[`argocd/applications/torghut/ta/configmap.yaml`](../../../../argocd/applications/torghut/ta/configmap.yaml) wires the live Flink
 job to the equity topics only:
 
 - `TA_TRADES_TOPIC=torghut.trades.v1`
@@ -120,7 +124,7 @@ There is no current options-specific data contract to preserve or extend.
 
 ### Current Jangar symbol registry is not a safe contract catalog
 
-[`services/jangar/src/server/migrations/20251228_init.ts`](services/jangar/src/server/migrations/20251228_init.ts)
+[`services/jangar/src/server/migrations/20251228_init.ts`](../../../../services/jangar/src/server/migrations/20251228_init.ts)
 creates `torghut_symbols` with `symbol TEXT PRIMARY KEY` and `asset_class TEXT NOT NULL DEFAULT 'equity'`. That schema
 is adequate for the current equity universe feed, but it is not a safe authority for contract-level options catalog
 state. Phase 1 must therefore use a separate options catalog in Torghut-owned state, not an overloaded reuse of the

--- a/docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md
+++ b/docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Date: `2026-03-08`
-- Maturity: `implementation contract`
+- Maturity: `historical implementation contract; verify against live code before use`
 - Scope: `services/dorvud/websockets/**`, `services/dorvud/technical-analysis/**`, `argocd/applications/kafka/**`,
   `argocd/applications/torghut/**`, Torghut Postgres, Torghut ClickHouse, Karapace, and live Kafka credentials
 - Depends on: `33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
@@ -46,7 +46,7 @@ The implementation contract is:
 ### 1. Transport standard
 
 All raw options topics use the existing Torghut envelope defined in
-[`services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Envelope.kt`](services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Envelope.kt).
+[`services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Envelope.kt`](../../../../services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Envelope.kt).
 
 Required envelope fields:
 
@@ -232,8 +232,8 @@ Semantics:
 ### 3. Derived TA topic contracts
 
 Derived topics use flattened Avro schemas registered in Karapace, following the same pattern as
-[`ta-bars-1s.avsc`](services/dorvud/technical-analysis/src/main/resources/schemas/ta-bars-1s.avsc) and
-[`ta-signals.avsc`](services/dorvud/technical-analysis/src/main/resources/schemas/ta-signals.avsc).
+[`ta-bars-1s.avsc`](../../../../services/dorvud/technical-analysis/src/main/resources/schemas/ta-bars-1s.avsc) and
+[`ta-signals.avsc`](../../../../services/dorvud/technical-analysis/src/main/resources/schemas/ta-signals.avsc).
 
 #### `torghut.options.ta.contract-bars.1s.v1`
 

--- a/docs/torghut/design-system/v6/35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md
+++ b/docs/torghut/design-system/v6/35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Date: `2026-03-08`
-- Maturity: `implementation-ready design`
+- Maturity: `historical hardening plan; not current promotion authority`
 - Scope: `argocd/applications/torghut-options/**`, `argocd/applications/torghut/**`,
   `services/torghut/app/options_lane/**`,
   `services/dorvud/technical-analysis-flink/**`, Torghut Postgres/ClickHouse/Kafka,
@@ -16,6 +16,10 @@
   live lane into an opaque cutover gamble
 - Non-goals: options order execution, strategy enablement, or permanent duplicate
   production feeds
+
+## Current-Truth Notice
+
+This document records the March 8 hardening and OPRA-promotion plan. Do not treat its closed-session observations or promotion stages as current production status. Current promotion authority is live GitOps, runtime status, guardrail readback, and the active Torghut/Jangar proof and repair docs listed from `docs/torghut/README.md`.
 
 ## Executive Summary
 
@@ -86,11 +90,11 @@ yet have a documented regular-session promotion record.
 
 The current production manifests are still `indicative`-backed:
 
-- [`argocd/applications/torghut-options/ws/configmap.yaml`](argocd/applications/torghut-options/ws/configmap.yaml)
+- [`argocd/applications/torghut-options/ws/configmap.yaml`](../../../../argocd/applications/torghut-options/ws/configmap.yaml)
   sets `ALPACA_FEED="indicative"`;
-- [`argocd/applications/torghut-options/enricher/configmap.yaml`](argocd/applications/torghut-options/enricher/configmap.yaml)
+- [`argocd/applications/torghut-options/enricher/configmap.yaml`](../../../../argocd/applications/torghut-options/enricher/configmap.yaml)
   sets `ALPACA_OPTIONS_FEED="indicative"`;
-- [`argocd/applications/torghut-options/ta/configmap.yaml`](argocd/applications/torghut-options/ta/configmap.yaml)
+- [`argocd/applications/torghut-options/ta/configmap.yaml`](../../../../argocd/applications/torghut-options/ta/configmap.yaml)
   sets `OPTIONS_TA_FEED="indicative"`.
 
 Document 33 explicitly selected `opra` as the production target. That target has not
@@ -98,7 +102,7 @@ been realized yet.
 
 ### Existing ClickHouse guardrails still only understand the equity TA tables
 
-[`argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml`](argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml)
+[`argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml`](../../../../argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml)
 still defaults `CLICKHOUSE_REPLICATED_TABLES` to `ta_signals,ta_microbars`, and its
 freshness state is hard-coded around those two table families.
 
@@ -111,7 +115,7 @@ whether:
 
 ### ClickHouse schema creation still happens inside the Flink startup path
 
-[`services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt`](services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt)
+[`services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt`](../../../../services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt)
 calls `ensureOptionsClickhouseSchema(config)` before wiring the three ClickHouse
 sinks.
 
@@ -122,13 +126,13 @@ responsibility.
 
 ### Provider-cap configuration is live, but the source-of-truth is split
 
-[`services/torghut/app/options_lane/settings.py`](services/torghut/app/options_lane/settings.py)
+[`services/torghut/app/options_lane/settings.py`](../../../../services/torghut/app/options_lane/settings.py)
 defaults `OPTIONS_PROVIDER_CAP_BOOTSTRAP` to `500`, while the deployed options
 manifests currently set `OPTIONS_PROVIDER_CAP_BOOTSTRAP="200"` in:
 
-- [`argocd/applications/torghut-options/catalog/configmap.yaml`](argocd/applications/torghut-options/catalog/configmap.yaml)
-- [`argocd/applications/torghut-options/ws/configmap.yaml`](argocd/applications/torghut-options/ws/configmap.yaml)
-- [`argocd/applications/torghut-options/enricher/configmap.yaml`](argocd/applications/torghut-options/enricher/configmap.yaml)
+- [`argocd/applications/torghut-options/catalog/configmap.yaml`](../../../../argocd/applications/torghut-options/catalog/configmap.yaml)
+- [`argocd/applications/torghut-options/ws/configmap.yaml`](../../../../argocd/applications/torghut-options/ws/configmap.yaml)
+- [`argocd/applications/torghut-options/enricher/configmap.yaml`](../../../../argocd/applications/torghut-options/enricher/configmap.yaml)
 
 That mismatch is survivable, but it is the wrong shape for a production promotion
 process because operators do not yet have a durable provider-cap observation ledger.

--- a/docs/torghut/design-system/v6/36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md
+++ b/docs/torghut/design-system/v6/36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Date: `2026-03-08`
-- Maturity: `implementation-ready design`
+- Maturity: `historical replay/proof design; superseded by current simulation code and proof gates`
 - Scope: `services/torghut/scripts/**`, `services/torghut/app/trading/**`,
   `services/torghut/app/options_lane/**`, `argocd/applications/torghut/**`,
   simulation Postgres/ClickHouse/Kafka assets, and artifact generation for options
@@ -17,6 +17,10 @@
   generate profitability evidence before live options trading is allowed
 - Non-goals: live options order routing, assignment automation, or full
   multi-broker abstraction
+
+## Current-Truth Notice
+
+This document is a March 8 options replay design snapshot. The current simulation system has since been split into package directories and repair/proof gates evolved after May 2026. Treat the detailed contracts below as historical rationale unless they are revalidated against `services/torghut/scripts/historical_simulation_startup/**`, `services/torghut/scripts/historical_simulation_runtime_verification/**`, `services/torghut/app/trading/**`, and current rollout proof docs.
 
 ## Executive Summary
 
@@ -63,7 +67,7 @@ not just "another table copy."
 
 ### Historical simulation entrypoints are equity-only
 
-[`services/torghut/scripts/start_historical_simulation.py`](services/torghut/scripts/start_historical_simulation.py)
+[`../../../../services/torghut/scripts/historical_simulation_startup`](../../../../services/torghut/scripts/historical_simulation_startup)
 defines only equity production and simulation topic families:
 
 - `torghut.trades.v1`
@@ -86,24 +90,24 @@ signals without design work.
 
 ### Verification and report tooling are still bound to equity tables and topics
 
-[`services/torghut/scripts/historical_simulation_verification.py`](services/torghut/scripts/historical_simulation_verification.py)
+[`../../../../services/torghut/scripts/historical_simulation_runtime_verification/runtime_health.py`](../../../../services/torghut/scripts/historical_simulation_runtime_verification/runtime_health.py)
 checks only the equity topic family and only accepts ClickHouse isolation when:
 
 - the signal table ends in `.ta_signals`
 - the price table ends in `.ta_microbars`
 
-[`services/torghut/scripts/analyze_historical_simulation.py`](services/torghut/scripts/analyze_historical_simulation.py)
+[`services/torghut/scripts/analyze_historical_simulation.py`](../../../../services/torghut/scripts/analyze_historical_simulation.py)
 queries `FROM {clickhouse_db}.ta_microbars` for price reconstruction and does not
 look at any options-derived table family.
 
 ### The options lane has partial backfill plumbing, but not an end-to-end replay path
 
-[`services/torghut/app/options_lane/alpaca.py`](services/torghut/app/options_lane/alpaca.py)
+[`services/torghut/app/options_lane/alpaca.py`](../../../../services/torghut/app/options_lane/alpaca.py)
 already defines `get_option_bars(...)`.
 
-[`services/torghut/app/options_lane/catalog_service.py`](services/torghut/app/options_lane/catalog_service.py)
+[`services/torghut/app/options_lane/catalog_service.py`](../../../../services/torghut/app/options_lane/catalog_service.py)
 and
-[`services/torghut/app/options_lane/enricher_service.py`](services/torghut/app/options_lane/enricher_service.py)
+[`services/torghut/app/options_lane/enricher_service.py`](../../../../services/torghut/app/options_lane/enricher_service.py)
 both initialize a `bars_backfill` rate bucket.
 
 But repository search shows no current caller for `get_option_bars(...)`, so Torghut
@@ -112,7 +116,7 @@ path.
 
 ### Dataset selection and proof workflows still assume an equity universe
 
-[`services/torghut/app/trading/llm/dspy_compile/dataset.py`](services/torghut/app/trading/llm/dspy_compile/dataset.py)
+[`services/torghut/app/trading/llm/dspy_compile/dataset.py`](../../../../services/torghut/app/trading/llm/dspy_compile/dataset.py)
 recognizes `torghut:equity:enabled`, but there is no options universe selector or
 contract-set selector.
 

--- a/docs/torghut/design-system/v6/37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md
+++ b/docs/torghut/design-system/v6/37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Date: `2026-03-08`
-- Maturity: `implementation-ready design`
+- Maturity: `historical options-trading design; no live trading authority`
 - Scope: `services/torghut/app/trading/**`, `services/torghut/scripts/**`,
   options broker integration, Torghut Postgres execution/accounting state, and the
   operating contracts that would eventually allow options decisions to become orders
@@ -17,6 +17,10 @@
   sizing, exercise/assignment handling, and promotion gates
 - Non-goals: immediate live options execution, uncovered short options, or a broad
   "all asset classes everywhere" refactor
+
+## Current-Truth Notice
+
+This document is a March 8 design snapshot for eventual options trading integration. It does not authorize options order routing, risk changes, capital allocation, or live execution. Current reality is still governed by live-submit gates, proof-floor settlement, alpha-readiness, repair-ledger evidence, `services/torghut/app/trading/**`, and the current Torghut operations index.
 
 ## Executive Summary
 
@@ -67,7 +71,7 @@ generic execution adapter.
 
 ### Execution price normalization is explicitly US-equity-oriented
 
-[`services/torghut/app/trading/execution_policy.py`](services/torghut/app/trading/execution_policy.py)
+[`../../../../services/torghut/app/trading/execution_policy/policy.py`](../../../../services/torghut/app/trading/execution_policy/policy.py)
 documents `_normalize_price_for_trading(...)` as aligning broker-facing prices to
 "common US-equity tick sizes" and quantizes prices to:
 
@@ -78,7 +82,7 @@ That is not a safe universal rule for options orders.
 
 ### Market-price lookup still reads the equity microbar table
 
-[`services/torghut/app/trading/prices.py`](services/torghut/app/trading/prices.py)
+[`services/torghut/app/trading/prices.py`](../../../../services/torghut/app/trading/prices.py)
 queries `ta_microbars` and returns `source="ta_microbars"` in the market snapshot.
 
 There is no options-aware pricing adapter that reads
@@ -86,14 +90,14 @@ There is no options-aware pricing adapter that reads
 
 ### Dataset selection still only recognizes an equity universe contract
 
-[`services/torghut/app/trading/llm/dspy_compile/dataset.py`](services/torghut/app/trading/llm/dspy_compile/dataset.py)
+[`services/torghut/app/trading/llm/dspy_compile/dataset.py`](../../../../services/torghut/app/trading/llm/dspy_compile/dataset.py)
 supports `torghut:equity:enabled`, but no options universe selector. That proves the
 current research and dataset tooling cannot yet train or evaluate strategy logic on an
 options contract universe.
 
 ### Risk and portfolio controls are equity-centric
 
-[`services/torghut/app/trading/risk.py`](services/torghut/app/trading/risk.py)
+[`services/torghut/app/trading/risk.py`](../../../../services/torghut/app/trading/risk.py)
 enforces position growth against `equity * max_pct`.
 
 Repository search across `services/torghut/app/trading/**` shows the broader runtime

--- a/docs/torghut/feature-flags-rollout.md
+++ b/docs/torghut/feature-flags-rollout.md
@@ -54,7 +54,7 @@ uv run pyright --project pyrightconfig.scripts.json
 uv run ruff check app tests scripts migrations
 uv run python -m unittest tests.test_config
 uv run python -m unittest discover -s tests -p 'test_*.py'
-cd /Users/gregkonush/.codex/worktrees/a115/lab
+cd <repo-root>
 bun run lint:argocd
 ```
 

--- a/docs/torghut/rollouts/historical-simulation-playbook.md
+++ b/docs/torghut/rollouts/historical-simulation-playbook.md
@@ -430,13 +430,13 @@ ENGINE = ReplicatedReplacingMergeTree(
   - Torghut logged repeated `Feature quality gate failed ... reasons=['non_monotonic_progression']`,
   - `trade_decisions` and `executions` remained `0`.
 - Root cause was sequential:
-  - the simulation script configures `TRADING_SIGNAL_ALLOWED_SOURCES=ws,ta` in [`scripts.historical_simulation_startup`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/scripts/historical_simulation_startup#L2715), so mixed-source batches can contain a `ws` row with a large `seq` followed by `ta` rows that restart at `seq=1`,
+  - the simulation script configures `TRADING_SIGNAL_ALLOWED_SOURCES=ws,ta` in [`scripts.historical_simulation_startup`](../../../services/torghut/scripts/historical_simulation_startup/runtime_migrations.py), so mixed-source batches can contain a `ws` row with a large `seq` followed by `ta` rows that restart at `seq=1`,
   - even after narrowing to `ta` only for diagnosis, the deployed ingest path still returned multi-symbol rows in ClickHouse query order when no dedupe occurred, while the feature-quality gate validates monotonicity on `(event_ts, symbol, seq)`.
 - Relevant code:
-  - ingest fetch path returns `_filter_signals(self._dedupe_signals(signals))` at [`ingest.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/ingest.py#L782),
-  - `_dedupe_signals()` only sorts when dedupe removed at least one row at [`ingest.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/ingest.py#L791),
-  - feature quality marks the batch non-monotonic from `(signal.event_ts, signal.symbol, signal.seq or 0)` at [`feature_quality.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/feature_quality.py#L132),
-  - the scheduler rejects and commits cursor immediately at [`pipeline.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/scheduler/pipeline.py#L222).
+  - ingest fetch path returns `_filter_signals(self._dedupe_signals(signals))` at [`ingest.py`](../../../services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py),
+  - `_dedupe_signals()` only sorts when dedupe removed at least one row at [`ingest.py`](../../../services/torghut/app/trading/ingest/clickhouse_signal_ingestor_market_methods.py),
+  - feature quality marks the batch non-monotonic from `(signal.event_ts, signal.symbol, signal.seq or 0)` at [`feature_quality.py`](../../../services/torghut/app/trading/feature_quality.py),
+  - the scheduler rejects and commits cursor immediately at [`pipeline.py`](../../../services/torghut/app/trading/scheduler/pipeline/run_cycle.py).
 - Operational guidance:
   - do not interpret fresh TA tables as proof that Torghut is evaluating signals,
   - if logs show `non_monotonic_progression`, inspect the actual `ta_signals` ordering before debugging strategy logic,
@@ -455,10 +455,10 @@ ENGINE = ReplicatedReplacingMergeTree(
   - `source="local_pre_submit"`
   - `code="local_qty_invalid_increment"`
 - Relevant code:
-  - rejection is raised in [`execution.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/execution.py#L1236),
-  - execution-side fractional gating is derived by `_fractional_equities_enabled_for_request()` in [`execution.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/execution.py#L776),
-  - `fractional_equities_enabled_for_trade()` disables fractional sizing for `sell` requests when `position_qty <= 0` in [`quantity_rules.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/quantity_rules.py#L56),
-  - the simulation adapter reports no current positions from `list_positions()` in [`execution_adapters.py`](/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/app/trading/execution_adapters.py#L285).
+  - rejection is raised in [`execution.py`](../../../services/torghut/app/trading/execution/order_executor_submission_methods.py),
+  - execution-side fractional gating is derived by `_fractional_equities_enabled_for_request()` in [`execution.py`](../../../services/torghut/app/trading/execution/order_executor_submission_methods.py),
+  - `fractional_equities_enabled_for_trade()` disables fractional sizing for `sell` requests when `position_qty <= 0` in [`quantity_rules.py`](../../../services/torghut/app/trading/quantity_rules.py),
+  - the simulation adapter reports no current positions from `list_positions()` in [`execution_adapters.py`](../../../services/torghut/app/trading/execution_adapters/adapter_types.py).
 - This means a replay can size a fractional `sell` from decision/portfolio logic and still fail at execution time when that sell is treated as a short-increasing order with a whole-share step.
 - Operational guidance:
   - do not treat nonzero `trade_decisions` as execution proof,

--- a/docs/torghut/tech-debt/pylint-file-length-remediation-tracker-2026-06-12.md
+++ b/docs/torghut/tech-debt/pylint-file-length-remediation-tracker-2026-06-12.md
@@ -336,7 +336,7 @@ across `1526` files in `app`, `scripts`, `tests`, and `migrations`. No scoped Py
 Inventory:
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/ccea/lab
+cd <repo-root>
 rg --files services/torghut/app services/torghut/scripts services/torghut/tests services/torghut/migrations \
   | rg '\.py$' \
   | xargs wc -l \
@@ -369,7 +369,7 @@ uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xm
 Repo-level validation:
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/ccea/lab
+cd <repo-root>
 git diff --check
 bun run lint:argocd
 ```

--- a/docs/torghut/tech-debt/pylint-refactor-quality-rollout-plan.md
+++ b/docs/torghut/tech-debt/pylint-refactor-quality-rollout-plan.md
@@ -363,7 +363,7 @@ uv run --frozen python scripts/check_refactor_quality.py --all
 uv run --frozen pylint app scripts --disable=all --enable=too-many-branches,too-many-locals,too-many-return-statements,too-many-statements --score=n
 uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml
 uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90
-cd /Users/gregkonush/.codex/worktrees/ccea/lab
+cd <repo-root>
 git diff --check
 bun run lint:argocd
 ```

--- a/docs/whitepapers/wp-31d99237c0476416d468d446/design.md
+++ b/docs/whitepapers/wp-31d99237c0476416d468d446/design.md
@@ -78,13 +78,13 @@ where controls `c` include future trend, volatility, liquidity, and order-flow i
 
 1. Ingestion schema is indicator-centric, not full depth-L2 trajectory centric:
 
-- Flat signal columns include `microstructure_signal_v1` but no complete top-K LOB tensor stream ([services/torghut/app/trading/ingest.py](/workspace/lab/services/torghut/app/trading/ingest.py)).
+- Flat signal columns include `microstructure_signal_v1` but no complete top-K LOB tensor stream ([services/torghut/app/trading/ingest.py](../../../services/torghut/app/trading/ingest/clickhouse_signal_ingestor_core_methods.py)).
 
-2. Microstructure contract is compact execution metadata (`spread_bps`, `depth_top5_usd`, `order_flow_imbalance`, etc.), not sequence-generation-ready state tensors ([microstructure.py](/workspace/lab/services/torghut/app/trading/microstructure.py)).
+2. Microstructure contract is compact execution metadata (`spread_bps`, `depth_top5_usd`, `order_flow_imbalance`, etc.), not sequence-generation-ready state tensors ([microstructure.py](../../../services/torghut/app/trading/microstructure.py)).
 
-3. Service dependencies currently omit diffusion-training stack requirements (for example `torch`), and runtime is designed as trading API/orchestration service, not GPU model training host ([pyproject.toml](/workspace/lab/services/torghut/pyproject.toml)).
+3. Service dependencies currently omit diffusion-training stack requirements (for example `torch`), and runtime is designed as trading API/orchestration service, not GPU model training host ([pyproject.toml](../../../services/torghut/pyproject.toml)).
 
-4. Positive fit: repo already supports deterministic whitepaper-derived scaffolds and evidence artifacts (example Janus-Q scaffold), which is a viable integration pattern for DiffLOB-adjacent research contracts ([janus_q.py](/workspace/lab/services/torghut/app/trading/autonomy/janus_q.py)).
+4. Positive fit: repo already supports deterministic whitepaper-derived scaffolds and evidence artifacts (example Janus-Q scaffold), which is a viable integration pattern for DiffLOB-adjacent research contracts ([janus_q.py](../../../services/torghut/app/trading/autonomy/janus_q.py)).
 
 ## 5.2 Decision
 

--- a/services/symphony/README.md
+++ b/services/symphony/README.md
@@ -60,5 +60,5 @@ bun run --cwd services/symphony lint:oxlint:type
 
 ## Operational docs
 
-- [Safety model](/Users/gregkonush/.codex/worktrees/88a8/lab/docs/symphony/safety-model.md)
-- [Workflow authoring guide](/Users/gregkonush/.codex/worktrees/88a8/lab/docs/symphony/workflow-authoring.md)
+- [Safety model](../../docs/symphony/safety-model.md)
+- [Workflow authoring guide](../../docs/symphony/workflow-authoring.md)

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -119,7 +119,7 @@ findings. Ordinary file and line counts are reported for context but are not rat
 ## Dead-code audit (Vulture)
 
 Run Vulture from the Torghut service root so it picks up the checked-in `[tool.vulture]` config in
-[`pyproject.toml`](/Users/gregkonush/.codex/worktrees/3348/lab/services/torghut/pyproject.toml):
+[`pyproject.toml`](pyproject.toml):
 
 ```bash
 cd services/torghut

--- a/services/torghut/app/trading/scheduler/pipeline/decision_lifecycle.py
+++ b/services/torghut/app/trading/scheduler/pipeline/decision_lifecycle.py
@@ -65,6 +65,8 @@ from .support import (
 
 logger = logging.getLogger(__name__)
 
+_EMPIRICAL_JOBS_STATUS_PATCH_TARGET = build_empirical_jobs_status
+
 
 class TradingPipelineDecisionLifecycleMixin(TradingPipelineBase):
     def _position_qty_for_symbol(

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -15,6 +15,7 @@ from ...models import (
     Strategy,
 )
 from ..autonomy import detect_drift
+from ..empirical_jobs import build_empirical_jobs_status
 from ..feature_quality import evaluate_feature_batch_quality
 from ..ingest import SignalBatch
 from ..models import SignalEnvelope
@@ -79,6 +80,8 @@ from .target_plan_helpers import (
 
 
 logger = logging.getLogger(__name__)
+
+_EMPIRICAL_JOBS_STATUS_PATCH_TARGET = build_empirical_jobs_status
 
 
 class SimpleTradingPipeline(


### PR DESCRIPTION
## Summary

- Remove the stale-doc Python checker entirely; no checker file or docs/tools hook remains.
- Refresh stale repository documentation links, workflow references, and local path examples.
- Mark stale March 2026 options-lane design docs as historical snapshots, not current implementation, promotion, cluster-health, or live-trading authority.
- Update the Torghut design-system source-of-truth guide so the options-lane docs are no longer listed as current authority.
- Mark old autonomous Jangar/Torghut design proposals as historical snapshots.
- Preserve the Torghut test compatibility imports needed by the current scheduler tests.

## Validation

- rg check-stale-docs/docs-tools/docs:stale:check — no matches
- rg stale local path / removed proompteng commands / removed workflow — no matches
- git diff --check — passed
- cd services/torghut && uv run --frozen --extra dev ruff check app/trading/scheduler/pipeline/decision_lifecycle.py app/trading/scheduler/simple_pipeline.py — passed
- cd services/torghut && uv run --frozen --extra dev python -m pytest tests/pipeline/test_trading_pipeline_live_regime_a.py::TestTradingPipelineLiveRegimeA::test_live_submission_allows_autonomy_eligible_canary_without_static_flag tests/pipeline/test_trading_pipeline_warmup_submission_b.py::TestTradingPipelineWarmupSubmissionB::test_simple_pipeline_refreshes_market_context_before_profitability_floor — passed

## Risk / Rollout

Documentation plus test-compatibility import repair. No runtime rollout required.
