### PR TITLE
ci(jangar): skip workflow-only image builds

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -20,7 +20,6 @@ on:
       - 'packages/temporal-bun-sdk/**'
       - 'skills/**'
       - 'bun.lock'
-      - '.github/workflows/jangar-build-push.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
+++ b/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
@@ -111,6 +111,21 @@ describe('resolve-release-metadata', () => {
     expect(__private.isBuildTriggerPath('package.json')).toBe(false)
   })
 
+  it('does not treat workflow-only changes as Jangar build changes', () => {
+    const decision = __private.evaluateWorkflowRunStaleness({
+      sourceSha: ddd07d2f,
+      mainHead: bf889391,
+      isAncestor: true,
+      changedMainFiles: ['.github/workflows/jangar-build-push.yaml'],
+    })
+
+    expect(decision).toEqual({
+      promote: true,
+      reason: 'newer-main-non-jangar-only',
+    })
+    expect(__private.isBuildTriggerPath('.github/workflows/jangar-build-push.yaml')).toBe(false)
+  })
+
   it('regression from git history fixture: blocks f22a8cbc promotion when newer main has jangar changes', () => {
     const decision = __private.evaluateWorkflowRunStaleness({
       sourceSha: f22a8cbc,

--- a/packages/scripts/src/jangar/resolve-release-metadata.ts
+++ b/packages/scripts/src/jangar/resolve-release-metadata.ts
@@ -12,7 +12,7 @@ const defaultContractPath = '.artifacts/jangar/jangar-release-contract.json'
 const defaultImage = 'registry.ide-newton.ts.net/lab/jangar'
 
 const buildTriggerPathRegex =
-  /^(services\/jangar\/|packages\/scripts\/src\/jangar\/|packages\/scripts\/src\/shared\/|packages\/otel\/|packages\/temporal-bun-sdk\/|bun\.lock$|\.github\/workflows\/jangar-build-push\.yaml$)/
+  /^(services\/jangar\/|packages\/scripts\/src\/jangar\/|packages\/scripts\/src\/shared\/|packages\/otel\/|packages\/temporal-bun-sdk\/|bun\.lock$)/
 
 type CliOptions = {
   eventName?: string


### PR DESCRIPTION
## Summary

- Remove `.github/workflows/jangar-build-push.yaml` from the `jangar-build-push` path trigger so workflow-only edits do not build and push a Jangar image.
- Align Jangar release staleness checks so workflow-only changes are treated as non-runtime changes.
- Add regression coverage for workflow-only Jangar changes.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check .github/workflows/jangar-build-push.yaml packages/scripts/src/jangar/resolve-release-metadata.ts packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
