### PR TITLE
fix(torghut): set python path for nix migration hook

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -26,6 +26,7 @@ spec:
         - name: migrate
           imagePullPolicy: IfNotPresent
           image: registry.ide-newton.ts.net/lab/torghut@sha256:24347644d88a213c40b3e6576bcce50de62edc94d947fae92cfef7d582bd99b2
+          workingDir: /app
           command:
             - /bin/sh
             - -ec
@@ -366,6 +367,8 @@ spec:
                   )
               PY
           env:
+            - name: PYTHONPATH
+              value: /app
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
@@ -21,6 +21,34 @@ from tests.live_config_manifest_contract.support import (
 )
 
 
+def _migration_job_context() -> tuple[
+    Mapping[str, object],
+    str,
+    set[object],
+    dict[object, Mapping[str, object]],
+    list[object],
+]:
+    manifest = _load_yaml_mapping("argocd/applications/torghut/db-migrations-job.yaml")
+    containers = (
+        manifest.get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+    )
+    if not containers:
+        raise AssertionError("migration job is missing containers")
+    container = cast(Mapping[str, object], containers[0])
+    args = "\n".join(str(item) for item in container.get("args", []))
+    env = [item for item in container.get("env", []) if isinstance(item, Mapping)]
+    return (
+        container,
+        args,
+        {item.get("name") for item in env},
+        {item.get("name"): item for item in env},
+        [item.get("name") for item in env],
+    )
+
+
 class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
     _TestLiveConfigManifestContractBase
 ):
@@ -141,28 +169,15 @@ class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
         self.assertNotIn("empirical-promotion-renewal-cronjob.yaml", resources)
 
     def test_migration_job_prepares_sim_database_before_sim_upgrade(self) -> None:
-        manifest = _load_yaml_mapping(
-            "argocd/applications/torghut/db-migrations-job.yaml"
-        )
-        containers = (
-            manifest.get("spec", {})
-            .get("template", {})
-            .get("spec", {})
-            .get("containers", [])
-        )
-        self.assertTrue(containers)
-        container = containers[0]
-        args = "\n".join(str(item) for item in container.get("args", []))
-        env = [item for item in container.get("env", []) if isinstance(item, Mapping)]
+        container, args, env_names, env_by_name, env_order = _migration_job_context()
         upgrade_to_research_objects = (
             'DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" alembic -c /app/alembic.ini '
             "upgrade 0026_strategy_factory_research_objects"
         )
         upgrade_heads = 'DB_DSN="${TORGHUT_SIM_ADMIN_DSN}" alembic -c /app/alembic.ini upgrade heads'
-        env_names = {item.get("name") for item in env}
-        env_by_name = {item.get("name"): item for item in env}
-        env_order = [item.get("name") for item in env]
 
+        self.assertEqual(container.get("workingDir"), "/app")
+        self.assertEqual(env_by_name["PYTHONPATH"].get("value"), "/app")
         self.assertIn("TORGHUT_POSTGRES_ADMIN_URI", env_names)
         self.assertIn("TORGHUT_SIM_ADMIN_DSN", env_names)
         self.assertLess(


### PR DESCRIPTION
## Summary
- Set the Torghut db migration hook working directory to `/app` for the Nix-built image.
- Add `PYTHONPATH=/app` so Alembic can import `app.config` from `/app/migrations/env.py`.
- Extend the live config manifest contract to lock this behavior.

## Testing
- `kustomize build argocd/applications/torghut >/tmp/torghut-kustomize-pythonpath.out`
- `cd services/torghut && uv run --frozen pytest tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py -k migration_job_prepares_sim_database_before_sim_upgrade -q`
- `cd services/torghut && uv run --frozen ruff check tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `git diff --check`

## Rollout / Risk
- GitOps-only Torghut hook fix. No image, Talos, Ceph, Rook, OBC, PVC, or storage changes.
- Intended to unblock the Argo PreSync `torghut-db-migrations` hook after the Nix image migration.
