### PR TITLE
fix(argocd): ignore rook generated secret metadata

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -87,6 +87,9 @@ spec:
                       namespace: rook-ceph
                       jsonPointers:
                         - /data
+                        - /metadata/labels
+                        - /metadata/ownerReferences
+                        - /metadata/annotations/argocd.argoproj.io~1tracking-id
                 - name: local-path
                   path: argocd/applications/local-path
                   namespace: local-path-storage


### PR DESCRIPTION
## Summary

- Expand the Rook Ceph ApplicationSet diff ignore for the generated Loki RGW Secret.
- Ignore Rook-owned Secret `data`, labels, ownerReferences, and Argo's own tracking annotation.
- Keep reflector annotations compared so GitOps still enforces the cross-namespace reflection contract.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Live verification before this GitOps change: `rook-ceph` Application reported `Synced` after applying the same ignore pointers to the live ApplicationSet.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
