### PR TITLE
fix(froussard): keep AgentRun goal objective compact

### DIFF
--- a/apps/froussard/src/routes/webhooks.test.ts
+++ b/apps/froussard/src/routes/webhooks.test.ts
@@ -110,7 +110,7 @@ const findAgentRunSubmission = (fetchMock: ReturnType<typeof vi.fn>) =>
 
 const expectAgentRunSubmission = (
   fetchMock: ReturnType<typeof vi.fn>,
-  options: { deliveryId: string; issueNumber: number },
+  options: { deliveryId: string; issueNumber: number; issueTitle: string; issueUrl: string },
 ) => {
   const call = findAgentRunSubmission(fetchMock)
   expect(call).toBeTruthy()
@@ -131,7 +131,16 @@ const expectAgentRunSubmission = (
       text: 'PROMPT',
       source: { provider: 'github', externalId: `owner/repo#${options.issueNumber}` },
     },
-    goal: { objective: 'PROMPT', tokenBudget: 250000 },
+    goal: {
+      objective: [
+        `Implement GitHub issue owner/repo#${options.issueNumber}: ${options.issueTitle}.`,
+        `Issue URL: ${options.issueUrl}.`,
+        'Base branch: main.',
+        'Head branch: codex/issue-1-test.',
+        'Use implementation.text for the full issue body, requirements, and acceptance criteria.',
+      ].join('\n'),
+      tokenBudget: 250000,
+    },
     runtime: { type: 'job', config: { serviceAccountName: 'agents-sa' } },
     parameters: {
       repository: 'owner/repo',
@@ -397,7 +406,12 @@ describe('createWebhookHandler', () => {
         expect(body).toMatchObject({ codexStageTriggered: 'implementation' })
         expect(publishedMessages).toHaveLength(1)
         expect(publishedMessages.some((message) => message.topic === 'github.issues.codex.tasks')).toBe(false)
-        expectAgentRunSubmission(fetchMock, { deliveryId: 'delivery-issues-opened', issueNumber: 42 })
+        expectAgentRunSubmission(fetchMock, {
+          deliveryId: 'delivery-issues-opened',
+          issueNumber: 42,
+          issueTitle: 'Implement feature',
+          issueUrl: 'https://github.com/owner/repo/issues/42',
+        })
         expect(githubServiceMock.postIssueReaction).toHaveBeenCalledWith(
           expect.objectContaining({
             repositoryFullName: 'owner/repo',
@@ -436,7 +450,12 @@ describe('createWebhookHandler', () => {
       assert: (body) => {
         expect(body).toMatchObject({ codexStageTriggered: 'implementation' })
         expect(publishedMessages.some((message) => message.topic === 'github.issues.codex.tasks')).toBe(false)
-        expectAgentRunSubmission(fetchMock, { deliveryId: 'delivery-issue_comment-created', issueNumber: 99 })
+        expectAgentRunSubmission(fetchMock, {
+          deliveryId: 'delivery-issue_comment-created',
+          issueNumber: 99,
+          issueTitle: 'Ship feature',
+          issueUrl: 'https://github.com/owner/repo/issues/99',
+        })
         expect(githubServiceMock.postIssueCommentReaction).toHaveBeenCalledWith(
           expect.objectContaining({
             repositoryFullName: 'owner/repo',
@@ -701,7 +720,12 @@ describe('createWebhookHandler', () => {
     expect(response.status).toBe(202)
     expect(publishedMessages).toHaveLength(1)
     const [rawJsonMessage] = publishedMessages
-    expectAgentRunSubmission(fetchMock, { deliveryId: 'delivery-123', issueNumber: 1 })
+    expectAgentRunSubmission(fetchMock, {
+      deliveryId: 'delivery-123',
+      issueNumber: 1,
+      issueTitle: 'Test issue',
+      issueUrl: 'https://example.com',
+    })
     expect(rawJsonMessage).toMatchObject({ topic: 'raw-topic', key: 'delivery-123' })
     expect(githubServiceMock.postIssueReaction).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -738,7 +762,12 @@ describe('createWebhookHandler', () => {
     const response = await handler(buildRequest(payload, headers), 'github')
     expect(response.status).toBe(202)
     expect(publishedMessages).toHaveLength(1)
-    expectAgentRunSubmission(fetchMock, { deliveryId: 'delivery-dup', issueNumber: 1 })
+    expectAgentRunSubmission(fetchMock, {
+      deliveryId: 'delivery-dup',
+      issueNumber: 1,
+      issueTitle: 'Test issue',
+      issueUrl: 'https://example.com',
+    })
     expect(githubServiceMock.postIssueReaction).toHaveBeenCalledTimes(1)
 
     const duplicateResponse = await handler(buildRequest(payload, headers), 'github')
@@ -779,7 +808,12 @@ describe('createWebhookHandler', () => {
 
     expect(publishedMessages).toHaveLength(1)
     const [rawJsonMessage] = publishedMessages
-    expectAgentRunSubmission(fetchMock, { deliveryId: 'delivery-999', issueNumber: 2 })
+    expectAgentRunSubmission(fetchMock, {
+      deliveryId: 'delivery-999',
+      issueNumber: 2,
+      issueTitle: 'Implementation issue',
+      issueUrl: 'https://issue',
+    })
     expect(rawJsonMessage).toMatchObject({ topic: 'raw-topic', key: 'delivery-999' })
     expect(githubServiceMock.postIssueReaction).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/froussard/src/services/agents.test.ts
+++ b/apps/froussard/src/services/agents.test.ts
@@ -72,7 +72,13 @@ describe('agents service submissions', () => {
         },
       },
       goal: {
-        objective: 'Implement this issue',
+        objective: [
+          'Implement GitHub issue owner/repo#42: Ship the feature.',
+          'Issue URL: https://github.com/owner/repo/issues/42.',
+          'Base branch: main.',
+          'Head branch: codex/issue-42-test.',
+          'Use implementation.text for the full issue body, requirements, and acceptance criteria.',
+        ].join('\n'),
         tokenBudget: 250_000,
       },
       runtime: {
@@ -101,7 +107,7 @@ describe('agents service submissions', () => {
     })
   })
 
-  it('keeps long issue content out of AgentRun parameters', () => {
+  it('keeps long issue content out of AgentRun parameters and goal objective', () => {
     const longPrompt = 'Implement the issue.\n\n'.repeat(300)
     const payload = buildGithubIssueAgentRunPayload(
       config,
@@ -111,13 +117,33 @@ describe('agents service submissions', () => {
 
     expect(payload).toMatchObject({
       implementation: { text: longPrompt },
-      goal: { objective: longPrompt },
     })
+    const goal = payload.goal as { objective: string }
+    expect(goal.objective).not.toBe(longPrompt)
+    expect(goal.objective).toContain('Implement GitHub issue owner/repo#42: Ship the feature.')
+    expect(goal.objective).toContain('Use implementation.text for the full issue body')
+    expect(goal.objective.length).toBeLessThanOrEqual(4000)
+
     const parameters = payload.parameters as Record<string, string>
     expect(parameters.codexPrompt).toBeUndefined()
     expect(parameters.codex_prompt).toBeUndefined()
     expect(parameters.issueBody).toBeUndefined()
     expect(Object.values(parameters).every((value) => new TextEncoder().encode(value).length <= 2048)).toBe(true)
+  })
+
+  it('caps the goal objective when issue metadata is unusually large', () => {
+    const payload = buildGithubIssueAgentRunPayload(
+      config,
+      {
+        ...request,
+        issueTitle: 'large-title '.repeat(800),
+      },
+      'delivery-large-title',
+    )
+    const goal = payload.goal as { objective: string }
+
+    expect(goal.objective).toContain('Implement GitHub issue owner/repo#42:')
+    expect(goal.objective.length).toBeLessThanOrEqual(4000)
   })
 
   it('uses the configured Agents service endpoint and client name', async () => {

--- a/apps/froussard/src/services/agents.ts
+++ b/apps/froussard/src/services/agents.ts
@@ -20,6 +20,25 @@ const optionalString = (value: string | undefined | null) => {
 
 const issueExternalId = (request: GithubIssueAgentRunRequest) => `${request.repository}#${request.issueNumber}`
 
+const maxGoalObjectiveLength = 4000
+const truncatedObjectiveSuffix = '\n...'
+
+const truncateGoalObjective = (objective: string) => {
+  if (objective.length <= maxGoalObjectiveLength) return objective
+  return `${objective.slice(0, maxGoalObjectiveLength - truncatedObjectiveSuffix.length).trimEnd()}${truncatedObjectiveSuffix}`
+}
+
+export const buildGithubIssueGoalObjective = (request: GithubIssueAgentRunRequest): string =>
+  truncateGoalObjective(
+    [
+      `Implement GitHub issue ${issueExternalId(request)}: ${request.issueTitle}.`,
+      `Issue URL: ${request.issueUrl}.`,
+      `Base branch: ${request.base}.`,
+      `Head branch: ${request.head}.`,
+      'Use implementation.text for the full issue body, requirements, and acceptance criteria.',
+    ].join('\n'),
+  )
+
 export const buildGithubIssueAgentRunPayload = (
   config: FroussardAgentsConfig,
   request: GithubIssueAgentRunRequest,
@@ -48,7 +67,7 @@ export const buildGithubIssueAgentRunPayload = (
     },
   },
   goal: {
-    objective: request.prompt,
+    objective: buildGithubIssueGoalObjective(request),
     tokenBudget: config.goalTokenBudget,
   },
   runtime: {


### PR DESCRIPTION
## Summary

- Keeps Froussard AgentRun `goal.objective` as compact GitHub issue metadata instead of copying the full implementation prompt.
- Leaves the complete issue prompt in `implementation.text`, so the runner still receives the full issue body and acceptance criteria.
- Adds regression coverage for long issue prompts and unusually large issue titles so the objective remains within the 4000-character runner limit.

## Related Issues

Fixes #11885

## Testing

- `bun run --filter froussard test`
- `bun run --filter froussard typecheck`
- `bunx oxfmt --check apps/froussard/src/services/agents.ts apps/froussard/src/services/agents.test.ts apps/froussard/src/routes/webhooks.test.ts`
- `git diff --check`
- `bun run --filter froussard lint:oxlint`
- `bun run --filter froussard build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
