### PR TITLE
fix(torghut): set pythonpath in nix runtime

### DIFF
--- a/nix/images/torghut.nix
+++ b/nix/images/torghut.nix
@@ -173,6 +173,7 @@ pkgs.dockerTools.buildLayeredImage {
     Env = [
       "PATH=${pythonDeps}/venv/bin:${runtimePath}"
       "LD_LIBRARY_PATH=${runtimeLibraryPath}"
+      "PYTHONPATH=/app"
       "PYTHONDONTWRITEBYTECODE=1"
       "PYTHONUNBUFFERED=1"
       "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -823,6 +823,7 @@ describe('native OCI build workflows', () => {
     expect(torghutImageModule).toContain('pkgs.bash')
     expect(torghutImageModule).toContain('pkgs.stdenv.cc.cc.lib')
     expect(torghutImageModule).toContain('"LD_LIBRARY_PATH=${runtimeLibraryPath}"')
+    expect(torghutImageModule).toContain('"PYTHONPATH=/app"')
     expect(torghutTaImageModule).toContain('pkgs.dockerTools.pullImage')
     expect(torghutTaImageModule).toContain('sha256:d357b0e1eb89eb4377735a008dfcbd35f7f06af6cba24dfbb6062379fb70a9a9')
     expect(torghutTaImageModule).toContain('sha256:c0b3512ea891d604c585d3cb217b75a2bf920d9faaa9f0770496476189d5f57f')


### PR DESCRIPTION
## Summary

- Set `PYTHONPATH=/app` in the Torghut Nix image runtime environment.
- Preserve script-style hook execution such as `python scripts/verify_tigerbeetle_ledger.py` after moving to the Nix image.
- Add an OCI contract regression assertion for the image runtime import path.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts -t 'routes the enabled Torghut family images through real Nix OCI attrs'`
- `nix eval --raw .#packages.aarch64-linux.torghut-image.imageName`
- `nix eval --raw .#packages.x86_64-linux.torghut-image.imageName`
- `nix build --dry-run .#packages.aarch64-linux.torghut-image`
- `nix build --dry-run .#packages.x86_64-linux.torghut-image`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
