### PR TITLE
chore(analysis): promote image 6e24ad104f8b

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 26217d1e7bbb9cb8b56c4fa623422069c1a5b9d5
+    newTag: 6e24ad104f8b860908f81e6d563220b065ba2ada


### PR DESCRIPTION
## Summary

- Promotes `argocd/applications/analysis` to `registry.ide-newton.ts.net/lab/analysis:6e24ad104f8b860908f81e6d563220b065ba2ada`.
- Deploys the OKTA research refresh and capital-readiness map update from analysis commit `6e24ad104f8b860908f81e6d563220b065ba2ada`.

## Testing

- `scripts/verify-analysis-image.sh 6e24ad104f8b860908f81e6d563220b065ba2ada latest`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None