### PR TITLE
chore(torghut): promote image sha-7155950ce2c6deeac72298920df2e43b3774d96e

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -52,7 +52,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: b0a6e724f8d8d33f0912e97ae2ccad7605164c28
+              value: 7155950ce2c6deeac72298920df2e43b3774d96e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:24347644d88a213c40b3e6576bcce50de62edc94d947fae92cfef7d582bd99b2
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: b0a6e724f8d8d33f0912e97ae2ccad7605164c28
+              value: 7155950ce2c6deeac72298920df2e43b3774d96e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:24347644d88a213c40b3e6576bcce50de62edc94d947fae92cfef7d582bd99b2
             - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-05T03:41:10Z"
+        client.knative.dev/updateTimestamp: "2026-07-05T05:39:39Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -539,9 +539,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1406-gb0a6e724f
+              value: v0.596.0-1415-g7155950ce
             - name: TORGHUT_COMMIT
-              value: b0a6e724f8d8d33f0912e97ae2ccad7605164c28
+              value: 7155950ce2c6deeac72298920df2e43b3774d96e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:24347644d88a213c40b3e6576bcce50de62edc94d947fae92cfef7d582bd99b2
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-05T03:41:10Z"
+        client.knative.dev/updateTimestamp: "2026-07-05T05:39:39Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -414,9 +414,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1406-gb0a6e724f
+              value: v0.596.0-1415-g7155950ce
             - name: TORGHUT_COMMIT
-              value: b0a6e724f8d8d33f0912e97ae2ccad7605164c28
+              value: 7155950ce2c6deeac72298920df2e43b3774d96e
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:24347644d88a213c40b3e6576bcce50de62edc94d947fae92cfef7d582bd99b2
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `7155950ce2c6deeac72298920df2e43b3774d96e`
- Image tag: `sha-7155950ce2c6deeac72298920df2e43b3774d96e`
- Image digest: `sha256:24347644d88a213c40b3e6576bcce50de62edc94d947fae92cfef7d582bd99b2`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher