### PR TITLE
chore(torghut): promote image sha-eb473c093e120e52850e6cb9e2360e37424f8521

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 84125e70a0cf92e13c61e92461a6641f73d92333
+              value: eb473c093e120e52850e6cb9e2360e37424f8521
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 84125e70a0cf92e13c61e92461a6641f73d92333
+              value: eb473c093e120e52850e6cb9e2360e37424f8521
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-05T07:00:29Z"
+        client.knative.dev/updateTimestamp: "2026-07-05T07:23:53Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
           ports:
             - name: http1
               containerPort: 8181
@@ -539,11 +539,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1419-g84125e70a
+              value: v0.596.0-1423-geb473c093
             - name: TORGHUT_COMMIT
-              value: 84125e70a0cf92e13c61e92461a6641f73d92333
+              value: eb473c093e120e52850e6cb9e2360e37424f8521
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-05T07:00:29Z"
+        client.knative.dev/updateTimestamp: "2026-07-05T07:23:53Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
           ports:
             - name: http1
               containerPort: 8181
@@ -414,11 +414,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1419-g84125e70a
+              value: v0.596.0-1423-geb473c093
             - name: TORGHUT_COMMIT
-              value: 84125e70a0cf92e13c61e92461a6641f73d92333
+              value: eb473c093e120e52850e6cb9e2360e37424f8521
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:d07523adc2434ae33555cb3c55bd122ec852c5c95622178a1c7bc127b695b7cc
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `eb473c093e120e52850e6cb9e2360e37424f8521`
- Image tag: `sha-eb473c093e120e52850e6cb9e2360e37424f8521`
- Image digest: `sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher