### PR TITLE
fix(rook-ceph): use recovery profile with kafka guardrails

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -32,25 +32,17 @@ cephClusterSpec:
       mon_data_avail_warn: "15"
     osd:
       bluestore_cache_autotune: "true"
-      # Keep recovery moving during the current Turin/Altra PG backfill window while protecting Kafka latency.
+      # Use Ceph's recovery-biased mClock profile, but keep concurrency bounded so Kafka stays responsive.
       # Ceph mClock ignores recovery/backfill concurrency overrides unless this gate is enabled.
-      osd_mclock_profile: "custom"
+      osd_mclock_profile: "high_recovery_ops"
       osd_mclock_override_recovery_settings: "true"
-      osd_mclock_scheduler_background_recovery_res: "0.050000"
-      osd_mclock_scheduler_background_recovery_lim: "0.150000"
-      osd_mclock_scheduler_client_res: "0.850000"
-      osd_mclock_scheduler_client_lim: "1.000000"
-      osd_mclock_scheduler_background_best_effort_res: "0.100000"
-      osd_mclock_scheduler_background_recovery_wgt: "12"
-      osd_mclock_scheduler_client_wgt: "1"
-      osd_mclock_scheduler_background_best_effort_wgt: "1"
       osd_memory_target: "6442450944"
-      osd_max_backfills: "1"
-      osd_recovery_max_active: "2"
-      osd_recovery_max_active_hdd: "2"
+      osd_max_backfills: "2"
+      osd_recovery_max_active: "4"
+      osd_recovery_max_active_hdd: "4"
       osd_recovery_max_single_start: "1"
-      osd_recovery_op_priority: "1"
-      osd_recovery_sleep_hdd: "0.050000"
+      osd_recovery_op_priority: "3"
+      osd_recovery_sleep_hdd: "0"
 
   dataDirHostPath: /var/lib/rook
 


### PR DESCRIPTION
## Summary

- Switch Rook Ceph from the custom client-protect mClock profile to Ceph's built-in `high_recovery_ops` profile.
- Keep Kafka guardrails by bounding recovery concurrency with `osd_max_backfills=2`, `osd_recovery_max_active=4`, and one-at-a-time recovery starts.
- Remove the low-level custom mClock reservation and limit overrides so the recovery profile semantics are used directly.

## Related Issues

None

## Testing

- `/nix/var/nix/profiles/default/bin/nix develop --command bash -lc 'bun run lint:argocd'`
- Live validation: applied `high_recovery_ops` with bounded recovery settings, then watched eight samples after increasing to `osd_max_backfills=2` and `osd_recovery_max_active_hdd=4`; Kafka stayed `Ready=True` and all KafkaUser resources stayed `Ready=True`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
