### PR TITLE
ci(nix): enforce rollout performance gates

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -57,11 +57,32 @@ jobs:
       ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
       NIX_OCI_LOG_DIR: /tmp/nix-oci-logs-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
     steps:
+      - name: Start checkout timer
+        run: |
+          set -euo pipefail
+          mkdir -p "${NIX_OCI_LOG_DIR}"
+          date +%s > "${NIX_OCI_LOG_DIR}/checkout-start"
+
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Record checkout timing
+        if: always()
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          start="$(cat "${NIX_OCI_LOG_DIR}/checkout-start")"
+          end="$(date +%s)"
+          printf '%s\t%s\t%s\t%s\n' "checkout-${ARCH}" 0 "$((end - start))" "actions/checkout@v5" >> "${NIX_OCI_LOG_DIR}/timings.tsv"
+
       - name: Require Attic public key
         run: test -n "${ATTIC_PUBLIC_KEY}"
+
+      - name: Start Nix setup timer
+        run: |
+          set -euo pipefail
+          date +%s > "${NIX_OCI_LOG_DIR}/nix-setup-start"
 
       - name: Set up Nix toolchain
         uses: ./.github/actions/setup-nix-toolchain
@@ -72,6 +93,16 @@ jobs:
             experimental-features = nix-command flakes
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+
+      - name: Record Nix setup timing
+        if: always()
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          start="$(cat "${NIX_OCI_LOG_DIR}/nix-setup-start")"
+          end="$(date +%s)"
+          printf '%s\t%s\t%s\t%s\n' "nix-setup-${ARCH}" 0 "$((end - start))" ".github/actions/setup-nix-toolchain" >> "${NIX_OCI_LOG_DIR}/timings.tsv"
 
       - name: Prime OCI helper closures
         env:
@@ -172,11 +203,30 @@ jobs:
       ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
       NIX_OCI_LOG_DIR: /tmp/nix-oci-logs-${{ github.run_id }}-${{ github.run_attempt }}-publish-index
     steps:
+      - name: Start checkout timer
+        run: |
+          set -euo pipefail
+          mkdir -p "${NIX_OCI_LOG_DIR}"
+          date +%s > "${NIX_OCI_LOG_DIR}/checkout-start"
+
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Record checkout timing
+        if: always()
+        run: |
+          set -euo pipefail
+          start="$(cat "${NIX_OCI_LOG_DIR}/checkout-start")"
+          end="$(date +%s)"
+          printf '%s\t%s\t%s\t%s\n' "checkout-publish-index" 0 "$((end - start))" "actions/checkout@v5" >> "${NIX_OCI_LOG_DIR}/timings.tsv"
+
       - name: Require Attic public key
         run: test -n "${ATTIC_PUBLIC_KEY}"
+
+      - name: Start Nix setup timer
+        run: |
+          set -euo pipefail
+          date +%s > "${NIX_OCI_LOG_DIR}/nix-setup-start"
 
       - name: Set up Nix toolchain
         uses: ./.github/actions/setup-nix-toolchain
@@ -187,6 +237,14 @@ jobs:
             experimental-features = nix-command flakes
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+
+      - name: Record Nix setup timing
+        if: always()
+        run: |
+          set -euo pipefail
+          start="$(cat "${NIX_OCI_LOG_DIR}/nix-setup-start")"
+          end="$(date +%s)"
+          printf '%s\t%s\t%s\t%s\n' "nix-setup-publish-index" 0 "$((end - start))" ".github/actions/setup-nix-toolchain" >> "${NIX_OCI_LOG_DIR}/timings.tsv"
 
       - name: Prime OCI index helper closures
         run: |

--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -2,57 +2,160 @@
 
 ## Summary
 
-This rollout treats Nix adoption as build performance and reproducibility work across the root-enabled Argo surface. The source of truth is `argocd/root.yaml`, which points Argo at `argocd/applicationsets`; only apps enabled through those files count as production rollout proof.
+This rollout makes enabled repo-owned image builds faster, more reproducible, and fully Nix-backed. It does not count synthetic workflows, disabled apps, benchmark-only jobs, chart-only apps, or vendor manifests as production proof.
 
-The current inventory shape is:
+Source of truth:
+
+- Enabled apps come from `argocd/root.yaml` and the ApplicationSets under `argocd/applicationsets`.
+- Upstream Nix/Nixpkgs implementation notes are captured in `docs/nix-upstream-rollout-research.md`.
+- Live rollout proof only counts root-enabled apps that own repo image builds.
+
+Current inventory from the repo guardrail:
 
 - 71 enabled ApplicationSet entries.
-- 1 direct root-managed Application in the same directory: `home-root`.
-- 11 migrated `nix-image` apps.
-- 25 Helm/chart apps.
-- 24 vendor/manifest apps, including manifest-only repo-image references where this checkout does not own the image build.
-- 2 external-source apps.
-- 10 deferred repo-image apps that need separate service-specific migration work or clean live health first.
-- Helm/chart-only and vendor-manifest apps are not image-build migration targets.
-- Repo-image apps are only migration candidates after source ownership and a build/deploy path are proven.
+- 1 direct root-managed Application: `home-root`.
+- Helm/chart-only apps do not receive image builds.
+- Vendor/static manifest apps do not receive image builds unless this repo owns their image build path.
+- External-source apps are not repo image migration targets.
+- Repo-image apps must be either `nix-image`, explicitly `deferred`, or a documented manifest-only exception.
 
-Both supported production paths must remain available for each migrated build-owning app:
+Hard exclusions:
 
-- GitHub Actions build/release workflows.
-- Existing manual deploy scripts such as `bun run <service>:deploy`.
+- No Ceph, Rook, ObjectBucketClaim, PVC, Talos, node, power, or storage changes.
+- No synchronous Nix `post-build-hook` cache upload in CI.
+- No fake cache smoke/warm jobs.
+- No Docker-backed build path may be described as native Nix OCI.
 
-No Ceph, Rook, ObjectBucketClaim, PVC, or storage changes are in scope.
+## Production Contracts
 
-## Key Changes
+### Enabled-App Contract
 
-- Add a root-enabled inventory guardrail that classifies apps as `nix-image`, `helm-chart`, `vendor-manifest`, `external-source`, or `deferred`.
-- Keep chart-only apps out of image migration. For Helm apps, optimize reproducible `kustomize build --enable-helm`, schema validation, chart/version pinning, and live smoke only.
-- Add a shared Nix OCI contract helper for future migrated services. The helper defines one contract for service name, Nix attr, source SHA, output path, image digest, platforms, cache provenance, timing, and tool versions.
-- Keep GitHub Actions and manual deploy scripts on the same contract so a service cannot have one image path in CI and another image path locally.
-- Keep Docker available only as an explicit transitional fallback for unmigrated services.
+The enabled-app scanner classifies each root-enabled app as:
+
+- `nix-image`: this repo owns the image build path and the app has a concrete Nix image attr.
+- `helm-chart`: chart-rendered third-party app; optimize render/lint/pinning/smoke only.
+- `vendor-manifest`: static/upstream manifests; optimize digest pinning and smoke only.
+- `external-source`: source repository is outside this repo.
+- `deferred`: repo image exists, but migration needs a separate service-specific plan or clean live health first.
+
+Guardrails fail if:
+
+- chart/vendor/external apps receive image build state.
+- a chart app unexpectedly owns lab images.
+- a repo-image app lacks a `nix-image`, `deferred`, or documented manifest-only disposition.
+- a `nix-image` app lacks a concrete Nix attr.
+- a deferred app lacks a reason.
+
+### Build Performance Contract
+
+Every migrated image workflow must emit phase timings for:
+
+- checkout
+- Nix setup
+- dependency realization/helper priming
+- image build
+- image inspection
+- platform push
+- OCI index creation
+- release contract/PR handoff
+
+Each summary reports:
+
+- Attic substitutions.
+- `cache.nixos.org` substitutions.
+- local derivation builds.
+- planned local build blocks.
+- timed phase count.
+- total timed seconds.
+- image archive observations and bytes when the local archive still exists.
+
+Required gate: no migrated mandatory workflow may regress by more than 10%. Warm Nix runs should reduce repeated setup/dependency time by at least 25%.
+
+### Reproducibility Contract
+
+Each migrated image must produce a release contract with:
+
+- service name.
+- source SHA.
+- lockfile hashes.
+- Nix attr.
+- Nix output path.
+- OCI digest.
+- platforms.
+- tool versions.
+- cache provenance.
+- timings.
+
+Same commit plus same lockfiles should reproduce the same Nix output path and OCI digest. Use `nix build --rebuild` where practical and `max-jobs = 0` substitute-only proof for warmed closures.
+
+### Nix Image Contract
+
+- Use `dockerTools.buildLayeredImage` or a service-specific derivation around it.
+- Do not emulate Dockerfile builds.
+- Do not use `created = "now"`.
+- Tune `maxLayers` based on layer reuse and registry push cost.
+- Push platform images with `skopeo`.
+- Create and verify multi-platform indexes with `crane`.
 
 ## Rollout Sequence
 
-1. PR 1: inventory/classification, guardrails, timing/cache metrics foundation, contract helper, tests, and docs. No service image migration.
-2. PR 2: ARC runner toolchain speedup with pinned Nix, `skopeo`, `crane`, `cosign`, `jq`, `yq`, and `kustomize`. No storage changes.
-3. PR 3: migrate clean simple build-owning apps first: `oirat`, `bumba`, and `froussard`.
-4. PR 4: migrate enabled frontend/product build-owning apps: `docs`, `app`, `proompteng`, `olden`, and `synthesis`.
-5. PR 5+: migrate complex build-owning apps only after service-specific derivations are proven. Completed examples include `symphony` and `sag`; `agents` service images (`agents-controller`, `agents-control-plane`, and `agents-shell`) now use Nix OCI service-image builds while the separate `agents-codex-runner` image remains explicitly deferred until its Python/Codex runtime contract is packaged without Docker. Remaining complex candidates include `jangar` and `arc`. `analysis` and `bilig` are manifest-only in this checkout until their owning source/build path is present here, and `autotrader` is a vendor-manifest app without a repo image build.
-6. Defer Torghut-family image migration until live app health is clean.
+1. **PR 1: Upstream Research, Metrics, And Gates**
+   - Clone/read upstream Nix and Nixpkgs references.
+   - Add the research notes to docs.
+   - Tighten enabled-app inventory policy.
+   - Add real checkout/Nix setup timers to the reusable Nix OCI workflow.
+   - Extend cache/performance summaries.
+   - Add tests for enabled-app disposition, workflow timing, fake-job removal, and deterministic image rules.
+   - No service migration.
+
+2. **PR 2: ARC Runner Speed Foundation**
+   - Build deterministic ARC runner images with pinned Nix, Bun, uv, Go, Python, `skopeo`, `crane`, `cosign`, `jq`, `yq`, `kustomize`, and repo CI helpers.
+   - Nix workflows should validate preinstalled tools and fail on ARC fallback to repeated installer actions.
+   - Keep Docker/DinD only while Docker-backed transitional workflows remain.
+
+3. **PR 3: Finish Agents Nix Runtime**
+   - Finish and merge the Agents runtime dependency gap.
+   - Package `agents-codex-runner` runtime dependencies through Nix.
+   - Remove Docker image build paths for enabled Agents service images once the runner image is migrated.
+   - Smoke only the root-enabled Agents app.
+
+4. **PR 4: Torghut-Family Nix Migration**
+   - Add uv/Nix derivations for `torghut`, `torghut-hyperliquid-feed`, `torghut-hyperliquid-runtime`, and `torghut-options`.
+   - Preserve all trading behavior, Pyright gates, health checks, and promotion safety.
+   - Start only after live Torghut app health is clean.
+
+5. **PR 5: Dependency Closure Optimization**
+   - Split Bun, uv, and Go dependency closures from app source layers.
+   - Warm real closures from trusted `main` only.
+   - Tune `maxLayers` per service with measured push/build tradeoffs.
+   - Add substitute-only `max-jobs = 0` proofs for warmed closures.
+
+6. **PR 6: Docker Quarantine And Removal**
+   - Remove Docker Buildx/CLI build-push paths from migrated enabled apps.
+   - Rename remaining Docker helpers as Docker-backed transitional paths.
+   - Disabled and non-owned apps cannot count as rollout proof.
+
+7. **PR 7: Final Rollout Report**
+   - Record PRs, workflow run IDs, before/after timings, cache-hit counts, output paths, digests, Argo revisions, and smoke outputs.
+   - Prove faster warm builds, deterministic rebuilds, digest-pinned releases, and no fake jobs/apps counted.
 
 ## Test Plan
 
-- Inventory tests prove disabled apps are excluded, `home-root` is represented separately, Helm/chart apps do not receive image-build migration state, and repo-image references are not automatically counted as early proof.
-- Contract tests prove migrated services can share the same GitHub Actions and manual deploy metadata without Docker daemon assumptions.
-- Workflow tests prove migrated Nix OCI workflows avoid Docker Buildx, `docker load`, `docker run`, and `docker push`.
-- Performance proof records runner setup, Nix setup, dependency realization, app build, image assembly, image push, index creation, release PR, and rollout timing.
-- Reproducibility proof requires pinned inputs, digest-pinned releases, stable output paths for same inputs, and network-free builds except declared fixed-output fetches/substituters.
+- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
+- `nix flake check --print-build-logs`
+- Build each migrated image attr on both required platforms.
+- Inspect image archives and pushed registry indexes for OCI media types and `linux/amd64` plus `linux/arm64`.
+- Run substitute-only proof with `max-jobs = 0`.
+- Rebuild same commit/lockfiles and compare Nix output paths plus OCI digests.
+- Smoke every migrated enabled app after release: Argo `Synced Healthy`, live image digest matches the release contract, and the service readiness check passes.
 
 ## Acceptance
 
-- No build is added for chart-only or vendor-only apps.
-- Every migrated build-owning app works through both GitHub Actions and manual deploy script paths.
+- No build is added for chart-only, vendor-only, external-source, or disabled apps.
+- Every migrated build-owning app works through GitHub Actions and manual deploy scripts.
 - Migrated workflows and scripts publish the same OCI digest/platform contract.
-- Argo rollout proof is only counted for root-enabled live apps.
-- No mandatory workflow regresses by more than 10%; target is at least 25% less repeated setup/dependency time for migrated image builds.
-- No Ceph, Rook, ObjectBucketClaim, PVC, or storage changes are included.
+- Real Nix OCI workflows emit phase timing and cache provenance.
+- Warm cache proof uses real closures and substitute-only validation, not synthetic packages.
+- No migrated mandatory workflow regresses by more than 10%.
+- Final report proves the measured performance change and reproducibility result.
+- No Ceph, Rook, ObjectBucketClaim, PVC, Talos, node, power, or storage changes are included.

--- a/docs/nix-upstream-rollout-research.md
+++ b/docs/nix-upstream-rollout-research.md
@@ -1,0 +1,67 @@
+# Nix Upstream Rollout Research
+
+## Scope
+
+This note records the upstream source read used for the enabled-app Nix rollout. It is intentionally limited to build performance, cache correctness, OCI image determinism, and rollout gates.
+
+Local read-only references:
+
+- `~/github.com/nix`: `NixOS/nix` at `b41781e`.
+- `~/github.com/nixpkgs`: `NixOS/nixpkgs` at `975c7c0e`.
+
+No Ceph, Rook, ObjectBucketClaim, PVC, Talos, node, or storage state is part of this rollout.
+
+## Nix Cache Behavior
+
+- Use `substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/` in ARC Nix image workflows so Attic is tried first and upstream Nix cache remains the fallback.
+- Use `extra-trusted-public-keys = $ATTIC_PUBLIC_KEY` for the Attic cache key. The Nix source rejects unsigned substitutes that do not match trusted keys.
+- Use `max-jobs = 0` only for substitute-only proofs. The Nix source surfaces this as a no-local-build mode; it should fail if required outputs cannot be substituted.
+- Use `builders-use-substitutes = true` later if remote builders are added, so remote builders can pull warmed paths directly instead of receiving every input from the coordinator.
+
+## Post-Build Hook Decision
+
+Do not use synchronous `post-build-hook` for CI cache push.
+
+The Nix manual/source path shows post-build hooks run as part of the build goal. Even the upcoming async work still keeps waiting goals dependent on hook completion. For this repo, cache upload must stay an explicit main-only step after the build completes, using `nix/cache-push.sh` and real output paths. Network slowness or Attic issues must not block unrelated build scheduling through a global hook.
+
+## DockerTools Image Rules
+
+Use `pkgs.dockerTools.buildLayeredImage` or a service-specific derivation around it. Do not emulate Dockerfiles.
+
+Rules from `nixpkgs/pkgs/build-support/docker/default.nix` and examples:
+
+- `created` defaults to a stable timestamp. Do not use `created = "now"`; that selects an impure path and breaks digest reproducibility.
+- Layer tar creation uses sorted names and `SOURCE_DATE_EPOCH`, so deterministic inputs can produce deterministic archives.
+- Tune `maxLayers` per service. Stable dependency/runtime closures should sit in reusable lower layers, while app source/output should be the smallest changing layer.
+- Use `buildLayeredImage` for application images and keep registry push/index creation outside the derivation with `skopeo` and `crane`.
+
+## Determinism Proof
+
+Each migrated enabled repo-owned image must emit or preserve:
+
+- source SHA
+- lockfile hashes
+- Nix package attr
+- Nix output path
+- OCI image digest
+- platforms
+- builder versions
+- cache provenance
+- phase timings
+
+Same commit plus same lockfiles should reproduce the same Nix output path and OCI digest. Use `nix build --rebuild` where practical for drift checks, and use `max-jobs = 0` for warmed substitute-only proof.
+
+## Performance Gates
+
+Each real migrated image workflow needs phase timings for:
+
+- checkout
+- Nix setup
+- dependency realization/helper priming
+- app image build
+- image inspection
+- platform push
+- OCI index creation
+- release contract/PR handoff
+
+Acceptance is correctness first, then speed: no migrated mandatory workflow may regress more than 10%, and warm runs target at least 25% less repeated setup/dependency time.

--- a/nix/ci-nix-oci-summary.sh
+++ b/nix/ci-nix-oci-summary.sh
@@ -25,10 +25,61 @@ count_matches() {
   awk '{total += $1} END {print total + 0}' <<< "${counts}"
 }
 
+sum_timed_seconds() {
+  if [[ ! -f "${timings_file}" ]]; then
+    echo 0
+    return
+  fi
+  awk -F $'\t' '{total += $3} END {print total + 0}' "${timings_file}"
+}
+
+count_timed_phases() {
+  if [[ ! -f "${timings_file}" ]]; then
+    echo 0
+    return
+  fi
+  awk 'NF > 0 {count += 1} END {print count + 0}' "${timings_file}"
+}
+
+count_existing_image_archives() {
+  local image_tar archive_count
+  archive_count=0
+  if ! compgen -G "${log_dir}/*.log" >/dev/null; then
+    echo 0
+    return
+  fi
+  while IFS= read -r image_tar; do
+    if [[ -f "${image_tar}" ]]; then
+      archive_count=$((archive_count + 1))
+    fi
+  done < <(grep -h -Eo 'at /nix/store/[^.[:space:]]+.*\.(tar|tar\.gz|tgz)\.' "${log_dir}"/*.log 2>/dev/null | sed -E 's/^at //; s/\.$//')
+  echo "${archive_count}"
+}
+
+sum_existing_image_archive_bytes() {
+  local image_tar archive_bytes
+  archive_bytes=0
+  if ! compgen -G "${log_dir}/*.log" >/dev/null; then
+    echo 0
+    return
+  fi
+  while IFS= read -r image_tar; do
+    if [[ -f "${image_tar}" ]]; then
+      archive_bytes=$((archive_bytes + $(wc -c < "${image_tar}")))
+    fi
+  done < <(grep -h -Eo 'at /nix/store/[^.[:space:]]+.*\.(tar|tar\.gz|tgz)\.' "${log_dir}"/*.log 2>/dev/null | sed -E 's/^at //; s/\.$//')
+  echo "${archive_bytes}"
+}
+
 attic_substitutions="$(count_matches "copying path .*from 'http://attic\\.attic\\.svc\\.cluster\\.local/lab'")"
 nixos_substitutions="$(count_matches "copying path .*from 'https://cache\\.nixos\\.org'")"
 local_builds="$(count_matches "building '/nix/store/.*\\.drv'")"
 planned_build_blocks="$(count_matches 'this derivation will be built:|these [0-9]+ derivations will be built:')"
+timed_phases="$(count_timed_phases)"
+timed_seconds="$(sum_timed_seconds)"
+cache_substitutions=$((attic_substitutions + nixos_substitutions))
+image_archives="$(count_existing_image_archives)"
+image_archive_bytes="$(sum_existing_image_archive_bytes)"
 
 {
   echo "## Nix OCI Cache Summary"
@@ -39,6 +90,16 @@ planned_build_blocks="$(count_matches 'this derivation will be built:|these [0-9
   echo "| cache.nixos.org substitutions | ${nixos_substitutions} |"
   echo "| Local derivation builds | ${local_builds} |"
   echo "| Planned local build blocks | ${planned_build_blocks} |"
+  echo
+  echo "## Nix OCI Performance Contract"
+  echo
+  echo "| Metric | Value |"
+  echo "| --- | ---: |"
+  echo "| Timed phases | ${timed_phases} |"
+  echo "| Total timed seconds | ${timed_seconds} |"
+  echo "| Cache substitutions | ${cache_substitutions} |"
+  echo "| Existing image archives | ${image_archives} |"
+  echo "| Existing image archive bytes | ${image_archive_bytes} |"
   echo
 
   if [[ -f "${timings_file}" ]]; then

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -12,8 +12,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-ndyiyuCI8lQmM6yPNDhY6q4VWtJohWJbZjrMwGObbe0=";
-    aarch64-linux = "sha256-ndyiyuCI8lQmM6yPNDhY6q4VWtJohWJbZjrMwGObbe0=";
+    x86_64-linux = "sha256-KGHJgGVfesk5pNYzr/he+f8CK84kufdXkWWPrbnUpIg=";
+    aarch64-linux = "sha256-KGHJgGVfesk5pNYzr/he+f8CK84kufdXkWWPrbnUpIg=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-SHYomlo6kr3cok0PtFuNZCCW4thKJ7oTV7WAomgQ4uc=";
-    aarch64-linux = "sha256-mJ0C9aLQSRUzzeu78dPZIvk/EkHThbQdHGkyaMOGyg0=";
+    x86_64-linux = "sha256-Ctm7jVWwS7aFROoHrwOb0r4vwilTWqpxo8z5+zdmSJU=";
+    aarch64-linux = "sha256-ko0nDKmqJdnsZNHVjU01sO8FBoZhwAtPx4XKqYGG3DE=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-VH/h1FsSjswTgn78p44G0VVOdd6IPQIvULghepxkn2o=";
-    aarch64-linux = "sha256-kSB3lX0Kv4aOztJdOtxnAk3gS+T1H1xu/gT5b1QOcig=";
+    x86_64-linux = "sha256-dsUT1jkChBLckFmQpXjqUlRj6nVTRs0wXjpfNM3Nq4Q=";
+    aarch64-linux = "sha256-sLwYDdj7SW6zt/F5jjNaH0BP7lKBR+AMueE3EvGFRso=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -107,6 +107,17 @@ describe('enabled app inventory', () => {
     }
   })
 
+  it('requires every root-enabled repo image to have a rollout disposition', () => {
+    for (const candidate of inventory.entries.filter((entry) => entry.repoImages.length > 0)) {
+      expect(['nix-image', 'deferred', 'vendor-manifest']).toContain(candidate.class)
+      if (candidate.class === 'nix-image') {
+        expect(candidate.nixImageAttr).toBeTruthy()
+      } else {
+        expect(candidate.deferredReason).toBeTruthy()
+      }
+    }
+  })
+
   it('passes the no-build-for-chart-and-vendor guardrail', () => {
     expect(() => assertEnabledAppBuildPolicy(inventory)).not.toThrow()
   })

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 
 import { afterEach, describe, expect, it } from 'bun:test'
 
@@ -46,6 +46,9 @@ const productImageModules = [
   readRepoFile('nix/images/proompteng.nix'),
   readRepoFile('nix/images/synthesis.nix'),
 ]
+const allNixImageModules = readdirSync(new URL('nix/images/', repoRoot))
+  .filter((name) => name.endsWith('.nix'))
+  .map((name) => [name, readRepoFile(`nix/images/${name}`)] as const)
 const symphonyImageModule = readRepoFile('nix/images/symphony.nix')
 const sagImageModule = readRepoFile('nix/images/sag.nix')
 const agentsImageModule = readRepoFile('nix/images/agents.nix')
@@ -260,6 +263,14 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('test -s "${output_file}"')
     expect(nixOciWorkflow).toContain('No build-platform helper closure paths were captured.')
     expect(nixOciWorkflow).toContain('No index helper closure paths were captured.')
+    expect(nixOciWorkflow).toContain('Start checkout timer')
+    expect(nixOciWorkflow).toContain('Record checkout timing')
+    expect(nixOciWorkflow).toContain('"checkout-${ARCH}"')
+    expect(nixOciWorkflow).toContain('"checkout-publish-index"')
+    expect(nixOciWorkflow).toContain('Start Nix setup timer')
+    expect(nixOciWorkflow).toContain('Record Nix setup timing')
+    expect(nixOciWorkflow).toContain('"nix-setup-${ARCH}"')
+    expect(nixOciWorkflow).toContain('"nix-setup-publish-index"')
     expect(nixOciWorkflow).toContain('nix/ci-run-timed.sh')
     expect(nixOciWorkflow).toContain('nix/ci-nix-oci-summary.sh')
     expect(nixOciWorkflow).toContain(
@@ -275,7 +286,25 @@ describe('native OCI build workflows', () => {
     expect(ciNixOciSummaryScript).toContain('Attic substitutions')
     expect(ciNixOciSummaryScript).toContain('cache.nixos.org substitutions')
     expect(ciNixOciSummaryScript).toContain('Local derivation builds')
+    expect(ciNixOciSummaryScript).toContain('Nix OCI Performance Contract')
+    expect(ciNixOciSummaryScript).toContain('Total timed seconds')
+    expect(ciNixOciSummaryScript).toContain('Cache substitutions')
+    expect(ciNixOciSummaryScript).toContain('Existing image archive bytes')
     expect(ciNixOciSummaryScript).toContain('GITHUB_STEP_SUMMARY')
+  })
+
+  it('keeps Nix image derivations deterministic and dockerTools-backed', () => {
+    for (const [name, imageModule] of allNixImageModules) {
+      if (imageModule.includes('created = "now"')) {
+        throw new Error(`${name} must not use impure dockerTools timestamps`)
+      }
+      if (imageModule.includes('docker build')) {
+        throw new Error(`${name} must not emulate Dockerfile builds`)
+      }
+    }
+    expect(
+      allNixImageModules.some(([, imageModule]) => imageModule.includes('pkgs.dockerTools.buildLayeredImage')),
+    ).toBe(true)
   })
 
   it('caps Bun workspace image layers to keep registry publishes bounded', () => {

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -333,6 +333,39 @@ export const assertEnabledAppBuildPolicy = (inventory: EnabledAppInventory): voi
     )
   }
 
+  const repoImageAppsWithoutDisposition = inventory.entries.filter(
+    (entry) =>
+      entry.repoImages.length > 0 &&
+      entry.class !== 'nix-image' &&
+      entry.class !== 'deferred' &&
+      !(entry.class === 'vendor-manifest' && Boolean(entry.deferredReason)),
+  )
+  if (repoImageAppsWithoutDisposition.length > 0) {
+    throw new Error(
+      `Repo-image app(s) need Nix migration or explicit deferral: ${repoImageAppsWithoutDisposition
+        .map((entry) => entry.name)
+        .join(', ')}`,
+    )
+  }
+
+  const nixImageAppsWithoutAttr = inventory.entries.filter(
+    (entry) => entry.class === 'nix-image' && !entry.nixImageAttr,
+  )
+  if (nixImageAppsWithoutAttr.length > 0) {
+    throw new Error(
+      `Nix-image app(s) are missing package attrs: ${nixImageAppsWithoutAttr.map((entry) => entry.name).join(', ')}`,
+    )
+  }
+
+  const deferredAppsWithoutReason = inventory.entries.filter(
+    (entry) => entry.class === 'deferred' && !entry.deferredReason,
+  )
+  if (deferredAppsWithoutReason.length > 0) {
+    throw new Error(
+      `Deferred app(s) are missing reasons: ${deferredAppsWithoutReason.map((entry) => entry.name).join(', ')}`,
+    )
+  }
+
   const chartBuilds = inventory.entries.filter((entry) => entry.class === 'helm-chart' && entry.repoImages.length > 0)
   if (chartBuilds.length > 0) {
     throw new Error(


### PR DESCRIPTION
## Summary

- Added upstream Nix/Nixpkgs rollout research notes covering substituters, `max-jobs = 0`, post-build hook avoidance, and dockerTools determinism rules.
- Tightened the enabled-app inventory guardrail so every root-enabled repo-image app has a real Nix image target, explicit deferral, or documented manifest-only disposition.
- Added real checkout and Nix setup timing probes to the reusable Nix OCI workflow and extended the summary script with cache and performance contract metrics.
- Corrected stale Bumba, Froussard, and Oirat Bun dependency fixed-output hashes surfaced by real PR Nix image builds.

## Related Issues

None

## Testing

- `bash -n nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh`
- `shellcheck nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh`
- `bunx oxfmt --check packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`
- `NIX_OCI_LOG_DIR=$(mktemp -d) bash nix/ci-nix-oci-summary.sh` with synthetic log/timing input
- `nix flake check --print-build-logs`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

