### PR TITLE
chore(analysis): promote image 26217d1e7bbb

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 6143ad8f608fe583011264272d381a742c0360b1
+    newTag: 26217d1e7bbb9cb8b56c4fa623422069c1a5b9d5


### PR DESCRIPTION
## Summary

- Promotes the analysis app image to registry.ide-newton.ts.net/lab/analysis:26217d1e7bbb9cb8b56c4fa623422069c1a5b9d5.
- Keeps the GitOps change scoped to argocd/applications/analysis/kustomization.yaml.

## Testing

- scripts/verify-analysis-image.sh 26217d1e7bbb9cb8b56c4fa623422069c1a5b9d5 latest
- kubectl kustomize argocd/applications/analysis