### PR TITLE
ci(arc): raise lab runner max concurrency

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -28,7 +28,7 @@ spec:
           scaleSetLabels:
             - arc-arm64
           minRunners: 1
-          maxRunners: 3
+          maxRunners: 5
           listenerTemplate:
             spec:
               dnsConfig:
@@ -159,7 +159,7 @@ spec:
           scaleSetLabels:
             - arc-amd64
           minRunners: 0
-          maxRunners: 2
+          maxRunners: 5
           listenerTemplate:
             spec:
               dnsConfig:
@@ -285,8 +285,8 @@ spec:
           runnerScaleSetName: analysis-arm64
           scaleSetLabels:
             - arc-arm64
-          minRunners: 0
-          maxRunners: 2
+          minRunners: 1
+          maxRunners: 5
           listenerTemplate:
             spec:
               dnsConfig:

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -25,6 +25,14 @@ const flake = readRepoFile('flake.nix')
 const nixPackages = readRepoFile('nix/packages.nix')
 const toolchainDoctor = readRepoFile('nix/toolchain-doctor.sh')
 
+const runnerScaleSetBlock = (name: string): string => {
+  const start = arcApplication.indexOf(`runnerScaleSetName: ${name}`)
+  expect(start).toBeGreaterThan(-1)
+
+  const next = arcApplication.indexOf('runnerScaleSetName:', start + 1)
+  return arcApplication.slice(start, next === -1 ? arcApplication.length : next)
+}
+
 describe('ARC Nix runner toolchain', () => {
   it('keeps ARC storage and Docker sidecar unchanged while making runner images releasable by digest', () => {
     expect(arcApplication).toContain('runnerScaleSetName: arc-arm64')
@@ -40,6 +48,14 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerReleaseWorkflow).toContain('grep -F \'storageClassName: "rook-ceph-block"\'')
     expect(arcRunnerReleaseWorkflow).not.toContain('ObjectBucketClaim')
     expect(arcRunnerReleaseWorkflow).not.toContain('PersistentVolumeClaim')
+  })
+
+  it('allows five concurrent ARC runners per scale set and keeps arm runners warm', () => {
+    expect(runnerScaleSetBlock('arc-arm64')).toContain('maxRunners: 5')
+    expect(runnerScaleSetBlock('arc-arm64')).toContain('minRunners: 1')
+    expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 5')
+    expect(runnerScaleSetBlock('analysis-arm64')).toContain('maxRunners: 5')
+    expect(runnerScaleSetBlock('analysis-arm64')).toContain('minRunners: 1')
   })
 
   it('builds a custom actions runner image with pinned Nix CI tools preinstalled', () => {


### PR DESCRIPTION
## Summary

- Raise the lab `arc-arm64` runner scale set max from 3 to 5.
- Raise the lab `arc-amd64` runner scale set max from 2 to 5.
- Raise `analysis-arm64` to min 1 / max 5 so arm runner capacity stays warm.
- Add a regression test so ARC runner concurrency does not drift below the requested limits.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`
- `yq -o=json '.' argocd/applications/arc/application.yaml >/tmp/arc-application.json`
- `yq -r '.spec.sources[].helm.valuesObject? | select(.runnerScaleSetName == "arc-arm64" or .runnerScaleSetName == "arc-amd64" or .runnerScaleSetName == "analysis-arm64") | [.runnerScaleSetName, .minRunners, .maxRunners] | @tsv' argocd/applications/arc/application.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
