### PR TITLE
chore(torghut): promote image 851deaba

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -51,9 +51,9 @@ spec:
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: bb853ace7f75786af7af0b9ba4b2acedfce60d54
+              value: 851deabaff2445780543baa64b9ef0336fb2cf35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: bb853ace7f75786af7af0b9ba4b2acedfce60d54
+              value: 851deabaff2445780543baa64b9ef0336fb2cf35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T01:01:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T01:53:48Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
           ports:
             - name: http1
               containerPort: 8181
@@ -539,11 +539,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1313-gbb853ace7
+              value: v0.596.0-1316-g851deabaf
             - name: TORGHUT_COMMIT
-              value: bb853ace7f75786af7af0b9ba4b2acedfce60d54
+              value: 851deabaff2445780543baa64b9ef0336fb2cf35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T01:01:03Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T01:53:48Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
           ports:
             - name: http1
               containerPort: 8181
@@ -414,11 +414,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1313-gbb853ace7
+              value: v0.596.0-1316-g851deabaf
             - name: TORGHUT_COMMIT
-              value: bb853ace7f75786af7af0b9ba4b2acedfce60d54
+              value: 851deabaff2445780543baa64b9ef0336fb2cf35
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:7b9140a6f7d850d8cd26b589bd7bddb3a3d2ce00e3e1bca4bab713aa4c7c2ed5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -355,22 +355,25 @@ describe('validatePostDeployEvidence', () => {
     ).toThrow('max_notional_per_order must be 100')
   })
 
-  it('rejects healthy readyz when empirical jobs are still stale', () => {
-    expect(() =>
-      validatePostDeployEvidence({
-        readyzHttpStatus: '200',
-        readyz: { status: 'ok' },
-        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
-        tradingStatus: {
-          ...baseTradingStatus,
-          empirical_jobs: {
-            ready: false,
-            status: 'degraded',
-            blocked_reasons: ['job_stale'],
-          },
+  it('reports stale empirical jobs as diagnostics without blocking live-submit rollout acceptance', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '200',
+      readyz: { status: 'ok' },
+      revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+      tradingStatus: {
+        ...baseTradingStatus,
+        empirical_jobs: {
+          ready: false,
+          status: 'degraded',
+          blocked_reasons: ['job_stale'],
         },
-      }),
-    ).toThrow('empirical jobs must be fresh')
+      },
+    })
+
+    expect(result.liveSubmitContract).toBe('bounded_live_submit_active')
+    expect(result.summaryLines.join('\n')).toContain(
+      'Empirical jobs diagnostic: ready=`false`, status=`degraded`, blocked=`job_stale`',
+    )
   })
 
   it('accepts repair-only zero-notional readyz 503 without treating it as a rollout failure', () => {

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -310,7 +310,6 @@ const assertBoundedLiveSubmitContract = (status: JsonObject): LiveSubmitContract
     liveSubmissionGate.live_submit_activation,
     'torghut status live_submission_gate.live_submit_activation',
   )
-  const empiricalJobs = requireObject(status.empirical_jobs, 'torghut status empirical_jobs')
 
   if (requireBoolean(status.autonomy_enabled, 'torghut status autonomy_enabled') !== false) {
     throw new Error('torghut status autonomy_enabled must be false for bounded live-submit rollout')
@@ -332,11 +331,23 @@ const assertBoundedLiveSubmitContract = (status: JsonObject): LiveSubmitContract
       'torghut live_submission_gate.blocked_reasons',
     )
   }
-  if (requireBoolean(empiricalJobs.ready, 'torghut empirical_jobs.ready') !== true) {
-    throw new Error('torghut empirical jobs must be fresh before bounded live-submit rollout acceptance')
-  }
-  requireScalarValue(empiricalJobs.status, 'healthy', 'torghut empirical_jobs.status')
   return liveSubmitContract
+}
+
+const empiricalJobsDiagnosticLine = (status: JsonObject): string | undefined => {
+  const value = status.empirical_jobs
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const empiricalJobs = value as JsonObject
+  const blockedReasons = Array.isArray(empiricalJobs.blocked_reasons)
+    ? empiricalJobs.blocked_reasons.map((reason) => formatScalar(reason, '')).filter(Boolean)
+    : []
+  const parts = [`ready=\`${formatScalar(empiricalJobs.ready)}\``, `status=\`${formatScalar(empiricalJobs.status)}\``]
+  if (blockedReasons.length > 0) {
+    parts.push(`blocked=${blockedReasons.map((reason) => `\`${reason}\``).join(',')}`)
+  }
+  return `- Empirical jobs diagnostic: ${parts.join(', ')}`
 }
 
 const assertShadowZeroNotionalGateClosedContract = (status: JsonObject, digest: JsonObject): LiveSubmitContract => {
@@ -832,6 +843,10 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
   ]
   if (liveSubmitContract) {
     lines.push(`- Live submit contract: \`${liveSubmitContract}\``)
+  }
+  const empiricalJobsDiagnostic = empiricalJobsDiagnosticLine(status)
+  if (empiricalJobsDiagnostic) {
+    lines.push(empiricalJobsDiagnostic)
   }
   if (blockerReasons.length > 0) {
     lines.push(`- Blockers: ${blockerReasons.map((reason) => `\`${reason}\``).join(', ')}`)


### PR DESCRIPTION
## Summary

- Promote Torghut core, simulation, job, workflow, and Hyperliquid runtime manifests to image `registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19`.
- Set deployed metadata to source commit `851deabaff2445780543baa64b9ef0336fb2cf35` / version `v0.596.0-1316-g851deabaf`.
- Preserve the live-submit activation lease added on main for Torghut trading recovery.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `cd services/torghut && uv run --frozen pytest tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py -q`
- `git diff --check`
- `git grep -n -E 'alpha_readiness_not_promotion_eligible|retire_alpha_readiness_not_promotion_eligible|alpha_hypothesis_not_promotion_eligible' -- . ':!bun.lock'` returned no matches

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
