### PR TITLE
chore(analysis): promote image 7106e014

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: cd2ff380e64d30da043512472736aa1edf71f20f
+    newTag: 7106e01429089a4f362903e3c35514a093de59b3


### PR DESCRIPTION
Promotes the analysis site image built from gregkonush/analysis@7106e01429089a4f362903e3c35514a093de59b3.\n\nValidation performed before promotion:\n- analysis repo audit/tests/lint/typecheck/markdownlint/site check/site build/diff-check passed\n- image tag and latest digest verified: sha256:a593ef7ca3511d3290f4f565c6ff301a5868802e69f195fe8aef984f98da1fd1\n- kubectl kustomize argocd/applications/analysis renders the promoted image tag