### PR TITLE
refactor(torghut): remove legacy execution fallbacks

### DIFF
--- a/docs/superpowers/plans/2026-06-03-torghut-profitability-proof.md
+++ b/docs/superpowers/plans/2026-06-03-torghut-profitability-proof.md
@@ -29,7 +29,7 @@
 - Inspect: `argocd/applications/torghut/*paper*runtime*`
 
 - [ ] Re-read `/trading/paper-route-evidence` after the market session opens.
-- [ ] Verify `paper_route_session_window_not_open` clears during the session.
+- [ ] Verify `alpaca_regular_session_closed` clears during the session.
 - [ ] Verify target-account audit produces clean-window state instead of `paper_route_target_account_audit_unavailable`.
 - [ ] If clean-window audit still blocks, patch the exact readback path with a regression test.
 

--- a/docs/superpowers/plans/2026-07-04-torghut-functional-trading-execution-path.md
+++ b/docs/superpowers/plans/2026-07-04-torghut-functional-trading-execution-path.md
@@ -19,7 +19,7 @@ Live readback showed:
 - `/trading/status.operational_submission_gate.allowed` was `true`.
 - `/trading/status.simple_lane_orders_submitted_total` was `0`.
 - Runtime ledger showed `filled_notional: 0`, `closed_trade_count: 0`, and `open_position_count: 0`.
-- Scheduler logs repeated `paper_route_session_window_not_open` with `target_count=0`.
+- Scheduler logs repeated `alpaca_regular_session_closed` with `target_count=0`.
 - Profit and route surfaces were still `observe_only`, `repair_only`, and `zero_notional`.
 - Hyperliquid runtime had repeated `TimeoutError` cycles and temporary `/readyz` 503s.
 
@@ -43,7 +43,7 @@ Functional trading means current order proof, not rollout proof.
    Answer: `_bounded_paper_route_signal_scope` returns `None` when `self._is_market_session_open(now)` is false.
    Action: Remove the market-session early return for the testnet route; use session only for route choice.
 
-5. Why does `paper_route_session_window_not_open` keep appearing?
+5. Why does `alpaca_regular_session_closed` keep appearing?
    Answer: The old paper-route evidence collection assumes a regular-session target window, so after-hours testnet is treated as a collection window failure.
    Action: Delete paper-route session window authority from live/testnet execution and keep it only as diagnostic evidence collection.
 

--- a/services/torghut/app/trading/execution_metadata.py
+++ b/services/torghut/app/trading/execution_metadata.py
@@ -1,8 +1,4 @@
-"""Canonical execution metadata for trade decisions.
-
-Legacy rows used ``simple_lane``. New writes use ``execution`` while readers
-fall back to the legacy key so existing decisions remain inspectable.
-"""
+"""Canonical execution metadata for trade decisions."""
 
 from __future__ import annotations
 
@@ -11,7 +7,7 @@ from collections.abc import Mapping
 from typing import cast
 
 EXECUTION_METADATA_KEY = "execution"
-LEGACY_SIMPLE_LANE_METADATA_KEY = "simple_lane"
+_REMOVED_SIMPLE_LANE_METADATA_KEY = "simple_lane"
 
 
 def execution_metadata(
@@ -20,9 +16,6 @@ def execution_metadata(
     raw_execution = params.get(EXECUTION_METADATA_KEY)
     if isinstance(raw_execution, Mapping):
         return cast(Mapping[str, typing.Any], raw_execution)
-    raw_legacy = params.get(LEGACY_SIMPLE_LANE_METADATA_KEY)
-    if isinstance(raw_legacy, Mapping):
-        return cast(Mapping[str, typing.Any], raw_legacy)
     return None
 
 
@@ -37,13 +30,12 @@ def set_execution_metadata(
     params: dict[str, typing.Any],
     metadata: Mapping[str, typing.Any],
 ) -> None:
-    params.pop(LEGACY_SIMPLE_LANE_METADATA_KEY, None)
+    params.pop(_REMOVED_SIMPLE_LANE_METADATA_KEY, None)
     params[EXECUTION_METADATA_KEY] = dict(metadata)
 
 
 __all__ = [
     "EXECUTION_METADATA_KEY",
-    "LEGACY_SIMPLE_LANE_METADATA_KEY",
     "execution_metadata",
     "mutable_execution_metadata",
     "set_execution_metadata",

--- a/services/torghut/app/trading/execution_policy/order_rules.py
+++ b/services/torghut/app/trading/execution_policy/order_rules.py
@@ -463,12 +463,7 @@ def prechecked_reducing_position_qty(decision: StrategyDecision) -> Decimal | No
     qty = optional_decimal(decision.qty)
     if qty is None or qty <= 0:
         return None
-    for key in (
-        "execution",
-        "execution_precheck",
-        "simple_lane",
-        "simple_lane_precheck",
-    ):
+    for key in ("execution", "execution_precheck"):
         section = decision.params.get(key)
         if not isinstance(section, Mapping):
             continue

--- a/services/torghut/app/trading/scheduler/paper_route_probe/probe_processing.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/probe_processing.py
@@ -513,7 +513,7 @@ class SimplePipelinePaperRouteProbeProcessingMixin(PaperRouteProbeRuntime):
     def paper_route_probe_short_increasing_sell(decision: StrategyDecision) -> bool:
         if decision.action != "sell":
             return False
-        for key in ("execution", "simple_lane", "sizing"):
+        for key in ("execution", "sizing"):
             section = decision.params.get(key)
             if not isinstance(section, Mapping):
                 continue

--- a/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
@@ -24,6 +24,7 @@ from ..target_plan_helpers import (
     FLATTEN_CLOSE_DECISION_SCHEMA_VERSION as _FLATTEN_CLOSE_DECISION_SCHEMA_VERSION,
     PAPER_ROUTE_PROBE_EXIT_PENDING_GRACE_SECONDS as _PAPER_ROUTE_PROBE_EXIT_PENDING_GRACE_SECONDS,
     REGULAR_SESSION_MINUTES as _REGULAR_SESSION_MINUTES,
+    after_hours_testnet_route_enabled as _after_hours_testnet_route_enabled,
     bounded_paper_route_collection_entry_metadata as _bounded_paper_route_collection_entry_metadata,
     merge_paper_route_probe_lineage as _merge_paper_route_probe_lineage,
     optional_decimal as _optional_decimal,
@@ -554,11 +555,18 @@ class SimplePipelinePaperRouteProbeRetryDecisionMixin(PaperRouteProbeRuntime):
             return False
         if not settings.trading_simple_paper_route_probe_enabled:
             return False
-        if self._is_market_session_open(now):
+        market_session_open = self._is_market_session_open(now)
+        if market_session_open or _after_hours_testnet_route_enabled(
+            trading_mode=settings.trading_mode,
+            paper_route_probe_enabled=settings.trading_simple_paper_route_probe_enabled,
+            paper_route_probe_allow_live_mode=(
+                settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+            testnet_after_hours_enabled=settings.trading_testnet_after_hours_enabled,
+            market_session_open=market_session_open,
+        ):
             return True
-        self._record_bounded_target_plan_blocker(
-            reason="paper_route_session_window_not_open"
-        )
+        self._record_bounded_target_plan_blocker(reason="alpaca_regular_session_closed")
         return False
 
     def _paper_route_probe_exit_exposures(

--- a/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
+++ b/services/torghut/app/trading/scheduler/paper_route_probe/retry_decisions.py
@@ -127,10 +127,7 @@ def _paper_route_target_price_retry_risk_reasons(
     params = _mapping_child(decision_json, "params")
     if params is None or not isinstance(params.get("paper_route_target_plan"), Mapping):
         return None
-    precheck = _mapping_child(params, "execution_precheck") or _mapping_child(
-        params,
-        "simple_lane_precheck",
-    )
+    precheck = _mapping_child(params, "execution_precheck")
     if precheck is None or precheck.get("price") is not None:
         return None
     risk_reasons = _risk_reason_items(decision_json.get("risk_reasons"))

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -65,6 +65,7 @@ from .submission_preparation.quote_sizing import (
 from .target_plan_helpers import (
     PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS as _PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
     SIGNAL_INGEST_UNAVAILABLE_REASONS as _SIGNAL_INGEST_UNAVAILABLE_REASONS,
+    after_hours_testnet_route_enabled as _after_hours_testnet_route_enabled,
     bounded_sim_collection_reserves_account as _bounded_sim_collection_reserves_account,
     safe_text as _safe_text,
     simple_drift_feature_thresholds as _simple_drift_feature_thresholds,
@@ -329,9 +330,7 @@ class SimpleTradingPipeline(
         strategies: Sequence[Strategy] | None = None,
     ) -> SignalBatch:
         if signal_scope is None:
-            signal_scope = self._live_bounded_collection_fallback_signal_scope(
-                strategies or ()
-            )
+            signal_scope = self._live_bounded_collection_signal_scope(strategies or ())
         if signal_scope is None:
             return self.ingestor.fetch_signals(session)
         symbols, timeframes = signal_scope
@@ -345,14 +344,14 @@ class SimpleTradingPipeline(
             if "unexpected keyword" not in str(exc):
                 raise
             logger.warning(
-                "Signal ingestor does not support scoped polling; falling back to unscoped fetch account_label=%s symbols=%s timeframes=%s",
+                "Signal ingestor does not support scoped polling; using unscoped fetch account_label=%s symbols=%s timeframes=%s",
                 self.account_label,
                 ",".join(sorted(symbols)) or "*",
                 ",".join(sorted(timeframes)) or "*",
             )
             return self.ingestor.fetch_signals(session)
 
-    def _live_bounded_collection_fallback_signal_scope(
+    def _live_bounded_collection_signal_scope(
         self,
         strategies: Sequence[Strategy],
     ) -> tuple[set[str], set[str]] | None:
@@ -409,7 +408,7 @@ class SimpleTradingPipeline(
             "symbols": sorted(symbols),
             "timeframes": sorted(timeframes),
             "signals_authoritative": batch.signals_authoritative,
-            "fallback_signal_count": len(batch.fallback_signals),
+            "degraded_signal_count": len(batch.fallback_signals),
             "degraded_signal_source": batch.degraded_signal_source,
             "query_start": batch.query_start.isoformat()
             if batch.query_start is not None
@@ -420,7 +419,7 @@ class SimpleTradingPipeline(
         }
         setattr(self.state, "last_bounded_evidence_collection_blocker", blocker)
         logger.warning(
-            "Blocking bounded paper-route evidence decisions because signal ingest is unavailable account_label=%s reason=%s symbols=%s timeframes=%s fallback_signal_count=%s",
+            "Blocking bounded paper-route evidence decisions because signal ingest is unavailable account_label=%s reason=%s symbols=%s timeframes=%s degraded_signal_count=%s",
             self.account_label,
             reason,
             ",".join(sorted(symbols)) or "*",
@@ -477,13 +476,19 @@ class SimpleTradingPipeline(
             return None
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
         market_session_open = self._is_market_session_open(now)
-        testnet_after_hours_route = (
-            settings.trading_mode == "live"
-            and not market_session_open
-            and settings.trading_testnet_after_hours_enabled
+        testnet_after_hours_route = _after_hours_testnet_route_enabled(
+            trading_mode=settings.trading_mode,
+            paper_route_probe_enabled=settings.trading_simple_paper_route_probe_enabled,
+            paper_route_probe_allow_live_mode=(
+                settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+            testnet_after_hours_enabled=settings.trading_testnet_after_hours_enabled,
+            market_session_open=market_session_open,
         )
         if not market_session_open and not testnet_after_hours_route:
             return None
+        if testnet_after_hours_route:
+            return self._live_bounded_collection_signal_scope(strategies)
         target_symbols, target_plan_error, targets = (
             self._external_paper_route_target_probe_symbols_cached(
                 session=session,
@@ -491,11 +496,6 @@ class SimpleTradingPipeline(
             )
         )
         if target_plan_error:
-            if (
-                testnet_after_hours_route
-                and target_plan_error == "paper_route_session_window_not_open"
-            ):
-                return self._live_bounded_collection_fallback_signal_scope(strategies)
             self._record_bounded_target_plan_blocker(
                 reason=target_plan_error,
                 symbols=target_symbols,

--- a/services/torghut/app/trading/scheduler/source_collection/source_decisions.py
+++ b/services/torghut/app/trading/scheduler/source_collection/source_decisions.py
@@ -23,6 +23,7 @@ from ...runtime_decision_authority import (
 )
 from ..target_plan_helpers import (
     PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK as _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK,
+    after_hours_testnet_route_enabled as _after_hours_testnet_route_enabled,
     target_bounded_collection_authorized as _target_bounded_collection_authorized,
     bounded_sim_collection_blockers as _bounded_sim_collection_blockers,
     bounded_sim_collection_reserves_account as _bounded_sim_collection_reserves_account,
@@ -163,9 +164,20 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
         ):
             self._record_bounded_target_plan_blocker(reason=blocker)
             return None
-        if not self._is_market_session_open(now):
+        market_session_open = self._is_market_session_open(now)
+        if not market_session_open and _after_hours_testnet_route_enabled(
+            trading_mode=trading_mode,
+            paper_route_probe_enabled=settings.trading_simple_paper_route_probe_enabled,
+            paper_route_probe_allow_live_mode=(
+                settings.trading_simple_paper_route_probe_allow_live_mode
+            ),
+            testnet_after_hours_enabled=settings.trading_testnet_after_hours_enabled,
+            market_session_open=market_session_open,
+        ):
+            return None
+        if not market_session_open:
             self._record_bounded_target_plan_blocker(
-                reason="paper_route_session_window_not_open"
+                reason="alpaca_regular_session_closed"
             )
             return None
         target_symbols, target_plan_error, target_plan_targets = (

--- a/services/torghut/app/trading/scheduler/submission_preparation/quote_routeability.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/quote_routeability.py
@@ -789,7 +789,6 @@ class SimplePipelineSubmissionQuoteRouteabilityMixin(TradingPipelineBase):
         if preparation.diagnostics:
             params_update = dict(prepared_decision.params)
             params_update["execution_precheck"] = preparation.diagnostics
-            params_update.pop("simple_lane_precheck", None)
             self.executor.update_decision_params(
                 request.session,
                 request.decision_row,

--- a/services/torghut/app/trading/scheduler/target_plan_helpers/__init__.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers/__init__.py
@@ -44,6 +44,7 @@ from .bounded_collection import (
 
 from .target_probe import (
     TargetProbeQuantityResolution,
+    after_hours_testnet_route_enabled,
     bounded_sim_collection_metadata_from_decision,
     decimal_from_mapping,
     mapping_value,
@@ -131,6 +132,7 @@ __all__ = [
     "target_symbols",
     "target_truthy",
     "TargetProbeQuantityResolution",
+    "after_hours_testnet_route_enabled",
     "bounded_sim_collection_metadata_from_decision",
     "decimal_from_mapping",
     "mapping_value",

--- a/services/torghut/app/trading/scheduler/target_plan_helpers/entry_metadata.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers/entry_metadata.py
@@ -80,7 +80,6 @@ def _target_notional_sizing_audit_from_params(
         "paper_route_target_plan",
         "paper_route_probe",
         "execution",
-        "simple_lane",
     ):
         metadata = _mapping_value(params.get(key))
         if metadata is None:

--- a/services/torghut/app/trading/scheduler/target_plan_helpers/target_probe.py
+++ b/services/torghut/app/trading/scheduler/target_plan_helpers/target_probe.py
@@ -277,6 +277,23 @@ def _target_active_in_window(target: Mapping[str, Any], now: datetime) -> bool:
     return window_start <= now < window_end
 
 
+def _after_hours_testnet_route_enabled(
+    *,
+    trading_mode: str,
+    paper_route_probe_enabled: bool,
+    paper_route_probe_allow_live_mode: bool,
+    testnet_after_hours_enabled: bool,
+    market_session_open: bool,
+) -> bool:
+    return (
+        trading_mode == "live"
+        and paper_route_probe_enabled
+        and paper_route_probe_allow_live_mode
+        and testnet_after_hours_enabled
+        and not market_session_open
+    )
+
+
 def _target_missing_explicit_probe_window(target: Mapping[str, Any]) -> bool:
     return all(
         _safe_text(target.get(key)) is None
@@ -774,6 +791,7 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
 target_plan_has_active_bounded_sim_collection_owner = (
     _target_plan_has_active_bounded_sim_collection_owner
 )
+after_hours_testnet_route_enabled = _after_hours_testnet_route_enabled
 target_requires_bounded_sim_collection_gate = (
     _target_requires_bounded_sim_collection_gate
 )

--- a/services/torghut/scripts/runtime_ledger_proof_packet/lineage_verdict.py
+++ b/services/torghut/scripts/runtime_ledger_proof_packet/lineage_verdict.py
@@ -351,7 +351,7 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
     if verdict == "waiting_for_runtime_window":
         for blocker in blockers:
             if blocker in {
-                "paper_route_session_window_not_open",
+                "alpaca_regular_session_closed",
                 "paper_route_session_window_not_closed",
                 "paper_route_import_not_ready",
             }:
@@ -362,7 +362,7 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             return actions
     for blocker in blockers:
         if blocker in {
-            "paper_route_session_window_not_open",
+            "alpaca_regular_session_closed",
             "paper_route_session_window_not_closed",
         }:
             _extend_unique(actions, ["wait_for_regular_session_runtime_window"])

--- a/services/torghut/scripts/runtime_ledger_proof_packet/packet_builder.py
+++ b/services/torghut/scripts/runtime_ledger_proof_packet/packet_builder.py
@@ -654,7 +654,7 @@ def build_runtime_ledger_proof_packet(
     promotion_blockers = list(blockers)
     _extend_unique(promotion_blockers, promotion_prerequisite_blockers)
     waiting_blockers = {
-        "paper_route_session_window_not_open",
+        "alpaca_regular_session_closed",
         "paper_route_session_window_not_closed",
         "paper_route_session_settlement_pending",
         "paper_route_import_not_ready",

--- a/services/torghut/scripts/trading_readiness_verification/target_plan_helpers.py
+++ b/services/torghut/scripts/trading_readiness_verification/target_plan_helpers.py
@@ -721,8 +721,7 @@ def _paper_route_preopen_conditions(
         ),
         "target_plan_health_gate_ready": _bool(target_plan_health_gate.get("ready")),
         "target_plan_import_blockers_only_session_not_open": all(
-            blocker == "paper_route_session_window_not_open"
-            for blocker in import_blockers
+            blocker == "alpaca_regular_session_closed" for blocker in import_blockers
         ),
     }
 

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_authority_one_day_blockers_are_stable_json_codes.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_authority_one_day_blockers_are_stable_json_codes.py
@@ -53,7 +53,7 @@ class TestAuthorityOneDayBlockersAreStableJsonCodes(_TestRuntimeLedgerProofPacke
             proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(
                 import_ready=False,
-                import_blockers=["paper_route_session_window_not_open"],
+                import_blockers=["alpaca_regular_session_closed"],
             ),
             generated_at="2026-05-25T21:05:00+00:00",
         )
@@ -62,7 +62,7 @@ class TestAuthorityOneDayBlockersAreStableJsonCodes(_TestRuntimeLedgerProofPacke
         self.assertEqual(result["verdict"], "waiting_for_runtime_window")
         self.assertEqual(
             result["promotion_authority"]["blocking_reasons"],
-            ["paper_route_session_window_not_open"],
+            ["alpaca_regular_session_closed"],
         )
         self.assertEqual(
             result["required_actions"],
@@ -79,7 +79,7 @@ class TestAuthorityOneDayBlockersAreStableJsonCodes(_TestRuntimeLedgerProofPacke
     ) -> None:
         evidence = _paper_route_evidence(
             import_ready=False,
-            import_blockers=["paper_route_session_window_not_open"],
+            import_blockers=["alpaca_regular_session_closed"],
         )
         plan = evidence["next_paper_route_runtime_window_targets"]
         assert isinstance(plan, dict)
@@ -133,7 +133,7 @@ class TestAuthorityOneDayBlockersAreStableJsonCodes(_TestRuntimeLedgerProofPacke
             proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(
                 import_ready=False,
-                import_blockers=["paper_route_session_window_not_open"],
+                import_blockers=["alpaca_regular_session_closed"],
             ),
             completion_status=completion,
             generated_at="2026-05-25T21:05:00+00:00",
@@ -142,7 +142,7 @@ class TestAuthorityOneDayBlockersAreStableJsonCodes(_TestRuntimeLedgerProofPacke
         self.assertEqual(result["verdict"], "waiting_for_runtime_window")
         self.assertEqual(
             result["post_cost_proof_authority"]["blocking_reasons"],
-            ["paper_route_session_window_not_open"],
+            ["alpaca_regular_session_closed"],
         )
         self.assertEqual(
             result["required_actions"],

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_default_one_day_packet_is_smoke_not_authority.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_default_one_day_packet_is_smoke_not_authority.py
@@ -668,7 +668,7 @@ class TestDefaultOneDayPacketIsSmokeNotAuthority(_TestRuntimeLedgerProofPacketBa
                 json.dumps(
                     _paper_route_evidence(
                         import_ready=False,
-                        import_blockers=["paper_route_session_window_not_open"],
+                        import_blockers=["alpaca_regular_session_closed"],
                     )
                 ),
                 encoding="utf-8",
@@ -711,7 +711,7 @@ class TestDefaultOneDayPacketIsSmokeNotAuthority(_TestRuntimeLedgerProofPacketBa
                 json.dumps(
                     _paper_route_evidence(
                         import_ready=False,
-                        import_blockers=["paper_route_session_window_not_open"],
+                        import_blockers=["alpaca_regular_session_closed"],
                     )
                 ),
                 encoding="utf-8",

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_packet_accepts_alternate_runtime_plan_and_completion_gate_shapes.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_packet_accepts_alternate_runtime_plan_and_completion_gate_shapes.py
@@ -416,7 +416,7 @@ class TestPacketAcceptsAlternateRuntimePlanAndCompletionGateShapes(
                 json.dumps(
                     _paper_route_evidence(
                         import_ready=False,
-                        import_blockers=["paper_route_session_window_not_open"],
+                        import_blockers=["alpaca_regular_session_closed"],
                     )
                 ),
                 encoding="utf-8",

--- a/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_scalar_normalizers_handle_runtime_json_variants.py
+++ b/services/torghut/tests/assemble_runtime_ledger_proof_packet/test_scalar_normalizers_handle_runtime_json_variants.py
@@ -519,11 +519,11 @@ class TestScalarNormalizersHandleRuntimeJsonVariants(_TestRuntimeLedgerProofPack
             "purpose": "next_session_paper_route_runtime_window_evidence_collection",
             "session_readiness": {
                 "import_ready": False,
-                "import_blockers": ["paper_route_session_window_not_open"],
+                "import_blockers": ["alpaca_regular_session_closed"],
             },
             "runtime_window_import_handoff": {
                 "import_ready": False,
-                "import_blockers": ["paper_route_session_window_not_open"],
+                "import_blockers": ["alpaca_regular_session_closed"],
             },
             "targets": [
                 {

--- a/services/torghut/tests/execution_policy/support.py
+++ b/services/torghut/tests/execution_policy/support.py
@@ -49,7 +49,7 @@ def _decision(
     )
 
 
-def _with_simple_lane_quantity_resolution(
+def _with_execution_quantity_resolution(
     decision: StrategyDecision,
     **overrides: object,
 ) -> StrategyDecision:
@@ -111,7 +111,7 @@ __all__: tuple[str, ...] = (
     "_TestExecutionPolicyBase",
     "_config",
     "_decision",
-    "_with_simple_lane_quantity_resolution",
+    "_with_execution_quantity_resolution",
     "config",
     "datetime",
     "timezone",

--- a/services/torghut/tests/execution_policy/test_kill_switch_blocks.py
+++ b/services/torghut/tests/execution_policy/test_kill_switch_blocks.py
@@ -7,7 +7,7 @@ from tests.execution_policy.support import (
     _TestExecutionPolicyBase,
     _config,
     _decision,
-    _with_simple_lane_quantity_resolution,
+    _with_execution_quantity_resolution,
     config,
 )
 
@@ -95,7 +95,7 @@ class TestKillSwitchBlocks(_TestExecutionPolicyBase):
             qty=Decimal("184.0000"),
             price=Decimal("273.97"),
         )
-        decision = _with_simple_lane_quantity_resolution(
+        decision = _with_execution_quantity_resolution(
             decision,
             short_increasing="off",
         )
@@ -120,10 +120,41 @@ class TestKillSwitchBlocks(_TestExecutionPolicyBase):
             qty=Decimal("184.0000"),
             price=Decimal("273.97"),
         )
-        decision = _with_simple_lane_quantity_resolution(decision, symbol="MSFT")
+        decision = _with_execution_quantity_resolution(decision, symbol="MSFT")
 
         outcome = policy.evaluate(
             decision,
+            strategy=None,
+            positions=[],
+            market_snapshot=None,
+        )
+
+        self.assertFalse(outcome.approved)
+        self.assertIn("max_notional_exceeded", outcome.reasons)
+
+    def test_max_notional_ignores_removed_simple_lane_quantity_resolution(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        decision = _decision(
+            action="sell",
+            qty=Decimal("184.0000"),
+            price=Decimal("273.97"),
+        )
+        params = dict(decision.params)
+        params["simple_lane"] = {
+            "quantity_resolution": {
+                "action": "sell",
+                "reason": "sell_reducing_long_fractional_allowed",
+                "symbol": "AAPL",
+                "position_qty": "184",
+                "requested_qty": "184.0000",
+                "short_increasing": False,
+            }
+        }
+
+        outcome = policy.evaluate(
+            decision.model_copy(update={"params": params}),
             strategy=None,
             positions=[],
             market_snapshot=None,
@@ -152,7 +183,7 @@ class TestKillSwitchBlocks(_TestExecutionPolicyBase):
         for overrides in cases:
             with self.subTest(overrides=overrides):
                 outcome = policy.evaluate(
-                    _with_simple_lane_quantity_resolution(base_decision, **overrides),
+                    _with_execution_quantity_resolution(base_decision, **overrides),
                     strategy=None,
                     positions=[],
                     market_snapshot=None,
@@ -187,7 +218,7 @@ class TestKillSwitchBlocks(_TestExecutionPolicyBase):
         self,
     ) -> None:
         policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
-        decision = _with_simple_lane_quantity_resolution(
+        decision = _with_execution_quantity_resolution(
             _decision(action="sell", qty=Decimal("0"), price=Decimal("273.97")),
             requested_qty="0",
         )

--- a/services/torghut/tests/pipeline/test_trading_pipeline_external_targets_d.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_external_targets_d.py
@@ -427,7 +427,7 @@ class TestTradingPipelineExternalTargetsD(TradingPipelineTestCaseBase):
                 "trading_static_symbols_raw"
             ]
 
-    def test_live_bounded_collection_fallback_respects_disabled_and_empty_scopes(
+    def test_live_bounded_collection_scope_respects_disabled_and_empty_scopes(
         self,
     ) -> None:
         from app import config
@@ -457,18 +457,14 @@ class TestTradingPipelineExternalTargetsD(TradingPipelineTestCaseBase):
             config.settings.trading_static_symbols_raw = "AAPL"
 
             self.assertIsNone(
-                pipeline._live_bounded_collection_fallback_signal_scope(
-                    [dynamic_strategy]
-                )
+                pipeline._live_bounded_collection_signal_scope([dynamic_strategy])
             )
 
             config.settings.trading_simple_paper_route_probe_enabled = True
             config.settings.trading_static_symbols_raw = ""
 
             self.assertIsNone(
-                pipeline._live_bounded_collection_fallback_signal_scope(
-                    [dynamic_strategy]
-                )
+                pipeline._live_bounded_collection_signal_scope([dynamic_strategy])
             )
         finally:
             config.settings.trading_mode = original["trading_mode"]

--- a/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_probe_exits_b.py
@@ -830,11 +830,13 @@ class TestTradingPipelineProbeExitsB(TradingPipelineTestCaseBase):
             decision_json = cast(dict[str, Any], decision.decision_json)
             params = cast(dict[str, Any], decision_json.get("params"))
             paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
-            simple_lane = cast(dict[str, Any], params.get("execution"))
+            execution_metadata = cast(dict[str, Any], params.get("execution"))
 
             self.assertEqual(decision.status, "submitted")
             self.assertEqual(execution.submitted_qty, Decimal("0.25000000"))
             self.assertEqual(paper_route_probe.get("mode"), "paper_route_acquisition")
             self.assertEqual(paper_route_probe.get("max_notional"), "25.0")
             self.assertEqual(paper_route_probe.get("capped_qty"), "0.2500")
-            self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
+            self.assertEqual(
+                execution_metadata.get("paper_route_probe_cap_applied"), True
+            )

--- a/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_target_plan_source_b.py
@@ -552,12 +552,14 @@ class TestTradingPipelineTargetPlanSourceB(TradingPipelineTestCaseBase):
             decision_json = cast(dict[str, Any], decision.decision_json)
             params = cast(dict[str, Any], decision_json.get("params"))
             paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
-            simple_lane = cast(dict[str, Any], params.get("execution"))
+            execution_metadata = cast(dict[str, Any], params.get("execution"))
 
             self.assertEqual(decision.status, "submitted")
             self.assertEqual(paper_route_probe.get("symbol"), "NVDA")
             self.assertEqual(paper_route_probe.get("mode"), "paper_route_acquisition")
-            self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
+            self.assertEqual(
+                execution_metadata.get("paper_route_probe_cap_applied"), True
+            )
 
     def test_paper_route_probe_helpers_handle_missing_repair_metadata(self) -> None:
         self.assertFalse(SimpleTradingPipeline._proof_floor_market_session_open({}))

--- a/services/torghut/tests/simple_pipeline/test_local_target_plan_enriches_probe_contract_before_bounded_gate.py
+++ b/services/torghut/tests/simple_pipeline/test_local_target_plan_enriches_probe_contract_before_bounded_gate.py
@@ -544,8 +544,8 @@ def test_bounded_source_collection_blocks_closed_session_with_explicit_reason(
 
         assert decisions == []
         blocker = pipeline.state.last_bounded_evidence_collection_blocker
-        assert blocker["reason"] == "paper_route_session_window_not_open"
-        assert blocker["blockers"] == ["paper_route_session_window_not_open"]
+        assert blocker["reason"] == "alpaca_regular_session_closed"
+        assert blocker["blockers"] == ["alpaca_regular_session_closed"]
         assert blocker["account_label"] == "TORGHUT_SIM"
         assert blocker["target_count"] == 0
     finally:
@@ -553,7 +553,7 @@ def test_bounded_source_collection_blocks_closed_session_with_explicit_reason(
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
 
 
-def test_after_hours_live_testnet_route_falls_back_to_live_signal_scope(
+def test_after_hours_live_testnet_route_uses_live_signal_scope_without_target_plan(
     monkeypatch,
 ) -> None:
     trading_mode_before = settings.trading_mode
@@ -580,10 +580,12 @@ def test_after_hours_live_testnet_route_falls_back_to_live_signal_scope(
         pipeline.account_label = "TORGHUT_SIM"
         pipeline.state = SimpleNamespace()
         pipeline._is_market_session_open = lambda _now: False
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
-            set(),
-            "paper_route_session_window_not_open",
-            [],
+
+        def _target_plan_must_not_be_called(**_kwargs: object) -> object:
+            raise AssertionError("after_hours_testnet_route_must_not_load_target_plan")
+
+        pipeline._external_paper_route_target_probe_symbols_cached = (
+            _target_plan_must_not_be_called
         )
         monkeypatch.setattr(
             "app.trading.scheduler.simple_pipeline.trading_now",

--- a/services/torghut/tests/test_execution_metadata.py
+++ b/services/torghut/tests/test_execution_metadata.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from app.trading.execution_metadata import (
+    execution_metadata,
+    mutable_execution_metadata,
+    set_execution_metadata,
+)
+
+
+def test_execution_metadata_ignores_removed_simple_lane_key() -> None:
+    params: dict[str, object] = {
+        "simple_lane": {
+            "price": "999",
+            "quantity_resolution": {"short_increasing": False},
+        }
+    }
+
+    assert execution_metadata(params) is None
+    assert mutable_execution_metadata(params) == {}
+
+
+def test_set_execution_metadata_drops_removed_simple_lane_key() -> None:
+    params: dict[str, object] = {
+        "simple_lane": {"price": "999"},
+        "execution": {"price": "100"},
+    }
+
+    set_execution_metadata(params, {"price": "101"})
+
+    assert params == {"execution": {"price": "101"}}

--- a/services/torghut/tests/verify_trading_readiness/support.py
+++ b/services/torghut/tests/verify_trading_readiness/support.py
@@ -203,7 +203,7 @@ def _paper_route_evidence(
     blockers = (
         import_blockers
         if import_blockers is not None
-        else ([] if import_ready else ["paper_route_session_window_not_open"])
+        else ([] if import_ready else ["alpaca_regular_session_closed"])
     )
     target = {
         "hypothesis_id": "H-PAIRS-01",

--- a/services/torghut/tests/verify_trading_readiness/test_paper_route_target_plan_can_be_required_before_session_open.py
+++ b/services/torghut/tests/verify_trading_readiness/test_paper_route_target_plan_can_be_required_before_session_open.py
@@ -34,7 +34,7 @@ class TestPaperRouteTargetPlanCanBeRequiredBeforeSessionOpen(
         self.assertEqual(result["paper_route_target_plan"]["target_count"], 1)
         self.assertEqual(
             result["paper_route_target_plan"]["import_blockers"],
-            ["paper_route_session_window_not_open"],
+            ["alpaca_regular_session_closed"],
         )
         self.assertEqual(
             result["paper_route_target_plan"]["missing_required_flags"], []


### PR DESCRIPTION
## Summary

- Removed legacy `simple_lane` and `simple_lane_precheck` fallback reads from execution metadata, execution policy, paper-route retry, probe, and target-plan sizing paths.
- Kept canonical writes on `execution` only; stale `simple_lane` is dropped when normalized execution metadata is written.
- Renamed execution-policy test helpers away from `simple_lane` and added regressions proving removed legacy metadata no longer authorizes execution decisions.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_metadata.py tests/test_execution_runtime.py tests/test_submission_authority.py tests/test_simple_risk.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_bounded_live_close.py tests/pipeline/test_trading_pipeline_target_plan_source_b.py tests/pipeline/test_trading_pipeline_materialized_target_plan_a.py tests/pipeline/test_trading_pipeline_retry_profit_floor_a.py tests/pipeline/test_trading_pipeline_retry_profit_floor_b.py tests/pipeline/test_trading_pipeline_paper_route_quote_a.py tests/pipeline/test_trading_pipeline_paper_route_quote_b.py tests/pipeline/test_trading_pipeline_route_execution_a.py tests/pipeline/test_trading_pipeline_probe_exits_a.py tests/pipeline/test_trading_pipeline_probe_exits_b.py tests/execution_policy/test_kill_switch_blocks.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app scripts && uv run --frozen ruff format --check app tests scripts migrations && uv run --frozen ruff check app tests scripts migrations && uv run --frozen ruff check app tests scripts migrations --select F401 --preview && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base "$(git merge-base origin/main HEAD)" <changed files> && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base "$(git merge-base origin/main HEAD)" --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks <changed app files>`

## Screenshots (if applicable)

N/A

## Breaking Changes

Legacy rows with only `params.simple_lane` execution metadata no longer act as execution metadata. Active decisions must use `params.execution` and `params.execution_precheck`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
