### PR TITLE
fix(nix): include platform digests in OCI release contracts

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -324,6 +324,8 @@ jobs:
           REFERENCE: ${{ steps.oci.outputs.reference }}
           PACKAGE_ATTR: ${{ inputs.package_attr }}
           PLATFORMS: linux/amd64,linux/arm64
+          PLATFORM_DIGEST_AMD64: ${{ steps.oci.outputs.platform_digest_amd64 }}
+          PLATFORM_DIGEST_ARM64: ${{ steps.oci.outputs.platform_digest_arm64 }}
         run: |
           set -euo pipefail
           bash nix/ci-run-timed.sh "write-release-contract" "${NIX_OCI_LOG_DIR}/write-release-contract.log" \

--- a/nix/oci-release-contract.sh
+++ b/nix/oci-release-contract.sh
@@ -8,7 +8,18 @@ fi
 
 output_path="$1"
 
-required_env=(SERVICE IMAGE TAG DIGEST REFERENCE GITHUB_SHA PACKAGE_ATTR PLATFORMS)
+required_env=(
+  SERVICE
+  IMAGE
+  TAG
+  DIGEST
+  REFERENCE
+  GITHUB_SHA
+  PACKAGE_ATTR
+  PLATFORMS
+  PLATFORM_DIGEST_AMD64
+  PLATFORM_DIGEST_ARM64
+)
 for name in "${required_env[@]}"; do
   if [[ -z "${!name:-}" ]]; then
     echo "${name} is required" >&2
@@ -26,6 +37,9 @@ jq -n \
   --arg sourceSha "${GITHUB_SHA}" \
   --arg packageAttr "${PACKAGE_ATTR}" \
   --arg platforms "${PLATFORMS}" \
+  --arg platformDigestAmd64 "${PLATFORM_DIGEST_AMD64}" \
+  --arg platformDigestArm64 "${PLATFORM_DIGEST_ARM64}" \
+  --arg createdAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '{
     service: $service,
     image: $image,
@@ -35,8 +49,13 @@ jq -n \
     sourceSha: $sourceSha,
     packageAttr: $packageAttr,
     platforms: ($platforms | split(",") | map(select(length > 0))),
+    platformDigests: {
+      "linux/amd64": $platformDigestAmd64,
+      "linux/arm64": $platformDigestArm64
+    },
     builder: "nix-dockerTools-skopeo",
-    invocation: "github-actions"
+    invocation: "github-actions",
+    createdAt: $createdAt
   }' > "${output_path}"
 
 cat "${output_path}"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -17,6 +17,7 @@ const atticGcCronJob = readRepoFile('argocd/applications/attic/gc-cronjob.yaml')
 const productApplicationSet = readRepoFile('argocd/applicationsets/product.yaml')
 const flake = readRepoFile('flake.nix')
 const inspectOciArchiveScript = readRepoFile('nix/oci-inspect-archive.sh')
+const ociReleaseContractScript = readRepoFile('nix/oci-release-contract.sh')
 const ciRunTimedScript = readRepoFile('nix/ci-run-timed.sh')
 const ciNixOciSummaryScript = readRepoFile('nix/ci-nix-oci-summary.sh')
 const nixOciWorkflow = readRepoFile('.github/workflows/nix-oci-build-common.yml')
@@ -287,6 +288,8 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).not.toContain('cache_paths=("${helper_paths[@]}" "${image_paths[@]}")')
     expect(nixOciWorkflow).not.toContain('nix run .#cache-push -- "${cache_paths[@]}"')
     expect(nixOciWorkflow).toContain('nix run .#write-oci-release-contract --')
+    expect(nixOciWorkflow).toContain('PLATFORM_DIGEST_AMD64: ${{ steps.oci.outputs.platform_digest_amd64 }}')
+    expect(nixOciWorkflow).toContain('PLATFORM_DIGEST_ARM64: ${{ steps.oci.outputs.platform_digest_arm64 }}')
     expect(nixOciWorkflow).toContain('substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/')
     expect(nixOciWorkflow).not.toContain('extra-substituters = http://attic.attic.svc.cluster.local/lab')
     expect(nixOciWorkflow).toContain('nix build --print-build-logs --no-link --print-out-paths "$@"')
@@ -310,6 +313,15 @@ describe('native OCI build workflows', () => {
       'helper_attrs=(.#createOciIndex .#assertOciPlatforms .#writeOciReleaseContract .#cachePush)',
     )
     expect(nixOciWorkflow).not.toContain('nix develop -c')
+  })
+
+  it('writes release contracts with platform digests for strict Torghut promotion', () => {
+    expect(ociReleaseContractScript).toContain('PLATFORM_DIGEST_AMD64')
+    expect(ociReleaseContractScript).toContain('PLATFORM_DIGEST_ARM64')
+    expect(ociReleaseContractScript).toContain('platformDigests: {')
+    expect(ociReleaseContractScript).toContain('"linux/amd64": $platformDigestAmd64')
+    expect(ociReleaseContractScript).toContain('"linux/arm64": $platformDigestArm64')
+    expect(ociReleaseContractScript).toContain('createdAt: $createdAt')
   })
 
   it('records real Nix OCI timing and cache-hit summaries', () => {


### PR DESCRIPTION
## Summary

- Adds platform digest and creation timestamp fields to the shared Nix OCI release contract artifact.
- Passes `create-oci-index` platform digest outputs into `write-oci-release-contract` from the reusable workflow.
- Covers the contract shape with tests so strict Torghut release promotion can parse Nix OCI artifacts.

## Related Issues

None. Fixes the failed `torghut-release` workflow run `28700996011` from PR #11843 rollout.

## Testing

- `SERVICE=torghut IMAGE=registry.ide-newton.ts.net/lab/torghut TAG=sha-1234567890abcdef1234567890abcdef12345678 DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa REFERENCE=registry.ide-newton.ts.net/lab/torghut@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa GITHUB_SHA=1234567890abcdef1234567890abcdef12345678 PACKAGE_ATTR=torghut-image PLATFORMS=linux/amd64,linux/arm64 PLATFORM_DIGEST_AMD64=sha256:1111111111111111111111111111111111111111111111111111111111111111 PLATFORM_DIGEST_ARM64=sha256:2222222222222222222222222222222222222222222222222222222222222222 bash nix/oci-release-contract.sh "$tmp/release-contract.json" && bun run packages/scripts/src/torghut/release-contract.ts get --path "$tmp/release-contract.json" --field digest && bun run packages/scripts/src/torghut/release-contract.ts get --path "$tmp/release-contract.json" --field platformDigests`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/torghut/__tests__/release-contract.test.ts`
- `shellcheck nix/oci-release-contract.sh`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`
- `nix flake check --all-systems --print-build-logs --no-build`

## Screenshots (if applicable)

N/A - CI release contract fix only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
