### PR TITLE
refactor(torghut): remove simple lane execution residue

### DIFF
--- a/services/torghut/app/trading/execution_metadata.py
+++ b/services/torghut/app/trading/execution_metadata.py
@@ -1,0 +1,50 @@
+"""Canonical execution metadata for trade decisions.
+
+Legacy rows used ``simple_lane``. New writes use ``execution`` while readers
+fall back to the legacy key so existing decisions remain inspectable.
+"""
+
+from __future__ import annotations
+
+import typing
+from collections.abc import Mapping
+from typing import cast
+
+EXECUTION_METADATA_KEY = "execution"
+LEGACY_SIMPLE_LANE_METADATA_KEY = "simple_lane"
+
+
+def execution_metadata(
+    params: Mapping[str, typing.Any],
+) -> Mapping[str, typing.Any] | None:
+    raw_execution = params.get(EXECUTION_METADATA_KEY)
+    if isinstance(raw_execution, Mapping):
+        return cast(Mapping[str, typing.Any], raw_execution)
+    raw_legacy = params.get(LEGACY_SIMPLE_LANE_METADATA_KEY)
+    if isinstance(raw_legacy, Mapping):
+        return cast(Mapping[str, typing.Any], raw_legacy)
+    return None
+
+
+def mutable_execution_metadata(
+    params: Mapping[str, typing.Any],
+) -> dict[str, typing.Any]:
+    metadata = execution_metadata(params)
+    return dict(metadata) if metadata is not None else {}
+
+
+def set_execution_metadata(
+    params: dict[str, typing.Any],
+    metadata: Mapping[str, typing.Any],
+) -> None:
+    params.pop(LEGACY_SIMPLE_LANE_METADATA_KEY, None)
+    params[EXECUTION_METADATA_KEY] = dict(metadata)
+
+
+__all__ = [
+    "EXECUTION_METADATA_KEY",
+    "LEGACY_SIMPLE_LANE_METADATA_KEY",
+    "execution_metadata",
+    "mutable_execution_metadata",
+    "set_execution_metadata",
+]

--- a/services/torghut/app/trading/execution_policy/order_rules.py
+++ b/services/torghut/app/trading/execution_policy/order_rules.py
@@ -463,7 +463,12 @@ def prechecked_reducing_position_qty(decision: StrategyDecision) -> Decimal | No
     qty = optional_decimal(decision.qty)
     if qty is None or qty <= 0:
         return None
-    for key in ("simple_lane", "simple_lane_precheck"):
+    for key in (
+        "execution",
+        "execution_precheck",
+        "simple_lane",
+        "simple_lane_precheck",
+    ):
         section = decision.params.get(key)
         if not isinstance(section, Mapping):
             continue

--- a/services/torghut/app/trading/scheduler/paper_route_materialization.py
+++ b/services/torghut/app/trading/scheduler/paper_route_materialization.py
@@ -14,6 +14,7 @@ from ...models import (
     Strategy,
     TradeDecision,
 )
+from ..execution_metadata import set_execution_metadata
 from ..models import StrategyDecision
 from ..promotion_authority import source_collection_authority
 from ..runtime_decision_authority import (
@@ -52,7 +53,7 @@ class _MaterializedDecisionBuild:
     symbol_quantities: Mapping[str, Decimal]
     metadata: dict[str, Any]
     execution_metadata: Mapping[str, Any]
-    simple_lane: dict[str, Any]
+    execution: dict[str, Any]
     params: dict[str, Any]
 
 
@@ -102,6 +103,17 @@ class _MaterializedPlanningResult:
 class _MaterializedPlanningWindowResult:
     window_cap: _MaterializedWindowCap | None
     expired: bool = False
+
+
+@dataclass(frozen=True)
+class _MaterializedExecutionMetadataRequest:
+    metadata: Mapping[str, Any]
+    execution_metadata: Mapping[str, Any]
+    symbol_quantities: Mapping[str, Decimal]
+    action: Literal["buy", "sell"]
+    window_start: datetime
+    window_end: datetime
+    max_notional: Decimal
 
 
 class SimplePipelinePaperRouteMaterializationMixin(
@@ -290,38 +302,33 @@ class SimplePipelinePaperRouteMaterializationMixin(
         return target_symbols, symbol_quantities, metadata, execution_metadata
 
     @staticmethod
-    def _paper_route_materialized_simple_lane(
-        *,
-        metadata: Mapping[str, Any],
-        execution_metadata: Mapping[str, Any],
-        symbol_quantities: Mapping[str, Decimal],
-        action: Literal["buy", "sell"],
-        window_start: datetime,
-        window_end: datetime,
-        max_notional: Decimal,
+    def _paper_route_materialized_execution_metadata(
+        request: _MaterializedExecutionMetadataRequest,
     ) -> dict[str, Any]:
-        simple_lane = {
+        execution = {
             "source": "paper_route_target_plan_materializer",
             "target_plan_source_decision": True,
             "paper_route_target_plan_materialized": True,
-            "paper_route_probe_max_notional": str(max_notional),
-            "paper_route_probe_window_start": window_start.isoformat(),
-            "paper_route_probe_window_end": window_end.isoformat(),
-            "paper_route_probe_symbol_actions": metadata[
+            "paper_route_probe_max_notional": str(request.max_notional),
+            "paper_route_probe_window_start": request.window_start.isoformat(),
+            "paper_route_probe_window_end": request.window_end.isoformat(),
+            "paper_route_probe_symbol_actions": request.metadata[
                 "paper_route_probe_symbol_actions"
             ],
-            "paper_route_probe_leg_action": action,
+            "paper_route_probe_leg_action": request.action,
             "live_capital_routing_enabled": False,
             "client_order_id_basis": "materialized_trade_decision_hash",
-            "execution_account_label": execution_metadata["execution_account_label"],
-            "submit_path": execution_metadata["submit_path"],
+            "execution_account_label": request.execution_metadata[
+                "execution_account_label"
+            ],
+            "submit_path": request.execution_metadata["submit_path"],
         }
-        if symbol_quantities:
-            simple_lane["paper_route_probe_symbol_quantities"] = {
+        if request.symbol_quantities:
+            execution["paper_route_probe_symbol_quantities"] = {
                 item_symbol: str(quantity)
-                for item_symbol, quantity in symbol_quantities.items()
+                for item_symbol, quantity in request.symbol_quantities.items()
             }
-        return simple_lane
+        return execution
 
     @staticmethod
     def _paper_route_materialized_params(
@@ -330,7 +337,7 @@ class SimplePipelinePaperRouteMaterializationMixin(
         target: Mapping[str, Any],
         metadata: Mapping[str, Any],
         execution_metadata: Mapping[str, Any],
-        simple_lane: Mapping[str, Any],
+        execution: Mapping[str, Any],
         symbol: str,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
@@ -339,7 +346,6 @@ class SimplePipelinePaperRouteMaterializationMixin(
             "paper_route_materialized_decision_hash": decision_row.decision_hash,
             "paper_route_target_plan": metadata,
             "paper_route_target_plan_source_decision": metadata,
-            "simple_lane": simple_lane,
             "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
             "profit_proof_eligible": True,
             "hypothesis_id": metadata.get("hypothesis_id"),
@@ -373,6 +379,7 @@ class SimplePipelinePaperRouteMaterializationMixin(
         }
         if "exit_minute_after_open" in metadata:
             params["exit_minute_after_open"] = metadata["exit_minute_after_open"]
+        set_execution_metadata(params, execution)
         _merge_paper_route_probe_lineage(
             params,
             _paper_route_probe_lineage_from_params(params),
@@ -403,21 +410,23 @@ class SimplePipelinePaperRouteMaterializationMixin(
                 max_notional=max_notional,
             )
         )
-        simple_lane = self._paper_route_materialized_simple_lane(
-            metadata=metadata,
-            execution_metadata=execution_metadata,
-            symbol_quantities=symbol_quantities,
-            action=action,
-            window_start=window_start,
-            window_end=window_end,
-            max_notional=max_notional,
+        execution = self._paper_route_materialized_execution_metadata(
+            _MaterializedExecutionMetadataRequest(
+                metadata=metadata,
+                execution_metadata=execution_metadata,
+                symbol_quantities=symbol_quantities,
+                action=action,
+                window_start=window_start,
+                window_end=window_end,
+                max_notional=max_notional,
+            )
         )
         params = self._paper_route_materialized_params(
             decision_row=decision_row,
             target=target,
             metadata=metadata,
             execution_metadata=execution_metadata,
-            simple_lane=simple_lane,
+            execution=execution,
             symbol=symbol,
         )
         return _MaterializedDecisionBuild(
@@ -425,7 +434,7 @@ class SimplePipelinePaperRouteMaterializationMixin(
             symbol_quantities=symbol_quantities,
             metadata=metadata,
             execution_metadata=execution_metadata,
-            simple_lane=simple_lane,
+            execution=execution,
             params=params,
         )
 
@@ -530,12 +539,13 @@ class SimplePipelinePaperRouteMaterializationMixin(
         quantity_resolution: _TargetProbeQuantityResolution,
     ) -> None:
         build.metadata["paper_route_target_notional_sizing"] = quantity_resolution.audit
-        build.simple_lane["paper_route_target_notional_sizing"] = (
+        build.execution["paper_route_target_notional_sizing"] = (
             quantity_resolution.audit
         )
-        build.simple_lane["target_source_notional_sized"] = (
+        build.execution["target_source_notional_sized"] = (
             quantity_resolution.audit.get("sizing_source") == "target_notional"
         )
+        set_execution_metadata(build.params, build.execution)
         build.params["paper_route_target_notional_sizing"] = quantity_resolution.audit
         build.params.update(quantity_resolution.price_params)
 

--- a/services/torghut/app/trading/scheduler/paper_route_probe/probe_processing.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/probe_processing.py
@@ -13,6 +13,11 @@ from ....models import (
     Strategy,
     TradeDecision,
 )
+from ...execution_metadata import (
+    execution_metadata,
+    mutable_execution_metadata,
+    set_execution_metadata,
+)
 from ...models import StrategyDecision
 from ...runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
@@ -337,9 +342,9 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
         )
         params = dict(decision.params)
         metadata = dict(cast(Mapping[str, Any], params["paper_route_probe_exit"]))
-        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
+        execution = mutable_execution_metadata(params)
         quantity_resolution = dict(
-            cast(Mapping[str, Any], simple_lane.get("quantity_resolution") or {})
+            cast(Mapping[str, Any], execution.get("quantity_resolution") or {})
         )
         is_short_exit = decision.action == "buy"
         effective_position_qty = abs(current_qty)
@@ -378,13 +383,13 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
         metadata["effective_position_qty"] = str(effective_position_qty)
 
         quantity_resolution["position_qty"] = str(decision.qty)
-        simple_lane["final_qty"] = str(decision.qty)
-        simple_lane["quantity_resolution"] = quantity_resolution
+        execution["final_qty"] = str(decision.qty)
+        execution["quantity_resolution"] = quantity_resolution
         price = _optional_decimal(params.get("price"))
         if price is not None and price > 0:
-            simple_lane["notional"] = str(decision.qty * price)
+            execution["notional"] = str(decision.qty * price)
         params["paper_route_probe_exit"] = metadata
-        params["simple_lane"] = simple_lane
+        set_execution_metadata(params, execution)
         return decision.model_copy(update={"params": params})
 
     def _process_paper_route_probe_retry_decisions(
@@ -486,11 +491,7 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
         for value in (
             decision.limit_price,
             decision.params.get("price"),
-            cast(Mapping[str, Any], decision.params.get("simple_lane") or {}).get(
-                "price"
-            )
-            if isinstance(decision.params.get("simple_lane"), Mapping)
-            else None,
+            (execution_metadata(decision.params) or {}).get("price"),
             cast(Mapping[str, Any], decision.params.get("price_snapshot") or {}).get(
                 "price"
             )
@@ -512,7 +513,7 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
     def paper_route_probe_short_increasing_sell(decision: StrategyDecision) -> bool:
         if decision.action != "sell":
             return False
-        for key in ("simple_lane", "sizing"):
+        for key in ("execution", "simple_lane", "sizing"):
             section = decision.params.get(key)
             if not isinstance(section, Mapping):
                 continue
@@ -760,17 +761,17 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
 
         capped_notional = capped_qty * price
         params = dict(decision.params)
-        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
-        simple_lane["final_qty"] = str(capped_qty)
-        simple_lane["notional"] = str(capped_notional)
-        simple_lane["paper_route_probe_cap_applied"] = True
+        execution = mutable_execution_metadata(params)
+        execution["final_qty"] = str(capped_qty)
+        execution["notional"] = str(capped_notional)
+        execution["paper_route_probe_cap_applied"] = True
         if target_source_authorized:
-            simple_lane["target_source_notional_sized"] = True
+            execution["target_source_notional_sized"] = True
         if target_notional_sizing is not None:
-            simple_lane["paper_route_target_notional_sizing"] = dict(
+            execution["paper_route_target_notional_sizing"] = dict(
                 target_notional_sizing
             )
-        params["simple_lane"] = simple_lane
+        set_execution_metadata(params, execution)
         paper_route_probe = {
             **dict(context),
             "reference_price": str(price),
@@ -803,19 +804,19 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
 
         notional = decision.qty * price
         params = dict(decision.params)
-        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
-        simple_lane["final_qty"] = str(decision.qty)
-        simple_lane["notional"] = str(notional)
-        simple_lane["paper_route_probe_cap_applied"] = True
+        execution = mutable_execution_metadata(params)
+        execution["final_qty"] = str(decision.qty)
+        execution["notional"] = str(notional)
+        execution["paper_route_probe_cap_applied"] = True
         if bool(metadata.get("target_source_authorized")):
-            simple_lane["target_source_notional_sized"] = True
+            execution["target_source_notional_sized"] = True
 
         probe_metadata = dict(metadata)
         probe_metadata["reference_price"] = str(price)
         probe_metadata["capped_qty"] = str(decision.qty)
         probe_metadata["capped_notional"] = str(notional)
 
-        params["simple_lane"] = simple_lane
+        set_execution_metadata(params, execution)
         params["paper_route_probe"] = probe_metadata
         _merge_paper_route_probe_lineage(
             params,

--- a/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
@@ -17,6 +17,7 @@ from ....models import (
     TradeDecision,
 )
 from ....strategies.catalog import extract_catalog_metadata
+from ...execution_metadata import set_execution_metadata
 from ...models import StrategyDecision
 from ...session_context import regular_session_open_utc_for
 from ..target_plan_helpers import (
@@ -126,7 +127,10 @@ def _paper_route_target_price_retry_risk_reasons(
     params = _mapping_child(decision_json, "params")
     if params is None or not isinstance(params.get("paper_route_target_plan"), Mapping):
         return None
-    precheck = _mapping_child(params, "simple_lane_precheck")
+    precheck = _mapping_child(params, "execution_precheck") or _mapping_child(
+        params,
+        "simple_lane_precheck",
+    )
     if precheck is None or precheck.get("price") is not None:
         return None
     risk_reasons = _risk_reason_items(decision_json.get("risk_reasons"))
@@ -199,11 +203,14 @@ def _paper_route_probe_exit_params(
     }
     params: dict[str, Any] = {
         "paper_route_probe_exit": exit_metadata,
-        "simple_lane": _paper_route_probe_exit_simple_lane(
+    }
+    set_execution_metadata(
+        params,
+        _paper_route_probe_exit_execution_metadata(
             exposure=exposure,
             avg_entry_price=avg_entry_price,
         ),
-    }
+    )
     for key in ("source_decision_mode", "profit_proof_eligible"):
         if key in exposure.lineage:
             params[key] = exposure.lineage[key]
@@ -214,7 +221,7 @@ def _paper_route_probe_exit_params(
     return params
 
 
-def _paper_route_probe_exit_simple_lane(
+def _paper_route_probe_exit_execution_metadata(
     *,
     exposure: PaperRouteProbeExposure,
     avg_entry_price: Decimal | None,

--- a/services/torghut/app/trading/scheduler/source_collection/decision_helpers.py
+++ b/services/torghut/app/trading/scheduler/source_collection/decision_helpers.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from ....config import settings
 from ...decisions.positions_for_strategy_action import position_qty_for_symbol
+from ...execution_metadata import set_execution_metadata
 from ...promotion_authority import source_collection_authority
 from ...quantity_rules import quantize_qty_for_symbol, resolve_quantity_resolution
 from ...runtime_decision_authority import source_decision_mode_is_profit_proof_eligible
@@ -185,14 +186,14 @@ def balanced_pair_needs_short_permission(
     )
 
 
-def source_collection_simple_lane(
+def source_collection_execution_metadata(
     context: SourceCollectionTargetContext,
     *,
     metadata: Mapping[str, Any],
     mode: SourceCollectionMode,
     action: str,
 ) -> dict[str, Any]:
-    simple_lane: dict[str, Any] = {
+    execution: dict[str, Any] = {
         "source": "external_target_plan_url",
         "target_plan_source_decision": True,
         "paper_route_probe_max_notional": str(context.target_cap),
@@ -205,17 +206,17 @@ def source_collection_simple_lane(
         "client_order_id_basis": "trade_decision_hash",
     }
     if context.symbol_quantities:
-        simple_lane["paper_route_probe_symbol_quantities"] = {
+        execution["paper_route_probe_symbol_quantities"] = {
             item_symbol: str(quantity)
             for item_symbol, quantity in context.symbol_quantities.items()
         }
     if mode.execution_metadata:
-        simple_lane["execution_account_label"] = mode.execution_metadata[
+        execution["execution_account_label"] = mode.execution_metadata[
             "execution_account_label"
         ]
-        simple_lane["submit_path"] = mode.execution_metadata["submit_path"]
+        execution["submit_path"] = mode.execution_metadata["submit_path"]
     del metadata
-    return simple_lane
+    return execution
 
 
 def source_collection_params(
@@ -223,13 +224,12 @@ def source_collection_params(
     *,
     symbol: str,
     metadata: dict[str, Any],
-    simple_lane: dict[str, Any],
+    execution_metadata: dict[str, Any],
     mode: SourceCollectionMode,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {
         "paper_route_target_plan": metadata,
         "paper_route_target_plan_source_decision": metadata,
-        "simple_lane": simple_lane,
         "source_decision_mode": mode.source_decision_mode,
         "profit_proof_eligible": mode.profit_proof_eligible,
         "hypothesis_id": metadata.get("hypothesis_id"),
@@ -260,6 +260,7 @@ def source_collection_params(
     }
     if "exit_minute_after_open" in metadata:
         params["exit_minute_after_open"] = metadata["exit_minute_after_open"]
+    set_execution_metadata(params, execution_metadata)
     return params
 
 
@@ -371,15 +372,16 @@ def source_collection_broker_quantity_resolution(
 def apply_source_collection_quantity_resolution(
     *,
     metadata: dict[str, Any],
-    simple_lane: dict[str, Any],
+    execution_metadata: dict[str, Any],
     params: dict[str, Any],
     quantity_resolution: Any,
 ) -> None:
     metadata["paper_route_target_notional_sizing"] = quantity_resolution.audit
-    simple_lane["paper_route_target_notional_sizing"] = quantity_resolution.audit
-    simple_lane["target_source_notional_sized"] = (
+    execution_metadata["paper_route_target_notional_sizing"] = quantity_resolution.audit
+    execution_metadata["target_source_notional_sized"] = (
         quantity_resolution.audit.get("sizing_source") == "target_notional"
     )
+    set_execution_metadata(params, execution_metadata)
     params["paper_route_target_notional_sizing"] = quantity_resolution.audit
     params.update(quantity_resolution.price_params)
 
@@ -393,7 +395,7 @@ __all__ = [
     "source_collection_has_unrepaired_exposure",
     "source_collection_params",
     "source_collection_profit_proof_exposure",
-    "source_collection_simple_lane",
+    "source_collection_execution_metadata",
     "source_collection_strategy_exposure",
     "source_collection_symbols",
     "source_collection_timeframe",

--- a/services/torghut/app/trading/scheduler/source_collection/source_decisions.py
+++ b/services/torghut/app/trading/scheduler/source_collection/source_decisions.py
@@ -62,7 +62,7 @@ from .decision_helpers import (
     source_collection_has_unrepaired_exposure,
     source_collection_params,
     source_collection_profit_proof_exposure,
-    source_collection_simple_lane,
+    source_collection_execution_metadata,
     source_collection_strategy_exposure,
     source_collection_symbols,
     source_collection_timeframe,
@@ -520,7 +520,7 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
             symbol=symbol,
             action=action,
         )
-        simple_lane = source_collection_simple_lane(
+        execution_metadata = source_collection_execution_metadata(
             context,
             metadata=metadata,
             mode=mode,
@@ -530,7 +530,7 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
             context,
             symbol=symbol,
             metadata=metadata,
-            simple_lane=simple_lane,
+            execution_metadata=execution_metadata,
             mode=mode,
         )
         _merge_paper_route_probe_lineage(
@@ -572,7 +572,7 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
             return None
         apply_source_collection_quantity_resolution(
             metadata=metadata,
-            simple_lane=simple_lane,
+            execution_metadata=execution_metadata,
             params=params,
             quantity_resolution=broker_quantity_resolution,
         )

--- a/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/direct_submission.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import typing
 from collections.abc import Mapping
-from datetime import timezone
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 
 from ....config import settings
@@ -13,7 +13,6 @@ from ...simple_risk import (
     position_qty_for_symbol,
 )
 from ..target_plan_helpers import (
-    bounded_paper_route_collection_entry_metadata,
     bounded_sim_collection_metadata_from_decision,
     optional_decimal,
     paper_route_probe_entry_metadata,
@@ -37,10 +36,7 @@ from .shared import (
     SubmissionDecisionContext,
     SubmitRejectionRequest,
     TradingSubmissionRequest,
-    logger,
 )
-
-_BOUNDED_PAPER_ROUTE_CLOSE_SOURCE = "filled_bounded_paper_route_collection_executions"
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -184,11 +180,6 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
                 inputs=LiveSubmissionGateInputs(session=request.session)
             )
             if not bool(live_submission_gate.get("allowed", False)):
-                if self._bounded_live_paper_route_probe_request_allowed(
-                    request,
-                    live_submission_gate,
-                ):
-                    return True
                 self._block_decision_submission(
                     DecisionBlockRequest(
                         session=request.session,
@@ -204,170 +195,6 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
                 )
                 return False
         return True
-
-    def _bounded_live_paper_route_probe_request_allowed(
-        self,
-        request: TradingSubmissionRequest,
-        live_submission_gate: Mapping[str, Any],
-    ) -> bool:
-        if self._bounded_live_paper_route_probe_submission_allowed(
-            request.decision,
-            live_submission_gate,
-        ):
-            return True
-        close_metadata = self._bounded_live_paper_route_close_metadata(request)
-        if close_metadata is None:
-            return False
-        if not self._bounded_live_paper_route_collection_gate_allows(
-            live_submission_gate
-        ):
-            return False
-        request.decision.params.update(close_metadata)
-        self.executor.update_decision_params(
-            request.session,
-            request.decision_row,
-            close_metadata,
-        )
-        return True
-
-    def _bounded_live_paper_route_probe_submission_allowed(
-        self,
-        decision: StrategyDecision,
-        live_submission_gate: Mapping[str, Any],
-    ) -> bool:
-        if not self._bounded_live_paper_route_probe_decision_applies(decision):
-            return False
-        return self._bounded_live_paper_route_collection_gate_allows(
-            live_submission_gate
-        )
-
-    @staticmethod
-    def _bounded_live_paper_route_collection_gate_allows(
-        live_submission_gate: Mapping[str, Any],
-    ) -> bool:
-        collection_gate = live_submission_gate.get("bounded_live_paper_collection_gate")
-        if isinstance(collection_gate, Mapping):
-            collection_gate_mapping = cast(Mapping[str, Any], collection_gate)
-            return collection_gate_mapping.get("allowed") is True
-        return False
-
-    def _bounded_live_paper_route_close_metadata(
-        self,
-        request: TradingSubmissionRequest,
-    ) -> dict[str, Any] | None:
-        if not self._bounded_live_paper_route_close_mode_enabled(request.decision):
-            return None
-        exposure = self._bounded_live_paper_route_close_exposure(request)
-        if exposure is None:
-            return None
-        lineage = dict(cast(Mapping[str, Any], getattr(exposure, "lineage", {}) or {}))
-        exit_metadata = {
-            "mode": "paper_route_exit",
-            "source": _BOUNDED_PAPER_ROUTE_CLOSE_SOURCE,
-            "symbol": getattr(exposure, "symbol"),
-            "strategy_id": str(getattr(getattr(exposure, "strategy"), "id")),
-            "db_open_qty": str(getattr(exposure, "exit_qty")),
-            "db_open_signed_qty": str(getattr(exposure, "net_qty")),
-            "db_open_side": "long" if getattr(exposure, "net_qty") > 0 else "short",
-            "exit_minute_after_open": getattr(exposure, "exit_minute_after_open", None),
-            "session_open": getattr(exposure, "session_open").isoformat(),
-            "latest_entry_at": (
-                getattr(exposure, "latest_entry_at").isoformat()
-                if getattr(exposure, "latest_entry_at", None) is not None
-                else None
-            ),
-            "live_bounded_paper_route_close": True,
-            **lineage,
-        }
-        simple_lane = request.decision.params.get("simple_lane")
-        if isinstance(simple_lane, Mapping):
-            simple_lane_payload = dict(cast(Mapping[str, Any], simple_lane))
-        else:
-            simple_lane_payload = {}
-        simple_lane_payload.update(
-            {
-                "bounded_live_paper_route_close": True,
-                "submit_path": "bounded_paper_route_collection",
-            }
-        )
-        metadata: dict[str, Any] = {
-            "paper_route_probe_exit": exit_metadata,
-            "simple_lane": simple_lane_payload,
-            "bounded_live_paper_route_close": True,
-            "bounded_paper_route_submit_path": "bounded_paper_route_collection",
-        }
-        for key in ("source_decision_mode", "profit_proof_eligible"):
-            if key in lineage:
-                metadata[key] = lineage[key]
-        return metadata
-
-    def _bounded_live_paper_route_close_mode_enabled(
-        self,
-        decision: StrategyDecision,
-    ) -> bool:
-        return (
-            settings.trading_mode == "live"
-            and settings.trading_simple_submit_enabled
-            and settings.trading_simple_paper_route_probe_enabled
-            and settings.trading_simple_paper_route_probe_allow_live_mode
-            and self._paper_route_probe_exit_metadata(decision) is None
-            and bounded_paper_route_collection_entry_metadata(decision.params) is None
-            and decision.action in {"buy", "sell"}
-            and decision.qty > 0
-        )
-
-    def _bounded_live_paper_route_close_exposure(
-        self,
-        request: TradingSubmissionRequest,
-    ) -> Any | None:
-        exposures_fn = getattr(self, "_paper_route_probe_exit_exposures", None)
-        if not callable(exposures_fn):
-            return None
-        try:
-            exposures = exposures_fn(
-                session=request.session,
-                now=self._trading_now().astimezone(timezone.utc),
-            )
-        except Exception:
-            logger.exception(
-                "Failed to inspect bounded paper-route close exposure "
-                "decision_id=%s symbol=%s",
-                request.decision_row.id,
-                request.decision.symbol,
-            )
-            return None
-        if not isinstance(exposures, Mapping):
-            return None
-        exposure_mapping = cast(Mapping[Any, Any], exposures)
-        for exposure in exposure_mapping.values():
-            if not self._bounded_live_paper_route_close_matches_exposure(
-                request.decision,
-                exposure,
-            ):
-                continue
-            return exposure
-        return None
-
-    @staticmethod
-    def _bounded_live_paper_route_close_matches_exposure(
-        decision: StrategyDecision,
-        exposure: Any,
-    ) -> bool:
-        strategy = getattr(exposure, "strategy", None)
-        if str(getattr(strategy, "id", "")).strip() != str(decision.strategy_id):
-            return False
-        if str(getattr(exposure, "symbol", "")).strip().upper() != decision.symbol:
-            return False
-        if str(getattr(exposure, "exit_source", "") or "").strip() != (
-            _BOUNDED_PAPER_ROUTE_CLOSE_SOURCE
-        ):
-            return False
-        if getattr(exposure, "exit_action", None) != decision.action:
-            return False
-        exit_qty = getattr(exposure, "exit_qty", Decimal("0"))
-        if not isinstance(exit_qty, Decimal):
-            exit_qty = Decimal(str(exit_qty))
-        return decision.qty <= exit_qty
 
     def _profitability_floor_submission_allowed(
         self,
@@ -512,7 +339,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
     def _bounded_sim_collection_metadata(
         self,
         decision: StrategyDecision,
-    ) -> Mapping[str, Any] | None:
+    ) -> Mapping[str, typing.Any] | None:
         return bounded_sim_collection_metadata_from_decision(
             decision,
             account_label=self.account_label,
@@ -522,7 +349,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
     def _paper_route_probe_applies(
         self,
         decision: StrategyDecision,
-        collection_metadata: Mapping[str, Any] | None,
+        collection_metadata: Mapping[str, typing.Any] | None,
     ) -> bool:
         return settings.trading_mode == "paper" and (
             self._paper_route_probe_exit_metadata(decision) is not None
@@ -530,33 +357,16 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
             or collection_metadata is not None
         )
 
-    def _bounded_live_paper_route_probe_decision_applies(
-        self,
-        decision: StrategyDecision,
-    ) -> bool:
-        return (
-            settings.trading_mode == "live"
-            and settings.trading_simple_submit_enabled
-            and settings.trading_simple_paper_route_probe_enabled
-            and settings.trading_simple_paper_route_probe_allow_live_mode
-            and (
-                self._paper_route_probe_exit_metadata(decision) is not None
-                or paper_route_probe_entry_metadata(decision.params) is not None
-                or bounded_paper_route_collection_entry_metadata(decision.params)
-                is not None
-            )
-        )
-
     def _execution_client_for_symbol(
         self, symbol: str, *, symbol_allowlist: set[str] | None = None
-    ) -> Any:
+    ) -> typing.Any:
         _ = (symbol, symbol_allowlist)
         return self.execution_adapter
 
     def _submit_order_with_handling(
         self,
         request: OrderSubmitRequest,
-    ) -> tuple[Any | None, bool]:
+    ) -> tuple[typing.Any | None, bool]:
         try:
             retry_delays_seconds = [float(delay) for delay in request.retry_delays]
             execution = self.executor.submit_order(
@@ -627,7 +437,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
         return None, True
 
     @staticmethod
-    def _map_submit_exception(payload: Mapping[str, Any]) -> str:
+    def _map_submit_exception(payload: Mapping[str, typing.Any]) -> str:
         source = str(payload.get("source") or "").strip().lower()
         code = str(payload.get("code") or "").strip().lower()
         if source == "local_pre_submit":
@@ -650,7 +460,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
         self,
         *,
         decision: StrategyDecision,
-        positions: list[dict[str, Any]],
+        positions: list[dict[str, typing.Any]],
     ) -> str | None:
         if not self._sell_order_needs_shortability(decision, positions):
             return None
@@ -661,7 +471,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
     @staticmethod
     def _sell_order_needs_shortability(
         decision: StrategyDecision,
-        positions: list[dict[str, Any]],
+        positions: list[dict[str, typing.Any]],
     ) -> bool:
         if decision.action != "sell":
             return False
@@ -691,7 +501,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
 
     @staticmethod
     def _apply_simple_projected_position(
-        positions: list[dict[str, Any]],
+        positions: list[dict[str, typing.Any]],
         decision: StrategyDecision,
     ) -> None:
         normalized_symbol = decision.symbol.strip().upper()
@@ -724,7 +534,7 @@ class SimplePipelineDirectSubmissionMixin(TradingPipelineBase):
     @staticmethod
     def _apply_simple_projected_buying_power(
         account: dict[str, str],
-        positions: list[dict[str, Any]],
+        positions: list[dict[str, typing.Any]],
         decision: StrategyDecision,
     ) -> None:
         buying_power = optional_decimal(account.get("buying_power"))

--- a/services/torghut/app/trading/scheduler/submission_preparation/quote_routeability.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/quote_routeability.py
@@ -10,6 +10,11 @@ from ....config import settings
 from ....models import (
     TradeDecision,
 )
+from ...execution_metadata import (
+    execution_metadata,
+    mutable_execution_metadata,
+    set_execution_metadata,
+)
 from ...models import StrategyDecision
 from ...promotion_authority import capital_blocked_authority
 from ...prices import MarketSnapshot
@@ -465,7 +470,7 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
         request = self._submission_request_with_decision(request, decision)
         decision = self._paper_route_probe_capped_submission_decision(request)
         request = self._submission_request_with_decision(request, decision)
-        preparation = self._simple_lane_preparation(request)
+        preparation = self._execution_preparation(request)
         prepared_decision = self._prechecked_target_aligned_decision(preparation)
         return self._finalize_prepared_submission(
             request=request,
@@ -637,7 +642,7 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
                 return capped_decision
         return decision
 
-    def _simple_lane_preparation(
+    def _execution_preparation(
         self,
         request: SubmissionPreparationRequest,
     ) -> Any:
@@ -749,18 +754,16 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
                     preparation.decision.qty * reference_price
                 )
             adjusted_audit["resolved_qty"] = str(preparation.decision.qty)
-            simple_lane_precheck = mapping_value(
-                preparation.decision.params.get("simple_lane")
-            )
-            if simple_lane_precheck is not None:
+            execution_precheck = execution_metadata(preparation.decision.params)
+            if execution_precheck is not None:
                 for key in (
                     "capped_by_order",
                     "capped_by_symbol",
                     "capped_by_buying_power",
                 ):
-                    if key in simple_lane_precheck:
+                    if key in execution_precheck:
                         adjusted_audit[f"precheck_{key}"] = bool(
-                            simple_lane_precheck.get(key)
+                            execution_precheck.get(key)
                         )
             return adjusted_audit
         if target_notional_sizing is None:
@@ -785,7 +788,8 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
         )
         if preparation.diagnostics:
             params_update = dict(prepared_decision.params)
-            params_update["simple_lane_precheck"] = preparation.diagnostics
+            params_update["execution_precheck"] = preparation.diagnostics
+            params_update.pop("simple_lane_precheck", None)
             self.executor.update_decision_params(
                 request.session,
                 request.decision_row,
@@ -858,10 +862,10 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
         params = decision.params
         if params.get("bounded_live_paper_route_close") is True:
             return True
-        simple_lane = mapping_value(params.get("simple_lane"))
+        execution = execution_metadata(params)
         if (
-            simple_lane is not None
-            and simple_lane.get("bounded_live_paper_route_close") is True
+            execution is not None
+            and execution.get("bounded_live_paper_route_close") is True
         ):
             return True
         exit_metadata = mapping_value(params.get("paper_route_probe_exit"))
@@ -942,7 +946,7 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
             )
 
         params["bounded_live_paper_route_close_order"] = audit
-        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
-        simple_lane["bounded_live_paper_route_close_order"] = audit
-        params["simple_lane"] = simple_lane
+        execution = mutable_execution_metadata(params)
+        execution["bounded_live_paper_route_close_order"] = audit
+        set_execution_metadata(params, execution)
         return decision.model_copy(update={"params": params})

--- a/services/torghut/app/trading/scheduler/submission_preparation/quote_sizing.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/quote_sizing.py
@@ -11,6 +11,10 @@ from ....models import (
     Strategy,
 )
 from ...models import SignalEnvelope, StrategyDecision
+from ...execution_metadata import (
+    mutable_execution_metadata,
+    set_execution_metadata,
+)
 from ...prices import MarketSnapshot
 from ...quantity_rules import quantize_qty_for_symbol, resolve_quantity_resolution
 from ...runtime_decision_authority import (
@@ -472,9 +476,9 @@ class SimplePipelineSubmissionQuoteSizingMixin(TradingPipelineBase):
         }
         params = dict(decision.params)
         params["bounded_paper_route_target_exit_window"] = audit
-        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
-        simple_lane["bounded_paper_route_target_exit_window"] = audit
-        params["simple_lane"] = simple_lane
+        execution = mutable_execution_metadata(params)
+        execution["bounded_paper_route_target_exit_window"] = audit
+        set_execution_metadata(params, execution)
 
         for key in (
             "paper_route_target_plan_source_decision",
@@ -530,15 +534,15 @@ class SimplePipelineSubmissionQuoteSizingMixin(TradingPipelineBase):
 
         reference_price = optional_decimal(audit_payload.get("reference_price"))
         notional = qty * reference_price if reference_price is not None else None
-        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
-        simple_lane["final_qty"] = str(qty)
-        simple_lane["paper_route_target_notional_sizing"] = audit_payload
-        simple_lane["target_source_notional_sized"] = (
+        execution = mutable_execution_metadata(params)
+        execution["final_qty"] = str(qty)
+        execution["paper_route_target_notional_sizing"] = audit_payload
+        execution["target_source_notional_sized"] = (
             safe_text(audit_payload.get("sizing_source")) == "target_notional"
         )
         if notional is not None:
-            simple_lane["notional"] = str(notional)
-        params["simple_lane"] = simple_lane
+            execution["notional"] = str(notional)
+        set_execution_metadata(params, execution)
 
         for key in (
             "paper_route_target_plan_source_decision",

--- a/services/torghut/app/trading/scheduler/target_plan_helpers/entry_metadata.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers/entry_metadata.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from ....config import settings
 from ...autonomy import DriftThresholds
 from ...feature_quality import FeatureQualityThresholds
+from ...execution_metadata import execution_metadata
 from ...models import StrategyDecision
 from ...runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
@@ -78,6 +79,7 @@ def _target_notional_sizing_audit_from_params(
         "paper_route_target_plan_source_decision",
         "paper_route_target_plan",
         "paper_route_probe",
+        "execution",
         "simple_lane",
     ):
         metadata = _mapping_value(params.get(key))
@@ -342,10 +344,9 @@ def _pct_cap_to_notional(
 
 
 def _simple_decision_notional(decision: StrategyDecision) -> Decimal | None:
-    simple_lane = decision.params.get("simple_lane")
-    if isinstance(simple_lane, Mapping):
-        simple_lane_payload = cast(Mapping[str, Any], simple_lane)
-        notional = _optional_decimal(simple_lane_payload.get("notional"))
+    execution = execution_metadata(decision.params)
+    if execution is not None:
+        notional = _optional_decimal(execution.get("notional"))
         if notional is not None:
             return notional
     price = _optional_decimal(decision.params.get("price"))

--- a/services/torghut/app/trading/simple_risk.py
+++ b/services/torghut/app/trading/simple_risk.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from collections.abc import Mapping
 from typing import Any, cast
 
+from .execution_metadata import set_execution_metadata
 from .models import StrategyDecision
 from .prices import resolve_execution_reference_price
 from .quantity_rules import (
@@ -696,17 +697,20 @@ def _approved_simple_risk(
     params = dict(context.decision.params)
     params["execution_lane"] = "simple"
     params["submit_path"] = "direct_alpaca"
-    params["simple_lane"] = {
-        "requested_qty": str(context.decision.qty),
-        "final_qty": str(caps.adjusted_qty),
-        "price": str(context.price),
-        "notional": str(final.notional),
-        "quantity_resolution": context.resolution.to_payload(),
-        "capped_by_order": caps.capped_by_order,
-        "capped_by_symbol": caps.capped_by_symbol,
-        "capped_by_gross": caps.capped_by_gross,
-        "capped_by_buying_power": caps.capped_by_buying_power,
-    }
+    set_execution_metadata(
+        params,
+        {
+            "requested_qty": str(context.decision.qty),
+            "final_qty": str(caps.adjusted_qty),
+            "price": str(context.price),
+            "notional": str(final.notional),
+            "quantity_resolution": context.resolution.to_payload(),
+            "capped_by_order": caps.capped_by_order,
+            "capped_by_symbol": caps.capped_by_symbol,
+            "capped_by_gross": caps.capped_by_gross,
+            "capped_by_buying_power": caps.capped_by_buying_power,
+        },
+    )
     return SimpleRiskPreparation(
         approved=True,
         decision=context.decision.model_copy(

--- a/services/torghut/app/trading/submission_authority.py
+++ b/services/torghut/app/trading/submission_authority.py
@@ -25,12 +25,9 @@ _DIAGNOSTIC_SUBMISSION_REASONS = frozenset(
 
 def build_submission_authority_status(
     live_submission_gate: Mapping[str, Any],
-    *,
-    simple_lane_status: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
     """Summarize effective submit authority from operational blockers only."""
 
-    _ = simple_lane_status
     operational_gate = operational_submission_gate_status(live_submission_gate)
     operational_allowed = _bool(operational_gate.get("allowed"))
     effective_mode = "operational_submission" if operational_allowed else "blocked"

--- a/services/torghut/tests/execution_policy/support.py
+++ b/services/torghut/tests/execution_policy/support.py
@@ -63,7 +63,7 @@ def _with_simple_lane_quantity_resolution(
     }
     resolution.update(overrides)
     params = dict(decision.params)
-    params["simple_lane"] = {"quantity_resolution": resolution}
+    params["execution"] = {"quantity_resolution": resolution}
     return decision.model_copy(update={"params": params})
 
 

--- a/services/torghut/tests/execution_policy/test_kill_switch_blocks.py
+++ b/services/torghut/tests/execution_policy/test_kill_switch_blocks.py
@@ -171,7 +171,7 @@ class TestKillSwitchBlocks(_TestExecutionPolicyBase):
             price=Decimal("273.97"),
         )
         params = dict(decision.params)
-        params["simple_lane"] = {"quantity_resolution": "not-a-resolution"}
+        params["execution"] = {"quantity_resolution": "not-a-resolution"}
 
         outcome = policy.evaluate(
             decision.model_copy(update={"params": params}),

--- a/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_bounded_live_close.py
@@ -11,7 +11,6 @@ from tests.pipeline.trading_pipeline_base import (
     Reconciler,
     RiskEngine,
     SimpleTradingPipeline,
-    SimpleNamespace,
     Strategy,
     StrategyDecision,
     TradingPipelineTestCaseBase,
@@ -22,10 +21,6 @@ from tests.pipeline.trading_pipeline_base import (
     patch,
     select,
     timezone,
-)
-
-from app.trading.scheduler.submission_preparation.shared import (
-    TradingSubmissionRequest,
 )
 
 
@@ -63,7 +58,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                     "bid": "298.17",
                     "ask": "298.23",
                 },
-                "simple_lane": {
+                "execution": {
                     "bounded_live_paper_route_close": True,
                 },
             },
@@ -82,9 +77,9 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
         self.assertEqual(audit["state"], "marketable_limit_adjusted")
         self.assertEqual(audit["original_limit_price"], "298.19")
         self.assertEqual(audit["marketable_limit_price"], "298.17")
-        simple_lane = cast(dict[str, Any], prepared.params["simple_lane"])
+        execution_metadata = cast(dict[str, Any], prepared.params["execution"])
         self.assertEqual(
-            simple_lane["bounded_live_paper_route_close_order"],
+            execution_metadata["bounded_live_paper_route_close_order"],
             audit,
         )
 
@@ -123,7 +118,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
         self.assertEqual(audit["original_limit_price"], "298.20")
         self.assertEqual(audit["marketable_limit_price"], "298.23")
 
-    def test_live_bounded_close_simple_lane_marker_is_marketable(self) -> None:
+    def test_live_bounded_close_execution_marker_is_marketable(self) -> None:
         decision = StrategyDecision(
             strategy_id="strategy-a",
             symbol="AAPL",
@@ -134,7 +129,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
             order_type="limit",
             limit_price=Decimal("298.19"),
             params={
-                "simple_lane": {
+                "execution": {
                     "bounded_live_paper_route_close": True,
                 },
                 "price_snapshot": {
@@ -250,7 +245,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
         self.assertEqual(bid, Decimal("298.11"))
         self.assertEqual(ask, Decimal("298.29"))
 
-    def test_live_bounded_paper_route_close_ignores_retired_gate_blockers(
+    def test_live_bounded_paper_route_close_does_not_bypass_closed_live_gate(
         self,
     ) -> None:
         from app import config
@@ -284,6 +279,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
             pipeline = self._pipeline(self.session_local)
             gate = {
                 "allowed": False,
+                "reason": "live_submission_gate_blocked",
                 "blocked_reasons": [
                     "hypothesis_not_promotion_eligible",
                     "runtime_window_import_required",
@@ -291,16 +287,6 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                 "bounded_live_paper_collection_gate": {
                     "allowed": True,
                     "authority_scope": "bounded_evidence_collection_only",
-                },
-            }
-            proof_floor = {
-                "route_state": "repair_only",
-                "capital_state": "paper",
-                "max_notional": "100",
-                "market_window": {"session_open": True},
-                "blocking_reasons": ["runtime_window_import_required"],
-                "route_reacquisition_book": {
-                    "summary": {"paper_route_probe_eligible_symbols": ["AAPL"]}
                 },
             }
             with self.session_local() as session:
@@ -314,7 +300,7 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                     qty=Decimal("2"),
                     rationale="strategy-close-existing-bounded-collection-position",
                     params={
-                        "simple_lane": {
+                        "execution": {
                             "quantity_resolution": {
                                 "reason": "sell_reducing_long_fractional_allowed",
                                 "short_increasing": False,
@@ -335,17 +321,8 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                         "_live_submission_gate",
                         return_value=gate,
                     ),
-                    patch.object(
-                        SimpleTradingPipeline,
-                        "_profitability_proof_floor",
-                        return_value=proof_floor,
-                    ),
-                    patch(
-                        "app.trading.scheduler.simple_pipeline.trading_now",
-                        return_value=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
-                    ),
                 ):
-                    self.assertTrue(
+                    self.assertFalse(
                         pipeline._is_trading_submission_allowed(
                             session=session,
                             decision=decision,
@@ -357,14 +334,11 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
                 decision_json = cast(dict[str, Any], decision_row.decision_json)
 
             params = cast(dict[str, Any], decision_json["params"])
-            exit_metadata = cast(
-                dict[str, Any],
-                params["paper_route_probe_exit"],
+            self.assertEqual(
+                decision_json["submission_stage"],
+                "blocked_live_submission_gate",
             )
-            simple_lane = cast(dict[str, Any], params["simple_lane"])
-            self.assertEqual(exit_metadata["mode"], "paper_route_exit")
-            self.assertTrue(exit_metadata["live_bounded_paper_route_close"])
-            self.assertTrue(simple_lane["bounded_live_paper_route_close"])
+            self.assertNotIn("paper_route_probe_exit", params)
         finally:
             config.settings.trading_mode = original["trading_mode"]
             config.settings.trading_enabled = original["trading_enabled"]
@@ -557,164 +531,3 @@ class TestTradingPipelineBoundedLiveClose(TradingPipelineTestCaseBase):
             config.settings.trading_simple_paper_route_probe_allow_live_mode = original[
                 "trading_simple_paper_route_probe_allow_live_mode"
             ]
-
-    def test_bounded_paper_route_close_exposure_lookup_fail_closed(self) -> None:
-        pipeline = self._pipeline(self.session_local)
-        with self.session_local() as session:
-            strategy = Strategy(
-                name="lookup-fail-closed",
-                description="lookup failures must not authorize closes",
-                enabled=True,
-                base_timeframe="1Min",
-                universe_type="static",
-                universe_symbols=["AAPL"],
-            )
-            session.add(strategy)
-            session.commit()
-            session.refresh(strategy)
-            decision = StrategyDecision(
-                strategy_id=str(strategy.id),
-                symbol="AAPL",
-                event_ts=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
-                timeframe="1Min",
-                action="sell",
-                qty=Decimal("1"),
-                rationale="lookup-fail-closed",
-                params={},
-            )
-            decision_row = OrderExecutor().ensure_decision(
-                session,
-                decision,
-                strategy,
-                "paper",
-            )
-            request = TradingSubmissionRequest(
-                session=session,
-                decision=decision,
-                decision_row=decision_row,
-            )
-
-            with patch.object(
-                pipeline,
-                "_paper_route_probe_exit_exposures",
-                None,
-            ):
-                self.assertIsNone(
-                    pipeline._bounded_live_paper_route_close_exposure(request)
-                )
-            with patch.object(
-                pipeline,
-                "_paper_route_probe_exit_exposures",
-                side_effect=RuntimeError("boom"),
-            ):
-                self.assertIsNone(
-                    pipeline._bounded_live_paper_route_close_exposure(request)
-                )
-            with patch.object(
-                pipeline,
-                "_paper_route_probe_exit_exposures",
-                return_value=[],
-            ):
-                self.assertIsNone(
-                    pipeline._bounded_live_paper_route_close_exposure(request)
-                )
-
-    def test_bounded_paper_route_close_matches_only_linked_exposure(self) -> None:
-        source = "filled_bounded_paper_route_collection_executions"
-        pipeline = self._pipeline(self.session_local)
-        with self.session_local() as session:
-            strategy = Strategy(
-                name="linked-close-match",
-                description="close matching fixture",
-                enabled=True,
-                base_timeframe="1Min",
-                universe_type="static",
-                universe_symbols=["AAPL"],
-            )
-            session.add(strategy)
-            session.commit()
-            session.refresh(strategy)
-            decision = StrategyDecision(
-                strategy_id=str(strategy.id),
-                symbol="AAPL",
-                event_ts=datetime(2026, 3, 26, 16, 0, tzinfo=timezone.utc),
-                timeframe="1Min",
-                action="sell",
-                qty=Decimal("1"),
-                rationale="linked-close-match",
-                params={},
-            )
-            decision_row = OrderExecutor().ensure_decision(
-                session,
-                decision,
-                strategy,
-                "paper",
-            )
-            request = TradingSubmissionRequest(
-                session=session,
-                decision=decision,
-                decision_row=decision_row,
-            )
-            wrong_strategy = SimpleNamespace(
-                strategy=SimpleNamespace(id="wrong"),
-                symbol="AAPL",
-                exit_source=source,
-                exit_action="sell",
-                exit_qty=Decimal("2"),
-            )
-            matching = SimpleNamespace(
-                strategy=SimpleNamespace(id=strategy.id),
-                symbol="AAPL",
-                exit_source=source,
-                exit_action="sell",
-                exit_qty="2",
-            )
-            wrong_symbol = SimpleNamespace(
-                strategy=SimpleNamespace(id=strategy.id),
-                symbol="MSFT",
-                exit_source=source,
-                exit_action="sell",
-                exit_qty=Decimal("2"),
-            )
-            wrong_source = SimpleNamespace(
-                strategy=SimpleNamespace(id=strategy.id),
-                symbol="AAPL",
-                exit_source="manual_close",
-                exit_action="sell",
-                exit_qty=Decimal("2"),
-            )
-            wrong_action = SimpleNamespace(
-                strategy=SimpleNamespace(id=strategy.id),
-                symbol="AAPL",
-                exit_source=source,
-                exit_action="buy",
-                exit_qty=Decimal("2"),
-            )
-
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_close_matches_exposure(
-                    decision,
-                    wrong_symbol,
-                )
-            )
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_close_matches_exposure(
-                    decision,
-                    wrong_source,
-                )
-            )
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_close_matches_exposure(
-                    decision,
-                    wrong_action,
-                )
-            )
-            with patch.object(
-                pipeline,
-                "_paper_route_probe_exit_exposures",
-                return_value={"wrong": wrong_strategy, "match": matching},
-            ):
-                self.assertIs(
-                    pipeline._bounded_live_paper_route_close_exposure(request),
-                    matching,
-                )

--- a/services/torghut/tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py
@@ -193,13 +193,13 @@ class TestTradingPipelineMaterializedTargetPlanA(TradingPipelineTestCaseBase):
                 params.get("paper_route_target_plan_source_decision"),
             )
             paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
-            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
-            simple_lane_precheck = cast(
-                dict[str, Any], params.get("simple_lane_precheck")
-            )
+            execution_metadata = cast(dict[str, Any], params.get("execution"))
+            execution_precheck = cast(dict[str, Any], params.get("execution_precheck"))
             bounded_execution_policy = cast(
                 dict[str, Any], params.get("bounded_paper_route_execution_policy")
             )
+            self.assertNotIn("simple_lane", params)
+            self.assertNotIn("simple_lane_precheck", params)
 
             self.assertEqual(decision.status, "submitted")
             self.assertEqual(Decimal(str(decision_json["qty"])), Decimal("2.4997"))
@@ -276,12 +276,14 @@ class TestTradingPipelineMaterializedTargetPlanA(TradingPipelineTestCaseBase):
                 Decimal("249.994997"),
             )
             self.assertTrue(paper_route_probe["target_source_notional_sized"])
-            self.assertEqual(Decimal(str(simple_lane["final_qty"])), Decimal("2.4997"))
             self.assertEqual(
-                Decimal(str(simple_lane["notional"])), Decimal("249.994997")
+                Decimal(str(execution_metadata["final_qty"])), Decimal("2.4997")
             )
-            self.assertEqual(simple_lane_precheck["requested_qty"], "2.4997")
-            self.assertEqual(simple_lane_precheck["final_qty"], "2.4997")
+            self.assertEqual(
+                Decimal(str(execution_metadata["notional"])), Decimal("249.994997")
+            )
+            self.assertEqual(execution_precheck["requested_qty"], "2.4997")
+            self.assertEqual(execution_precheck["final_qty"], "2.4997")
             self.assertEqual(
                 bounded_execution_policy["authority"],
                 "bounded_paper_route_collection_only",

--- a/services/torghut/tests/pipeline/test_trading_pipeline_paper_route_quote_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_paper_route_quote_a.py
@@ -738,7 +738,7 @@ class TestTradingPipelinePaperRouteQuoteA(TradingPipelineTestCaseBase):
             row_json = cast(dict[str, Any], row.decision_json)
             params = cast(dict[str, Any], row_json["params"])
             sizing = cast(dict[str, Any], params["paper_route_target_notional_sizing"])
-            simple_lane = cast(dict[str, Any], params["simple_lane"])
+            execution_metadata = cast(dict[str, Any], params["execution"])
             source_metadata = cast(dict[str, Any], params["paper_route_target_plan"])
 
         self.assertIsNotNone(prepared)
@@ -755,8 +755,8 @@ class TestTradingPipelinePaperRouteQuoteA(TradingPipelineTestCaseBase):
             "sell_short_increasing_integer_only",
         )
         self.assertFalse(sizing["broker_quantity_resolution"]["fractional_allowed"])
-        self.assertEqual(simple_lane["final_qty"], "150")
-        self.assertTrue(simple_lane["target_source_notional_sized"])
+        self.assertEqual(execution_metadata["final_qty"], "150")
+        self.assertTrue(execution_metadata["target_source_notional_sized"])
         self.assertEqual(
             source_metadata["paper_route_target_notional_sizing"]["resolved_qty"],
             "150",

--- a/services/torghut/tests/pipeline/test_trading_pipeline_paper_route_quote_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_paper_route_quote_b.py
@@ -480,7 +480,7 @@ class TestTradingPipelinePaperRouteQuoteB(TradingPipelineTestCaseBase):
         nested_audit = {"sizing_source": "target_notional", "resolved_qty": "3"}
         self.assertEqual(
             _target_notional_sizing_audit_from_params(
-                {"simple_lane": {"paper_route_target_notional_sizing": nested_audit}}
+                {"execution": {"paper_route_target_notional_sizing": nested_audit}}
             ),
             nested_audit,
         )

--- a/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_a.py
@@ -155,7 +155,7 @@ class TestTradingPipelineProbeExitsA(TradingPipelineTestCaseBase):
             refreshed_json = cast(dict[str, Any], refreshed.decision_json)
             params = cast(dict[str, Any], refreshed_json.get("params"))
             paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
-            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
+            execution_metadata = cast(dict[str, Any], params.get("execution"))
             retry = cast(dict[str, Any], refreshed_json.get("paper_route_probe_retry"))
 
             self.assertEqual(refreshed.status, "submitted")
@@ -165,7 +165,9 @@ class TestTradingPipelineProbeExitsA(TradingPipelineTestCaseBase):
                 Decimal(str(paper_route_probe.get("capped_notional"))),
                 Decimal("25.000000"),
             )
-            self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
+            self.assertEqual(
+                execution_metadata.get("paper_route_probe_cap_applied"), True
+            )
             self.assertEqual(
                 retry.get("previous_submission_block_reason"),
                 "hypothesis_not_promotion_eligible",

--- a/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_b.py
@@ -237,7 +237,7 @@ class TestTradingPipelineProbeExitsB(TradingPipelineTestCaseBase):
                     "db_open_qty": "34.69970000",
                     "db_open_side": "long",
                 },
-                "simple_lane": {
+                "execution": {
                     "quantity_resolution": {
                         "action": "sell",
                         "symbol": "INTC",
@@ -314,7 +314,7 @@ class TestTradingPipelineProbeExitsB(TradingPipelineTestCaseBase):
                     "db_open_qty": "34.69970000",
                     "db_open_side": "long",
                 },
-                "simple_lane": {
+                "execution": {
                     "quantity_resolution": {
                         "action": "sell",
                         "symbol": "INTC",
@@ -649,7 +649,7 @@ class TestTradingPipelineProbeExitsB(TradingPipelineTestCaseBase):
                 "params": {
                     "price": Decimal("100"),
                     "paper_route_probe_exit": {"mode": "paper_route_exit"},
-                    "simple_lane": {"quantity_resolution": {}},
+                    "execution": {"quantity_resolution": {}},
                 }
             }
         )
@@ -830,7 +830,7 @@ class TestTradingPipelineProbeExitsB(TradingPipelineTestCaseBase):
             decision_json = cast(dict[str, Any], decision.decision_json)
             params = cast(dict[str, Any], decision_json.get("params"))
             paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
-            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
+            simple_lane = cast(dict[str, Any], params.get("execution"))
 
             self.assertEqual(decision.status, "submitted")
             self.assertEqual(execution.submitted_qty, Decimal("0.25000000"))

--- a/services/torghut/tests/pipeline/test_trading_pipeline_retry_profit_floor_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_retry_profit_floor_a.py
@@ -534,7 +534,7 @@ class TestTradingPipelineRetryProfitFloorA(TradingPipelineTestCaseBase):
                 "candidate_id": "candidate-1",
                 "hypothesis_id": "H-PAIRS-01",
             },
-            "simple_lane_precheck": {
+            "execution_precheck": {
                 "price": None,
                 "requested_qty": "1",
             },
@@ -556,7 +556,7 @@ class TestTradingPipelineRetryProfitFloorA(TradingPipelineTestCaseBase):
                         **base_json,
                         "params": {
                             **base_params,
-                            "simple_lane_precheck": {"price": "100"},
+                            "execution_precheck": {"price": "100"},
                         },
                     }
                 )
@@ -642,7 +642,7 @@ class TestTradingPipelineRetryProfitFloorA(TradingPipelineTestCaseBase):
             )
             decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
             params = dict(cast(Mapping[str, Any], decision_json.get("params") or {}))
-            params["simple_lane_precheck"] = {
+            params["execution_precheck"] = {
                 "price": None,
                 "requested_qty": "1",
             }

--- a/services/torghut/tests/pipeline/test_trading_pipeline_retry_profit_floor_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_retry_profit_floor_b.py
@@ -79,7 +79,7 @@ class TestTradingPipelineRetryProfitFloorB(TradingPipelineTestCaseBase):
             )
             decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
             params = dict(cast(Mapping[str, Any], decision_json.get("params") or {}))
-            params["simple_lane_precheck"] = {
+            params["execution_precheck"] = {
                 "price": None,
                 "requested_qty": "1",
             }

--- a/services/torghut/tests/pipeline/test_trading_pipeline_route_execution_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_route_execution_a.py
@@ -224,7 +224,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
                 decision.model_copy(
                     update={
                         "action": "sell",
-                        "params": {"simple_lane": "missing-resolution"},
+                        "params": {"execution": "missing-resolution"},
                     }
                 )
             )
@@ -234,7 +234,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
                 decision.model_copy(
                     update={
                         "action": "sell",
-                        "params": {"simple_lane": {"quantity_resolution": "missing"}},
+                        "params": {"execution": {"quantity_resolution": "missing"}},
                     }
                 )
             )
@@ -245,7 +245,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
                     update={
                         "action": "sell",
                         "params": {
-                            "simple_lane": {
+                            "execution": {
                                 "quantity_resolution": {"short_increasing": "yes"}
                             }
                         },
@@ -259,7 +259,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
                     update={
                         "action": "sell",
                         "params": {
-                            "simple_lane": {
+                            "execution": {
                                 "quantity_resolution": {"short_increasing": "off"}
                             }
                         },
@@ -724,7 +724,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
             action="buy",
             qty=Decimal("1"),
             rationale="buying-power-projection",
-            params={"price": "100", "simple_lane": {"notional": "100"}},
+            params={"price": "100", "execution": {"notional": "100"}},
         )
 
         SimpleTradingPipeline._apply_simple_projected_buying_power(
@@ -748,7 +748,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
             action="sell",
             qty=Decimal("3"),
             rationale="short-increase-projection",
-            params={"price": "50", "simple_lane": {"notional": "150"}},
+            params={"price": "50", "execution": {"notional": "150"}},
         )
 
         SimpleTradingPipeline._apply_simple_projected_buying_power(
@@ -841,7 +841,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
             action="sell",
             qty=Decimal("1"),
             rationale="reducing-sell",
-            params={"price": "100", "simple_lane": {"notional": "100"}},
+            params={"price": "100", "execution": {"notional": "100"}},
         )
 
         SimpleTradingPipeline._apply_simple_projected_buying_power(
@@ -868,7 +868,7 @@ class TestTradingPipelineRouteExecutionA(TradingPipelineTestCaseBase):
             action="sell",
             qty=Decimal("0"),
             rationale="zero-qty-sell",
-            params={"price": "100", "simple_lane": {"notional": "100"}},
+            params={"price": "100", "execution": {"notional": "100"}},
         )
 
         SimpleTradingPipeline._apply_simple_projected_buying_power(

--- a/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
@@ -36,6 +36,7 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
 
         original = {
             "trading_mode": config.settings.trading_mode,
+            "trading_enabled": config.settings.trading_enabled,
             "trading_simple_submit_enabled": (
                 config.settings.trading_simple_submit_enabled
             ),
@@ -47,6 +48,7 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
             ),
         }
         config.settings.trading_mode = "live"
+        config.settings.trading_enabled = True
         config.settings.trading_simple_submit_enabled = True
         config.settings.trading_simple_paper_route_probe_enabled = True
         config.settings.trading_simple_paper_route_probe_allow_live_mode = True
@@ -65,96 +67,83 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
                 account_label="paper",
                 session_factory=self.session_local,
             )
-            strategy_id = str(uuid4())
-            decision = StrategyDecision(
-                strategy_id=strategy_id,
-                symbol="AAPL",
-                event_ts=datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc),
-                timeframe="1Min",
-                action="buy",
-                qty=Decimal("1"),
-                rationale="bounded-paper-route-probe",
-                params={
-                    "source_decision_mode": "bounded_paper_route_collection",
-                    "profit_proof_eligible": True,
-                    "paper_route_probe": {
-                        "source_decision_mode": "bounded_paper_route_collection",
-                        "profit_proof_eligible": True,
-                    },
-                },
-            )
             gate = {
                 "allowed": False,
+                "reason": "live_submission_gate_blocked",
                 "blocked_reasons": [
                     "hypothesis_not_promotion_eligible",
                     "runtime_window_import_required",
                     "runtime_profit_target_import_required",
                 ],
+                "bounded_live_paper_collection_gate": {
+                    "allowed": True,
+                    "authority_scope": "bounded_evidence_collection_only",
+                },
             }
 
-            config.settings.trading_simple_paper_route_probe_allow_live_mode = False
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_probe_submission_allowed(
-                    decision,
-                    gate,
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name=f"bounded-live-probe-{uuid4()}",
+                    description="bounded paper route probe must not bypass live gate",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
                 )
-            )
+                session.add(strategy)
+                session.commit()
+                session.refresh(strategy)
+                decision = StrategyDecision(
+                    strategy_id=str(strategy.id),
+                    symbol="AAPL",
+                    event_ts=datetime(2026, 6, 17, 13, 45, tzinfo=timezone.utc),
+                    timeframe="1Min",
+                    action="buy",
+                    qty=Decimal("1"),
+                    rationale="bounded-paper-route-probe",
+                    params={
+                        "source_decision_mode": "bounded_paper_route_collection",
+                        "profit_proof_eligible": True,
+                        "paper_route_probe": {
+                            "source_decision_mode": "bounded_paper_route_collection",
+                            "profit_proof_eligible": True,
+                        },
+                    },
+                )
+                decision_row = OrderExecutor().ensure_decision(
+                    session,
+                    decision,
+                    strategy,
+                    "paper",
+                )
 
-            config.settings.trading_simple_paper_route_probe_allow_live_mode = True
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_probe_submission_allowed(
-                    decision,
-                    gate,
-                )
+                with patch.object(
+                    SimpleTradingPipeline,
+                    "_live_submission_gate",
+                    return_value=gate,
+                ):
+                    self.assertFalse(
+                        pipeline._is_trading_submission_allowed(
+                            session=session,
+                            decision=decision,
+                            decision_row=decision_row,
+                        )
+                    )
+
+                session.refresh(decision_row)
+                decision_json = cast(dict[str, Any], decision_row.decision_json)
+
+            self.assertEqual(
+                decision_json["submission_stage"],
+                "blocked_live_submission_gate",
             )
-            self.assertTrue(
-                pipeline._bounded_live_paper_route_probe_submission_allowed(
-                    decision,
-                    {
-                        **gate,
-                        "blocked_reasons": [
-                            *cast(list[str], gate["blocked_reasons"]),
-                            "empirical_jobs_not_ready",
-                        ],
-                        "bounded_live_paper_collection_gate": {
-                            "allowed": True,
-                            "authority_scope": "bounded_evidence_collection_only",
-                        },
-                    },
-                )
-            )
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_probe_submission_allowed(
-                    decision,
-                    {
-                        **gate,
-                        "bounded_live_paper_collection_gate": {
-                            "allowed": False,
-                            "reason": "live_submit_activation_expired",
-                        },
-                    },
-                )
-            )
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_probe_submission_allowed(
-                    decision,
-                    {
-                        **gate,
-                        "blocked_reasons": [
-                            *cast(list[str], gate["blocked_reasons"]),
-                            "empirical_jobs_not_ready",
-                        ],
-                    },
-                )
-            )
-            self.assertFalse(
-                pipeline._bounded_live_paper_route_probe_submission_allowed(
-                    decision,
-                    {**gate, "blocked_reasons": []},
-                )
+            self.assertNotIn(
+                "paper_route_probe_exit",
+                cast(dict[str, Any], decision_json.get("params") or {}),
             )
         finally:
             config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_simple_submit_enabled = original[
                 "trading_simple_submit_enabled"
             ]
@@ -563,7 +552,7 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
             decision_json = cast(dict[str, Any], decision.decision_json)
             params = cast(dict[str, Any], decision_json.get("params"))
             paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
-            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
+            simple_lane = cast(dict[str, Any], params.get("execution"))
 
             self.assertEqual(decision.status, "submitted")
             self.assertEqual(paper_route_probe.get("symbol"), "NVDA")
@@ -746,7 +735,7 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
                 "action": "sell",
                 "params": {
                     "price": "100",
-                    "simple_lane": {
+                    "execution": {
                         "quantity_resolution": {
                             "action": "sell",
                             "reason": "sell_reducing_long_fractional_allowed",

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -85,21 +85,10 @@ def test_simple_live_submission_gate_drops_retired_source_collection_blockers(
         settings.trading_emergency_stop_enabled = emergency_stop_before
 
 
-def test_bounded_live_paper_route_requires_explicit_collection_gate() -> None:
-    assert not SimpleTradingPipeline._bounded_live_paper_route_collection_gate_allows(
-        {
-            "allowed": False,
-            "reason": "runtime_window_import_required",
-            "blocked_reasons": ["runtime_window_import_required"],
-        }
-    )
-    assert SimpleTradingPipeline._bounded_live_paper_route_collection_gate_allows(
-        {
-            "bounded_live_paper_collection_gate": {
-                "allowed": True,
-                "reason": "explicit_collection_contract",
-            }
-        }
+def test_bounded_live_paper_route_collection_gate_bypass_is_removed() -> None:
+    assert not hasattr(
+        SimpleTradingPipeline,
+        "_bounded_live_paper_route_collection_gate_allows",
     )
 
 

--- a/services/torghut/tests/simple_pipeline/test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates.py
+++ b/services/torghut/tests/simple_pipeline/test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates.py
@@ -583,7 +583,7 @@ def test_target_source_decisions_size_default_quantities_from_target_notional(
             assert sizing["overrode_requested_qty"] is True
             assert decision.params["reference_price"] == Decimal("100")
             assert (
-                decision.params["simple_lane"]["paper_route_target_notional_sizing"]
+                decision.params["execution"]["paper_route_target_notional_sizing"]
                 == sizing
             )
     finally:
@@ -681,7 +681,7 @@ def test_source_collection_target_defaults_current_session_probe_contract(
             "AMZN": Decimal("375.0000"),
         }
         actions = {
-            decision.symbol: decision.params["simple_lane"][
+            decision.symbol: decision.params["execution"][
                 "paper_route_probe_leg_action"
             ]
             for decision in decisions

--- a/services/torghut/tests/test_simple_risk.py
+++ b/services/torghut/tests/test_simple_risk.py
@@ -78,7 +78,7 @@ class TestSimpleRisk(TestCase):
         self.assertTrue(result.approved)
         self.assertEqual(result.notional, Decimal("767.984776"))
         self.assertEqual(result.diagnostics["price"], "316.93")
-        self.assertEqual(result.decision.params["simple_lane"]["price"], "316.93")
+        self.assertEqual(result.decision.params["execution"]["price"], "316.93")
 
     def test_rejects_when_symbol_exposure_cap_leaves_less_than_min_qty(self) -> None:
         result = prepare_simple_decision(
@@ -112,7 +112,7 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.notional, Decimal("200"))
         self.assertEqual(result.diagnostics["buying_power_cap_qty"], "2")
         self.assertEqual(result.diagnostics["final_qty"], "2")
-        self.assertTrue(result.decision.params["simple_lane"]["capped_by_buying_power"])
+        self.assertTrue(result.decision.params["execution"]["capped_by_buying_power"])
 
     def test_buying_power_reserve_keeps_capped_order_below_available_cash(self) -> None:
         result = prepare_simple_decision(
@@ -127,7 +127,7 @@ class TestSimpleRisk(TestCase):
         )
 
         self.assertTrue(result.approved)
-        self.assertTrue(result.decision.params["simple_lane"]["capped_by_buying_power"])
+        self.assertTrue(result.decision.params["execution"]["capped_by_buying_power"])
         self.assertLess(result.decision.qty, Decimal("0.9027"))
         self.assertEqual(result.diagnostics["buying_power_reserve_bps"], "25")
         self.assertEqual(result.diagnostics["buying_power_after_reserve"], "372.865500")
@@ -180,9 +180,7 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.decision.qty, Decimal("1"))
         self.assertEqual(result.diagnostics["buying_power_cap_qty"], "1")
         self.assertEqual(result.diagnostics["buying_power_required_notional"], "0")
-        self.assertFalse(
-            result.decision.params["simple_lane"]["capped_by_buying_power"]
-        )
+        self.assertFalse(result.decision.params["execution"]["capped_by_buying_power"])
 
     def test_buy_cover_short_with_zero_buying_power_caps_flip_to_long(self) -> None:
         result = prepare_simple_decision(
@@ -199,7 +197,7 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.decision.qty, Decimal("1"))
         self.assertEqual(result.diagnostics["buying_power_cap_qty"], "1")
         self.assertEqual(result.diagnostics["buying_power_required_notional"], "0")
-        self.assertTrue(result.decision.params["simple_lane"]["capped_by_buying_power"])
+        self.assertTrue(result.decision.params["execution"]["capped_by_buying_power"])
 
     def test_buy_cover_short_with_buying_power_caps_only_flip_to_long_excess(
         self,
@@ -219,7 +217,7 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.notional, Decimal("300"))
         self.assertEqual(result.diagnostics["buying_power_cap_qty"], "3")
         self.assertEqual(result.diagnostics["buying_power_required_notional"], "200")
-        self.assertTrue(result.decision.params["simple_lane"]["capped_by_buying_power"])
+        self.assertTrue(result.decision.params["execution"]["capped_by_buying_power"])
 
     def test_equity_order_cap_limits_large_new_exposure(self) -> None:
         result = prepare_simple_decision(
@@ -237,7 +235,7 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.decision.qty, Decimal("100"))
         self.assertEqual(result.notional, Decimal("10000"))
         self.assertEqual(result.diagnostics["equity_order_cap_notional"], "10000.00")
-        self.assertTrue(result.decision.params["simple_lane"]["capped_by_order"])
+        self.assertTrue(result.decision.params["execution"]["capped_by_order"])
 
     def test_equity_order_cap_rejects_missing_equity_for_new_exposure(self) -> None:
         result = prepare_simple_decision(
@@ -276,7 +274,7 @@ class TestSimpleRisk(TestCase):
 
         self.assertTrue(close_result.approved)
         self.assertEqual(close_result.decision.qty, Decimal("1"))
-        self.assertTrue(close_result.decision.params["simple_lane"]["capped_by_symbol"])
+        self.assertTrue(close_result.decision.params["execution"]["capped_by_symbol"])
         self.assertFalse(new_exposure_result.approved)
         self.assertEqual(
             new_exposure_result.reject_reason,
@@ -309,8 +307,8 @@ class TestSimpleRisk(TestCase):
 
         self.assertTrue(sell_close.approved)
         self.assertTrue(buy_cover.approved)
-        self.assertFalse(sell_close.decision.params["simple_lane"]["capped_by_gross"])
-        self.assertFalse(buy_cover.decision.params["simple_lane"]["capped_by_gross"])
+        self.assertFalse(sell_close.decision.params["execution"]["capped_by_gross"])
+        self.assertFalse(buy_cover.decision.params["execution"]["capped_by_gross"])
 
     def test_gross_exposure_cap_rejects_missing_equity_for_new_exposure(self) -> None:
         result = prepare_simple_decision(
@@ -353,7 +351,7 @@ class TestSimpleRisk(TestCase):
 
         self.assertTrue(close_result.approved)
         self.assertEqual(close_result.decision.qty, Decimal("1"))
-        self.assertTrue(close_result.decision.params["simple_lane"]["capped_by_gross"])
+        self.assertTrue(close_result.decision.params["execution"]["capped_by_gross"])
         self.assertFalse(new_exposure_result.approved)
         self.assertEqual(
             new_exposure_result.reject_reason,
@@ -391,7 +389,7 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.notional, Decimal("400"))
         self.assertEqual(result.diagnostics["buying_power_cap_qty"], "4")
         self.assertEqual(result.diagnostics["buying_power_required_notional"], "200")
-        self.assertTrue(result.decision.params["simple_lane"]["capped_by_buying_power"])
+        self.assertTrue(result.decision.params["execution"]["capped_by_buying_power"])
 
     def test_rejects_short_increase_when_shorts_are_disabled(self) -> None:
         result = prepare_simple_decision(
@@ -437,9 +435,7 @@ class TestSimpleRisk(TestCase):
         self.assertEqual(result.notional, Decimal("49.932822"))
         self.assertEqual(result.diagnostics["close_only_requested_qty"], "1382")
         self.assertEqual(result.diagnostics["close_only_position_qty"], "0.1671")
-        quantity_resolution = result.decision.params["simple_lane"][
-            "quantity_resolution"
-        ]
+        quantity_resolution = result.decision.params["execution"]["quantity_resolution"]
         self.assertEqual(
             quantity_resolution["reason"],
             "sell_reducing_long_fractional_allowed",

--- a/services/torghut/tests/test_submission_authority.py
+++ b/services/torghut/tests/test_submission_authority.py
@@ -16,15 +16,6 @@ def test_submission_authority_allows_operational_submission() -> None:
                 },
             },
         },
-        simple_lane_status={
-            "submit_enabled": True,
-            "live_submit_enabled": True,
-            "paper_route_probe_enabled": True,
-            "paper_route_probe_allow_live_mode": True,
-            "max_notional_per_order": 100.0,
-            "max_notional_per_symbol": 250.0,
-            "max_gross_exposure_pct_equity": 0.05,
-        },
     )
 
     assert status["effective_submit_mode"] == "operational_submission"
@@ -58,7 +49,6 @@ def test_submission_authority_blocks_on_operational_blocker() -> None:
                 },
             },
         },
-        simple_lane_status={"submit_enabled": True, "live_submit_enabled": True},
     )
 
     assert status["effective_submit_mode"] == "blocked"
@@ -81,7 +71,6 @@ def test_submission_authority_accepts_compatibility_gate_payload() -> None:
                 "alpaca_regular_session_open": True,
             },
         },
-        simple_lane_status={"submit_enabled": True, "live_submit_enabled": True},
     )
 
     assert status["effective_submit_mode"] == "operational_submission"
@@ -111,7 +100,6 @@ def test_submission_authority_diagnostic_reasons_do_not_block() -> None:
                 "alpaca_regular_session_open": False,
             },
         },
-        simple_lane_status={"submit_enabled": True, "live_submit_enabled": True},
     )
 
     assert status["effective_submit_mode"] == "operational_submission"


### PR DESCRIPTION
## Summary

- Removed the retired bounded live paper-route collection bypass from live submission checks so a closed operational live gate blocks normally.
- Added canonical Torghut decision execution metadata under `execution`, with legacy `simple_lane` read fallback for existing persisted decisions.
- Moved new simple-risk, paper-route, source-collection, probe, retry, and close-order metadata writes from `simple_lane`/`simple_lane_precheck` to `execution`/`execution_precheck`.
- Removed the fake `simple_lane_status` argument from submission authority and updated regressions around diagnostics-only blockers.

## Related Issues

None

## Testing

-
  `cd services/torghut && uv sync --frozen --extra dev`
-
  `cd services/torghut && uv run --frozen pytest tests/test_execution_runtime.py tests/test_submission_authority.py tests/test_simple_risk.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py tests/pipeline/test_trading_pipeline_retry_profit_floor_a.py tests/pipeline/test_trading_pipeline_retry_profit_floor_b.py tests/pipeline/test_trading_pipeline_paper_route_quote_a.py tests/pipeline/test_trading_pipeline_paper_route_quote_b.py tests/pipeline/test_trading_pipeline_route_execution_a.py tests/pipeline/test_trading_pipeline_probe_exits_b.py tests/execution_policy/test_kill_switch_blocks.py`
-
  `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
-
  `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
-
  `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
-
  `cd services/torghut && uv run --frozen ruff check app/trading/execution_metadata.py app/trading/simple_risk.py app/trading/submission_authority.py app/trading/execution_policy/order_rules.py app/trading/scheduler/submission_preparation/direct_submission.py app/trading/scheduler/submission_preparation/quote_sizing.py app/trading/scheduler/submission_preparation/quote_routeability.py app/trading/scheduler/paper_route_probe/probe_processing.py app/trading/scheduler/paper_route_probe/retry_decisions.py app/trading/scheduler/source_collection/decision_helpers.py app/trading/scheduler/source_collection/source_decisions.py app/trading/scheduler/paper_route_materialization.py app/trading/scheduler/target_plan_helpers/entry_metadata.py tests/test_simple_risk.py tests/test_submission_authority.py tests/test_execution_runtime.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py tests/pipeline/test_trading_pipeline_retry_profit_floor_a.py tests/pipeline/test_trading_pipeline_retry_profit_floor_b.py tests/pipeline/test_trading_pipeline_paper_route_quote_a.py tests/pipeline/test_trading_pipeline_paper_route_quote_b.py tests/pipeline/test_trading_pipeline_route_execution_a.py tests/pipeline/test_trading_pipeline_probe_exits_b.py tests/execution_policy/test_kill_switch_blocks.py tests/execution_policy/support.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/simple_pipeline/test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates.py`
-
  `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

New Torghut decision metadata writes use `params.execution` and `params.execution_precheck`. Readers keep fallback support for legacy `params.simple_lane` and `params.simple_lane_precheck` rows.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
