### PR TITLE
feat(torghut): expose nix image build scripts

### DIFF
--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -118,6 +118,36 @@ describe('enabled app inventory', () => {
     expect(entry('froussard').workflowPaths).toContain('.github/workflows/froussard-ci.yml')
   })
 
+  it('tracks Torghut-family enabled apps through explicit Nix image ownership paths', () => {
+    expect(entry('torghut-hyperliquid-feed')).toMatchObject({
+      class: 'nix-image',
+      nixImageAttr: 'torghut-hyperliquid-feed-image',
+      buildScriptPath: 'packages/scripts/src/torghut/build-hyperliquid-feed-image.ts',
+      deployScriptPath: 'packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts',
+    })
+    expect(entry('torghut-hyperliquid-feed').workflowPaths).toContain(
+      '.github/workflows/torghut-hyperliquid-feed-build-push.yaml',
+    )
+
+    expect(entry('torghut-hyperliquid-runtime')).toMatchObject({
+      class: 'nix-image',
+      nixImageAttr: 'torghut-image',
+      buildScriptPath: 'packages/scripts/src/torghut/build-image.ts',
+      deployScriptPath: 'packages/scripts/src/torghut/update-manifests.ts',
+    })
+    expect(entry('torghut-hyperliquid-runtime').workflowPaths).toContain('.github/workflows/torghut-build-push.yaml')
+
+    expect(entry('torghut-options')).toMatchObject({
+      class: 'nix-image',
+      nixImageAttr: 'torghut-image',
+      buildScriptPath: 'packages/scripts/src/torghut/build-image.ts',
+      deployScriptPath: 'packages/scripts/src/torghut/update-manifests.ts',
+    })
+    expect(entry('torghut-options').workflowPaths).toContain('.github/workflows/torghut-build-push.yaml')
+    expect(entry('torghut-options').workflowPaths).toContain('.github/workflows/torghut-ws-build-push.yaml')
+    expect(entry('torghut-options').workflowPaths).toContain('.github/workflows/torghut-ta-build-push.yaml')
+  })
+
   it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
     for (const name of ['jangar', 'symphony-jangar', 'symphony-torghut']) {
       expect(entry(name).class).toBe('deferred')

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -83,6 +83,10 @@ const sagDeployScript = readRepoFile('packages/scripts/src/sag/deploy-service.ts
 const agentsBuildScript = readRepoFile('packages/scripts/src/agents/build-image.ts')
 const agentsDeployScript = readRepoFile('packages/scripts/src/agents/deploy-service.ts')
 const torghutBuildScript = readRepoFile('packages/scripts/src/torghut/build-image.ts')
+const torghutImageBuildersScript = readRepoFile('packages/scripts/src/torghut/image-builders.ts')
+const torghutWsBuildScript = readRepoFile('packages/scripts/src/torghut/build-ws-image.ts')
+const torghutTaBuildScript = readRepoFile('packages/scripts/src/torghut/build-ta-image.ts')
+const torghutHyperliquidFeedBuildScript = readRepoFile('packages/scripts/src/torghut/build-hyperliquid-feed-image.ts')
 const torghutDeployScript = readRepoFile('packages/scripts/src/torghut/deploy-service.ts')
 const torghutTaDeployScript = readRepoFile('packages/scripts/src/torghut/deploy-ta.ts')
 const torghutUpdateScripts = [
@@ -957,9 +961,7 @@ describe('native OCI build workflows', () => {
       sagBuildScript,
       agentsBuildScript,
       agentsDeployScript,
-      torghutBuildScript,
-      torghutDeployScript,
-      torghutTaDeployScript,
+      torghutImageBuildersScript,
       ...productBuildScripts,
     ]) {
       expect(script).toContain("from '../shared/nix-oci-deploy'")
@@ -1002,6 +1004,23 @@ describe('native OCI build workflows', () => {
     expect(agentsDeployScript).toContain('runnerRepository')
     expect(agentsDeployScript).toContain('agents-codex-runner-image')
     expect(agentsDeployScript).not.toContain('readRunnerImagePin')
+    expect(torghutBuildScript).toContain("from './image-builders'")
+    expect(torghutWsBuildScript).toContain("from './image-builders'")
+    expect(torghutWsBuildScript).toContain("buildTorghutImage('ws'")
+    expect(torghutTaBuildScript).toContain("from './image-builders'")
+    expect(torghutTaBuildScript).toContain("buildTorghutImage('ta'")
+    expect(torghutHyperliquidFeedBuildScript).toContain("from './image-builders'")
+    expect(torghutHyperliquidFeedBuildScript).toContain("buildTorghutImage('hyperliquid-feed'")
+    expect(torghutDeployScript).not.toContain("from '../shared/docker'")
+    expect(torghutDeployScript).not.toContain('buildAndPushDockerImage')
+    expect(torghutDeployScript).not.toContain("from '../shared/nix-oci-deploy'")
+    expect(torghutDeployScript).toContain("from './build-image'")
+    expect(torghutDeployScript).toContain("from './build-ws-image'")
+    expect(torghutDeployScript).toContain("from './build-ta-image'")
+    expect(torghutTaDeployScript).not.toContain("from '../shared/docker'")
+    expect(torghutTaDeployScript).not.toContain('buildAndPushDockerImage')
+    expect(torghutTaDeployScript).not.toContain("from '../shared/nix-oci-deploy'")
+    expect(torghutTaDeployScript).toContain("from './build-ta-image'")
 
     for (const script of torghutUpdateScripts) {
       expect(script).not.toContain("from '../shared/docker'")

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -82,6 +82,31 @@ const appToNixAttr = new Map<string, string>([
   ['torghut-options', 'torghut-image'],
 ])
 
+const appToBuildScriptPath = new Map<string, string>([
+  ['torghut-hyperliquid-feed', 'packages/scripts/src/torghut/build-hyperliquid-feed-image.ts'],
+  ['torghut-hyperliquid-runtime', 'packages/scripts/src/torghut/build-image.ts'],
+  ['torghut-options', 'packages/scripts/src/torghut/build-image.ts'],
+])
+
+const appToDeployScriptPath = new Map<string, string>([
+  ['torghut-hyperliquid-feed', 'packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts'],
+  ['torghut-hyperliquid-runtime', 'packages/scripts/src/torghut/update-manifests.ts'],
+  ['torghut-options', 'packages/scripts/src/torghut/update-manifests.ts'],
+])
+
+const appToWorkflowPaths = new Map<string, string[]>([
+  ['torghut-hyperliquid-feed', ['.github/workflows/torghut-hyperliquid-feed-build-push.yaml']],
+  ['torghut-hyperliquid-runtime', ['.github/workflows/torghut-build-push.yaml']],
+  [
+    'torghut-options',
+    [
+      '.github/workflows/torghut-build-push.yaml',
+      '.github/workflows/torghut-ta-build-push.yaml',
+      '.github/workflows/torghut-ws-build-push.yaml',
+    ],
+  ],
+])
+
 const manifestOnlyRepoImageApps = new Map<string, string>([
   ['analysis', 'repo image is tracked by image updater, but no local source build/deploy path exists in this repo'],
   ['bilig', 'repo image is produced outside this checkout; this app is GitOps/image-updater managed here'],
@@ -239,15 +264,20 @@ const inspectApplicationPath = (root: string, entry: EnabledAppInventoryEntry): 
     }
   }
 
-  const buildScriptPath = `packages/scripts/src/${entry.name}/build-image.ts`
-  const deployScriptPath = `packages/scripts/src/${entry.name}/deploy-service.ts`
-  const workflowPaths = listYamlFiles(resolve(root, '.github/workflows')).filter((path) => {
+  const buildScriptPath = appToBuildScriptPath.get(entry.name) ?? `packages/scripts/src/${entry.name}/build-image.ts`
+  const deployScriptPath =
+    appToDeployScriptPath.get(entry.name) ?? `packages/scripts/src/${entry.name}/deploy-service.ts`
+  const detectedWorkflowPaths = listYamlFiles(resolve(root, '.github/workflows')).filter((path) => {
     const workflow = readFileSync(path, 'utf8')
     return (
       workflow.includes(`image_name: ${entry.name}`) ||
       workflow.includes(`registry.ide-newton.ts.net/lab/${entry.name}`)
     )
   })
+  const workflowPaths = uniqueSorted([
+    ...detectedWorkflowPaths.map((path) => relative(root, path)),
+    ...(appToWorkflowPaths.get(entry.name) ?? []).filter((path) => existsSync(resolve(root, path))),
+  ])
 
   return {
     ...entry,
@@ -255,7 +285,7 @@ const inspectApplicationPath = (root: string, entry: EnabledAppInventoryEntry): 
     repoImages: uniqueSorted(repoImages),
     buildScriptPath: existsSync(resolve(root, buildScriptPath)) ? buildScriptPath : undefined,
     deployScriptPath: existsSync(resolve(root, deployScriptPath)) ? deployScriptPath : undefined,
-    workflowPaths: workflowPaths.map((path) => relative(root, path)).sort(),
+    workflowPaths,
     nixImageAttr: appToNixAttr.get(entry.name),
   }
 }

--- a/packages/scripts/src/torghut/__tests__/build-image.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-image.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 
 import type { BuildAndPushNixImageOptions } from '../../shared/nix-oci-deploy'
+import { buildHyperliquidFeedImage } from '../build-hyperliquid-feed-image'
 import { __private, buildImage } from '../build-image'
+import { buildTechnicalAnalysisImage } from '../build-ta-image'
+import { buildWebsocketImage } from '../build-ws-image'
 
 afterEach(() => {
   __private.setBuildAndPushNixImage()
@@ -9,16 +12,17 @@ afterEach(() => {
 })
 
 describe('buildImage', () => {
-  it('builds the core Torghut image through the Nix OCI helper', async () => {
-    let captured: BuildAndPushNixImageOptions | undefined
-
+  const stubGit = () => {
     __private.setExecGit((args) => {
       if (args[0] === 'describe') return 'v0.1.0'
       if (args[0] === 'rev-parse') return '0123456789abcdef0123456789abcdef01234567'
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
+  }
+
+  const stubBuild = (capture: (options: BuildAndPushNixImageOptions) => void) => {
     __private.setBuildAndPushNixImage(async (options) => {
-      captured = options
+      capture(options)
       return {
         service: options.service,
         image: `${options.registry}/${options.repository}`,
@@ -27,13 +31,22 @@ describe('buildImage', () => {
         reference: `${options.registry}/${options.repository}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
         sourceSha: options.sourceSha ?? '',
         packageAttr: options.packageAttr,
-        contractPath: '.artifacts/torghut/manual-release-contract.json',
+        contractPath: `.artifacts/${options.service}/manual-release-contract.json`,
         platforms: ['linux/amd64'],
         platformDigests: {
           'linux/amd64': 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         },
-        imageTarPath: '/nix/store/torghut-image.tar',
+        imageTarPath: `/nix/store/${options.imageName}-image.tar`,
       }
+    })
+  }
+
+  it('builds the core Torghut image through the Nix OCI helper', async () => {
+    let captured: BuildAndPushNixImageOptions | undefined
+
+    stubGit()
+    stubBuild((options) => {
+      captured = options
     })
 
     const result = await buildImage({
@@ -64,11 +77,7 @@ describe('buildImage', () => {
   it('propagates dry-run mode to the Nix OCI helper', async () => {
     let captured: BuildAndPushNixImageOptions | undefined
 
-    __private.setExecGit((args) => {
-      if (args[0] === 'describe') return 'v0.1.0'
-      if (args[0] === 'rev-parse') return '0123456789abcdef0123456789abcdef01234567'
-      throw new Error(`unexpected git command: ${args.join(' ')}`)
-    })
+    stubGit()
     __private.setBuildAndPushNixImage(async (options) => {
       captured = options
       return {
@@ -89,5 +98,82 @@ describe('buildImage', () => {
     await buildImage({ tag: '01234567', dryRun: true })
 
     expect(captured?.dryRun).toBe(true)
+  })
+
+  it('builds every Torghut-family image through the explicit Nix attr', async () => {
+    for (const [build, expected] of [
+      [
+        buildImage,
+        {
+          service: 'torghut',
+          imageName: 'torghut',
+          packageAttr: 'torghut-image',
+          repository: 'lab/torghut',
+        },
+      ],
+      [
+        buildWebsocketImage,
+        {
+          service: 'torghut-ws',
+          imageName: 'torghut-ws',
+          packageAttr: 'torghut-ws-image',
+          repository: 'lab/torghut-ws',
+        },
+      ],
+      [
+        buildTechnicalAnalysisImage,
+        {
+          service: 'torghut-ta',
+          imageName: 'torghut-ta',
+          packageAttr: 'torghut-ta-image',
+          repository: 'lab/torghut-ta',
+        },
+      ],
+      [
+        buildHyperliquidFeedImage,
+        {
+          service: 'torghut-hyperliquid-feed',
+          imageName: 'torghut-hyperliquid-feed',
+          packageAttr: 'torghut-hyperliquid-feed-image',
+          repository: 'lab/torghut-hyperliquid-feed',
+        },
+      ],
+    ] as const) {
+      let captured: BuildAndPushNixImageOptions | undefined
+
+      stubGit()
+      stubBuild((options) => {
+        captured = options
+      })
+
+      const result = await build({ tag: '01234567', dryRun: true })
+
+      expect(captured).toMatchObject({
+        ...expected,
+        registry: 'registry.ide-newton.ts.net',
+        tag: '01234567',
+        sourceSha: '0123456789abcdef0123456789abcdef01234567',
+        latestTag: 'latest',
+        dryRun: true,
+      })
+      expect(result.digest).toBe(
+        `registry.ide-newton.ts.net/${expected.repository}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
+      )
+
+      __private.setBuildAndPushNixImage()
+      __private.setExecGit()
+    }
+  })
+
+  it('rejects Docker-only build options on Torghut Nix image builds', async () => {
+    try {
+      await buildImage({ context: 'services/torghut' })
+      throw new Error('expected Torghut Nix image build to reject Docker-only options')
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).toBe(
+        'Torghut core Nix image builds do not accept Docker-only option(s): context',
+      )
+    }
   })
 })

--- a/packages/scripts/src/torghut/build-hyperliquid-feed-image.ts
+++ b/packages/scripts/src/torghut/build-hyperliquid-feed-image.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+
+import { type BuildImageOptions, buildTorghutImage, parseBuildImageArgs } from './image-builders'
+
+export type { BuildImageOptions }
+
+export const buildHyperliquidFeedImage = async (options: BuildImageOptions = {}) =>
+  buildTorghutImage('hyperliquid-feed', options)
+
+if (import.meta.main) {
+  buildHyperliquidFeedImage(parseBuildImageArgs(process.argv.slice(2))).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/packages/scripts/src/torghut/build-image.ts
+++ b/packages/scripts/src/torghut/build-image.ts
@@ -1,54 +1,16 @@
 #!/usr/bin/env bun
 
-import { execGit } from '../shared/git'
-import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
+import { type BuildImageOptions, __private, buildTorghutImage, parseBuildImageArgs } from './image-builders'
 
-export type BuildImageOptions = {
-  registry?: string
-  repository?: string
-  tag?: string
-  dryRun?: boolean
-}
+export type { BuildImageOptions }
 
-let buildAndPushNixImageImpl = buildAndPushNixImage
-let execGitImpl = execGit
-
-export const buildImage = async (options: BuildImageOptions = {}) => {
-  const registry = options.registry ?? process.env.TORGHUT_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
-  const repository = options.repository ?? process.env.TORGHUT_IMAGE_REPOSITORY ?? 'lab/torghut'
-  const tag = options.tag ?? process.env.TORGHUT_IMAGE_TAG ?? 'latest'
-
-  const version = execGitImpl(['describe', '--tags', '--always'])
-  const commit = execGitImpl(['rev-parse', 'HEAD'])
-
-  const result = await buildAndPushNixImageImpl({
-    service: 'torghut',
-    imageName: 'torghut',
-    packageAttr: 'torghut-image',
-    registry,
-    repository,
-    tag,
-    sourceSha: commit,
-    latestTag: 'latest',
-    dryRun: options.dryRun,
-  })
-
-  return { image: `${registry}/${repository}:${tag}`, digest: result.reference, version, commit }
-}
+export const buildImage = async (options: BuildImageOptions = {}) => buildTorghutImage('core', options)
 
 if (import.meta.main) {
-  buildImage().catch((error) => {
+  buildImage(parseBuildImageArgs(process.argv.slice(2))).catch((error) => {
     console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
   })
 }
 
-export const __private = {
-  execGit,
-  setBuildAndPushNixImage: (impl: typeof buildAndPushNixImage = buildAndPushNixImage) => {
-    buildAndPushNixImageImpl = impl
-  },
-  setExecGit: (impl: typeof execGit = execGit) => {
-    execGitImpl = impl
-  },
-}
+export { __private }

--- a/packages/scripts/src/torghut/build-ta-image.ts
+++ b/packages/scripts/src/torghut/build-ta-image.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+
+import { type BuildImageOptions, buildTorghutImage, parseBuildImageArgs } from './image-builders'
+
+export type { BuildImageOptions }
+
+export const buildTechnicalAnalysisImage = async (options: BuildImageOptions = {}) => buildTorghutImage('ta', options)
+
+if (import.meta.main) {
+  buildTechnicalAnalysisImage(parseBuildImageArgs(process.argv.slice(2))).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/packages/scripts/src/torghut/build-ws-image.ts
+++ b/packages/scripts/src/torghut/build-ws-image.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+
+import { type BuildImageOptions, buildTorghutImage, parseBuildImageArgs } from './image-builders'
+
+export type { BuildImageOptions }
+
+export const buildWebsocketImage = async (options: BuildImageOptions = {}) => buildTorghutImage('ws', options)
+
+if (import.meta.main) {
+  buildWebsocketImage(parseBuildImageArgs(process.argv.slice(2))).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/packages/scripts/src/torghut/deploy-service.ts
+++ b/packages/scripts/src/torghut/deploy-service.ts
@@ -7,8 +7,9 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import YAML from 'yaml'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
 import { buildImage } from './build-image'
+import { buildTechnicalAnalysisImage } from './build-ta-image'
+import { buildWebsocketImage } from './build-ws-image'
 
 const manifestPath = resolve(repoRoot, 'argocd/applications/torghut/knative-service.yaml')
 const websocketDeploymentPath = resolve(repoRoot, 'argocd/applications/torghut/ws/deployment.yaml')
@@ -334,44 +335,6 @@ const updateManifest = (image: string, version: string, commit: string) => {
   console.log(`Updated ${manifestPath} with image ${image}`)
 }
 
-const buildWebsocketImage = async (commit: string) => {
-  const registry = process.env.TORGHUT_WS_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
-  const repository = process.env.TORGHUT_WS_IMAGE_REPOSITORY ?? 'lab/torghut-ws'
-  const tag = process.env.TORGHUT_WS_IMAGE_TAG ?? 'latest'
-
-  const result = await buildAndPushNixImage({
-    service: 'torghut-ws',
-    imageName: 'torghut-ws',
-    packageAttr: 'torghut-ws-image',
-    registry,
-    repository,
-    tag,
-    sourceSha: commit,
-    latestTag: 'latest',
-  })
-
-  return { image: `${result.image}:${result.tag}`, digest: result.reference }
-}
-
-const buildTechnicalAnalysisImage = async (commit: string) => {
-  const registry = process.env.TORGHUT_TA_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
-  const repository = process.env.TORGHUT_TA_IMAGE_REPOSITORY ?? 'lab/torghut-ta'
-  const tag = process.env.TORGHUT_TA_IMAGE_TAG ?? 'latest'
-
-  const result = await buildAndPushNixImage({
-    service: 'torghut-ta',
-    imageName: 'torghut-ta',
-    packageAttr: 'torghut-ta-image',
-    registry,
-    repository,
-    tag,
-    sourceSha: commit,
-    latestTag: 'latest',
-  })
-
-  return { image: `${result.image}:${result.tag}`, digest: result.reference }
-}
-
 const updateWebsocketDeployment = (image: string, version: string, commit: string) => {
   const raw = readFileSync(websocketDeploymentPath, 'utf8')
   const doc = YAML.parse(raw)
@@ -585,9 +548,9 @@ const main = async () => {
 
   const { digest: digestRef, version, commit } = await buildImage()
 
-  const websocketImage = await buildWebsocketImage(commit)
+  const websocketImage = await buildWebsocketImage({ commit })
 
-  const taImage = await buildTechnicalAnalysisImage(commit)
+  const taImage = await buildTechnicalAnalysisImage({ commit })
 
   updateManifest(digestRef, version, commit)
   updateWebsocketDeployment(websocketImage.digest, version, commit)

--- a/packages/scripts/src/torghut/deploy-ta.ts
+++ b/packages/scripts/src/torghut/deploy-ta.ts
@@ -4,8 +4,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import YAML from 'yaml'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { execGit } from '../shared/git'
-import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
+import { buildTechnicalAnalysisImage } from './build-ta-image'
 
 const taDeploymentPath = resolve(
   repoRoot,
@@ -18,27 +17,6 @@ const ensureTools = () => {
   ensureCli('crane')
   ensureCli('kubectl')
   ensureCli('git')
-}
-
-const buildTechnicalAnalysisImage = async () => {
-  const registry = process.env.TORGHUT_TA_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
-  const repository = process.env.TORGHUT_TA_IMAGE_REPOSITORY ?? 'lab/torghut-ta'
-  const tag = process.env.TORGHUT_TA_IMAGE_TAG ?? 'latest'
-  const version = execGit(['describe', '--tags', '--always'])
-  const commit = execGit(['rev-parse', 'HEAD'])
-
-  const result = await buildAndPushNixImage({
-    service: 'torghut-ta',
-    imageName: 'torghut-ta',
-    packageAttr: 'torghut-ta-image',
-    registry,
-    repository,
-    tag,
-    sourceSha: commit,
-    latestTag: 'latest',
-  })
-
-  return { image: `${result.image}:${result.tag}`, digest: result.reference, version, commit }
 }
 
 const updateTechnicalAnalysisDeployment = (image: string, version: string, commit: string) => {

--- a/packages/scripts/src/torghut/image-builders.ts
+++ b/packages/scripts/src/torghut/image-builders.ts
@@ -1,0 +1,203 @@
+import { execGit } from '../shared/git'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
+
+export type BuildImageOptions = {
+  registry?: string
+  repository?: string
+  tag?: string
+  version?: string
+  commit?: string
+  dryRun?: boolean
+  context?: string
+  dockerfile?: string
+  platforms?: string[]
+  cacheRef?: string
+}
+
+export type BuildImageResult = {
+  image: string
+  digest: string
+  version: string
+  commit: string
+}
+
+type TorghutImageVariant = 'core' | 'ws' | 'ta' | 'hyperliquid-feed'
+
+type TorghutImageConfig = {
+  service: string
+  imageName: string
+  packageAttr: string
+  repository: string
+  envPrefix: string
+  defaultTag: string
+}
+
+type BuildConfiguration = {
+  registry: string
+  repository: string
+  tag: string
+  version: string
+  commit: string
+  dryRun?: boolean
+}
+
+const dockerOnlyOptionNames = ['context', 'dockerfile', 'platforms', 'cacheRef'] as const
+
+const imageConfigs: Record<TorghutImageVariant, TorghutImageConfig> = {
+  core: {
+    service: 'torghut',
+    imageName: 'torghut',
+    packageAttr: 'torghut-image',
+    repository: 'lab/torghut',
+    envPrefix: 'TORGHUT_IMAGE',
+    defaultTag: 'latest',
+  },
+  ws: {
+    service: 'torghut-ws',
+    imageName: 'torghut-ws',
+    packageAttr: 'torghut-ws-image',
+    repository: 'lab/torghut-ws',
+    envPrefix: 'TORGHUT_WS_IMAGE',
+    defaultTag: 'latest',
+  },
+  ta: {
+    service: 'torghut-ta',
+    imageName: 'torghut-ta',
+    packageAttr: 'torghut-ta-image',
+    repository: 'lab/torghut-ta',
+    envPrefix: 'TORGHUT_TA_IMAGE',
+    defaultTag: 'latest',
+  },
+  'hyperliquid-feed': {
+    service: 'torghut-hyperliquid-feed',
+    imageName: 'torghut-hyperliquid-feed',
+    packageAttr: 'torghut-hyperliquid-feed-image',
+    repository: 'lab/torghut-hyperliquid-feed',
+    envPrefix: 'TORGHUT_HYPERLIQUID_FEED_IMAGE',
+    defaultTag: 'latest',
+  },
+}
+
+let buildAndPushNixImageImpl = buildAndPushNixImage
+let execGitImpl = execGit
+
+const readEnv = (name: string) => process.env[name]?.trim()
+
+const sanitizeTag = (value: string) => {
+  const normalized = value
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return normalized.length > 0 ? normalized : 'latest'
+}
+
+const rejectDockerOptions = (variant: TorghutImageVariant, options: BuildImageOptions): void => {
+  const present = dockerOnlyOptionNames.filter((name) => options[name] !== undefined)
+  if (present.length > 0) {
+    throw new Error(`Torghut ${variant} Nix image builds do not accept Docker-only option(s): ${present.join(', ')}`)
+  }
+}
+
+export const parseBuildImageArgs = (args: string[]): BuildImageOptions => {
+  const options: BuildImageOptions = {}
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (!arg) continue
+
+    if (arg === '--tag') {
+      options.tag = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--tag=')) {
+      options.tag = arg.slice('--tag='.length)
+      continue
+    }
+    if (arg === '--repository') {
+      options.repository = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--repository=')) {
+      options.repository = arg.slice('--repository='.length)
+      continue
+    }
+    if (arg === '--registry') {
+      options.registry = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--registry=')) {
+      options.registry = arg.slice('--registry='.length)
+      continue
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true
+      continue
+    }
+    if (!arg.startsWith('-') && options.tag === undefined) {
+      options.tag = arg
+    }
+  }
+  return options
+}
+
+const resolveBuildConfiguration = (
+  variant: TorghutImageVariant,
+  options: BuildImageOptions = {},
+): BuildConfiguration => {
+  rejectDockerOptions(variant, options)
+
+  const config = imageConfigs[variant]
+  const version = options.version ?? readEnv('TORGHUT_VERSION') ?? execGitImpl(['describe', '--tags', '--always'])
+  const commit = options.commit ?? readEnv('TORGHUT_COMMIT') ?? execGitImpl(['rev-parse', 'HEAD'])
+  const tag = options.tag ?? readEnv(`${config.envPrefix}_TAG`) ?? sanitizeTag(config.defaultTag)
+
+  return {
+    registry: options.registry ?? readEnv(`${config.envPrefix}_REGISTRY`) ?? 'registry.ide-newton.ts.net',
+    repository: options.repository ?? readEnv(`${config.envPrefix}_REPOSITORY`) ?? config.repository,
+    tag,
+    version,
+    commit,
+    dryRun: options.dryRun,
+  }
+}
+
+export const buildTorghutImage = async (
+  variant: TorghutImageVariant,
+  options: BuildImageOptions = {},
+): Promise<BuildImageResult> => {
+  const imageConfig = imageConfigs[variant]
+  const buildConfig = resolveBuildConfiguration(variant, options)
+  const result = await buildAndPushNixImageImpl({
+    service: imageConfig.service,
+    imageName: imageConfig.imageName,
+    packageAttr: imageConfig.packageAttr,
+    registry: buildConfig.registry,
+    repository: buildConfig.repository,
+    tag: buildConfig.tag,
+    sourceSha: buildConfig.commit,
+    latestTag: 'latest',
+    dryRun: buildConfig.dryRun,
+  })
+
+  return {
+    image: `${buildConfig.registry}/${buildConfig.repository}:${buildConfig.tag}`,
+    digest: result.reference,
+    version: buildConfig.version,
+    commit: buildConfig.commit,
+  }
+}
+
+export const __private = {
+  parseBuildImageArgs,
+  rejectDockerOptions,
+  resolveBuildConfiguration,
+  sanitizeTag,
+  setBuildAndPushNixImage: (impl: typeof buildAndPushNixImage = buildAndPushNixImage) => {
+    buildAndPushNixImageImpl = impl
+  },
+  setExecGit: (impl: typeof execGit = execGit) => {
+    execGitImpl = impl
+  },
+}


### PR DESCRIPTION
## Summary

- Added explicit Torghut-family Nix image build scripts for WS, TA, and Hyperliquid feed images.
- Moved shared Torghut image build configuration into one helper used by core, WS, TA, feed, and deploy scripts.
- Updated enabled-app inventory guardrails so Torghut Hyperliquid/feed/options apps map to their real Nix build, workflow, and manifest update paths.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-image.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/build-image.ts packages/scripts/src/torghut/build-ws-image.ts packages/scripts/src/torghut/build-ta-image.ts packages/scripts/src/torghut/build-hyperliquid-feed-image.ts packages/scripts/src/torghut/image-builders.ts packages/scripts/src/torghut/deploy-service.ts packages/scripts/src/torghut/deploy-ta.ts packages/scripts/src/torghut/__tests__/build-image.test.ts packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun run packages/scripts/src/shared/enabled-apps.ts --assert --json | jq '[.entries[] | select(.class=="nix-image" and ((.buildScriptPath==null) or (.deployScriptPath==null))) | {name,nixImageAttr,buildScriptPath,deployScriptPath,workflowPaths}]'`
- `git diff --check`
- `bun run --cwd packages/scripts lint:oxlint:type` passed with existing warnings outside this change.
- Dry-run contracts: `bun run packages/scripts/src/torghut/build-image.ts --dry-run --tag torghut-dry-run`, `bun run packages/scripts/src/torghut/build-ws-image.ts --dry-run --tag torghut-ws-dry-run`, `bun run packages/scripts/src/torghut/build-ta-image.ts --dry-run --tag torghut-ta-dry-run`, `bun run packages/scripts/src/torghut/build-hyperliquid-feed-image.ts --dry-run --tag torghut-feed-dry-run`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
