### PR TITLE
chore(torghut): promote image ac2ecd83

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -51,9 +51,9 @@ spec:
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 48192e5f7ddcadb74d89a2155205b218a0c5eeed
+              value: ac2ecd83caf4120042269b2f94cea2b7ab6f352d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+              value: sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 48192e5f7ddcadb74d89a2155205b218a0c5eeed
+              value: ac2ecd83caf4120042269b2f94cea2b7ab6f352d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+              value: sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T02:42:17Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T05:41:35Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
           ports:
             - name: http1
               containerPort: 8181
@@ -539,11 +539,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1322-g48192e5f7
+              value: v0.596.0-1329-gac2ecd83c
             - name: TORGHUT_COMMIT
-              value: 48192e5f7ddcadb74d89a2155205b218a0c5eeed
+              value: ac2ecd83caf4120042269b2f94cea2b7ab6f352d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+              value: sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-04T02:42:17Z"
+        client.knative.dev/updateTimestamp: "2026-07-04T05:41:35Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
           ports:
             - name: http1
               containerPort: 8181
@@ -414,11 +414,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1322-g48192e5f7
+              value: v0.596.0-1329-gac2ecd83c
             - name: TORGHUT_COMMIT
-              value: 48192e5f7ddcadb74d89a2155205b218a0c5eeed
+              value: ac2ecd83caf4120042269b2f94cea2b7ab6f352d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+              value: sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:1d21d983db2d49252ba88a77455cfb117690360edadcb0dc6301535d872ba89b
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ac2ecd83caf4120042269b2f94cea2b7ab6f352d`
- Image tag: `ac2ecd83`
- Image digest: `sha256:e68bc59dad20ca6e73cdfd4183b048043ad43b68439302daa4976e5618c7be99`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher