### PR TITLE
docs(talos): plan altra v1.13.5 upgrade

### DIFF
--- a/argocd/applications/nvidia-gpu-operator/altra-nvidia-device-plugin.yaml
+++ b/argocd/applications/nvidia-gpu-operator/altra-nvidia-device-plugin.yaml
@@ -1,0 +1,145 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: altra-nvidia-device-plugin
+  namespace: gpu-operator
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: altra-nvidia-device-plugin-config
+  namespace: gpu-operator
+data:
+  config.yaml: |
+    version: v1
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        failRequestsGreaterThanOne: true
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: altra-nvidia-device-plugin
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: altra-nvidia-device-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: altra-nvidia-device-plugin
+subjects:
+  - kind: ServiceAccount
+    name: altra-nvidia-device-plugin
+    namespace: gpu-operator
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: altra-nvidia-device-plugin
+  namespace: gpu-operator
+  labels:
+    app: altra-nvidia-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app: altra-nvidia-device-plugin
+  template:
+    metadata:
+      annotations:
+        platform.proompteng.ai/gpu-sharing-config-version: altra-exclusive-1
+      labels:
+        app: altra-nvidia-device-plugin
+    spec:
+      serviceAccountName: altra-nvidia-device-plugin
+      priorityClassName: system-node-critical
+      runtimeClassName: nvidia
+      nodeSelector:
+        kubernetes.io/hostname: talos-192-168-1-85
+        nvidia.com/gpu.present: "true"
+        platform.proompteng.ai/altra-gpu-container-ready: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: nvidia-device-plugin
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --nvidia-driver-root=/
+            - --nvidia-dev-root=/
+          env:
+            - name: PASS_DEVICE_SPECS
+              value: "true"
+            - name: FAIL_ON_INIT_ERROR
+              value: "true"
+            - name: DEVICE_LIST_STRATEGY
+              value: cdi-annotations,cdi-cri
+            - name: DEVICE_ID_STRATEGY
+              value: uuid
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: all
+            - name: NVIDIA_DEV_ROOT
+              value: /
+            - name: MIG_STRATEGY
+              value: single
+            - name: CDI_ENABLED
+              value: "true"
+            - name: CDI_ANNOTATION_PREFIX
+              value: cdi.k8s.io/
+            - name: CONFIG_FILE
+              value: /config/config.yaml
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: driver-install-dir
+              mountPath: /driver-root
+              mountPropagation: HostToContainer
+            - name: host-root
+              mountPath: /host
+              readOnly: true
+              mountPropagation: HostToContainer
+            - name: cdi-root
+              mountPath: /var/run/cdi
+      volumes:
+        - name: config
+          configMap:
+            name: altra-nvidia-device-plugin-config
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: driver-install-dir
+          hostPath:
+            path: /
+        - name: host-root
+          hostPath:
+            path: /
+        - name: cdi-root
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate

--- a/argocd/applications/nvidia-gpu-operator/kustomization.yaml
+++ b/argocd/applications/nvidia-gpu-operator/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: gpu-operator
 
 resources:
+  - altra-nvidia-device-plugin.yaml
   - turin-nvidia-device-plugin.yaml
 
 helmCharts:

--- a/argocd/applications/nvidia-gpu-operator/values.yaml
+++ b/argocd/applications/nvidia-gpu-operator/values.yaml
@@ -1,6 +1,8 @@
 # Talos owns host NVIDIA drivers and the container toolkit through system
 # extensions. This chart provides GPU Operator CRDs/components, while
-# a repo-owned node-specific device-plugin DaemonSet advertises Turin GPUs:
+# repo-owned node-specific device-plugin DaemonSets advertise GPUs:
+# - `altra-nvidia-device-plugin`: RTX 3090 on Altra, gated until the Talos
+#   NVIDIA extension upgrade and container-GPU validation are complete.
 # - `turin-nvidia-device-plugin`: Blackwell on `turin`, time-sliced for shared use.
 #
 # Sandbox/KubeVirt/vfio passthrough is intentionally disabled. It created the

--- a/devices/altra/manifests/installer-image.tailscale-nvidia-lts.patch.yaml
+++ b/devices/altra/manifests/installer-image.tailscale-nvidia-lts.patch.yaml
@@ -1,3 +1,3 @@
 machine:
   install:
-    image: factory.talos.dev/metal-installer/6e246b622304aee389cfed7ed4f13dd4dac4a751243ed43bae10d73c63195e7d:v1.13.4
+    image: factory.talos.dev/metal-installer/6e246b622304aee389cfed7ed4f13dd4dac4a751243ed43bae10d73c63195e7d:v1.13.5

--- a/docs/runbooks/talos-latest-upgrade-plan.md
+++ b/docs/runbooks/talos-latest-upgrade-plan.md
@@ -1,410 +1,138 @@
 # Talos latest upgrade plan
 
-This runbook tracks the `galactic` Talos OS upgrade to the latest stable Talos
-release. It documents the process proven on Ryzen and the remaining production
-gates for Altra. It does not authorize an upgrade while the cluster is degraded
-or while drain blockers remain unresolved.
+This runbook is the production plan for upgrading the remaining Altra node in
+the `galactic` Talos cluster. It also gates Kubernetes GPU pod enablement on
+Altra. The upgrade is OS-only: do not change the Kubernetes minor version.
 
 ## Target
 
-- Target Talos release: `v1.13.4`.
-- Release date: 2026-06-09.
-- Default upstream installer: `ghcr.io/siderolabs/installer:v1.13.4`.
-- Cluster: `ryzen` / Kubernetes `galactic`.
+- Target node: `talos-192-168-1-85`.
+- Target node IP: `100.100.244.142`.
+- Target Talos release: `v1.13.5`.
+- Target Kubernetes release: keep the existing `v1.35.0`.
+- Target installer source:
+  `devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml`.
+- Target installer image:
+  `factory.talos.dev/metal-installer/6e246b622304aee389cfed7ed4f13dd4dac4a751243ed43bae10d73c63195e7d:v1.13.5`.
 - Primary Kubernetes context: `galactic-lan`.
+- Fresh branch for this run: `codex/talos-altra-v1135-upgrade`.
 
-Sources checked on 2026-06-17; live status refreshed on 2026-06-27:
+Sources checked on 2026-07-03:
 
 - Talos releases: <https://github.com/siderolabs/talos/releases>
+- Talos Image Factory: <https://factory.talos.dev/>
 - Talos upgrade guide:
   <https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos>
-- Talos support matrix:
-  <https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix>
-- Local access runbook: `docs/runbooks/galactic-kubernetes-access.md`
+- Talos Image Factory docs:
+  <https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory>
+- Talos system extensions docs:
+  <https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions>
 - Local Rook-Ceph runbook: `docs/runbooks/rook-ceph-on-talos.md`
-- Local Turin Talos runbook: `devices/turin/docs/cluster-join-plan.md`
-
-Talos OS upgrades are separate from Kubernetes upgrades. Do not change
-Kubernetes minor versions as part of this runbook.
-
-## Live snapshot
-
-Read-only checks after the Ryzen window showed this state; Altra was refreshed
-again on 2026-06-27 during the Saigak 3090 container-GPU cutover:
-
-| Kubernetes node        | IP              | Talos | Kubernetes | Role          | Upgrade action |
-| ---------------------- | --------------- | ----- | ---------- | ------------- | -------------- |
-| `talos-192-168-1-194`  | `100.100.244.141` | `v1.13.4` | Ready | control plane | Complete; validate only |
-| `talos-192-168-1-85`   | `100.100.244.142` | `v1.12.4` | Ready | control plane, OSD host | Pending; upgrade only after Altra gates pass |
-| `turin`                | `100.100.244.171` | `v1.13.4` | Ready | control plane, OSD host | Already at target; validate only |
-
-Current Altra gates:
-
-1. `talos-192-168-1-85` is still running Talos `v1.12.4`, while its live
-   machine config already points `machine.install.image` at a `v1.13.4` Image
-   Factory installer. Do not trust that drift blindly. Regenerate the Altra
-   target image from
-   `devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml` and
-   patch the machine config immediately before the actual upgrade.
-1. A server-side drain dry-run on 2026-06-27 still hit PDB blockers on Altra:
-   CNPG primaries `coder-cluster-1`, `keycloak-db-1`, `tsag-db-1`,
-   `jangar-db-1`, and `posthog-db-1`; Kafka brokers `kafka-pool-a-0`,
-   `kafka-pool-a-2`, `kafka-pool-b-4`, and `kafka-pool-b-5`; Knative
-   `activator` and `webhook`; Tempo ingesters; `torghut-tigerbeetle-0`;
-   `torghut-ta`; `torghut-hyperliquid-runtime`; the ClickHouse operator;
-   `forgejo-runners-arm64-0`; and
-   `torghut/chi-torghut-clickhouse-default-0-0-0`, which currently matches
-   more than one PDB and cannot be evicted through the eviction subresource.
-1. The CNPG blockers have a known zero-data-loss pattern from Ryzen: create
-   replicas, wait for them, promote a replica off the target node, drain, then
-   restore the singleton posture after acceptance.
-1. The non-database blockers need an explicit per-workload action before Altra:
-   scale temporary HA where supported, add capacity, or accept a written
-   maintenance outage for singleton runner/TigerBeetle workloads. Do not use
-   `--disable-eviction`, `--force`, or manual pod deletion to bypass them.
-
-Do not run `talosctl upgrade` on Altra until those blockers are fixed or
-explicitly accepted in a maintenance decision record.
-
-## Ryzen execution record
-
-Ryzen was upgraded successfully on 2026-06-19 using the replica-first process.
-The evidence directory was:
-
-```text
-/tmp/ryzen-talos-v1.13.4-20260618T222737Z
-```
-
-Final accepted state:
-
-1. Talos server version: `v1.13.4`.
-1. `MachineStatus`: `stage=running`, `ready=true`.
-1. Kubernetes node: `Ready`, schedulable, no maintenance taint.
-1. Required Ryzen extensions: `kata-containers`, `glibc`, `tailscale`,
-   `amdgpu`, `amd-ucode`, and schematic
-   `317c1c8cf1562c7ce77b79d6f0af8315c336151b6f752f44f84e52deeccf1c16`.
-1. AMD GPU capacity remained `1`.
-1. Etcd retained three non-learner voters.
-1. Rook-Ceph returned to `HEALTH_OK`, 6/6 OSDs up/in, and all PGs
-   `active+clean`.
-1. Temporary CNPG, Knative, Tempo, ClickHouse PDB, Forgejo runner, and Argo CD
-   maintenance patches were restored.
-
-The durable lesson from Ryzen is that the node OS step is short, but the
-production work is the drain preparation and cleanup. Treat Altra the same way:
-read-only preflight, workload capacity, successful drain dry-run, etcd snapshot,
-Talos upgrade, acceptance, and restoration.
-
-## Version and image policy
-
-Use adjacent minor upgrades only. The current non-Turin nodes are `v1.12.4`, so
-`v1.12.4 -> v1.13.4` is the supported path. If any node is older than `v1.12.x`
-at execution time, upgrade it to the latest `v1.12` patch first, then to
-`v1.13.4`.
-
-Always pass the target image explicitly. Do not rely on the local `talosctl`
-default image.
-
-Use custom Image Factory installer images when the node has required system
-extensions:
-
-| Node profile | Source schematic | Required extensions | Target image form |
-| ------------ | ---------------- | ------------------- | ----------------- |
-| Ryzen / `talos-192-168-1-194` | `devices/ryzen/manifests/ryzen-tailscale-schematic.yaml` | Kata Containers, glibc, Tailscale, AMD GPU, AMD ucode | `factory.talos.dev/metal-installer/<schematic-id>:v1.13.4` |
-| Altra / `talos-192-168-1-85` | `devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml` | Tailscale, NVIDIA open LTS kernel modules, NVIDIA toolkit LTS | `factory.talos.dev/metal-installer/<schematic-id>:v1.13.4` |
-| Turin / `turin` | `devices/turin/manifests/turin-talos-nvidia-lts-schematic.yaml` | Tailscale, NVIDIA open LTS kernel modules, NVIDIA toolkit LTS | already `v1.13.4` |
-
-Do not downgrade Altra or Ryzen to a vanilla installer image. Altra depends on
-node-level Tailscale and the NVIDIA extensions for RTX 3090 container GPU
-serving, and Ryzen depends on Kata Containers, glibc, Tailscale, AMD GPU/ucode
-extensions, and kernel args.
-
-Use a `talosctl` version matching the source node version for issuing the
-upgrade when practical. Keep `talosctl v1.13.4` available for post-upgrade
-validation. A newer client can read the older nodes but emits compatibility
-warnings.
-
-## Preflight gate
-
-Run all checks before each upgrade window:
-
-```bash
-export CTX=galactic-lan
-export ROOK_TOOLS='deploy/rook-ceph-tools'
-
-kubectl --context "$CTX" get nodes -o wide
-kubectl --context "$CTX" get --raw='/readyz?verbose'
-kubectl --context "$CTX" get pdb -A
-kubectl --context "$CTX" -n rook-ceph get pods -o wide
-kubectl --context "$CTX" -n rook-ceph exec "$ROOK_TOOLS" -- ceph -s
-kubectl --context "$CTX" -n rook-ceph exec "$ROOK_TOOLS" -- ceph health detail
-kubectl --context "$CTX" -n rook-ceph exec "$ROOK_TOOLS" -- ceph osd tree
-
-talosctl config info
-talosctl -n 100.100.244.141 -e 100.100.244.141 version
-talosctl -n 100.100.244.141 -e 100.100.244.141 get machinestatus -o yaml
-talosctl -n 100.100.244.141 -e 100.100.244.141 get extensions
-talosctl -n 100.100.244.142 -e 100.100.244.142 version
-talosctl -n 100.100.244.142 -e 100.100.244.142 get machinestatus -o yaml
-talosctl -n 100.100.244.142 -e 100.100.244.142 get extensions
-talosctl -n 100.100.244.171 -e 100.100.244.171 version
-talosctl -n 100.100.244.171 -e 100.100.244.171 get machinestatus -o yaml
-talosctl -n 100.100.244.171 -e 100.100.244.171 get extensions
-```
-
-The gate passes only when:
-
-1. All intended upgrade targets are Kubernetes `Ready`.
-1. No target node is already in Talos `stage: upgrading`.
-1. Etcd has quorum and all expected members are healthy.
-1. Rook-Ceph has no inactive, down, or undersized PGs.
-1. Any explicit `noout`, `norecover`, `nobackfill`, or `pause` Ceph flags are
-   understood and documented for the maintenance window.
-1. No PDB with zero allowed disruptions protects a pod that must move off the
-   target node during drain.
-1. The target Image Factory installer image exists and can be pulled by the
-   node.
-1. A fresh etcd snapshot has been captured.
-
-Capture the etcd snapshot from a healthy control-plane node:
-
-```bash
-talosctl -n 100.100.244.171 -e 100.100.244.171 etcd snapshot \
-  /tmp/galactic-etcd-before-talos-v1.13.4-$(date -u +%Y%m%dT%H%M%SZ).db
-```
-
-## Proven production process
-
-Use this sequence for every remaining node. This is the process that succeeded
-on Ryzen.
-
-1. Refresh live truth: node versions, `MachineStatus`, extensions, API readyz,
-   etcd members, Ceph health, Ceph flags, target-node pods, and PDBs.
-1. Generate the target Image Factory installer from the repo schematic for that
-   hardware profile.
-1. Capture evidence under a dated `/tmp` directory.
-1. Pause Argo automation only for apps whose live specs will be patched during
-   maintenance. If an app is generated by an ApplicationSet, patch the
-   ApplicationSet generator, not only the generated Application.
-1. Cordon the target node only after preflight is green.
-1. Add drain-safe capacity: CNPG replicas and promotions, temporary HA for
-   Knative/Tempo/operator workloads, and a written decision for singleton
-   workloads that cannot be kept available.
-1. Run `kubectl drain --dry-run=server` and stop on any PDB violation.
-1. Capture an etcd snapshot from a healthy control-plane node.
-1. Patch `machine.install.image` to the exact target installer image with
-   `--mode=no-reboot`.
-1. Run `talosctl upgrade` with the same image.
-1. Wait for Talos, Kubernetes, etcd, GPU/extensions, and Ceph acceptance.
-1. Restore temporary workload posture, uncordon if needed, restore Argo
-   automation, and run final acceptance.
-
-## Pre-execution recovery lane
-
-Do this before the Talos upgrade window. Keep it read-only until the actual
-repair action is known. This lane is a verification gate, not part of the normal
-Talos upgrade.
-
-For `talos-192-168-1-85`:
-
-```bash
-kubectl --context galactic-lan describe node talos-192-168-1-85
-kubectl --context galactic-lan get pods -A -o wide \
-  --field-selector spec.nodeName=talos-192-168-1-85
-
-talosctl -n 100.100.244.142 -e 100.100.244.142 get machinestatus -o yaml
-talosctl -n 100.100.244.142 -e 100.100.244.142 services
-talosctl -n 100.100.244.142 -e 100.100.244.142 service kubelet status
-talosctl -n 100.100.244.142 -e 100.100.244.142 logs kubelet --tail 200
-talosctl -n 100.100.244.142 -e 100.100.244.142 dmesg
-```
-
-For Rook-Ceph:
-
-```bash
-kubectl --context galactic-lan -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
-kubectl --context galactic-lan -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail
-kubectl --context galactic-lan -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd tree
-kubectl --context galactic-lan -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd stat
-kubectl --context galactic-lan -n rook-ceph get pods -o wide
-```
-
-The recovery lane is complete only when `talos-192-168-1-85` is either healthy
-and ready to upgrade, or deliberately excluded from the window with a written
-reason and a confirmed safe quorum/storage posture.
-
-## Upgrade order
-
-Upgrade one node at a time. Do not launch parallel node upgrades in this
-cluster. Rook-Ceph and the control plane both have quorum/disruption
-constraints, and the Talos docs explicitly warn that components like Rook/Ceph
-may not survive multiple near-simultaneous node reboots.
-
-Preferred order after all gates pass:
-
-1. Validate `turin` as the existing `v1.13.4` reference.
-1. Keep `talos-192-168-1-194` in validation-only mode; it is already upgraded.
-1. Upgrade `talos-192-168-1-85` from `v1.12.4` to `v1.13.4` only after the
-   Altra drain blockers are cleared.
-1. Re-run full acceptance criteria.
-
-If a historical `talos-192-168-1-203` node appears again, stop and update the
-inventory before continuing. Do not infer that `203` is an upgrade target from
-old docs alone.
-
-## Build target installer images
-
-Build or refresh Image Factory schematics before the window:
-
-### Ryzen image
-
-```bash
-RYZEN_SCHEMATIC_ID="$(
-  curl -sS -X POST \
-    --data-binary @devices/ryzen/manifests/ryzen-tailscale-schematic.yaml \
-    https://factory.talos.dev/schematics \
-    | jq -r .id
-)"
-
-RYZEN_IMAGE="factory.talos.dev/metal-installer/${RYZEN_SCHEMATIC_ID}:v1.13.4"
-printf '%s\n' "$RYZEN_IMAGE"
-```
-
-### Altra image
-
-```bash
-ALTRA_SCHEMATIC_ID="$(
-  curl -sS -X POST \
-    --data-binary @devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml \
-    https://factory.talos.dev/schematics \
-    | jq -r .id
-)"
-
-ALTRA_IMAGE="factory.talos.dev/metal-installer/${ALTRA_SCHEMATIC_ID}:v1.13.4"
-printf '%s\n' "$ALTRA_IMAGE"
-```
-
-### Turin image
-
-For Turin validation only:
-
-```bash
-TURIN_SCHEMATIC_ID="$(
-  curl -sS -X POST \
-    --data-binary @devices/turin/manifests/turin-talos-nvidia-lts-schematic.yaml \
-    https://factory.talos.dev/schematics \
-    | jq -r .id
-)"
-
-TURIN_IMAGE="factory.talos.dev/metal-installer/${TURIN_SCHEMATIC_ID}:v1.13.4"
-printf '%s\n' "$TURIN_IMAGE"
-```
-
-The Altra source is tracked at
-`devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml`.
-
-## Node upgrade commands
-
-For each node, persist the installer image in machine config, then perform the
-upgrade with the same image. This keeps the installed state and future reset
-path aligned.
-
-### Ryzen: `talos-192-168-1-194`
-
-```bash
-cat >/tmp/ryzen-v1.13.4-installer.patch.yaml <<EOF
-machine:
-  install:
-    image: ${RYZEN_IMAGE}
-EOF
-
-talosctl patch machineconfig \
-  -n 100.100.244.141 \
-  -e 100.100.244.141 \
-  --patch @/tmp/ryzen-v1.13.4-installer.patch.yaml \
-  --mode=no-reboot
-
-talosctl upgrade \
-  -n 100.100.244.141 \
-  -e 100.100.244.141 \
-  --image "$RYZEN_IMAGE" \
-  --wait \
-  --progress plain \
-  --drain-timeout 20m \
-  --timeout 45m
-```
-
-Expected post-upgrade extension set includes:
-
-1. `kata-containers`
-1. `glibc`
-1. `tailscale`
-1. `amdgpu`
-1. `amd-ucode`
-
-### Altra: `talos-192-168-1-85`
-
-```bash
-cat >/tmp/altra-v1.13.4-installer.patch.yaml <<EOF
-machine:
-  install:
-    image: ${ALTRA_IMAGE}
-EOF
-
-talosctl patch machineconfig \
-  -n 100.100.244.142 \
-  -e 100.100.244.142 \
-  --patch @/tmp/altra-v1.13.4-installer.patch.yaml \
-  --mode=no-reboot
-
-talosctl upgrade \
-  -n 100.100.244.142 \
-  -e 100.100.244.142 \
-  --image "$ALTRA_IMAGE" \
-  --wait \
-  --progress plain \
-  --drain-timeout 20m \
-  --timeout 45m
-```
-
-Expected post-upgrade extension set includes:
-
-1. `tailscale`
-1. `nvidia-open-gpu-kernel-modules-lts`
-1. `nvidia-container-toolkit-lts`
-
-Do not pass deprecated upgrade flags. For `v1.13`, prefer the streaming upgrade
-API used by current `talosctl upgrade`.
-
-If `talosctl upgrade --wait` fails before starting the upgrade while waiting for
-an actor ID, verify that the node is still on the old version and
-`MachineStatus` is still `running/ready=true`, then retry with `--wait=false`.
-Do not retry blindly after the node has started upgrading or rebooting.
-
-## Altra execution checklist
-
-Use these Altra-specific variables:
+- Local Altra manifests: `devices/altra/manifests/`
+- Local GPU operator app: `argocd/applications/nvidia-gpu-operator/`
+
+The Image Factory stable recommendation is `1.13.5`. `1.14.0-alpha.2` is a
+pre-release and is not a production target for this run.
+
+## Current live state
+
+Read-only checks on 2026-07-03 showed:
+
+| Kubernetes node       | Tailscale IP      | Talos     | Kubernetes | Role                                   | Action                             |
+| --------------------- | ----------------- | --------- | ---------- | -------------------------------------- | ---------------------------------- |
+| `talos-192-168-1-194` | `100.100.244.141` | `v1.13.4` | `v1.35.0`  | control plane                          | Read-only peer                     |
+| `talos-192-168-1-85`  | `100.100.244.142` | `v1.12.4` | `v1.35.0`  | control plane, OSD host, RTX 3090 host | Upgrade target                     |
+| `turin`               | `100.100.244.190` | `v1.13.4` | `v1.35.0`  | control plane, OSD host, NVIDIA host   | Read-only peer and snapshot source |
+
+Do not use stale Turin endpoint `100.100.244.171`; it is not reachable in the
+current environment.
+
+The current hard blockers are:
+
+1. Rook-Ceph is `HEALTH_WARN` with `noout,noscrub,nodeep-scrub`, slow BlueStore
+   alerts, recent crashes, and remapped PGs still recovering.
+1. Altra's live machine config says `machine.install.disk: /dev/nvme1n1`, but
+   live Talos volumes prove `STATE`, `META`, `EPHEMERAL`, and local-path are on
+   `/dev/nvme0n1`.
+1. `/dev/nvme1n1` backs Ceph DB/WAL LVM devices and must not be used as the
+   Talos install disk.
+1. A server-side drain dry-run blocks on Altra Rook-Ceph OSD pods,
+   `torghut/torghut-tigerbeetle-0`,
+   `forgejo-runners/forgejo-runners-arm64-0`, and
+   `knative-eventing/eventing-webhook`.
+1. Altra has NVIDIA PCI presence labels, but it does not currently advertise
+   `nvidia.com/gpu` capacity. Kubernetes GPU pods on Altra are not enabled
+   until the Talos NVIDIA extensions, device plugin, and smoke test pass.
+
+## Non-negotiable rules
+
+1. Upgrade only Altra in this run. Do not upgrade Ryzen or Turin.
+1. Do not change Kubernetes versions.
+1. Do not run `talosctl upgrade` while Ceph is recovering or while any Altra
+   OSD PDB blocks drain.
+1. Do not use `--disable-eviction`, `--force`, or manual pod deletion to bypass
+   PDBs.
+1. Do not use `/dev/nvme1n1` as the Talos install disk.
+1. Do not remove etcd members, delete Kubernetes nodes, purge OSDs, or clear
+   Ceph state as part of rollback without a separate recovery runbook.
+1. Enable Altra GPU pods only after the node returns healthy on Talos `v1.13.5`
+   with NVIDIA extensions loaded.
+
+## Documentation and PR gate
+
+Do this before any live upgrade action:
+
+1. Update this runbook and the Altra installer patch to target `v1.13.5`.
+1. Keep the Altra Image Factory schematic source at
+   `devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml`.
+1. Keep the corrected Altra install disk at `/dev/nvme0n1`.
+1. Add the gated Altra NVIDIA device plugin to
+   `argocd/applications/nvidia-gpu-operator/`.
+1. Run basic repo checks for the changed files.
+1. Open a PR from `codex/talos-altra-v1135-upgrade` using
+   `.github/PULL_REQUEST_TEMPLATE.md`.
+1. Merge only after required checks are green.
+
+The PR documents and stages the safe desired state. It does not by itself
+approve live upgrade execution if the Ceph or drain gates are still blocked.
+
+## Variables
+
+Use these variables for the live run:
 
 ```bash
 export CTX=galactic-lan
 export ALTRA_NODE=talos-192-168-1-85
 export ALTRA_IP=100.100.244.142
-export TURIN_IP=100.100.244.171
+export TURIN_IP=100.100.244.190
+export TALOS_TARGET=v1.13.5
 export TS="$(date -u +%Y%m%dT%H%M%SZ)"
-export EVIDENCE_DIR="/tmp/altra-talos-v1.13.4-${TS}"
+export EVIDENCE_DIR="/tmp/altra-talos-v1.13.5-${TS}"
 mkdir -p "$EVIDENCE_DIR"
+```
 
+Generate the Altra installer image from the repo schematic:
+
+```bash
 export ALTRA_SCHEMATIC_ID="$(
   curl -sS -X POST \
     --data-binary @devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml \
     https://factory.talos.dev/schematics \
     | jq -r .id
 )"
-export ALTRA_IMAGE="factory.talos.dev/metal-installer/${ALTRA_SCHEMATIC_ID}:v1.13.4"
+export ALTRA_IMAGE="factory.talos.dev/metal-installer/${ALTRA_SCHEMATIC_ID}:${TALOS_TARGET}"
 printf '%s\n' "$ALTRA_IMAGE" | tee "$EVIDENCE_DIR/altra-image.txt"
 ```
 
-Capture Altra preflight:
+Current expected schematic ID for the checked-in Altra NVIDIA LTS schematic:
+
+```text
+6e246b622304aee389cfed7ed4f13dd4dac4a751243ed43bae10d73c63195e7d
+```
+
+## Preflight evidence
+
+Capture all evidence before changing live state:
 
 ```bash
 kubectl --context "$CTX" get nodes -o wide | tee "$EVIDENCE_DIR/nodes.before.txt"
@@ -412,400 +140,379 @@ kubectl --context "$CTX" get --raw='/readyz?verbose' | tee "$EVIDENCE_DIR/readyz
 kubectl --context "$CTX" get pods -A --field-selector "spec.nodeName=${ALTRA_NODE}" -o wide \
   | tee "$EVIDENCE_DIR/altra-pods.before.txt"
 kubectl --context "$CTX" get pdb -A | tee "$EVIDENCE_DIR/pdb.before.txt"
+kubectl --context "$CTX" -n argocd get applications.argoproj.io -o wide \
+  | tee "$EVIDENCE_DIR/argocd.before.txt"
 
-talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" version | tee "$EVIDENCE_DIR/altra-version.before.txt"
-talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get machinestatus | tee "$EVIDENCE_DIR/altra-machinestatus.before.txt"
-talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get extensions | tee "$EVIDENCE_DIR/altra-extensions.before.txt"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" version \
+  | tee "$EVIDENCE_DIR/altra-version.before.txt"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get machinestatus -o yaml \
+  | tee "$EVIDENCE_DIR/altra-machinestatus.before.yaml"
 talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get machineconfig -o yaml \
   | tee "$EVIDENCE_DIR/altra-machineconfig.before.yaml"
-talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" service etcd | tee "$EVIDENCE_DIR/etcd-service.before.txt"
-talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" etcd members | tee "$EVIDENCE_DIR/etcd-members.before.txt"
-
-kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s --format json-pretty \
-  | tee "$EVIDENCE_DIR/ceph.before.json"
-kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd dump --format json-pretty \
-  | tee "$EVIDENCE_DIR/ceph-osd-dump.before.json"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get disks -o yaml \
+  | tee "$EVIDENCE_DIR/altra-disks.before.yaml"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get volumestatus -o yaml \
+  | tee "$EVIDENCE_DIR/altra-volumestatus.before.yaml"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get extensions \
+  | tee "$EVIDENCE_DIR/altra-extensions.before.txt"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" etcd members \
+  | tee "$EVIDENCE_DIR/etcd-members.before.txt"
 ```
 
-Known Altra drain blockers from the 2026-06-27 dry-run:
+Abort unless all of these are true:
 
-1. CNPG singleton primaries: `coder/coder-cluster`, `keycloak/keycloak-db`,
-   `jangar/jangar-db`, `posthog/posthog-db`, and `tsag/tsag-db`.
-1. Kafka: brokers `kafka-pool-a-0`, `kafka-pool-a-2`, `kafka-pool-b-4`, and
-   `kafka-pool-b-5`; do not proceed while the Kafka PDB reports
-   `disruptionsAllowed=0`.
-1. Knative: `activator` and `webhook` PDBs.
-1. Observability: Tempo ingester PDBs.
-1. Torghut: `torghut-tigerbeetle-0`, `torghut-ta`, and
-   `torghut-hyperliquid-runtime`.
-1. ClickHouse: ClickHouse operator PDB and the Torghut ClickHouse pod
-   `chi-torghut-clickhouse-default-0-0-0`, which currently matches multiple
-   PDBs.
-1. Forgejo runners: `forgejo-runners-arm64-0`.
+1. Altra is Kubernetes `Ready`.
+1. API readyz passes.
+1. Altra `MachineStatus` is `stage=running` and `ready=true`.
+1. Etcd has three non-learner voters.
+1. Live volume evidence proves `/dev/nvme0n1` is the Talos install disk.
+1. Live disk evidence shows `/dev/nvme1n1` is Ceph DB/WAL backing storage, not
+   Talos install storage.
 
-Resolve CNPG the same way Ryzen was resolved:
+Use these focused extraction commands to prove the disk gate:
 
 ```bash
-cat >"$EVIDENCE_DIR/cnpg-altra-targets.tsv" <<'EOF'
-coder	coder-cluster
-keycloak	keycloak-db
-jangar	jangar-db
-posthog	posthog-db
-tsag	tsag-db
-EOF
-
-while read -r ns cluster; do
-  kubectl --context "$CTX" -n "$ns" patch clusters.postgresql.cnpg.io "$cluster" \
-    --type merge -p '{"spec":{"instances":2}}'
-  kubectl --context "$CTX" -n "$ns" wait pod -l "cnpg.io/cluster=${cluster}" \
-    --for=condition=Ready --timeout=30m
-  candidate="$(
-    kubectl --context "$CTX" -n "$ns" get pods -l "cnpg.io/cluster=${cluster},role=replica" -o json \
-      | jq -r --arg node "$ALTRA_NODE" '.items[] | select(.spec.nodeName != $node) | .metadata.labels["cnpg.io/instanceName"]' \
-      | head -1
-  )"
-  test -n "$candidate"
-  kubectl cnpg --context "$CTX" -n "$ns" promote "$cluster" "$candidate"
-  until [ "$(kubectl --context "$CTX" -n "$ns" get cluster "$cluster" -o jsonpath='{.status.currentPrimary}')" = "$candidate" ]; do
-    sleep 5
-  done
-done <"$EVIDENCE_DIR/cnpg-altra-targets.tsv"
+yq '.spec.machine.install.disk' "$EVIDENCE_DIR/altra-machineconfig.before.yaml" \
+  | tee "$EVIDENCE_DIR/altra-install-disk.before.txt"
+yq -r '.spec | [.metadata.id, .parent, .location] | @tsv' \
+  "$EVIDENCE_DIR/altra-volumestatus.before.yaml" \
+  | tee "$EVIDENCE_DIR/altra-volume-parents.before.tsv"
+yq -r '.spec | [.devPath, .symlinks[]?] | @tsv' "$EVIDENCE_DIR/altra-disks.before.yaml" \
+  | rg 'nvme1n1|ceph|block.db|block.wal' \
+  | tee "$EVIDENCE_DIR/altra-nvme1n1-ceph-evidence.before.tsv"
 ```
 
-Resolve the non-CNPG blockers explicitly. Save original objects before every
-temporary patch, and pause Argo automation for the owning apps at the
-ApplicationSet/root layer before applying live changes.
+## Ceph gate
 
-Kafka has four brokers on Altra in the 2026-06-27 readback and its PDB reported
-`disruptionsAllowed=0`. Do not bypass that PDB. Move or rebalance brokers
-through Strimzi first, then prove the Kafka app and broker ISR are healthy
-before attempting the node drain:
+Capture Ceph state:
 
 ```bash
-kubectl --context "$CTX" -n kafka get kafka,kafkanodepool,pods -o wide \
-  | tee "$EVIDENCE_DIR/kafka.before.txt"
-kubectl --context "$CTX" -n kafka get pdb kafka-kafka -o yaml \
-  >"$EVIDENCE_DIR/kafka-pdb.before.yaml"
-
-# Choose a Strimzi-supported broker movement or capacity action for the current
-# cluster state. Do not delete broker pods or relax the Kafka PDB as a shortcut.
-kubectl --context "$CTX" -n kafka get kafka kafka -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason} {.message}{"\n"}{end}' \
-  | tee "$EVIDENCE_DIR/kafka-status.before-drain.txt"
-kubectl --context "$CTX" -n kafka get pdb kafka-kafka \
-  | tee "$EVIDENCE_DIR/kafka-pdb.before-drain.txt"
+kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s \
+  | tee "$EVIDENCE_DIR/ceph.before.txt"
+kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail \
+  | tee "$EVIDENCE_DIR/ceph-health.before.txt"
+kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd tree \
+  | tee "$EVIDENCE_DIR/ceph-osd-tree.before.txt"
+kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd dump \
+  | tee "$EVIDENCE_DIR/ceph-osd-dump.before.txt"
 ```
 
-Proceed only when `kafka-kafka` allows at least one disruption and the brokers
-that would be evicted are no longer concentrated on Altra.
+Do not continue until:
 
-Knative Serving uses `80%` PDBs for singleton `activator` and `webhook`
-deployments. Use the operator HA knob, then prove both PDBs allow at least one
-disruption:
+1. No PGs are `remapped`, `backfilling`, `backfill_wait`, `degraded`,
+   `undersized`, `inactive`, or `down`.
+1. No OSD is down or out.
+1. `noout`, `norecover`, `nobackfill`, and `pause` are absent, or the exact
+   remaining flag is documented as safe for this maintenance window.
+1. The Altra OSD-host PDB no longer blocks a server-side drain dry-run.
 
-```bash
-kubectl --context "$CTX" -n knative-serving patch knativeserving.operator.knative.dev knative-serving \
-  --type merge -p '{"spec":{"high-availability":{"replicas":5}}}'
-kubectl --context "$CTX" -n knative-serving rollout status deployment/activator --timeout=15m
-kubectl --context "$CTX" -n knative-serving rollout status deployment/webhook --timeout=15m
-kubectl --context "$CTX" -n knative-serving get pdb activator-pdb webhook-pdb \
-  | tee "$EVIDENCE_DIR/knative-pdb.after-ha.txt"
-```
+Scrub-age warnings alone can be accepted. Active recovery, remapped PGs, OSD
+loss, or OSD PDB blockage cannot be accepted for this Talos reboot.
 
-Tempo ingesters currently run both replicas on Altra and the PDB has
-`maxUnavailable: 0`. Scale out first, then allow one disruption:
+## Drain gate
 
-```bash
-kubectl --context "$CTX" -n observability get pdb observability-tempo-ingester -o yaml \
-  >"$EVIDENCE_DIR/tempo-ingester-pdb.before-temp-patch.yaml"
-kubectl --context "$CTX" -n observability get statefulset observability-tempo-ingester -o yaml \
-  >"$EVIDENCE_DIR/tempo-ingester-statefulset.before-temp-scale.yaml"
-
-kubectl --context "$CTX" -n observability scale statefulset/observability-tempo-ingester --replicas=4
-kubectl --context "$CTX" -n observability rollout status statefulset/observability-tempo-ingester --timeout=15m
-kubectl --context "$CTX" -n observability patch pdb observability-tempo-ingester \
-  --type merge -p '{"spec":{"maxUnavailable":1}}'
-kubectl --context "$CTX" -n observability get pods -l app.kubernetes.io/component=ingester,app.kubernetes.io/name=tempo -o wide \
-  | tee "$EVIDENCE_DIR/tempo-ingester-pods.after-scale.txt"
-```
-
-The ClickHouse operator is a singleton Deployment protected by
-`maxUnavailable: 0`. Scale it to two replicas and temporarily allow one
-disruption:
-
-```bash
-kubectl --context "$CTX" -n clickhouse-operator get pdb clickhouse-operator -o yaml \
-  >"$EVIDENCE_DIR/clickhouse-operator-pdb.before-temp-patch.yaml"
-kubectl --context "$CTX" -n clickhouse-operator scale deployment/clickhouse-operator-altinity-clickhouse-operator \
-  --replicas=2
-kubectl --context "$CTX" -n clickhouse-operator rollout status deployment/clickhouse-operator-altinity-clickhouse-operator \
-  --timeout=15m
-kubectl --context "$CTX" -n clickhouse-operator patch pdb clickhouse-operator \
-  --type merge -p '{"spec":{"maxUnavailable":1}}'
-kubectl --context "$CTX" -n clickhouse-operator get pods -o wide \
-  | tee "$EVIDENCE_DIR/clickhouse-operator-pods.after-scale.txt"
-```
-
-Torghut ClickHouse currently has a pod that matches multiple PDBs, which makes
-the eviction subresource refuse the drain even before PDB budget is considered.
-Fix the overlapping PDBs through GitOps or a documented temporary patch before
-the maintenance window:
-
-```bash
-kubectl --context "$CTX" -n torghut get pdb -o yaml \
-  >"$EVIDENCE_DIR/torghut-pdb.before-clickhouse-overlap.yaml"
-kubectl --context "$CTX" -n torghut describe pod chi-torghut-clickhouse-default-0-0-0 \
-  >"$EVIDENCE_DIR/torghut-clickhouse-pod.before-overlap-fix.txt"
-
-# After the owning PDB definitions are corrected, this must not emit
-# MultiplePodDisruptionBudgets for the ClickHouse pod.
-kubectl --context "$CTX" -n torghut get events --field-selector type=Warning --sort-by=.lastTimestamp \
-  | grep -E 'MultiplePodDisruptionBudgets|chi-torghut-clickhouse-default-0-0-0' \
-  | tee "$EVIDENCE_DIR/torghut-clickhouse-pdb-overlap-events.txt"
-```
-
-Do not continue while the ClickHouse pod still has multiple matching PDBs.
-
-`torghut-tigerbeetle-0` has no replica-first path in this runbook. Treat it as
-a maintenance outage unless a separate TigerBeetle HA plan exists. If the outage
-is accepted, temporarily relax only its PDB:
-
-```bash
-kubectl --context "$CTX" -n torghut get pdb torghut-tigerbeetle -o yaml \
-  >"$EVIDENCE_DIR/torghut-tigerbeetle-pdb.before-temp-patch.yaml"
-kubectl --context "$CTX" -n torghut patch pdb torghut-tigerbeetle \
-  --type merge -p '{"spec":{"minAvailable":0}}'
-```
-
-`torghut-ta` and `torghut-hyperliquid-runtime` were also PDB blockers in the
-2026-06-27 dry-run. Prefer scaling or moving replicas so their PDBs allow one
-disruption. If the maintenance decision accepts temporary downtime, save and
-relax only those PDBs, then restore them after acceptance:
-
-```bash
-kubectl --context "$CTX" -n torghut get pdb torghut-ta torghut-hyperliquid-runtime -o yaml \
-  >"$EVIDENCE_DIR/torghut-runtime-pdbs.before-temp-patch.yaml"
-kubectl --context "$CTX" -n torghut get deploy torghut-ta torghut-hyperliquid-runtime -o wide \
-  | tee "$EVIDENCE_DIR/torghut-runtime-deployments.before.txt"
-
-# Prefer replica/capacity repair. Only patch these PDBs after a written
-# maintenance decision accepts the impact.
-kubectl --context "$CTX" -n torghut patch pdb torghut-ta \
-  --type merge -p '{"spec":{"minAvailable":0}}'
-kubectl --context "$CTX" -n torghut patch pdb torghut-hyperliquid-runtime \
-  --type merge -p '{"spec":{"minAvailable":0}}'
-```
-
-`forgejo-runners-arm64-0` is the only ARM64 Forgejo runner on Altra. Do not
-pretend it has HA on the current hardware. If runner downtime is accepted for
-the node upgrade, relax only the ARM64 runner PDB:
-
-```bash
-kubectl --context "$CTX" -n forgejo-runners get pdb forgejo-runners-arm64 -o yaml \
-  >"$EVIDENCE_DIR/forgejo-runners-arm64-pdb.before-temp-patch.yaml"
-kubectl --context "$CTX" -n forgejo-runners patch pdb forgejo-runners-arm64 \
-  --type merge -p '{"spec":{"minAvailable":0}}'
-```
-
-Do not proceed until the dry-run drain succeeds:
+Run the dry-run before any cordon or live drain:
 
 ```bash
 kubectl --context "$CTX" drain "$ALTRA_NODE" \
   --ignore-daemonsets \
   --delete-emptydir-data \
   --dry-run=server \
-  --timeout=10m | tee "$EVIDENCE_DIR/drain-dry-run.txt"
+  --timeout=10m | tee "$EVIDENCE_DIR/drain-dry-run.before.txt"
 ```
 
-After the dry-run passes, snapshot etcd and upgrade:
+Abort if any Ceph OSD pod is listed as an eviction blocker.
+
+If the only remaining blockers are approved singleton non-Ceph workloads,
+planned downtime is acceptable for:
+
+1. `torghut/torghut-tigerbeetle-0`
+1. `forgejo-runners/forgejo-runners-arm64-0`
+1. `knative-eventing/eventing-webhook`
+
+Save original objects before every temporary change:
 
 ```bash
-talosctl -n "$TURIN_IP" -e "$TURIN_IP" etcd snapshot \
-  "$EVIDENCE_DIR/galactic-etcd-before-altra-talos-v1.13.4-${TS}.db"
+kubectl --context "$CTX" -n torghut get pdb torghut-tigerbeetle -o yaml \
+  >"$EVIDENCE_DIR/torghut-tigerbeetle-pdb.before.yaml"
+kubectl --context "$CTX" -n forgejo-runners get pdb forgejo-runners-arm64 -o yaml \
+  >"$EVIDENCE_DIR/forgejo-runners-arm64-pdb.before.yaml"
+kubectl --context "$CTX" -n knative-eventing get pdb eventing-webhook -o yaml \
+  >"$EVIDENCE_DIR/knative-eventing-webhook-pdb.before.yaml"
+kubectl --context "$CTX" -n knative-eventing get deployment eventing-webhook -o yaml \
+  >"$EVIDENCE_DIR/knative-eventing-webhook-deployment.before.yaml"
+```
 
-cat >"$EVIDENCE_DIR/altra-v1.13.4-installer.patch.yaml" <<EOF
+Prefer adding safe replica capacity for the Knative Eventing webhook:
+
+```bash
+kubectl --context "$CTX" -n knative-eventing scale deployment/eventing-webhook --replicas=2
+kubectl --context "$CTX" -n knative-eventing rollout status deployment/eventing-webhook --timeout=15m
+kubectl --context "$CTX" -n knative-eventing get pdb eventing-webhook \
+  | tee "$EVIDENCE_DIR/knative-eventing-webhook-pdb.after-scale.txt"
+```
+
+Only after the maintenance decision accepts downtime, relax the singleton PDBs:
+
+```bash
+kubectl --context "$CTX" -n torghut patch pdb torghut-tigerbeetle \
+  --type merge -p '{"spec":{"minAvailable":0}}'
+kubectl --context "$CTX" -n forgejo-runners patch pdb forgejo-runners-arm64 \
+  --type merge -p '{"spec":{"minAvailable":0}}'
+```
+
+Re-run the dry-run and stop unless it succeeds:
+
+```bash
+kubectl --context "$CTX" drain "$ALTRA_NODE" \
+  --ignore-daemonsets \
+  --delete-emptydir-data \
+  --dry-run=server \
+  --timeout=10m | tee "$EVIDENCE_DIR/drain-dry-run.after.txt"
+```
+
+## Patch Altra machine config
+
+Patch both the corrected install disk and the target installer image:
+
+```bash
+cat >"$EVIDENCE_DIR/altra-v1.13.5-installer.patch.yaml" <<EOF
 machine:
   install:
+    disk: /dev/nvme0n1
     image: ${ALTRA_IMAGE}
 EOF
 
 talosctl patch machineconfig -n "$ALTRA_IP" -e "$ALTRA_IP" \
-  --patch @"$EVIDENCE_DIR/altra-v1.13.4-installer.patch.yaml" \
+  --patch @"$EVIDENCE_DIR/altra-v1.13.5-installer.patch.yaml" \
   --mode=no-reboot
 
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get machineconfig -o yaml \
+  | tee "$EVIDENCE_DIR/altra-machineconfig.patched.yaml"
+```
+
+Abort unless the re-read machine config has:
+
+```text
+machine.install.disk: /dev/nvme0n1
+machine.install.image: ${ALTRA_IMAGE}
+```
+
+## Snapshot, cordon, drain, upgrade
+
+Snapshot etcd from healthy Turin:
+
+```bash
+talosctl -n "$TURIN_IP" -e "$TURIN_IP" etcd snapshot \
+  "$EVIDENCE_DIR/galactic-etcd-before-altra-v1.13.5.db"
+```
+
+Cordon and drain only after the dry-run is clean:
+
+```bash
+kubectl --context "$CTX" cordon "$ALTRA_NODE"
+kubectl --context "$CTX" drain "$ALTRA_NODE" \
+  --ignore-daemonsets \
+  --delete-emptydir-data \
+  --timeout=20m | tee "$EVIDENCE_DIR/drain.txt"
+```
+
+Upgrade Altra:
+
+```bash
 talosctl upgrade -n "$ALTRA_IP" -e "$ALTRA_IP" \
   --image "$ALTRA_IMAGE" \
   --wait \
   --progress plain \
   --drain-timeout 20m \
-  --timeout 45m
+  --timeout 45m | tee "$EVIDENCE_DIR/talos-upgrade.txt"
 ```
 
-Altra is accepted only when it reports Talos `v1.13.4`, `MachineStatus` is
-`running/ready=true`, `tailscale` is still present, Kubernetes is `Ready` and
-schedulable, etcd still has three voters, Ceph has no OSD or PG regression, and
-all temporary workload changes have been restored.
+## Kubernetes GPU pod enablement
 
-Restore Altra temporary changes after acceptance:
+The repo-owned GPU Operator app disables chart-wide driver, toolkit, and device
+plugin installation because Talos owns host NVIDIA drivers and the container
+toolkit through system extensions. Altra GPU pods require all of this:
+
+1. Talos extensions include `nvidia-open-gpu-kernel-modules-lts` and
+   `nvidia-container-toolkit-lts`.
+1. NVIDIA kernel modules are loaded on Altra.
+1. The `nvidia` RuntimeClass still exists.
+1. The gated `altra-nvidia-device-plugin` DaemonSet is allowed to schedule.
+1. Altra advertises `nvidia.com/gpu: 1`.
+1. A real Kubernetes pod requesting `nvidia.com/gpu: 1` runs successfully on
+   Altra and can execute `nvidia-smi`.
+
+Do not enable the Altra device plugin before Talos and Kubernetes acceptance.
+The DaemonSet is gated by this label:
+
+```text
+platform.proompteng.ai/altra-gpu-container-ready=true
+```
+
+Enable it after the node returns healthy:
 
 ```bash
-while read -r ns cluster; do
-  target="${cluster}-1"
-  if kubectl --context "$CTX" -n "$ns" get pod "$target" >/dev/null 2>&1; then
-    kubectl --context "$CTX" -n "$ns" wait pod "$target" --for=condition=Ready --timeout=15m
-    if [ "$(kubectl --context "$CTX" -n "$ns" get cluster "$cluster" -o jsonpath='{.status.currentPrimary}')" != "$target" ]; then
-      kubectl cnpg --context "$CTX" -n "$ns" promote "$cluster" "$target"
-      until [ "$(kubectl --context "$CTX" -n "$ns" get cluster "$cluster" -o jsonpath='{.status.currentPrimary}')" = "$target" ]; do
-        sleep 5
-      done
-    fi
-    kubectl --context "$CTX" -n "$ns" patch clusters.postgresql.cnpg.io "$cluster" \
-      --type merge -p '{"spec":{"instances":1}}'
-  else
-    echo "KEEPING ${ns}/${cluster} at current instances; ${target} is missing"
-  fi
-done <"$EVIDENCE_DIR/cnpg-altra-targets.tsv"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get extensions \
+  | tee "$EVIDENCE_DIR/altra-extensions.gpu-before-label.txt"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" read /proc/modules \
+  | rg '^nvidia' | tee "$EVIDENCE_DIR/altra-nvidia-modules.after.txt"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" read /proc/driver/nvidia/version \
+  | tee "$EVIDENCE_DIR/altra-nvidia-driver-version.after.txt"
+kubectl --context "$CTX" get runtimeclass nvidia nvidia-cdi nvidia-legacy \
+  | tee "$EVIDENCE_DIR/nvidia-runtimeclasses.after.txt"
 
-kubectl --context "$CTX" -n knative-serving patch knativeserving.operator.knative.dev knative-serving \
-  --type json -p='[{"op":"remove","path":"/spec/high-availability"}]'
+kubectl --context "$CTX" label node "$ALTRA_NODE" nvidia.com/gpu.workload.config- --overwrite
+kubectl --context "$CTX" label node "$ALTRA_NODE" \
+  platform.proompteng.ai/altra-gpu-container-ready=true --overwrite
 
-kubectl --context "$CTX" -n observability scale statefulset/observability-tempo-ingester --replicas=2
-kubectl --context "$CTX" -n observability patch pdb observability-tempo-ingester \
-  --type merge -p '{"spec":{"maxUnavailable":0}}'
-
-kubectl --context "$CTX" -n clickhouse-operator scale deployment/clickhouse-operator-altinity-clickhouse-operator \
-  --replicas=1
-kubectl --context "$CTX" -n clickhouse-operator patch pdb clickhouse-operator \
-  --type merge -p '{"spec":{"maxUnavailable":0}}'
-
-kubectl --context "$CTX" -n torghut patch pdb torghut-tigerbeetle \
-  --type merge -p '{"spec":{"minAvailable":1}}'
-kubectl --context "$CTX" -n torghut patch pdb torghut-ta \
-  --type merge -p '{"spec":{"minAvailable":1}}'
-kubectl --context "$CTX" -n torghut patch pdb torghut-hyperliquid-runtime \
-  --type merge -p '{"spec":{"minAvailable":1}}'
-kubectl --context "$CTX" -n forgejo-runners patch pdb forgejo-runners-arm64 \
-  --type merge -p '{"spec":{"minAvailable":1}}'
+argocd --core app sync nvidia-gpu-operator --timeout 900
+kubectl --context "$CTX" -n gpu-operator rollout status ds/altra-nvidia-device-plugin --timeout=10m
+kubectl --context "$CTX" -n gpu-operator get pods -l app=altra-nvidia-device-plugin -o wide \
+  | tee "$EVIDENCE_DIR/altra-device-plugin.after.txt"
+kubectl --context "$CTX" get node "$ALTRA_NODE" -o json \
+  | jq -r '.status.capacity["nvidia.com/gpu"], .status.allocatable["nvidia.com/gpu"]' \
+  | tee "$EVIDENCE_DIR/altra-gpu-capacity.after.txt"
 ```
 
-Final cleanup verification:
+Run a Kubernetes GPU pod smoke test:
 
 ```bash
-kubectl --context "$CTX" -n knative-serving get deploy activator webhook -o wide
-kubectl --context "$CTX" -n knative-serving get pdb activator-pdb webhook-pdb
-kubectl --context "$CTX" -n observability get statefulset observability-tempo-ingester
-kubectl --context "$CTX" -n observability get pdb observability-tempo-ingester
-kubectl --context "$CTX" -n clickhouse-operator get deployment,pdb,pods -o wide
-kubectl --context "$CTX" -n kafka get kafka,kafkanodepool,pods,pdb -o wide
-kubectl --context "$CTX" -n torghut get pdb torghut-tigerbeetle torghut-ta torghut-hyperliquid-runtime
-kubectl --context "$CTX" -n torghut get events --field-selector type=Warning --sort-by=.lastTimestamp \
-  | grep -E 'MultiplePodDisruptionBudgets|chi-torghut-clickhouse-default-0-0-0' || true
-kubectl --context "$CTX" -n forgejo-runners get pdb forgejo-runners-arm64
+cat >"$EVIDENCE_DIR/altra-gpu-smoke-pod.yaml" <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: altra-gpu-smoke
+  namespace: gpu-operator
+spec:
+  restartPolicy: Never
+  runtimeClassName: nvidia
+  nodeSelector:
+    kubernetes.io/hostname: talos-192-168-1-85
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  containers:
+    - name: cuda
+      image: nvcr.io/nvidia/cuda:13.0.2-base-ubuntu24.04
+      command:
+        - nvidia-smi
+        - -L
+      resources:
+        limits:
+          nvidia.com/gpu: "1"
+EOF
+
+kubectl --context "$CTX" apply -f "$EVIDENCE_DIR/altra-gpu-smoke-pod.yaml"
+kubectl --context "$CTX" -n gpu-operator wait pod/altra-gpu-smoke \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=10m
+kubectl --context "$CTX" -n gpu-operator logs pod/altra-gpu-smoke \
+  | tee "$EVIDENCE_DIR/altra-gpu-smoke.log"
+kubectl --context "$CTX" -n gpu-operator delete pod/altra-gpu-smoke --wait=true
 ```
 
-## Per-node acceptance checks
+If the smoke pod image is not multi-arch for `linux/arm64`, stop and select a
+validated CUDA image for Altra. Do not mark GPU pod enablement complete from the
+device-plugin DaemonSet alone.
 
-Run these after each node returns:
+## Restore
+
+Restore every temporary workload change:
 
 ```bash
-NODE_IP='<node-ip>'
-NODE_NAME='<kubernetes-node-name>'
-
-talosctl -n "$NODE_IP" -e "$NODE_IP" version
-talosctl -n "$NODE_IP" -e "$NODE_IP" get machinestatus -o yaml
-talosctl -n "$NODE_IP" -e "$NODE_IP" get extensions
-talosctl -n "$NODE_IP" -e "$NODE_IP" services
-talosctl -n "$NODE_IP" -e "$NODE_IP" service kubelet status
-
-kubectl --context galactic-lan get node "$NODE_NAME" -o wide
-kubectl --context galactic-lan describe node "$NODE_NAME"
-kubectl --context galactic-lan get pods -A -o wide \
-  --field-selector spec.nodeName="$NODE_NAME"
+kubectl --context "$CTX" -n torghut apply -f "$EVIDENCE_DIR/torghut-tigerbeetle-pdb.before.yaml"
+kubectl --context "$CTX" -n forgejo-runners apply -f "$EVIDENCE_DIR/forgejo-runners-arm64-pdb.before.yaml"
+kubectl --context "$CTX" -n knative-eventing apply -f "$EVIDENCE_DIR/knative-eventing-webhook-pdb.before.yaml"
+kubectl --context "$CTX" -n knative-eventing apply -f "$EVIDENCE_DIR/knative-eventing-webhook-deployment.before.yaml"
+kubectl --context "$CTX" -n knative-eventing rollout status deployment/eventing-webhook --timeout=15m
 ```
 
-The node passes only when:
-
-1. Talos reports `v1.13.4`.
-1. `MachineStatus` is `stage: running` and `ready: true`.
-1. Required extensions are present for that hardware profile.
-1. The Kubernetes node is `Ready`.
-1. The node is not accidentally left cordoned unless a maintenance decision says
-   it should stay cordoned.
-1. No system pods are crash-looping due to missing runtime classes, extensions,
-   or host drivers.
-
-## Cluster acceptance checks
-
-Run these after every node and again at the end:
+Uncordon only after Talos, Kubernetes, etcd, Ceph, and GPU gates pass:
 
 ```bash
-kubectl --context galactic-lan get nodes -o wide
-kubectl --context galactic-lan get --raw='/readyz?verbose'
-
-talosctl -n 100.100.244.171 -e 100.100.244.171 etcd members
-talosctl -n 100.100.244.171 -e 100.100.244.171 etcd status
-
-kubectl --context galactic-lan -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
-kubectl --context galactic-lan -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail
-kubectl --context galactic-lan -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd tree
-kubectl --context galactic-lan -n rook-ceph get pods -o wide
+kubectl --context "$CTX" uncordon "$ALTRA_NODE"
 ```
 
-Final success criteria:
+If the upgrade fails before acceptance, keep the node cordoned unless the
+rollback/recovery lead explicitly decides otherwise.
 
-1. All live Talos nodes are on `v1.13.4`.
-1. Kubernetes remains on the intended existing version.
-1. All intended nodes are `Ready`.
-1. Etcd has the expected voters and no failed members.
-1. Rook-Ceph has no down OSDs, inactive/down PGs, or unexpected maintenance
-   flags.
-1. Node-level Tailscale still works, including image pulls from
-   `registry.ide-newton.ts.net`.
-1. GPU-related extensions remain loaded on the Ryzen, Altra, and Turin hardware
-   profiles. Altra must advertise `nvidia.com/gpu: 1` before the Saigak GPU pod
-   rollout is accepted.
-1. Argo CD and critical stateful namespaces have returned to their pre-window
-   health posture or better.
+## Final acceptance
 
-## Rollback and stop conditions
-
-Stop immediately if any of these occur:
-
-1. Etcd loses quorum or a control-plane member fails to rejoin.
-1. A node stays NotReady after the upgrade timeout.
-1. Rook-Ceph gains new inactive/down PGs or loses another OSD host.
-1. Required system extensions disappear after reboot.
-1. Workload drain blocks on PDBs and the window has no explicit approval to
-   relax those workloads.
-
-Rollback the last upgraded node only after confirming the node can still answer
-the Talos API:
+Altra is accepted only when every check passes:
 
 ```bash
-talosctl rollback -n <node-ip> -e <endpoint-ip>
-talosctl -n <node-ip> -e <endpoint-ip> get machinestatus -o yaml
-kubectl --context galactic-lan get node <kubernetes-node-name> -o wide
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" version \
+  | tee "$EVIDENCE_DIR/altra-version.after.txt"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get machinestatus -o yaml \
+  | tee "$EVIDENCE_DIR/altra-machinestatus.after.yaml"
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get extensions \
+  | tee "$EVIDENCE_DIR/altra-extensions.after.txt"
+kubectl --context "$CTX" get node "$ALTRA_NODE" -o wide \
+  | tee "$EVIDENCE_DIR/altra-node.after.txt"
+kubectl --context "$CTX" get --raw='/readyz?verbose' \
+  | tee "$EVIDENCE_DIR/readyz.after.txt"
+talosctl -n "$TURIN_IP" -e "$TURIN_IP" etcd members \
+  | tee "$EVIDENCE_DIR/etcd-members.after.txt"
+kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s \
+  | tee "$EVIDENCE_DIR/ceph.after.txt"
+kubectl --context "$CTX" -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail \
+  | tee "$EVIDENCE_DIR/ceph-health.after.txt"
+kubectl --context "$CTX" -n argocd get applications.argoproj.io -o wide \
+  | tee "$EVIDENCE_DIR/argocd.after.txt"
+kubectl --context "$CTX" get node "$ALTRA_NODE" -o json \
+  | jq -r '.status.capacity["nvidia.com/gpu"], .status.allocatable["nvidia.com/gpu"]' \
+  | tee "$EVIDENCE_DIR/altra-gpu.after.txt"
+kubectl --context "$CTX" -n gpu-operator get pods -l app=altra-nvidia-device-plugin -o wide \
+  | tee "$EVIDENCE_DIR/altra-device-plugin.final.txt"
 ```
 
-If the node cannot answer Talos API after a failed upgrade, use the BMC/console
-path for that hardware and keep Kubernetes/Ceph changes frozen until the node's
-boot state is known.
+Required outcomes:
 
-Do not clear Ceph flags, purge OSDs, remove etcd members, or delete Kubernetes
-nodes as part of Talos rollback unless a separate recovery runbook says to do
-that exact action for the observed failure.
+1. Altra Talos reports `v1.13.5`.
+1. Kubernetes remains `v1.35.0`.
+1. Altra is `Ready`, schedulable, and not accidentally left cordoned.
+1. Altra `MachineStatus` is `stage=running` and `ready=true`.
+1. Extensions include `tailscale`, `nvidia-open-gpu-kernel-modules-lts`, and
+   `nvidia-container-toolkit-lts`.
+1. Altra advertises `nvidia.com/gpu: 1` capacity and allocatable.
+1. A Kubernetes GPU smoke pod ran on Altra and logged `nvidia-smi -L`.
+1. Etcd retains three non-learner voters.
+1. Ceph has no new OSD or PG regression.
+1. Argo apps return to the pre-window health posture or better.
 
-## Evidence to save
+## Rollback
 
-Save a dated transcript or markdown note with:
+Rollback trigger: Altra fails to boot, stays NotReady, loses required
+extensions, fails the corrected install-disk gate, or causes Ceph/etcd
+regression.
 
-1. The exact target release and installer image per node.
-1. Preflight `kubectl get nodes -o wide`.
-1. Preflight `ceph -s` and `ceph health detail`.
-1. Etcd snapshot path.
-1. Per-node `talosctl version`, `get machinestatus`, and `get extensions`
-   before and after upgrade.
-1. Final cluster acceptance checks.
+If the Talos API responds:
 
-Commit any durable runbook updates separately from the operational execution
-evidence. Do not commit generated Talos configs, Tailscale auth material, BMC
-credentials, or etcd snapshots.
+```bash
+talosctl rollback -n "$ALTRA_IP" -e "$ALTRA_IP"
+kubectl --context "$CTX" get node "$ALTRA_NODE" -o wide
+talosctl -n "$ALTRA_IP" -e "$ALTRA_IP" get machinestatus -o yaml
+```
+
+If the Talos API does not respond, use the Altra BMC/console recovery path and
+do not mutate Ceph or etcd until the boot state is known.
+
+Do not remove etcd members, clear Ceph flags, purge OSDs, or delete the
+Kubernetes node during rollback unless a separate recovery runbook is written
+for the observed failure.
+
+## Evidence retention
+
+Keep all execution evidence under:
+
+```text
+/tmp/altra-talos-v1.13.5-${TS}
+```
+
+Do not commit generated Talos configs, Tailscale auth material, BMC credentials,
+etcd snapshots, or live evidence transcripts. Commit only durable runbook and
+GitOps manifest changes.


### PR DESCRIPTION
## Summary

- Updates the Talos upgrade runbook for the Altra-only `v1.12.4` to `v1.13.5` production path, including current endpoints, Image Factory target, corrected `/dev/nvme0n1` install disk, Ceph gate, and drain blockers.
- Updates the checked-in Altra NVIDIA LTS installer patch to the `v1.13.5` Image Factory image from the current schematic.
- Adds a gated Altra NVIDIA device-plugin DaemonSet so Kubernetes GPU pods can be enabled only after Talos NVIDIA extensions and post-upgrade validation pass.

## Related Issues

None

## Testing

- `curl -sS -X POST --data-binary @devices/altra/manifests/altra-tailscale-nvidia-lts-schematic.yaml https://factory.talos.dev/schematics | jq -r .id`
- `bunx oxfmt --check docs/runbooks/talos-latest-upgrade-plan.md argocd/applications/nvidia-gpu-operator/altra-nvidia-device-plugin.yaml argocd/applications/nvidia-gpu-operator/kustomization.yaml argocd/applications/nvidia-gpu-operator/values.yaml devices/altra/manifests/installer-image.tailscale-nvidia-lts.patch.yaml`
- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/nvidia-gpu-operator >/tmp/nvidia-gpu-operator.rendered.yaml`
- `kubectl --context galactic-lan apply --dry-run=server -f argocd/applications/nvidia-gpu-operator/altra-nvidia-device-plugin.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

No breaking changes. The Altra upgrade remains blocked by the runbook until Ceph recovery, Ceph flags, and drain gates pass. The new Altra device-plugin DaemonSet is gated by `platform.proompteng.ai/altra-gpu-container-ready=true`, so it will not schedule until the live upgrade run labels the node after NVIDIA extension validation.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
