### PR TITLE
fix(torghut): restart failed alerting workloads

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
   imagePullPolicy: IfNotPresent
-  restartNonce: 18
+  restartNonce: 19
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,8 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-01T01:13:29Z"
+        client.knative.dev/updateTimestamp: "2026-07-03T18:45:00Z"
+        torghut.proompteng.ai/recovery-roll: "2026-07-03T18:45:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
   imagePullPolicy: IfNotPresent
-  restartNonce: 15
+  restartNonce: 16
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:


### PR DESCRIPTION
## Summary

- Bumps `torghut-ta` restartNonce from 15 to 16 to recover the failed Flink job after Kafka producer timeouts.
- Bumps `torghut-options-ta` restartNonce from 18 to 19 to recover the failed options Flink job after Kafka consumer-position timeouts.
- Rolls the Torghut Knative pod template annotation to replace failed revision `torghut-01361`.

## Related Issues

None

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop --command bash -lc 'bun run lint:argocd'`
- `/nix/var/nix/profiles/default/bin/nix develop --command bash -lc 'bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
