### PR TITLE
fix(torghut): use nix python entrypoints in hooks

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -61,7 +61,7 @@ spec:
                       - >-
                         set -euo pipefail &&
                         cd /app &&
-                        /opt/venv/bin/python scripts/run_simulation_analysis.py activity
+                        python scripts/run_simulation_analysis.py activity
                         --run-id "{{args.runId}}"
                         --dataset-id "{{args.datasetId}}"
                         --namespace "{{args.namespace}}"

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -32,6 +32,6 @@ spec:
                       - >-
                         set -euo pipefail &&
                         cd /app &&
-                        /opt/venv/bin/python scripts/run_simulation_analysis.py artifact-bundle
+                        python scripts/run_simulation_analysis.py artifact-bundle
                         --run-dir "{{args.runDir}}"
                         --json

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -42,7 +42,7 @@ spec:
                       - >-
                         set -euo pipefail &&
                         cd /app &&
-                        /opt/venv/bin/python scripts/run_simulation_analysis.py runtime-ready
+                        python scripts/run_simulation_analysis.py runtime-ready
                         --run-id "{{args.runId}}"
                         --dataset-id "{{args.datasetId}}"
                         --namespace "{{args.namespace}}"

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -46,7 +46,7 @@ spec:
                       - >-
                         set -euo pipefail &&
                         cd /app &&
-                        /opt/venv/bin/python scripts/run_simulation_analysis.py teardown-clean
+                        python scripts/run_simulation_analysis.py teardown-clean
                         --run-id "{{args.runId}}"
                         --dataset-id "{{args.datasetId}}"
                         --namespace "{{args.namespace}}"

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -36,7 +36,7 @@ spec:
                 dsn="$2"
                 timeout_seconds="$3"
                 database="${4:-}"
-                DB_WAIT_LABEL="${label}" DB_WAIT_DSN="${dsn}" DB_WAIT_TIMEOUT_SECONDS="${timeout_seconds}" DB_WAIT_DATABASE="${database}" /opt/venv/bin/python - <<'PY'
+                DB_WAIT_LABEL="${label}" DB_WAIT_DSN="${dsn}" DB_WAIT_TIMEOUT_SECONDS="${timeout_seconds}" DB_WAIT_DATABASE="${database}" python - <<'PY'
               import os
               import time
               from urllib.parse import urlsplit
@@ -85,9 +85,9 @@ spec:
               }
 
               wait_for_database "torghut app database" "${DB_DSN}" 300
-              /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
+              alembic -c /app/alembic.ini upgrade heads
               wait_for_database "postgres superuser database" "${TORGHUT_POSTGRES_ADMIN_URI}" 300 postgres
-              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" /opt/venv/bin/python - <<'PY'
+              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" python - <<'PY'
               import os
               from urllib.parse import urlsplit
 
@@ -204,8 +204,8 @@ spec:
                       )
                       print(f'stamped existing simulation runtime context as {context_revision}')
               PY
-              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" /opt/venv/bin/alembic -c /app/alembic.ini upgrade 0026_strategy_factory_research_objects
-              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" /opt/venv/bin/python - <<'PY'
+              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" alembic -c /app/alembic.ini upgrade 0026_strategy_factory_research_objects
+              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" python - <<'PY'
               import os
 
               from sqlalchemy import create_engine, text
@@ -261,8 +261,8 @@ spec:
                       )
                       print(f'stamped existing whitepaper/autoresearch ledger objects as {target_revision}')
               PY
-              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads
-              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" /opt/venv/bin/python - <<'PY'
+              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" alembic -c /app/alembic.ini upgrade heads
+              DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" python - <<'PY'
               import os
 
               from sqlalchemy import create_engine, text

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -45,7 +45,7 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
-                  /opt/venv/bin/python scripts/prune_kubernetes_residue.py \
+                  python scripts/prune_kubernetes_residue.py \
                     --namespace torghut \
                     --analysis-run-prefix torghut-sim- \
                     --analysis-run-max-age-hours 168 \

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -119,7 +119,7 @@ spec:
           printf '%s' "{{inputs.parameters.datasetManifestB64}}" | base64 -d > "${MANIFEST_PATH}"
           echo "RUN_LOG manifest_written path=${MANIFEST_PATH}"
           echo "RUN_LOG runtime_secret_present name=TORGHUT_SIM_KAFKA_PASSWORD present=${TORGHUT_SIM_KAFKA_PASSWORD:+1}"
-          /opt/venv/bin/python - <<'PY'
+          python - <<'PY'
           import os
           import yaml
 
@@ -226,7 +226,7 @@ spec:
 
           mkdir -p "$OUTPUT_ROOT"
           echo "RUN_LOG invoking_python"
-          /opt/venv/bin/python -u -m scripts.historical_simulation_startup "${SCRIPT_ARGS[@]}"
+          python -u -m scripts.historical_simulation_startup "${SCRIPT_ARGS[@]}"
     outputs:
       artifacts:
         - name: simulation-output

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -43,7 +43,7 @@ spec:
                   set -euo pipefail
                   cd /app
                   target_plan_readback_args=()
-                  if /opt/venv/bin/python scripts/flatten_paper_account_positions.py --help \
+                  if python scripts/flatten_paper_account_positions.py --help \
                     | grep -q -- '--target-plan-readback-url'; then
                     target_plan_readback_args=(
                       --target-plan-readback-url 'http://torghut.torghut.svc.cluster.local/trading/proofs?kind=runtime_window&window=next&full_audit=true&limit=20'
@@ -53,7 +53,7 @@ spec:
                     )
                   fi
                   echo "stage=flatten_paper_account started_at=$(date -Iseconds)"
-                  /opt/venv/bin/python scripts/flatten_paper_account_positions.py \
+                  python scripts/flatten_paper_account_positions.py \
                     --account-label PA3SX7FYNUTF \
                     --expected-account-label PA3SX7FYNUTF \
                     --trading-mode paper \

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -47,7 +47,7 @@ spec:
             - |
               set -euo pipefail
               cd /app
-              /opt/venv/bin/python scripts/verify_tigerbeetle_ledger.py --mode smoke
+              python scripts/verify_tigerbeetle_ledger.py --mode smoke
           env:
             - name: TORGHUT_TIGERBEETLE_ENABLED
               value: "true"

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -46,7 +46,7 @@ spec:
                   set -euo pipefail
                   cd /app
                   echo "stage=zero_notional_drift_repair service=torghut-sim started_at=$(date -Iseconds)"
-                  /opt/venv/bin/python scripts/run_zero_notional_repair.py \
+                  python scripts/run_zero_notional_repair.py \
                     --service-url http://torghut-sim.torghut.svc.cluster.local \
                     --action rerun_drift_checks_for_blocked_hypotheses \
                     --execute \
@@ -59,7 +59,7 @@ spec:
                     --allow-no-signal-blocked \
                     --json
                   echo "stage=zero_notional_drift_repair service=torghut started_at=$(date -Iseconds)"
-                  /opt/venv/bin/python scripts/run_zero_notional_repair.py \
+                  python scripts/run_zero_notional_repair.py \
                     --service-url http://torghut.torghut.svc.cluster.local \
                     --action rerun_drift_checks_for_blocked_hypotheses \
                     --execute \

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 import YAML from 'yaml'
@@ -58,7 +58,28 @@ const parseManifest = (path: string): JsonRecord => YAML.parse(readFileSync(join
 const parseManifestDocuments = (path: string): JsonRecord[] =>
   YAML.parseAllDocuments(readFileSync(join(repoRoot, path), 'utf8')).map((document) => document.toJSON() as JsonRecord)
 
+const collectYamlFiles = (path: string): string[] => {
+  const absolutePath = join(repoRoot, path)
+  const stat = statSync(absolutePath)
+  if (stat.isFile()) {
+    return /\.(ya?ml)$/.test(path) ? [path] : []
+  }
+  return readdirSync(absolutePath).flatMap((entry) => collectYamlFiles(join(path, entry)))
+}
+
 describe('Torghut manifest scheduling', () => {
+  it('uses PATH-resolved Python entrypoints for Nix-built Torghut images', () => {
+    const manifestPaths = [
+      ...collectYamlFiles('argocd/applications/torghut'),
+      ...collectYamlFiles('argocd/applications/torghut-hyperliquid-runtime'),
+    ]
+
+    for (const path of manifestPaths) {
+      const manifest = readFileSync(join(repoRoot, path), 'utf8')
+      expect(manifest, path).not.toContain('/opt/venv/bin/')
+    }
+  })
+
   it('caps revision history for high-churn Torghut deployments', () => {
     const deploymentPaths = [
       'argocd/applications/symphony-torghut/deployment.patch.yaml',

--- a/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
@@ -155,10 +155,10 @@ class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
         args = "\n".join(str(item) for item in container.get("args", []))
         env = [item for item in container.get("env", []) if isinstance(item, Mapping)]
         upgrade_to_research_objects = (
-            'DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" /opt/venv/bin/alembic -c /app/alembic.ini '
+            'DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" alembic -c /app/alembic.ini '
             "upgrade 0026_strategy_factory_research_objects"
         )
-        upgrade_heads = 'DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" /opt/venv/bin/alembic -c /app/alembic.ini upgrade heads'
+        upgrade_heads = 'DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" alembic -c /app/alembic.ini upgrade heads'
         env_names = {item.get("name") for item in env}
         env_by_name = {item.get("name"): item for item in env}
         env_order = [item.get("name") for item in env]
@@ -190,8 +190,8 @@ class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
         self.assertIn("owner_statement = (", args)
         self.assertIn("ALTER {owned_relation['object_type']}", args)
         self.assertIn("{owned_relation['object_name']} OWNER TO {quoted_role}", args)
-        self.assertNotIn("DO $$", args)
-        self.assertNotIn("format(", args)
+        for forbidden_snippet in ("DO $$", "format(", "/opt/venv/bin/"):
+            self.assertNotIn(forbidden_snippet, args)
         self.assertIn(upgrade_to_research_objects, args)
         self.assertIn("0028_autoresearch_epoch_ledgers", args)
         self.assertIn("whitepaper_claims", args)


### PR DESCRIPTION
## Summary

- Replaces Docker-era `/opt/venv/bin/python` and `/opt/venv/bin/alembic` references in Torghut GitOps hooks with PATH-resolved `python` and `alembic` for the Nix-built image.
- Covers db migrations, AnalysisTemplate hooks, scheduled repair/cleanup cronjobs, historical simulation startup, and TigerBeetle smoke hooks.
- Adds Torghut manifest and live-config contract coverage that rejects stale `/opt/venv/bin/` paths.

## Related Issues

None

## Testing

- `rg -n "/opt/venv/bin" argocd/applications/torghut argocd/applications/torghut-hyperliquid-runtime packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `cd services/torghut && uv run --frozen pytest tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py -k migration_job_prepares_sim_database_before_sim_upgrade -q`
- `cd services/torghut && uv run --frozen ruff check tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `git diff --check`
- `kustomize build argocd/applications/torghut >/tmp/torghut-kustomize.out`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
