### PR TITLE
ci(nix): decouple image publish from attic warm

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -169,7 +169,7 @@ jobs:
           fi
           bash nix/ci-run-timed.sh "push-platform-image-${ARCH}" "${NIX_OCI_LOG_DIR}/oci-push-${ARCH}.log" "${args[@]}"
 
-      - name: Push build platform closures to Attic
+      - name: Push build platform helper closures to Attic
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
@@ -183,14 +183,35 @@ jobs:
             echo "No build-platform helper closure paths were captured." >&2
             exit 2
           fi
+          bash nix/ci-run-timed.sh "push-build-platform-helper-closures-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-helpers-${ARCH}.log" \
+            nix run .#cache-push -- "${helper_paths[@]}"
+
+      - name: Warm Nix image archive closure in Attic
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          test -n "${ATTIC_TOKEN}"
           mapfile -t image_paths < "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"
           if [[ "${#image_paths[@]}" -eq 0 ]]; then
             echo "No Nix image closure paths were captured." >&2
             exit 2
           fi
-          cache_paths=("${helper_paths[@]}" "${image_paths[@]}")
-          bash nix/ci-run-timed.sh "push-build-platform-closures-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-${ARCH}.log" \
-            nix run .#cache-push -- "${cache_paths[@]}"
+          status_file="${NIX_OCI_LOG_DIR}/image-cache-push-status-${ARCH}.txt"
+          set +e
+          bash nix/ci-run-timed.sh "push-image-archive-closure-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-image-${ARCH}.log" \
+            nix run .#cache-push -- "${image_paths[@]}"
+          status="$?"
+          set -e
+          if [[ "${status}" -ne 0 ]]; then
+            printf 'failed\t%s\n' "${status}" > "${status_file}"
+            echo "::warning title=Attic image closure warm failed::Attic image closure push failed for ${ARCH}; registry image push remains authoritative. See cache-push-image-${ARCH}.log."
+            exit 0
+          fi
+          printf 'succeeded\t0\n' > "${status_file}"
 
       - name: Summarize Nix OCI cache use
         if: always()

--- a/nix/ci-nix-oci-summary.sh
+++ b/nix/ci-nix-oci-summary.sh
@@ -41,6 +41,22 @@ count_timed_phases() {
   awk 'NF > 0 {count += 1} END {print count + 0}' "${timings_file}"
 }
 
+count_image_cache_status() {
+  local expected_status="$1"
+  local count file
+  count=0
+  if ! compgen -G "${log_dir}/image-cache-push-status-*.txt" >/dev/null; then
+    echo 0
+    return
+  fi
+  for file in "${log_dir}"/image-cache-push-status-*.txt; do
+    if grep -q -E "^${expected_status}[[:space:]]" "${file}"; then
+      count=$((count + 1))
+    fi
+  done
+  echo "${count}"
+}
+
 count_existing_image_archives() {
   local image_tar archive_count
   archive_count=0
@@ -80,6 +96,8 @@ timed_seconds="$(sum_timed_seconds)"
 cache_substitutions=$((attic_substitutions + nixos_substitutions))
 image_archives="$(count_existing_image_archives)"
 image_archive_bytes="$(sum_existing_image_archive_bytes)"
+image_cache_warm_successes="$(count_image_cache_status succeeded)"
+image_cache_warm_failures="$(count_image_cache_status failed)"
 
 {
   echo "## Nix OCI Cache Summary"
@@ -100,6 +118,8 @@ image_archive_bytes="$(sum_existing_image_archive_bytes)"
   echo "| Cache substitutions | ${cache_substitutions} |"
   echo "| Existing image archives | ${image_archives} |"
   echo "| Existing image archive bytes | ${image_archive_bytes} |"
+  echo "| Image archive Attic warm successes | ${image_cache_warm_successes} |"
+  echo "| Image archive Attic warm failures | ${image_cache_warm_failures} |"
   echo
 
   if [[ -f "${timings_file}" ]]; then

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -253,9 +253,16 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('nix run .#create-oci-index --')
     expect(nixOciWorkflow).toContain('nix run .#assert-oci-platforms --')
     expect(nixOciWorkflow).toContain('printf \'%s\\n\' "${image_tar}" > "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
+    expect(nixOciWorkflow).toContain('Push build platform helper closures to Attic')
+    expect(nixOciWorkflow).toContain('nix run .#cache-push -- "${helper_paths[@]}"')
+    expect(nixOciWorkflow).toContain('Warm Nix image archive closure in Attic')
     expect(nixOciWorkflow).toContain('mapfile -t image_paths < "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
-    expect(nixOciWorkflow).toContain('cache_paths=("${helper_paths[@]}" "${image_paths[@]}")')
-    expect(nixOciWorkflow).toContain('nix run .#cache-push -- "${cache_paths[@]}"')
+    expect(nixOciWorkflow).toContain('nix run .#cache-push -- "${image_paths[@]}"')
+    expect(nixOciWorkflow).toContain(
+      'Attic image closure push failed for ${ARCH}; registry image push remains authoritative.',
+    )
+    expect(nixOciWorkflow).not.toContain('cache_paths=("${helper_paths[@]}" "${image_paths[@]}")')
+    expect(nixOciWorkflow).not.toContain('nix run .#cache-push -- "${cache_paths[@]}"')
     expect(nixOciWorkflow).toContain('nix run .#write-oci-release-contract --')
     expect(nixOciWorkflow).toContain('substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/')
     expect(nixOciWorkflow).not.toContain('extra-substituters = http://attic.attic.svc.cluster.local/lab')
@@ -293,6 +300,8 @@ describe('native OCI build workflows', () => {
     expect(ciNixOciSummaryScript).toContain('Total timed seconds')
     expect(ciNixOciSummaryScript).toContain('Cache substitutions')
     expect(ciNixOciSummaryScript).toContain('Existing image archive bytes')
+    expect(ciNixOciSummaryScript).toContain('Image archive Attic warm successes')
+    expect(ciNixOciSummaryScript).toContain('Image archive Attic warm failures')
     expect(ciNixOciSummaryScript).toContain('GITHUB_STEP_SUMMARY')
   })
 


### PR DESCRIPTION
## Summary

- Split main-branch Attic warming into strict helper-closure push and warning-only image archive closure warm.
- Preserve real registry image publishing and OCI index release when Attic rejects a large image archive upload.
- Add Nix OCI summary counters for image archive Attic warm successes/failures so cache proof gaps stay visible.
- Update OCI workflow contract tests for the split cache behavior.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `shellcheck nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh nix/cache-push.sh`
- `git diff --check`
- `nix flake check --print-build-logs`
- `nix flake check --all-systems --print-build-logs`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
