### PR TITLE
ci(jangar): avoid root package trigger fanout

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -19,7 +19,6 @@ on:
       - 'packages/otel/**'
       - 'packages/temporal-bun-sdk/**'
       - 'skills/**'
-      - 'package.json'
       - 'bun.lock'
       - '.github/workflows/jangar-build-push.yaml'
   workflow_dispatch:

--- a/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
+++ b/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
@@ -96,6 +96,21 @@ describe('resolve-release-metadata', () => {
     })
   })
 
+  it('does not treat root package script changes as Jangar build changes', () => {
+    const decision = __private.evaluateWorkflowRunStaleness({
+      sourceSha: ddd07d2f,
+      mainHead: bf889391,
+      isAncestor: true,
+      changedMainFiles: ['package.json'],
+    })
+
+    expect(decision).toEqual({
+      promote: true,
+      reason: 'newer-main-non-jangar-only',
+    })
+    expect(__private.isBuildTriggerPath('package.json')).toBe(false)
+  })
+
   it('regression from git history fixture: blocks f22a8cbc promotion when newer main has jangar changes', () => {
     const decision = __private.evaluateWorkflowRunStaleness({
       sourceSha: f22a8cbc,

--- a/packages/scripts/src/jangar/resolve-release-metadata.ts
+++ b/packages/scripts/src/jangar/resolve-release-metadata.ts
@@ -12,7 +12,7 @@ const defaultContractPath = '.artifacts/jangar/jangar-release-contract.json'
 const defaultImage = 'registry.ide-newton.ts.net/lab/jangar'
 
 const buildTriggerPathRegex =
-  /^(services\/jangar\/|packages\/scripts\/src\/jangar\/|packages\/scripts\/src\/shared\/|packages\/otel\/|packages\/temporal-bun-sdk\/|package\.json$|bun\.lock$|\.github\/workflows\/jangar-build-push\.yaml$)/
+  /^(services\/jangar\/|packages\/scripts\/src\/jangar\/|packages\/scripts\/src\/shared\/|packages\/otel\/|packages\/temporal-bun-sdk\/|bun\.lock$|\.github\/workflows\/jangar-build-push\.yaml$)/
 
 type CliOptions = {
   eventName?: string

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -487,6 +487,7 @@ describe('native OCI build workflows', () => {
       froussardWorkflow,
       productNixWorkflow,
       agentsBuildWorkflow,
+      jangarBuildWorkflow,
       symphonyBuildWorkflow,
       sagBuildWorkflow,
     ]) {


### PR DESCRIPTION
## Summary

- Remove root `package.json` from the `jangar-build-push` path trigger so root script-only changes do not start an unrelated image build.
- Align Jangar release staleness checks with that trigger so `package.json` alone does not block or create promotion logic.
- Add regression coverage in the Jangar metadata resolver and shared OCI workflow policy tests.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check .github/workflows/jangar-build-push.yaml packages/scripts/src/jangar/resolve-release-metadata.ts packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
