### PR TITLE
fix(torghut): restore Argo render after proof lane removal

### DIFF
--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -36,7 +36,6 @@ resources:
   - paper-account-flatten-cronjob.yaml
   - generated-resource-retention-rbac.yaml
   - generated-resource-retention-cronjob.yaml
-  - whitepaper-autoresearch-workflowtemplate.yaml
   - historical-simulation-workflowtemplate.yaml
   - analysis-template-runtime-ready.yaml
   - analysis-template-activity.yaml


### PR DESCRIPTION
## Summary
- Removes a stale missing workflowtemplate entry from Torghut kustomization.
- Restores Argo manifest rendering after the empirical proof job lane removal.

## Testing
- kubectl kustomize argocd/applications/torghut
- git diff --check
