### PR TITLE
feat(froussard): add nix image build script

### DIFF
--- a/packages/scripts/src/froussard/__tests__/build-image.test.ts
+++ b/packages/scripts/src/froussard/__tests__/build-image.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+
+import type { BuildAndPushNixImageOptions } from '../../shared/nix-oci-deploy'
+import { __private, buildImage } from '../build-image'
+
+afterEach(() => {
+  __private.setBuildAndPushNixImage()
+  __private.setExecGit()
+})
+
+describe('froussard build-image helpers', () => {
+  it('builds the Froussard image through the shared Nix OCI helper', async () => {
+    let captured: BuildAndPushNixImageOptions | undefined
+
+    __private.setExecGit((args) => {
+      if (args[0] === 'describe') return 'release/v1.2.3+test'
+      if (args[0] === 'rev-parse') return 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+    __private.setBuildAndPushNixImage(async (options) => {
+      captured = options
+      return {
+        service: options.service,
+        image: `${options.registry}/${options.repository}`,
+        tag: options.tag ?? 'latest',
+        digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        reference: `${options.registry}/${options.repository}@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`,
+        sourceSha: options.sourceSha ?? '',
+        packageAttr: options.packageAttr,
+        contractPath: '.artifacts/froussard/manual-release-contract.json',
+        platforms: ['linux/amd64', 'linux/arm64'],
+        platformDigests: {
+          'linux/amd64': 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+          'linux/arm64': 'sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        },
+        imageTarPath: '/nix/store/froussard-image.tar',
+      }
+    })
+
+    const result = await buildImage({
+      registry: 'registry.ide-newton.ts.net',
+      repository: 'lab/froussard',
+    })
+
+    expect(captured).toMatchObject({
+      service: 'froussard',
+      imageName: 'froussard',
+      packageAttr: 'froussard-image',
+      registry: 'registry.ide-newton.ts.net',
+      repository: 'lab/froussard',
+      tag: 'release-v1.2.3-test',
+      sourceSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      latestTag: 'latest',
+    })
+    expect(result).toEqual({
+      image: 'registry.ide-newton.ts.net/lab/froussard:release-v1.2.3-test',
+      digest:
+        'registry.ide-newton.ts.net/lab/froussard@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      version: 'release/v1.2.3+test',
+      commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+  })
+
+  it('propagates dry-run mode to the Nix OCI helper', async () => {
+    let captured: BuildAndPushNixImageOptions | undefined
+
+    __private.setExecGit((args) => {
+      if (args[0] === 'describe') return 'v0.1.0'
+      if (args[0] === 'rev-parse') return 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+    __private.setBuildAndPushNixImage(async (options) => {
+      captured = options
+      return {
+        service: options.service,
+        image: `${options.registry}/${options.repository}`,
+        tag: options.tag ?? 'latest',
+        digest: 'sha256:dry-run',
+        reference: `${options.registry}/${options.repository}@sha256:dry-run`,
+        sourceSha: options.sourceSha ?? '',
+        packageAttr: options.packageAttr,
+        contractPath: '.artifacts/froussard/manual-release-contract.json',
+        platforms: [],
+        platformDigests: {},
+        dryRun: true,
+      }
+    })
+
+    await buildImage({ tag: 'sha-test', dryRun: true })
+
+    expect(captured?.dryRun).toBe(true)
+  })
+
+  it('rejects Docker-only options instead of preserving a fallback path', () => {
+    expect(() =>
+      __private.resolveBuildConfiguration({
+        dockerfile: 'Dockerfile',
+        tag: 'sha-test',
+        commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      }),
+    ).toThrow('Froussard Nix image builds do not accept Docker-only option(s): dockerfile')
+
+    expect(() =>
+      __private.resolveBuildConfiguration({
+        context: '.',
+        platforms: ['linux/amd64'],
+        cacheRef: 'registry.example/cache',
+        tag: 'sha-test',
+        commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      }),
+    ).toThrow('context, platforms, cacheRef')
+  })
+
+  it('parses manual CLI tag, registry, repository, and dry-run flags', () => {
+    expect(
+      __private.parseArgs([
+        '--tag=sha-test',
+        '--registry',
+        'registry.ide-newton.ts.net',
+        '--repository=lab/froussard',
+        '--dry-run',
+      ]),
+    ).toEqual({
+      tag: 'sha-test',
+      registry: 'registry.ide-newton.ts.net',
+      repository: 'lab/froussard',
+      dryRun: true,
+    })
+  })
+})

--- a/packages/scripts/src/froussard/build-image.ts
+++ b/packages/scripts/src/froussard/build-image.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+
+import { execGit } from '../shared/git'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
+
+export type BuildImageOptions = {
+  registry?: string
+  repository?: string
+  tag?: string
+  version?: string
+  commit?: string
+  dryRun?: boolean
+  context?: string
+  dockerfile?: string
+  platforms?: string[]
+  cacheRef?: string
+}
+
+type BuildConfiguration = {
+  registry: string
+  repository: string
+  tag: string
+  version: string
+  commit: string
+  dryRun?: boolean
+}
+
+const dockerOnlyOptionNames = ['context', 'dockerfile', 'platforms', 'cacheRef'] as const
+
+let buildAndPushNixImageImpl = buildAndPushNixImage
+let execGitImpl = execGit
+
+const readEnv = (name: string) => process.env[name]?.trim()
+
+const sanitizeTag = (value: string) => {
+  const normalized = value
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return normalized.length > 0 ? normalized : 'latest'
+}
+
+const rejectDockerOptions = (options: BuildImageOptions): void => {
+  const present = dockerOnlyOptionNames.filter((name) => options[name] !== undefined)
+  if (present.length > 0) {
+    throw new Error(`Froussard Nix image builds do not accept Docker-only option(s): ${present.join(', ')}`)
+  }
+}
+
+const resolveBuildConfiguration = (options: BuildImageOptions = {}): BuildConfiguration => {
+  rejectDockerOptions(options)
+
+  const registry = options.registry ?? readEnv('FROUSSARD_IMAGE_REGISTRY') ?? 'registry.ide-newton.ts.net'
+  const repository = options.repository ?? readEnv('FROUSSARD_IMAGE_REPOSITORY') ?? 'lab/froussard'
+  const version = options.version ?? readEnv('FROUSSARD_VERSION') ?? execGitImpl(['describe', '--tags', '--always'])
+  const commit = options.commit ?? readEnv('FROUSSARD_COMMIT') ?? execGitImpl(['rev-parse', 'HEAD'])
+  const tag = options.tag ?? readEnv('FROUSSARD_IMAGE_TAG') ?? sanitizeTag(version)
+
+  return { registry, repository, tag, version, commit, dryRun: options.dryRun }
+}
+
+const parseArgs = (args: string[]): BuildImageOptions => {
+  const options: BuildImageOptions = {}
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (!arg) continue
+
+    if (arg === '--tag') {
+      options.tag = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--tag=')) {
+      options.tag = arg.slice('--tag='.length)
+      continue
+    }
+    if (arg === '--repository') {
+      options.repository = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--repository=')) {
+      options.repository = arg.slice('--repository='.length)
+      continue
+    }
+    if (arg === '--registry') {
+      options.registry = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--registry=')) {
+      options.registry = arg.slice('--registry='.length)
+      continue
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true
+      continue
+    }
+    if (!arg.startsWith('-') && options.tag === undefined) {
+      options.tag = arg
+    }
+  }
+  return options
+}
+
+export const buildImage = async (options: BuildImageOptions = {}) => {
+  const config = resolveBuildConfiguration(options)
+  const result = await buildAndPushNixImageImpl({
+    service: 'froussard',
+    imageName: 'froussard',
+    packageAttr: 'froussard-image',
+    registry: config.registry,
+    repository: config.repository,
+    tag: config.tag,
+    sourceSha: config.commit,
+    latestTag: 'latest',
+    dryRun: config.dryRun,
+  })
+
+  return {
+    image: `${config.registry}/${config.repository}:${config.tag}`,
+    digest: result.reference,
+    version: config.version,
+    commit: config.commit,
+  }
+}
+
+if (import.meta.main) {
+  buildImage(parseArgs(process.argv.slice(2))).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}
+
+export const __private = {
+  parseArgs,
+  rejectDockerOptions,
+  resolveBuildConfiguration,
+  sanitizeTag,
+  setBuildAndPushNixImage: (impl: typeof buildAndPushNixImage = buildAndPushNixImage) => {
+    buildAndPushNixImageImpl = impl
+  },
+  setExecGit: (impl: typeof execGit = execGit) => {
+    execGitImpl = impl
+  },
+}

--- a/packages/scripts/src/froussard/deploy-service.ts
+++ b/packages/scripts/src/froussard/deploy-service.ts
@@ -4,7 +4,7 @@ import { relative, resolve } from 'node:path'
 import process from 'node:process'
 
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
+import { buildImage } from './build-image'
 
 const defaultManifestPath = 'argocd/applications/froussard/knative-service.yaml'
 const defaultRegistry = 'registry.ide-newton.ts.net'
@@ -84,20 +84,16 @@ const resolveImageBuildConfig = ({ version }: VersionMetadata): ImageBuildConfig
 const buildFroussardImage = async (config: ImageBuildConfig, { commit }: VersionMetadata): Promise<BuildResult> => {
   console.log(`Building image ${config.registry}/${config.repository}:${config.tag}`)
 
-  const result = await buildAndPushNixImage({
-    service: 'froussard',
-    imageName: 'froussard',
-    packageAttr: 'froussard-image',
+  const result = await buildImage({
     registry: config.registry,
     repository: config.repository,
     tag: config.tag,
-    sourceSha: commit,
-    latestTag: 'latest',
+    commit,
   })
 
-  console.log(`Published ${result.image}:${result.tag} (${result.reference})`)
+  console.log(`Published ${result.image} (${result.digest})`)
 
-  return { image: `${result.image}:${result.tag}`, digest: result.reference }
+  return { image: result.image, digest: result.digest }
 }
 
 type ManifestUpdateOptions = {

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -108,6 +108,16 @@ describe('enabled app inventory', () => {
     expect(entry('attic').workflowPaths).toContain('.github/workflows/attic-build-push.yaml')
   })
 
+  it('tracks Froussard through both GitHub Actions and manual Nix image paths', () => {
+    expect(entry('froussard')).toMatchObject({
+      class: 'nix-image',
+      nixImageAttr: 'froussard-image',
+      buildScriptPath: 'packages/scripts/src/froussard/build-image.ts',
+      deployScriptPath: 'packages/scripts/src/froussard/deploy-service.ts',
+    })
+    expect(entry('froussard').workflowPaths).toContain('.github/workflows/froussard-ci.yml')
+  })
+
   it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
     for (const name of ['jangar', 'symphony-jangar', 'symphony-torghut']) {
       expect(entry(name).class).toBe('deferred')

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -74,6 +74,7 @@ const oiratBuildScript = readRepoFile('packages/scripts/src/oirat/build-image.ts
 const bumbaBuildScript = readRepoFile('packages/scripts/src/bumba/build-image.ts')
 const atticBuildScript = readRepoFile('packages/scripts/src/attic/build-image.ts')
 const atticDeployScript = readRepoFile('packages/scripts/src/attic/deploy-service.ts')
+const froussardBuildScript = readRepoFile('packages/scripts/src/froussard/build-image.ts')
 const froussardDeployScript = readRepoFile('packages/scripts/src/froussard/deploy-service.ts')
 const symphonyBuildScript = readRepoFile('packages/scripts/src/symphony/build-image.ts')
 const symphonyDeployScript = readRepoFile('packages/scripts/src/symphony/deploy-service.ts')
@@ -951,7 +952,7 @@ describe('native OCI build workflows', () => {
       oiratBuildScript,
       bumbaBuildScript,
       atticBuildScript,
-      froussardDeployScript,
+      froussardBuildScript,
       symphonyBuildScript,
       sagBuildScript,
       agentsBuildScript,
@@ -980,6 +981,10 @@ describe('native OCI build workflows', () => {
     expect(atticDeployScript).toContain('no-apply')
     expect(atticDeployScript).toContain('registry.ide-newton.ts.net/lab/attic@sha256:<64 hex>')
     expect(atticDeployScript).toContain('gc-cronjob.yaml')
+    expect(froussardDeployScript).not.toContain("from '../shared/docker'")
+    expect(froussardDeployScript).not.toContain('buildAndPushDockerImage')
+    expect(froussardDeployScript).not.toContain('inspectImageDigest')
+    expect(froussardDeployScript).toContain("from './build-image'")
     expect(symphonyDeployScript).not.toContain("from '../shared/docker'")
     expect(symphonyDeployScript).not.toContain('inspectImageDigest')
     expect(symphonyDeployScript).toContain('dryRun')


### PR DESCRIPTION
## Summary

- Add `packages/scripts/src/froussard/build-image.ts` so Froussard has a standalone manual Nix OCI image build path without adding root `package.json` fanout.
- Have `froussard:deploy` reuse that same helper instead of duplicating Nix image build logic.
- Extend enabled-app and OCI guardrails so Froussard is tracked through both GitHub Actions and manual build/deploy paths without Docker fallback.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/froussard/__tests__/build-image.test.ts packages/scripts/src/froussard/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/froussard/build-image.ts packages/scripts/src/froussard/deploy-service.ts packages/scripts/src/froussard/__tests__/build-image.test.ts packages/scripts/src/froussard/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type` (passes with existing warnings outside this change)
- `bun run packages/scripts/src/froussard/build-image.ts --dry-run`
- `bun run packages/scripts/src/shared/enabled-apps.ts --assert --json | jq '{froussard:[.entries[] | select(.name=="froussard")][0], missing:[.entries[] | select(.class=="nix-image" and ((.buildScriptPath==null) or (.deployScriptPath==null))) | {name,nixImageAttr,buildScriptPath,deployScriptPath}]}'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
