### PR TITLE
fix(torghut): retire runtime source blockers

### DIFF
--- a/docs/superpowers/plans/2026-06-01-torghut-cuda-research-acceleration.md
+++ b/docs/superpowers/plans/2026-06-01-torghut-cuda-research-acceleration.md
@@ -24,7 +24,7 @@
 
 - CUDA output is advisory research evidence only.
 - Promotion remains blocked unless live-paper parity, runtime-ledger buckets, exact replay, explicit costs, lineage, TigerBeetle refs, and closed lifecycle checks pass.
-- `simple_submit_disabled`, `hypothesis_not_promotion_eligible`, and `runtime_ledger_source_collection_pending` must not be bypassed by this plan.
+- CUDA research output must not enable submit paths; runtime import state remains repair diagnostic metadata.
 - No required PyTorch dependency is added to the base Torghut environment in this slice; CUDA support is optional and selected explicitly.
 
 ## Implementation Checkpoint

--- a/docs/superpowers/plans/2026-06-17-torghut-promotion-authority-refactor.md
+++ b/docs/superpowers/plans/2026-06-17-torghut-promotion-authority-refactor.md
@@ -774,7 +774,7 @@ Replace direct false promotion fields in `source_collection_bounded_execution_pa
 
 ```python
 **source_collection_authority(
-    blockers=["runtime_ledger_source_collection_pending"],
+    blockers=[],
 ).as_target_fields(),
 ```
 

--- a/docs/torghut/local-cuda-research-acceleration.md
+++ b/docs/torghut/local-cuda-research-acceleration.md
@@ -81,6 +81,5 @@ evidence stack proves them:
 - post-cost PnL against the active profit target
 - existing firewall and promotion blockers cleared by their owning services
 
-The CUDA ranker must not clear `simple_submit_disabled`,
-`hypothesis_not_promotion_eligible`, or
-`runtime_ledger_source_collection_pending`.
+The CUDA ranker must not enable submit paths. Runtime import state remains
+repair diagnostic metadata.

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -245,8 +245,8 @@ describe('validatePostDeployEvidence', () => {
           blocked_reasons: [
             'empirical_jobs_not_ready',
             'hypothesis_not_promotion_eligible',
-            'runtime_ledger_profit_target_source_collection_pending',
-            'runtime_ledger_source_collection_pending',
+            'runtime_profit_target_import_required',
+            'runtime_window_import_required',
           ],
           capital_stage: 'shadow',
           capital_state: 'observe',

--- a/services/torghut/app/trading/revenue_repair/evidence_summaries.py
+++ b/services/torghut/app/trading/revenue_repair/evidence_summaries.py
@@ -299,8 +299,9 @@ def _summarize_runtime_window_import_repair(
             }
             for target in skipped_targets[:5]
         ],
+        "diagnostic_reasons": ["runtime_window_import_required"],
         **capital_blocked_authority(
-            blockers=["runtime_ledger_source_collection_pending"],
+            blockers=[],
         ).as_target_fields(),
     }
 

--- a/services/torghut/app/trading/revenue_repair/repair_queue.py
+++ b/services/torghut/app/trading/revenue_repair/repair_queue.py
@@ -17,7 +17,7 @@ _REPAIR_CATALOG: dict[str, tuple[str, str, str, int, int]] = {
         70,
         6,
     ),
-    "runtime_ledger_source_collection_pending": (
+    "runtime_window_import_required": (
         "repair_source_runtime_window_import",
         "runtime_window_import",
         "import_source_collection_runtime_ledger_window_before_alpha_promotion",
@@ -113,7 +113,7 @@ _REPAIR_METADATA: dict[str, dict[str, object]] = {
             "capital_replay_board",
         ],
     },
-    "runtime_ledger_source_collection_pending": {
+    "runtime_window_import_required": {
         "value_gate": "routeable_candidate_count",
         "required_output_receipt": "torghut.runtime-window-import-readback.v1",
         "required_receipts": [

--- a/services/torghut/app/trading/scheduler/source_collection/decision_helpers.py
+++ b/services/torghut/app/trading/scheduler/source_collection/decision_helpers.py
@@ -249,8 +249,9 @@ def source_collection_params(
         "paper_route_probe_symbols": metadata.get("paper_route_probe_symbols"),
         "observed_stage": _safe_text(context.target.get("observed_stage")) or "paper",
         "bounded_collection_stage": "bounded_paper_collection",
+        "source_collection_diagnostics": ["runtime_window_import_required"],
         **source_collection_authority(
-            blockers=["runtime_ledger_source_collection_pending"],
+            blockers=[],
         ).as_target_fields(),
         "live_capital_routing_enabled": False,
         **mode.execution_metadata,

--- a/services/torghut/app/trading/scheduler/source_collection/target_plan_fetch.py
+++ b/services/torghut/app/trading/scheduler/source_collection/target_plan_fetch.py
@@ -708,8 +708,9 @@ class SimplePipelineSourceCollectionTargetPlanMixin(SourceCollectionRuntimeMixin
                 or "paper_route_probe_next_session_only"
             ),
             "bounded_evidence_collection_max_notional": str(context.target_cap),
+            "source_collection_diagnostics": ["runtime_window_import_required"],
             **source_collection_authority(
-                blockers=["runtime_ledger_source_collection_pending"],
+                blockers=[],
                 bounded_live_paper_collection_authorized=(
                     bounded_collection_authorized
                 ),

--- a/services/torghut/app/trading/submission_authority.py
+++ b/services/torghut/app/trading/submission_authority.py
@@ -6,11 +6,11 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 
-_RETIRED_SUBMISSION_AUTHORITY_BLOCKERS = frozenset(
+_DIAGNOSTIC_SUBMISSION_REASONS = frozenset(
     {
         "hypothesis_not_promotion_eligible",
-        "runtime_ledger_profit_target_source_collection_pending",
-        "runtime_ledger_source_collection_pending",
+        "runtime_profit_target_import_required",
+        "runtime_window_import_required",
     }
 )
 
@@ -20,7 +20,7 @@ def build_submission_authority_status(
     *,
     simple_lane_status: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
-    """Summarize the effective submit authority after retiring proof blockers."""
+    """Summarize effective submit authority from operational blockers only."""
 
     simple_lane = _mapping(simple_lane_status)
     operational_gate = operational_submission_gate_status(live_submission_gate)
@@ -61,7 +61,7 @@ def build_submission_authority_status(
 def operational_submission_gate_status(
     live_submission_gate: Mapping[str, Any],
 ) -> dict[str, object]:
-    """Return the effective operational gate with retired proof blockers removed."""
+    """Return the effective operational gate with diagnostic reasons removed."""
 
     nested_gate = _mapping(live_submission_gate.get("operational_submission_gate"))
     gate = nested_gate or live_submission_gate
@@ -97,7 +97,7 @@ def _active_submission_allowed(
         return False
     if raw_allowed:
         return True
-    if _is_retired_submission_blocker(raw_reason):
+    if _is_diagnostic_submission_reason(raw_reason):
         return True
     if raw_blocked_reasons and not active_blocked_reasons:
         return True
@@ -108,7 +108,7 @@ def _active_submission_blockers(blocked_reasons: list[str]) -> list[str]:
     return [
         reason
         for reason in blocked_reasons
-        if not _is_retired_submission_blocker(reason)
+        if not _is_diagnostic_submission_reason(reason)
     ]
 
 
@@ -119,15 +119,15 @@ def _active_submission_reason(
 ) -> str:
     if blocked_reasons:
         return blocked_reasons[0]
-    if _is_retired_submission_blocker(raw_reason):
+    if _is_diagnostic_submission_reason(raw_reason):
         return "operational_submission_ready"
     if raw_allowed:
         return raw_reason or "operational_submission_ready"
     return raw_reason or "unknown"
 
 
-def _is_retired_submission_blocker(reason: str) -> bool:
-    return reason in _RETIRED_SUBMISSION_AUTHORITY_BLOCKERS
+def _is_diagnostic_submission_reason(reason: str) -> bool:
+    return reason in _DIAGNOSTIC_SUBMISSION_REASONS
 
 
 def _mapping(value: object) -> Mapping[str, Any]:

--- a/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
+++ b/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
@@ -115,11 +115,11 @@ class TestTradingApiSimpleLaneProfitFloor(TradingApiTestCaseBase):
                 payload["live_submission_gate"]["blocked_reasons"],
             )
             self.assertNotIn(
-                "runtime_ledger_source_collection_pending",
+                "runtime_window_import_required",
                 payload["live_submission_gate"]["blocked_reasons"],
             )
             self.assertNotIn(
-                "runtime_ledger_profit_target_source_collection_pending",
+                "runtime_profit_target_import_required",
                 payload["live_submission_gate"]["blocked_reasons"],
             )
             self.assertTrue(

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_scalar_normalizers_handle_runtime_json_variants.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_scalar_normalizers_handle_runtime_json_variants.py
@@ -613,7 +613,7 @@ class TestScalarNormalizersHandleRuntimeJsonVariants(_TestRuntimeLedgerProofPack
         evidence["runtime_window_import_plan"] = import_plan
 
         result = packet.build_runtime_ledger_proof_packet(
-            _status(blockers=["runtime_ledger_source_collection_pending"]),
+            _status(blockers=["runtime_window_import_required"]),
             proof_mode="authority",
             paper_route_evidence=evidence,
             runtime_window_import=_runtime_import(),
@@ -625,7 +625,7 @@ class TestScalarNormalizersHandleRuntimeJsonVariants(_TestRuntimeLedgerProofPack
         )
 
         self.assertFalse(result["ok"])
-        self.assertIn("runtime_ledger_source_collection_pending", result["blockers"])
+        self.assertIn("runtime_window_import_required", result["blockers"])
         for blocker in (
             "runtime_window_import_health_gate_missing",
             "dependency_quorum_not_allow",

--- a/services/torghut/tests/build_revenue_repair_digest/test_direct_script_execution_supports_help.py
+++ b/services/torghut/tests/build_revenue_repair_digest/test_direct_script_execution_supports_help.py
@@ -437,7 +437,7 @@ class TestDirectScriptExecutionSupportsHelp(_TestBuildRevenueRepairDigestBase):
         self.assertIsInstance(live_gate, dict)
         live_gate["blocked_reasons"] = [
             "simple_submit_disabled",
-            "runtime_ledger_source_collection_pending",
+            "runtime_window_import_required",
         ]
         live_gate["runtime_ledger_paper_probation_import_plan"] = {
             "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
@@ -594,7 +594,7 @@ class TestDirectScriptExecutionSupportsHelp(_TestBuildRevenueRepairDigestBase):
 
         skipped_summary = _summarize_runtime_window_import_repair(
             {
-                "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                "blocked_reasons": ["runtime_window_import_required"],
                 "runtime_ledger_paper_probation_import_plan": {
                     "target_count": 0,
                     "skipped_target_count": 1,

--- a/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
@@ -286,7 +286,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                 "allowed": False,
                 "blocked_reasons": [
                     "hypothesis_not_promotion_eligible",
-                    "runtime_ledger_source_collection_pending",
+                    "runtime_window_import_required",
                 ],
                 "bounded_live_paper_collection_gate": {
                     "allowed": True,
@@ -298,7 +298,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                 "capital_state": "paper",
                 "max_notional": "100",
                 "market_window": {"session_open": True},
-                "blocking_reasons": ["runtime_ledger_source_collection_pending"],
+                "blocking_reasons": ["runtime_window_import_required"],
                 "route_reacquisition_book": {
                     "summary": {"paper_route_probe_eligible_symbols": ["AAPL"]}
                 },

--- a/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
@@ -87,8 +87,8 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
                 "allowed": False,
                 "blocked_reasons": [
                     "hypothesis_not_promotion_eligible",
-                    "runtime_ledger_source_collection_pending",
-                    "runtime_ledger_profit_target_source_collection_pending",
+                    "runtime_window_import_required",
+                    "runtime_profit_target_import_required",
                 ],
             }
 
@@ -300,15 +300,15 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
                 "allowed": False,
                 "blocked_reasons": [
                     "hypothesis_not_promotion_eligible",
-                    "runtime_ledger_source_collection_pending",
-                    "runtime_ledger_profit_target_source_collection_pending",
+                    "runtime_window_import_required",
+                    "runtime_profit_target_import_required",
                 ],
             }
             proof_floor = {
                 "route_state": "repair_only",
                 "capital_state": "zero_notional",
                 "max_notional": "0",
-                "blocking_reasons": ["runtime_ledger_source_collection_pending"],
+                "blocking_reasons": ["runtime_window_import_required"],
             }
 
             with self.session_local() as session:

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -46,8 +46,8 @@ def test_simple_live_submission_gate_drops_retired_source_collection_blockers(
                 "reason": "hypothesis_not_promotion_eligible",
                 "blocked_reasons": [
                     "hypothesis_not_promotion_eligible",
-                    "runtime_ledger_profit_target_source_collection_pending",
-                    "runtime_ledger_source_collection_pending",
+                    "runtime_profit_target_import_required",
+                    "runtime_window_import_required",
                 ],
                 "execution_route": {
                     "route": "testnet",
@@ -89,8 +89,8 @@ def test_bounded_live_paper_route_requires_explicit_collection_gate() -> None:
     assert not SimpleTradingPipeline._bounded_live_paper_route_collection_gate_allows(
         {
             "allowed": False,
-            "reason": "runtime_ledger_source_collection_pending",
-            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+            "reason": "runtime_window_import_required",
+            "blocked_reasons": ["runtime_window_import_required"],
         }
     )
     assert SimpleTradingPipeline._bounded_live_paper_route_collection_gate_allows(
@@ -119,8 +119,8 @@ def test_live_profitability_proof_floor_is_diagnostic_for_runtime_ledger_blocker
             "max_notional": "0",
             "blocking_reasons": [
                 "hypothesis_not_promotion_eligible",
-                "runtime_ledger_profit_target_source_collection_pending",
-                "runtime_ledger_source_collection_pending",
+                "runtime_profit_target_import_required",
+                "runtime_window_import_required",
             ],
         }
         blocks: list[object] = []
@@ -888,7 +888,7 @@ def test_live_profitability_symbol_floor_is_diagnostic_for_runtime_ledger_blocke
             "capital_state": "shadow",
         }
         pipeline._proof_floor_symbol_block_reason = lambda proof_floor, symbol: (
-            "runtime_ledger_source_collection_pending"
+            "runtime_window_import_required"
         )
         blocks: list[object] = []
         pipeline._block_decision_submission = lambda request: blocks.append(request)

--- a/services/torghut/tests/submission_council/test_live_submission_gate.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate.py
@@ -270,7 +270,7 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
 
         self.assertTrue(result["allowed"])
         self.assertNotIn(
-            "runtime_ledger_source_collection_pending",
+            "runtime_window_import_required",
             result["blocked_reasons"],
         )
         import_plan = result["runtime_ledger_paper_probation_import_plan"]

--- a/services/torghut/tests/submission_council/test_paper_probation_import_plan.py
+++ b/services/torghut/tests/submission_council/test_paper_probation_import_plan.py
@@ -184,9 +184,9 @@ class TestSubmissionCouncilPaperProbationImportPlan(SubmissionCouncilTestCase):
                     "bucket_ended_at": "2026-05-29T20:00:00+00:00",
                     "source_collection_candidate": True,
                     "source_collection_reason_codes": [
-                        "runtime_ledger_source_collection_pending"
+                        "runtime_window_import_required"
                     ],
-                    "reason_codes": ["runtime_ledger_source_collection_pending"],
+                    "reason_codes": ["runtime_window_import_required"],
                 }
             ]
         )

--- a/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
+++ b/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
@@ -95,9 +95,7 @@ class TestSubmissionCouncilRuntimeCertificateMerge(SubmissionCouncilTestCase):
         self.assertEqual(gate["reason"], "operational_submission_ready")
         self.assertFalse(gate["runtime_ledger_paper_probation_candidates"])
         self.assertFalse(gate["runtime_ledger_source_collection_candidates"])
-        self.assertNotIn(
-            "runtime_ledger_source_collection_pending", gate["blocked_reasons"]
-        )
+        self.assertNotIn("runtime_window_import_required", gate["blocked_reasons"])
         import_plan = gate["runtime_ledger_paper_probation_import_plan"]
         self.assertEqual(
             import_plan["schema_version"],

--- a/services/torghut/tests/submission_council/test_source_collection_candidates.py
+++ b/services/torghut/tests/submission_council/test_source_collection_candidates.py
@@ -916,11 +916,9 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
 
         self.assertEqual(gate["paper_probation_eligible_total"], 0)
         self.assertEqual(gate["runtime_ledger_paper_probation_eligible_total"], 0)
+        self.assertNotIn("runtime_window_import_required", gate["blocked_reasons"])
         self.assertNotIn(
-            "runtime_ledger_source_collection_pending", gate["blocked_reasons"]
-        )
-        self.assertNotIn(
-            "runtime_ledger_profit_target_source_collection_pending",
+            "runtime_profit_target_import_required",
             gate["blocked_reasons"],
         )
         self.assertTrue(gate["allowed"])

--- a/services/torghut/tests/test_submission_authority.py
+++ b/services/torghut/tests/test_submission_authority.py
@@ -93,15 +93,15 @@ def test_submission_authority_accepts_compatibility_gate_payload() -> None:
     }
 
 
-def test_submission_authority_retired_source_collection_blockers_do_not_block() -> None:
+def test_submission_authority_diagnostic_reasons_do_not_block() -> None:
     status = build_submission_authority_status(
         {
             "allowed": False,
             "reason": "hypothesis_not_promotion_eligible",
             "blocked_reasons": [
                 "hypothesis_not_promotion_eligible",
-                "runtime_ledger_profit_target_source_collection_pending",
-                "runtime_ledger_source_collection_pending",
+                "runtime_profit_target_import_required",
+                "runtime_window_import_required",
             ],
             "execution_route": {
                 "route": "testnet",


### PR DESCRIPTION
## Summary

- Removes the retired runtime-ledger/source-collection pending reason codes from Torghut submission authority and fixtures.
- Keeps runtime import state as diagnostic/repair metadata instead of promotion/submission blocker fields.
- Updates source-collection target materialization, revenue-repair summaries, post-deploy fixtures, and docs to match the operational submission contract.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_authority.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/submission_council/test_live_submission_gate.py tests/submission_council/test_runtime_certificate_merge.py tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py tests/build_revenue_repair_digest/test_direct_script_execution_supports_help.py tests/api/test_trading_api_simple_lane_profit_floor.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_authority.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_authority.py app/trading/revenue_repair/evidence_summaries.py app/trading/scheduler/source_collection/decision_helpers.py app/trading/scheduler/source_collection/target_plan_fetch.py tests/test_submission_authority.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/submission_council/test_live_submission_gate.py tests/submission_council/test_runtime_certificate_merge.py tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py tests/build_revenue_repair_digest/test_direct_script_execution_supports_help.py tests/api/test_trading_api_simple_lane_profit_floor.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_authority.py app/trading/revenue_repair/evidence_summaries.py app/trading/scheduler/source_collection/decision_helpers.py app/trading/scheduler/source_collection/target_plan_fetch.py tests/test_submission_authority.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/submission_council/test_live_submission_gate.py tests/submission_council/test_runtime_certificate_merge.py tests/submission_council/test_source_collection_candidates.py tests/submission_council/test_paper_probation_import_plan.py tests/build_revenue_repair_digest/test_direct_script_execution_supports_help.py tests/api/test_trading_api_simple_lane_profit_floor.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `git diff --check`
- `rg -n "alpha_readiness_not_promotion_eligible|retire_alpha_readiness_not_promotion_eligible|alpha_hypothesis_not_promotion_eligible|runtime_ledger_profit_target_source_collection_pending|runtime_ledger_source_collection_pending" . -g '!bun.lock'` returned no matches.
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
