### PR TITLE
chore(jangar): promote image 131730e6

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-30T15:18:56Z
+    deploy.knative.dev/rollout: 2026-07-04T01:56:13Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 2c392bf93edd4004a8e917d26079b136da283e96
+              value: 131730e66e80c5f1cc0dc4b60be8369ecb2c192d
             - name: JANGAR_GITOPS_REVISION
-              value: 2c392bf93edd4004a8e917d26079b136da283e96
+              value: 131730e66e80c5f1cc0dc4b60be8369ecb2c192d
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28454358302"
+              value: "28691124668"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:1c50c47d76bc1ec7fa086b1f59c768db2a619481829f81c29d5ef46a2c421631
+              value: sha256:ef40d13f0376c983402072a352867f5d6c2442e183ca75c6df69b2ad33f47c46
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 2c392bf93edd4004a8e917d26079b136da283e96
+              value: 131730e66e80c5f1cc0dc4b60be8369ecb2c192d
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:1c50c47d76bc1ec7fa086b1f59c768db2a619481829f81c29d5ef46a2c421631
+              value: sha256:ef40d13f0376c983402072a352867f5d6c2442e183ca75c6df69b2ad33f47c46
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 2c392bf9
-    digest: sha256:1c50c47d76bc1ec7fa086b1f59c768db2a619481829f81c29d5ef46a2c421631
+    newTag: "131730e6"
+    digest: sha256:ef40d13f0376c983402072a352867f5d6c2442e183ca75c6df69b2ad33f47c46


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `131730e66e80c5f1cc0dc4b60be8369ecb2c192d`
- Image tag: `131730e6`
- Image digest: `sha256:ef40d13f0376c983402072a352867f5d6c2442e183ca75c6df69b2ad33f47c46`
- Source CI run: `28691124668`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates