### PR TITLE
fix(torghut): accept zero-notional repair verifier state

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -267,6 +267,60 @@ describe('validatePostDeployEvidence', () => {
     expect(result.summaryLines.join('\n')).toContain('Live submit contract: `shadow_zero_notional_gate_closed`')
   })
 
+  it('accepts 2xx readyz with operational submission ready but capital still zero-notional repair-only', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '200',
+      readyz: { status: 'ok' },
+      revenueRepairDigest: {
+        ...baseDigest,
+        capital: {
+          live_submission_allowed: true,
+          live_submission_reason: 'operational_submission_ready',
+          capital_stage: 'live',
+          capital_state: 'zero_notional',
+          configured_live_promotion: false,
+          max_notional: '0',
+          proof_floor_state: 'repair_only',
+          route_state: 'repair_only',
+        },
+        health: {
+          ...baseDigest.health,
+          readyz_status: 'ok',
+          readyz_ok: true,
+          dependency_failures: [{ name: 'profitability_proof_floor', detail: 'repair_only' }],
+        },
+        repair_queue: [],
+      },
+      tradingStatus: {
+        ...baseTradingStatus,
+        empirical_jobs: {
+          ready: false,
+          status: 'degraded',
+          blocked_reasons: ['job_stale'],
+        },
+        operational_submission_gate: {
+          allowed: true,
+          blocked_reasons: [],
+          reason: 'operational_submission_ready',
+          execution_route: {
+            route: 'testnet',
+            reason: 'alpaca_regular_session_closed',
+            testnet_after_hours_enabled: true,
+          },
+        },
+        proof_floor: {
+          floor_state: 'repair_only',
+          capital_state: 'zero_notional',
+          max_notional: '0',
+        },
+      },
+    })
+
+    expect(result.readyzAcceptedReason).toBe('repair_only_zero_notional')
+    expect(result.liveSubmitContract).toBe('operational_zero_notional_repair')
+    expect(result.summaryLines.join('\n')).toContain('Live submit contract: `operational_zero_notional_repair`')
+  })
+
   it('accepts healthy readyz after live submit activation expiry when live submit is blocked', () => {
     const result = validatePostDeployEvidence({
       readyzHttpStatus: '200',

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -30,6 +30,7 @@ type PostDeployEvidenceInput = {
 type LiveSubmitContract =
   | 'bounded_live_submit_active'
   | 'expired_activation_blocked'
+  | 'operational_zero_notional_repair'
   | 'shadow_zero_notional_gate_closed'
 
 export type PostDeployEvidenceResult = {
@@ -385,6 +386,72 @@ const assertShadowZeroNotionalGateClosedContract = (status: JsonObject, digest: 
   return 'shadow_zero_notional_gate_closed'
 }
 
+const assertOperationalZeroNotionalRepairContract = (status: JsonObject, digest: JsonObject): LiveSubmitContract => {
+  const capital = requireObject(digest.capital, 'torghut revenue repair digest capital')
+  if (
+    digest.business_state !== 'repair_only' ||
+    digest.revenue_ready !== false ||
+    capital.capital_state !== 'zero_notional' ||
+    formatScalar(capital.max_notional, '') !== '0'
+  ) {
+    throw new Error('operational repair-only rollout acceptance requires repair_only zero_notional max_notional=0')
+  }
+  requireScalarValue(
+    capital.proof_floor_state,
+    'repair_only',
+    'torghut revenue repair digest capital.proof_floor_state',
+  )
+  requireScalarValue(capital.route_state, 'repair_only', 'torghut revenue repair digest capital.route_state')
+  if (
+    requireBoolean(capital.live_submission_allowed, 'torghut revenue repair digest capital.live_submission_allowed') !==
+    true
+  ) {
+    throw new Error('operational repair-only rollout acceptance requires live_submission_allowed=true')
+  }
+  requireScalarValue(
+    capital.live_submission_reason,
+    'operational_submission_ready',
+    'torghut revenue repair digest capital.live_submission_reason',
+  )
+
+  const liveSubmissionGate = requireObject(status.live_submission_gate, 'torghut status live_submission_gate')
+  const operationalSubmissionGate = requireObject(
+    status.operational_submission_gate,
+    'torghut status operational_submission_gate',
+  )
+  const proofFloor = requireObject(status.proof_floor, 'torghut status proof_floor')
+
+  if (requireBoolean(status.autonomy_enabled, 'torghut status autonomy_enabled') !== false) {
+    throw new Error('torghut status autonomy_enabled must be false for operational zero-notional repair rollout')
+  }
+  if (requireBoolean(liveSubmissionGate.allowed, 'torghut status live_submission_gate.allowed') !== true) {
+    throw new Error('operational repair-only rollout acceptance requires live_submission_gate.allowed=true')
+  }
+  if (
+    requireBoolean(operationalSubmissionGate.allowed, 'torghut status operational_submission_gate.allowed') !== true
+  ) {
+    throw new Error('operational repair-only rollout acceptance requires operational_submission_gate.allowed=true')
+  }
+  requireScalarValue(
+    operationalSubmissionGate.reason,
+    'operational_submission_ready',
+    'torghut status operational_submission_gate.reason',
+  )
+  requireScalarValue(proofFloor.floor_state, 'repair_only', 'torghut status proof_floor.floor_state')
+  requireScalarValue(proofFloor.capital_state, 'zero_notional', 'torghut status proof_floor.capital_state')
+  requireScalarValue(proofFloor.max_notional, '0', 'torghut status proof_floor.max_notional')
+
+  assertSimpleLaneCaps(status, liveSubmissionGate)
+  assertLiveSubmitActivationContract(
+    requireObject(
+      liveSubmissionGate.live_submit_activation,
+      'torghut status live_submission_gate.live_submit_activation',
+    ),
+  )
+
+  return 'operational_zero_notional_repair'
+}
+
 const isRepairOnlyZeroNotionalCandidate = (status: JsonObject, digest: JsonObject): boolean => {
   const capital =
     digest.capital && typeof digest.capital === 'object' && !Array.isArray(digest.capital)
@@ -405,11 +472,14 @@ const isRepairOnlyZeroNotionalCandidate = (status: JsonObject, digest: JsonObjec
   return (
     digest.business_state === 'repair_only' &&
     digest.revenue_ready === false &&
-    capital.live_submission_allowed === false &&
     capital.capital_state === 'zero_notional' &&
     formatScalar(capital.max_notional, '') === '0' &&
-    liveSubmissionGate.allowed === false &&
-    activation.configured === false
+    ((capital.live_submission_allowed === false &&
+      liveSubmissionGate.allowed === false &&
+      activation.configured === false) ||
+      (capital.live_submission_allowed === true &&
+        liveSubmissionGate.allowed === true &&
+        activation.configured === true))
   )
 }
 
@@ -754,7 +824,11 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     }
   } else {
     if (isRepairOnlyZeroNotionalCandidate(status, digest)) {
-      liveSubmitContract = assertShadowZeroNotionalGateClosedContract(status, digest)
+      const capital = requireObject(digest.capital, 'torghut revenue repair digest capital')
+      liveSubmitContract =
+        capital.live_submission_allowed === true
+          ? assertOperationalZeroNotionalRepairContract(status, digest)
+          : assertShadowZeroNotionalGateClosedContract(status, digest)
       readyzAcceptedReason = 'repair_only_zero_notional'
     } else {
       liveSubmitContract = assertBoundedLiveSubmitContract(status)


### PR DESCRIPTION
## Summary

- Teach the Torghut post-deploy evidence validator about the current operational zero-notional repair state.
- Preserve the hard safety checks: repair-only business state, max_notional=0, autonomy disabled, valid live-submit activation, simple lane caps, and operational submission route.
- Keep stale empirical jobs diagnostic-only for this repair-only rollout acceptance path, instead of treating them as bounded live capital authority.
- Add a regression test for HTTP 200 /readyz with operational submission ready while capital remains zero-notional repair-only.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --filter @proompteng/scripts lint`
- Live replay from running pod `torghut-01366-deployment-7ff866f7d-dcwv8`: captured `/readyz`, `/trading/status`, and `/trading/revenue-repair`, then ran `bun run packages/scripts/src/torghut/post-deploy-evidence.ts`; output: `Torghut readyz accepted as repair_only_zero_notional (HTTP 200)`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
