### PR TITLE
revert(torghut): rollback failed promotion b55022788d8360ee86fcf3a3c8784d9875670c5d

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T01:01:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T00:31:25Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
           ports:
             - name: http1
               containerPort: 8181
@@ -539,11 +539,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1313-gbb853ace7
+              value: v0.596.0-1309-g8cb5e32c5
             - name: TORGHUT_COMMIT
-              value: bb853ace7f75786af7af0b9ba4b2acedfce60d54
+              value: 8cb5e32c5dc3f9a0ac204dc118dce5bdc44ca8c5
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              value: sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T01:01:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T00:31:25Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
           ports:
             - name: http1
               containerPort: 8181
@@ -412,11 +412,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1313-gbb853ace7
+              value: v0.596.0-1309-g8cb5e32c5
             - name: TORGHUT_COMMIT
-              value: bb853ace7f75786af7af0b9ba4b2acedfce60d54
+              value: 8cb5e32c5dc3f9a0ac204dc118dce5bdc44ca8c5
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              value: sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ce61c2cb0173b66e11d21c93bfe41f368e84bcbb4f7d899b033d0b0ae68e35d4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `b55022788d8360ee86fcf3a3c8784d9875670c5d`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28690270882`
- Rollback source: `HEAD^` manifests from the failed run checkout