### PR TITLE
fix(agents): retry disappearing idempotency conflicts

### DIFF
--- a/services/agents/src/server/primitives-store.test.ts
+++ b/services/agents/src/server/primitives-store.test.ts
@@ -30,7 +30,14 @@ const makeIdempotencyRow = (overrides: Partial<IdempotencyDbRow> = {}): Idempote
   ...overrides,
 })
 
-const makeFakeDb = (options: { insertedRow?: IdempotencyDbRow; existingRow?: IdempotencyDbRow }) => {
+const makeFakeDb = (options: {
+  insertedRow?: IdempotencyDbRow
+  existingRow?: IdempotencyDbRow
+  insertedRows?: Array<IdempotencyDbRow | undefined>
+  existingRows?: Array<IdempotencyDbRow | undefined>
+}) => {
+  const insertedRows = [...(options.insertedRows ?? [options.insertedRow])]
+  const existingRows = [...(options.existingRows ?? [options.existingRow])]
   const doNothing = vi.fn()
   const columns = vi.fn(() => ({ doNothing }))
   const insertBuilder = {
@@ -51,11 +58,11 @@ const makeFakeDb = (options: { insertedRow?: IdempotencyDbRow; existingRow?: Ide
     return insertBuilder
   })
   insertBuilder.returningAll.mockReturnValue(insertBuilder)
-  insertBuilder.executeTakeFirst.mockResolvedValue(options.insertedRow)
+  insertBuilder.executeTakeFirst.mockImplementation(async () => insertedRows.shift())
 
   selectBuilder.selectAll.mockReturnValue(selectBuilder)
   selectBuilder.where.mockReturnValue(selectBuilder)
-  selectBuilder.executeTakeFirst.mockResolvedValue(options.existingRow)
+  selectBuilder.executeTakeFirst.mockImplementation(async () => existingRows.shift())
 
   const db = {
     insertInto: vi.fn(() => insertBuilder),
@@ -131,6 +138,36 @@ describe('createPrimitivesStore', () => {
         agentRunName: 'codex-agent-existing',
       },
     })
+    expect(selectBuilder.executeTakeFirst).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries reservation when the conflicting key disappears before lookup', async () => {
+    const insertedRow = makeIdempotencyRow({ id: 'idempotency-2' })
+    const { db, insertBuilder, selectBuilder } = makeFakeDb({
+      insertedRows: [undefined, insertedRow],
+      existingRows: [undefined],
+    })
+    const store = createPrimitivesStore({
+      url: 'postgresql://user:pass@localhost:5432/agents',
+      createDb: () => db,
+    })
+
+    const result = await store.reserveAgentRunIdempotencyKey({
+      namespace: 'agents',
+      agentName: 'codex-agent',
+      idempotencyKey: 'delivery-1',
+    })
+
+    expect(result).toMatchObject({
+      created: true,
+      record: {
+        id: 'idempotency-2',
+        namespace: 'agents',
+        agentName: 'codex-agent',
+        idempotencyKey: 'delivery-1',
+      },
+    })
+    expect(insertBuilder.executeTakeFirst).toHaveBeenCalledTimes(2)
     expect(selectBuilder.executeTakeFirst).toHaveBeenCalledTimes(1)
   })
 })

--- a/services/agents/src/server/primitives-store.ts
+++ b/services/agents/src/server/primitives-store.ts
@@ -222,6 +222,7 @@ type PrimitivesStoreOptions = {
 }
 
 const DEFAULT_RUN_STATUS = 'Pending'
+const AGENT_RUN_IDEMPOTENCY_RESERVATION_ATTEMPTS = 3
 
 const toAgentRunRecord = (row: {
   id: string
@@ -663,38 +664,40 @@ export const createPrimitivesStore = (options: PrimitivesStoreOptions = {}): Pri
 
   const reserveAgentRunIdempotencyKey: PrimitivesStore['reserveAgentRunIdempotencyKey'] = async (input) => {
     await ready
-    const inserted = await db
-      .insertInto('agent_run_idempotency_keys')
-      .values({
-        namespace: input.namespace,
-        agent_name: input.agentName,
-        idempotency_key: input.idempotencyKey,
-        agent_run_name: null,
-        agent_run_uid: null,
-        terminal_phase: null,
-        terminal_at: null,
-      })
-      .onConflict((oc) => oc.columns(['namespace', 'agent_name', 'idempotency_key']).doNothing())
-      .returningAll()
-      .executeTakeFirst()
+    for (let attempt = 1; attempt <= AGENT_RUN_IDEMPOTENCY_RESERVATION_ATTEMPTS; attempt += 1) {
+      const inserted = await db
+        .insertInto('agent_run_idempotency_keys')
+        .values({
+          namespace: input.namespace,
+          agent_name: input.agentName,
+          idempotency_key: input.idempotencyKey,
+          agent_run_name: null,
+          agent_run_uid: null,
+          terminal_phase: null,
+          terminal_at: null,
+        })
+        .onConflict((oc) => oc.columns(['namespace', 'agent_name', 'idempotency_key']).doNothing())
+        .returningAll()
+        .executeTakeFirst()
 
-    if (inserted) {
-      return { record: toAgentRunIdempotencyRecord(inserted), created: true }
+      if (inserted) {
+        return { record: toAgentRunIdempotencyRecord(inserted), created: true }
+      }
+
+      const existing = await db
+        .selectFrom('agent_run_idempotency_keys')
+        .selectAll()
+        .where('namespace', '=', input.namespace)
+        .where('agent_name', '=', input.agentName)
+        .where('idempotency_key', '=', input.idempotencyKey)
+        .executeTakeFirst()
+
+      if (existing) {
+        return { record: toAgentRunIdempotencyRecord(existing), created: false }
+      }
     }
 
-    const existing = await db
-      .selectFrom('agent_run_idempotency_keys')
-      .selectAll()
-      .where('namespace', '=', input.namespace)
-      .where('agent_name', '=', input.agentName)
-      .where('idempotency_key', '=', input.idempotencyKey)
-      .executeTakeFirst()
-
-    if (!existing) {
-      throw new Error('failed to resolve agent run idempotency key after conflict')
-    }
-
-    return { record: toAgentRunIdempotencyRecord(existing), created: false }
+    throw new Error('failed to resolve agent run idempotency key after conflict')
   }
 
   const assignAgentRunIdempotencyKey: PrimitivesStore['assignAgentRunIdempotencyKey'] = async (input) => {


### PR DESCRIPTION
## Summary

- Address Codex review feedback from #11895 for the stale-reservation deletion race.
- Retry AgentRun idempotency reservation when `ON CONFLICT DO NOTHING` loses but the follow-up lookup no longer finds the conflicted row.
- Add regression coverage for the disappearing-conflict interleaving.

## Related Issues

Related to #11895, #11891, and #11885.

## Testing

- `bun run --filter @proompteng/agents test -- src/server/primitives-store.test.ts`
- `bun run --filter @proompteng/agents test -- src/server/v1/agent-runs.test.ts -t "idempotency|audit persistence"`
- `bunx oxfmt --check services/agents/src/server/primitives-store.ts services/agents/src/server/primitives-store.test.ts`
- `bun run --filter @proompteng/agents tsc`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
