### PR TITLE
chore(torghut): promote ws image d4c895a6

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:1103c3a67207b5b41b8bb1bfd1bc775f82c00ffbdbdfb20ea7957227042d8127
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:90cb375944f4e04d6e83cd2858f9d97115100df302938e213b0845ce1e9ea8a2
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-56167552
+              value: main-d4c895a6
             - name: TORGHUT_WS_COMMIT
-              value: 561675522428e44625744dc04646c30d9490d99f
+              value: d4c895a619802cdc7d149aafe298b3fa56b631a5
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:1103c3a67207b5b41b8bb1bfd1bc775f82c00ffbdbdfb20ea7957227042d8127
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:90cb375944f4e04d6e83cd2858f9d97115100df302938e213b0845ce1e9ea8a2
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-56167552
+              value: main-d4c895a6
             - name: TORGHUT_WS_COMMIT
-              value: 561675522428e44625744dc04646c30d9490d99f
+              value: d4c895a619802cdc7d149aafe298b3fa56b631a5
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `d4c895a619802cdc7d149aafe298b3fa56b631a5`
- Image tag: `d4c895a6`
- Image digest: `sha256:90cb375944f4e04d6e83cd2858f9d97115100df302938e213b0845ce1e9ea8a2`