### PR TITLE
fix(torghut): let db migration hook schedule

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -20,8 +20,6 @@ spec:
         app.kubernetes.io/part-of: lab
     spec:
       restartPolicy: OnFailure
-      nodeSelector:
-        kubernetes.io/arch: arm64
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Removes the hard arm64 node selector from the Torghut DB migration hook.
- Allows the PreSync migration job to schedule on currently available nodes so Argo can complete sync and prune removed empirical resources.

## Testing
- kubectl kustomize argocd/applications/torghut
- git diff --check
