### PR TITLE
fix(agents): avoid idempotency reservation race

### DIFF
--- a/services/agents/src/server/primitives-store.test.ts
+++ b/services/agents/src/server/primitives-store.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Db } from './db'
+import { createPrimitivesStore } from './primitives-store'
+
+type IdempotencyDbRow = {
+  id: string
+  namespace: string
+  agent_name: string
+  idempotency_key: string
+  agent_run_name: string | null
+  agent_run_uid: string | null
+  terminal_phase: string | null
+  terminal_at: Date | null
+  created_at: Date
+  updated_at: Date
+}
+
+const makeIdempotencyRow = (overrides: Partial<IdempotencyDbRow> = {}): IdempotencyDbRow => ({
+  id: 'idempotency-1',
+  namespace: 'agents',
+  agent_name: 'codex-agent',
+  idempotency_key: 'delivery-1',
+  agent_run_name: null,
+  agent_run_uid: null,
+  terminal_phase: null,
+  terminal_at: null,
+  created_at: new Date('2026-07-04T00:00:00.000Z'),
+  updated_at: new Date('2026-07-04T00:00:00.000Z'),
+  ...overrides,
+})
+
+const makeFakeDb = (options: { insertedRow?: IdempotencyDbRow; existingRow?: IdempotencyDbRow }) => {
+  const doNothing = vi.fn()
+  const columns = vi.fn(() => ({ doNothing }))
+  const insertBuilder = {
+    values: vi.fn(),
+    onConflict: vi.fn(),
+    returningAll: vi.fn(),
+    executeTakeFirst: vi.fn(),
+  }
+  const selectBuilder = {
+    selectAll: vi.fn(),
+    where: vi.fn(),
+    executeTakeFirst: vi.fn(),
+  }
+
+  insertBuilder.values.mockReturnValue(insertBuilder)
+  insertBuilder.onConflict.mockImplementation((callback: (builder: { columns: typeof columns }) => unknown) => {
+    callback({ columns })
+    return insertBuilder
+  })
+  insertBuilder.returningAll.mockReturnValue(insertBuilder)
+  insertBuilder.executeTakeFirst.mockResolvedValue(options.insertedRow)
+
+  selectBuilder.selectAll.mockReturnValue(selectBuilder)
+  selectBuilder.where.mockReturnValue(selectBuilder)
+  selectBuilder.executeTakeFirst.mockResolvedValue(options.existingRow)
+
+  const db = {
+    insertInto: vi.fn(() => insertBuilder),
+    selectFrom: vi.fn(() => selectBuilder),
+    destroy: vi.fn(async () => {}),
+  }
+
+  return { db: db as unknown as Db, insertBuilder, selectBuilder }
+}
+
+describe('createPrimitivesStore', () => {
+  const previousMigrationsMode = process.env.AGENTS_MIGRATIONS
+
+  beforeEach(() => {
+    process.env.AGENTS_MIGRATIONS = 'skip'
+  })
+
+  afterEach(() => {
+    if (previousMigrationsMode === undefined) {
+      delete process.env.AGENTS_MIGRATIONS
+    } else {
+      process.env.AGENTS_MIGRATIONS = previousMigrationsMode
+    }
+  })
+
+  it('reserves new AgentRun idempotency keys without a follow-up lookup', async () => {
+    const insertedRow = makeIdempotencyRow()
+    const { db, selectBuilder } = makeFakeDb({ insertedRow })
+    const store = createPrimitivesStore({
+      url: 'postgresql://user:pass@localhost:5432/agents',
+      createDb: () => db,
+    })
+
+    const result = await store.reserveAgentRunIdempotencyKey({
+      namespace: 'agents',
+      agentName: 'codex-agent',
+      idempotencyKey: 'delivery-1',
+    })
+
+    expect(result).toMatchObject({
+      created: true,
+      record: {
+        id: 'idempotency-1',
+        namespace: 'agents',
+        agentName: 'codex-agent',
+        idempotencyKey: 'delivery-1',
+      },
+    })
+    expect(selectBuilder.executeTakeFirst).not.toHaveBeenCalled()
+  })
+
+  it('resolves conflicting AgentRun idempotency keys in a separate statement', async () => {
+    const existingRow = makeIdempotencyRow({ agent_run_name: 'codex-agent-existing' })
+    const { db, selectBuilder } = makeFakeDb({ existingRow })
+    const store = createPrimitivesStore({
+      url: 'postgresql://user:pass@localhost:5432/agents',
+      createDb: () => db,
+    })
+
+    const result = await store.reserveAgentRunIdempotencyKey({
+      namespace: 'agents',
+      agentName: 'codex-agent',
+      idempotencyKey: 'delivery-1',
+    })
+
+    expect(result).toMatchObject({
+      created: false,
+      record: {
+        id: 'idempotency-1',
+        namespace: 'agents',
+        agentName: 'codex-agent',
+        idempotencyKey: 'delivery-1',
+        agentRunName: 'codex-agent-existing',
+      },
+    })
+    expect(selectBuilder.executeTakeFirst).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/agents/src/server/primitives-store.ts
+++ b/services/agents/src/server/primitives-store.ts
@@ -309,9 +309,6 @@ const toAgentRunIdempotencyRecord = (row: {
   updatedAt: row.updated_at,
 })
 
-type AgentRunIdempotencyRow = Parameters<typeof toAgentRunIdempotencyRecord>[0]
-type AgentRunIdempotencyReservationRow = AgentRunIdempotencyRow & { created: boolean }
-
 const toAgentRunRerunSubmissionRecord = (row: {
   id: string
   parent_ref: string
@@ -666,49 +663,38 @@ export const createPrimitivesStore = (options: PrimitivesStoreOptions = {}): Pri
 
   const reserveAgentRunIdempotencyKey: PrimitivesStore['reserveAgentRunIdempotencyKey'] = async (input) => {
     await ready
-    const result = await sql<AgentRunIdempotencyReservationRow>`
-      WITH inserted AS (
-        INSERT INTO agent_run_idempotency_keys (
-          namespace,
-          agent_name,
-          idempotency_key,
-          agent_run_name,
-          agent_run_uid,
-          terminal_phase,
-          terminal_at
-        )
-        VALUES (
-          ${input.namespace},
-          ${input.agentName},
-          ${input.idempotencyKey},
-          NULL,
-          NULL,
-          NULL,
-          NULL
-        )
-        ON CONFLICT (namespace, agent_name, idempotency_key) DO NOTHING
-        RETURNING *, TRUE AS created
-      ),
-      existing AS (
-        SELECT *, FALSE AS created
-        FROM agent_run_idempotency_keys
-        WHERE namespace = ${input.namespace}
-          AND agent_name = ${input.agentName}
-          AND idempotency_key = ${input.idempotencyKey}
-          AND NOT EXISTS (SELECT 1 FROM inserted)
-      )
-      SELECT * FROM inserted
-      UNION ALL
-      SELECT * FROM existing
-      LIMIT 1;
-    `.execute(db)
-    const row = result.rows[0]
+    const inserted = await db
+      .insertInto('agent_run_idempotency_keys')
+      .values({
+        namespace: input.namespace,
+        agent_name: input.agentName,
+        idempotency_key: input.idempotencyKey,
+        agent_run_name: null,
+        agent_run_uid: null,
+        terminal_phase: null,
+        terminal_at: null,
+      })
+      .onConflict((oc) => oc.columns(['namespace', 'agent_name', 'idempotency_key']).doNothing())
+      .returningAll()
+      .executeTakeFirst()
 
-    if (!row) {
+    if (inserted) {
+      return { record: toAgentRunIdempotencyRecord(inserted), created: true }
+    }
+
+    const existing = await db
+      .selectFrom('agent_run_idempotency_keys')
+      .selectAll()
+      .where('namespace', '=', input.namespace)
+      .where('agent_name', '=', input.agentName)
+      .where('idempotency_key', '=', input.idempotencyKey)
+      .executeTakeFirst()
+
+    if (!existing) {
       throw new Error('failed to resolve agent run idempotency key after conflict')
     }
 
-    return { record: toAgentRunIdempotencyRecord(row), created: row.created }
+    return { record: toAgentRunIdempotencyRecord(existing), created: false }
   }
 
   const assignAgentRunIdempotencyKey: PrimitivesStore['assignAgentRunIdempotencyKey'] = async (input) => {


### PR DESCRIPTION
## Summary

- Address Codex review feedback from #11891 by removing the single-statement idempotency reservation CTE.
- Keep the fast insert path for new keys, then perform a separate lookup only when `ON CONFLICT DO NOTHING` returns no row.
- Add direct primitives-store regression coverage for new reservations and duplicate idempotency key reservations.

## Related Issues

Related to #11891 and #11885.

## Testing

- `bun run --filter @proompteng/agents test -- src/server/primitives-store.test.ts`
- `bun run --filter @proompteng/agents test -- src/server/v1/agent-runs.test.ts -t "idempotency|audit persistence"`
- `bunx oxfmt --check services/agents/src/server/primitives-store.ts services/agents/src/server/primitives-store.test.ts`
- `bun run --filter @proompteng/agents tsc`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
