### PR TITLE
fix(ceph): enable bounded scrub auto repair

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -36,6 +36,9 @@ cephClusterSpec:
       # Recovery/backfill overrides are intentionally omitted so the built-in mClock profile controls QoS.
       osd_mclock_profile: "high_client_ops"
       osd_memory_target: "8589934592"
+      # Automatically repair small scrub inconsistencies. Larger damage still requires operator review.
+      osd_scrub_auto_repair: "true"
+      osd_scrub_auto_repair_num_errors: "5"
 
   dataDirHostPath: /var/lib/rook
 

--- a/docs/runbooks/rook-ceph-on-talos.md
+++ b/docs/runbooks/rook-ceph-on-talos.md
@@ -95,6 +95,7 @@ Current GitOps target in `argocd/applications/rook-ceph/cluster-values.yaml`:
 1. `bluestore_cache_autotune: "true"`
 1. `osd_mclock_profile: "high_client_ops"`
 1. `osd_memory_target: "8589934592"` (8Gi)
+1. `osd_scrub_auto_repair: "true"` with `osd_scrub_auto_repair_num_errors: "5"`
 1. OSD pod resources: request `1000m` CPU and `8Gi` memory, limit `12Gi`
 1. CSI read affinity enabled with `kubernetes.io/hostname`
 
@@ -128,7 +129,7 @@ Verify live state:
 ```bash
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config dump \
-  | egrep 'osd_mclock_profile|osd_mclock_override_recovery_settings|osd_max_backfills|osd_recovery_max_active|osd_recovery_max_single_start|osd_recovery_op_priority|osd_recovery_sleep_hdd|osd_memory_target'
+  | egrep 'osd_mclock_profile|osd_mclock_override_recovery_settings|osd_max_backfills|osd_recovery_max_active|osd_recovery_max_single_start|osd_recovery_op_priority|osd_recovery_sleep_hdd|osd_memory_target|osd_scrub_auto_repair'
 kubectl -n rook-ceph get deploy -l app=rook-ceph-osd -o json \
   | jq -r '.items[] | .metadata.name as $n | .spec.template.spec.containers[] | select(.name=="osd") | [$n,.resources.requests.memory,.resources.limits.memory] | @tsv' \
   | sort
@@ -140,6 +141,8 @@ Expected steady-state readback:
 1. No degraded, remapped, recovering, backfilling, undersized, or misplaced PGs.
 1. `osd_mclock_profile` is `high_client_ops`.
 1. `osd_memory_target` is `8589934592`.
+1. `osd_scrub_auto_repair` is `true`.
+1. `osd_scrub_auto_repair_num_errors` is `5`.
 1. No recovery override keys remain in `ceph config dump`.
 1. Every OSD deployment reports memory request `8Gi` and limit `12Gi`.
 


### PR DESCRIPTION
## Summary

- Enables bounded Ceph OSD scrub auto-repair in the Rook `CephCluster` config.
- Keeps the auto-repair cap at 5 scrub errors so larger damage still requires operator review.
- Updates the Rook/Ceph Talos runbook verification checklist to include auto-repair readback.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-auto-repair.render.yaml`
- Live readback: `ceph config get osd osd_scrub_auto_repair` returned `true` after applying the emergency live config.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
