### PR TITLE
fix(rook-ceph): protect kafka during recovery

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -32,20 +32,25 @@ cephClusterSpec:
       mon_data_avail_warn: "15"
     osd:
       bluestore_cache_autotune: "true"
-      # Keep recovery prioritized during the current Turin/Altra PG backfill window.
+      # Keep recovery moving during the current Turin/Altra PG backfill window while protecting Kafka latency.
       # Ceph mClock ignores recovery/backfill concurrency overrides unless this gate is enabled.
       osd_mclock_profile: "custom"
       osd_mclock_override_recovery_settings: "true"
-      osd_mclock_scheduler_background_recovery_res: "0.600000"
-      osd_mclock_scheduler_client_res: "0.300000"
+      osd_mclock_scheduler_background_recovery_res: "0.050000"
+      osd_mclock_scheduler_background_recovery_lim: "0.150000"
+      osd_mclock_scheduler_client_res: "0.850000"
+      osd_mclock_scheduler_client_lim: "1.000000"
       osd_mclock_scheduler_background_best_effort_res: "0.100000"
       osd_mclock_scheduler_background_recovery_wgt: "12"
       osd_mclock_scheduler_client_wgt: "1"
       osd_mclock_scheduler_background_best_effort_wgt: "1"
       osd_memory_target: "6442450944"
-      osd_max_backfills: "16"
-      osd_recovery_max_active: "32"
-      osd_recovery_max_active_hdd: "32"
+      osd_max_backfills: "1"
+      osd_recovery_max_active: "2"
+      osd_recovery_max_active_hdd: "2"
+      osd_recovery_max_single_start: "1"
+      osd_recovery_op_priority: "1"
+      osd_recovery_sleep_hdd: "0.050000"
 
   dataDirHostPath: /var/lib/rook
 

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
   imagePullPolicy: IfNotPresent
-  restartNonce: 20
+  restartNonce: 21
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:


### PR DESCRIPTION
## Summary

- Make the live Ceph client-protect recovery profile durable in GitOps.
- Reduce recovery/backfill concurrency and mClock recovery bandwidth so Kafka control-plane latency is protected during backfill.
- Restart the failed `torghut-ta-sim` FlinkDeployment by bumping `restartNonce` after Argo reported it as the remaining degraded Torghut child.

## Related Issues

None

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop --command bash -lc 'bun run lint:argocd'`
- Live validation: Alertmanager critical alerts cleared; Kafka app is Healthy; all KafkaUser resources report `Ready=True`; Ceph is recovering with one active backfill after the live throttle.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
