### PR TITLE
fix(torghut): retire proof blockers from live submission

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-execution-v2-testnet-short-proof-20260625
+        proompteng.ai/config-revision: hyperliquid-execution-v2-testnet-cap-250-reduce-only-20260703a
       labels:
         app: torghut-hyperliquid-runtime
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -288,7 +288,7 @@ describe('Torghut manifest scheduling', () => {
     expect(getAtPath(runtimeDeployment, ['spec']).replicas).toBe(1)
     expect(getAtPath(runtimeDeployment, ['spec']).revisionHistoryLimit).toBe(2)
     expect(getAtPath(runtimeDeployment, ['spec', 'template', 'metadata', 'annotations'])).toMatchObject({
-      'proompteng.ai/config-revision': 'hyperliquid-execution-v2-testnet-short-proof-20260625',
+      'proompteng.ai/config-revision': 'hyperliquid-execution-v2-testnet-cap-250-reduce-only-20260703a',
     })
     const runtimeContainer = getAtPath(runtimeDeployment, ['spec', 'template', 'spec', 'containers', 0])
     expect(runtimeContainer.command).toContain('app.hyperliquid_execution.api:app')

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -22,6 +22,7 @@ from ..paper_route_target_plan import (
     fetch_paper_route_target_plan_url,
 )
 from ..proof_floor import build_profitability_proof_floor_receipt
+from ..submission_authority import operational_submission_gate_status
 from ..submission_council import (
     build_hypothesis_runtime_summary,
     build_submission_gate_market_context_status,
@@ -569,28 +570,41 @@ class SimpleTradingPipeline(
                 )
             )
 
+        operational_gate = operational_submission_gate_status(gate)
         gate_blocked_reasons = [
             str(item).strip()
-            for item in cast(list[object], gate.get("blocked_reasons") or [])
+            for item in cast(
+                list[object], operational_gate.get("blocked_reasons") or []
+            )
             if str(item).strip()
         ]
         merged_blocked_reasons = list(
             dict.fromkeys([*gate_blocked_reasons, *simple_blocked_reasons])
         )
-        gate["allowed"] = (
-            bool(gate.get("allowed", False)) and not simple_blocked_reasons
+        allowed = bool(operational_gate.get("allowed", False)) and not (
+            simple_blocked_reasons
         )
+        reason = str(
+            simple_blocked_reasons[0]
+            if simple_blocked_reasons
+            else operational_gate.get("reason") or "operational_submission_ready"
+        )
+        gate["allowed"] = allowed
         gate["blocked_reasons"] = merged_blocked_reasons
+        gate["reason"] = reason
         if simple_blocked_reasons:
-            gate["reason"] = simple_blocked_reasons[0]
             gate["capital_stage"] = "shadow"
             gate["capital_state"] = "observe"
+        elif allowed:
+            gate["capital_stage"] = "live"
+            gate["capital_state"] = "live"
         gate["pipeline_mode"] = "simple"
         gate["operational_submission_gate"] = {
-            "allowed": bool(gate.get("allowed", False)),
-            "reason": str(gate.get("reason") or "unknown"),
+            "allowed": allowed,
+            "reason": reason,
             "blocked_reasons": merged_blocked_reasons,
-            "execution_route": gate.get("execution_route"),
+            "execution_route": operational_gate.get("execution_route")
+            or gate.get("execution_route"),
         }
         gate["simple_lane"] = {
             "submit_enabled": settings.trading_simple_submit_enabled,

--- a/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
@@ -40,8 +40,6 @@ from .shared import (
     logger,
 )
 
-_LIVE_GATE_BOUNDED_PAPER_ROUTE_BYPASS_REASONS: frozenset[str] = frozenset()
-
 _BOUNDED_PAPER_ROUTE_CLOSE_SOURCE = "filled_bounded_paper_route_collection_executions"
 
 if TYPE_CHECKING:
@@ -251,17 +249,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
         if isinstance(collection_gate, Mapping):
             collection_gate_mapping = cast(Mapping[str, Any], collection_gate)
             return collection_gate_mapping.get("allowed") is True
-        blocked_reasons = {
-            str(reason).strip()
-            for reason in cast(
-                list[object],
-                live_submission_gate.get("blocked_reasons") or [],
-            )
-            if str(reason).strip()
-        }
-        if not blocked_reasons:
-            return False
-        return blocked_reasons.issubset(_LIVE_GATE_BOUNDED_PAPER_ROUTE_BYPASS_REASONS)
+        return False
 
     def _bounded_live_paper_route_close_metadata(
         self,
@@ -381,21 +369,12 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
             exit_qty = Decimal(str(exit_qty))
         return decision.qty <= exit_qty
 
-    def _bounded_live_paper_route_probe_profit_floor_allowed(
-        self,
-        decision: StrategyDecision,
-        proof_floor_block_reason: str,
-    ) -> bool:
-        return (
-            self._bounded_live_paper_route_probe_decision_applies(decision)
-            and proof_floor_block_reason
-            in _LIVE_GATE_BOUNDED_PAPER_ROUTE_BYPASS_REASONS
-        )
-
     def _profitability_floor_submission_allowed(
         self,
         request: TradingSubmissionRequest,
     ) -> bool:
+        if settings.trading_mode == "live":
+            return True
         decision = request.decision
         session = request.session
         decision_row = request.decision_row
@@ -409,11 +388,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
         if not settings.trading_simple_submit_enabled and collection_metadata is None:
             self._block_simple_submit_disabled(request, proof_floor_block_reason)
             return False
-        if self._paper_route_probe_applies(
-            decision, collection_metadata
-        ) or self._bounded_live_paper_route_probe_profit_floor_allowed(
-            decision, proof_floor_block_reason
-        ):
+        if self._paper_route_probe_applies(decision, collection_metadata):
             return True
         self._block_decision_submission(
             DecisionBlockRequest(
@@ -432,6 +407,8 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
         self,
         request: TradingSubmissionRequest,
     ) -> bool:
+        if settings.trading_mode == "live":
+            return True
         decision = request.decision
         collection_metadata = self._bounded_sim_collection_metadata(decision)
         if self._paper_route_probe_applies(decision, collection_metadata):
@@ -442,11 +419,6 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
             decision.symbol,
         )
         if proof_floor_symbol_block_reason is not None:
-            if self._bounded_live_paper_route_probe_profit_floor_allowed(
-                decision,
-                proof_floor_symbol_block_reason,
-            ):
-                return True
             self._block_decision_submission(
                 DecisionBlockRequest(
                     session=request.session,

--- a/services/torghut/app/trading/submission_authority.py
+++ b/services/torghut/app/trading/submission_authority.py
@@ -6,18 +6,24 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 
+_RETIRED_SUBMISSION_AUTHORITY_BLOCKERS = frozenset(
+    {
+        "alpha_readiness_not_promotion_eligible",
+        "runtime_ledger_profit_target_source_collection_pending",
+        "runtime_ledger_source_collection_pending",
+    }
+)
+
+
 def build_submission_authority_status(
     live_submission_gate: Mapping[str, Any],
     *,
     simple_lane_status: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
-    """Summarize the effective submit authority without changing gate decisions."""
+    """Summarize the effective submit authority after retiring proof blockers."""
 
     simple_lane = _mapping(simple_lane_status)
-    operational_gate = (
-        _mapping(live_submission_gate.get("operational_submission_gate"))
-        or live_submission_gate
-    )
+    operational_gate = operational_submission_gate_status(live_submission_gate)
     operational_allowed = _bool(operational_gate.get("allowed"))
     effective_mode = "operational_submission" if operational_allowed else "blocked"
     return {
@@ -52,6 +58,78 @@ def build_submission_authority_status(
     }
 
 
+def operational_submission_gate_status(
+    live_submission_gate: Mapping[str, Any],
+) -> dict[str, object]:
+    """Return the effective operational gate with retired proof blockers removed."""
+
+    nested_gate = _mapping(live_submission_gate.get("operational_submission_gate"))
+    gate = nested_gate or live_submission_gate
+    raw_blocked_reasons = _strings(gate.get("blocked_reasons"))
+    blocked_reasons = _active_submission_blockers(raw_blocked_reasons)
+    raw_reason = _text(gate.get("reason"), "")
+    raw_allowed = _bool(gate.get("allowed"))
+    reason = _active_submission_reason(raw_reason, blocked_reasons, raw_allowed)
+    allowed = _active_submission_allowed(
+        raw_allowed=raw_allowed,
+        raw_reason=raw_reason,
+        raw_blocked_reasons=raw_blocked_reasons,
+        active_blocked_reasons=blocked_reasons,
+    )
+    if allowed and not blocked_reasons:
+        reason = "operational_submission_ready"
+    return {
+        "allowed": allowed,
+        "reason": reason,
+        "blocked_reasons": blocked_reasons,
+        "execution_route": _mapping(gate.get("execution_route")),
+    }
+
+
+def _active_submission_allowed(
+    *,
+    raw_allowed: bool,
+    raw_reason: str,
+    raw_blocked_reasons: list[str],
+    active_blocked_reasons: list[str],
+) -> bool:
+    if active_blocked_reasons:
+        return False
+    if raw_allowed:
+        return True
+    if _is_retired_submission_blocker(raw_reason):
+        return True
+    if raw_blocked_reasons and not active_blocked_reasons:
+        return True
+    return False
+
+
+def _active_submission_blockers(blocked_reasons: list[str]) -> list[str]:
+    return [
+        reason
+        for reason in blocked_reasons
+        if not _is_retired_submission_blocker(reason)
+    ]
+
+
+def _active_submission_reason(
+    raw_reason: str,
+    blocked_reasons: list[str],
+    raw_allowed: bool,
+) -> str:
+    if blocked_reasons:
+        return blocked_reasons[0]
+    if _is_retired_submission_blocker(raw_reason):
+        return "operational_submission_ready"
+    if raw_allowed:
+        return raw_reason or "operational_submission_ready"
+    return raw_reason or "unknown"
+
+
+def _is_retired_submission_blocker(reason: str) -> bool:
+    return reason in _RETIRED_SUBMISSION_AUTHORITY_BLOCKERS
+
+
 def _mapping(value: object) -> Mapping[str, Any]:
     if isinstance(value, Mapping):
         return cast(Mapping[str, Any], value)
@@ -82,4 +160,4 @@ def _strings(value: object) -> list[str]:
     return strings
 
 
-__all__ = ["build_submission_authority_status"]
+__all__ = ["build_submission_authority_status", "operational_submission_gate_status"]

--- a/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
+++ b/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
@@ -55,4 +55,13 @@ def test_manifest_uses_v2_command_and_env_prefix_only() -> None:
     assert "HYPERLIQUID_EXECUTION_ORDER_POLICY: marketable_ioc" in configmap
     assert "HYPERLIQUID_EXECUTION_MAKER_TIF: Ioc" in configmap
     assert 'HYPERLIQUID_EXECUTION_MAKER_TTL_SECONDS: "10"' in configmap
+    assert 'HYPERLIQUID_EXECUTION_MAX_GROSS_EXPOSURE_USD: "250"' in configmap
+    assert 'HYPERLIQUID_EXECUTION_MAX_SYMBOL_EXPOSURE_USD: "50"' in configmap
+    assert (
+        'HYPERLIQUID_EXECUTION_MAINTENANCE_REDUCE_ONLY_CLOSE_ENABLED: "true"'
+        in configmap
+    )
+    assert (
+        "hyperliquid-execution-v2-testnet-cap-250-reduce-only-20260703a" in deployment
+    )
     assert "HYPERLIQUID_RUNTIME_" not in configmap

--- a/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
@@ -250,7 +250,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
         self.assertEqual(bid, Decimal("298.11"))
         self.assertEqual(ask, Decimal("298.29"))
 
-    def test_live_bounded_paper_route_close_does_not_bypass_retired_gate(
+    def test_live_bounded_paper_route_close_ignores_retired_gate_blockers(
         self,
     ) -> None:
         from app import config
@@ -345,7 +345,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                         return_value=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
                     ),
                 ):
-                    self.assertFalse(
+                    self.assertTrue(
                         pipeline._is_trading_submission_allowed(
                             session=session,
                             decision=decision,
@@ -356,10 +356,6 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                 session.refresh(decision_row)
                 decision_json = cast(dict[str, Any], decision_row.decision_json)
 
-            self.assertEqual(
-                decision_json["submission_stage"],
-                "blocked_profitability_proof_floor",
-            )
             params = cast(dict[str, Any], decision_json["params"])
             exit_metadata = cast(
                 dict[str, Any],

--- a/services/torghut/tests/pipeline/test_trading_pipeline_route_execution_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_route_execution_a.py
@@ -346,7 +346,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
             )
         )
 
-    def test_simple_pipeline_blocks_symbol_excluded_from_route_candidates(
+    def test_simple_pipeline_treats_route_candidate_floor_as_live_diagnostic(
         self,
     ) -> None:
         from app import config
@@ -437,28 +437,17 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
         ):
             pipeline.run_once()
 
-        self.assertEqual(len(alpaca_client.submitted), 0)
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["symbol"], "NVDA")
         with self.session_local() as session:
             decision = session.execute(select(TradeDecision)).scalar_one()
             decision_json = cast(dict[str, Any], decision.decision_json)
-            persisted_floor = cast(
-                dict[str, Any], decision_json.get("profitability_proof_floor")
-            )
-            route_book = cast(
-                dict[str, Any], persisted_floor.get("route_reacquisition_book")
-            )
-            route_summary = cast(dict[str, Any], route_book.get("summary"))
-
-            self.assertEqual(decision.status, "blocked")
-            self.assertEqual(
+            self.assertEqual(decision.status, "submitted")
+            self.assertNotEqual(
                 decision_json.get("submission_stage"),
                 "blocked_profitability_route_symbol",
             )
-            self.assertEqual(
-                decision_json.get("submission_block_reason"),
-                "profitability_route_symbol_excluded",
-            )
-            self.assertEqual(route_summary.get("candidate_symbols"), ["AAPL"])
+            self.assertNotIn("submission_block_reason", decision_json)
 
     def test_simple_pipeline_skips_out_of_strategy_universe_signals_before_quote_quality(
         self,

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -18,6 +18,127 @@ from tests.simple_pipeline.support import (
 )
 
 
+def test_simple_live_submission_gate_drops_retired_source_collection_blockers(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    trading_enabled_before = settings.trading_enabled
+    kill_switch_before = settings.trading_kill_switch_enabled
+    simple_submit_before = settings.trading_simple_submit_enabled
+    live_submit_before = settings.trading_live_submit_enabled
+    emergency_stop_before = settings.trading_emergency_stop_enabled
+    try:
+        settings.trading_mode = "live"
+        settings.trading_enabled = True
+        settings.trading_kill_switch_enabled = False
+        settings.trading_simple_submit_enabled = True
+        settings.trading_live_submit_enabled = True
+        settings.trading_emergency_stop_enabled = False
+
+        def _legacy_gate(
+            self: object,
+            *,
+            inputs: object | None = None,
+        ) -> dict[str, object]:
+            _ = self, inputs
+            return {
+                "allowed": False,
+                "reason": "alpha_readiness_not_promotion_eligible",
+                "blocked_reasons": [
+                    "alpha_readiness_not_promotion_eligible",
+                    "runtime_ledger_profit_target_source_collection_pending",
+                    "runtime_ledger_source_collection_pending",
+                ],
+                "execution_route": {
+                    "route": "testnet",
+                    "alpaca_regular_session_open": False,
+                },
+            }
+
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.TradingPipeline._live_submission_gate",
+            _legacy_gate,
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.state = SimpleNamespace(emergency_stop_active=False)
+
+        gate = pipeline._live_submission_gate()
+
+        assert gate["allowed"] is True
+        assert gate["reason"] == "operational_submission_ready"
+        assert gate["blocked_reasons"] == []
+        assert gate["operational_submission_gate"] == {
+            "allowed": True,
+            "reason": "operational_submission_ready",
+            "blocked_reasons": [],
+            "execution_route": {
+                "route": "testnet",
+                "alpaca_regular_session_open": False,
+            },
+        }
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_enabled = trading_enabled_before
+        settings.trading_kill_switch_enabled = kill_switch_before
+        settings.trading_simple_submit_enabled = simple_submit_before
+        settings.trading_live_submit_enabled = live_submit_before
+        settings.trading_emergency_stop_enabled = emergency_stop_before
+
+
+def test_bounded_live_paper_route_requires_explicit_collection_gate() -> None:
+    assert not SimpleTradingPipeline._bounded_live_paper_route_collection_gate_allows(
+        {
+            "allowed": False,
+            "reason": "runtime_ledger_source_collection_pending",
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+        }
+    )
+    assert SimpleTradingPipeline._bounded_live_paper_route_collection_gate_allows(
+        {
+            "bounded_live_paper_collection_gate": {
+                "allowed": True,
+                "reason": "explicit_collection_contract",
+            }
+        }
+    )
+
+
+def test_live_profitability_proof_floor_is_diagnostic_for_runtime_ledger_blockers() -> (
+    None
+):
+    trading_mode_before = settings.trading_mode
+    submit_enabled_before = settings.trading_simple_submit_enabled
+    try:
+        settings.trading_mode = "live"
+        settings.trading_simple_submit_enabled = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "PA3SX7FYNUTF"
+        pipeline._profitability_proof_floor = lambda session: {
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "runtime_ledger_profit_target_source_collection_pending",
+                "runtime_ledger_source_collection_pending",
+            ],
+        }
+        blocks: list[object] = []
+        pipeline._block_decision_submission = lambda request: blocks.append(request)
+
+        assert pipeline._profitability_floor_submission_allowed(
+            TradingSubmissionRequest(
+                session=SimpleNamespace(),
+                decision=_routeability_decision(),
+                decision_row=SimpleNamespace(status="planned"),
+            )
+        )
+        assert blocks == []
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_submit_enabled = submit_enabled_before
+
+
 def test_live_bounded_paper_route_target_generates_capped_source_decisions(
     monkeypatch,
 ) -> None:
@@ -749,7 +870,7 @@ def test_live_bounded_paper_route_target_rejects_missing_cap_and_symbols(
         )
 
 
-def test_live_bounded_paper_route_symbol_floor_does_not_bypass_runtime_ledger_blocker() -> (
+def test_live_profitability_symbol_floor_is_diagnostic_for_runtime_ledger_blocker() -> (
     None
 ):
     trading_mode_before = settings.trading_mode
@@ -782,16 +903,14 @@ def test_live_bounded_paper_route_symbol_floor_does_not_bypass_runtime_ledger_bl
             }
         )
 
-        assert not pipeline._profitability_floor_symbol_submission_allowed(
+        assert pipeline._profitability_floor_symbol_submission_allowed(
             TradingSubmissionRequest(
                 session=SimpleNamespace(),
                 decision=decision,
                 decision_row=SimpleNamespace(status="planned"),
             )
         )
-        assert (
-            getattr(blocks[0], "reason") == "runtime_ledger_source_collection_pending"
-        )
+        assert blocks == []
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before

--- a/services/torghut/tests/test_submission_authority.py
+++ b/services/torghut/tests/test_submission_authority.py
@@ -91,3 +91,28 @@ def test_submission_authority_accepts_compatibility_gate_payload() -> None:
         "route": "alpaca",
         "alpaca_regular_session_open": True,
     }
+
+
+def test_submission_authority_retired_source_collection_blockers_do_not_block() -> None:
+    status = build_submission_authority_status(
+        {
+            "allowed": False,
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "blocked_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "runtime_ledger_profit_target_source_collection_pending",
+                "runtime_ledger_source_collection_pending",
+            ],
+            "execution_route": {
+                "route": "testnet",
+                "alpaca_regular_session_open": False,
+            },
+        },
+        simple_lane_status={"submit_enabled": True, "live_submit_enabled": True},
+    )
+
+    assert status["effective_submit_mode"] == "operational_submission"
+    assert status["can_submit_now"] is True
+    assert status["authority_scope"] == "operational_submission"
+    assert status["reason"] == "operational_submission_ready"
+    assert status["operational_submission_gate"]["blocked_reasons"] == []


### PR DESCRIPTION
## Summary

- Retired alpha/runtime-ledger/source-collection proof blockers from live submission authority and the simple live-gate merge path.
- Made live proof-floor and route-candidate state diagnostic-only for direct order submission while preserving operational and risk blockers.
- Forced the Hyperliquid runtime deployment to roll onto the existing $250 gross, $50 per-symbol, reduce-only recovery config.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_authority.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py::test_simple_live_submission_gate_drops_retired_source_collection_blockers tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py::test_bounded_live_paper_route_requires_explicit_collection_gate tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py::test_live_profitability_proof_floor_is_diagnostic_for_runtime_ledger_blockers tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py::test_live_profitability_symbol_floor_is_diagnostic_for_runtime_ledger_blocker tests/pipeline/test_trading_pipeline_route_execution_a.py::TestTradingPipelineRouteExecutionA::test_simple_pipeline_treats_route_candidate_floor_as_live_diagnostic tests/submission_council/test_live_submission_gate.py tests/api/test_trading_api_live_gate_llm.py tests/test_execution_adapters.py::TestExecutionAdapters::test_session_router_submits_to_alpaca_testnet_or_blocks tests/test_execution_adapters.py::TestExecutionAdapters::test_session_router_routes_management_calls_and_seed_helpers tests/test_execution_adapters.py::TestExecutionAdapters::test_session_router_uses_alpaca_during_regular_market_hours tests/test_execution_adapters.py::TestExecutionAdapters::test_session_router_uses_testnet_outside_regular_market_hours tests/hyperliquid_execution/test_migration_manifest.py tests/hyperliquid_execution/test_runtime_surfaces.py::test_service_over_cap_runs_reduce_only_before_normal_orders tests/hyperliquid_execution/test_maintenance.py`
- `bun test packages/scripts/src`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
