### PR TITLE
docs(altra): document bmc ipmi address

### DIFF
--- a/devices/altra/README.md
+++ b/devices/altra/README.md
@@ -5,12 +5,14 @@ This directory contains a reproducible runbook and patches for the `altra` node.
 Inventory:
 
 - Node: `altra` (`192.168.1.85`)
+- BMC/IPMI: `192.168.0.100`
 - Joined cluster: `ryzen` (kubeconfig context: `galactic`)
 - Kubernetes API endpoint (behind the NUC LB): `https://nuc:6443` (also `https://192.168.1.130:6443`)
 - Install disk: `/dev/nvme0n1`
 
 Docs:
 
+- `devices/altra/docs/bmc-ipmi.md` (BMC/IPMI address, access, and power-control safety)
 - `devices/altra/docs/cluster-bootstrap.md` (install + join existing cluster)
 - `devices/altra/docs/relayout-volumes.md` (EPHEMERAL=300GB, local-path on OS disk + extra local-path on second NVMe)
 - `docs/incidents/2026-02-18-altra-volume-relayout-etcd-rejoin.md` (failure modes, root causes, and recovery sequence from this session)

--- a/devices/altra/docs/bmc-ipmi.md
+++ b/devices/altra/docs/bmc-ipmi.md
@@ -1,0 +1,106 @@
+# Altra BMC and IPMI
+
+This runbook records the out-of-band management address for the Altra Talos
+node and the safe read-only IPMI commands to verify access.
+
+## Identity
+
+- BMC/IPMI address: `192.168.0.100`
+- BMC subnet: `192.168.0.0/24`
+- IPMI user: `admin`
+- Talos node name: `talos-192-168-1-85`
+- Legacy Talos LAN address: `192.168.1.85`
+- Current Talos/Tailscale endpoint: `100.100.244.142`
+
+Do not confuse the BMC address with the Talos node addresses. The BMC does not
+answer on the `100.100.244.128/25` provider-managed/Tailscale network; reach it
+on the default BMC subnet.
+
+## Authentication
+
+Do not put the BMC password on the command line. `ipmitool` reads the password
+from `IPMI_PASSWORD` when `-E` is passed.
+
+```bash
+export IPMI_PASSWORD='...'
+
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis power status
+```
+
+## Temporary macOS reachability
+
+If the workstation is not already on `192.168.0.0/24`, add a temporary address
+alias to the connected interface before using IPMI or the BMC web UI:
+
+```bash
+sudo ifconfig en0 alias 192.168.0.10 255.255.255.0
+ping -c 3 192.168.0.100
+```
+
+Remove the alias when finished:
+
+```bash
+sudo ifconfig en0 -alias 192.168.0.10
+```
+
+Use the actual active interface if it is not `en0`.
+
+## Read-only checks
+
+```bash
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis power status
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E sdr elist
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E sel elist | tail -n 50
+```
+
+## Power control
+
+Use power control only after checking Kubernetes, etcd, and Ceph safety gates.
+For Talos maintenance, prefer `talosctl reboot` or `talosctl shutdown` while the
+Talos API is healthy.
+
+```bash
+# Power on
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis power on
+
+# Graceful ACPI shutdown request
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis power soft
+
+# Warm reset
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis power reset
+
+# Forced power off; use only during explicit recovery
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis power off
+```
+
+## One-time boot override
+
+```bash
+# Boot into BIOS setup on next boot
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis bootdev bios
+
+# Boot from virtual CD/DVD on next boot
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis bootdev cdrom
+
+# PXE on next boot
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E chassis bootdev pxe
+```
+
+Then reboot through the safest available path.
+
+## Serial-over-LAN
+
+```bash
+ipmitool -I lanplus -H 192.168.0.100 -U admin -E sol activate
+```
+
+Exit SOL with `~.` on a new line. If the default SOL channel does not work,
+inspect BMC channel settings before trying board-specific bridge options.
+
+## Safety notes
+
+- Do not commit BMC credentials.
+- Do not reset or power-cycle Altra during Ceph recovery unless the Talos node
+  is already failed and a separate recovery decision has been made.
+- Before planned Talos work, capture `kubectl get nodes`, etcd members,
+  `ceph -s`, and a server-side drain dry-run.


### PR DESCRIPTION
## Summary

- Adds `devices/altra/docs/bmc-ipmi.md` with the Altra BMC/IPMI address, safe IPMI usage, macOS reachability notes, power-control commands, and sensor/SEL checks.
- Links the BMC/IPMI runbook from `devices/altra/README.md` and records the inventory address there.
- Keeps BMC credentials out of the repo and documents password-safe `ipmitool -E` usage.

## Related Issues

None

## Testing

- `bunx oxfmt --check devices/altra/README.md devices/altra/docs/bmc-ipmi.md`
- `git diff --check`
- `ping -c 2 -W 1000 192.168.0.100`
- `nc -vz -w 3 192.168.0.100 623 80 443 5900`

## Screenshots (if applicable)

N/A

## Breaking Changes

No breaking changes. This is documentation-only and does not add credentials or change any cluster/BMC state.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
