### PR TITLE
fix(torghut): use nix image binaries for runtime migrations

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -30,7 +30,7 @@ spec:
           args:
             - |
               deadline=$((SECONDS + 300))
-              until /opt/venv/bin/python - <<'PY'
+              until python - <<'PY'
               import os
               from sqlalchemy import create_engine, text
 
@@ -48,7 +48,7 @@ spec:
                 fi
                 sleep 5
               done
-              /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
+              alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
               value: 9afbcac4b27576a5911e617ad8f98dd327c645b2

--- a/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
+++ b/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
@@ -17,6 +17,9 @@ CONFIGMAP = REPO_ROOT / "argocd/applications/torghut-hyperliquid-runtime/configm
 DEPLOYMENT = (
     REPO_ROOT / "argocd/applications/torghut-hyperliquid-runtime/deployment.yaml"
 )
+DB_MIGRATIONS_JOB = (
+    REPO_ROOT / "argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml"
+)
 
 
 def test_hard_reset_migration_drops_v1_tables_and_creates_v2_tables() -> None:
@@ -63,3 +66,11 @@ def test_manifest_uses_v2_command_and_env_prefix_only() -> None:
     )
     assert "hyperliquid-execution-v2-feed-readiness-gate-20260704a" in deployment
     assert "HYPERLIQUID_RUNTIME_" not in configmap
+
+
+def test_runtime_migration_hook_uses_image_path_binaries() -> None:
+    manifest = DB_MIGRATIONS_JOB.read_text()
+
+    assert "until python - <<'PY'" in manifest
+    assert "alembic -c /app/alembic.ini upgrade heads" in manifest
+    assert "/opt/venv/bin/" not in manifest


### PR DESCRIPTION
## Summary

- Fixes the Hyperliquid runtime PreSync migration hook for the Nix Torghut image by using `python` and `alembic` from `PATH` instead of the removed Docker-era `/opt/venv` path.
- Adds a regression test covering the runtime migration hook command contract.
- Keeps the current digest-pinned runtime deployment unchanged except for the hook command needed to unblock Argo sync.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/hyperliquid_execution/test_migration_manifest.py -q`
- `uv run --frozen ruff format --check tests/hyperliquid_execution/test_migration_manifest.py`
- `uv run --frozen ruff check tests/hyperliquid_execution/test_migration_manifest.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
