### PR TITLE
fix(torghut-options): respect market holidays in ws readiness

### DIFF
--- a/argocd/applications/torghut-options/ws/configmap.yaml
+++ b/argocd/applications/torghut-options/ws/configmap.yaml
@@ -9,6 +9,7 @@ data:
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
   ALPACA_MARKET_DATA_CHANNELS: "trades,quotes"
+  OPTIONS_MARKET_HOLIDAYS: "2026-07-03"
   JANGAR_SYMBOLS_URL: "http://torghut-options-catalog.torghut.svc.cluster.local/v1/options/hot-set"
   SYMBOLS: ""
   SYMBOLS_POLL_INTERVAL_MS: "30000"

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -59,6 +59,7 @@ import org.msgpack.jackson.dataformat.MessagePackFactory
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -442,6 +443,7 @@ class ForwarderApp(
             subscribedSince = subscribedSince.get(),
             subscribedCount = if (subscribedOk) 1 else 0,
             marketType = config.alpacaMarketType,
+            marketHolidays = config.optionsMarketHolidays,
           )
         if (config.alpacaMarketType == AlpacaMarketType.OPTIONS) {
           metrics.setOptionsEventStarvation(eventStarved)
@@ -602,6 +604,7 @@ class ForwarderApp(
                   subscribedSince = subscribedSince.get(),
                   subscribedCount = subscribedCount,
                   marketType = config.alpacaMarketType,
+                  marketHolidays = config.optionsMarketHolidays,
                 )
               metrics.setOptionsEventStarvation(eventStarved)
               if (eventStarved) {
@@ -1447,6 +1450,7 @@ class ForwarderApp(
 
   private fun currentSessionState(now: Instant): String {
     val marketNow = now.atZone(marketSessionZoneId)
+    if (marketNow.toLocalDate() in config.optionsMarketHolidays) return "holiday"
     if (marketNow.dayOfWeek.value >= 6) return "weekend"
     val minuteOfDay = (marketNow.hour * 60) + marketNow.minute
     return when {
@@ -1509,17 +1513,22 @@ internal fun optionsEventStarved(
   subscribedSince: Instant?,
   subscribedCount: Int,
   marketType: AlpacaMarketType,
+  marketHolidays: Set<LocalDate> = emptySet(),
   grace: Duration = Duration.ofSeconds(90),
 ): Boolean {
-  if (marketType != AlpacaMarketType.OPTIONS || subscribedCount <= 0 || !isRegularMarketSession(now)) {
+  if (marketType != AlpacaMarketType.OPTIONS || subscribedCount <= 0 || !isRegularMarketSession(now, marketHolidays)) {
     return false
   }
   val lastHealthyEvent = lastEventAt ?: subscribedSince ?: return false
   return Duration.between(lastHealthyEvent, now) >= grace
 }
 
-private fun isRegularMarketSession(now: Instant): Boolean {
+private fun isRegularMarketSession(
+  now: Instant,
+  marketHolidays: Set<LocalDate> = emptySet(),
+): Boolean {
   val marketNow = now.atZone(marketSessionZoneId)
+  if (marketNow.toLocalDate() in marketHolidays) return false
   if (marketNow.dayOfWeek.value >= 6) return false
   val minuteOfDay = (marketNow.hour * 60) + marketNow.minute
   return minuteOfDay in (9 * 60 + 30) until (16 * 60)

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
@@ -5,6 +5,7 @@ import ai.proompteng.dorvud.platform.KafkaProducerSettings
 import ai.proompteng.dorvud.platform.KafkaTls
 import io.github.cdimascio.dotenv.dotenv
 import java.io.File
+import java.time.LocalDate
 import java.util.Properties
 
 data class TopicConfig(
@@ -39,6 +40,7 @@ data class ForwarderConfig(
   val alpacaBaseUrl: String,
   val alpacaTradeStreamUrl: String?,
   val alpacaMarketDataChannels: List<String>,
+  val optionsMarketHolidays: Set<LocalDate> = emptySet(),
   val jangarSymbolsUrl: String?,
   val staticSymbols: List<String>,
   val symbolAllowlist: Set<String>,
@@ -131,6 +133,7 @@ data class ForwarderConfig(
             "for market type ${alpacaMarketType.name.lowercase()} (allowed: $allowed)",
         )
       }
+      val optionsMarketHolidays = parseIsoDateSet(mergedEnv["OPTIONS_MARKET_HOLIDAYS"])
 
       val jangarSymbolsUrl =
         mergedEnv["JANGAR_SYMBOLS_URL"]?.trim()?.takeIf { it.isNotEmpty() }
@@ -209,6 +212,7 @@ data class ForwarderConfig(
         alpacaBaseUrl = mergedEnv["ALPACA_BASE_URL"] ?: "https://data.alpaca.markets",
         alpacaTradeStreamUrl = mergedEnv["ALPACA_TRADE_STREAM_URL"]?.trim()?.takeIf { it.isNotEmpty() },
         alpacaMarketDataChannels = alpacaMarketDataChannels,
+        optionsMarketHolidays = optionsMarketHolidays,
         jangarSymbolsUrl = jangarSymbolsUrl,
         staticSymbols = staticSymbols,
         symbolAllowlist = symbolAllowlist,
@@ -237,6 +241,22 @@ data class ForwarderConfig(
       val merged = dotEnvEntries.toMutableMap()
       merged.putAll(System.getenv())
       return merged
+    }
+
+    private fun parseIsoDateSet(raw: String?): Set<LocalDate> {
+      val trimmed = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return emptySet()
+      if (trimmed == "[]") return emptySet()
+      return trimmed
+        .trim('[', ']')
+        .split(",", "\n", ";", " ")
+        .map { it.trim().trim('"', '\'') }
+        .filter { it.isNotEmpty() }
+        .map { token ->
+          runCatching { LocalDate.parse(token) }
+            .getOrElse {
+              error("OPTIONS_MARKET_HOLIDAYS must contain ISO-8601 dates (yyyy-MM-dd): $token")
+            }
+        }.toSet()
     }
 
     private fun loadDotEnv(): Map<String, String> {

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
@@ -2,6 +2,7 @@ package ai.proompteng.dorvud.ws
 
 import java.io.File
 import java.nio.file.Files
+import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -39,6 +40,7 @@ class ForwarderConfigTest {
     assertEquals(AlpacaMarketType.EQUITY, cfg.alpacaMarketType)
     assertEquals("us", cfg.alpacaCryptoLocation)
     assertEquals(listOf("trades", "quotes", "bars", "updatedBars"), cfg.alpacaMarketDataChannels)
+    assertEquals(emptySet(), cfg.optionsMarketHolidays)
     assertEquals("torghut.trades.v1", cfg.topics.trades)
   }
 
@@ -148,12 +150,14 @@ class ForwarderConfigTest {
           "TOPIC_TRADES" to "torghut.options.trades.v1",
           "TOPIC_QUOTES" to "torghut.options.quotes.v1",
           "TOPIC_STATUS" to "torghut.options.status.v1",
+          "OPTIONS_MARKET_HOLIDAYS" to "2026-07-03, 2026-12-25",
         ),
       )
 
     assertEquals(AlpacaMarketType.OPTIONS, cfg.alpacaMarketType)
     assertEquals("opra", cfg.alpacaFeed)
     assertEquals(listOf("trades", "quotes"), cfg.alpacaMarketDataChannels)
+    assertEquals(setOf(LocalDate.parse("2026-07-03"), LocalDate.parse("2026-12-25")), cfg.optionsMarketHolidays)
     assertEquals(null, cfg.topics.bars1m)
   }
 

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
@@ -2,6 +2,7 @@ package ai.proompteng.dorvud.ws
 
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -128,6 +129,17 @@ class ForwarderSubscriptionTest {
         subscribedSince = stale,
         subscribedCount = 0,
         marketType = AlpacaMarketType.OPTIONS,
+        grace = Duration.ofSeconds(90),
+      ),
+    )
+    assertFalse(
+      optionsEventStarved(
+        now = now,
+        lastEventAt = null,
+        subscribedSince = stale,
+        subscribedCount = 12,
+        marketType = AlpacaMarketType.OPTIONS,
+        marketHolidays = setOf(LocalDate.parse("2026-06-18")),
         grace = Duration.ofSeconds(90),
       ),
     )


### PR DESCRIPTION
## Summary

- Add `OPTIONS_MARKET_HOLIDAYS` parsing to the Dorvud websocket config.
- Skip options websocket event-starvation readiness failures during configured market holidays and publish `session_state=holiday`.
- Configure `torghut-ws-options` with the July 3 2026 observed market holiday.

## Related Issues

None

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop --command bash -lc 'cd services/dorvud && ./gradlew :websockets:test --tests "ai.proompteng.dorvud.ws.ForwarderSubscriptionTest" --tests "ai.proompteng.dorvud.ws.ForwarderConfigTest"'`
- `/nix/var/nix/profiles/default/bin/nix develop --command bash -lc 'bun run lint:argocd'`
- `/nix/var/nix/profiles/default/bin/nix develop --command bash -lc 'cd services/dorvud && ./gradlew :websockets:check'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
