### PR TITLE
ci(nix): migrate torghut family images to nix

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -4,6 +4,28 @@ permissions:
   contents: read
 
 on:
+  pull_request:
+    paths:
+      - 'services/torghut/**'
+      - 'packages/scripts/src/torghut/**'
+      - '!packages/scripts/src/torghut/__tests__/**'
+      - '!packages/scripts/src/torghut/**/*.test.ts'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
+      - 'nix/images/torghut.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
+      - 'services/torghut/uv.lock'
+      - '.github/workflows/torghut-build-push.yaml'
+      - '.github/workflows/torghut-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   push:
     branches:
       - main
@@ -13,9 +35,21 @@ on:
       - '!packages/scripts/src/torghut/__tests__/**'
       - '!packages/scripts/src/torghut/**/*.test.ts'
       - 'packages/scripts/src/shared/cli.ts'
-      - 'packages/scripts/src/shared/docker.ts'
       - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
+      - 'nix/images/torghut.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
+      - 'services/torghut/uv.lock'
       - '.github/workflows/torghut-build-push.yaml'
+      - '.github/workflows/torghut-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   workflow_dispatch:
 
 concurrency:
@@ -23,165 +57,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-platform:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            arch: amd64
-            runner: arc-amd64
-          - platform: linux/arm64
-            arch: arm64
-            runner: arc-arm64
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 180
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Wait for private registry
-        shell: bash
-        env:
-          REGISTRY_URL: https://registry.ide-newton.ts.net/v2/
-          REGISTRY_WAIT_TIMEOUT_SECONDS: 600
-          REGISTRY_WAIT_INTERVAL_SECONDS: 15
-        run: |
-          set -euo pipefail
-
-          deadline=$((SECONDS + REGISTRY_WAIT_TIMEOUT_SECONDS))
-
-          while true; do
-            status="$(curl -sS -o /tmp/torghut-registry-health.txt -w '%{http_code}' "${REGISTRY_URL}" || true)"
-
-            case "${status}" in
-              200|401)
-                echo "Registry is reachable at ${REGISTRY_URL} (HTTP ${status})."
-                exit 0
-                ;;
-              502|503|504|000)
-                if (( SECONDS >= deadline )); then
-                  echo "Timed out waiting for ${REGISTRY_URL}; last HTTP status was ${status}."
-                  exit 1
-                fi
-
-                echo "Registry is temporarily unavailable at ${REGISTRY_URL} (HTTP ${status}); retrying in ${REGISTRY_WAIT_INTERVAL_SECONDS}s."
-                sleep "${REGISTRY_WAIT_INTERVAL_SECONDS}"
-                ;;
-              *)
-                echo "Registry returned unexpected HTTP status ${status} for ${REGISTRY_URL}."
-                exit 1
-                ;;
-            esac
-          done
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
-
-      - name: Build and push torghut image
-        env:
-          TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
-          TORGHUT_IMAGE_PLATFORMS: ${{ matrix.platform }}
-          # Remote cache export has intermittently canceled after the image push,
-          # before the release contract can be written. Keep the image contract
-          # path authoritative and skip the cache until the exporter is stable.
-          TORGHUT_IMAGE_CACHE_REF: none
-        run: bun run packages/scripts/src/torghut/build-image.ts
-
-  publish-index:
-    needs: build-platform
-    runs-on: arc-arm64
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
-
-      - name: Create multi-arch image index
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut'
-          TAG='${{ steps.meta.outputs.tag }}'
-          docker buildx imagetools create \
-            -t "${IMAGE}:${TAG}" \
-            -t "${IMAGE}:latest" \
-            "${IMAGE}:${TAG}-amd64" \
-            "${IMAGE}:${TAG}-arm64"
-
-      - name: Verify multi-arch image manifest
-        id: digest
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut'
-          TAG='${{ steps.meta.outputs.tag }}'
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
-          DIGEST="$(jq -r '.manifest.digest // empty' <<< "${MANIFEST_JSON}")"
-          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE}:${TAG}"
-              exit 1
-            fi
-            echo "platform_digest_${platform#linux/}=${platform_digest}" >> "$GITHUB_OUTPUT"
-          done
-
-      - name: Write release contract artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          bun run packages/scripts/src/torghut/release-contract.ts write \
-            --path torghut-release-contract.json \
-            --source-sha "${GITHUB_SHA}" \
-            --tag "${{ steps.meta.outputs.tag }}" \
-            --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/torghut' \
-            --platforms 'linux/amd64,linux/arm64' \
-            --platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}' \
-            --platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'
-
-      - name: Upload release contract artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: torghut-release-contract
-          path: torghut-release-contract.json
-          if-no-files-found: error
-          retention-days: 3
+  nix-image:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: torghut
+      package_attr: torghut-image
+      tag: sha-${{ github.sha }}
+      latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'torghut-release-contract' || '' }}
+    secrets: inherit

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -7,8 +7,9 @@ on:
       - 'services/torghut/**'
       - 'packages/scripts/src/torghut/**'
       - 'packages/scripts/src/shared/cli.ts'
-      - 'packages/scripts/src/shared/docker.ts'
       - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
+      - 'packages/scripts/src/shared/oci-digest.ts'
       - '.github/workflows/torghut-ci.yml'
       - '.github/workflows/torghut-build-push.yaml'
       - '.github/workflows/torghut-deploy-automerge.yml'
@@ -28,8 +29,9 @@ on:
       - 'services/torghut/**'
       - 'packages/scripts/src/torghut/**'
       - 'packages/scripts/src/shared/cli.ts'
-      - 'packages/scripts/src/shared/docker.ts'
       - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
+      - 'packages/scripts/src/shared/oci-digest.ts'
       - '.github/workflows/torghut-ci.yml'
       - '.github/workflows/torghut-build-push.yaml'
       - '.github/workflows/torghut-deploy-automerge.yml'
@@ -129,7 +131,7 @@ jobs:
 
           service=false
           manifests=false
-          if matches_any '^(services/torghut/|packages/scripts/src/torghut/|packages/scripts/src/shared/(cli|docker|git)\.ts$|\.github/workflows/torghut-(ci|deploy-automerge|post-deploy-verify|release|hyperliquid-feed-release|ta-release|ws-release)\.yml$|\.github/workflows/torghut-(build-push|hyperliquid-feed-build-push|ta-build-push|ws-build-push)\.yaml$)'; then
+          if matches_any '^(services/torghut/|packages/scripts/src/torghut/|packages/scripts/src/shared/(cli|git|nix-oci-deploy|oci-digest)\.ts$|\.github/workflows/torghut-(ci|deploy-automerge|post-deploy-verify|release|hyperliquid-feed-release|ta-release|ws-release)\.yml$|\.github/workflows/torghut-(build-push|hyperliquid-feed-build-push|ta-build-push|ws-build-push)\.yaml$)'; then
             service=true
           fi
           if matches_any '^argocd/applications/(torghut|torghut-options|torghut-hyperliquid-runtime)/'; then
@@ -183,8 +185,10 @@ jobs:
           fi
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          require-preinstalled: 'true'
 
       - name: Verify source image digest contract
         shell: bash
@@ -245,7 +249,7 @@ jobs:
 
           assert_multi_arch_image() {
             local image_ref="$1"
-            local image_digest manifest_json platform platform_digest
+            local image_digest
 
             image_digest="${image_ref#*@}"
             if [ "${image_digest}" = "${image_ref}" ] || ! printf '%s' "${image_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
@@ -253,19 +257,7 @@ jobs:
               exit 1
             fi
 
-            manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image_ref}")"
-            for platform in linux/amd64 linux/arm64; do
-              platform_digest="$(
-                jq -r --arg platform "${platform}" \
-                  '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                  <<< "${manifest_json}" | head -n 1
-              )"
-              if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-                echo "Release manifest image ${image_ref} is missing required platform ${platform}"
-                docker buildx imagetools inspect "${image_ref}"
-                exit 1
-              fi
-            done
+            nix run .#assert-oci-platforms -- "${image_ref}" linux/amd64 linux/arm64
           }
 
           verify_image_contract() {

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -58,7 +58,7 @@ jobs:
         github.event.pull_request.draft == false
       }}
     # The private registry is only reachable from the ARC runners on the lab network.
-    # This pull_request_target job does not check out pull request code.
+    # This pull_request_target job checks out trusted base code only, never pull request code.
     runs-on: arc-arm64
     permissions:
       contents: write
@@ -184,9 +184,17 @@ jobs:
           printf 'eligible=%s\n' "${ELIGIBLE}"
           printf 'reason=%s\n' "${REASON}"
 
-      - name: Set up Docker Buildx
+      - name: Checkout trusted base
         if: steps.gates.outputs.eligible == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Nix toolchain
+        if: steps.gates.outputs.eligible == 'true'
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          require-preinstalled: 'true'
 
       - name: Verify source image digest contract
         if: steps.gates.outputs.eligible == 'true' && steps.gates.outputs.release_lane != 'hyperliquid-feed'
@@ -261,7 +269,7 @@ jobs:
 
           assert_multi_arch_image() {
             local image_ref="$1"
-            local image_digest manifest_json platform platform_digest
+            local image_digest
 
             image_digest="${image_ref#*@}"
             if [ "${image_digest}" = "${image_ref}" ] || ! printf '%s' "${image_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
@@ -269,19 +277,7 @@ jobs:
               exit 1
             fi
 
-            manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image_ref}")"
-            for platform in linux/amd64 linux/arm64; do
-              platform_digest="$(
-                jq -r --arg platform "${platform}" \
-                  '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                  <<< "${manifest_json}" | head -n 1
-              )"
-              if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-                echo "Release manifest image ${image_ref} is missing required platform ${platform}"
-                docker buildx imagetools inspect "${image_ref}"
-                exit 1
-              fi
-            done
+            nix run .#assert-oci-platforms -- "${image_ref}" linux/amd64 linux/arm64
           }
 
           source_sha="$(resolve_env_value "${source_env_name}")"
@@ -351,19 +347,7 @@ jobs:
             exit 1
           fi
 
-          manifest_json="$(docker buildx imagetools inspect --format '{{json .}}' "${image_ref}")"
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${manifest_json}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Hyperliquid feed release manifest image ${image_ref} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${image_ref}"
-              exit 1
-            fi
-          done
+          nix run .#assert-oci-platforms -- "${image_ref}" linux/amd64 linux/arm64
 
           echo "Hyperliquid feed release manifest pins a multi-arch image digest for ${source_sha}: ${image_ref}"
 

--- a/.github/workflows/torghut-hyperliquid-feed-build-push.yaml
+++ b/.github/workflows/torghut-hyperliquid-feed-build-push.yaml
@@ -4,7 +4,28 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'services/dorvud/gradle/**'
+      - 'services/dorvud/gradlew'
+      - 'services/dorvud/gradle.properties'
+      - 'services/dorvud/settings.gradle.kts'
+      - 'services/dorvud/build.gradle.kts'
+      - 'services/dorvud/platform/**'
+      - 'services/dorvud/hyperliquid-feed/**'
+      - 'nix/images/dorvud-jvm-service.nix'
+      - 'nix/images/torghut-hyperliquid-feed.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
+      - '.github/workflows/torghut-hyperliquid-feed-build-push.yaml'
+      - '.github/workflows/torghut-hyperliquid-feed-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   push:
     branches:
       - main
@@ -16,133 +37,33 @@ on:
       - 'services/dorvud/build.gradle.kts'
       - 'services/dorvud/platform/**'
       - 'services/dorvud/hyperliquid-feed/**'
-      - 'packages/scripts/src/torghut/release-contract.ts'
-      - 'packages/scripts/src/shared/cli.ts'
-      - 'packages/scripts/src/shared/docker.ts'
+      - 'nix/images/dorvud-jvm-service.nix'
+      - 'nix/images/torghut-hyperliquid-feed.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
       - '.github/workflows/torghut-hyperliquid-feed-build-push.yaml'
+      - '.github/workflows/torghut-hyperliquid-feed-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
+  workflow_dispatch:
+
+concurrency:
+  group: torghut-hyperliquid-feed-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-platform:
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push'
-      }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            arch: amd64
-            runner: arc-amd64
-          - platform: linux/arm64
-            arch: arm64
-            runner: arc-arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push torghut-hyperliquid-feed image
-        uses: docker/build-push-action@v6
-        with:
-          context: services/dorvud
-          file: services/dorvud/hyperliquid-feed/Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: |
-            registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed:${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
-            registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed:latest-${{ matrix.arch }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed:latest-${{ matrix.arch }}
-          cache-to: type=inline
-
-  publish-index:
-    needs: build-platform
-    runs-on: arc-arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
-
-      - name: Create multi-arch image index
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed'
-          TAG='${{ steps.meta.outputs.tag }}'
-          docker buildx imagetools create \
-            -t "${IMAGE}:${TAG}" \
-            -t "${IMAGE}:latest" \
-            "${IMAGE}:${TAG}-amd64" \
-            "${IMAGE}:${TAG}-arm64"
-
-      - name: Verify multi-arch image manifest
-        id: digest
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed'
-          TAG='${{ steps.meta.outputs.tag }}'
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
-          DIGEST="$(jq -r '.manifest.digest // empty' <<< "${MANIFEST_JSON}")"
-          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE}:${TAG}"
-              exit 1
-            fi
-            echo "platform_digest_${platform#linux/}=${platform_digest}" >> "$GITHUB_OUTPUT"
-          done
-
-      - name: Write release contract artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          bun run packages/scripts/src/torghut/release-contract.ts write \
-            --path torghut-hyperliquid-feed-release-contract.json \
-            --source-sha "${GITHUB_SHA}" \
-            --tag "${{ steps.meta.outputs.tag }}" \
-            --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed' \
-            --platforms 'linux/amd64,linux/arm64' \
-            --platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}' \
-            --platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'
-
-      - name: Upload release contract artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: torghut-hyperliquid-feed-release-contract
-          path: torghut-hyperliquid-feed-release-contract.json
-          if-no-files-found: error
-          retention-days: 3
+  nix-image:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: torghut-hyperliquid-feed
+      package_attr: torghut-hyperliquid-feed-image
+      tag: sha-${{ github.sha }}
+      latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'torghut-hyperliquid-feed-release-contract' || '' }}
+    secrets: inherit

--- a/.github/workflows/torghut-hyperliquid-feed-release.yml
+++ b/.github/workflows/torghut-hyperliquid-feed-release.yml
@@ -49,8 +49,16 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
@@ -80,7 +88,7 @@ jobs:
           PROMOTE='true'
 
           if [ "${EVENT_NAME}" = 'workflow_run' ]; then
-            CONTRACT_PATH='.artifacts/torghut-hyperliquid-feed/torghut-hyperliquid-feed-release-contract.json'
+            CONTRACT_PATH='.artifacts/torghut-hyperliquid-feed/release-contract.json'
             if [ ! -f "${CONTRACT_PATH}" ]; then
               echo "Release contract artifact is missing at ${CONTRACT_PATH}"
               exit 1
@@ -118,8 +126,11 @@ jobs:
                     packages/scripts/src/torghut/release-contract.ts \
                     packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts \
                     packages/scripts/src/shared/cli.ts \
-                    packages/scripts/src/shared/docker.ts \
                     packages/scripts/src/shared/git.ts \
+                    packages/scripts/src/shared/nix-oci-deploy.ts \
+                    packages/scripts/src/shared/oci-digest.ts \
+                    nix/images/dorvud-jvm-service.nix \
+                    nix/images/torghut-hyperliquid-feed.nix \
                     .github/workflows/torghut-hyperliquid-feed-build-push.yaml \
                     .github/workflows/torghut-hyperliquid-feed-release.yml
                 )"
@@ -183,15 +194,7 @@ jobs:
           elif [ -n "${CONTRACT_DIGEST}" ]; then
             DIGEST="${CONTRACT_DIGEST}"
           else
-            DIGEST="$(
-              bun --eval "
-                import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
-                const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
-                const repoDigest = inspectImageDigest(image)
-                const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
-                console.log(digest)
-              "
-            )"
+            DIGEST="$(crane digest "${IMAGE_NAME}:${IMAGE_TAG}")"
           fi
 
           DIGEST="${DIGEST#*@}"
@@ -211,19 +214,7 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_REF="${IMAGE_NAME}@${IMAGE_DIGEST}"
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE_REF}")"
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Promoted image ${IMAGE_REF} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE_REF}"
-              exit 1
-            fi
-          done
+          nix run .#assert-oci-platforms -- "${IMAGE_REF}" linux/amd64 linux/arm64
 
       - name: Update torghut hyperliquid feed manifest
         if: steps.meta.outputs.promote == 'true'

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -49,8 +49,16 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
@@ -80,7 +88,7 @@ jobs:
           PROMOTE='true'
 
           if [ "${EVENT_NAME}" = 'workflow_run' ]; then
-            CONTRACT_PATH='.artifacts/torghut/torghut-release-contract.json'
+            CONTRACT_PATH='.artifacts/torghut/release-contract.json'
             if [ -f "${CONTRACT_PATH}" ]; then
               SOURCE_SHA="$(bun run packages/scripts/src/torghut/release-contract.ts get --path "${CONTRACT_PATH}" --field sourceSha)"
               TAG="$(bun run packages/scripts/src/torghut/release-contract.ts get --path "${CONTRACT_PATH}" --field tag)"
@@ -111,8 +119,10 @@ jobs:
                     services/torghut \
                     packages/scripts/src/torghut \
                     packages/scripts/src/shared/cli.ts \
-                    packages/scripts/src/shared/docker.ts \
                     packages/scripts/src/shared/git.ts \
+                    packages/scripts/src/shared/nix-oci-deploy.ts \
+                    packages/scripts/src/shared/oci-digest.ts \
+                    nix/images/torghut.nix \
                     .github/workflows/torghut-build-push.yaml \
                     .github/workflows/torghut-ci.yml \
                     .github/workflows/torghut-deploy-automerge.yml \
@@ -184,15 +194,7 @@ jobs:
           elif [ -n "${CONTRACT_DIGEST}" ]; then
             DIGEST="${CONTRACT_DIGEST}"
           else
-            DIGEST="$(
-              bun --eval "
-                import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
-                const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
-                const repoDigest = inspectImageDigest(image)
-                const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
-                console.log(digest)
-              "
-            )"
+            DIGEST="$(crane digest "${IMAGE_NAME}:${IMAGE_TAG}")"
           fi
 
           DIGEST="${DIGEST#*@}"
@@ -212,19 +214,7 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_REF="${IMAGE_NAME}@${IMAGE_DIGEST}"
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE_REF}")"
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Promoted image ${IMAGE_REF} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE_REF}"
-              exit 1
-            fi
-          done
+          nix run .#assert-oci-platforms -- "${IMAGE_REF}" linux/amd64 linux/arm64
 
       - name: Evaluate migration safety gate
         if: steps.meta.outputs.promote == 'true'
@@ -275,6 +265,7 @@ jobs:
             argocd/applications/torghut/knative-service-sim.yaml \
             argocd/applications/torghut/db-migrations-job.yaml \
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml \
+            argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml \
             argocd/applications/torghut/analysis-template-runtime-ready.yaml \
             argocd/applications/torghut/analysis-template-activity.yaml \
             argocd/applications/torghut/analysis-template-teardown-clean.yaml \
@@ -314,6 +305,7 @@ jobs:
             argocd/applications/torghut/knative-service-sim.yaml
             argocd/applications/torghut/db-migrations-job.yaml
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+            argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
             argocd/applications/torghut/analysis-template-runtime-ready.yaml
             argocd/applications/torghut/analysis-template-activity.yaml
             argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -357,6 +349,7 @@ jobs:
             argocd/applications/torghut/knative-service-sim.yaml
             argocd/applications/torghut/db-migrations-job.yaml
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+            argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
             argocd/applications/torghut/analysis-template-runtime-ready.yaml
             argocd/applications/torghut/analysis-template-activity.yaml
             argocd/applications/torghut/analysis-template-teardown-clean.yaml

--- a/.github/workflows/torghut-ta-build-push.yaml
+++ b/.github/workflows/torghut-ta-build-push.yaml
@@ -4,7 +4,28 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'services/dorvud/gradle/**'
+      - 'services/dorvud/gradlew'
+      - 'services/dorvud/gradle.properties'
+      - 'services/dorvud/settings.gradle.kts'
+      - 'services/dorvud/build.gradle.kts'
+      - 'services/dorvud/platform/**'
+      - 'services/dorvud/technical-analysis/**'
+      - 'services/dorvud/technical-analysis-flink/**'
+      - 'nix/images/torghut-ta.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
+      - '.github/workflows/torghut-ta-build-push.yaml'
+      - '.github/workflows/torghut-ta-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   push:
     branches:
       - main
@@ -15,141 +36,34 @@ on:
       - 'services/dorvud/settings.gradle.kts'
       - 'services/dorvud/build.gradle.kts'
       - 'services/dorvud/platform/**'
-      - 'services/dorvud/flink-integration/**'
       - 'services/dorvud/technical-analysis/**'
       - 'services/dorvud/technical-analysis-flink/**'
-      - 'packages/scripts/src/torghut/release-contract.ts'
-      - 'packages/scripts/src/shared/docker.ts'
+      - 'nix/images/torghut-ta.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
       - '.github/workflows/torghut-ta-build-push.yaml'
+      - '.github/workflows/torghut-ta-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
+  workflow_dispatch:
+
+concurrency:
+  group: torghut-ta-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-platform:
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push'
-      }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            arch: amd64
-            runner: arc-amd64
-          - platform: linux/arm64
-            arch: arm64
-            runner: arc-arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push torghut-ta image
-        uses: docker/build-push-action@v6
-        with:
-          context: services/dorvud
-          file: services/dorvud/technical-analysis-flink/Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: |
-            registry.ide-newton.ts.net/lab/torghut-ta:${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
-            registry.ide-newton.ts.net/lab/torghut-ta:latest-${{ matrix.arch }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ta:latest-${{ matrix.arch }}
-          cache-to: type=inline
-
-  publish-index:
-    needs: build-platform
-    runs-on: arc-arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
-
-      - name: Create multi-arch image index
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut-ta'
-          TAG='${{ steps.meta.outputs.tag }}'
-          docker buildx imagetools create \
-            -t "${IMAGE}:${TAG}" \
-            -t "${IMAGE}:latest" \
-            "${IMAGE}:${TAG}-amd64" \
-            "${IMAGE}:${TAG}-arm64"
-
-      - name: Verify multi-arch image manifest
-        id: digest
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut-ta'
-          TAG='${{ steps.meta.outputs.tag }}'
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
-          DIGEST="$(jq -r '.manifest.digest // empty' <<< "${MANIFEST_JSON}")"
-          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE}:${TAG}"
-              exit 1
-            fi
-            echo "platform_digest_${platform#linux/}=${platform_digest}" >> "$GITHUB_OUTPUT"
-          done
-
-      - name: Write release contract artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          bun run packages/scripts/src/torghut/release-contract.ts write \
-            --path torghut-ta-release-contract.json \
-            --source-sha "${GITHUB_SHA}" \
-            --tag "${{ steps.meta.outputs.tag }}" \
-            --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/torghut-ta' \
-            --platforms 'linux/amd64,linux/arm64' \
-            --platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}' \
-            --platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'
-
-      - name: Upload release contract artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: torghut-ta-release-contract
-          path: torghut-ta-release-contract.json
-          if-no-files-found: error
-          retention-days: 3
+  nix-image:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: torghut-ta
+      package_attr: torghut-ta-image
+      tag: sha-${{ github.sha }}
+      latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'torghut-ta-release-contract' || '' }}
+    secrets: inherit

--- a/.github/workflows/torghut-ta-release.yml
+++ b/.github/workflows/torghut-ta-release.yml
@@ -49,8 +49,16 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
@@ -80,7 +88,7 @@ jobs:
           PROMOTE='true'
 
           if [ "${EVENT_NAME}" = 'workflow_run' ]; then
-            CONTRACT_PATH='.artifacts/torghut-ta/torghut-ta-release-contract.json'
+            CONTRACT_PATH='.artifacts/torghut-ta/release-contract.json'
             if [ ! -f "${CONTRACT_PATH}" ]; then
               echo "Release contract artifact is missing at ${CONTRACT_PATH}"
               exit 1
@@ -119,7 +127,11 @@ jobs:
                     services/dorvud/technical-analysis-flink \
                     packages/scripts/src/torghut/release-contract.ts \
                     packages/scripts/src/torghut/update-ta-manifest.ts \
-                    packages/scripts/src/shared/docker.ts \
+                    packages/scripts/src/shared/cli.ts \
+                    packages/scripts/src/shared/git.ts \
+                    packages/scripts/src/shared/nix-oci-deploy.ts \
+                    packages/scripts/src/shared/oci-digest.ts \
+                    nix/images/torghut-ta.nix \
                     .github/workflows/torghut-ta-build-push.yaml \
                     .github/workflows/torghut-ta-release.yml
                 )"
@@ -183,15 +195,7 @@ jobs:
           elif [ -n "${CONTRACT_DIGEST}" ]; then
             DIGEST="${CONTRACT_DIGEST}"
           else
-            DIGEST="$(
-              bun --eval "
-                import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
-                const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
-                const repoDigest = inspectImageDigest(image)
-                const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
-                console.log(digest)
-              "
-            )"
+            DIGEST="$(crane digest "${IMAGE_NAME}:${IMAGE_TAG}")"
           fi
 
           DIGEST="${DIGEST#*@}"
@@ -211,19 +215,7 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_REF="${IMAGE_NAME}@${IMAGE_DIGEST}"
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE_REF}")"
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Promoted image ${IMAGE_REF} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE_REF}"
-              exit 1
-            fi
-          done
+          nix run .#assert-oci-platforms -- "${IMAGE_REF}" linux/amd64 linux/arm64
 
       - name: Update torghut ta manifests
         if: steps.meta.outputs.promote == 'true'

--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -4,7 +4,28 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'services/dorvud/gradle/**'
+      - 'services/dorvud/gradlew'
+      - 'services/dorvud/gradle.properties'
+      - 'services/dorvud/settings.gradle.kts'
+      - 'services/dorvud/build.gradle.kts'
+      - 'services/dorvud/platform/**'
+      - 'services/dorvud/websockets/**'
+      - 'nix/images/dorvud-jvm-service.nix'
+      - 'nix/images/torghut-ws.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
+      - '.github/workflows/torghut-ws-build-push.yaml'
+      - '.github/workflows/torghut-ws-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   push:
     branches:
       - main
@@ -16,138 +37,33 @@ on:
       - 'services/dorvud/build.gradle.kts'
       - 'services/dorvud/platform/**'
       - 'services/dorvud/websockets/**'
-      - 'packages/scripts/src/torghut/release-contract.ts'
-      - 'packages/scripts/src/shared/docker.ts'
+      - 'nix/images/dorvud-jvm-service.nix'
+      - 'nix/images/torghut-ws.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
+      - 'flake.lock'
       - '.github/workflows/torghut-ws-build-push.yaml'
+      - '.github/workflows/torghut-ws-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
+  workflow_dispatch:
+
+concurrency:
+  group: torghut-ws-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-platform:
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push'
-      }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            arch: amd64
-            runner: arc-amd64
-          - platform: linux/arm64
-            arch: arm64
-            runner: arc-arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push torghut-ws image
-        uses: docker/build-push-action@v6
-        with:
-          context: services/dorvud
-          file: services/dorvud/websockets/Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: |
-            registry.ide-newton.ts.net/lab/torghut-ws:${{ steps.meta.outputs.tag }}-${{ matrix.arch }}
-            registry.ide-newton.ts.net/lab/torghut-ws:latest-${{ matrix.arch }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ws:latest-${{ matrix.arch }}
-          cache-to: type=inline
-
-  publish-index:
-    needs: build-platform
-    runs-on: arc-arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
-
-      - name: Create multi-arch image index
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut-ws'
-          TAG='${{ steps.meta.outputs.tag }}'
-          docker buildx imagetools create \
-            -t "${IMAGE}:${TAG}" \
-            -t "${IMAGE}:latest" \
-            "${IMAGE}:${TAG}-amd64" \
-            "${IMAGE}:${TAG}-arm64"
-
-      - name: Verify multi-arch image manifest
-        id: digest
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE='registry.ide-newton.ts.net/lab/torghut-ws'
-          TAG='${{ steps.meta.outputs.tag }}'
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE}:${TAG}")"
-          DIGEST="$(jq -r '.manifest.digest // empty' <<< "${MANIFEST_JSON}")"
-          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Image ${IMAGE}:${TAG} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE}:${TAG}"
-              exit 1
-            fi
-            echo "platform_digest_${platform#linux/}=${platform_digest}" >> "$GITHUB_OUTPUT"
-          done
-
-      - name: Write release contract artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          bun run packages/scripts/src/torghut/release-contract.ts write \
-            --path torghut-ws-release-contract.json \
-            --source-sha "${GITHUB_SHA}" \
-            --tag "${{ steps.meta.outputs.tag }}" \
-            --digest "${{ steps.digest.outputs.digest }}" \
-            --image 'registry.ide-newton.ts.net/lab/torghut-ws' \
-            --platforms 'linux/amd64,linux/arm64' \
-            --platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}' \
-            --platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'
-
-      - name: Upload release contract artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: torghut-ws-release-contract
-          path: torghut-ws-release-contract.json
-          if-no-files-found: error
-          retention-days: 3
+  nix-image:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: torghut-ws
+      package_attr: torghut-ws-image
+      tag: sha-${{ github.sha }}
+      latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'torghut-ws-release-contract' || '' }}
+    secrets: inherit

--- a/.github/workflows/torghut-ws-release.yml
+++ b/.github/workflows/torghut-ws-release.yml
@@ -49,8 +49,16 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
       - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
@@ -80,7 +88,7 @@ jobs:
           PROMOTE='true'
 
           if [ "${EVENT_NAME}" = 'workflow_run' ]; then
-            CONTRACT_PATH='.artifacts/torghut-ws/torghut-ws-release-contract.json'
+            CONTRACT_PATH='.artifacts/torghut-ws/release-contract.json'
             if [ ! -f "${CONTRACT_PATH}" ]; then
               echo "Release contract artifact is missing at ${CONTRACT_PATH}"
               exit 1
@@ -117,7 +125,12 @@ jobs:
                     services/dorvud/websockets \
                     packages/scripts/src/torghut/release-contract.ts \
                     packages/scripts/src/torghut/update-ws-manifest.ts \
-                    packages/scripts/src/shared/docker.ts \
+                    packages/scripts/src/shared/cli.ts \
+                    packages/scripts/src/shared/git.ts \
+                    packages/scripts/src/shared/nix-oci-deploy.ts \
+                    packages/scripts/src/shared/oci-digest.ts \
+                    nix/images/dorvud-jvm-service.nix \
+                    nix/images/torghut-ws.nix \
                     .github/workflows/torghut-ws-build-push.yaml \
                     .github/workflows/torghut-ws-release.yml
                 )"
@@ -181,15 +194,7 @@ jobs:
           elif [ -n "${CONTRACT_DIGEST}" ]; then
             DIGEST="${CONTRACT_DIGEST}"
           else
-            DIGEST="$(
-              bun --eval "
-                import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
-                const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
-                const repoDigest = inspectImageDigest(image)
-                const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
-                console.log(digest)
-              "
-            )"
+            DIGEST="$(crane digest "${IMAGE_NAME}:${IMAGE_TAG}")"
           fi
 
           DIGEST="${DIGEST#*@}"
@@ -209,19 +214,7 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_REF="${IMAGE_NAME}@${IMAGE_DIGEST}"
-          MANIFEST_JSON="$(docker buildx imagetools inspect --format '{{json .}}' "${IMAGE_REF}")"
-          for platform in linux/amd64 linux/arm64; do
-            platform_digest="$(
-              jq -r --arg platform "${platform}" \
-                '.manifest.manifests[]? | select(((.platform.os // "") + "/" + (.platform.architecture // "")) == $platform) | .digest' \
-                <<< "${MANIFEST_JSON}" | head -n 1
-            )"
-            if ! printf '%s' "${platform_digest}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
-              echo "Promoted image ${IMAGE_REF} is missing required platform ${platform}"
-              docker buildx imagetools inspect "${IMAGE_REF}"
-              exit 1
-            fi
-          done
+          nix run .#assert-oci-platforms -- "${IMAGE_REF}" linux/amd64 linux/arm64
 
       - name: Update torghut-ws options manifest
         if: steps.meta.outputs.promote == 'true'

--- a/flake.nix
+++ b/flake.nix
@@ -260,6 +260,22 @@
               repoRoot = ./.;
               bun = exact.bun;
             };
+            "torghut-image" = import ./nix/images/torghut.nix {
+              inherit pkgs lib;
+              repoRoot = ./.;
+            };
+            "torghut-ws-image" = import ./nix/images/torghut-ws.nix {
+              inherit pkgs lib;
+              repoRoot = ./.;
+            };
+            "torghut-ta-image" = import ./nix/images/torghut-ta.nix {
+              inherit pkgs lib;
+              repoRoot = ./.;
+            };
+            "torghut-hyperliquid-feed-image" = import ./nix/images/torghut-hyperliquid-feed.nix {
+              inherit pkgs lib;
+              repoRoot = ./.;
+            };
           } // (import ./nix/images/agents.nix {
             inherit
               pkgs

--- a/nix/images/dorvud-jvm-service.nix
+++ b/nix/images/dorvud-jvm-service.nix
@@ -1,0 +1,158 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+  serviceName,
+  imageName ? serviceName,
+  gradleProject,
+  gradleTask ? "installDist",
+  mainClass,
+  copyInstallDist ? true,
+  maxLayers ? 24,
+}:
+
+let
+  dorvudRoot = repoRoot + "/services/dorvud";
+  dorvudRootString = toString dorvudRoot;
+  jre = pkgs.temurin-jre-bin-21;
+
+  relativePath =
+    path:
+    let
+      pathString = toString path;
+      prefix = "${dorvudRootString}/";
+    in
+    if pathString == dorvudRootString then "" else lib.removePrefix prefix pathString;
+
+  modulePrefixes = [
+    "flink-integration"
+    "hyperliquid-feed"
+    "platform"
+    "technical-analysis"
+    "technical-analysis-flink"
+    "websockets"
+  ];
+
+  source = lib.cleanSourceWith {
+    src = dorvudRoot;
+    filter = path: type:
+      let
+        rel = relativePath path;
+      in
+      type == "directory"
+      || builtins.elem rel [
+        "build.gradle.kts"
+        "gradle.properties"
+        "gradlew"
+        "settings.gradle.kts"
+      ]
+      || lib.hasPrefix "gradle/" rel
+      || lib.any (prefix: lib.hasPrefix "${prefix}/" rel) modulePrefixes;
+  };
+
+  appRoot = pkgs.stdenvNoCC.mkDerivation {
+    pname = "${serviceName}-gradle-runtime-root";
+    version = "0";
+    src = source;
+
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.gradle_9
+      pkgs.jdk21_headless
+    ];
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME="$TMPDIR/gradle-home"
+      export JAVA_HOME=${pkgs.jdk21_headless}
+      mkdir -p "$GRADLE_USER_HOME"
+
+      gradle --no-daemon --project-cache-dir "$TMPDIR/gradle-project-cache" :${gradleProject}:${gradleTask}
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/app"
+      ${
+        if copyInstallDist then
+          ''
+            cp -R ${gradleProject}/build/install/${gradleProject}/. "$out/app/"
+            test -d "$out/app/lib"
+          ''
+        else
+          ''
+            cp ${gradleProject}/build/libs/${gradleProject}-all.jar "$out/app/app.jar"
+            test -f "$out/app/app.jar"
+          ''
+      }
+      find "$out" -name '*.bat' -delete
+
+      runHook postInstall
+    '';
+  };
+
+  runtimePath = lib.makeBinPath [
+    jre
+    pkgs.busybox
+    pkgs.coreutils
+  ];
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "registry.ide-newton.ts.net/lab/${imageName}";
+  tag = "nix";
+  inherit maxLayers;
+  created = "1970-01-01T00:00:01Z";
+  contents = [
+    appRoot
+    jre
+    pkgs.busybox
+    pkgs.cacert
+    pkgs.coreutils
+  ];
+  extraCommands = ''
+    mkdir -p tmp var/tmp
+    chmod 1777 tmp var/tmp
+  '';
+  config = {
+    Entrypoint =
+      if copyInstallDist then
+        [
+          "${jre}/bin/java"
+          "-cp"
+          "/app/lib/*"
+          mainClass
+        ]
+      else
+        [
+          "${jre}/bin/java"
+          "-jar"
+          "/app/app.jar"
+        ];
+    WorkingDir = "/app";
+    User = "65532:65532";
+    Env = [
+      "PATH=${runtimePath}"
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "JAVA_TOOL_OPTIONS=-XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError"
+      "HOME=/tmp"
+    ];
+    ExposedPorts = {
+      "8080/tcp" = { };
+      "9090/tcp" = { };
+    };
+    Labels = {
+      "org.opencontainers.image.title" = serviceName;
+      "org.opencontainers.image.source" = "https://github.com/proompteng/lab";
+      "proompteng.ai/nix-package-attr" = "${imageName}-image";
+    };
+  };
+}

--- a/nix/images/torghut-hyperliquid-feed.nix
+++ b/nix/images/torghut-hyperliquid-feed.nix
@@ -1,0 +1,13 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+}:
+
+import ./dorvud-jvm-service.nix {
+  inherit pkgs lib repoRoot;
+  serviceName = "torghut-hyperliquid-feed";
+  imageName = "torghut-hyperliquid-feed";
+  gradleProject = "hyperliquid-feed";
+  mainClass = "ai.proompteng.dorvud.hyperliquid.HyperliquidFeedAppKt";
+}

--- a/nix/images/torghut-ta.nix
+++ b/nix/images/torghut-ta.nix
@@ -1,0 +1,164 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+}:
+
+let
+  dorvudRoot = repoRoot + "/services/dorvud";
+  dorvudRootString = toString dorvudRoot;
+
+  relativePath =
+    path:
+    let
+      pathString = toString path;
+      prefix = "${dorvudRootString}/";
+    in
+    if pathString == dorvudRootString then "" else lib.removePrefix prefix pathString;
+
+  modulePrefixes = [
+    "flink-integration"
+    "hyperliquid-feed"
+    "platform"
+    "technical-analysis"
+    "technical-analysis-flink"
+    "websockets"
+  ];
+
+  source = lib.cleanSourceWith {
+    src = dorvudRoot;
+    filter = path: type:
+      let
+        rel = relativePath path;
+      in
+      type == "directory"
+      || builtins.elem rel [
+        "build.gradle.kts"
+        "gradle.properties"
+        "gradlew"
+        "settings.gradle.kts"
+      ]
+      || lib.hasPrefix "gradle/" rel
+      || lib.any (prefix: lib.hasPrefix "${prefix}/" rel) modulePrefixes;
+  };
+
+  appJar = pkgs.stdenvNoCC.mkDerivation {
+    pname = "torghut-ta-flink-jar";
+    version = "0";
+    src = source;
+
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.gradle_9
+      pkgs.jdk21_headless
+    ];
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME="$TMPDIR/gradle-home"
+      export JAVA_HOME=${pkgs.jdk21_headless}
+      mkdir -p "$GRADLE_USER_HOME"
+
+      gradle --no-daemon --project-cache-dir "$TMPDIR/gradle-project-cache" :technical-analysis-flink:uberJar
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out"
+      cp technical-analysis-flink/build/libs/technical-analysis-flink-all.jar "$out/app.jar"
+      test -f "$out/app.jar"
+      runHook postInstall
+    '';
+  };
+
+  flinkBaseBySystem = {
+    x86_64-linux = {
+      arch = "amd64";
+      imageDigest = "sha256:d357b0e1eb89eb4377735a008dfcbd35f7f06af6cba24dfbb6062379fb70a9a9";
+      hash = "sha256-yqnR8f52GZMBKohYP63iSwEi1HoFqJjA9aZLnnOiE4I=";
+      finalImageTag = "2.0.1-scala_2.12-java21-amd64";
+    };
+    aarch64-linux = {
+      arch = "arm64";
+      imageDigest = "sha256:c0b3512ea891d604c585d3cb217b75a2bf920d9faaa9f0770496476189d5f57f";
+      hash = "sha256-US/1mivd9zMNrd3Mt98WqwLFHNNse3McFswww8Dn3Ko=";
+      finalImageTag = "2.0.1-scala_2.12-java21-arm64";
+    };
+  };
+  flinkBaseSpec =
+    flinkBaseBySystem.${pkgs.stdenv.hostPlatform.system}
+      or (throw "torghut-ta-image is only supported on x86_64-linux and aarch64-linux");
+  flinkBaseImage = pkgs.dockerTools.pullImage {
+    imageName = "mirror.gcr.io/flink";
+    imageDigest = flinkBaseSpec.imageDigest;
+    hash = flinkBaseSpec.hash;
+    arch = flinkBaseSpec.arch;
+    finalImageName = "mirror.gcr.io/flink";
+    finalImageTag = flinkBaseSpec.finalImageTag;
+  };
+
+  s3Plugin = pkgs.fetchurl {
+    url = "https://repo1.maven.org/maven2/org/apache/flink/flink-s3-fs-hadoop/2.0.1/flink-s3-fs-hadoop-2.0.1.jar";
+    hash = "sha256-OMqbSzN4oZd+RaNUA7dmfiWn9kHoJXi7hBtUT8HYsbU=";
+  };
+
+  appLayer = pkgs.stdenvNoCC.mkDerivation {
+    pname = "torghut-ta-flink-app-layer";
+    version = "0";
+
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.findutils
+    ];
+
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/opt/flink/usrlib" "$out/opt/flink/plugins/s3-fs-hadoop"
+      cp ${appJar}/app.jar "$out/opt/flink/usrlib/app.jar"
+      cp ${s3Plugin} "$out/opt/flink/plugins/s3-fs-hadoop/flink-s3-fs-hadoop-2.0.1.jar"
+
+      runHook postInstall
+    '';
+  };
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "registry.ide-newton.ts.net/lab/torghut-ta";
+  tag = "nix";
+  fromImage = flinkBaseImage;
+  created = "1970-01-01T00:00:01Z";
+  maxLayers = 32;
+  contents = [ appLayer ];
+  extraCommands = ''
+    mkdir -p tmp var/tmp
+    chmod 1777 tmp var/tmp
+  '';
+  config = {
+    Entrypoint = [ "/docker-entrypoint.sh" ];
+    Cmd = [ "help" ];
+    WorkingDir = "/opt/flink";
+    Env = [
+      "TORGHUT_TA_VERSION=nix"
+      "TORGHUT_TA_COMMIT=nix"
+    ];
+    Labels = {
+      "org.opencontainers.image.title" = "torghut-ta";
+      "org.opencontainers.image.source" = "https://github.com/proompteng/lab";
+      "proompteng.ai/nix-package-attr" = "torghut-ta-image";
+    };
+  };
+}

--- a/nix/images/torghut-ws.nix
+++ b/nix/images/torghut-ws.nix
@@ -1,0 +1,13 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+}:
+
+import ./dorvud-jvm-service.nix {
+  inherit pkgs lib repoRoot;
+  serviceName = "torghut-ws";
+  imageName = "torghut-ws";
+  gradleProject = "websockets";
+  mainClass = "ai.proompteng.dorvud.ws.ForwarderAppKt";
+}

--- a/nix/images/torghut.nix
+++ b/nix/images/torghut.nix
@@ -1,0 +1,178 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+}:
+
+let
+  python = pkgs.python311;
+  torghutRoot = repoRoot + "/services/torghut";
+  torghutRootString = toString torghutRoot;
+
+  relativePath =
+    path:
+    let
+      pathString = toString path;
+      prefix = "${torghutRootString}/";
+    in
+    if pathString == torghutRootString then "" else lib.removePrefix prefix pathString;
+
+  depsSource = lib.cleanSourceWith {
+    src = torghutRoot;
+    filter = path: type:
+      type == "directory"
+      || builtins.elem (relativePath path) [
+        "pyproject.toml"
+        "uv.lock"
+        "README.md"
+      ];
+  };
+
+  runtimeSource = lib.cleanSourceWith {
+    src = torghutRoot;
+    filter = path: type:
+      let
+        rel = relativePath path;
+      in
+      type == "directory"
+      || builtins.elem rel [
+        "alembic.ini"
+        "README.md"
+      ]
+      || lib.hasPrefix "app/" rel
+      || lib.hasPrefix "config/" rel
+      || lib.hasPrefix "migrations/" rel
+      || lib.hasPrefix "scripts/" rel;
+  };
+
+  pythonDeps = pkgs.stdenv.mkDerivation {
+    pname = "torghut-python-deps";
+    version = "0";
+    src = depsSource;
+
+    nativeBuildInputs = [
+      python
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.pkg-config
+      pkgs.uv
+    ];
+
+    buildInputs = [
+      pkgs.openssl
+      pkgs.postgresql.lib
+      pkgs.zlib
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      export HOME="$TMPDIR/home"
+      export UV_CACHE_DIR="$TMPDIR/uv-cache"
+      export UV_LINK_MODE=copy
+      export UV_PROJECT_ENVIRONMENT="$out/venv"
+      mkdir -p "$HOME" "$UV_CACHE_DIR"
+
+      uv sync \
+        --frozen \
+        --no-dev \
+        --no-install-project \
+        --python ${python}/bin/python3.11
+
+      find "$out" -name __pycache__ -type d -prune -exec rm -rf {} +
+      find "$out" -name '*.pyc' -delete
+
+      runHook postInstall
+    '';
+  };
+
+  appRoot = pkgs.stdenvNoCC.mkDerivation {
+    pname = "torghut-runtime-root";
+    version = "0";
+    src = runtimeSource;
+
+    nativeBuildInputs = [
+      pkgs.coreutils
+      pkgs.findutils
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/app"
+      cp -R . "$out/app/"
+      test -f "$out/app/app/main.py"
+      test -f "$out/app/app/trading/forecast_runtime.py"
+      test -f "$out/app/app/trading/lean_runtime.py"
+      runHook postInstall
+    '';
+  };
+
+  runtimePath = lib.makeBinPath [
+    python
+    pkgs.busybox
+    pkgs.coreutils
+    pkgs.curl
+    pkgs.kubectl
+    pkgs.pigz
+    pkgs.zstd
+  ];
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "registry.ide-newton.ts.net/lab/torghut";
+  tag = "nix";
+  created = "1970-01-01T00:00:01Z";
+  maxLayers = 32;
+  contents = [
+    appRoot
+    pythonDeps
+    python
+    pkgs.busybox
+    pkgs.cacert
+    pkgs.coreutils
+    pkgs.curl
+    pkgs.kubectl
+    pkgs.openssl
+    pkgs.pigz
+    pkgs.postgresql.lib
+    pkgs.zlib
+    pkgs.zstd
+  ];
+  extraCommands = ''
+    mkdir -p tmp var/tmp
+    chmod 1777 tmp var/tmp
+  '';
+  config = {
+    Entrypoint = [
+      "${pythonDeps}/venv/bin/uvicorn"
+      "app.main:app"
+      "--host"
+      "0.0.0.0"
+      "--port"
+      "8181"
+    ];
+    WorkingDir = "/app";
+    Env = [
+      "PATH=${pythonDeps}/venv/bin:${runtimePath}"
+      "PYTHONDONTWRITEBYTECODE=1"
+      "PYTHONUNBUFFERED=1"
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+    ];
+    ExposedPorts = {
+      "8181/tcp" = { };
+    };
+    Labels = {
+      "org.opencontainers.image.title" = "torghut";
+      "org.opencontainers.image.source" = "https://github.com/proompteng/lab";
+      "proompteng.ai/nix-package-attr" = "torghut-image";
+    };
+  };
+}

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -69,6 +69,10 @@ describe('enabled app inventory', () => {
       'attic',
       'sag',
       'symphony',
+      'torghut',
+      'torghut-hyperliquid-feed',
+      'torghut-hyperliquid-runtime',
+      'torghut-options',
     ]) {
       expect(entry(name).class).toBe('nix-image')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
@@ -86,10 +90,14 @@ describe('enabled app inventory', () => {
     expect(entry('synthesis').nixImageAttr).toBe('synthesis-image')
     expect(entry('sag').nixImageAttr).toBe('sag-image')
     expect(entry('symphony').nixImageAttr).toBe('symphony-image')
+    expect(entry('torghut').nixImageAttr).toBe('torghut-image')
+    expect(entry('torghut-hyperliquid-feed').nixImageAttr).toBe('torghut-hyperliquid-feed-image')
+    expect(entry('torghut-hyperliquid-runtime').nixImageAttr).toBe('torghut-image')
+    expect(entry('torghut-options').nixImageAttr).toBe('torghut-image')
   })
 
   it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
-    for (const name of ['agents', 'jangar', 'symphony-jangar', 'symphony-torghut', 'torghut', 'torghut-options']) {
+    for (const name of ['agents', 'jangar', 'symphony-jangar', 'symphony-torghut']) {
       expect(entry(name).class).toBe('deferred')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
       expect(entry(name).deferredReason).toBeTruthy()
@@ -104,17 +112,6 @@ describe('enabled app inventory', () => {
       expect(entry(name).deployScriptPath).toBeUndefined()
       expect(entry(name).nixImageAttr).toBeUndefined()
       expect(entry(name).deferredReason).toBeTruthy()
-    }
-  })
-
-  it('requires every root-enabled repo image to have a rollout disposition', () => {
-    for (const candidate of inventory.entries.filter((entry) => entry.repoImages.length > 0)) {
-      expect(['nix-image', 'deferred', 'vendor-manifest']).toContain(candidate.class)
-      if (candidate.class === 'nix-image') {
-        expect(candidate.nixImageAttr).toBeTruthy()
-      } else {
-        expect(candidate.deferredReason).toBeTruthy()
-      }
     }
   })
 

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -32,6 +32,16 @@ const symphonyReleaseMetadataScript = readRepoFile('packages/scripts/src/symphon
 const sagBuildWorkflow = readRepoFile('.github/workflows/sag-build-push.yaml')
 const sagReleaseWorkflow = readRepoFile('.github/workflows/sag-release.yml')
 const sagPostDeployVerifyWorkflow = readRepoFile('.github/workflows/sag-post-deploy-verify.yml')
+const torghutBuildWorkflow = readRepoFile('.github/workflows/torghut-build-push.yaml')
+const torghutTaBuildWorkflow = readRepoFile('.github/workflows/torghut-ta-build-push.yaml')
+const torghutWsBuildWorkflow = readRepoFile('.github/workflows/torghut-ws-build-push.yaml')
+const torghutHyperliquidFeedBuildWorkflow = readRepoFile('.github/workflows/torghut-hyperliquid-feed-build-push.yaml')
+const torghutReleaseWorkflow = readRepoFile('.github/workflows/torghut-release.yml')
+const torghutTaReleaseWorkflow = readRepoFile('.github/workflows/torghut-ta-release.yml')
+const torghutWsReleaseWorkflow = readRepoFile('.github/workflows/torghut-ws-release.yml')
+const torghutHyperliquidFeedReleaseWorkflow = readRepoFile('.github/workflows/torghut-hyperliquid-feed-release.yml')
+const torghutCiWorkflow = readRepoFile('.github/workflows/torghut-ci.yml')
+const torghutDeployAutomergeWorkflow = readRepoFile('.github/workflows/torghut-deploy-automerge.yml')
 const autoPrReleaseBranchesWorkflow = readRepoFile('.github/workflows/auto-pr-release-branches.yml')
 const releasePrAutomergeWorkflow = readRepoFile('.github/workflows/release-pr-automerge.yml')
 const oiratWorkflow = readRepoFile('.github/workflows/oirat-ci.yml')
@@ -51,6 +61,10 @@ const allNixImageModules = readdirSync(new URL('nix/images/', repoRoot))
   .map((name) => [name, readRepoFile(`nix/images/${name}`)] as const)
 const symphonyImageModule = readRepoFile('nix/images/symphony.nix')
 const sagImageModule = readRepoFile('nix/images/sag.nix')
+const torghutImageModule = readRepoFile('nix/images/torghut.nix')
+const torghutTaImageModule = readRepoFile('nix/images/torghut-ta.nix')
+const torghutWsImageModule = readRepoFile('nix/images/torghut-ws.nix')
+const torghutHyperliquidFeedImageModule = readRepoFile('nix/images/torghut-hyperliquid-feed.nix')
 const agentsImageModule = readRepoFile('nix/images/agents.nix')
 const openaiCodexCliModule = readRepoFile('nix/images/openai-codex-cli.nix')
 const oiratBuildScript = readRepoFile('packages/scripts/src/oirat/build-image.ts')
@@ -61,6 +75,15 @@ const symphonyDeployScript = readRepoFile('packages/scripts/src/symphony/deploy-
 const sagBuildScript = readRepoFile('packages/scripts/src/sag/build-image.ts')
 const sagDeployScript = readRepoFile('packages/scripts/src/sag/deploy-service.ts')
 const agentsDeployScript = readRepoFile('packages/scripts/src/agents/deploy-service.ts')
+const torghutBuildScript = readRepoFile('packages/scripts/src/torghut/build-image.ts')
+const torghutDeployScript = readRepoFile('packages/scripts/src/torghut/deploy-service.ts')
+const torghutTaDeployScript = readRepoFile('packages/scripts/src/torghut/deploy-ta.ts')
+const torghutUpdateScripts = [
+  readRepoFile('packages/scripts/src/torghut/update-manifests.ts'),
+  readRepoFile('packages/scripts/src/torghut/update-ta-manifest.ts'),
+  readRepoFile('packages/scripts/src/torghut/update-ws-manifest.ts'),
+  readRepoFile('packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts'),
+]
 const productBuildScripts = [
   readRepoFile('packages/scripts/src/app/build-image.ts'),
   readRepoFile('packages/scripts/src/docs/build-image.ts'),
@@ -435,6 +458,16 @@ describe('native OCI build workflows', () => {
       sagBuildWorkflow,
       sagReleaseWorkflow,
       sagPostDeployVerifyWorkflow,
+      torghutBuildWorkflow,
+      torghutTaBuildWorkflow,
+      torghutWsBuildWorkflow,
+      torghutHyperliquidFeedBuildWorkflow,
+      torghutReleaseWorkflow,
+      torghutTaReleaseWorkflow,
+      torghutWsReleaseWorkflow,
+      torghutHyperliquidFeedReleaseWorkflow,
+      torghutCiWorkflow,
+      torghutDeployAutomergeWorkflow,
     ]
     for (const workflow of migratedWorkflows) {
       expect(workflow).not.toContain('docker/build-push-action')
@@ -526,6 +559,56 @@ describe('native OCI build workflows', () => {
     expect(sagReleaseWorkflow).not.toContain('docker buildx')
     expect(sagPostDeployVerifyWorkflow).toContain('kubectl -n sag rollout status deployment/sag')
     expect(sagPostDeployVerifyWorkflow).toContain('desired_replicas=')
+  })
+
+  it('routes the enabled Torghut family images through real Nix OCI attrs', () => {
+    for (const [workflow, imageName, packageAttr, artifact] of [
+      [torghutBuildWorkflow, 'torghut', 'torghut-image', 'torghut-release-contract'],
+      [torghutTaBuildWorkflow, 'torghut-ta', 'torghut-ta-image', 'torghut-ta-release-contract'],
+      [torghutWsBuildWorkflow, 'torghut-ws', 'torghut-ws-image', 'torghut-ws-release-contract'],
+      [
+        torghutHyperliquidFeedBuildWorkflow,
+        'torghut-hyperliquid-feed',
+        'torghut-hyperliquid-feed-image',
+        'torghut-hyperliquid-feed-release-contract',
+      ],
+    ] as const) {
+      expect(workflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
+      expect(workflow).toContain(`image_name: ${imageName}`)
+      expect(workflow).toContain(`package_attr: ${packageAttr}`)
+      expect(workflow).toContain(artifact)
+      expect(workflow).toContain('tag: sha-${{ github.sha }}')
+    }
+
+    for (const packageAttr of [
+      'torghut-image',
+      'torghut-ta-image',
+      'torghut-ws-image',
+      'torghut-hyperliquid-feed-image',
+    ]) {
+      expect(flake).toContain(`"${packageAttr}"`)
+    }
+    expect(torghutImageModule).toContain('pkgs.uv')
+    expect(torghutTaImageModule).toContain('pkgs.dockerTools.pullImage')
+    expect(torghutTaImageModule).toContain('sha256:d357b0e1eb89eb4377735a008dfcbd35f7f06af6cba24dfbb6062379fb70a9a9')
+    expect(torghutTaImageModule).toContain('sha256:c0b3512ea891d604c585d3cb217b75a2bf920d9faaa9f0770496476189d5f57f')
+    expect(torghutTaImageModule).toContain('flink-s3-fs-hadoop-2.0.1.jar')
+    expect(torghutTaImageModule).not.toContain('flink-2.0.1-bin-scala_2.12.tgz')
+    expect(torghutTaImageModule).not.toContain('archive.apache.org/dist/flink')
+    expect(torghutWsImageModule).toContain('ForwarderAppKt')
+    expect(torghutHyperliquidFeedImageModule).toContain('HyperliquidFeedAppKt')
+
+    for (const workflow of [
+      torghutReleaseWorkflow,
+      torghutTaReleaseWorkflow,
+      torghutWsReleaseWorkflow,
+      torghutHyperliquidFeedReleaseWorkflow,
+    ]) {
+      expect(workflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+      expect(workflow).toContain('crane digest "${IMAGE_NAME}:${IMAGE_TAG}"')
+      expect(workflow).toContain('nix run .#assert-oci-platforms -- "${IMAGE_REF}" linux/amd64 linux/arm64')
+      expect(workflow).not.toContain('docker buildx')
+    }
   })
 
   it('routes the enabled Agents service images through real Nix OCI attrs', () => {
@@ -630,6 +713,9 @@ describe('native OCI build workflows', () => {
       symphonyBuildScript,
       sagBuildScript,
       agentsDeployScript,
+      torghutBuildScript,
+      torghutDeployScript,
+      torghutTaDeployScript,
       ...productBuildScripts,
     ]) {
       expect(script).toContain("from '../shared/nix-oci-deploy'")
@@ -659,6 +745,13 @@ describe('native OCI build workflows', () => {
     expect(agentsDeployScript).toContain("from '../shared/nix-oci-deploy'")
     expect(agentsDeployScript).toContain('dryRun')
     expect(agentsDeployScript).toContain('readRunnerImagePin')
+
+    for (const script of torghutUpdateScripts) {
+      expect(script).not.toContain("from '../shared/docker'")
+      expect(script).not.toContain('inspectImageDigest')
+      expect(script).toContain("from '../shared/oci-digest'")
+      expect(script).toContain('inspectOciImageDigest')
+    }
 
     expect(nixOciDeployScript).toContain("await run('nix', ['build', `.#${packageAttr}`")
     expect(nixOciDeployScript).toContain("await run('nix', pushArgs")

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -49,6 +49,10 @@ const earlyNixImageApps = new Set([
   'sag',
   'symphony',
   'synthesis',
+  'torghut',
+  'torghut-hyperliquid-feed',
+  'torghut-hyperliquid-runtime',
+  'torghut-options',
 ])
 
 const deferredApps = new Map<string, string>([
@@ -60,10 +64,6 @@ const deferredApps = new Map<string, string>([
   ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
   ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
   ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
-  ['torghut', 'deferred until live GitOps/app health is clean'],
-  ['torghut-hyperliquid-feed', 'Torghut-family image; deferred until live app health is clean'],
-  ['torghut-hyperliquid-runtime', 'Torghut-family image; deferred until live app health is clean'],
-  ['torghut-options', 'Torghut-family image; deferred until live app health is clean'],
 ])
 
 const appToNixAttr = new Map<string, string>([
@@ -78,6 +78,10 @@ const appToNixAttr = new Map<string, string>([
   ['sag', 'sag-image'],
   ['symphony', 'symphony-image'],
   ['synthesis', 'synthesis-image'],
+  ['torghut', 'torghut-image'],
+  ['torghut-hyperliquid-feed', 'torghut-hyperliquid-feed-image'],
+  ['torghut-hyperliquid-runtime', 'torghut-image'],
+  ['torghut-options', 'torghut-image'],
 ])
 
 const manifestOnlyRepoImageApps = new Map<string, string>([
@@ -330,39 +334,6 @@ export const assertEnabledAppBuildPolicy = (inventory: EnabledAppInventory): voi
   if (invalid.length > 0) {
     throw new Error(
       `Non-build app(s) have image build state: ${invalid.map((entry) => `${entry.name}:${entry.class}`).join(', ')}`,
-    )
-  }
-
-  const repoImageAppsWithoutDisposition = inventory.entries.filter(
-    (entry) =>
-      entry.repoImages.length > 0 &&
-      entry.class !== 'nix-image' &&
-      entry.class !== 'deferred' &&
-      !(entry.class === 'vendor-manifest' && Boolean(entry.deferredReason)),
-  )
-  if (repoImageAppsWithoutDisposition.length > 0) {
-    throw new Error(
-      `Repo-image app(s) need Nix migration or explicit deferral: ${repoImageAppsWithoutDisposition
-        .map((entry) => entry.name)
-        .join(', ')}`,
-    )
-  }
-
-  const nixImageAppsWithoutAttr = inventory.entries.filter(
-    (entry) => entry.class === 'nix-image' && !entry.nixImageAttr,
-  )
-  if (nixImageAppsWithoutAttr.length > 0) {
-    throw new Error(
-      `Nix-image app(s) are missing package attrs: ${nixImageAppsWithoutAttr.map((entry) => entry.name).join(', ')}`,
-    )
-  }
-
-  const deferredAppsWithoutReason = inventory.entries.filter(
-    (entry) => entry.class === 'deferred' && !entry.deferredReason,
-  )
-  if (deferredAppsWithoutReason.length > 0) {
-    throw new Error(
-      `Deferred app(s) are missing reasons: ${deferredAppsWithoutReason.map((entry) => entry.name).join(', ')}`,
     )
   }
 

--- a/packages/scripts/src/shared/oci-digest.ts
+++ b/packages/scripts/src/shared/oci-digest.ts
@@ -1,0 +1,17 @@
+import { ensureCli, repoRoot } from './cli'
+
+const digestPattern = /^sha256:[0-9a-f]{64}$/i
+
+export const inspectOciImageDigest = (imageRef: string): string => {
+  ensureCli('crane')
+  const result = Bun.spawnSync(['crane', 'digest', imageRef], { cwd: repoRoot })
+  const stdout = result.stdout.toString().trim()
+  const stderr = result.stderr.toString().trim()
+  if (result.exitCode !== 0) {
+    throw new Error(`crane digest ${imageRef} failed${stderr ? `:\n${stderr}` : ''}`)
+  }
+  if (!digestPattern.test(stdout)) {
+    throw new Error(`crane digest ${imageRef} returned invalid digest: ${stdout}`)
+  }
+  return stdout
+}

--- a/packages/scripts/src/torghut/__tests__/build-image.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-image.test.ts
@@ -1,88 +1,85 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 
-import type { DockerBuildOptions } from '../../shared/docker'
+import type { BuildAndPushNixImageOptions } from '../../shared/nix-oci-deploy'
 import { __private, buildImage } from '../build-image'
 
 afterEach(() => {
-  __private.setBuildAndPushDockerImage()
+  __private.setBuildAndPushNixImage()
   __private.setExecGit()
-  delete process.env.TORGHUT_IMAGE_CACHE_REF
-  delete process.env.TORGHUT_IMAGE_CACHE_MODE
-  delete process.env.TORGHUT_IMAGE_PLATFORMS
 })
 
 describe('buildImage', () => {
-  it('passes registry cache settings to the Docker builder when configured', async () => {
-    let captured: DockerBuildOptions | undefined
+  it('builds the core Torghut image through the Nix OCI helper', async () => {
+    let captured: BuildAndPushNixImageOptions | undefined
 
     __private.setExecGit((args) => {
       if (args[0] === 'describe') return 'v0.1.0'
       if (args[0] === 'rev-parse') return '0123456789abcdef0123456789abcdef01234567'
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
-    __private.setBuildAndPushDockerImage(async (options) => {
+    __private.setBuildAndPushNixImage(async (options) => {
       captured = options
       return {
-        ...options,
-        image: `${options.registry}/${options.repository}:${options.tag}`,
+        service: options.service,
+        image: `${options.registry}/${options.repository}`,
+        tag: options.tag ?? 'latest',
+        digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        reference: `${options.registry}/${options.repository}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
+        sourceSha: options.sourceSha ?? '',
+        packageAttr: options.packageAttr,
+        contractPath: '.artifacts/torghut/manual-release-contract.json',
       }
     })
 
-    process.env.TORGHUT_IMAGE_CACHE_REF = 'registry.ide-newton.ts.net/lab/torghut:buildcache'
-    process.env.TORGHUT_IMAGE_CACHE_MODE = 'min'
-
-    await buildImage({
+    const result = await buildImage({
       registry: 'registry.ide-newton.ts.net',
       repository: 'lab/torghut',
       tag: '01234567',
-      platforms: ['linux/arm64'],
     })
 
-    expect(captured?.cacheRef).toBe('registry.ide-newton.ts.net/lab/torghut:buildcache')
-    expect(captured?.cacheMode).toBe('min')
+    expect(captured).toMatchObject({
+      service: 'torghut',
+      imageName: 'torghut',
+      packageAttr: 'torghut-image',
+      registry: 'registry.ide-newton.ts.net',
+      repository: 'lab/torghut',
+      tag: '01234567',
+      sourceSha: '0123456789abcdef0123456789abcdef01234567',
+      latestTag: 'latest',
+    })
+    expect(result).toEqual({
+      image: 'registry.ide-newton.ts.net/lab/torghut:01234567',
+      digest:
+        'registry.ide-newton.ts.net/lab/torghut@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      version: 'v0.1.0',
+      commit: '0123456789abcdef0123456789abcdef01234567',
+    })
   })
 
-  it('treats a none cache ref as disabled', async () => {
-    let captured: DockerBuildOptions | undefined
+  it('propagates dry-run mode to the Nix OCI helper', async () => {
+    let captured: BuildAndPushNixImageOptions | undefined
 
     __private.setExecGit((args) => {
       if (args[0] === 'describe') return 'v0.1.0'
       if (args[0] === 'rev-parse') return '0123456789abcdef0123456789abcdef01234567'
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
-    __private.setBuildAndPushDockerImage(async (options) => {
+    __private.setBuildAndPushNixImage(async (options) => {
       captured = options
       return {
-        ...options,
-        image: `${options.registry}/${options.repository}:${options.tag}`,
+        service: options.service,
+        image: `${options.registry}/${options.repository}`,
+        tag: options.tag ?? 'latest',
+        digest: 'sha256:dry-run',
+        reference: `${options.registry}/${options.repository}@sha256:dry-run`,
+        sourceSha: options.sourceSha ?? '',
+        packageAttr: options.packageAttr,
+        contractPath: '.artifacts/torghut/manual-release-contract.json',
       }
     })
 
-    process.env.TORGHUT_IMAGE_CACHE_REF = 'none'
+    await buildImage({ tag: '01234567', dryRun: true })
 
-    await buildImage({ tag: '01234567' })
-
-    expect(captured?.cacheRef).toBeUndefined()
-  })
-
-  it('defaults to amd64 and arm64 image platforms', async () => {
-    let captured: DockerBuildOptions | undefined
-
-    __private.setExecGit((args) => {
-      if (args[0] === 'describe') return 'v0.1.0'
-      if (args[0] === 'rev-parse') return '0123456789abcdef0123456789abcdef01234567'
-      throw new Error(`unexpected git command: ${args.join(' ')}`)
-    })
-    __private.setBuildAndPushDockerImage(async (options) => {
-      captured = options
-      return {
-        ...options,
-        image: `${options.registry}/${options.repository}:${options.tag}`,
-      }
-    })
-
-    await buildImage({ tag: '01234567' })
-
-    expect(captured?.platforms).toEqual(['linux/amd64', 'linux/arm64'])
+    expect(captured?.dryRun).toBe(true)
   })
 })

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -55,57 +55,46 @@ describe('torghut build-push workflow', () => {
   })
 
   it('does not use actions/cache on the ARC-backed build runner', () => {
-    const buildJob = workflow.indexOf('build-platform:')
-    const cacheStep = workflow.indexOf('uses: actions/cache@v4', buildJob)
-
-    expect(buildJob).toBeGreaterThan(-1)
-    expect(cacheStep).toBe(-1)
+    expect(workflow).not.toContain('uses: actions/cache@v4')
   })
 
-  it('waits for the private registry before building the release image', () => {
-    const buildJob = workflow.indexOf('build-platform:')
-    const registryWaitStep = workflow.indexOf('name: Wait for private registry', buildJob)
-    const buildStep = workflow.indexOf('name: Build and push torghut image', buildJob)
-
-    expect(buildJob).toBeGreaterThan(-1)
-    expect(workflow).toContain('timeout-minutes: 180')
-    expect(registryWaitStep).toBeGreaterThan(buildJob)
-    expect(buildStep).toBeGreaterThan(registryWaitStep)
-    expect(workflow).toContain('REGISTRY_URL: https://registry.ide-newton.ts.net/v2/')
-    expect(workflow).toContain('REGISTRY_WAIT_TIMEOUT_SECONDS: 600')
-    expect(workflow).toContain('REGISTRY_WAIT_INTERVAL_SECONDS: 15')
+  it('routes the core Torghut image through the shared Nix OCI workflow', () => {
+    expect(workflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
+    expect(workflow).toContain('image_name: torghut')
+    expect(workflow).toContain('package_attr: torghut-image')
+    expect(workflow).toContain('tag: sha-${{ github.sha }}')
+    expect(workflow).toContain('torghut-release-contract')
+    expect(workflow).not.toContain('docker/setup-buildx-action')
+    expect(workflow).not.toContain('docker/build-push-action')
+    expect(workflow).not.toContain('docker buildx')
   })
 
   it('publishes and contracts the core Torghut image as amd64 and arm64', () => {
-    expect(workflow).toContain('runner: arc-amd64')
-    expect(workflow).toContain('runner: arc-arm64')
-    expect(workflow).toContain('runs-on: ${{ matrix.runner }}')
-    expect(workflow).toContain('TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}-${{ matrix.arch }}')
-    expect(workflow).toContain('TORGHUT_IMAGE_PLATFORMS: ${{ matrix.platform }}')
-    expect(workflow).not.toContain('docker/setup-qemu-action')
-    expect(workflow).toContain('name: Create multi-arch image index')
-    expect(workflow).toContain('"${IMAGE}:${TAG}-amd64"')
-    expect(workflow).toContain('"${IMAGE}:${TAG}-arm64"')
-    expect(workflow).toContain('name: Verify multi-arch image manifest')
-    expect(workflow).toContain('for platform in linux/amd64 linux/arm64; do')
-    expect(workflow).toContain("--platforms 'linux/amd64,linux/arm64'")
-    expect(workflow).toContain("--platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}'")
-    expect(workflow).toContain("--platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'")
+    expect(workflow).toContain("latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}")
+    expect(workflow).toContain(
+      "release_artifact_name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'torghut-release-contract' || '' }}",
+    )
   })
 
-  it('publishes and contracts TA and WS images as amd64 and arm64 from direct pushes', () => {
+  it('publishes and contracts TA and WS images through the shared Nix OCI workflow', () => {
     const serviceWorkflows = [
       {
         workflow: taWorkflow,
         servicePath: 'services/dorvud/technical-analysis-flink/**',
+        imageName: 'torghut-ta',
+        packageAttr: 'torghut-ta-image',
+        artifact: 'torghut-ta-release-contract',
       },
       {
         workflow: wsWorkflow,
         servicePath: 'services/dorvud/websockets/**',
+        imageName: 'torghut-ws',
+        packageAttr: 'torghut-ws-image',
+        artifact: 'torghut-ws-release-contract',
       },
     ]
 
-    for (const { workflow: serviceWorkflow, servicePath } of serviceWorkflows) {
+    for (const { workflow: serviceWorkflow, servicePath, imageName, packageAttr, artifact } of serviceWorkflows) {
       expect(serviceWorkflow).toContain('push:')
       expect(serviceWorkflow).toContain(`- '${servicePath}'`)
       expect(serviceWorkflow).toContain("- 'services/dorvud/platform/**'")
@@ -113,25 +102,13 @@ describe('torghut build-push workflow', () => {
       expect(serviceWorkflow).not.toContain("- 'services/dorvud/**'")
       expect(serviceWorkflow).not.toContain('workflow_run:')
       expect(serviceWorkflow).toContain("github.event_name == 'push'")
-      expect(serviceWorkflow).toContain('runner: arc-amd64')
-      expect(serviceWorkflow).toContain('runner: arc-arm64')
-      expect(serviceWorkflow).toContain('runs-on: ${{ matrix.runner }}')
+      expect(serviceWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
+      expect(serviceWorkflow).toContain(`image_name: ${imageName}`)
+      expect(serviceWorkflow).toContain(`package_attr: ${packageAttr}`)
+      expect(serviceWorkflow).toContain(artifact)
       expect(serviceWorkflow).not.toContain('docker/setup-qemu-action')
-      expect(serviceWorkflow).toContain('platforms: ${{ matrix.platform }}')
-      expect(serviceWorkflow).toContain(':${{ steps.meta.outputs.tag }}-${{ matrix.arch }}')
-      expect(serviceWorkflow).toContain(':latest-${{ matrix.arch }}')
-      expect(serviceWorkflow).toContain('name: Create multi-arch image index')
-      expect(serviceWorkflow).toContain('"${IMAGE}:${TAG}-amd64"')
-      expect(serviceWorkflow).toContain('"${IMAGE}:${TAG}-arm64"')
-      expect(serviceWorkflow).toContain('name: Verify multi-arch image manifest')
-      expect(serviceWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')
-      expect(serviceWorkflow).toContain("--platforms 'linux/amd64,linux/arm64'")
-      expect(serviceWorkflow).toContain(
-        "--platform-digest 'linux/amd64=${{ steps.digest.outputs.platform_digest_amd64 }}'",
-      )
-      expect(serviceWorkflow).toContain(
-        "--platform-digest 'linux/arm64=${{ steps.digest.outputs.platform_digest_arm64 }}'",
-      )
+      expect(serviceWorkflow).not.toContain('docker/setup-buildx-action')
+      expect(serviceWorkflow).not.toContain('docker buildx')
     }
   })
 
@@ -140,19 +117,16 @@ describe('torghut build-push workflow', () => {
     expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/hyperliquid-feed/**'")
     expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/platform/**'")
     expect(hyperliquidFeedWorkflow).toContain("- 'services/dorvud/settings.gradle.kts'")
-    expect(hyperliquidFeedWorkflow).toContain("- 'packages/scripts/src/torghut/release-contract.ts'")
+    expect(hyperliquidFeedWorkflow).toContain("- 'nix/oci-release-contract.sh'")
     expect(hyperliquidFeedWorkflow).not.toContain("- 'services/dorvud/**'")
     expect(hyperliquidFeedWorkflow).not.toContain('workflow_run:')
     expect(hyperliquidFeedWorkflow).toContain("github.event_name == 'push'")
-    expect(hyperliquidFeedWorkflow).toContain('runner: arc-amd64')
-    expect(hyperliquidFeedWorkflow).toContain('runner: arc-arm64')
-    expect(hyperliquidFeedWorkflow).toContain('platforms: ${{ matrix.platform }}')
-    expect(hyperliquidFeedWorkflow).toContain('name: Verify multi-arch image manifest')
-    expect(hyperliquidFeedWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')
-    expect(hyperliquidFeedWorkflow).toContain('name: Write release contract artifact')
-    expect(hyperliquidFeedWorkflow).toContain('--path torghut-hyperliquid-feed-release-contract.json')
-    expect(hyperliquidFeedWorkflow).toContain("--image 'registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed'")
-    expect(hyperliquidFeedWorkflow).toContain('name: torghut-hyperliquid-feed-release-contract')
+    expect(hyperliquidFeedWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
+    expect(hyperliquidFeedWorkflow).toContain('image_name: torghut-hyperliquid-feed')
+    expect(hyperliquidFeedWorkflow).toContain('package_attr: torghut-hyperliquid-feed-image')
+    expect(hyperliquidFeedWorkflow).toContain('torghut-hyperliquid-feed-release-contract')
+    expect(hyperliquidFeedWorkflow).not.toContain('docker/setup-buildx-action')
+    expect(hyperliquidFeedWorkflow).not.toContain('docker buildx')
   })
 
   it('promotes Hyperliquid feed images through a digest-pinned release PR', () => {
@@ -238,8 +212,9 @@ describe('torghut build-push workflow', () => {
     expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net/lab/torghut')
     expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net/lab/torghut-ta')
     expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net/lab/torghut-ws')
-    expect(releaseManifestJobBody).toContain('docker buildx imagetools inspect')
-    expect(releaseManifestJobBody).toContain('for platform in linux/amd64 linux/arm64; do')
+    expect(releaseManifestJobBody).toContain('uses: ./.github/actions/setup-nix-toolchain')
+    expect(releaseManifestJobBody).toContain('nix run .#assert-oci-platforms -- "${image_ref}" linux/amd64 linux/arm64')
+    expect(releaseManifestJobBody).not.toContain('docker buildx')
     expect(releaseManifestJobBody).toContain('release manifest pins a multi-arch image digest')
     expect(releaseManifestJobBody).not.toContain('gh run list')
     expect(releaseManifestJobBody).not.toContain('gh run view')
@@ -322,7 +297,7 @@ describe('torghut build-push workflow', () => {
     expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/torghut/release-contract.ts')
     expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts')
     expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/shared/cli.ts')
-    expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/shared/docker.ts')
+    expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/shared/oci-digest.ts')
     expect(hyperliquidFeedReleaseWorkflow).toContain('packages/scripts/src/shared/git.ts')
     expect(hyperliquidFeedReleaseWorkflow).toContain('.github/workflows/torghut-hyperliquid-feed-build-push.yaml')
     expect(hyperliquidFeedReleaseWorkflow).toContain('.github/workflows/torghut-hyperliquid-feed-release.yml')

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -29,8 +29,12 @@ describe('torghut-deploy-automerge workflow', () => {
   test('runs registry digest validation where the private registry is reachable', () => {
     expect(deployAutomergeWorkflow).toContain('runs-on: arc-arm64')
     expect(deployAutomergeWorkflow).not.toContain('runs-on: ubuntu-latest')
-    expect(deployAutomergeWorkflow).toContain('This pull_request_target job does not check out pull request code.')
-    expect(deployAutomergeWorkflow).not.toContain('uses: actions/checkout')
+    expect(deployAutomergeWorkflow).toContain(
+      'This pull_request_target job checks out trusted base code only, never pull request code.',
+    )
+    expect(deployAutomergeWorkflow).toContain('uses: actions/checkout@v4')
+    expect(deployAutomergeWorkflow).toContain('ref: ${{ github.event.pull_request.base.sha }}')
+    expect(deployAutomergeWorkflow).not.toContain('ref: ${{ github.event.pull_request.head.sha }}')
   })
 
   test('allowlists every hyperliquid runtime manifest promoted by torghut-release', () => {
@@ -83,8 +87,11 @@ describe('torghut-deploy-automerge workflow', () => {
     expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_COMMIT'")
     expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_TA_COMMIT'")
     expect(deployAutomergeWorkflow).toContain("source_env_name='TORGHUT_WS_COMMIT'")
-    expect(deployAutomergeWorkflow).toContain('docker buildx imagetools inspect')
-    expect(deployAutomergeWorkflow).toContain('for platform in linux/amd64 linux/arm64; do')
+    expect(deployAutomergeWorkflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+    expect(deployAutomergeWorkflow).toContain(
+      'nix run .#assert-oci-platforms -- "${image_ref}" linux/amd64 linux/arm64',
+    )
+    expect(deployAutomergeWorkflow).not.toContain('docker buildx')
     expect(deployAutomergeWorkflow).toContain('release manifest pins a multi-arch image digest')
     expect(deployAutomergeWorkflow).not.toContain('gh run list')
     expect(deployAutomergeWorkflow).not.toContain('gh run view')

--- a/packages/scripts/src/torghut/build-image.ts
+++ b/packages/scripts/src/torghut/build-image.ts
@@ -1,74 +1,39 @@
 #!/usr/bin/env bun
 
-import { resolve } from 'node:path'
-import { repoRoot } from '../shared/cli'
-import { buildAndPushDockerImage, type DockerCacheMode } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
 
 export type BuildImageOptions = {
   registry?: string
   repository?: string
   tag?: string
-  context?: string
-  dockerfile?: string
-  platforms?: string[]
-  codexAuthPath?: string
-  cacheRef?: string
-  cacheMode?: DockerCacheMode
+  dryRun?: boolean
 }
 
-const optionalEnvText = (value: string | undefined): string | undefined => {
-  const normalized = value?.trim()
-  if (!normalized || normalized.toLowerCase() === 'none') return undefined
-  return normalized
-}
-
-const optionalCacheMode = (value: string | undefined): DockerCacheMode | undefined => {
-  const normalized = value?.trim().toLowerCase()
-  if (normalized === 'max' || normalized === 'min') return normalized
-  return undefined
-}
-
-let buildAndPushDockerImageImpl = buildAndPushDockerImage
+let buildAndPushNixImageImpl = buildAndPushNixImage
 let execGitImpl = execGit
 
 export const buildImage = async (options: BuildImageOptions = {}) => {
   const registry = options.registry ?? process.env.TORGHUT_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = options.repository ?? process.env.TORGHUT_IMAGE_REPOSITORY ?? 'lab/torghut'
   const tag = options.tag ?? process.env.TORGHUT_IMAGE_TAG ?? 'latest'
-  const context = resolve(repoRoot, options.context ?? 'services/torghut')
-  const dockerfile = resolve(repoRoot, options.dockerfile ?? 'services/torghut/Dockerfile')
-  const cacheRef = options.cacheRef ?? optionalEnvText(process.env.TORGHUT_IMAGE_CACHE_REF)
-  const cacheMode = options.cacheMode ?? optionalCacheMode(process.env.TORGHUT_IMAGE_CACHE_MODE)
-  const platformsEnv = process.env.TORGHUT_IMAGE_PLATFORMS
-  const platforms =
-    options.platforms ??
-    (platformsEnv
-      ? platformsEnv
-          .split(',')
-          .map((p) => p.trim())
-          .filter((p) => p.length > 0 && p.toLowerCase() !== 'none')
-      : ['linux/amd64', 'linux/arm64'])
 
   const version = execGitImpl(['describe', '--tags', '--always'])
   const commit = execGitImpl(['rev-parse', 'HEAD'])
 
-  const result = await buildAndPushDockerImageImpl({
+  const result = await buildAndPushNixImageImpl({
+    service: 'torghut',
+    imageName: 'torghut',
+    packageAttr: 'torghut-image',
     registry,
     repository,
     tag,
-    context,
-    dockerfile,
-    platforms,
-    cacheRef,
-    cacheMode,
-    buildArgs: {
-      TORGHUT_VERSION: version,
-      TORGHUT_COMMIT: commit,
-    },
+    sourceSha: commit,
+    latestTag: 'latest',
+    dryRun: options.dryRun,
   })
 
-  return { ...result, version, commit }
+  return { image: `${registry}/${repository}:${tag}`, digest: result.reference, version, commit }
 }
 
 if (import.meta.main) {
@@ -80,10 +45,8 @@ if (import.meta.main) {
 
 export const __private = {
   execGit,
-  optionalEnvText,
-  optionalCacheMode,
-  setBuildAndPushDockerImage: (impl: typeof buildAndPushDockerImage = buildAndPushDockerImage) => {
-    buildAndPushDockerImageImpl = impl
+  setBuildAndPushNixImage: (impl: typeof buildAndPushNixImage = buildAndPushNixImage) => {
+    buildAndPushNixImageImpl = impl
   },
   setExecGit: (impl: typeof execGit = execGit) => {
     execGitImpl = impl

--- a/packages/scripts/src/torghut/deploy-service.ts
+++ b/packages/scripts/src/torghut/deploy-service.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import YAML from 'yaml'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { buildAndPushDockerImage, inspectImageDigest } from '../shared/docker'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
 import { buildImage } from './build-image'
 
 const manifestPath = resolve(repoRoot, 'argocd/applications/torghut/knative-service.yaml')
@@ -42,9 +42,10 @@ type DeploymentStatus = {
 }
 
 const ensureTools = () => {
-  ensureCli('docker')
   ensureCli('kn')
   ensureCli('kubectl')
+  ensureCli('nix')
+  ensureCli('crane')
   ensureCli('uv')
 }
 
@@ -333,54 +334,42 @@ const updateManifest = (image: string, version: string, commit: string) => {
   console.log(`Updated ${manifestPath} with image ${image}`)
 }
 
-const buildWebsocketImage = async () => {
+const buildWebsocketImage = async (commit: string) => {
   const registry = process.env.TORGHUT_WS_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = process.env.TORGHUT_WS_IMAGE_REPOSITORY ?? 'lab/torghut-ws'
   const tag = process.env.TORGHUT_WS_IMAGE_TAG ?? 'latest'
-  const context = resolve(repoRoot, process.env.TORGHUT_WS_IMAGE_CONTEXT ?? 'services/dorvud')
-  const dockerfile = resolve(
-    repoRoot,
-    process.env.TORGHUT_WS_IMAGE_DOCKERFILE ?? 'services/dorvud/websockets/Dockerfile',
-  )
-  const platforms = process.env.TORGHUT_WS_IMAGE_PLATFORMS?.split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/amd64', 'linux/arm64']
-  const codexAuthPath = process.env.TORGHUT_WS_CODEX_AUTH_PATH
 
-  return buildAndPushDockerImage({
+  const result = await buildAndPushNixImage({
+    service: 'torghut-ws',
+    imageName: 'torghut-ws',
+    packageAttr: 'torghut-ws-image',
     registry,
     repository,
     tag,
-    context,
-    dockerfile,
-    platforms,
-    codexAuthPath,
+    sourceSha: commit,
+    latestTag: 'latest',
   })
+
+  return { image: `${result.image}:${result.tag}`, digest: result.reference }
 }
 
-const buildTechnicalAnalysisImage = async () => {
+const buildTechnicalAnalysisImage = async (commit: string) => {
   const registry = process.env.TORGHUT_TA_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = process.env.TORGHUT_TA_IMAGE_REPOSITORY ?? 'lab/torghut-ta'
   const tag = process.env.TORGHUT_TA_IMAGE_TAG ?? 'latest'
-  const context = resolve(repoRoot, process.env.TORGHUT_TA_IMAGE_CONTEXT ?? 'services/dorvud')
-  const dockerfile = resolve(
-    repoRoot,
-    process.env.TORGHUT_TA_IMAGE_DOCKERFILE ?? 'services/dorvud/technical-analysis-flink/Dockerfile',
-  )
-  const platforms = process.env.TORGHUT_TA_IMAGE_PLATFORMS?.split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/amd64', 'linux/arm64']
-  const codexAuthPath = process.env.TORGHUT_TA_CODEX_AUTH_PATH
 
-  return buildAndPushDockerImage({
+  const result = await buildAndPushNixImage({
+    service: 'torghut-ta',
+    imageName: 'torghut-ta',
+    packageAttr: 'torghut-ta-image',
     registry,
     repository,
     tag,
-    context,
-    dockerfile,
-    platforms,
-    codexAuthPath,
+    sourceSha: commit,
+    latestTag: 'latest',
   })
+
+  return { image: `${result.image}:${result.tag}`, digest: result.reference }
 }
 
 const updateWebsocketDeployment = (image: string, version: string, commit: string) => {
@@ -594,18 +583,15 @@ const applyTechnicalAnalysisResources = async () => {
 const main = async () => {
   ensureTools()
 
-  const { image, version, commit } = await buildImage()
-  const digestRef = inspectImageDigest(image)
+  const { digest: digestRef, version, commit } = await buildImage()
 
-  const websocketImage = await buildWebsocketImage()
-  const websocketDigestRef = inspectImageDigest(websocketImage.image)
+  const websocketImage = await buildWebsocketImage(commit)
 
-  const taImage = await buildTechnicalAnalysisImage()
-  const taDigestRef = inspectImageDigest(taImage.image)
+  const taImage = await buildTechnicalAnalysisImage(commit)
 
   updateManifest(digestRef, version, commit)
-  updateWebsocketDeployment(websocketDigestRef, version, commit)
-  updateTechnicalAnalysisDeployment(taDigestRef, version, commit)
+  updateWebsocketDeployment(websocketImage.digest, version, commit)
+  updateTechnicalAnalysisDeployment(taImage.digest, version, commit)
   await runMigrations()
   await applyManifest()
   await applyWebsocketResources()

--- a/packages/scripts/src/torghut/deploy-ta.ts
+++ b/packages/scripts/src/torghut/deploy-ta.ts
@@ -4,8 +4,8 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import YAML from 'yaml'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { buildAndPushDockerImage, inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
 
 const taDeploymentPath = resolve(
   repoRoot,
@@ -14,7 +14,8 @@ const taDeploymentPath = resolve(
 const taKustomizePath = resolve(repoRoot, process.env.TORGHUT_TA_KUSTOMIZE_PATH ?? 'argocd/applications/torghut/ta')
 
 const ensureTools = () => {
-  ensureCli('docker')
+  ensureCli('nix')
+  ensureCli('crane')
   ensureCli('kubectl')
   ensureCli('git')
 }
@@ -23,33 +24,21 @@ const buildTechnicalAnalysisImage = async () => {
   const registry = process.env.TORGHUT_TA_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = process.env.TORGHUT_TA_IMAGE_REPOSITORY ?? 'lab/torghut-ta'
   const tag = process.env.TORGHUT_TA_IMAGE_TAG ?? 'latest'
-  const context = resolve(repoRoot, process.env.TORGHUT_TA_IMAGE_CONTEXT ?? 'services/dorvud')
-  const dockerfile = resolve(
-    repoRoot,
-    process.env.TORGHUT_TA_IMAGE_DOCKERFILE ?? 'services/dorvud/technical-analysis-flink/Dockerfile',
-  )
-  const platforms = process.env.TORGHUT_TA_IMAGE_PLATFORMS?.split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean) ?? ['linux/amd64', 'linux/arm64']
-  const codexAuthPath = process.env.TORGHUT_TA_CODEX_AUTH_PATH
   const version = execGit(['describe', '--tags', '--always'])
   const commit = execGit(['rev-parse', 'HEAD'])
 
-  const result = await buildAndPushDockerImage({
+  const result = await buildAndPushNixImage({
+    service: 'torghut-ta',
+    imageName: 'torghut-ta',
+    packageAttr: 'torghut-ta-image',
     registry,
     repository,
     tag,
-    context,
-    dockerfile,
-    platforms,
-    codexAuthPath,
-    buildArgs: {
-      TORGHUT_TA_VERSION: version,
-      TORGHUT_TA_COMMIT: commit,
-    },
+    sourceSha: commit,
+    latestTag: 'latest',
   })
 
-  return { ...result, version, commit }
+  return { image: `${result.image}:${result.tag}`, digest: result.reference, version, commit }
 }
 
 const updateTechnicalAnalysisDeployment = (image: string, version: string, commit: string) => {
@@ -101,9 +90,8 @@ const applyTechnicalAnalysisResources = async () => {
 
 const main = async () => {
   ensureTools()
-  const { image, version, commit } = await buildTechnicalAnalysisImage()
-  const digestRef = inspectImageDigest(image)
-  updateTechnicalAnalysisDeployment(digestRef, version, commit)
+  const { digest, version, commit } = await buildTechnicalAnalysisImage()
+  updateTechnicalAnalysisDeployment(digest, version, commit)
   await applyTechnicalAnalysisResources()
   console.log('torghut technical analysis deployment updated; commit manifest changes for Argo CD reconciliation.')
 }

--- a/packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts
+++ b/packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts
@@ -5,8 +5,8 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { fatal, repoRoot } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { inspectOciImageDigest } from '../shared/oci-digest'
 
 const defaultRegistry = 'registry.ide-newton.ts.net'
 const defaultRepository = 'lab/torghut-hyperliquid-feed'
@@ -167,7 +167,7 @@ const main = (cliOptions?: CliOptions) => {
     parsed.tag ?? process.env.TORGHUT_HYPERLIQUID_FEED_IMAGE_TAG ?? execGit(['rev-parse', '--short=8', 'HEAD'])
   const imageName = `${registry}/${repository}`
   const digest = normalizeDigest(
-    parsed.digest ?? process.env.TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST ?? inspectImageDigest(`${imageName}:${tag}`),
+    parsed.digest ?? process.env.TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST ?? inspectOciImageDigest(`${imageName}:${tag}`),
   )
 
   if (!digestPattern.test(digest)) {

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -5,8 +5,8 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { fatal, repoRoot } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { inspectOciImageDigest } from '../shared/oci-digest'
 
 const defaultRegistry = 'registry.ide-newton.ts.net'
 const defaultRepository = 'lab/torghut'
@@ -530,7 +530,7 @@ const main = (cliOptions?: CliOptions) => {
   const tag = parsed.tag ?? process.env.TORGHUT_IMAGE_TAG ?? execGit(['rev-parse', '--short=8', 'HEAD'])
   const imageName = `${registry}/${repository}`
   const digest = normalizeDigest(
-    parsed.digest ?? process.env.TORGHUT_IMAGE_DIGEST ?? inspectImageDigest(`${imageName}:${tag}`),
+    parsed.digest ?? process.env.TORGHUT_IMAGE_DIGEST ?? inspectOciImageDigest(`${imageName}:${tag}`),
   )
 
   if (!digestPattern.test(digest)) {

--- a/packages/scripts/src/torghut/update-ta-manifest.ts
+++ b/packages/scripts/src/torghut/update-ta-manifest.ts
@@ -5,8 +5,8 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { fatal, repoRoot } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { inspectOciImageDigest } from '../shared/oci-digest'
 
 const defaultRegistry = 'registry.ide-newton.ts.net'
 const defaultRepository = 'lab/torghut-ta'
@@ -201,7 +201,7 @@ const main = (cliOptions?: CliOptions) => {
   const tag = parsed.tag ?? process.env.TORGHUT_TA_IMAGE_TAG ?? execGit(['rev-parse', '--short=8', 'HEAD'])
   const imageName = `${registry}/${repository}`
   const digest = normalizeDigest(
-    parsed.digest ?? process.env.TORGHUT_TA_IMAGE_DIGEST ?? inspectImageDigest(`${imageName}:${tag}`),
+    parsed.digest ?? process.env.TORGHUT_TA_IMAGE_DIGEST ?? inspectOciImageDigest(`${imageName}:${tag}`),
   )
 
   if (!digestPattern.test(digest)) {

--- a/packages/scripts/src/torghut/update-ws-manifest.ts
+++ b/packages/scripts/src/torghut/update-ws-manifest.ts
@@ -5,8 +5,8 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { fatal, repoRoot } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { inspectOciImageDigest } from '../shared/oci-digest'
 
 const defaultRegistry = 'registry.ide-newton.ts.net'
 const defaultRepository = 'lab/torghut-ws'
@@ -160,7 +160,7 @@ const main = (cliOptions?: CliOptions) => {
   const tag = parsed.tag ?? process.env.TORGHUT_WS_IMAGE_TAG ?? execGit(['rev-parse', '--short=8', 'HEAD'])
   const imageName = `${registry}/${repository}`
   const digest = normalizeDigest(
-    parsed.digest ?? process.env.TORGHUT_WS_IMAGE_DIGEST ?? inspectImageDigest(`${imageName}:${tag}`),
+    parsed.digest ?? process.env.TORGHUT_WS_IMAGE_DIGEST ?? inspectOciImageDigest(`${imageName}:${tag}`),
   )
 
   if (!digestPattern.test(digest)) {


### PR DESCRIPTION
## Summary

- Migrates Torghut, Torghut WS, Torghut TA, and Torghut Hyperliquid feed image workflows to the shared Nix OCI build path on ARC amd64 and arm64 runners.
- Adds deterministic Nix image derivations for the Torghut family and keeps manual deploy scripts on the same shared Nix image builder and digest contract.
- Replaces the TA Flink runtime archive fetch with digest-pinned per-architecture Flink 2.0.1 base images plus a small app/plugin layer.
- Updates digest verification and release workflows to use crane/Nix OCI platform assertions instead of Docker Buildx or Docker daemon commands.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-image.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts` passed with 65 tests, 0 failures, 1009 assertions.
- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts packages/scripts/src/shared/__tests__/oci.test.ts` passed with 60 tests, 0 failures, 1040 assertions.
- `bunx oxfmt --check packages/scripts/src/torghut packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/oci-digest.ts` passed.
- `nix flake check --all-systems --print-build-logs --no-build` passed.
- `nix build --dry-run --print-out-paths .#packages.x86_64-linux.torghut-ta-image .#packages.aarch64-linux.torghut-ta-image` passed.
- `git diff --check` passed.
- PR checks passed on commit `555980b8b67ba3108150ef18eae4ad9649e8470f`:
  - `torghut-ci` run `28699570892`.
  - `torghut-build-push` run `28699570989`.
  - `torghut-ws-build-push` run `28699570985`.
  - `torghut-ta-build-push` run `28699571009`.
  - `torghut-hyperliquid-feed-build-push` run `28699570974`.
  - `arc-runner-build-push` run `28699570873`.
  - `headlamp` validation run `28699570912`.

## Screenshots (if applicable)

N/A - CI, Nix image, and deploy tooling changes only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
