### PR TITLE
fix(torghut): include bash in nix runtime

### DIFF
--- a/nix/images/torghut.nix
+++ b/nix/images/torghut.nix
@@ -118,6 +118,7 @@ let
 
   runtimePath = lib.makeBinPath [
     python
+    pkgs.bash
     pkgs.busybox
     pkgs.coreutils
     pkgs.curl
@@ -142,6 +143,7 @@ pkgs.dockerTools.buildLayeredImage {
     appRoot
     pythonDeps
     python
+    pkgs.bash
     pkgs.busybox
     pkgs.cacert
     pkgs.coreutils

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -820,6 +820,7 @@ describe('native OCI build workflows', () => {
       expect(flake).toContain(`"${packageAttr}"`)
     }
     expect(torghutImageModule).toContain('pkgs.uv')
+    expect(torghutImageModule).toContain('pkgs.bash')
     expect(torghutImageModule).toContain('pkgs.stdenv.cc.cc.lib')
     expect(torghutImageModule).toContain('"LD_LIBRARY_PATH=${runtimeLibraryPath}"')
     expect(torghutTaImageModule).toContain('pkgs.dockerTools.pullImage')


### PR DESCRIPTION
## Summary

- Add `bash` to the Torghut Nix image contents and runtime `PATH`.
- Preserve the existing `/bin/bash` contract used by Torghut GitOps hooks and workflow templates.
- Add an OCI contract regression assertion so the runtime dependency is not dropped again.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts -t 'routes the enabled Torghut family images through real Nix OCI attrs'`
- `nix eval --raw .#packages.aarch64-linux.torghut-image.imageName`
- `nix eval --raw .#packages.x86_64-linux.torghut-image.imageName`
- `nix build --dry-run .#packages.aarch64-linux.torghut-image`
- `nix build --dry-run .#packages.x86_64-linux.torghut-image`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
