### PR TITLE
fix(torghut-options): align promoted image

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c2014dbf926afc33de70aa2890b01dc2ab06d7836fece344a5cc22ce56fbbc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:607af89da76b14c984939adb5d9d6e11726fe7b82f14ab2d0072189012e96e72
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1247-gc1e630bf5
+              value: v0.596.0-1343-gc78993192
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8e1ae9a8c668c206afc6885ca817039da226810b
+              value: c789931929fb3116093abb4a1e9d3a28efe562fb
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c2014dbf926afc33de70aa2890b01dc2ab06d7836fece344a5cc22ce56fbbc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:607af89da76b14c984939adb5d9d6e11726fe7b82f14ab2d0072189012e96e72
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1247-gc1e630bf5
+              value: v0.596.0-1343-gc78993192
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8e1ae9a8c668c206afc6885ca817039da226810b
+              value: c789931929fb3116093abb4a1e9d3a28efe562fb
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Summary

- Promotes `torghut-options` catalog and enricher to the same Torghut image digest as PR #11845.
- Aligns `TORGHUT_OPTIONS_VERSION` and `TORGHUT_OPTIONS_COMMIT` with promoted source `c7899319`.
- Addresses the Codex review feedback that rollout proof was inconsistent for options services.

## Related Issues

Addresses Codex review feedback on https://github.com/proompteng/lab/pull/11845#discussion_r3522829601

## Testing

- `git diff --check`
- `rg -n "0c2014dbf926|8e1ae9a8c668|v0\\.596\\.0-1247|TORGHUT_OPTIONS_COMMIT|TORGHUT_OPTIONS_VERSION|607af89da76|c789931929f|v0\\.596\\.0-1343" argocd/applications/torghut-options/catalog/deployment.yaml argocd/applications/torghut-options/enricher/deployment.yaml`
- `nix develop -c bun run lint:argocd`
- `nix run .#assert-oci-platforms -- registry.ide-newton.ts.net/lab/torghut@sha256:607af89da76b14c984939adb5d9d6e11726fe7b82f14ab2d0072189012e96e72 linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A - GitOps manifest-only change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.