### PR TITLE
fix(torghut): set migration hook python path

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -24,6 +24,7 @@ spec:
         - name: migrate
           image: registry.ide-newton.ts.net/lab/torghut@sha256:03a55dcd405376a3f713ea50e64f1455ffc3f5ac3634726a7f680c8f8fd5dc1c
           imagePullPolicy: Always
+          workingDir: /app
           command:
             - /bin/sh
             - -ec
@@ -54,6 +55,8 @@ spec:
               value: 9afbcac4b27576a5911e617ad8f98dd327c645b2
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:03a55dcd405376a3f713ea50e64f1455ffc3f5ac3634726a7f680c8f8fd5dc1c
+            - name: PYTHONPATH
+              value: /app
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
+++ b/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
@@ -71,6 +71,8 @@ def test_manifest_uses_v2_command_and_env_prefix_only() -> None:
 def test_runtime_migration_hook_uses_image_path_binaries() -> None:
     manifest = DB_MIGRATIONS_JOB.read_text()
 
+    assert "workingDir: /app" in manifest
+    assert "name: PYTHONPATH\n              value: /app" in manifest
     assert "until python - <<'PY'" in manifest
     assert "alembic -c /app/alembic.ini upgrade heads" in manifest
     assert "/opt/venv/bin/" not in manifest


### PR DESCRIPTION
## Summary

- Set the Hyperliquid runtime migration hook `workingDir` to `/app`.
- Export `PYTHONPATH=/app` so Alembic can import `app.config` from the Nix-built image.
- Extend the migration manifest contract test to cover the explicit runtime import path.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/torghut-hyperliquid-runtime >/tmp/torghut-runtime-render.yaml && rg -n "workingDir: /app|name: PYTHONPATH|value: /app|alembic -c /app" /tmp/torghut-runtime-render.yaml`
- `uv run --frozen pytest tests/hyperliquid_execution/test_migration_manifest.py -q`
- `uv run --frozen ruff format --check tests/hyperliquid_execution/test_migration_manifest.py && uv run --frozen ruff check tests/hyperliquid_execution/test_migration_manifest.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
