### PR TITLE
chore(agents): promote images 55730d97

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: sha-fd8a82e5ab507101e3e01a01fd648fb7e12a2659
-  digest: sha256:08d4af8003f6d31b0cbf3a75c85796e926195e74b5ed59ff5753569e84e616e5
+  tag: sha-55730d97fb5cc3c5a72a68e459efc996b5552f3f
+  digest: sha256:c5f4aa1e1e8c297fc5cf25ddb5f9518a17c56b451404a1c71e21f62b52cfc59b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -14,21 +14,21 @@ tolerations:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: sha-fd8a82e5ab507101e3e01a01fd648fb7e12a2659
-    digest: sha256:743804c5f3029864d0fe89a14228a19b6677ca91a464ef8bfebc800b5bdb6f40
+    tag: sha-55730d97fb5cc3c5a72a68e459efc996b5552f3f
+    digest: sha256:36b5175c957935746644e1d02e417a2e00136188461b145ecdaeea06cdd72066
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: fd8a82e5ab507101e3e01a01fd648fb7e12a2659
-      AGENTS_GITOPS_REVISION: fd8a82e5ab507101e3e01a01fd648fb7e12a2659
-      AGENTS_SOURCE_CI_RUN_ID: "28723857906"
+      AGENTS_SOURCE_HEAD_SHA: 55730d97fb5cc3c5a72a68e459efc996b5552f3f
+      AGENTS_GITOPS_REVISION: 55730d97fb5cc3c5a72a68e459efc996b5552f3f
+      AGENTS_SOURCE_CI_RUN_ID: "28725070615"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:743804c5f3029864d0fe89a14228a19b6677ca91a464ef8bfebc800b5bdb6f40
-      AGENTS_SERVING_BUILD_COMMIT: fd8a82e5ab507101e3e01a01fd648fb7e12a2659
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:743804c5f3029864d0fe89a14228a19b6677ca91a464ef8bfebc800b5bdb6f40
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:36b5175c957935746644e1d02e417a2e00136188461b145ecdaeea06cdd72066
+      AGENTS_SERVING_BUILD_COMMIT: 55730d97fb5cc3c5a72a68e459efc996b5552f3f
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:36b5175c957935746644e1d02e417a2e00136188461b145ecdaeea06cdd72066
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
@@ -38,8 +38,8 @@ agentsShell:
   enabled: true
   image:
     repository: registry.ide-newton.ts.net/lab/agents-shell
-    tag: sha-fd8a82e5ab507101e3e01a01fd648fb7e12a2659
-    digest: sha256:b17118f5e842ac789176703ea63f32a2d4a05388c4eabb27d01f811c3548a462
+    tag: sha-55730d97fb5cc3c5a72a68e459efc996b5552f3f
+    digest: sha256:7f855dd734ddd449153c32620d579a4c083e3c5d547a65e8d8b2ad6a2a0a3dfa
     pullPolicy: IfNotPresent
   env:
     vars:
@@ -159,8 +159,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: sha-fd8a82e5ab507101e3e01a01fd648fb7e12a2659
-    digest: sha256:08d4af8003f6d31b0cbf3a75c85796e926195e74b5ed59ff5753569e84e616e5
+    tag: sha-55730d97fb5cc3c5a72a68e459efc996b5552f3f
+    digest: sha256:c5f4aa1e1e8c297fc5cf25ddb5f9518a17c56b451404a1c71e21f62b52cfc59b
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents Nix-built service images into GitOps manifests.

- Source commit: `55730d97fb5cc3c5a72a68e459efc996b5552f3f`
- Image tag: `55730d97`
- Agents build run: `28725070615`
- Promotion source: `manual_dispatch`
- Service images: `agents-controller`, `agents-control-plane`, `agents-shell`
- Runner image: preserved from the previous GitOps pin