### PR TITLE
chore(symphony): promote image sha-3061f810b8e912bdc8fccffc5659408f42afeb2b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-01T03:54:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-03T23:52:30Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-67efb77c315182233a779b0cb6dfe41370f6f5d7"
-    digest: sha256:6bc777ca66bd110e63f65e66713f335a1e416dc47de499b82b24f3ef6a2fc9b1
+    newTag: "sha-3061f810b8e912bdc8fccffc5659408f42afeb2b"
+    digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-01T03:54:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-03T23:52:30Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-67efb77c315182233a779b0cb6dfe41370f6f5d7"
-    digest: sha256:6bc777ca66bd110e63f65e66713f335a1e416dc47de499b82b24f3ef6a2fc9b1
+    newTag: "sha-3061f810b8e912bdc8fccffc5659408f42afeb2b"
+    digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-01T03:54:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-03T23:52:30Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-67efb77c315182233a779b0cb6dfe41370f6f5d7"
-    digest: sha256:6bc777ca66bd110e63f65e66713f335a1e416dc47de499b82b24f3ef6a2fc9b1
+    newTag: "sha-3061f810b8e912bdc8fccffc5659408f42afeb2b"
+    digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `3061f810b8e912bdc8fccffc5659408f42afeb2b`
- Image tag: `sha-3061f810b8e912bdc8fccffc5659408f42afeb2b`
- Image digest: `sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367`