### PR TITLE
chore(symphony): promote image sha-3846851d28670d36fd4f9cf5ead22f8aad012623

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-03T23:52:30Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T02:25:58Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-3061f810b8e912bdc8fccffc5659408f42afeb2b"
+    newTag: "sha-3846851d28670d36fd4f9cf5ead22f8aad012623"
     digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-03T23:52:30Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T02:25:58Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-3061f810b8e912bdc8fccffc5659408f42afeb2b"
+    newTag: "sha-3846851d28670d36fd4f9cf5ead22f8aad012623"
     digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-03T23:52:30Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T02:25:58Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-3061f810b8e912bdc8fccffc5659408f42afeb2b"
+    newTag: "sha-3846851d28670d36fd4f9cf5ead22f8aad012623"
     digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `3846851d28670d36fd4f9cf5ead22f8aad012623`
- Image tag: `sha-3846851d28670d36fd4f9cf5ead22f8aad012623`
- Image digest: `sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367`