### PR TITLE
chore(symphony): promote image sha-5e046147da58bd014bca17565cbd731626ec875b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T07:29:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T11:12:35Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1"
-    digest: sha256:5105e0fcd6a824c797ffee298a9a1ed58508c051233295c0e17df41070ed8023
+    newTag: "sha-5e046147da58bd014bca17565cbd731626ec875b"
+    digest: sha256:8602e26cc30db8af3e1af8eabe3051c8661f36263086ae2db3b18a384e7fc391

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T07:29:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T11:12:35Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1"
-    digest: sha256:5105e0fcd6a824c797ffee298a9a1ed58508c051233295c0e17df41070ed8023
+    newTag: "sha-5e046147da58bd014bca17565cbd731626ec875b"
+    digest: sha256:8602e26cc30db8af3e1af8eabe3051c8661f36263086ae2db3b18a384e7fc391

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T07:29:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-04T11:12:35Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-74d7ec5e2e2851e39cf3dc11f346709e425714c1"
-    digest: sha256:5105e0fcd6a824c797ffee298a9a1ed58508c051233295c0e17df41070ed8023
+    newTag: "sha-5e046147da58bd014bca17565cbd731626ec875b"
+    digest: sha256:8602e26cc30db8af3e1af8eabe3051c8661f36263086ae2db3b18a384e7fc391


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `5e046147da58bd014bca17565cbd731626ec875b`
- Image tag: `sha-5e046147da58bd014bca17565cbd731626ec875b`
- Image digest: `sha256:8602e26cc30db8af3e1af8eabe3051c8661f36263086ae2db3b18a384e7fc391`