### PR TITLE
ci(arc): reduce lab runner ephemeral requests

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -80,7 +80,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "40Gi"
+                      ephemeral-storage: "8Gi"
                     limits:
                       cpu: "8"
                       memory: "16Gi"
@@ -112,7 +112,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "30Gi"
+                      ephemeral-storage: "12Gi"
                     limits:
                       cpu: "12"
                       memory: "16Gi"
@@ -207,7 +207,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "40Gi"
+                      ephemeral-storage: "8Gi"
                     limits:
                       cpu: "8"
                       memory: "16Gi"
@@ -239,7 +239,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "30Gi"
+                      ephemeral-storage: "12Gi"
                     limits:
                       cpu: "12"
                       memory: "16Gi"

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -59,6 +59,17 @@ describe('ARC Nix runner toolchain', () => {
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('minRunners: 1')
   })
 
+  it('keeps lab ARC ephemeral-storage requests small enough for the configured runner scale', () => {
+    for (const scaleSet of ['arc-arm64', 'arc-amd64']) {
+      const block = runnerScaleSetBlock(scaleSet)
+      expect(block).toContain('ephemeral-storage: "8Gi"')
+      expect(block).toContain('ephemeral-storage: "12Gi"')
+    }
+
+    expect(arcApplication).toContain('storageClassName: "rook-ceph-block"')
+    expect(arcApplication).toContain('storage: 20Gi')
+  })
+
   it('builds a custom actions runner image with pinned Nix CI tools preinstalled', () => {
     expect(arcRunnerDockerfile).toContain('FROM ${ACTIONS_RUNNER_BASE}')
     expect(arcRunnerDockerfile).toContain(


### PR DESCRIPTION
## Summary

- Reduce lab ARC runner ephemeral-storage requests from 40Gi to 8Gi.
- Reduce lab ARC dind sidecar ephemeral-storage requests from 30Gi to 12Gi.
- Keep limits and the Ceph-backed work PVC unchanged while making the requested 1/10 lab runner scale schedulable.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`
- `yq -r '.spec.sources[].helm.valuesObject? | select(.runnerScaleSetName == "arc-arm64" or .runnerScaleSetName == "arc-amd64") | .runnerScaleSetName as $name | .template.spec.containers[] | select(.name == "runner" or .name == "dind") | [$name, .name, .resources.requests."ephemeral-storage", .resources.limits."ephemeral-storage"] | @tsv' argocd/applications/arc/application.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
