### PR TITLE
docs: add source-read current state maps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,9 @@ Start here when deciding which documentation to trust.
 ## Current Operational Maps
 
 - Agents/Jangar: `agents/README.md`
+- Agents/Jangar source-read state: `agents/current-source-state.md`
 - Torghut: `torghut/README.md`
+- Torghut source-read state: `torghut/current-source-state.md`
 - Incidents: `incidents/README.md`
 - Temporal Bun SDK docs: `temporal-bun-sdk/README.md`
 - Secure action gateway: `secure-action-gateway/README.md`

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -11,6 +11,7 @@ and runtime validation.
 
 ## Start Here
 
+- Source-read current state: `current-source-state.md`
 - Operational/source-of-truth appendix (repo + chart + cluster): `designs/handoff-common.md`
 - Implementing the Helm chart and controllers (implementation-grade): `agents-helm-chart-implementation.md`
 - Chart intent and scope (high-level design): `agents-helm-chart-design.md`

--- a/docs/agents/current-source-state.md
+++ b/docs/agents/current-source-state.md
@@ -1,0 +1,118 @@
+# Agents / Jangar Current Source State
+
+Status: Current source-read snapshot.
+
+Source baseline inspected: `60f683dd0 chore(release/6f50bd9): automated release PR (#11846)`.
+
+This document is derived from current repository source, chart, and GitOps files. Dated design docs under
+`docs/agents/designs/**` remain rationale/history unless revalidated against these source paths.
+
+## Source Inputs Read
+
+Primary code and desired-state inputs:
+
+- Jangar runtime composition: `services/jangar/src/server/app.ts`
+- Server route tree: `services/jangar/src/routes/**`
+- Control-plane modules: `services/jangar/src/server/control-plane-*.ts`
+- Torghut integration modules: `services/jangar/src/server/torghut-*.ts` and `services/jangar/src/routes/api/torghut/**`
+- Agents chart: `charts/agents/**`
+- Agents CRDs: `charts/agents/crds/**`
+- Agents GitOps: `argocd/applications/agents/**`
+
+## Current Jangar Runtime Shape
+
+Jangar is a TanStack/Bun service that loads server-side routes from source globs in
+`services/jangar/src/server/app.ts`. The route loader includes:
+
+- `services/jangar/src/routes/api/**/*.{ts,tsx}`
+- `services/jangar/src/routes/openai/**/*.{ts,tsx}`
+- `services/jangar/src/routes/health.tsx`
+- `services/jangar/src/routes/ready.tsx`
+- `services/jangar/src/routes/mcp.ts`
+
+This means current route authority lives in `services/jangar/src/routes/**`, not in older design prose.
+
+## Current Route Families
+
+Current route files expose these functional areas:
+
+- OpenAI-compatible API: `services/jangar/src/routes/openai/v1/chat/completions.ts` and
+  `services/jangar/src/routes/openai/v1/models.ts`
+- health/readiness: `services/jangar/src/routes/health.tsx`, `services/jangar/src/routes/ready.tsx`, and
+  `services/jangar/src/routes/api/health.tsx`
+- Atlas/search/enrichment: `services/jangar/src/routes/api/atlas/**`, `services/jangar/src/routes/api/search.ts`,
+  `services/jangar/src/routes/api/code-search.ts`, and `services/jangar/src/routes/api/enrich.ts`
+- GitHub integrations: `services/jangar/src/routes/api/github/**` and `services/jangar/src/routes/github/**`
+- terminal/session APIs: `services/jangar/src/routes/api/terminals/**` and `services/jangar/src/routes/terminals/**`
+- Torghut UI/API integrations: `services/jangar/src/routes/api/torghut/**` and `services/jangar/src/routes/torghut/**`
+- whitepaper library/API: `services/jangar/src/routes/api/whitepapers/**` and
+  `services/jangar/src/routes/library/whitepapers/**`
+- OpenWebUI rich UI bridge: `services/jangar/src/routes/api/openwebui/**`
+
+## Current Control Plane Shape
+
+The current control plane is implemented as many source modules under `services/jangar/src/server/`, especially
+`control-plane-*.ts`. The source modules cover:
+
+- action custody and action clocks;
+- authority provenance and source rollout truth;
+- evidence pressure, material evidence, and material gate digests;
+- repair bid admission, repair slot escrow, repair warrant exchange, and terminal debt compaction;
+- stage clearance, stage credit, and controller ingestion settlement;
+- source-serving contract verdicts;
+- Torghut-specific evidence consumers for alpha readiness, freshness carry, repair outcomes, revenue repair, no-delta
+  repair reentry, and stage custody;
+- execution-trust and verify-trust foreclosure surfaces.
+
+Design docs that talk about a single simple Swarm loop are historical. Current behavior is distributed across these
+source modules and should be verified there.
+
+## Agents Chart And CRDs
+
+The Agents platform is charted in `charts/agents/**` and installed through `argocd/applications/agents/**`.
+
+Current chart CRDs include:
+
+- `Agent`, `AgentRun`, `AgentProvider`, `ImplementationSpec`, `ImplementationSource`, `VersionControlProvider`, `Memory`
+- `Orchestration`, `OrchestrationRun`
+- `ApprovalPolicy`, `Budget`, `SecretBinding`
+- `Signal`, `SignalDelivery`
+- `Tool`, `ToolRun`
+- `Schedule`, `Swarm`, `Artifact`, `Workspace`
+
+Current chart templates include control-plane deployments/services, controller deployments/services, RBAC, runner RBAC,
+network policies, resource quota/limit range, metrics services, service monitors, HPA/PDB support, and the agents-shell
+runtime resources.
+
+## Agents GitOps Current Shape
+
+`argocd/applications/agents/**` wires live desired state for:
+
+- Agents CRD primitive manifests;
+- Codex and Codex Spark agents/providers;
+- VersionControlProvider and SecretBinding resources;
+- sample approval, budget, and signal resources;
+- Agents service networking, Tailscale exposure, Postgres, object bucket claim, and observability pieces;
+- KafkaSource for Codex GitHub events.
+
+The chart and GitOps directories are current desired-state authority. Dated design docs under `docs/agents/designs/**`
+are context unless they cite these files and current runtime readback.
+
+## Torghut Integration In Jangar
+
+Jangar currently has a large Torghut integration surface:
+
+- API routes under `services/jangar/src/routes/api/torghut/**`
+- UI routes under `services/jangar/src/routes/torghut/**`
+- server modules such as `torghut-trading.ts`, `torghut-config.ts`, market-context modules, quant runtime modules, and
+  control-plane Torghut evidence modules
+- tests under `services/jangar/src/server/__tests__/torghut-*.test.ts` and route-specific tests
+
+Do not treat old Jangar/Torghut design docs as the current integration map. Use the route tree, server modules, and
+current tests.
+
+## Documentation Consequence
+
+Future Agents/Jangar docs must check `services/jangar/src/routes/**`, `services/jangar/src/server/**`,
+`charts/agents/**`, and `argocd/applications/agents/**` before describing current behavior. Update this file when route
+families, CRDs, or control-plane source modules change materially.

--- a/docs/documentation-authority.md
+++ b/docs/documentation-authority.md
@@ -50,6 +50,7 @@ Start from these before using any dated design file:
 - Repository/root operations: `README.md`, `AGENTS.md`, `CLAUDE.md`
 - Agents platform: `docs/agents/README.md`, `services/jangar/README.md`, `charts/agents/**`, `argocd/applications/agents/**`
 - Torghut: `docs/torghut/README.md`, `services/torghut/README.md`, `argocd/applications/torghut/**`, `argocd/applications/torghut-options/**`
+- Source-read snapshots: `docs/agents/current-source-state.md`, `docs/torghut/current-source-state.md`
 - Incidents: `docs/incidents/README.md`
 - Whitepapers: `docs/whitepapers/README.md`
 

--- a/docs/documentation-refresh-plan-2026-07-04.md
+++ b/docs/documentation-refresh-plan-2026-07-04.md
@@ -28,6 +28,11 @@ design docs retaining current-sounding language after source code, GitOps, and r
    - Use text search and `git diff --check` for local validation.
    - Avoid adding another committed checker script.
    - Keep Torghut scheduler compatibility fixes already required by current tests.
+7. Add source-read current-state documents.
+   - Read Torghut source, API routes, runtime modules, options/Hyperliquid lanes, and GitOps directories.
+   - Read Jangar/Agents source, routes, control-plane modules, chart CRDs, and GitOps resources.
+   - Write current-state docs from those inspected paths so the repository has source-backed state maps, not just
+     authority disclaimers.
 
 ## Completed Changes
 
@@ -36,6 +41,8 @@ design docs retaining current-sounding language after source code, GitOps, and r
 - Added `docs/agents/designs/README.md`.
 - Added `docs/whitepapers/README.md`.
 - Updated `README.md`, `docs/agents/README.md`, `docs/torghut/README.md`, and Torghut design-system index files.
+- Added `docs/agents/current-source-state.md` and `docs/torghut/current-source-state.md` from direct source/GitOps
+  inspection.
 - Left historical design documents in place, but made the archive and index authority clear.
 
 ## Follow-up Policy

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -8,6 +8,7 @@ documentation authority rules live in `../documentation-authority.md`.
 
 Trust these surfaces in order:
 
+- Source-read current state: `docs/torghut/current-source-state.md`
 - Live GitOps: `argocd/applications/torghut/**`, `argocd/applications/torghut-options/**`,
   `argocd/applications/torghut-hyperliquid-feed/**`, and
   `argocd/applications/torghut-hyperliquid-runtime/**`.
@@ -21,6 +22,7 @@ Trust these surfaces in order:
 
 - Torghut app GitOps and TA replay: `argocd/applications/torghut/README.md`
 - Trading service local development: `services/torghut/README.md`
+- Current source-state map: `docs/torghut/current-source-state.md`
 - DB migrations: `services/torghut/migrations/README.md`
 - CI/CD and release commands: `docs/torghut/ci-cd.md`
 - Historical simulation operations: `docs/torghut/rollouts/historical-simulation-playbook.md`

--- a/docs/torghut/current-source-state.md
+++ b/docs/torghut/current-source-state.md
@@ -1,0 +1,91 @@
+# Torghut Current Source State
+
+Status: Current source-read snapshot.
+
+Source baseline inspected: `60f683dd0 chore(release/6f50bd9): automated release PR (#11846)`.
+
+This document is derived from live repository source and GitOps files, not from the historical Torghut design corpus.
+When it conflicts with a dated design doc, this document is closer to the current source state, but source code, GitOps,
+runtime readback, and CI still outrank this prose.
+
+## Source Inputs Read
+
+Primary code and desired-state inputs:
+
+- API composition: `services/torghut/app/api/application.py`
+- API routes: `services/torghut/app/api/**`
+- Settings model: `services/torghut/app/config/settings.py`, `services/torghut/app/config/service_fields.py`,
+  `services/torghut/app/config/runtime_risk_fields.py`
+- Scheduler and trading runtime: `services/torghut/app/trading/scheduler/**`, `services/torghut/app/trading/execution_runtime.py`,
+  `services/torghut/app/trading/execution_adapters/**`, `services/torghut/app/trading/execution_policy/**`
+- Proof/readiness surfaces: `services/torghut/app/api/readiness_helpers/**`, `services/torghut/app/api/proof_floor_payloads/**`,
+  `services/torghut/app/trading/proof_floor/**`, `services/torghut/app/trading/submission_council/**`
+- Options lane: `services/torghut/app/options_lane/**`, `argocd/applications/torghut-options/**`
+- Hyperliquid lane: `services/torghut/app/hyperliquid_execution/**`, `argocd/applications/torghut-hyperliquid-feed/**`,
+  `argocd/applications/torghut-hyperliquid-runtime/**`
+- Whitepaper workflow: `services/torghut/app/whitepapers/**`, `services/torghut/app/api/whitepaper.py`
+- GitOps desired state: `argocd/applications/torghut/**`
+
+## Current Runtime Shape
+
+Torghut is a FastAPI service with a broad runtime API surface, not a single trading loop described by older design docs.
+The app composition layer registers routers from `services/torghut/app/api/application.py` and the route files under
+`services/torghut/app/api/**`.
+
+Current API families in source include readiness, trading health, loop status, trading status, revenue repair,
+zero-notional repair, proof/TCA, runtime profitability, consumer evidence, executions, autonomy, empirical jobs,
+decisions, metrics, simulation progress, Lean backtests, and whitepaper workflow routes.
+
+## Trading Runtime
+
+The current trading runtime is split into modules:
+
+- scheduler entry and modes: `services/torghut/app/trading/scheduler/runtime.py`,
+  `services/torghut/app/trading/scheduler/runtime_pipeline_factory.py`, `services/torghut/app/trading/scheduler/simple_pipeline.py`,
+  and `services/torghut/app/trading/scheduler/pipeline/**`;
+- decision and source collection: `services/torghut/app/trading/decisions/**`,
+  `services/torghut/app/trading/scheduler/source_collection/**`, and
+  `services/torghut/app/trading/scheduler/target_plan_helpers/**`;
+- execution path: `services/torghut/app/trading/execution_runtime.py`, `services/torghut/app/trading/execution/**`,
+  `services/torghut/app/trading/execution_adapters/**`, and `services/torghut/app/trading/execution_policy/**`;
+- proof and capital gating: `services/torghut/app/trading/submission_council/**`,
+  `services/torghut/app/trading/proof_floor/**`, `services/torghut/app/trading/profit_freshness_frontier/**`, and
+  `services/torghut/app/trading/executable_alpha_receipts/**`.
+
+Current source still has empirical proof/status concepts through `services/torghut/app/trading/empirical_jobs.py` and
+readiness/proof surfaces, but the old empirical-promotion job scripts and workflow templates that earlier designs cited
+are not the active authority. Use the API/readiness/proof modules above plus current GitOps instead.
+
+## Current Lanes
+
+Options lane:
+
+- source code: `services/torghut/app/options_lane/**`
+- settings: `services/torghut/app/options_lane/settings.py`
+- GitOps: `argocd/applications/torghut-options/**`, including catalog, enricher, websocket, and TA Flink deployment
+
+Hyperliquid lane:
+
+- source code: `services/torghut/app/hyperliquid_execution/**`
+- runtime service class: `HyperliquidExecutionService`
+- runtime readiness helper: `runtime_readiness`
+- GitOps: `argocd/applications/torghut-hyperliquid-feed/**` and `argocd/applications/torghut-hyperliquid-runtime/**`
+
+Older Torghut designs that model Torghut as only Alpaca/equity/options are incomplete for current source state.
+
+## GitOps Current Shape
+
+Current Torghut desired state is split across these Argo application directories:
+
+- `argocd/applications/torghut/**` for main service, ClickHouse, Postgres, TigerBeetle, TA, TA sim, simulations,
+  whitepaper buckets, rollout-analysis permissions, generated resource cleanup, and operational cronjobs;
+- `argocd/applications/torghut-options/**` for options catalog, enricher, websocket, and TA Flink deployment;
+- `argocd/applications/torghut-hyperliquid-feed/**` for Hyperliquid feed ingestion;
+- `argocd/applications/torghut-hyperliquid-runtime/**` for Hyperliquid execution/runtime service.
+
+Any design document that cites a removed Argo resource is historical until reconciled with these directories.
+
+## Documentation Consequence
+
+Future Torghut docs must check source and GitOps before using claims from `docs/torghut/design-system/**`. Include the
+inspected paths in any new current-state doc and update this file when source layout changes materially.


### PR DESCRIPTION
## Summary

- Add source-read current-state maps for Torghut and Agents/Jangar.
- Wire those maps into the docs index, Agents index, Torghut index, and documentation authority model.
- Update the executed documentation refresh plan to include the source-read step.

## Source read

Read current source/GitOps before writing docs:

- Torghut: `services/torghut/app/api/**`, `app/config/**`, `app/trading/scheduler/**`, `app/trading/execution_*`, `app/options_lane/**`, `app/hyperliquid_execution/**`, and Torghut Argo application directories.
- Agents/Jangar: `services/jangar/src/server/app.ts`, `services/jangar/src/routes/**`, `services/jangar/src/server/control-plane-*.ts`, `charts/agents/**`, and `argocd/applications/agents/**`.

## Validation

- `git diff --check HEAD~1..HEAD` — passed
- stale-path/removed-command search — no matches

## Risk / Rollout

Documentation-only change. No runtime rollout required.
