### PR TITLE
revert(torghut): rollback failed promotion ed37aabab1b970d14f12ade67b83d6f3667a4893

### DIFF
--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42a6b081697e9dce426291726e673f9426c1fe82b35ed2f3efc9949b8fa88b22
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
   imagePullPolicy: IfNotPresent
-  restartNonce: 22
+  restartNonce: 21
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-5e046147da58bd014bca17565cbd731626ec875b
+              value: 9ad8d81d
             - name: TORGHUT_TA_COMMIT
-              value: 5e046147da58bd014bca17565cbd731626ec875b
+              value: 9ad8d81dba03fa4e4ca38d3e898676ceed3261e5
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42a6b081697e9dce426291726e673f9426c1fe82b35ed2f3efc9949b8fa88b22
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:2be9bd7f3bfbb0d42aa200657b9115b5ef80733fa5d13aa5b4d53b8214d4f8c3
   imagePullPolicy: IfNotPresent
-  restartNonce: 17
+  restartNonce: 16
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-5e046147da58bd014bca17565cbd731626ec875b
+              value: 9ad8d81d
             - name: TORGHUT_TA_COMMIT
-              value: 5e046147da58bd014bca17565cbd731626ec875b
+              value: 9ad8d81dba03fa4e4ca38d3e898676ceed3261e5
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `ed37aabab1b970d14f12ade67b83d6f3667a4893`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/28704975062`
- Rollback source: `HEAD^` manifests from the failed run checkout