### PR TITLE
chore(torghut): promote image 1d7dc231

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -51,9 +51,9 @@ spec:
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 851deabaff2445780543baa64b9ef0336fb2cf35
+              value: 1d7dc23182f2be3ec7443a123bce6e047c99f4b0
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+              value: sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 851deabaff2445780543baa64b9ef0336fb2cf35
+              value: 1d7dc23182f2be3ec7443a123bce6e047c99f4b0
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+              value: sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T01:53:48Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T02:31:29Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
           ports:
             - name: http1
               containerPort: 8181
@@ -539,11 +539,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1316-g851deabaf
+              value: v0.596.0-1320-g1d7dc2318
             - name: TORGHUT_COMMIT
-              value: 851deabaff2445780543baa64b9ef0336fb2cf35
+              value: 1d7dc23182f2be3ec7443a123bce6e047c99f4b0
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+              value: sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T01:53:48Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T02:31:29Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
           ports:
             - name: http1
               containerPort: 8181
@@ -414,11 +414,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1316-g851deabaf
+              value: v0.596.0-1320-g1d7dc2318
             - name: TORGHUT_COMMIT
-              value: 851deabaff2445780543baa64b9ef0336fb2cf35
+              value: 1d7dc23182f2be3ec7443a123bce6e047c99f4b0
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+              value: sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:152d7a4b50bed7573f13b80408f40e28dce56fc50673bce0dd5b23115c81ec19
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `1d7dc23182f2be3ec7443a123bce6e047c99f4b0`
- Image tag: `1d7dc231`
- Image digest: `sha256:7c2fff038cbaa97f85bdbd30878e1db9f4112170df06564efffc6cd8a3faed05`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher