### PR TITLE
fix(agents): restore controller image workspace deps

### DIFF
--- a/nix/images/agents.nix
+++ b/nix/images/agents.nix
@@ -94,6 +94,24 @@ let
       fi
     }
 
+    linkBunIsolatedPackage() {
+      local package_name="$1"
+      local target_path="$2"
+      local package_path
+      local relative_package_path
+
+      package_path="$(find "$out/app/node_modules/.bun" -path "*/node_modules/$package_name" -type d -print -quit)"
+      if [ -z "$package_path" ]; then
+        echo "Bun isolated package not found in runtime image: $package_name" >&2
+        exit 1
+      fi
+      relative_package_path="$(realpath --relative-to="$(dirname "$target_path")" "$package_path")"
+
+      rm -rf "$target_path"
+      mkdir -p "$(dirname "$target_path")"
+      ln -s "$relative_package_path" "$target_path"
+    }
+
     cp -R "$TMPDIR/work/node_modules" "$out/app/node_modules"
     for package in agent-contracts codex cx-tools otel temporal-bun-sdk; do
       cp -R "$TMPDIR/work/packages/$package" "$out/app/packages/$package"
@@ -108,8 +126,7 @@ let
 
     chmod +x "$out/app/services/agents/scripts/agents-shell-entrypoint.sh"
     mkdir -p "$out/app/packages/agent-contracts/node_modules"
-    rm -rf "$out/app/packages/agent-contracts/node_modules/effect"
-    ln -s /app/node_modules/effect "$out/app/packages/agent-contracts/node_modules/effect"
+    linkBunIsolatedPackage "effect" "$out/app/packages/agent-contracts/node_modules/effect"
   '';
 
   scriptWrapper =

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -858,8 +858,9 @@ describe('native OCI build workflows', () => {
     )
     expect(agentsImageModule).toContain('rm -rf "$target_path"')
     expect(agentsImageModule).toContain('cp -R "$source_path/." "$target_path/"')
-    expect(agentsImageModule).toContain('rm -rf "$out/app/packages/agent-contracts/node_modules/effect"')
-    expect(agentsImageModule).toContain('ln -s /app/node_modules/effect')
+    expect(agentsImageModule).toContain('linkBunIsolatedPackage "effect"')
+    expect(agentsImageModule).toContain('realpath --relative-to="$(dirname "$target_path")" "$package_path"')
+    expect(agentsImageModule).toContain('Bun isolated package not found in runtime image')
   })
 
   it('routes enabled product app image builds through real Nix OCI attrs', () => {


### PR DESCRIPTION
## Summary

- Resolve the Agents controller image startup failure by linking `effect` from Bun's isolated `.bun` package store instead of `/app/node_modules/effect`.
- Create the workspace dependency link with a relative target so it works through both `/app` and the Nix store runtime path.
- Update the OCI workflow contract test to cover the isolated Bun package helper.

## Related Issues

Follow-up to #11902 rollout failure; review-fix chain for #11895/#11898.

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts -t "Agents service images"`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`
- `nix eval --system x86_64-linux .#agents-controller-image.drvPath`
- `nix build --system x86_64-linux .#agents-controller-image --dry-run`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
