### PR TITLE
docs: define documentation authority model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ TigerBeetle operator code lives in the standalone `proompteng/tigresse` reposito
 - `ansible/`: provisioning and operational playbooks
 - `devices/`: machine-specific infrastructure notes and manifests
 - `proto/`, `schemas/`: shared contracts and schema assets
-- `docs/`: design docs, runbooks, incidents, and architecture references
+- `docs/`: design docs, runbooks, incidents, and architecture references; start with `docs/README.md` and
+  `docs/documentation-authority.md` before treating dated designs as current truth
 - `skills/`: reusable agent skills
 
 ## Quick Start

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Repository Documentation
+
+Status: Current index.
+
+Start here when deciding which documentation to trust.
+
+## Authority
+
+- Documentation authority model: `documentation-authority.md`
+- Root repo operating guidance: `../README.md`, `../AGENTS.md`, `../CLAUDE.md`
+
+## Current Operational Maps
+
+- Agents/Jangar: `agents/README.md`
+- Torghut: `torghut/README.md`
+- Incidents: `incidents/README.md`
+- Temporal Bun SDK docs: `temporal-bun-sdk/README.md`
+- Secure action gateway: `secure-action-gateway/README.md`
+
+## Historical And Research Corpora
+
+- Agents design archive: `agents/designs/README.md`
+- Torghut design archive: `torghut/design-system/README.md`
+- Whitepaper research archive: `whitepapers/README.md`
+
+Dated design files and research workups are context. They are not current production authority unless they explicitly
+say so and point to live source, GitOps, runtime readback, and validation evidence.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -5,6 +5,10 @@ Status: Current (2026-02-07)
 This is the hub for `docs/agents/**`. It is intended to make the Agents documentation set composable:
 clear entrypoints, clear “source of truth”, and a complete catalog of related documents.
 
+Authority note: use `../documentation-authority.md` when deciding whether a design file is current. The `designs/**`
+tree is a dated design archive unless an individual file explicitly says it is current and points to live code, GitOps,
+and runtime validation.
+
 ## Start Here
 
 - Operational/source-of-truth appendix (repo + chart + cluster): `designs/handoff-common.md`
@@ -18,9 +22,10 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - How to validate changes in CI: `ci-validation-plan.md`
 - How to install/upgrade/debug (ops): `runbooks.md`
 - Fast Jangar/Torghut live analysis workflow: `designs/jangar-torghut-live-analysis-playbook.md`
-- Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
+- Historical autonomous Jangar/Torghut production proposal: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
-- Current Jangar/Torghut architecture contracts:
+- Jangar/Torghut architecture contract archive. Treat these as dated handoffs until verified against live code, GitOps,
+  and runtime status:
   - `designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`
   - `../torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
   - `designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`

--- a/docs/agents/designs/README.md
+++ b/docs/agents/designs/README.md
@@ -1,0 +1,21 @@
+# Agents Design Archive
+
+Status: Historical design and handoff archive.
+
+This directory contains dated design proposals, accepted handoffs, and architecture notes for the Agents/Jangar control
+plane. These files are valuable for rationale, but they are not automatically current implementation authority.
+
+For current behavior, start with:
+
+- `docs/agents/README.md`
+- `services/jangar/README.md`
+- `charts/agents/**`
+- `argocd/applications/agents/**`
+- current CRDs and controller code under `services/jangar/**`
+- live Argo/Kubernetes/CI readback
+
+Design files in this directory should be read as snapshots unless the file explicitly states that it is current and
+points to live desired state plus validation evidence. When a design conflicts with code, GitOps, or runtime status,
+code/GitOps/runtime status wins.
+
+Use `docs/documentation-authority.md` as the repository-wide authority model.

--- a/docs/documentation-authority.md
+++ b/docs/documentation-authority.md
@@ -1,0 +1,64 @@
+# Documentation Authority Model
+
+Status: Current documentation policy.
+
+This repository has several kinds of documentation: live runbooks, implementation references, dated design snapshots,
+research/whitepaper workups, incidents, and handoff records. They do not carry the same authority.
+
+Use this authority order when documents disagree.
+
+## Authority Order
+
+1. Live desired state and source code
+   - `argocd/**`, `.github/workflows/**`, `charts/**`, `nix/**`, `tofu/**`, `devices/**`
+   - Service source, tests, and local README files under `services/**`, `apps/**`, and `packages/**`
+2. Runtime readback
+   - Argo application status, Kubernetes objects, readiness endpoints, health/status APIs, logs, and CI results
+3. Current operational indexes and runbooks
+   - Current `README.md` files and runbooks that explicitly say they are current
+   - Files with a recent status section that points to live desired state and runtime checks
+4. Historical design snapshots and accepted handoffs
+   - `docs/agents/designs/**`
+   - `docs/agents/release-handoffs/**`
+   - `docs/torghut/design-system/**`
+   - dated rollout reports and closeout notes
+5. Research and whitepaper workups
+   - `docs/whitepapers/**`
+   - research-derived implementation ideas that still need current code/GitOps validation
+6. Incident reports
+   - factual historical evidence, useful for diagnosis, but not current desired state
+
+## Required Handling For Design Docs
+
+A design doc is authority only for its own historical decision. It is not current production truth unless it explicitly
+says so and points to live code, GitOps, and runtime readback.
+
+When updating a stale design doc, prefer one of these actions:
+
+- mark it as a historical snapshot and add a current-truth notice;
+- move current operational guidance into a maintained README or runbook;
+- replace “implementation-ready/current/source of truth” wording with “historical rationale” wording;
+- add links to live desired state, service code, runtime APIs, and current runbooks.
+
+Do not solve stale design drift by adding another link checker. Broken links are secondary. The main failure mode is an
+old design claiming current authority after implementation reality moved.
+
+## Current Source Maps
+
+Start from these before using any dated design file:
+
+- Repository/root operations: `README.md`, `AGENTS.md`, `CLAUDE.md`
+- Agents platform: `docs/agents/README.md`, `services/jangar/README.md`, `charts/agents/**`, `argocd/applications/agents/**`
+- Torghut: `docs/torghut/README.md`, `services/torghut/README.md`, `argocd/applications/torghut/**`, `argocd/applications/torghut-options/**`
+- Incidents: `docs/incidents/README.md`
+- Whitepapers: `docs/whitepapers/README.md`
+
+## Review Checklist
+
+Before treating a design doc as actionable, verify:
+
+- the referenced service paths still exist;
+- the referenced GitOps resources still exist;
+- the documented status is consistent with current runtime status and CI;
+- the document does not conflict with a current README/runbook;
+- implementation work has a validation path in tests, CI, or runtime readback.

--- a/docs/documentation-refresh-plan-2026-07-04.md
+++ b/docs/documentation-refresh-plan-2026-07-04.md
@@ -1,0 +1,47 @@
+# Documentation Refresh Plan — 2026-07-04
+
+Status: Executed in this documentation authority refresh.
+
+## Problem
+
+The repo contained many useful design documents, but readers had to infer whether a document was current truth,
+historical context, a handoff record, a research workup, or a runbook. The core drift was not broken links; it was old
+design docs retaining current-sounding language after source code, GitOps, and runtime behavior had moved.
+
+## Execution Plan
+
+1. Establish a repo-wide authority model.
+   - Add `docs/documentation-authority.md`.
+   - Define the authority order: code/GitOps, runtime readback, current runbooks, historical designs, research, incidents.
+2. Add a documentation landing page.
+   - Add `docs/README.md` as the top-level documentation entry point.
+   - Link current maps separately from historical/research corpora.
+3. Mark design archives as archives.
+   - Add `docs/agents/designs/README.md`.
+   - Strengthen `docs/torghut/design-system/README.md` and the historical source-of-truth guide.
+4. Update current service indexes.
+   - Update `docs/agents/README.md` so the long Jangar/Torghut contract list is clearly a dated contract archive.
+   - Update `docs/torghut/README.md` so dated accepted/current labels do not outrank live service behavior.
+5. Mark research corpus authority.
+   - Add `docs/whitepapers/README.md` so paper-derived designs are treated as implementation ideas until revalidated.
+6. Preserve local validation and CI discipline.
+   - Use text search and `git diff --check` for local validation.
+   - Avoid adding another committed checker script.
+   - Keep Torghut scheduler compatibility fixes already required by current tests.
+
+## Completed Changes
+
+- Added `docs/documentation-authority.md`.
+- Added `docs/README.md`.
+- Added `docs/agents/designs/README.md`.
+- Added `docs/whitepapers/README.md`.
+- Updated `README.md`, `docs/agents/README.md`, `docs/torghut/README.md`, and Torghut design-system index files.
+- Left historical design documents in place, but made the archive and index authority clear.
+
+## Follow-up Policy
+
+When future work touches a dated design, the PR should either:
+
+- update its status/current-truth notice;
+- move active operational guidance into a current README or runbook;
+- or explicitly state that the design is unchanged historical context.

--- a/docs/superpowers/plans/2026-07-04-torghut-functional-trading-execution-path.md
+++ b/docs/superpowers/plans/2026-07-04-torghut-functional-trading-execution-path.md
@@ -249,7 +249,7 @@ def test_trading_status_exposes_execution_not_simple_lane(client) -> None:
 - [ ] **Step 4: Run the focused tests and confirm they fail before implementation**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest tests/execution/test_execution_path_contract.py tests/api/test_trading_api_status_contract.py tests/api/test_trading_api_live_gate_llm.py -q
 ```
 
@@ -332,7 +332,7 @@ def build_execution_gate(
 - [ ] **Step 3: Run unit tests**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest tests/execution/test_execution_path_contract.py -q
 ```
 
@@ -370,7 +370,7 @@ assert alpaca market closed is not a blocker when route == "testnet"
 - [ ] **Step 3: Run route tests**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest tests/api/test_trading_api_live_gate_llm.py -q
 ```
 
@@ -411,7 +411,7 @@ Delete `bounded_live_paper_collection_gate` from operational authority output. I
 - [ ] **Step 4: Run old-field grep**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab
+cd <repo-root>
 rg -n "simple_lane_orders_submitted_total|simple_lane_reject_reason_totals|simple_lane_status|bounded_live_paper_collection_gate" services/torghut/app services/torghut/tests
 ```
 
@@ -465,7 +465,7 @@ default order notional: min(10 USD, remaining per-symbol capacity, remaining gro
 - [ ] **Step 4: Run target selection tests**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest tests/execution/test_execution_path_contract.py tests/simple_pipeline -q
 ```
 
@@ -516,7 +516,7 @@ runtime execution table
 - [ ] **Step 4: Run submission tests**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest tests/execution/test_execution_path_contract.py tests/journal_tigerbeetle_order_events -q
 ```
 
@@ -565,7 +565,7 @@ portfolio_runtime_ledger_summary_missing
 - [ ] **Step 3: Run diagnostic contract tests**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest tests/api/test_trading_api_status_contract.py -q
 ```
 
@@ -610,7 +610,7 @@ else:
 - [ ] **Step 4: Run Hyperliquid tests**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest tests/hyperliquid_execution/test_runtime_surfaces.py tests/hyperliquid_execution/test_maintenance.py -q
 ```
 
@@ -644,7 +644,7 @@ Keep backward-compatible env parsing in Python only if needed for one release, b
 - [ ] **Step 3: Run Argo lint**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab
+cd <repo-root>
 bun run lint:argocd
 ```
 
@@ -658,7 +658,7 @@ Expected result: Argo manifests render and lint.
 - [ ] **Step 1: Sync dev environment**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv sync --frozen --extra dev
 ```
 
@@ -667,7 +667,7 @@ Expected result: dependency sync succeeds without lockfile edits.
 - [ ] **Step 2: Run pyright profiles**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pyright --project pyrightconfig.json
 uv run --frozen pyright --project pyrightconfig.alpha.json
 uv run --frozen pyright --project pyrightconfig.scripts.json
@@ -678,7 +678,7 @@ Expected result: all three pyright profiles pass.
 - [ ] **Step 3: Run focused pytest suite**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab/services/torghut
+cd <repo-root>/services/torghut
 uv run --frozen pytest \
   tests/execution/test_execution_path_contract.py \
   tests/api/test_trading_api_status_contract.py \
@@ -693,7 +693,7 @@ Expected result: targeted Torghut execution, status, routing, and Hyperliquid te
 - [ ] **Step 4: Run app manifest lint**
 
 ```bash
-cd /Users/gregkonush/.codex/worktrees/2cf1/lab
+cd <repo-root>
 bun run lint:argocd
 ```
 

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -1,7 +1,8 @@
 # Torghut Documentation
 
 Use this page as the current operator source map. The historical design corpus remains useful context, but live
-decisions must start from GitOps, runtime code, readiness endpoints, and current runbooks.
+decisions must start from GitOps, runtime code, readiness endpoints, and current runbooks. Repository-wide
+documentation authority rules live in `../documentation-authority.md`.
 
 ## Current Truth
 
@@ -46,6 +47,10 @@ The design-system tree is an archive and background corpus, not the first source
   until verified against live GitOps, code, and runtime readback.
 - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md` is retained as a historical
   authority-map snapshot.
+
+When a design file says `Accepted`, `implementation-ready`, or `current`, read that as the status at the time the file
+was written unless the file explicitly points to current code, GitOps, runtime APIs, and validation evidence. Current
+service behavior wins over dated design text.
 
 ## Legacy And Supporting Notes
 

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -24,6 +24,12 @@ endpoints.
 - `v5/`: strategy build pack and per-paper technique synthesis.
 - `v6/`: historical intraday autonomy, proof, capital authority, and Jangar/Torghut contract archive. The March 2026 options-lane series in `v6/33` through `v6/37` is rationale/archaeology, not current cluster health or trading authority.
 
+## Authority
+
+This directory is an archive. A file inside it may explain why a design existed, but it is not current production truth
+without live code, GitOps, and runtime validation. Use `../../documentation-authority.md` and `../README.md` before
+treating any dated design as actionable.
+
 ## Operator Rule
 
 Before treating any dated design file as current truth, verify it against:

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -8,6 +8,10 @@
 - Archive note: this file is a historical authority-map snapshot. For current operations, start with
   `docs/torghut/README.md`, live GitOps, service code, and runtime readback.
 
+
+Current authority note: this file is retained as a historical map. It must not be used as the current priority list
+without validating against `docs/torghut/README.md`, live GitOps, service code, runtime endpoints, and CI.
+
 ## Why this document exists
 
 The Torghut design corpus has accumulated several generations of:

--- a/docs/whitepapers/README.md
+++ b/docs/whitepapers/README.md
@@ -1,0 +1,16 @@
+# Whitepaper Research Docs
+
+Status: Research archive and implementation-idea corpus, not current production authority.
+
+Files under `docs/whitepapers/**` capture paper-specific analysis and implementation ideas. They are useful for
+research traceability, but they are not live Torghut or Agents desired state.
+
+Before implementing from a whitepaper design:
+
+1. verify the target service paths and GitOps resources still exist;
+2. compare the design against `docs/documentation-authority.md`;
+3. check `docs/torghut/README.md` and `services/torghut/README.md` for current Torghut reality;
+4. convert the idea into a current implementation plan or PR before claiming it is adopted.
+
+Whitepaper designs that mention stale modules, retired empirical jobs, or old simulation paths should be treated as
+historical rationale until revalidated against current source code and runtime state.


### PR DESCRIPTION
## Summary

- Add a repo-wide documentation authority model so code/GitOps/runtime state outrank stale design prose.
- Add `docs/README.md`, `docs/agents/designs/README.md`, and `docs/whitepapers/README.md` as explicit current-vs-archive entrypoints.
- Update Agents and Torghut docs indexes so dated design contracts are treated as archives unless revalidated.
- Add an executed plan in `docs/documentation-refresh-plan-2026-07-04.md`.
- Clean newly merged absolute local worktree paths in the July 4 Torghut functional execution plan.

## Validation

- `git diff --check HEAD~1..HEAD` — passed
- `rg "check-stale-docs|docs:stale:check|/Users/.*/\.codex/worktrees|bun run (dev|start|lint):proompteng|apps/proompteng|docker-build-push\.yaml" --glob '*.md' --glob '*.mdx' --glob 'README*' --glob 'AGENTS.md' --glob 'CLAUDE.md' .` — no matches

## Risk / Rollout

Documentation-only change. No runtime rollout required.
