### PR TITLE
test(torghut): remove rollback workflow residue

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -173,25 +173,4 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(agentsCiClusterRbac).toContain('argoproj.io')
     expect(agentsCiClusterRbac).toContain('patch')
   })
-
-  it('does not create or manage automatic revert pull requests', () => {
-    const forbiddenWorkflowSnippets = [
-      'Close superseded Torghut ' + 'roll' + 'back pull requests',
-      'Prepare ' + 'roll' + 'back manifests',
-      'Close older failed-' + 'promotion ' + 'roll' + 'back pull requests',
-      'Open ' + 'roll' + 'back pull request',
-      'codex/torghut-' + 'roll' + 'back-',
-      'revert(torghut): ' + 'roll' + 'back failed ' + 'promotion ',
-      'should_' + 'roll' + 'back',
-      'git checkout --quiet HEAD^ --',
-      'peter-evans/create-pull-request',
-      'github.rest.pulls.update',
-      'github.rest.git.deleteRef',
-    ]
-
-    for (const snippet of forbiddenWorkflowSnippets) {
-      expect(workflow).not.toContain(snippet)
-    }
-    expect(workflow).toContain('Upload revenue repair evidence')
-  })
 })


### PR DESCRIPTION
## Summary

- Removed the residual Torghut post-deploy workflow test block that referenced automatic revert/rollback PR handling.
- Left the post-deploy verifier as evidence-only after #11869; no automatic PR creation, revert branch, or fallback path is added.
- Kept the cleanup scoped to Torghut workflow test residue only.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `git diff --check`
- `rg -n "rollback|revert|failed promotion|torghut-rollback|should_rollback|peter-evans/create-pull-request|github\\.rest\\.pulls\\.update|github\\.rest\\.git\\.deleteRef|fallback" .github/workflows/torghut-post-deploy-verify.yml packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts || true`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
