### PR TITLE
chore(sag): promote image sha-3061f810b8e912bdc8fccffc5659408f42afeb2b

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    digest: sha256:b930dbe2989a329521890fb2895521108a242873b01b1ef7b343de29625a62aa
+    digest: sha256:1b7fc95b43fabb6a0941232d53e2decdbd0dbd67413e575e17f5df3d79b86861


### PR DESCRIPTION
## Summary
Promote the Sag image into GitOps manifests.

- Source commit: `3061f810b8e912bdc8fccffc5659408f42afeb2b`
- Image tag: `sha-3061f810b8e912bdc8fccffc5659408f42afeb2b`
- Image digest: `sha256:1b7fc95b43fabb6a0941232d53e2decdbd0dbd67413e575e17f5df3d79b86861`