### PR TITLE
chore(torghut): promote ws image sha-b2bde9f21285e3733e8a25a664f9f7e10d1485b4

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:81b9750d5b96edd9742602c2c1939a317deeaef059988d269f22a029555d9fbc
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:b0b4dfec70bd0a002294a90847bad5c4c83690ea85bbc6348f6ee6bc1d127a00
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-5e046147da58bd014bca17565cbd731626ec875b
+              value: main-sha-b2bde9f21285e3733e8a25a664f9f7e10d1485b4
             - name: TORGHUT_WS_COMMIT
-              value: 5e046147da58bd014bca17565cbd731626ec875b
+              value: b2bde9f21285e3733e8a25a664f9f7e10d1485b4
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:81b9750d5b96edd9742602c2c1939a317deeaef059988d269f22a029555d9fbc
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:b0b4dfec70bd0a002294a90847bad5c4c83690ea85bbc6348f6ee6bc1d127a00
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-5e046147da58bd014bca17565cbd731626ec875b
+              value: main-sha-b2bde9f21285e3733e8a25a664f9f7e10d1485b4
             - name: TORGHUT_WS_COMMIT
-              value: 5e046147da58bd014bca17565cbd731626ec875b
+              value: b2bde9f21285e3733e8a25a664f9f7e10d1485b4
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `b2bde9f21285e3733e8a25a664f9f7e10d1485b4`
- Image tag: `sha-b2bde9f21285e3733e8a25a664f9f7e10d1485b4`
- Image digest: `sha256:b0b4dfec70bd0a002294a90847bad5c4c83690ea85bbc6348f6ee6bc1d127a00`