### PR TITLE
fix(torghut): include cxx runtime in nix image

### DIFF
--- a/nix/images/torghut.nix
+++ b/nix/images/torghut.nix
@@ -125,6 +125,13 @@ let
     pkgs.pigz
     pkgs.zstd
   ];
+
+  runtimeLibraryPath = lib.makeLibraryPath [
+    pkgs.openssl
+    pkgs.postgresql.lib
+    pkgs.stdenv.cc.cc.lib
+    pkgs.zlib
+  ];
 in
 pkgs.dockerTools.buildLayeredImage {
   name = "registry.ide-newton.ts.net/lab/torghut";
@@ -143,6 +150,7 @@ pkgs.dockerTools.buildLayeredImage {
     pkgs.openssl
     pkgs.pigz
     pkgs.postgresql.lib
+    pkgs.stdenv.cc.cc.lib
     pkgs.zlib
     pkgs.zstd
   ];
@@ -162,6 +170,7 @@ pkgs.dockerTools.buildLayeredImage {
     WorkingDir = "/app";
     Env = [
       "PATH=${pythonDeps}/venv/bin:${runtimePath}"
+      "LD_LIBRARY_PATH=${runtimeLibraryPath}"
       "PYTHONDONTWRITEBYTECODE=1"
       "PYTHONUNBUFFERED=1"
       "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -820,6 +820,8 @@ describe('native OCI build workflows', () => {
       expect(flake).toContain(`"${packageAttr}"`)
     }
     expect(torghutImageModule).toContain('pkgs.uv')
+    expect(torghutImageModule).toContain('pkgs.stdenv.cc.cc.lib')
+    expect(torghutImageModule).toContain('"LD_LIBRARY_PATH=${runtimeLibraryPath}"')
     expect(torghutTaImageModule).toContain('pkgs.dockerTools.pullImage')
     expect(torghutTaImageModule).toContain('sha256:d357b0e1eb89eb4377735a008dfcbd35f7f06af6cba24dfbb6062379fb70a9a9')
     expect(torghutTaImageModule).toContain('sha256:c0b3512ea891d604c585d3cb217b75a2bf920d9faaa9f0770496476189d5f57f')


### PR DESCRIPTION
## Summary

- Add the C++ runtime library to the Torghut Nix image contents.
- Set `LD_LIBRARY_PATH` from a Nix-built runtime library path so pandas/numpy native extensions can load `libstdc++.so.6`.
- Add an OCI contract regression assertion for the Torghut image module.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts -t 'routes the enabled Torghut family images through real Nix OCI attrs'`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `nix eval --raw .#packages.aarch64-linux.torghut-image.imageName`
- `nix eval --raw .#packages.x86_64-linux.torghut-image.imageName`
- `nix build --dry-run .#packages.aarch64-linux.torghut-image`
- `nix build --dry-run .#packages.x86_64-linux.torghut-image`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
