### PR TITLE
perf(nix): trim OCI image setup toolchain checks

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           require-preinstalled: 'true'
-          install-ci-toolchain: 'true'
+          install-ci-toolchain: 'false'
           extra-nix-config: |
             experimental-features = nix-command flakes
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
@@ -262,7 +262,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           require-preinstalled: 'true'
-          install-ci-toolchain: 'true'
+          install-ci-toolchain: 'false'
           extra-nix-config: |
             experimental-features = nix-command flakes
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -307,6 +307,9 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('Record Nix setup timing')
     expect(nixOciWorkflow).toContain('"nix-setup-${ARCH}"')
     expect(nixOciWorkflow).toContain('"nix-setup-publish-index"')
+    expect(nixOciWorkflow).toContain("require-preinstalled: 'true'")
+    expect(nixOciWorkflow).toContain("install-ci-toolchain: 'false'")
+    expect(nixOciWorkflow).not.toContain("install-ci-toolchain: 'true'")
     expect(nixOciWorkflow).toContain('nix/ci-run-timed.sh')
     expect(nixOciWorkflow).toContain('nix/ci-nix-oci-summary.sh')
     expect(nixOciWorkflow).toContain(


### PR DESCRIPTION
## Summary

- Reduce repeated setup time in real Nix OCI image jobs by requiring preinstalled Nix without validating the full monorepo CI toolchain on every image platform job.
- Keep the shared Nix image build, inspect, Skopeo push, OCI index, Attic pull, and main-only cache push flow unchanged.
- Add a workflow contract test so the shared Nix OCI workflow does not regress back to full toolchain checks for image archive/index jobs.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
