### PR TITLE
ci(arc): fit ten lab runners per node

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -80,7 +80,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "8Gi"
+                      ephemeral-storage: "4Gi"
                     limits:
                       cpu: "8"
                       memory: "16Gi"
@@ -112,7 +112,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "12Gi"
+                      ephemeral-storage: "6Gi"
                     limits:
                       cpu: "12"
                       memory: "16Gi"
@@ -207,7 +207,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "8Gi"
+                      ephemeral-storage: "4Gi"
                     limits:
                       cpu: "8"
                       memory: "16Gi"
@@ -239,7 +239,7 @@ spec:
                     requests:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "12Gi"
+                      ephemeral-storage: "6Gi"
                     limits:
                       cpu: "12"
                       memory: "16Gi"

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -62,8 +62,8 @@ describe('ARC Nix runner toolchain', () => {
   it('keeps lab ARC ephemeral-storage requests small enough for the configured runner scale', () => {
     for (const scaleSet of ['arc-arm64', 'arc-amd64']) {
       const block = runnerScaleSetBlock(scaleSet)
-      expect(block).toContain('ephemeral-storage: "8Gi"')
-      expect(block).toContain('ephemeral-storage: "12Gi"')
+      expect(block).toContain('ephemeral-storage: "4Gi"')
+      expect(block).toContain('ephemeral-storage: "6Gi"')
     }
 
     expect(arcApplication).toContain('storageClassName: "rook-ceph-block"')


### PR DESCRIPTION
## Summary

- Lower lab ARC runner ephemeral-storage requests so the configured 1/10 arm64 and amd64 runner sets can schedule more of their requested capacity.
- Keep runner limits, Docker sidecar limits, and the existing rook-ceph-block work volume unchanged.
- Update the ARC runner contract test to assert the smaller lab runner requests and unchanged work PVC surface.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`
- `yq '.spec.sources[] | select(.helm.valuesObject.runnerScaleSetName == "arc-arm64" or .helm.valuesObject.runnerScaleSetName == "arc-amd64" or .helm.valuesObject.runnerScaleSetName == "analysis-arm64") | [.helm.valuesObject.runnerScaleSetName, .helm.valuesObject.minRunners, .helm.valuesObject.maxRunners, (.helm.valuesObject.template.spec.containers[] | select(.name == "runner") | .resources.requests."ephemeral-storage"), (.helm.valuesObject.template.spec.containers[] | select(.name == "dind") | .resources.requests."ephemeral-storage"), (.helm.valuesObject.template.spec.volumes[]? | select(.name == "work") | .ephemeral.volumeClaimTemplate.spec.resources.requests.storage)] | @tsv' argocd/applications/arc/application.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
