### PR TITLE
perf(arc): use local workdirs for lab runners

### DIFF
--- a/.github/workflows/arc-runner-build-push.yml
+++ b/.github/workflows/arc-runner-build-push.yml
@@ -14,8 +14,6 @@ on:
       - 'nix/toolchain-doctor.sh'
       - '.github/actions/setup-nix-toolchain/**'
       - '.github/workflows/arc-runner-build-push.yml'
-      - '.github/workflows/arc-runner-release.yml'
-      - 'packages/scripts/src/shared/__tests__/arc-runner.test.ts'
   push:
     branches:
       - main
@@ -28,7 +26,6 @@ on:
       - 'nix/toolchain-doctor.sh'
       - '.github/actions/setup-nix-toolchain/**'
       - '.github/workflows/arc-runner-build-push.yml'
-      - '.github/workflows/arc-runner-release.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -131,7 +131,7 @@ jobs:
           perl -0pi -e 's#image:\s+(?:ghcr\.io/actions/actions-runner:latest|registry\.ide-newton\.ts\.net/lab/arc-runner\@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' argocd/applications/arc/application.yaml
           test "$(grep -cF "image: ${IMAGE_REF}" argocd/applications/arc/application.yaml)" -eq 6
           grep -F 'image: docker:dind' argocd/applications/arc/application.yaml >/dev/null
-          grep -F 'storageClassName: "rook-ceph-block"' argocd/applications/arc/application.yaml >/dev/null
+          test "$(grep -cF 'sizeLimit: 80Gi' argocd/applications/arc/application.yaml)" -eq 2
 
       - name: Create ARC runner release pull request
         if: steps.meta.outputs.promote == 'true'
@@ -145,7 +145,7 @@ jobs:
 
             - Promote ARC runner containers to `${{ steps.meta.outputs.image }}@${{ steps.meta.outputs.digest }}`.
             - Source commit: `${{ steps.meta.outputs.source_sha }}`.
-            - Keep `docker:dind`, runner PVC settings, and storage classes unchanged.
+            - Keep `docker:dind` unchanged and preserve node-local lab runner work dirs.
 
             ## Related Issues
 

--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -47,8 +47,8 @@ spec:
               securityContext:
                 runAsNonRoot: false
                 # ARC runners need a writable tool cache under /home/runner/_work/_tool.
-                # With PVC-backed work dirs, the volume is root-owned by default; set an fsGroup so the
-                # non-root runner user can create directories before any workflow steps run.
+                # Keep lab runners on node-local work dirs so high-concurrency Nix image builds do not
+                # block on dynamic PVC provisioning before the runner can accept a job.
                 fsGroup: 1001
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
@@ -131,14 +131,8 @@ spec:
                       mountPath: /home/runner/externals
               volumes:
                 - name: work
-                  ephemeral:
-                    volumeClaimTemplate:
-                      spec:
-                        accessModes: ["ReadWriteOnce"]
-                        storageClassName: "rook-ceph-block"
-                        resources:
-                          requests:
-                            storage: 20Gi
+                  emptyDir:
+                    sizeLimit: 80Gi
                 - name: dind-sock
                   emptyDir: {}
                 - name: dind-externals
@@ -258,14 +252,8 @@ spec:
                       mountPath: /home/runner/externals
               volumes:
                 - name: work
-                  ephemeral:
-                    volumeClaimTemplate:
-                      spec:
-                        accessModes: ["ReadWriteOnce"]
-                        storageClassName: "rook-ceph-block"
-                        resources:
-                          requests:
-                            storage: 20Gi
+                  emptyDir:
+                    sizeLimit: 80Gi
                 - name: dind-sock
                   emptyDir: {}
                 - name: dind-externals

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -34,18 +34,24 @@ const runnerScaleSetBlock = (name: string): string => {
 }
 
 describe('ARC Nix runner toolchain', () => {
-  it('keeps ARC storage and Docker sidecar unchanged while making runner images releasable by digest', () => {
+  it('keeps lab ARC runners on local work dirs while making runner images releasable by digest', () => {
     expect(arcApplication).toContain('runnerScaleSetName: arc-arm64')
     expect(arcApplication).toContain('runnerScaleSetName: arc-amd64')
     expect(arcApplication).toContain('runnerScaleSetName: analysis-arm64')
     expect(arcApplication).toContain('image: docker:dind')
-    expect(arcApplication).toContain('storageClassName: "rook-ceph-block"')
-    expect(arcApplication).toContain('volumeClaimTemplate:')
+    for (const scaleSet of ['arc-arm64', 'arc-amd64']) {
+      const block = runnerScaleSetBlock(scaleSet)
+      expect(block).toContain('emptyDir:')
+      expect(block).toContain('sizeLimit: 80Gi')
+      expect(block).not.toContain('storageClassName: "rook-ceph-block"')
+      expect(block).not.toContain('volumeClaimTemplate:')
+    }
+    expect(runnerScaleSetBlock('analysis-arm64')).toContain('storageClassName: "rook-ceph-block"')
     expect(arcRunnerReleaseWorkflow).toContain('registry.ide-newton.ts.net/lab/arc-runner')
     expect(arcRunnerReleaseWorkflow).toContain('arc-runner\\@sha256')
     expect(arcRunnerReleaseWorkflow).toContain('test "$(grep -cF "image: ${IMAGE_REF}"')
     expect(arcRunnerReleaseWorkflow).toContain("grep -F 'image: docker:dind'")
-    expect(arcRunnerReleaseWorkflow).toContain('grep -F \'storageClassName: "rook-ceph-block"\'')
+    expect(arcRunnerReleaseWorkflow).toContain("grep -cF 'sizeLimit: 80Gi'")
     expect(arcRunnerReleaseWorkflow).not.toContain('ObjectBucketClaim')
     expect(arcRunnerReleaseWorkflow).not.toContain('PersistentVolumeClaim')
   })
@@ -64,10 +70,12 @@ describe('ARC Nix runner toolchain', () => {
       const block = runnerScaleSetBlock(scaleSet)
       expect(block).toContain('ephemeral-storage: "4Gi"')
       expect(block).toContain('ephemeral-storage: "6Gi"')
+      expect(block).toContain('sizeLimit: 80Gi')
+      expect(block).not.toContain('storage: 20Gi')
     }
 
-    expect(arcApplication).toContain('storageClassName: "rook-ceph-block"')
-    expect(arcApplication).toContain('storage: 20Gi')
+    expect(runnerScaleSetBlock('analysis-arm64')).toContain('storageClassName: "rook-ceph-block"')
+    expect(runnerScaleSetBlock('analysis-arm64')).toContain('storage: 20Gi')
   })
 
   it('builds a custom actions runner image with pinned Nix CI tools preinstalled', () => {
@@ -136,6 +144,8 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerBuildWorkflow).toContain('linux/amd64')
     expect(arcRunnerBuildWorkflow).toContain('linux/arm64')
     expect(arcRunnerBuildWorkflow).toContain('arc-runner-release-contract')
+    expect(arcRunnerBuildWorkflow).not.toContain("'.github/workflows/arc-runner-release.yml'")
+    expect(arcRunnerBuildWorkflow).not.toContain("'packages/scripts/src/shared/__tests__/arc-runner.test.ts'")
     expect(arcRunnerReleaseWorkflow).toContain('workflows:')
     expect(arcRunnerReleaseWorkflow).toContain('arc-runner-build-push')
     expect(arcRunnerReleaseWorkflow).toContain('peter-evans/create-pull-request@v7')


### PR DESCRIPTION
## Summary

- Move the `arc-arm64` and `arc-amd64` lab runner work directories from dynamic `rook-ceph-block` ephemeral PVCs to node-local `emptyDir` volumes with an 80Gi size limit.
- Keep the existing DinD sidecar, runner image pinning, min/max runner counts, and the separate `analysis-arm64` runner PVC behavior unchanged.
- Update ARC runner release guards/tests and stop rebuilding ARC runner images for release-workflow or test-only edits.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `yq '.spec.sources[1].helm.valuesObject.template.spec.volumes' argocd/applications/arc/application.yaml`
- `yq '.spec.sources[2].helm.valuesObject.template.spec.volumes' argocd/applications/arc/application.yaml`
- `yq '.spec.sources[3].helm.valuesObject.template.spec.volumes' argocd/applications/arc/application.yaml`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This does not modify Ceph, Rook, OBC, PVC, Talos, or storage resources; it only changes the lab ARC runner pod template to stop creating per-runner work PVCs.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
