### PR TITLE
ci(agents): build codex runner with nix oci

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -21,6 +21,7 @@ on:
       - 'tsconfig.base.json'
       - 'flake.lock'
       - 'nix/images/agents.nix'
+      - 'nix/images/openai-codex-cli.nix'
       - 'nix/images/bun-workspace-service.nix'
       - 'nix/packages.nix'
       - 'nix/cache-push.sh'
@@ -48,6 +49,7 @@ on:
       - 'tsconfig.base.json'
       - 'flake.lock'
       - 'nix/images/agents.nix'
+      - 'nix/images/openai-codex-cli.nix'
       - 'nix/images/bun-workspace-service.nix'
       - 'nix/packages.nix'
       - 'nix/cache-push.sh'
@@ -93,12 +95,23 @@ jobs:
       release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'agents-shell-release-contract' || '' }}
     secrets: inherit
 
+  runner-image:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: agents-codex-runner
+      package_attr: agents-codex-runner-image
+      tag: sha-${{ github.sha }}
+      release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'agents-codex-runner-release-contract' || '' }}
+    secrets: inherit
+
   write-values:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs:
       - controller-image
       - control-plane-image
       - agents-shell-image
+      - runner-image
     runs-on: arc-arm64
     timeout-minutes: 15
     steps:
@@ -116,26 +129,15 @@ jobs:
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
-      - name: Resolve preserved runner image pin
-        id: published
-        run: |
-          bun run packages/scripts/src/agents/resolve-published-agents-images.ts \
-            --values-path argocd/applications/agents/values.yaml \
-            --output "${GITHUB_OUTPUT}"
-
       - name: Write rendered Agents values
         env:
           TAG: sha-${{ github.sha }}
           CONTROLLER_DIGEST: ${{ needs.controller-image.outputs.digest }}
           CONTROL_PLANE_DIGEST: ${{ needs.control-plane-image.outputs.digest }}
           AGENTS_SHELL_DIGEST: ${{ needs.agents-shell-image.outputs.digest }}
-          RUNNER_REPOSITORY: ${{ steps.published.outputs.runner_image_repository }}
-          RUNNER_TAG: ${{ steps.published.outputs.runner_image_tag }}
-          RUNNER_DIGEST: ${{ steps.published.outputs.runner_image_digest }}
+          RUNNER_DIGEST: ${{ needs.runner-image.outputs.digest }}
         run: |
           set -euo pipefail
-          test -n "${RUNNER_REPOSITORY}"
-          test -n "${RUNNER_TAG}"
           test -n "${RUNNER_DIGEST}"
           bun run packages/scripts/src/agents/update-values.ts \
             --values argocd/applications/agents/values.yaml \
@@ -146,8 +148,8 @@ jobs:
             --control-plane-digest "${CONTROL_PLANE_DIGEST}" \
             --agents-shell-repository registry.ide-newton.ts.net/lab/agents-shell \
             --agents-shell-digest "${AGENTS_SHELL_DIGEST}" \
-            --runner-repository "${RUNNER_REPOSITORY}" \
-            --runner-tag "${RUNNER_TAG}" \
+            --runner-repository registry.ide-newton.ts.net/lab/agents-codex-runner \
+            --runner-tag "${TAG}" \
             --runner-digest "${RUNNER_DIGEST}" \
             --source-sha "${GITHUB_SHA}" \
             --run-id "${GITHUB_RUN_ID}" \

--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: scripts/agents/validate-agents.sh
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: arc-amd64
     env:
       # ARC runners run with hostNetwork=true; a shared "kind" docker bridge subnet can collide across pods.
       # Use a per-run docker network for kind to keep routing deterministic.
@@ -250,6 +250,19 @@ jobs:
       - name: Build agentctl binary
         run: bun run --filter @proompteng/agentctl build:bin
 
+      - name: Set up Nix for local Agents image archives
+        if: steps.agents_image_mode.outputs.NEEDS_LOCAL_AGENTS_IMAGE == 'true'
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          install-ci-toolchain: 'false'
+          require-preinstalled: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+            fallback = true
+
       - name: Ensure kind Docker network
         run: scripts/agents/ensure-kind-network.sh
 
@@ -309,20 +322,18 @@ jobs:
             echo "BUILT_AGENTS_IMAGE_SOURCE_SHA=${IMAGE_SOURCE_SHA}"
           } >> "${GITHUB_ENV}"
 
-      - name: Build and preload local Agents images into kind
+      - name: Build and preload local Nix Agents image archives into kind
         if: steps.agents_image_mode.outputs.NEEDS_LOCAL_AGENTS_IMAGE == 'true'
         timeout-minutes: 45
         run: |
           set -euxo pipefail
 
-          WORKSPACE="${GITHUB_WORKSPACE}"
-          CONTROL_PLANE_IMAGE_REPOSITORY="${AGENTS_CONTROL_PLANE_IMAGE_REPOSITORY:-${AGENTS_IMAGE_REPOSITORY:-agents-control-plane-local}}"
-          CONTROLLER_IMAGE_REPOSITORY="${AGENTS_CONTROLLER_IMAGE_REPOSITORY:-agents-controller-local}"
-          RUNNER_IMAGE_REPOSITORY="${AGENTS_RUNNER_IMAGE_REPOSITORY:-agents-codex-runner-local}"
-          DEFAULT_IMAGE_TAG_SUFFIX="${GITHUB_SHA:-unknown}"
-          IMAGE_TAG="${AGENTS_IMAGE_TAG:-ci-$DEFAULT_IMAGE_TAG_SUFFIX}"
-          PRUNE_DIR="$(mktemp -d /tmp/agents-prune-XXXXXX)"
-          KIND_IMAGE_TAR="${RUNNER_TEMP:-/tmp}/agents-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_ATTEMPT:-0}-${IMAGE_TAG}.tar"
+          CONTROL_PLANE_IMAGE_REPOSITORY="registry.ide-newton.ts.net/lab/agents-control-plane"
+          CONTROLLER_IMAGE_REPOSITORY="registry.ide-newton.ts.net/lab/agents-controller"
+          RUNNER_IMAGE_REPOSITORY="registry.ide-newton.ts.net/lab/agents-codex-runner"
+          IMAGE_TAG="nix"
+          NIX_IMAGE_OUTPUT_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/agents-nix-images-XXXXXX")"
+          KIND_ARCHIVE_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/agents-kind-archives-XXXXXX")"
           BUILD_HEARTBEAT_PID=0
           KIND_HEARTBEAT_PID=0
           cleanup_preload_resources() {
@@ -334,10 +345,7 @@ jobs:
               kill "${KIND_HEARTBEAT_PID}" 2>/dev/null || true
               wait "${KIND_HEARTBEAT_PID}" 2>/dev/null || true
             fi
-            if [ -f "${KIND_IMAGE_TAR}" ]; then
-              rm -f "${KIND_IMAGE_TAR}"
-            fi
-            rm -rf "${PRUNE_DIR}"
+            rm -rf "${NIX_IMAGE_OUTPUT_DIR}" "${KIND_ARCHIVE_DIR}"
           }
           trap cleanup_preload_resources EXIT
 
@@ -358,10 +366,10 @@ jobs:
             ) &
             heartbeat_pid=$!
 
-            if [ "${phase}" = "Docker build" ]; then
-              BUILD_HEARTBEAT_PID="${heartbeat_pid}"
-            else
+            if [[ "${phase}" == kind* ]]; then
               KIND_HEARTBEAT_PID="${heartbeat_pid}"
+            else
+              BUILD_HEARTBEAT_PID="${heartbeat_pid}"
             fi
 
             if timeout -k 30s "${timeout_minutes}m" "$@"; then
@@ -371,14 +379,14 @@ jobs:
               timeout_status="$status"
             fi
 
-            if [ "${phase}" = "Docker build" ]; then
-              kill "${BUILD_HEARTBEAT_PID}" 2>/dev/null || true
-              wait "${BUILD_HEARTBEAT_PID}" 2>/dev/null || true
-              BUILD_HEARTBEAT_PID=0
-            else
+            if [[ "${phase}" == kind* ]]; then
               kill "${KIND_HEARTBEAT_PID}" 2>/dev/null || true
               wait "${KIND_HEARTBEAT_PID}" 2>/dev/null || true
               KIND_HEARTBEAT_PID=0
+            else
+              kill "${BUILD_HEARTBEAT_PID}" 2>/dev/null || true
+              wait "${BUILD_HEARTBEAT_PID}" 2>/dev/null || true
+              BUILD_HEARTBEAT_PID=0
             fi
 
             if [ "${status}" -ne 0 ]; then
@@ -391,6 +399,59 @@ jobs:
             return "${status}"
           }
 
+          build_nix_image_archive() {
+            local image_ref="$1"
+            local package_attr="$2"
+            local out_var="$3"
+            local path_file="${NIX_IMAGE_OUTPUT_DIR}/${package_attr}.path"
+            local archive_path
+
+            IMAGE="${image_ref}"
+            rm -f "${path_file}"
+            if run_with_progress "Nix image build" "${BUILD_TIMEOUT_MINUTES}" bash -c \
+              'set -euo pipefail; nix build ".#${1}" --print-out-paths --no-link | tee "${2}"' \
+              _ "${package_attr}" "${path_file}"; then
+              :
+            else
+              status=$?
+              run_step_failure "Failed to build Nix image archive ${package_attr}" "${status}"
+            fi
+
+            archive_path="$(tail -n 1 "${path_file}")"
+            if [ ! -f "${archive_path}" ]; then
+              run_step_failure "Nix image archive ${package_attr} did not produce a file at ${archive_path}" 1
+            fi
+
+            printf -v "${out_var}" '%s' "${archive_path}"
+            echo "Built Nix image archive ${package_attr}: ${archive_path}"
+          }
+
+          load_nix_image_archive() {
+            local image_ref="$1"
+            local archive_path="$2"
+            local load_archive="${archive_path}"
+
+            IMAGE="${image_ref}"
+            if [[ "${archive_path}" == *.gz ]]; then
+              load_archive="${KIND_ARCHIVE_DIR}/$(basename "${archive_path%.gz}")"
+              if run_with_progress "decompress image archive" "${KIND_LOAD_TIMEOUT_MINUTES}" bash -c \
+                'set -euo pipefail; gzip -dc "${1}" > "${2}"' \
+                _ "${archive_path}" "${load_archive}"; then
+                :
+              else
+                status=$?
+                run_step_failure "Failed to decompress Nix image archive ${archive_path}" "${status}"
+              fi
+            fi
+
+            if run_with_progress "kind load image-archive" "${KIND_LOAD_TIMEOUT_MINUTES}" kind load image-archive "${load_archive}" --name "${KIND_CLUSTER_NAME}"; then
+              echo "Loaded Nix image archive ${load_archive} for ${image_ref} into kind cluster ${KIND_CLUSTER_NAME}."
+            else
+              status=$?
+              run_step_failure "Failed to preload local image ${image_ref} into kind cluster ${KIND_CLUSTER_NAME}" "${status}"
+            fi
+          }
+
           run_step_failure() {
             local message="$1"
             local code="$2"
@@ -399,191 +460,20 @@ jobs:
             exit 1
           }
 
-          run_kind_load_with_fallback() {
-            if run_with_progress "kind load docker-image" "${KIND_LOAD_TIMEOUT_MINUTES}" kind load docker-image "${IMAGE}" --name "${KIND_CLUSTER_NAME}"; then
-              echo "Loaded local image ${IMAGE} into kind cluster ${KIND_CLUSTER_NAME}."
-              docker image rm "${IMAGE}" >/dev/null 2>&1 || true
-              return 0
-            fi
-
-            echo "kind load docker-image failed; retrying with image archive path."
-            rm -f "${KIND_IMAGE_TAR}"
-
-            if ! run_with_progress "docker save image archive" "${KIND_LOAD_TIMEOUT_MINUTES}" docker save --output "${KIND_IMAGE_TAR}" "${IMAGE}"; then
-              echo "Failed to save local image archive ${KIND_IMAGE_TAR}."
-              rm -f "${KIND_IMAGE_TAR}"
-              return 1
-            fi
-
-            echo "Saved image archive ${KIND_IMAGE_TAR}."
-
-            if run_with_progress "kind load image-archive" "${KIND_LOAD_TIMEOUT_MINUTES}" kind load image-archive "${KIND_IMAGE_TAR}" --name "${KIND_CLUSTER_NAME}"; then
-              echo "Loaded local image archive ${KIND_IMAGE_TAR} into kind cluster ${KIND_CLUSTER_NAME}."
-              rm -f "${KIND_IMAGE_TAR}"
-              docker image rm "${IMAGE}" >/dev/null 2>&1 || true
-              return 0
-            fi
-
-            rm -f "${KIND_IMAGE_TAR}"
-            return 1
-          }
-
-          PREP_TIMEOUT_MINUTES=25
-          echo "Pruning Agents image build context to ${PRUNE_DIR}"
-          IMAGE="agents-ci-prune-context"
-          if run_with_progress "Turbo prune context" "${PREP_TIMEOUT_MINUTES}" bunx turbo prune \
-            --scope=@proompteng/agents \
-            --scope=@proompteng/agent-contracts \
-            --scope=@proompteng/codex \
-            --scope=@proompteng/otel \
-            --scope=@proompteng/temporal-bun-sdk \
-            --docker \
-            --out-dir="${PRUNE_DIR}"; then
-            echo "Pruned Agents Docker build context to ${PRUNE_DIR}."
-          else
-            run_step_failure "Failed to prune Agents Docker build context" "$?"
-          fi
-          cp "${WORKSPACE}/tsconfig.base.json" "${PRUNE_DIR}/tsconfig.base.json"
-          # The runner Dockerfile is intentionally usable from the full repo root for release builds.
-          # The kind integration job builds it from the pruned context, so materialize the same root
-          # paths from Turbo's full workspace output.
-          mkdir -p "${PRUNE_DIR}/services" "${PRUNE_DIR}/packages"
-          cp -R "${PRUNE_DIR}/full/services/agents" "${PRUNE_DIR}/services/agents"
-          cp -R "${PRUNE_DIR}/full/packages/codex" "${PRUNE_DIR}/packages/codex"
-          if [ -d "${WORKSPACE}/skills" ]; then
-            mkdir -p "${PRUNE_DIR}/skills"
-            cp -R "${WORKSPACE}/skills/." "${PRUNE_DIR}/skills/"
-          fi
-          if [ -d "${WORKSPACE}/packages/cx-tools" ]; then
-            mkdir -p "${PRUNE_DIR}/full/packages" "${PRUNE_DIR}/json/packages"
-            cp -R "${WORKSPACE}/packages/cx-tools/." "${PRUNE_DIR}/full/packages/cx-tools/"
-            cp -R "${WORKSPACE}/packages/cx-tools/." "${PRUNE_DIR}/json/packages/cx-tools/"
-          fi
-
-          find "${PRUNE_DIR}/full" "${PRUNE_DIR}/json" \
-            -type d -name node_modules -prune -exec rm -rf {} +
-
-          copy_pruned_workspace_dist() {
-            local pkg_dir
-            local rel_path
-            local src_dir
-
-            shopt -s nullglob
-            for pkg_dir in "${PRUNE_DIR}/full/packages/"* "${PRUNE_DIR}/full/services/"*; do
-              [ -d "${pkg_dir}" ] || continue
-              rel_path="${pkg_dir#"${PRUNE_DIR}/full/"}"
-              src_dir="${WORKSPACE}/${rel_path}"
-
-              if [ ! -d "${src_dir}/dist" ]; then
-                continue
-              fi
-
-              cp -R "${src_dir}/dist" "${pkg_dir}"
-              mkdir -p "${PRUNE_DIR}/json/${rel_path}"
-              cp -R "${src_dir}/dist" "${PRUNE_DIR}/json/${rel_path}"
-            done
-            shopt -u nullglob
-          }
-          copy_pruned_workspace_dist
-
-          AGENTS_VERSION="$(git -C "${WORKSPACE}" rev-parse --short HEAD)"
-          AGENTS_COMMIT="$(git -C "${WORKSPACE}" rev-parse HEAD)"
           CONTROL_PLANE_IMAGE="${CONTROL_PLANE_IMAGE_REPOSITORY}:${IMAGE_TAG}"
           CONTROLLER_IMAGE="${CONTROLLER_IMAGE_REPOSITORY}:${IMAGE_TAG}"
           RUNNER_IMAGE="${RUNNER_IMAGE_REPOSITORY}:${IMAGE_TAG}"
 
-          # Use the mirror.gcr.io Bun mirror in CI to avoid Docker Hub anonymous pull limits.
-          # Local image rebuilds fail with explicit diagnostics on timeout.
-          # ARC arm64 runners can spend well over 18 minutes in a pruned Agents docker
-          # build while still making forward progress, so give the local image build enough headroom
-          # to complete instead of terminating a healthy build.
           BUILD_TIMEOUT_MINUTES=30
           KIND_LOAD_TIMEOUT_MINUTES=20
 
-          IMAGE="${CONTROL_PLANE_IMAGE}"
-          if run_with_progress "Docker build" "${BUILD_TIMEOUT_MINUTES}" env DOCKER_BUILDKIT=1 docker build \
-            -f "${WORKSPACE}/services/agents/Dockerfile" \
-            --target control-plane \
-            --network=host \
-            -t "${CONTROL_PLANE_IMAGE}" \
-            --build-arg "AGENTS_VERSION=${AGENTS_VERSION}" \
-            --build-arg "AGENTS_COMMIT=${AGENTS_COMMIT}" \
-            --build-arg "AGENTS_BUILD_CI=true" \
-            --build-arg "AGENTS_BUILD_SOURCEMAP=0" \
-            --build-arg "AGENTS_BUILD_LOG_LEVEL=warn" \
-            --build-arg "BUN_BASE_IMAGE=mirror.gcr.io/oven/bun" \
-            --progress=plain \
-            "${PRUNE_DIR}"; then
-            echo "Built local control-plane image ${CONTROL_PLANE_IMAGE}."
-          else
-            run_step_failure "Failed to build local image ${CONTROL_PLANE_IMAGE}" "$?"
-          fi
+          build_nix_image_archive "${CONTROL_PLANE_IMAGE}" agents-control-plane-image CONTROL_PLANE_ARCHIVE
+          build_nix_image_archive "${CONTROLLER_IMAGE}" agents-controller-image CONTROLLER_ARCHIVE
+          build_nix_image_archive "${RUNNER_IMAGE}" agents-codex-runner-image RUNNER_ARCHIVE
 
-          IMAGE="${CONTROLLER_IMAGE}"
-          if run_with_progress "Docker build" "${BUILD_TIMEOUT_MINUTES}" env DOCKER_BUILDKIT=1 docker build \
-            -f "${WORKSPACE}/services/agents/Dockerfile" \
-            --target controller \
-            --network=host \
-            -t "${CONTROLLER_IMAGE}" \
-            --build-arg "AGENTS_VERSION=${AGENTS_VERSION}" \
-            --build-arg "AGENTS_COMMIT=${AGENTS_COMMIT}" \
-            --build-arg "AGENTS_BUILD_CI=true" \
-            --build-arg "AGENTS_BUILD_SOURCEMAP=0" \
-            --build-arg "AGENTS_BUILD_LOG_LEVEL=warn" \
-            --build-arg "BUN_BASE_IMAGE=mirror.gcr.io/oven/bun" \
-            --progress=plain \
-            "${PRUNE_DIR}"; then
-            echo "Built local controller image ${CONTROLLER_IMAGE}."
-          else
-            run_step_failure "Failed to build local image ${CONTROLLER_IMAGE}" "$?"
-          fi
-
-          IMAGE="${RUNNER_IMAGE}"
-          if run_with_progress "Runner Docker build" "${BUILD_TIMEOUT_MINUTES}" env DOCKER_BUILDKIT=1 docker build \
-            -f "${WORKSPACE}/services/agents/Dockerfile.codex-runner" \
-            --network=host \
-            -t "${RUNNER_IMAGE}" \
-            --build-arg "BUN_BASE_IMAGE=mirror.gcr.io/oven/bun" \
-            --progress=plain \
-            "${PRUNE_DIR}"; then
-            echo "Built local runner image ${RUNNER_IMAGE}."
-          else
-            run_step_failure "Failed to build local image ${RUNNER_IMAGE}" "$?"
-          fi
-
-          RUNNER_SMOKE_SPEC_JSON="$(cat <<'JSON'
-          {
-            "schemaVersion": "agents.proompteng.ai/runner/v1",
-            "provider": "runner-image-smoke",
-            "providerSpec": {
-              "binary": "/bin/sh",
-              "argsTemplate": ["-c", "echo agents-runner-image-smoke"]
-            },
-            "adapter": {
-              "type": "exec"
-            }
-          }
-          JSON
-          )"
-          docker run --rm \
-            -e AGENT_RUNNER_SPEC="${RUNNER_SMOKE_SPEC_JSON}" \
-            "${RUNNER_IMAGE}" \
-            agent-runner
-
-          IMAGE="${CONTROL_PLANE_IMAGE}"
-          if ! run_kind_load_with_fallback; then
-            run_step_failure "Failed to preload local image ${CONTROL_PLANE_IMAGE} into kind cluster ${KIND_CLUSTER_NAME}" "$?"
-          fi
-
-          IMAGE="${CONTROLLER_IMAGE}"
-          if ! run_kind_load_with_fallback; then
-            run_step_failure "Failed to preload local image ${CONTROLLER_IMAGE} into kind cluster ${KIND_CLUSTER_NAME}" "$?"
-          fi
-
-          IMAGE="${RUNNER_IMAGE}"
-          if ! run_kind_load_with_fallback; then
-            run_step_failure "Failed to preload local image ${RUNNER_IMAGE} into kind cluster ${KIND_CLUSTER_NAME}" "$?"
-          fi
+          load_nix_image_archive "${CONTROL_PLANE_IMAGE}" "${CONTROL_PLANE_ARCHIVE}"
+          load_nix_image_archive "${CONTROLLER_IMAGE}" "${CONTROLLER_ARCHIVE}"
+          load_nix_image_archive "${RUNNER_IMAGE}" "${RUNNER_ARCHIVE}"
 
           {
             echo "BUILT_AGENTS_IMAGE_REPOSITORY=${CONTROL_PLANE_IMAGE_REPOSITORY}"

--- a/.github/workflows/agents-release.yml
+++ b/.github/workflows/agents-release.yml
@@ -125,14 +125,14 @@ jobs:
           add-paths: argocd/applications/agents/values.yaml
           body: |
             ## Summary
-            Promote Agents Nix-built service images into GitOps manifests.
+            Promote Agents Nix-built service and runner images into GitOps manifests.
 
             - Source commit: `${{ steps.meta.outputs.source_sha }}`
             - Image tag: `${{ steps.meta.outputs.tag }}`
             - Agents build run: `${{ steps.meta.outputs.run_id }}`
             - Promotion source: `${{ steps.meta.outputs.promotion_source }}`
             - Service images: `agents-controller`, `agents-control-plane`, `agents-shell`
-            - Runner image: preserved from the previous GitOps pin
+            - Runner image: `agents-codex-runner`
 
       - name: No manifest changes detected
         if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'

--- a/nix/images/agents.nix
+++ b/nix/images/agents.nix
@@ -10,6 +10,151 @@
 let
   kubectl = exact.kubectl or pkgs.kubectl;
   yq = exact.yq or pkgs.yq;
+  pythonPackages = pkgs.python312Packages;
+  openaiCodexCli = import ./openai-codex-cli.nix { inherit pkgs; };
+
+  mkPyWheel =
+    {
+      pname,
+      pypiPname ? pname,
+      version,
+      hash,
+      url ? null,
+      dist ? "py3",
+      python ? "py3",
+      propagatedBuildInputs ? [ ],
+      pythonImportsCheck ? [ ],
+    }:
+    pythonPackages.buildPythonPackage {
+      inherit
+        pname
+        version
+        propagatedBuildInputs
+        pythonImportsCheck
+        ;
+      format = "wheel";
+      src =
+        if url == null then
+          pkgs.fetchPypi {
+            pname = pypiPname;
+            inherit version dist python hash;
+            format = "wheel";
+          }
+        else
+          pkgs.fetchurl { inherit url hash; };
+      doCheck = false;
+    };
+
+  dotenv = mkPyWheel {
+    pname = "dotenv";
+    version = "0.9.9";
+    url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl";
+    hash = "sha256-Kc90oIezHa/bWkRrbX4Ry86O0nQVQOIznGn775LJTOk=";
+    python = "py2.py3";
+    propagatedBuildInputs = [ pythonPackages."python-dotenv" ];
+    pythonImportsCheck = [ "dotenv" ];
+  };
+
+  pyluach = mkPyWheel {
+    pname = "pyluach";
+    version = "2.3.0";
+    hash = "sha256-RJe3Ma71lQiwedv18AvFv0MprEUJCmzTe1qDdW8Oaas=";
+    pythonImportsCheck = [ "pyluach" ];
+  };
+
+  exchangeCalendars = mkPyWheel {
+    pname = "exchange-calendars";
+    pypiPname = "exchange_calendars";
+    version = "4.13.2";
+    hash = "sha256-/Foq0NYbXDplOaMGHNTLtVxZ9KkDRVzseSbkt5iRmZY=";
+    propagatedBuildInputs = [
+      pythonPackages."korean-lunar-calendar"
+      pythonPackages.numpy
+      pythonPackages.pandas
+      pyluach
+      pythonPackages.toolz
+      pythonPackages.tzdata
+    ];
+    pythonImportsCheck = [ "exchange_calendars" ];
+  };
+
+  pandasTaClassic = mkPyWheel {
+    pname = "pandas-ta-classic";
+    pypiPname = "pandas_ta_classic";
+    version = "0.6.52";
+    hash = "sha256-U5Vt3olpuKGsHNp+5RTHS0r2XYAjhzU4FIFKwuHZSeI=";
+    propagatedBuildInputs = [
+      pythonPackages.numpy
+      pythonPackages.pandas
+    ];
+    pythonImportsCheck = [ "pandas_ta_classic" ];
+  };
+
+  alpacaPy = mkPyWheel {
+    pname = "alpaca-py";
+    pypiPname = "alpaca_py";
+    version = "0.43.5";
+    hash = "sha256-C0ysm3Q4UTEPGfapqoT1fd+VrnW2ATUDlXRqiT9Uoto=";
+    propagatedBuildInputs = [
+      pythonPackages.msgpack
+      pythonPackages.pandas
+      pythonPackages.pydantic
+      pythonPackages.pytz
+      pythonPackages.requests
+      pythonPackages."sseclient-py"
+      pythonPackages.websockets
+    ];
+    pythonImportsCheck = [ "alpaca" ];
+  };
+
+  fastmcp = mkPyWheel {
+    pname = "fastmcp";
+    version = "2.0.0";
+    hash = "sha256-1cQREjOmop+pLtWs2/5P6ukiGRodHBVD8Khe/u8x+7k=";
+    propagatedBuildInputs = [
+      dotenv
+      pythonPackages.fastapi
+      pythonPackages.mcp
+      pythonPackages."openapi-pydantic"
+      pythonPackages.rich
+      pythonPackages.typer
+      pythonPackages.websockets
+    ];
+    pythonImportsCheck = [ "fastmcp" ];
+  };
+
+  alpacaMcpServer = mkPyWheel {
+    pname = "alpaca-mcp-server";
+    pypiPname = "alpaca_mcp_server";
+    version = "2.0.1";
+    hash = "sha256-XjcoNwD8EZmeirHnpLNdlFQle3QCx01MMBryAkIp3gU=";
+    propagatedBuildInputs = [
+      pythonPackages.click
+      fastmcp
+      pythonPackages.httpx
+      pythonPackages."python-dotenv"
+    ];
+    pythonImportsCheck = [ "alpaca_mcp_server" ];
+  };
+
+  runnerPython = pkgs.python312.withPackages (
+    ps: [
+      alpacaMcpServer
+      alpacaPy
+      ps.duckdb
+      exchangeCalendars
+      ps.httpx
+      ps.numpy
+      ps.orjson
+      ps.pandas
+      pandasTaClassic
+      ps.polars
+      ps.pyarrow
+      ps.pydantic
+      ps.tenacity
+    ]
+  );
+
   natsCliVersion = "0.4.0";
   natsCliArch =
     {
@@ -71,6 +216,7 @@ let
   ];
 
   buildCommands = [
+    "patchShebangs --build node_modules"
     "bun --cwd=packages/agent-contracts run build"
     "bun --cwd=packages/codex run build"
     "bun --cwd=packages/otel run build"
@@ -171,6 +317,22 @@ let
     pkgs.wget
   ];
 
+  runnerRuntimeContents = [
+    bun
+    nodejs
+    openaiCodexCli
+    pkgs.bash
+    pkgs.cacert
+    pkgs.coreutils
+    pkgs.curl
+    pkgs.gh
+    pkgs.git
+    pkgs.jq
+    pkgs.openssh
+    pkgs.uv
+    runnerPython
+  ];
+
   mkImage =
     {
       serviceName,
@@ -202,6 +364,94 @@ let
       inherit serviceName imageName;
       dependencyClosure = "bunCache";
       workingDir = "/app/services/agents";
+    };
+
+  runnerRuntimeInstallPhase = ''
+    mkdir -p \
+      "$out/app/node_modules/@proompteng/codex" \
+      "$out/app/services/agents/scripts/codex" \
+      "$out/root/.codex" \
+      "$out/usr/bin" \
+      "$out/usr/local/bin"
+
+    cp "$TMPDIR/work/packages/codex/package.json" "$out/app/node_modules/@proompteng/codex/package.json"
+    cp -R "$TMPDIR/work/packages/codex/dist" "$out/app/node_modules/@proompteng/codex/dist"
+    cp "$TMPDIR/agents-runner/agent-runner.js" "$out/app/services/agents/scripts/codex/agent-runner.js"
+    cp "$TMPDIR/agents-runner/fake-app-server.js" "$out/app/services/agents/scripts/codex/fake-app-server.js"
+    cp "$TMPDIR/work/services/agents/scripts/codex-config-container.toml" "$out/root/.codex/config.toml"
+    printf '{}\n' > "$out/root/.codex/auth.json"
+    printf '%s\n' unspecified > "$out/root/.codex/auth.checksum"
+
+    cat > "$out/usr/local/bin/agent-runner" <<'EOF'
+    #!/usr/bin/env bash
+    exec bun /app/services/agents/scripts/codex/agent-runner.js "$@"
+    EOF
+    cat > "$out/usr/local/bin/agents-fake-codex-app-server" <<'EOF'
+    #!/usr/bin/env bash
+    exec bun /app/services/agents/scripts/codex/fake-app-server.js "$@"
+    EOF
+    ln -s ${openaiCodexCli}/bin/codex "$out/usr/local/bin/codex"
+    ln -s ${openaiCodexCli}/bin/codex "$out/usr/bin/codex"
+    ln -s ${runnerPython}/bin/alpaca-mcp-server "$out/usr/local/bin/alpaca-mcp-server"
+    chmod +x \
+      "$out/usr/local/bin/agent-runner" \
+      "$out/usr/local/bin/agents-fake-codex-app-server" \
+      "$out/app/services/agents/scripts/codex/agent-runner.js" \
+      "$out/app/services/agents/scripts/codex/fake-app-server.js"
+
+    fake_server="$TMPDIR/agents-fake-codex-app-server"
+    cat > "$fake_server" <<EOF
+    #!${pkgs.bash}/bin/bash
+    exec ${bun}/bin/bun "$out/app/services/agents/scripts/codex/fake-app-server.js" "\$@"
+    EOF
+    chmod +x "$fake_server"
+    printf '%s\n' \
+      '{"implementation":{"text":"Write `/tmp/agents-runner-smoke/result.md` and respond OK."},"goal":{"objective":"image smoke"}}' \
+      > "$TMPDIR/agent-runner-run.json"
+    printf '%s\n' \
+      '{"schemaVersion":"agents.proompteng.ai/runner/v1","provider":"image-smoke","payloads":{"eventFilePath":"'"$TMPDIR"'/agent-runner-run.json"},"artifacts":{"statusPath":"'"$TMPDIR"'/agent-runner-status.json","logPath":"'"$TMPDIR"'/agent-runner.log"},"providerSpec":{"outputArtifacts":[{"name":"smoke-result","path":"/tmp/agents-runner-smoke/result.md"}]},"adapter":{"type":"codex-app-server","codex":{"binaryPath":"'"$fake_server"'","model":"agents-fake-codex-app-server","effort":"low","sandbox":"danger-full-access","approval":"never","prompt":"Write `/tmp/agents-runner-smoke/result.md` and respond OK.","goal":{"objective":"image smoke"}}}}' \
+      > "$TMPDIR/agent-runner-smoke.json"
+    ${bun}/bin/bun "$out/app/services/agents/scripts/codex/agent-runner.js" "$TMPDIR/agent-runner-smoke.json"
+    test -s /tmp/agents-runner-smoke/result.md
+    rm -f /tmp/agents-runner-smoke/result.md
+  '';
+
+  mkRunnerImage =
+    import ./bun-workspace-service.nix {
+      inherit
+        pkgs
+        lib
+        repoRoot
+        bun
+        nodejs
+        depsHash
+        installFilters
+        sourcePaths
+        ;
+      depsName = "agents-controller";
+      packageName = "@proompteng/agents-codex-runner";
+      serviceName = "agents-codex-runner";
+      imageName = "agents-codex-runner";
+      dependencyClosure = "bunCache";
+      buildCommands = buildCommands ++ [
+        ''mkdir -p "$TMPDIR/agents-runner"''
+        ''bun build services/agents/scripts/codex/agent-runner.ts --target bun --outfile "$TMPDIR/agents-runner/agent-runner.js"''
+        ''bun build services/agents/scripts/codex/fake-app-server.ts --target bun --outfile "$TMPDIR/agents-runner/fake-app-server.js"''
+      ];
+      runtimeInstallPhase = runnerRuntimeInstallPhase;
+      command = [ "bash" ];
+      workingDir = "/workspace";
+      extraContents = runnerRuntimeContents;
+      env = [
+        "WORKSPACE=/workspace"
+        "WORKTREE=/workspace/lab"
+        "GIT_TERMINAL_PROMPT=0"
+        "AGENTS_CODEX_BINARY=/usr/local/bin/codex"
+        "CODEX_BINARY=/usr/local/bin/codex"
+        "BUN_INSTALL=/usr/local"
+        "BUN_INSTALL_CACHE_DIR=/opt/bun/install/cache"
+        "BUN_INSTALL_CACHE_SEED_DIR=/opt/bun/install/cache"
+      ];
     };
 in
 {
@@ -268,4 +518,6 @@ in
       "3000/tcp" = { };
     };
   };
+
+  "agents-codex-runner-image" = mkRunnerImage;
 }

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { __private } from '../deploy-service'
 
-const envKeys = ['AGENTS_BUILD_RUNNER', 'AGENTS_DRY_RUN', 'AGENTS_IMAGE_TAG', 'AGENTS_IMAGE_PLATFORMS']
+const envKeys = ['AGENTS_DRY_RUN', 'AGENTS_IMAGE_TAG', 'AGENTS_IMAGE_PLATFORMS']
 
 afterEach(() => {
   for (const key of envKeys) {
@@ -14,9 +14,8 @@ afterEach(() => {
 })
 
 describe('agents deploy-service helpers', () => {
-  it('parses runner, apply, and dry-run rollout flags', () => {
-    expect(__private.parseArgs(['--skip-runner', '--no-apply', '--dry-run'])).toMatchObject({
-      buildRunner: false,
+  it('parses apply and dry-run rollout flags', () => {
+    expect(__private.parseArgs(['--no-apply', '--dry-run'])).toMatchObject({
       apply: false,
       dryRun: true,
     })
@@ -29,6 +28,7 @@ describe('agents deploy-service helpers', () => {
         repository: 'lab/agents-controller',
         controlPlaneRepository: 'lab/agents-control-plane',
         agentsShellRepository: 'lab/agents-shell',
+        runnerRepository: 'lab/agents-codex-runner',
         tag: 'abc1234',
         platforms: ['linux/arm64'],
       }),
@@ -54,17 +54,23 @@ describe('agents deploy-service helpers', () => {
         repository: 'lab/agents-shell',
         tag: 'abc1234',
       },
+      {
+        service: 'agents-codex-runner',
+        imageName: 'agents-codex-runner',
+        packageAttr: 'agents-codex-runner-image',
+        repository: 'lab/agents-codex-runner',
+        tag: 'abc1234',
+      },
     ])
   })
 
-  it('defaults to preserving the currently pinned runner image', () => {
+  it('defaults to building the Codex runner image through Nix', () => {
     process.env.AGENTS_IMAGE_TAG = 'abc123-amd64'
     process.env.AGENTS_IMAGE_PLATFORMS = 'native'
 
     const options = __private.resolveOptions()
 
     expect(options.platforms).toEqual([])
-    expect(options.buildRunner).toBeFalse()
     expect(__private.buildAgentsServiceImagePlans(options)).toEqual([
       {
         service: 'agents-controller',
@@ -85,6 +91,13 @@ describe('agents deploy-service helpers', () => {
         imageName: 'agents-shell',
         packageAttr: 'agents-shell-image',
         repository: 'lab/agents-shell',
+        tag: 'abc123-amd64',
+      },
+      {
+        service: 'agents-codex-runner',
+        imageName: 'agents-codex-runner',
+        packageAttr: 'agents-codex-runner-image',
+        repository: 'lab/agents-codex-runner',
         tag: 'abc123-amd64',
       },
     ])

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -139,17 +139,20 @@ describe('classifyAgentsImageMode', () => {
 })
 
 describe('agents-ci workflow local Agents image build', () => {
-  it('keeps integration validation on a hosted runner while cluster architecture is mixed', () => {
+  it('keeps local image integration validation on the amd64 ARC pool', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 
-    expect(workflow).toContain('integration:\n    runs-on: ubuntu-latest')
+    expect(workflow).toContain('integration:\n    runs-on: arc-amd64')
     expect(workflow).not.toContain('integration:\n    runs-on: arc-arm64')
   })
 
-  it('uses the mirrored Bun base image for local CI rebuilds', () => {
+  it('sets up Nix for local CI image archive builds', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 
-    expect(workflow).toContain('--build-arg "BUN_BASE_IMAGE=mirror.gcr.io/oven/bun" \\')
+    expect(workflow).toContain('Set up Nix for local Agents image archives')
+    expect(workflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+    expect(workflow).toContain("require-preinstalled: 'true'")
+    expect(workflow).toContain('substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/')
     expect(workflow).not.toContain('BUN_BASE_IMAGE=docker.io/oven/bun')
   })
 
@@ -168,12 +171,12 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).toContain('AGENTS_IMAGE_MODE="build-local-image"')
   })
 
-  it('bounds and emits progress for hosted local image prep', () => {
+  it('bounds and emits progress for ARC local image prep', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 
     expect(workflow).toContain('timeout-minutes: 45')
-    expect(workflow).toContain('run_with_progress "Turbo prune context"')
-    expect(workflow).toContain('PREP_TIMEOUT_MINUTES=25')
+    expect(workflow).toContain('run_with_progress "Nix image build"')
+    expect(workflow).toContain('run_with_progress "kind load image-archive"')
     expect(workflow).not.toContain('run_step "Prune turbo context"')
   })
 
@@ -247,8 +250,10 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).toContain('package_attr: agents-controller-image')
     expect(workflow).toContain('package_attr: agents-control-plane-image')
     expect(workflow).toContain('package_attr: agents-shell-image')
-    expect(workflow).toContain('Resolve preserved runner image pin')
-    expect(workflow).toContain('--runner-tag "${RUNNER_TAG}"')
+    expect(workflow).toContain('package_attr: agents-codex-runner-image')
+    expect(workflow).not.toContain('Resolve preserved runner image pin')
+    expect(workflow).toContain('--runner-tag "${TAG}"')
+    expect(workflow).toContain('--runner-repository registry.ide-newton.ts.net/lab/agents-codex-runner')
     expect(workflow).not.toContain('docker/setup-buildx-action')
     expect(workflow).not.toContain('docker buildx')
     expect(workflow).not.toContain('AGENTS_RUNNER_BUILD_CACHE_REF')
@@ -258,22 +263,23 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).toContain('packages/scripts/src/agents/update-values.ts')
   })
 
-  it('builds local Agents smoke images from the Agents Dockerfile', () => {
+  it('builds local Agents smoke images from Nix image archives', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 
-    expect(workflow).toContain('-f "${WORKSPACE}/services/agents/Dockerfile"')
-    expect(workflow).toContain('-f "${WORKSPACE}/services/agents/Dockerfile.codex-runner"')
-    expect(workflow).toContain('--scope=@proompteng/agent-contracts')
-    expect(workflow).toContain('--scope=@proompteng/codex')
-    expect(workflow).toContain('cp -R "${PRUNE_DIR}/full/services/agents" "${PRUNE_DIR}/services/agents"')
-    expect(workflow).toContain('cp -R "${PRUNE_DIR}/full/packages/codex" "${PRUNE_DIR}/packages/codex"')
+    expect(workflow).toContain('Build and preload local Nix Agents image archives into kind')
+    expect(workflow).toContain('build_nix_image_archive "${CONTROL_PLANE_IMAGE}" agents-control-plane-image')
+    expect(workflow).toContain('build_nix_image_archive "${CONTROLLER_IMAGE}" agents-controller-image')
+    expect(workflow).toContain('build_nix_image_archive "${RUNNER_IMAGE}" agents-codex-runner-image')
+    expect(workflow).toContain('load_nix_image_archive "${CONTROL_PLANE_IMAGE}" "${CONTROL_PLANE_ARCHIVE}"')
+    expect(workflow).toContain('load_nix_image_archive "${CONTROLLER_IMAGE}" "${CONTROLLER_ARCHIVE}"')
+    expect(workflow).toContain('load_nix_image_archive "${RUNNER_IMAGE}" "${RUNNER_ARCHIVE}"')
     expect(workflow).toContain('packages/agent-contracts/**')
-    expect(workflow).toContain('--target control-plane')
-    expect(workflow).toContain('--target controller')
     expect(workflow).toContain('BUILT_AGENTS_CONTROLLER_IMAGE_REPOSITORY')
     expect(workflow).toContain('BUILT_AGENTS_RUNNER_IMAGE_REPOSITORY')
-    expect(workflow).toContain('agents-runner-image-smoke')
-    expect(workflow).toContain('--build-arg "AGENTS_VERSION=${AGENTS_VERSION}"')
+    expect(workflow).not.toContain('-f "${WORKSPACE}/services/agents/Dockerfile"')
+    expect(workflow).not.toContain('-f "${WORKSPACE}/services/agents/Dockerfile.codex-runner"')
+    expect(workflow).not.toContain('docker build')
+    expect(workflow).not.toContain('docker run')
     expect(workflow).not.toContain('-f "${WORKSPACE}/services/jangar/Dockerfile"')
   })
 })

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -23,9 +23,9 @@ type Options = {
   repository: string
   controlPlaneRepository: string
   agentsShellRepository: string
+  runnerRepository: string
   tag: string
   platforms: string[]
-  buildRunner: boolean
   apply: boolean
   dryRun: boolean
 }
@@ -62,7 +62,13 @@ type AgentsServiceImagePlan = {
 const buildAgentsServiceImagePlans = (
   options: Pick<
     Options,
-    'registry' | 'repository' | 'controlPlaneRepository' | 'agentsShellRepository' | 'tag' | 'platforms'
+    | 'registry'
+    | 'repository'
+    | 'controlPlaneRepository'
+    | 'agentsShellRepository'
+    | 'runnerRepository'
+    | 'tag'
+    | 'platforms'
   >,
 ): AgentsServiceImagePlan[] => [
   {
@@ -84,6 +90,13 @@ const buildAgentsServiceImagePlans = (
     imageName: 'agents-shell',
     packageAttr: 'agents-shell-image',
     repository: options.agentsShellRepository,
+    tag: options.tag,
+  },
+  {
+    service: 'agents-codex-runner',
+    imageName: 'agents-codex-runner',
+    packageAttr: 'agents-codex-runner-image',
+    repository: options.runnerRepository,
     tag: options.tag,
   },
 ]
@@ -177,9 +190,6 @@ const parseArgs = (argv: string[]): Partial<Options> => {
       options.apply = false
       continue
     }
-    if (arg === '--skip-runner') {
-      options.buildRunner = false
-    }
   }
   return options
 }
@@ -195,6 +205,7 @@ const resolveOptions = (): Options => {
   const controlPlaneRepository =
     args.controlPlaneRepository ?? process.env.AGENTS_CONTROL_PLANE_IMAGE_REPOSITORY ?? 'lab/agents-control-plane'
   const agentsShellRepository = process.env.AGENTS_SHELL_IMAGE_REPOSITORY ?? 'lab/agents-shell'
+  const runnerRepository = process.env.AGENTS_RUNNER_IMAGE_REPOSITORY ?? 'lab/agents-codex-runner'
   const tag = args.tag ?? process.env.AGENTS_IMAGE_TAG ?? execGit(['rev-parse', '--short', 'HEAD'])
   const platforms = parsePlatforms(process.env.AGENTS_IMAGE_PLATFORMS) ?? ['linux/amd64', 'linux/arm64']
 
@@ -211,9 +222,9 @@ const resolveOptions = (): Options => {
     repository,
     controlPlaneRepository,
     agentsShellRepository,
+    runnerRepository,
     tag,
     platforms,
-    buildRunner: args.buildRunner ?? parseBoolean(process.env.AGENTS_BUILD_RUNNER, false),
     apply: args.apply ?? parseBoolean(process.env.AGENTS_APPLY, true),
     dryRun: args.dryRun ?? parseBoolean(process.env.AGENTS_DRY_RUN, false),
   }
@@ -412,20 +423,6 @@ const updateValuesFile = (
 
 export const updateAgentsValuesFile = updateValuesFile
 
-const readRunnerImagePin = (valuesPath: string): ImagePin => {
-  const values = YAML.parse(readFileSync(valuesPath, 'utf8')) ?? {}
-  const runnerImage = values.runner?.image
-  const repository = typeof runnerImage?.repository === 'string' ? runnerImage.repository : ''
-  const tag = typeof runnerImage?.tag === 'string' ? runnerImage.tag : ''
-  const digest = typeof runnerImage?.digest === 'string' ? runnerImage.digest : ''
-  if (!repository || !tag || !digest) {
-    fatal(
-      `Runner image pin missing from ${valuesPath}; cannot preserve runner image without repository, tag, and digest.`,
-    )
-  }
-  return { repository, tag, digest }
-}
-
 const normalizeDigest = (value: string): string => {
   const trimmed = value.trim()
   return trimmed.includes('@') ? trimmed.slice(trimmed.lastIndexOf('@') + 1) : trimmed
@@ -459,6 +456,7 @@ const buildAgentsServiceImages = async (options: Options) => {
     controller: pins['agents-controller'] ?? fatal('agents-controller Nix image result was not produced'),
     controlPlane: pins['agents-control-plane'] ?? fatal('agents-control-plane Nix image result was not produced'),
     agentsShell: pins['agents-shell'] ?? fatal('agents-shell Nix image result was not produced'),
+    runner: pins['agents-codex-runner'] ?? fatal('agents-codex-runner Nix image result was not produced'),
   }
 }
 
@@ -547,19 +545,11 @@ const renderAndApply = async (kustomizePath: string) => {
 
 const main = async () => {
   const options = resolveOptions()
-  if (options.buildRunner) {
-    fatal(
-      'agents:deploy no longer builds the agents-codex-runner image. The service image migration preserves the currently pinned runner image; migrate the runner through its own package once its Python/Codex runtime contract is proven.',
-    )
-  }
-
   const servicePins = await buildAgentsServiceImages(options)
   if (options.dryRun) {
     console.log('Dry run complete; Agents values and cluster state were not changed.')
     return
   }
-
-  const runnerPin = readRunnerImagePin(options.valuesPath)
 
   updateValuesFile(
     options.valuesPath,
@@ -572,9 +562,9 @@ const main = async () => {
     servicePins.agentsShell.repository,
     servicePins.agentsShell.tag,
     servicePins.agentsShell.digest,
-    runnerPin.repository,
-    runnerPin.tag,
-    runnerPin.digest,
+    servicePins.runner.repository,
+    servicePins.runner.tag,
+    servicePins.runner.digest,
     {
       sourceHeadSha: execGit(['rev-parse', 'HEAD']),
       gitopsRevision: execGit(['rev-parse', 'HEAD']),
@@ -606,7 +596,6 @@ export const __private = {
   isArgoHookManifest,
   renderAndApply,
   updateValuesFile,
-  readRunnerImagePin,
   buildAgentsServiceImages,
   resolveDatabaseSecretRequirement,
 }

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -59,6 +59,7 @@ describe('enabled app inventory', () => {
   it('marks only approved early build-owning apps as Nix image candidates', () => {
     for (const name of [
       'oirat',
+      'agents',
       'bumba',
       'froussard',
       'docs',
@@ -88,6 +89,7 @@ describe('enabled app inventory', () => {
     expect(entry('proompteng').nixImageAttr).toBe('proompteng-image')
     expect(entry('olden').nixImageAttr).toBe('olden-image')
     expect(entry('synthesis').nixImageAttr).toBe('synthesis-image')
+    expect(entry('agents').nixImageAttr).toBe('agents-codex-runner-image')
     expect(entry('sag').nixImageAttr).toBe('sag-image')
     expect(entry('symphony').nixImageAttr).toBe('symphony-image')
     expect(entry('torghut').nixImageAttr).toBe('torghut-image')
@@ -97,7 +99,7 @@ describe('enabled app inventory', () => {
   })
 
   it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
-    for (const name of ['agents', 'jangar', 'symphony-jangar', 'symphony-torghut']) {
+    for (const name of ['jangar', 'symphony-jangar', 'symphony-torghut']) {
       expect(entry(name).class).toBe('deferred')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
       expect(entry(name).deferredReason).toBeTruthy()

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -823,6 +823,7 @@ describe('native OCI build workflows', () => {
       ['agents-controller', 'agents-controller-image', 'agents-controller-release-contract'],
       ['agents-control-plane', 'agents-control-plane-image', 'agents-control-plane-release-contract'],
       ['agents-shell', 'agents-shell-image', 'agents-shell-release-contract'],
+      ['agents-codex-runner', 'agents-codex-runner-image', 'agents-codex-runner-release-contract'],
     ] as const) {
       expect(agentsImageModule).toContain(`"${packageAttr}"`)
       expect(agentsBuildWorkflow).toContain(`image_name: ${imageName}`)
@@ -831,10 +832,18 @@ describe('native OCI build workflows', () => {
     }
 
     expect(flake).toContain('import ./nix/images/agents.nix')
+    expect(agentsImageModule).toContain('import ./openai-codex-cli.nix')
+    expect(agentsImageModule).toContain('"agents-codex-runner-image"')
+    expect(agentsImageModule).toContain('pname = "alpaca-mcp-server";')
+    expect(agentsImageModule).toContain('version = "2.0.1";')
+    expect(agentsImageModule).toContain('pname = "alpaca-py";')
+    expect(agentsImageModule).toContain('pname = "pandas-ta-classic";')
+    expect(agentsImageModule).toContain('pythonPackages.buildPythonPackage')
     expect(agentsBuildWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
     expect(agentsBuildWorkflow).toContain('tag: sha-${{ github.sha }}')
-    expect(agentsBuildWorkflow).toContain('Resolve preserved runner image pin')
-    expect(agentsBuildWorkflow).toContain('--runner-tag "${RUNNER_TAG}"')
+    expect(agentsBuildWorkflow).not.toContain('Resolve preserved runner image pin')
+    expect(agentsBuildWorkflow).toContain('--runner-tag "${TAG}"')
+    expect(agentsBuildWorkflow).toContain('--runner-repository registry.ide-newton.ts.net/lab/agents-codex-runner')
     expect(agentsBuildWorkflow).toContain("'charts/agents/crds/**'")
     expect(agentsBuildWorkflow).not.toContain("'charts/agents/**'")
     expect(agentsBuildWorkflow).not.toContain("'argocd/applications/agents/**'")
@@ -849,6 +858,7 @@ describe('native OCI build workflows', () => {
     expect(agentsImageModule).toContain('"agents-controller-image"')
     expect(agentsImageModule).toContain('"agents-control-plane-image"')
     expect(agentsImageModule).toContain('"agents-shell-image"')
+    expect(agentsImageModule).toContain('"agents-codex-runner-image"')
   })
 
   it('preserves isolated Bun workspace runtime dependencies in Agents images', () => {
@@ -952,7 +962,9 @@ describe('native OCI build workflows', () => {
     expect(agentsDeployScript).not.toContain('inspectImageDigest')
     expect(agentsDeployScript).toContain("from '../shared/nix-oci-deploy'")
     expect(agentsDeployScript).toContain('dryRun')
-    expect(agentsDeployScript).toContain('readRunnerImagePin')
+    expect(agentsDeployScript).toContain('runnerRepository')
+    expect(agentsDeployScript).toContain('agents-codex-runner-image')
+    expect(agentsDeployScript).not.toContain('readRunnerImagePin')
 
     for (const script of torghutUpdateScripts) {
       expect(script).not.toContain("from '../shared/docker'")

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -38,6 +38,7 @@ const labRepoURL = 'https://github.com/proompteng/lab.git'
 const labImagePrefix = 'registry.ide-newton.ts.net/lab/'
 
 const earlyNixImageApps = new Set([
+  'agents',
   'app',
   'attic',
   'bumba',
@@ -56,10 +57,6 @@ const earlyNixImageApps = new Set([
 ])
 
 const deferredApps = new Map<string, string>([
-  [
-    'agents',
-    'service images are Nix OCI migrated; app remains deferred until the separate agents-codex-runner Python/Codex runtime image is migrated',
-  ],
   ['jangar', 'complex service plus OpenWebUI chart; requires a dedicated derivation and rollout proof'],
   ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
   ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
@@ -78,6 +75,7 @@ const appToNixAttr = new Map<string, string>([
   ['sag', 'sag-image'],
   ['symphony', 'symphony-image'],
   ['synthesis', 'synthesis-image'],
+  ['agents', 'agents-codex-runner-image'],
   ['torghut', 'torghut-image'],
   ['torghut-hyperliquid-feed', 'torghut-hyperliquid-feed-image'],
   ['torghut-hyperliquid-runtime', 'torghut-image'],

--- a/services/agents/src/server/__tests__/agents-ci-workflow.test.ts
+++ b/services/agents/src/server/__tests__/agents-ci-workflow.test.ts
@@ -3,11 +3,22 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('agents-ci workflow', () => {
-  it('uses the mirrored Bun base image for local Agents integration builds', () => {
+  it('builds local Agents integration images from Nix archives', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 
-    expect(workflow).toContain('--build-arg "BUN_BASE_IMAGE=mirror.gcr.io/oven/bun"')
-    expect(workflow).not.toContain('--build-arg "BUN_BASE_IMAGE=docker.io/oven/bun"')
+    expect(workflow).toContain('Build and preload local Nix Agents image archives into kind')
+    expect(workflow).toContain('nix build ".#${1}" --print-out-paths --no-link')
+    expect(workflow).toContain(
+      'build_nix_image_archive "${CONTROL_PLANE_IMAGE}" agents-control-plane-image CONTROL_PLANE_ARCHIVE',
+    )
+    expect(workflow).toContain(
+      'build_nix_image_archive "${CONTROLLER_IMAGE}" agents-controller-image CONTROLLER_ARCHIVE',
+    )
+    expect(workflow).toContain('build_nix_image_archive "${RUNNER_IMAGE}" agents-codex-runner-image RUNNER_ARCHIVE')
+    expect(workflow).toContain('kind load image-archive')
+    expect(workflow).not.toContain('--build-arg "BUN_BASE_IMAGE=')
+    expect(workflow).not.toContain('docker build')
+    expect(workflow).not.toContain('kind load docker-image')
   })
 
   it('bounds kubectl downloads so integration runners fail instead of hanging', () => {


### PR DESCRIPTION
## Summary

- Build `agents-codex-runner` as a real Nix OCI image with the pinned Codex CLI and Python runtime dependencies.
- Publish and release the runner image through the existing Agents Nix OCI build and GitOps values flow instead of preserving the old runner pin.
- Replace Agents CI local kind smoke Dockerfile builds with Nix image archive builds and direct `kind load image-archive` preloading.

## Related Issues

None

## Testing

- `bun test services/agents/src/server/__tests__/agents-ci-workflow.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `yq e '.' .github/workflows/agents-ci.yml .github/workflows/agents-build-push.yml .github/workflows/agents-release.yml`
- `yq e '.jobs.integration.steps[] | select(.name == "Build and preload local Nix Agents image archives into kind").run' .github/workflows/agents-ci.yml | bash -n`
- `bunx oxfmt --check services/agents/src/server/__tests__/agents-ci-workflow.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/deploy-service.ts packages/scripts/src/shared/enabled-apps.ts`
- `bunx oxlint --config .oxlintrc.json services/agents/src/server/__tests__/agents-ci-workflow.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/deploy-service.ts packages/scripts/src/shared/enabled-apps.ts`
- `git diff --check`
- `nix build .#packages.x86_64-linux.agents-control-plane-image .#packages.x86_64-linux.agents-controller-image .#packages.x86_64-linux.agents-codex-runner-image --no-link --dry-run`
- `nix build .#packages.aarch64-linux.agents-control-plane-image .#packages.aarch64-linux.agents-controller-image .#packages.aarch64-linux.agents-codex-runner-image --no-link --dry-run`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
