### PR TITLE
fix(torghut): configure live submit activation lease

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -130,6 +130,8 @@ spec:
               value: "true"
             - name: TRADING_LIVE_SUBMIT_ENABLED
               value: "true"
+            - name: TRADING_LIVE_SUBMIT_ACTIVATION_EXPIRES_AT
+              value: "2026-08-01T00:00:00Z"
             - name: TRADING_TESTNET_AFTER_HOURS_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -551,9 +551,9 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
 
         self.assertEqual(live_env.get("TRADING_MODE"), "live")
         self.assertTrue(_manifest_bool(live_env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
-        self.assertNotIn(
-            "TRADING_LIVE_SUBMIT_ACTIVATION_EXPIRES_AT",
-            live_env,
+        self.assertEqual(
+            live_env.get("TRADING_LIVE_SUBMIT_ACTIVATION_EXPIRES_AT"),
+            "2026-08-01T00:00:00Z",
         )
         self.assertTrue(
             _manifest_bool(live_env, "TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED"),


### PR DESCRIPTION
## Summary

- Configure the Torghut live submit activation lease in the GitOps Knative Service manifest.
- Update the Torghut manifest contract test so CI enforces the configured lease.
- Unblock post-deploy verification that failed on `live_submit_activation.configured=false`.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py -q`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run lint:argocd`
- `git grep -n -E 'alpha_readiness_not_promotion_eligible|retire_alpha_readiness_not_promotion_eligible|alpha_hypothesis_not_promotion_eligible' HEAD -- . ':!bun.lock'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
