### PR TITLE
perf(rook-ceph): prioritize client io after recovery

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -32,17 +32,10 @@ cephClusterSpec:
       mon_data_avail_warn: "15"
     osd:
       bluestore_cache_autotune: "true"
-      # Use Ceph's recovery-biased mClock profile, but keep concurrency bounded so Kafka stays responsive.
-      # Ceph mClock ignores recovery/backfill concurrency overrides unless this gate is enabled.
-      osd_mclock_profile: "high_recovery_ops"
-      osd_mclock_override_recovery_settings: "true"
-      osd_memory_target: "6442450944"
-      osd_max_backfills: "2"
-      osd_recovery_max_active: "4"
-      osd_recovery_max_active_hdd: "4"
-      osd_recovery_max_single_start: "1"
-      osd_recovery_op_priority: "3"
-      osd_recovery_sleep_hdd: "0"
+      # Prioritize client IO after the Turin BlueStore DB migration has recovered.
+      # Recovery/backfill overrides are intentionally omitted so the built-in mClock profile controls QoS.
+      osd_mclock_profile: "high_client_ops"
+      osd_memory_target: "8589934592"
 
   dataDirHostPath: /var/lib/rook
 
@@ -109,10 +102,10 @@ cephClusterSpec:
   resources:
     osd:
       limits:
-        memory: 8Gi
+        memory: 12Gi
       requests:
         cpu: 1000m
-        memory: 6Gi
+        memory: 8Gi
 
   csi:
     readAffinity:


### PR DESCRIPTION
## Summary

- Switch Rook Ceph OSDs from recovery-biased mClock to `high_client_ops` after the BlueStore DB migration recovered.
- Remove recovery/backfill override knobs so the built-in client-biased mClock profile controls QoS.
- Raise OSD BlueStore cache headroom to an 8Gi target with 8Gi request and 12Gi memory limit.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph`
- `bun run lint:argocd`
- Live Ceph readback: `ceph config dump` shows `osd_mclock_profile=high_client_ops` and `osd_memory_target=8589934592`.
- Live OSD deployment readback shows all six OSDs at `requests.memory=8Gi` and `limits.memory=12Gi`.
- Live Ceph status shows `6 osds: 6 up, 6 in`; remaining warning is stale deep-scrub backlog only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
