### PR TITLE
ci(nix): require preinstalled arc toolchain

### DIFF
--- a/.github/actions/setup-nix-toolchain/action.yml
+++ b/.github/actions/setup-nix-toolchain/action.yml
@@ -1,5 +1,5 @@
 name: setup-nix-toolchain
-description: Validate the ARC preinstalled Nix toolchain and fall back to installing Nix when needed.
+description: Validate the preinstalled Nix toolchain and optionally fail closed instead of falling back.
 
 inputs:
   github-token:
@@ -13,6 +13,10 @@ inputs:
       experimental-features = nix-command flakes
   install-ci-toolchain:
     description: Install and validate the repo CI toolchain when the runner image does not already provide it.
+    required: false
+    default: 'false'
+  require-preinstalled:
+    description: Fail instead of installing Nix or the CI toolchain. Use this for ARC jobs that must run on the custom runner image.
     required: false
     default: 'false'
 
@@ -31,8 +35,16 @@ runs:
           echo "nix_available=false" >> "${GITHUB_OUTPUT}"
         fi
 
+    - name: Reject missing preinstalled Nix
+      if: steps.detect.outputs.nix_available != 'true' && inputs.require-preinstalled == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "Nix is not preinstalled on this runner, and require-preinstalled=true forbids fallback installation." >&2
+        exit 1
+
     - name: Install xz for fallback Nix installer
-      if: steps.detect.outputs.nix_available != 'true'
+      if: steps.detect.outputs.nix_available != 'true' && inputs.require-preinstalled != 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -49,7 +61,7 @@ runs:
         fi
 
     - name: Install fallback Nix
-      if: steps.detect.outputs.nix_available != 'true'
+      if: steps.detect.outputs.nix_available != 'true' && inputs.require-preinstalled != 'true'
       uses: cachix/install-nix-action@v31
       with:
         github_access_token: ${{ inputs.github-token }}
@@ -78,17 +90,60 @@ runs:
     - name: Ensure repo CI toolchain
       if: inputs.install-ci-toolchain == 'true'
       shell: bash
+      env:
+        REQUIRE_PREINSTALLED: ${{ inputs.require-preinstalled }}
       run: |
         set -euo pipefail
         export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
-        missing=0
-        for cmd in nix skopeo crane cosign jq yq kustomize docker docker-buildx; do
+        missing=()
+        required_commands=(
+          nix
+          node
+          bun
+          go
+          ruby
+          python3.11
+          python3.12
+          uv
+          tofu
+          helm
+          kustomize
+          kubeconform
+          kubectl
+          argo
+          argocd
+          buf
+          gh
+          shellcheck
+          jq
+          yq
+          rg
+          fd
+          fzf
+          buildctl
+          buildkitd
+          docker
+          docker-buildx
+          crane
+          skopeo
+          regctl
+          cosign
+          toolchain-doctor
+          oci-doctor
+        )
+        for cmd in "${required_commands[@]}"; do
           if ! command -v "${cmd}" >/dev/null 2>&1; then
-            missing=1
-            break
+            missing+=("${cmd}")
           fi
         done
-        if [ "${missing}" -eq 1 ]; then
+        if [ "${#missing[@]}" -gt 0 ] && [ "${REQUIRE_PREINSTALLED}" = "true" ]; then
+          printf 'Required CI toolchain commands are missing from the preinstalled runner image:\n' >&2
+          printf '  %s\n' "${missing[@]}" >&2
+          exit 1
+        fi
+        if [ "${#missing[@]}" -gt 0 ]; then
+          printf 'Installing missing CI toolchain commands through Nix profile:\n'
+          printf '  %s\n' "${missing[@]}"
           nix profile install .#ciToolchain --priority 4
         fi
         toolchain-doctor

--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -117,6 +117,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/arc-runner-build-push.yml
+++ b/.github/workflows/arc-runner-build-push.yml
@@ -120,13 +120,27 @@ jobs:
           set -euo pipefail
           docker run --rm "lab-arc-runner:test-${ARCH}" bash -lc '
             set -euo pipefail
+            test "${LAB_ARC_RUNNER_TOOLCHAIN:-}" = "1"
             nix --version
+            command -v node
+            command -v bun
+            command -v go
+            command -v ruby
+            command -v python3.11
+            command -v python3.12
+            command -v uv
+            command -v tofu
+            command -v helm
             command -v skopeo
             command -v crane
             command -v cosign
             command -v jq
             command -v yq
             command -v kustomize
+            command -v toolchain-doctor
+            command -v oci-doctor
+            toolchain-doctor
+            oci-doctor
             test -d /home/runner/externals
           '
 

--- a/.github/workflows/attic-release.yml
+++ b/.github/workflows/attic-release.yml
@@ -57,6 +57,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/enabled-product-nix-release.yml
+++ b/.github/workflows/enabled-product-nix-release.yml
@@ -87,6 +87,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/enabled-simple-nix-release.yml
+++ b/.github/workflows/enabled-simple-nix-release.yml
@@ -90,6 +90,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -42,6 +42,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes
 

--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -88,6 +88,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes
@@ -232,6 +233,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/sag-release.yml
+++ b/.github/workflows/sag-release.yml
@@ -48,6 +48,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/symphony-release.yml
+++ b/.github/workflows/symphony-release.yml
@@ -48,6 +48,7 @@ jobs:
         uses: ./.github/actions/setup-nix-toolchain
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
             experimental-features = nix-command flakes

--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -111,6 +111,8 @@ Same commit plus same lockfiles should reproduce the same Nix output path and OC
 2. **PR 2: ARC Runner Speed Foundation**
    - Build deterministic ARC runner images with pinned Nix, Bun, uv, Go, Python, `skopeo`, `crane`, `cosign`, `jq`, `yq`, `kustomize`, and repo CI helpers.
    - Nix workflows should validate preinstalled tools and fail on ARC fallback to repeated installer actions.
+   - Shared setup action callers running on ARC must set `require-preinstalled: 'true'`; missing Nix or missing CI toolchain commands fail instead of invoking `cachix/install-nix-action` or `nix profile install`.
+   - Runner image smoke must execute `toolchain-doctor` and `oci-doctor` inside the built image before a release contract can be emitted.
    - Keep Docker/DinD only while Docker-backed transitional workflows remain.
 
 3. **PR 3: Finish Agents Nix Runtime**

--- a/images/arc-runner/Dockerfile
+++ b/images/arc-runner/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
 
 USER runner
 ENV USER=runner
+ENV LAB_ARC_RUNNER_TOOLCHAIN=1
 ENV PATH="/home/runner/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
 
 WORKDIR /tmp/lab-nix-toolchain

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 
 import { describe, expect, it } from 'bun:test'
 
@@ -12,10 +12,15 @@ const arcRunnerBuildWorkflow = readRepoFile('.github/workflows/arc-runner-build-
 const arcRunnerReleaseWorkflow = readRepoFile('.github/workflows/arc-runner-release.yml')
 const nixOciWorkflow = readRepoFile('.github/workflows/nix-oci-build-common.yml')
 const atticReleaseWorkflow = readRepoFile('.github/workflows/attic-release.yml')
+const agentsBuildWorkflow = readRepoFile('.github/workflows/agents-build-push.yml')
 const argoLintWorkflow = readRepoFile('.github/workflows/argo-lint.yml')
+const enabledProductReleaseWorkflow = readRepoFile('.github/workflows/enabled-product-nix-release.yml')
+const enabledSimpleReleaseWorkflow = readRepoFile('.github/workflows/enabled-simple-nix-release.yml')
 const kubeconformWorkflow = readRepoFile('.github/workflows/kubeconform.yml')
 const khoshutWorkflow = readRepoFile('.github/workflows/khoshut-ci.yml')
 const headlampWorkflow = readRepoFile('.github/workflows/headlamp-ci.yml')
+const sagReleaseWorkflow = readRepoFile('.github/workflows/sag-release.yml')
+const symphonyReleaseWorkflow = readRepoFile('.github/workflows/symphony-release.yml')
 const flake = readRepoFile('flake.nix')
 const nixPackages = readRepoFile('nix/packages.nix')
 const toolchainDoctor = readRepoFile('nix/toolchain-doctor.sh')
@@ -43,6 +48,7 @@ describe('ARC Nix runner toolchain', () => {
       'ghcr.io/actions/actions-runner@sha256:08c30b0a7105f64bddfc485d2487a22aa03932a791402393352fdf674bda2c29',
     )
     expect(arcRunnerDockerfile).not.toContain('ghcr.io/actions/actions-runner:latest')
+    expect(arcRunnerDockerfile).toContain('ENV LAB_ARC_RUNNER_TOOLCHAIN=1')
     expect(arcRunnerDockerfile).toContain('https://releases.nixos.org/nix/nix-2.28.5/install')
     expect(arcRunnerDockerfile).toContain('ARG LAB_NIX_EXTRA_SUBSTITUTERS=')
     expect(arcRunnerDockerfile).toContain('ARG LAB_NIX_EXTRA_TRUSTED_PUBLIC_KEYS=')
@@ -72,6 +78,16 @@ describe('ARC Nix runner toolchain', () => {
   it('publishes multi-arch ARC runner images and opens a digest-pinning release PR', () => {
     expect(arcRunnerBuildWorkflow).toContain('runner: arc-amd64')
     expect(arcRunnerBuildWorkflow).toContain('runner: arc-arm64')
+    expect(arcRunnerBuildWorkflow).toContain('Smoke PR runner image toolchain')
+    expect(arcRunnerBuildWorkflow).toContain('test "${LAB_ARC_RUNNER_TOOLCHAIN:-}" = "1"')
+    expect(arcRunnerBuildWorkflow).toContain('command -v bun')
+    expect(arcRunnerBuildWorkflow).toContain('command -v uv')
+    expect(arcRunnerBuildWorkflow).toContain('command -v go')
+    expect(arcRunnerBuildWorkflow).toContain('command -v python3.11')
+    expect(arcRunnerBuildWorkflow).toContain('command -v python3.12')
+    expect(arcRunnerBuildWorkflow).toContain('command -v tofu')
+    expect(arcRunnerBuildWorkflow).toContain('toolchain-doctor')
+    expect(arcRunnerBuildWorkflow).toContain('oci-doctor')
     expect(arcRunnerBuildWorkflow).toContain('Prepare minimal runner image context')
     expect(arcRunnerBuildWorkflow).toContain('cp flake.nix flake.lock .artifacts/arc-runner-context/')
     expect(arcRunnerBuildWorkflow).toContain('Require Attic public key')
@@ -100,10 +116,23 @@ describe('ARC Nix runner toolchain', () => {
 
   it('uses a shared setup action so Nix jobs validate preinstalled tools before falling back', () => {
     expect(setupAction).toContain('Detect preinstalled Nix')
+    expect(setupAction).toContain('require-preinstalled:')
+    expect(setupAction).toContain('Reject missing preinstalled Nix')
+    expect(setupAction).toContain("inputs.require-preinstalled == 'true'")
     expect(setupAction).toContain("steps.detect.outputs.nix_available != 'true'")
+    expect(setupAction).toContain(
+      "steps.detect.outputs.nix_available != 'true' && inputs.require-preinstalled != 'true'",
+    )
     expect(setupAction).toContain('uses: cachix/install-nix-action@v31')
     expect(setupAction).toContain('extra_nix_config: ${{ inputs.extra-nix-config }}')
     expect(setupAction).toContain('NIX_CONFIG<<__LAB_NIX_CONFIG__')
+    expect(setupAction).toContain('REQUIRE_PREINSTALLED: ${{ inputs.require-preinstalled }}')
+    expect(setupAction).toContain('Required CI toolchain commands are missing from the preinstalled runner image')
+    expect(setupAction).toContain('command -v "${cmd}"')
+    expect(setupAction).toContain('node')
+    expect(setupAction).toContain('bun')
+    expect(setupAction).toContain('uv')
+    expect(setupAction).toContain('buildctl')
     expect(setupAction).toContain('nix profile install .#ciToolchain --priority 4')
     expect(setupAction).toContain('toolchain-doctor')
     expect(setupAction).toContain('oci-doctor')
@@ -111,17 +140,42 @@ describe('ARC Nix runner toolchain', () => {
     for (const workflow of [
       nixOciWorkflow,
       atticReleaseWorkflow,
-      argoLintWorkflow,
-      kubeconformWorkflow,
-      khoshutWorkflow,
+      agentsBuildWorkflow,
+      enabledProductReleaseWorkflow,
+      enabledSimpleReleaseWorkflow,
       headlampWorkflow,
+      sagReleaseWorkflow,
+      symphonyReleaseWorkflow,
     ]) {
       expect(workflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+      expect(workflow).toContain("require-preinstalled: 'true'")
+    }
+
+    for (const workflow of [argoLintWorkflow, kubeconformWorkflow, khoshutWorkflow]) {
+      expect(workflow).toContain('runs-on: ubuntu-latest')
+      expect(workflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+      expect(workflow).not.toContain("require-preinstalled: 'true'")
     }
 
     expect(nixOciWorkflow).not.toContain('Install xz for Nix installer')
     expect(nixOciWorkflow).not.toContain('uses: cachix/install-nix-action@v31')
     expect(atticReleaseWorkflow).not.toContain('Install xz for Nix installer')
     expect(atticReleaseWorkflow).not.toContain('uses: cachix/install-nix-action@v31')
+  })
+
+  it('does not let ARC workflow callers silently use fallback Nix installation', () => {
+    const workflowDir = new URL('.github/workflows/', repoRoot)
+    const arcSetupCallers = readdirSync(workflowDir)
+      .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+      .map((file) => [file, readRepoFile(`.github/workflows/${file}`)] as const)
+      .filter(([, content]) => content.includes('uses: ./.github/actions/setup-nix-toolchain'))
+      .filter(([, content]) => content.includes('runs-on: arc-') || content.includes('runner: arc-'))
+
+    expect(arcSetupCallers.length).toBeGreaterThan(0)
+    for (const [file, content] of arcSetupCallers) {
+      expect(content, `${file} must require the preinstalled ARC Nix toolchain`).toContain(
+        "require-preinstalled: 'true'",
+      )
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Makes the shared Nix setup action fail closed when a workflow explicitly requires the preinstalled runner toolchain.
- Wires ARC Nix setup callers to `require-preinstalled: 'true'`, so ARC jobs cannot silently run fallback Nix installs.
- Keeps GitHub-hosted validation workflows on the fallback path because those runners do not own the custom ARC image.
- Tightens ARC runner image smoke coverage to validate the full pinned Nix CI toolchain, including Bun, uv, Go, Python, Skopeo, Crane, Cosign, and repo doctor commands.
- Updates the Nix rollout plan with the PR2 fail-closed contract.

## Related Issues

None

## Testing

- `bun install --frozen-lockfile`
- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `ruby -e 'require "psych"; ARGV.each { |path| Psych.load_file(path); puts "ok #{path}" }' .github/actions/setup-nix-toolchain/action.yml .github/workflows/arc-runner-build-push.yml .github/workflows/nix-oci-build-common.yml .github/workflows/agents-build-push.yml .github/workflows/attic-release.yml .github/workflows/enabled-product-nix-release.yml .github/workflows/enabled-simple-nix-release.yml .github/workflows/argo-lint.yml .github/workflows/kubeconform.yml .github/workflows/khoshut-ci.yml .github/workflows/headlamp-ci.yml .github/workflows/sag-release.yml .github/workflows/symphony-release.yml`
- `git diff --check origin/main...HEAD`
- `nix flake check --print-build-logs`
- `nix build .#ciToolchain --print-build-logs --no-link --print-out-paths`
- `nix run .#toolchain-doctor`
- Local note: `nix run .#oci-doctor` is not a local pass on this Darwin host because `buildkitd` is not present; the ARC runner image PR smoke now runs `oci-doctor` inside the Linux runner image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. ARC workflows now require the custom runner image to carry the preinstalled Nix CI toolchain; if an ARC runner is rolled back to a non-toolchain image, affected ARC jobs fail closed instead of paying fallback install cost.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
