### PR TITLE
ci(jangar): narrow image build script trigger

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -9,7 +9,7 @@ on:
       - main
     paths:
       - 'services/jangar/**'
-      - 'packages/scripts/src/jangar/**'
+      - 'packages/scripts/src/jangar/build-image.ts'
       - 'packages/scripts/src/shared/cli.ts'
       - 'packages/scripts/src/shared/docker.ts'
       - 'packages/scripts/src/shared/git.ts'

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -498,6 +498,8 @@ describe('native OCI build workflows', () => {
     }
 
     for (const workflow of [jangarBuildWorkflow]) {
+      expect(workflow).not.toContain("'packages/scripts/src/jangar/**'")
+      expect(workflow).toContain("'packages/scripts/src/jangar/build-image.ts'")
       expect(workflow).toContain("'packages/scripts/src/shared/cli.ts'")
       expect(workflow).toContain("'packages/scripts/src/shared/docker.ts'")
       expect(workflow).toContain("'packages/scripts/src/shared/git.ts'")


### PR DESCRIPTION
## Summary

- Narrow `jangar-build-push` so Jangar image builds watch `packages/scripts/src/jangar/build-image.ts` instead of the entire Jangar scripts directory.
- Keep shared CLI/Docker/Git helper triggers for the build path.
- Add workflow policy coverage proving broad Jangar script fanout does not return.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check .github/workflows/jangar-build-push.yaml packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
