### PR TITLE
ci(arc): raise lab runner scale limits

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -28,7 +28,7 @@ spec:
           scaleSetLabels:
             - arc-arm64
           minRunners: 1
-          maxRunners: 5
+          maxRunners: 10
           listenerTemplate:
             spec:
               dnsConfig:
@@ -158,8 +158,8 @@ spec:
           runnerScaleSetName: arc-amd64
           scaleSetLabels:
             - arc-amd64
-          minRunners: 0
-          maxRunners: 5
+          minRunners: 1
+          maxRunners: 10
           listenerTemplate:
             spec:
               dnsConfig:

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -50,10 +50,11 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerReleaseWorkflow).not.toContain('PersistentVolumeClaim')
   })
 
-  it('allows five concurrent ARC runners per scale set and keeps arm runners warm', () => {
-    expect(runnerScaleSetBlock('arc-arm64')).toContain('maxRunners: 5')
+  it('allows ten concurrent lab ARC runners per architecture and keeps runners warm', () => {
+    expect(runnerScaleSetBlock('arc-arm64')).toContain('maxRunners: 10')
     expect(runnerScaleSetBlock('arc-arm64')).toContain('minRunners: 1')
-    expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 5')
+    expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 10')
+    expect(runnerScaleSetBlock('arc-amd64')).toContain('minRunners: 1')
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('maxRunners: 5')
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('minRunners: 1')
   })


### PR DESCRIPTION
## Summary

- Set `arc-arm64` to min 1 / max 10.
- Set `arc-amd64` to min 1 / max 10.
- Update the ARC runner test guard for the requested lab runner scale limits.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`
- `yq -r '.spec.sources[].helm.valuesObject? | select(.runnerScaleSetName == "arc-arm64" or .runnerScaleSetName == "arc-amd64" or .runnerScaleSetName == "analysis-arm64") | [.runnerScaleSetName, .minRunners, .maxRunners] | @tsv' argocd/applications/arc/application.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
