### PR TITLE
fix(torghut): roll runtime after universe config changes

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/README.md
+++ b/argocd/applications/torghut-hyperliquid-runtime/README.md
@@ -9,6 +9,8 @@ V2 contract:
 - Market data network is `mainnet`.
 - Execution network is `testnet`.
 - Runtime env names use `HYPERLIQUID_EXECUTION_*`; old `HYPERLIQUID_RUNTIME_*` names are rejected by config validation.
+- ConfigMap-only runtime env changes must bump Deployment pod-template annotation `proompteng.ai/config-revision` so
+  Argo creates a new ReplicaSet and the process reads the new env.
 - The configured execution universe is
   `BTC,ETH,HYPE,SOL,xyz:SKHX,xyz:MU,xyz:XYZ100,xyz:CL,xyz:SNDK,xyz:MSTR,xyz:SILVER,xyz:GOLD`. Selection uses direct
   Hyperliquid mainnet `metaAndAssetCtxs` 24h notional volume (`dayNtlVlm`) and keeps only markets enabled in

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        proompteng.ai/config-revision: hyperliquid-execution-v2-testnet-cap-250-reduce-only-20260703a
+        proompteng.ai/config-revision: hyperliquid-execution-v2-top12-universe-20260704a
       labels:
         app: torghut-hyperliquid-runtime
     spec:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -290,7 +290,7 @@ describe('Torghut manifest scheduling', () => {
     expect(getAtPath(runtimeDeployment, ['spec']).replicas).toBe(1)
     expect(getAtPath(runtimeDeployment, ['spec']).revisionHistoryLimit).toBe(2)
     expect(getAtPath(runtimeDeployment, ['spec', 'template', 'metadata', 'annotations'])).toMatchObject({
-      'proompteng.ai/config-revision': 'hyperliquid-execution-v2-testnet-cap-250-reduce-only-20260703a',
+      'proompteng.ai/config-revision': 'hyperliquid-execution-v2-top12-universe-20260704a',
     })
     const runtimeContainer = getAtPath(runtimeDeployment, ['spec', 'template', 'spec', 'containers', 0])
     expect(runtimeContainer.command).toContain('app.hyperliquid_execution.api:app')

--- a/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
+++ b/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
@@ -61,7 +61,5 @@ def test_manifest_uses_v2_command_and_env_prefix_only() -> None:
         'HYPERLIQUID_EXECUTION_MAINTENANCE_REDUCE_ONLY_CLOSE_ENABLED: "true"'
         in configmap
     )
-    assert (
-        "hyperliquid-execution-v2-testnet-cap-250-reduce-only-20260703a" in deployment
-    )
+    assert "hyperliquid-execution-v2-top12-universe-20260704a" in deployment
     assert "HYPERLIQUID_RUNTIME_" not in configmap


### PR DESCRIPTION
## Summary

- Bump the Hyperliquid runtime Deployment pod-template config revision for the top-12 universe ConfigMap change.
- Update the manifest regression expectation so future universe/env changes require the matching rollout annotation.
- Document that ConfigMap-only runtime env changes must bump `proompteng.ai/config-revision`.

## Related Issues

Fixes review feedback from #11871.

## Testing

- `nix develop -c bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `nix develop -c bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
