### PR TITLE
chore(sag): promote image sha-00b160b172fa87faf374c1aa063e1c55766a4f63

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    digest: sha256:21b761b9664941ed922959757f5b99bc4660df2df51375a70d2601a95318a80e
+    digest: sha256:2c3151fcc38f9f60b40959fede74a34e47ba6face468dd27521f3b111a590850


### PR DESCRIPTION
## Summary
Promote the Sag image into GitOps manifests.

- Source commit: `00b160b172fa87faf374c1aa063e1c55766a4f63`
- Image tag: `sha-00b160b172fa87faf374c1aa063e1c55766a4f63`
- Image digest: `sha256:2c3151fcc38f9f60b40959fede74a34e47ba6face468dd27521f3b111a590850`