### PR TITLE
fix(torghut): expose hyperliquid loop status alias

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: string
         default: ''
+      publish_on_dispatch:
+        required: false
+        type: boolean
+        default: false
     outputs:
       image:
         value: ${{ jobs.publish-index.outputs.image }}
@@ -160,7 +164,14 @@ jobs:
             bash nix/oci-inspect-archive.sh "${IMAGE_TAR}"
 
       - name: Push platform image without Docker
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        if: >-
+          ${{
+            (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+            (
+              github.event_name == 'workflow_dispatch' &&
+              (github.ref == 'refs/heads/main' || inputs.publish_on_dispatch)
+            )
+          }}
         id: push
         env:
           IMAGE: registry.ide-newton.ts.net/lab/${{ inputs.image_name }}
@@ -213,7 +224,14 @@ jobs:
         run: bash nix/ci-nix-oci-summary.sh
 
   publish-index:
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    if: >-
+      ${{
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          (github.ref == 'refs/heads/main' || inputs.publish_on_dispatch)
+        )
+      }}
     needs: build-platform
     runs-on: arc-arm64
     outputs:

--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -7,6 +7,11 @@ on:
   pull_request:
     paths:
       - 'services/torghut/**'
+      - 'packages/scripts/src/torghut/**'
+      - '!packages/scripts/src/torghut/__tests__/**'
+      - '!packages/scripts/src/torghut/**/*.test.ts'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/git.ts'
       - 'nix/images/torghut.nix'
       - 'nix/cache-push.sh'
       - 'nix/ci-nix-oci-summary.sh'
@@ -16,11 +21,20 @@ on:
       - 'nix/oci-release-contract.sh'
       - 'flake.lock'
       - 'services/torghut/uv.lock'
+      - '.github/workflows/torghut-build-push.yaml'
+      - '.github/workflows/torghut-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   push:
     branches:
       - main
     paths:
       - 'services/torghut/**'
+      - 'packages/scripts/src/torghut/**'
+      - '!packages/scripts/src/torghut/__tests__/**'
+      - '!packages/scripts/src/torghut/**/*.test.ts'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/git.ts'
       - 'nix/images/torghut.nix'
       - 'nix/cache-push.sh'
       - 'nix/ci-nix-oci-summary.sh'
@@ -30,6 +44,10 @@ on:
       - 'nix/oci-release-contract.sh'
       - 'flake.lock'
       - 'services/torghut/uv.lock'
+      - '.github/workflows/torghut-build-push.yaml'
+      - '.github/workflows/torghut-release.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - '.github/actions/setup-nix-toolchain/**'
   workflow_dispatch:
 
 concurrency:
@@ -46,4 +64,5 @@ jobs:
       tag: sha-${{ github.sha }}
       latest: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
       release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'torghut-release-contract' || '' }}
+      publish_on_dispatch: true
     secrets: inherit

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -122,6 +122,8 @@ jobs:
                   git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" -- \
                     services/torghut \
                     packages/scripts/src/torghut \
+                    ':(glob,exclude)packages/scripts/src/torghut/__tests__/**' \
+                    ':(glob,exclude)packages/scripts/src/torghut/**/*.test.ts' \
                     packages/scripts/src/shared/cli.ts \
                     packages/scripts/src/shared/git.ts \
                     nix/images/torghut.nix \

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -117,6 +117,9 @@ jobs:
                 TORGHUT_CHANGES="$(
                   git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" -- \
                     services/torghut \
+                    packages/scripts/src/torghut \
+                    packages/scripts/src/shared/cli.ts \
+                    packages/scripts/src/shared/git.ts \
                     nix/images/torghut.nix \
                     nix/cache-push.sh \
                     nix/ci-nix-oci-summary.sh \
@@ -125,7 +128,11 @@ jobs:
                     nix/oci-push.sh \
                     nix/oci-release-contract.sh \
                     flake.lock \
-                    services/torghut/uv.lock
+                    services/torghut/uv.lock \
+                    .github/workflows/torghut-build-push.yaml \
+                    .github/workflows/torghut-release.yml \
+                    .github/workflows/nix-oci-build-common.yml \
+                    .github/actions/setup-nix-toolchain
                 )"
                 if [ -n "${TORGHUT_CHANGES}" ]; then
                   echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; newer Torghut build inputs changed:"
@@ -238,7 +245,7 @@ jobs:
           TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           TORGHUT_IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
           TORGHUT_COMMIT: ${{ steps.meta.outputs.source_sha }}
-          TORGHUT_INCLUDE_OPTIONS_MANIFESTS: "false"
+          TORGHUT_INCLUDE_OPTIONS_MANIFESTS: 'false'
         run: |
           set -euo pipefail
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -30,7 +30,11 @@ jobs:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
-        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' &&
+          github.event.workflow_run.event == 'push'
+        )
       }}
     runs-on: arc-arm64
     permissions:

--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -39,9 +39,9 @@ spec:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-00b160b172fa87faf374c1aa063e1c55766a4f63
+              value: main-sha-5e046147da58bd014bca17565cbd731626ec875b
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: 00b160b172fa87faf374c1aa063e1c55766a4f63
+              value: 5e046147da58bd014bca17565cbd731626ec875b
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
               value: sha256:e2c22b1073e02c3f5fe5f6d088b436da9496a752fd2de224225c9dea8595c5ce
             - name: KAFKA_SASL_USER

--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:607af89da76b14c984939adb5d9d6e11726fe7b82f14ab2d0072189012e96e72
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -51,9 +51,9 @@ spec:
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: c789931929fb3116093abb4a1e9d3a28efe562fb
+              value: f5cf060c8dfce37133b62ab580d321c3626daf8c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:607af89da76b14c984939adb5d9d6e11726fe7b82f14ab2d0072189012e96e72
+              value: sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:03a55dcd405376a3f713ea50e64f1455ffc3f5ac3634726a7f680c8f8fd5dc1c
           imagePullPolicy: Always
           command:
             - /bin/sh
@@ -51,9 +51,9 @@ spec:
               /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: f5cf060c8dfce37133b62ab580d321c3626daf8c
+              value: 9afbcac4b27576a5911e617ad8f98dd327c645b2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
+              value: sha256:03a55dcd405376a3f713ea50e64f1455ffc3f5ac3634726a7f680c8f8fd5dc1c
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:03a55dcd405376a3f713ea50e64f1455ffc3f5ac3634726a7f680c8f8fd5dc1c
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: f5cf060c8dfce37133b62ab580d321c3626daf8c
+              value: 9afbcac4b27576a5911e617ad8f98dd327c645b2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
+              value: sha256:03a55dcd405376a3f713ea50e64f1455ffc3f5ac3634726a7f680c8f8fd5dc1c
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:607af89da76b14c984939adb5d9d6e11726fe7b82f14ab2d0072189012e96e72
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: c789931929fb3116093abb4a1e9d3a28efe562fb
+              value: f5cf060c8dfce37133b62ab580d321c3626daf8c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:607af89da76b14c984939adb5d9d6e11726fe7b82f14ab2d0072189012e96e72
+              value: sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/docs/torghut/design-system/v1/component-trading-loop.md
+++ b/docs/torghut/design-system/v1/component-trading-loop.md
@@ -9,14 +9,14 @@
 
 ## Source Implementation Audit (2026-07-04)
 
-- Source baseline inspected: `6473f3ee7 ci(arc): fit ten lab runners per node (#11877)`.
+- Source baseline inspected: `0aee01702 fix(torghut): pin loop status runtime image (#11897)`.
 - Implementation status: **Implemented, but materially refactored from this v1 document.** The periodic trading loop exists, but not as the old monolithic `services/torghut/app/trading/scheduler.py` flow. Current runtime is split across `SimpleTradingPipeline`, shared pipeline mixins, source-collection helpers, paper-route materialization, submission policy, and execution/adapters.
 - Current source evidence:
   - `services/torghut/app/trading/scheduler/simple_pipeline.py` defines `SimpleTradingPipeline`, composed from paper-route, source-collection, proof-floor, quote-sizing, direct-submission, and base pipeline mixins.
   - `services/torghut/app/trading/scheduler/simple_pipeline.py::SimpleTradingPipeline.run_once` labels mature rejected-signal outcomes, loads strategies, captures runtime-window account snapshots, warms session context, bounds paper-route signal scope, fetches signals, and processes the batch.
   - `services/torghut/app/trading/scheduler/pipeline/run_cycle.py::TradingPipelineRunCycleMixin.run_once` keeps the generic dependency-driven run cycle for ingestor/decision/risk/executor/reconciler style operation.
   - `services/torghut/app/trading/scheduler/pipeline/submission_policy.py` gates decision submission with allocator rejection, notional extraction, market snapshots, and submission preparation.
-  - `argocd/applications/torghut/knative-service.yaml` currently sets `TRADING_ENABLED=true`, `TRADING_MODE=live`, `TRADING_PIPELINE_MODE=simple`, `TRADING_SIMPLE_SUBMIT_ENABLED=true`, `TRADING_LIVE_SUBMIT_ENABLED=true`, a live-submit activation expiry, and bounded simple risk caps.
+  - `argocd/applications/torghut/knative-service.yaml` currently sets `TRADING_ENABLED=true`, `TRADING_MODE=live`, `TRADING_PIPELINE_MODE=simple`, `TRADING_SIMPLE_SUBMIT_ENABLED=true`, `TRADING_LIVE_SUBMIT_ENABLED=true`, a live-submit activation expiry, `TRADING_TESTNET_AFTER_HOURS_ENABLED=true`, and bounded simple risk caps.
   - Pipeline behavior is covered by the `services/torghut/tests/pipeline/test_trading_pipeline_*.py` suite.
 - What is implemented from the design:
   - periodic service-owned trading loop;
@@ -84,9 +84,10 @@ From `argocd/applications/torghut/knative-service.yaml`:
 | --- | --- | --- |
 | `TRADING_ENABLED` | Enables loop | `true` |
 | `TRADING_MODE` | `paper` / `live` | `live` in the current manifest |
-| `TRADING_SIMPLE_SUBMIT_ENABLED` | broker submission gate | `true` in the current manifest |
+| `TRADING_SIMPLE_SUBMIT_ENABLED` | simple pipeline submission gate | `true` in the current manifest |
 | `TRADING_LIVE_SUBMIT_ENABLED` | live broker submission gate | `true` in the current manifest |
 | `TRADING_LIVE_SUBMIT_ACTIVATION_EXPIRES_AT` | time-bounds live-submit activation | set in the current manifest |
+| `TRADING_TESTNET_AFTER_HOURS_ENABLED` | testnet route outside Alpaca regular hours | `true` in the current manifest |
 | `TRADING_SIGNAL_SOURCE` | signal backend | `clickhouse` |
 | `TRADING_SIGNAL_TABLE` | ClickHouse table | `torghut.ta_signals` |
 | `TRADING_SIGNAL_SCHEMA` | Signals schema selector (`auto`/`envelope`/`flat`) | `auto` |
@@ -137,17 +138,17 @@ Risk engine enforces:
 
 Orders must be idempotent across retries (see `v1/component-order-execution-and-idempotency.md`).
 
-### Rollout/verification (paper-first + live-gate posture)
+### Rollout/verification (live-mode + explicit gate posture)
 
-- GitOps precondition for production:
-  - `TRADING_MODE=paper`
-  - `TRADING_ACCOUNTS_JSON` account entries in paper mode
-  - `LLM_FAIL_OPEN_LIVE_APPROVED=false`
-  - `TRADING_KILL_SWITCH_ENABLED=true`
-  - `TRADING_EMERGENCY_STOP_ENABLED=true`
+- Current GitOps posture:
+  - `TRADING_MODE=live`
+  - `TRADING_SIMPLE_SUBMIT_ENABLED=true`
+  - `TRADING_LIVE_SUBMIT_ENABLED=true`
+  - `TRADING_TESTNET_AFTER_HOURS_ENABLED=true`
+  - bounded simple risk caps in the Knative manifest
 - Verification:
-  - `/trading/status` reports `trading_mode=paper` and no live execution path is active.
-  - confirm new `/trading/executions` records are paper-labeled.
+  - `/trading/status` reports the selected execution route, live-submit gate, blockers, and risk caps.
+  - confirm new `/trading/executions`, broker orders, fills, and exposure records match the selected route.
 
 ## Failure modes, detection, recovery
 

--- a/docs/torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md
+++ b/docs/torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md
@@ -15,14 +15,16 @@ Current governing contracts:
 
 Merged PR evidence:
 
-- `#5854` capital evidence return lane, merged as `b05380736319cd68b17549615d9602adbc1abc46`.
-- `#6418` quant plan closeout handoff.
-- `#6592` alpha readiness settlement conveyor.
-- `#6618` verify trust foreclosure, merged as `4190b42ea61504130458da8fc49f3dfa1820ff76`.
+- PR `#5854`: `docs(torghut): define capital evidence return lane`, merged as
+  `b05380736319cd68b17549615d9602adbc1abc46`.
+- PR `#6418`: `docs(torghut): add quant plan closeout handoff`, merged on 2026-05-13.
+- PR `#6592`: `docs(torghut): define alpha readiness settlement conveyor`, merged on 2026-05-14.
+- PR `#6618`: `docs(jangar): define verify trust foreclosure`, merged as
+  `4190b42ea61504130458da8fc49f3dfa1820ff76`.
 
 ## Source Implementation Audit (2026-07-04)
 
-- Source baseline inspected: `6473f3ee7 ci(arc): fit ten lab runners per node (#11877)`.
+- Source baseline inspected: `0aee01702 fix(torghut): pin loop status runtime image (#11897)`.
 - Implementation status: Partially implemented: strategy/alpha/discovery/profile modules and tests exist, but research strategy proposals are not all promoted runtime strategies.
 - Matched implementation area: Strategy, alpha, TSMOM, regime, portfolio, and sizing.
 - Current source evidence:
@@ -32,7 +34,6 @@ Merged PR evidence:
   - `services/torghut/app/trading/discovery/candidate_specs.py`
   - `services/torghut/app/trading/portfolio`
 - Design drift note: A research/stress module is not enough to call a strategy live; promotion still depends on proof/readiness gates.
-
 
 ## Decision
 

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -359,6 +359,9 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('nix build ".#${PACKAGE_ATTR}"')
     expect(nixOciWorkflow).toContain('bash nix/oci-inspect-archive.sh "${IMAGE_TAR}"')
     expect(nixOciWorkflow).toContain('bash nix/oci-push.sh')
+    expect(nixOciWorkflow).toContain('publish_on_dispatch:')
+    expect(nixOciWorkflow).toContain("github.event_name == 'workflow_dispatch'")
+    expect(nixOciWorkflow).toContain("github.ref == 'refs/heads/main' || inputs.publish_on_dispatch")
     expect(nixOciWorkflow).toContain('bun run packages/scripts/src/shared/oci.ts create-index')
     expect(nixOciWorkflow).toContain('bun run packages/scripts/src/shared/oci.ts assert')
     expect(nixOciWorkflow).toContain('printf \'%s\\n\' "${image_tar}" > "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
@@ -502,7 +505,6 @@ describe('native OCI build workflows', () => {
       enabledSimpleReleaseWorkflow,
       enabledProductReleaseWorkflow,
       sagReleaseWorkflow,
-      torghutReleaseWorkflow,
       torghutTaReleaseWorkflow,
       torghutWsReleaseWorkflow,
       torghutHyperliquidFeedReleaseWorkflow,
@@ -531,7 +533,6 @@ describe('native OCI build workflows', () => {
       agentsBuildWorkflow,
       symphonyBuildWorkflow,
       sagBuildWorkflow,
-      torghutBuildWorkflow,
       torghutTaBuildWorkflow,
       torghutWsBuildWorkflow,
       torghutHyperliquidFeedBuildWorkflow,
@@ -680,7 +681,9 @@ describe('native OCI build workflows', () => {
     const mainDispatchPredicate =
       "(github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'"
 
-    expect(nixOciWorkflow).toContain(`if: ${mainDispatchPredicate}`)
+    expect(nixOciWorkflow).toContain("github.event_name == 'push' && github.ref == 'refs/heads/main'")
+    expect(nixOciWorkflow).toContain("github.event_name == 'workflow_dispatch'")
+    expect(nixOciWorkflow).toContain("github.ref == 'refs/heads/main' || inputs.publish_on_dispatch")
     expect(nixOciWorkflow).toContain('name: Push platform image without Docker')
     expect(nixOciWorkflow).toContain('name: Warm Nix image archive closure in Attic')
     expect(nixOciWorkflow).toContain('publish-index:')

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -43,6 +43,9 @@ const arcApplication = readFileSync(
 const pathPatternIndex = (pattern: string): number =>
   workflow.split('\n').findIndex((line) => line.trim() === `- '${pattern}'`)
 
+const pathPatternOccurrences = (pattern: string): number =>
+  workflow.split('\n').filter((line) => line.trim() === `- '${pattern}'`).length
+
 const ciPathPatternIndex = (pattern: string): number =>
   ciWorkflow.split('\n').findIndex((line) => line.trim() === `- '${pattern}'`)
 
@@ -62,15 +65,27 @@ const staleDiffBlockFor = (releaseWorkflow: string, markerPath: string): string 
 }
 
 describe('torghut build-push workflow', () => {
-  it('does not build the core Torghut image for release helper script changes', () => {
-    expect(pathPatternIndex('packages/scripts/src/torghut/**')).toBe(-1)
+  it('builds the core Torghut image for release helper and shared build changes', () => {
+    const requiredPatterns = [
+      'services/torghut/**',
+      'packages/scripts/src/torghut/**',
+      'packages/scripts/src/shared/cli.ts',
+      'packages/scripts/src/shared/git.ts',
+      'nix/images/torghut.nix',
+      '.github/workflows/torghut-build-push.yaml',
+      '.github/workflows/torghut-release.yml',
+      '.github/workflows/nix-oci-build-common.yml',
+      '.github/actions/setup-nix-toolchain/**',
+    ]
+
+    for (const pattern of requiredPatterns) {
+      expect(pathPatternOccurrences(pattern)).toBe(2)
+    }
+
+    const scriptsInclude = pathPatternIndex('packages/scripts/src/torghut/**')
+    expect(pathPatternIndex('!packages/scripts/src/torghut/__tests__/**')).toBeGreaterThan(scriptsInclude)
+    expect(pathPatternIndex('!packages/scripts/src/torghut/**/*.test.ts')).toBeGreaterThan(scriptsInclude)
     expect(pathPatternIndex('packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts')).toBe(-1)
-    expect(pathPatternIndex('packages/scripts/src/shared/cli.ts')).toBe(-1)
-    expect(pathPatternIndex('packages/scripts/src/shared/git.ts')).toBe(-1)
-    expect(pathPatternIndex('.github/workflows/torghut-build-push.yaml')).toBe(-1)
-    expect(pathPatternIndex('.github/workflows/nix-oci-build-common.yml')).toBe(-1)
-    expect(pathPatternIndex('services/torghut/**')).toBeGreaterThan(-1)
-    expect(pathPatternIndex('nix/images/torghut.nix')).toBeGreaterThan(-1)
   })
 
   it('does not run full Torghut service CI for the Hyperliquid feed release updater', () => {
@@ -96,6 +111,7 @@ describe('torghut build-push workflow', () => {
     expect(workflow).toContain('image_name: torghut')
     expect(workflow).toContain('package_attr: torghut-image')
     expect(workflow).toContain('tag: sha-${{ github.sha }}')
+    expect(workflow).toContain('publish_on_dispatch: true')
     expect(workflow).toContain('torghut-release-contract')
     expect(workflow).not.toContain('docker/setup-buildx-action')
     expect(workflow).not.toContain('docker/build-push-action')

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -132,6 +132,12 @@ describe('torghut build-push workflow', () => {
     )
   })
 
+  it('does not auto-promote manually dispatched Torghut image publishes without a release contract', () => {
+    expect(releaseWorkflow).toContain("github.event.workflow_run.event == 'push'")
+    expect(releaseWorkflow).toContain("github.event_name == 'workflow_dispatch'")
+    expect(releaseWorkflow).toContain('Download release contract artifact from triggering build')
+  })
+
   it('keeps core Torghut stale workflow promotions aligned with build trigger inputs', () => {
     const freshnessPaths = [
       'services/torghut',

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -156,6 +156,8 @@ describe('torghut build-push workflow', () => {
     for (const path of freshnessPaths) {
       expect(releaseWorkflow).toContain(path)
     }
+    expect(releaseWorkflow).toContain("':(glob,exclude)packages/scripts/src/torghut/__tests__/**'")
+    expect(releaseWorkflow).toContain("':(glob,exclude)packages/scripts/src/torghut/**/*.test.ts'")
     expect(releaseWorkflow).toContain('newer Torghut build inputs changed')
     expect(releaseWorkflow).toContain('newer main ${MAIN_HEAD} contains only unrelated changes')
   })

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -18,6 +18,10 @@ const hyperliquidFeedWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-hyperliquid-feed-build-push.yaml', import.meta.url),
   'utf8',
 )
+const releaseWorkflow = readFileSync(
+  new URL('../../../../../.github/workflows/torghut-release.yml', import.meta.url),
+  'utf8',
+)
 const taReleaseWorkflow = readFileSync(
   new URL('../../../../../.github/workflows/torghut-ta-release.yml', import.meta.url),
   'utf8',
@@ -126,6 +130,28 @@ describe('torghut build-push workflow', () => {
     expect(workflow).toContain(
       `release_artifact_name: \${{ ${mainDispatchPredicate} && 'torghut-release-contract' || '' }}`,
     )
+  })
+
+  it('keeps core Torghut stale workflow promotions aligned with build trigger inputs', () => {
+    const freshnessPaths = [
+      'services/torghut',
+      'packages/scripts/src/torghut',
+      'packages/scripts/src/shared/cli.ts',
+      'packages/scripts/src/shared/git.ts',
+      'nix/images/torghut.nix',
+      '.github/workflows/torghut-build-push.yaml',
+      '.github/workflows/torghut-release.yml',
+      '.github/workflows/nix-oci-build-common.yml',
+      '.github/actions/setup-nix-toolchain',
+    ]
+
+    expect(releaseWorkflow).toContain('git merge-base --is-ancestor "${SOURCE_SHA}" "${MAIN_HEAD}"')
+    expect(releaseWorkflow).toContain('git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" --')
+    for (const path of freshnessPaths) {
+      expect(releaseWorkflow).toContain(path)
+    }
+    expect(releaseWorkflow).toContain('newer Torghut build inputs changed')
+    expect(releaseWorkflow).toContain('newer main ${MAIN_HEAD} contains only unrelated changes')
   })
 
   it('publishes and contracts TA and WS images through the shared Nix OCI workflow', () => {

--- a/services/torghut/app/hyperliquid_execution/api.py
+++ b/services/torghut/app/hyperliquid_execution/api.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from datetime import datetime, timezone
+from typing import AsyncIterator, cast
 
 from fastapi import FastAPI, Response
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 
 from app.db import SessionLocal
+from app.trading.loop_status import (
+    LoopStatusOptions,
+    QuerySession,
+    build_trading_loop_status,
+)
 
 from .config import HyperliquidExecutionConfig
 from .exchange import exchange_from_config
@@ -92,7 +100,6 @@ def readyz(response: Response) -> dict[str, object]:
 
 
 @app.get("/trading/status")
-@app.get("/trading/loop/status")
 def trading_status() -> dict[str, object]:
     ready, reasons, dependencies = runtime_readiness(
         config=runtime_state.config,
@@ -120,6 +127,23 @@ def trading_status() -> dict[str, object]:
         "operational_submission_gate": gate,
         "live_submission_gate": dict(gate),
     }
+
+
+@app.get("/trading/loop/status")
+def trading_loop_status() -> JSONResponse:
+    session = SessionLocal()
+    try:
+        payload = build_trading_loop_status(
+            cast(QuerySession, session),
+            options=LoopStatusOptions(
+                generated_at=datetime.now(timezone.utc),
+                trading_mode=_loop_status_trading_mode(runtime_state.config),
+                trading_enabled=runtime_state.config.trading_enabled,
+            ),
+        )
+    finally:
+        session.close()
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
 @app.get("/metrics")
@@ -220,6 +244,12 @@ def _config_payload() -> dict[str, object]:
         "maintenance_reduce_only_close_enabled": config.maintenance_reduce_only_close_enabled,
         "sample_ready_fill_floor": 40,
     }
+
+
+def _loop_status_trading_mode(config: HyperliquidExecutionConfig) -> str:
+    if config.execution_network in {"mainnet", "live"}:
+        return "live"
+    return "paper"
 
 
 def _dependency_payload(dependency: RuntimeDependencyStatus) -> dict[str, object]:

--- a/services/torghut/app/hyperliquid_execution/api.py
+++ b/services/torghut/app/hyperliquid_execution/api.py
@@ -92,6 +92,7 @@ def readyz(response: Response) -> dict[str, object]:
 
 
 @app.get("/trading/status")
+@app.get("/trading/loop/status")
 def trading_status() -> dict[str, object]:
     ready, reasons, dependencies = runtime_readiness(
         config=runtime_state.config,

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_status_api.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_status_api.py
@@ -6,6 +6,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
+from fastapi.testclient import TestClient
+
 from app.hyperliquid_execution import api
 from app.hyperliquid_execution.config import HyperliquidExecutionConfig
 from app.hyperliquid_execution.models import CycleResult, RuntimeDependencyStatus
@@ -61,6 +63,32 @@ def test_trading_status_projects_runtime_cycle_and_compatibility_gate() -> None:
         "trading_disabled",
     ]
     assert payload["live_submission_gate"] == payload["operational_submission_gate"]
+
+
+def test_trading_loop_status_alias_uses_runtime_status_contract() -> None:
+    cycle = CycleResult(
+        observed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        markets_seen=1,
+        selected_coins=("BTC",),
+        signals_written=1,
+        orders_submitted=1,
+        orders_cancelled=0,
+        dependencies=(RuntimeDependencyStatus("hyperliquid_feed_service", True),),
+        universe_details={"selected": ["BTC"]},
+    )
+    config = HyperliquidExecutionConfig.from_env(
+        {"HYPERLIQUID_EXECUTION_ENABLED": "false"}
+    )
+
+    with _runtime_state(config=config, cycle=cycle):
+        response = TestClient(api.app).get("/trading/loop/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is True
+    assert payload["execution_route"] == "testnet"
+    assert payload["latest_cycle"]["orders_submitted"] == 1
+    assert payload["operational_submission_gate"] == payload["live_submission_gate"]
 
 
 def test_trading_status_reports_operational_gate_without_alpha_blockers() -> None:

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_status_api.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_status_api.py
@@ -6,11 +6,13 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.hyperliquid_execution import api
 from app.hyperliquid_execution.config import HyperliquidExecutionConfig
 from app.hyperliquid_execution.models import CycleResult, RuntimeDependencyStatus
+from app.trading.loop_status import LoopStatusOptions
 
 
 @contextmanager
@@ -65,30 +67,64 @@ def test_trading_status_projects_runtime_cycle_and_compatibility_gate() -> None:
     assert payload["live_submission_gate"] == payload["operational_submission_gate"]
 
 
-def test_trading_loop_status_alias_uses_runtime_status_contract() -> None:
-    cycle = CycleResult(
-        observed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-        markets_seen=1,
-        selected_coins=("BTC",),
-        signals_written=1,
-        orders_submitted=1,
-        orders_cancelled=0,
-        dependencies=(RuntimeDependencyStatus("hyperliquid_feed_service", True),),
-        universe_details={"selected": ["BTC"]},
-    )
+def test_trading_loop_status_route_uses_loop_proof_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _Session:
+        def close(self) -> None:
+            captured["closed"] = True
+
+    def fake_session_local() -> _Session:
+        session = _Session()
+        captured["session"] = session
+        return session
+
+    def fake_build(
+        session: object,
+        *,
+        options: LoopStatusOptions,
+    ) -> dict[str, object]:
+        captured["build_session"] = session
+        captured["options"] = options
+        return {
+            "schema_version": "torghut.trading-loop-status.v1",
+            "restored": False,
+            "runtime": {"status": "blocked"},
+            "market_data": {"fresh": False},
+            "fills": {"recent_count": 0},
+            "position": {"reconciled": False},
+            "blocker_reasons": ["hyperliquid_market_data_not_fresh"],
+        }
+
+    monkeypatch.setattr(api, "SessionLocal", fake_session_local)
+    monkeypatch.setattr(api, "build_trading_loop_status", fake_build)
     config = HyperliquidExecutionConfig.from_env(
-        {"HYPERLIQUID_EXECUTION_ENABLED": "false"}
+        {
+            "HYPERLIQUID_EXECUTION_ENABLED": "false",
+            "HYPERLIQUID_EXECUTION_TRADING_ENABLED": "true",
+            "HYPERLIQUID_EXECUTION_EXECUTION_NETWORK": "testnet",
+        }
     )
 
-    with _runtime_state(config=config, cycle=cycle):
+    with _runtime_state(config=config, cycle=None):
         response = TestClient(api.app).get("/trading/loop/status")
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["ready"] is True
-    assert payload["execution_route"] == "testnet"
-    assert payload["latest_cycle"]["orders_submitted"] == 1
-    assert payload["operational_submission_gate"] == payload["live_submission_gate"]
+    assert payload["schema_version"] == "torghut.trading-loop-status.v1"
+    assert payload["restored"] is False
+    assert payload["runtime"]["status"] == "blocked"
+    assert "ready" not in payload
+    assert "latest_cycle" not in payload
+    assert captured["build_session"] is captured["session"]
+    assert captured["closed"] is True
+    assert isinstance(captured["options"], LoopStatusOptions)
+    options = captured["options"]
+    assert isinstance(options, LoopStatusOptions)
+    assert options.trading_mode == "paper"
+    assert options.trading_enabled is True
 
 
 def test_trading_status_reports_operational_gate_without_alpha_blockers() -> None:


### PR DESCRIPTION
## Summary

- Add `/trading/loop/status` as a Hyperliquid execution runtime alias for the existing `/trading/status` payload.
- Cover the documented loop-status route with a FastAPI regression test so rollout checks do not regress to 404.
- Pin the Hyperliquid runtime Deployment and migration Job to a real multi-arch Torghut image digest built from commit `f5cf060c8dfce37133b62ab580d321c3626daf8c`, which contains `/trading/status`.

## Related Issues

Addresses review feedback on proompteng/lab#11892.

## Testing

- `uv run --frozen pytest tests/hyperliquid_execution/test_runtime_status_api.py -q`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `crane digest registry.ide-newton.ts.net/lab/torghut@sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4`
- `crane manifest registry.ide-newton.ts.net/lab/torghut@sha256:b1ac28ac8bc5de96f96761066c4efff18b3ea46d22d154eadd221ea49449c3c4 | jq -r '.manifests[] | [.platform.os,.platform.architecture,.digest] | @tsv'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.