### PR TITLE
chore(symphony): promote image sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T02:25:58Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T07:29:55Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-3846851d28670d36fd4f9cf5ead22f8aad012623"
-    digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367
+    newTag: "sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1"
+    digest: sha256:5105e0fcd6a824c797ffee298a9a1ed58508c051233295c0e17df41070ed8023

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T02:25:58Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T07:29:55Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-3846851d28670d36fd4f9cf5ead22f8aad012623"
-    digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367
+    newTag: "sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1"
+    digest: sha256:5105e0fcd6a824c797ffee298a9a1ed58508c051233295c0e17df41070ed8023

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T02:25:58Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T07:29:55Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-3846851d28670d36fd4f9cf5ead22f8aad012623"
-    digest: sha256:abce8ac8430ae09b534d716b049e8ccb48dc972223549d55ae9031eacbb02367
+    newTag: "sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1"
+    digest: sha256:5105e0fcd6a824c797ffee298a9a1ed58508c051233295c0e17df41070ed8023


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `74d7ec5e2e2851e39cf3dc11f346709e425714c1`
- Image tag: `sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1`
- Image digest: `sha256:5105e0fcd6a824c797ffee298a9a1ed58508c051233295c0e17df41070ed8023`