### PR TITLE
revert(torghut): rollback failed promotion 3acc9b06bb0a9adc4e6e2ec0beee818661424e31

### DIFF
--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:81b9750d5b96edd9742602c2c1939a317deeaef059988d269f22a029555d9fbc
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:90cb375944f4e04d6e83cd2858f9d97115100df302938e213b0845ce1e9ea8a2
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-5e046147da58bd014bca17565cbd731626ec875b
+              value: main-d4c895a6
             - name: TORGHUT_WS_COMMIT
-              value: 5e046147da58bd014bca17565cbd731626ec875b
+              value: d4c895a619802cdc7d149aafe298b3fa56b631a5
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `3acc9b06bb0a9adc4e6e2ec0beee818661424e31`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28704759224`
- Rollback source: `HEAD^` manifests from the failed run checkout