### PR TITLE
chore(analysis): promote image cd2ff380

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 6e24ad104f8b860908f81e6d563220b065ba2ada
+    newTag: cd2ff380e64d30da043512472736aa1edf71f20f


### PR DESCRIPTION
Promotes analysis image cd2ff380e64d30da043512472736aa1edf71f20f for the PTC reprice and ETF research lane update.\n\nValidation in analysis repo:\n- stock_analysis audit\n- unittest\n- ruff\n- mypy\n- markdownlint\n- site check\n- site build\n- git diff --check\n\nRegistry verification:\n- registry.ide-newton.ts.net/lab/analysis:cd2ff380e64d30da043512472736aa1edf71f20f -> sha256:a7d66e085829fa6453b7168f7b35dd2786626e7299d0ce312e5059a499a34acc\n- latest -> same digest