### PR TITLE
chore(torghut): promote image sha-2f3f7710

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: eb473c093e120e52850e6cb9e2360e37424f8521
+              value: 2f3f7710437d89c1824a82b3813b6c65302a16b9
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+              value: sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: eb473c093e120e52850e6cb9e2360e37424f8521
+              value: 2f3f7710437d89c1824a82b3813b6c65302a16b9
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+              value: sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-05T07:23:53Z"
+        client.knative.dev/updateTimestamp: "2026-07-05T07:55:20Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
           ports:
             - name: http1
               containerPort: 8181
@@ -539,11 +539,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1423-geb473c093
+              value: v0.596.0-1425-g2f3f77104
             - name: TORGHUT_COMMIT
-              value: eb473c093e120e52850e6cb9e2360e37424f8521
+              value: 2f3f7710437d89c1824a82b3813b6c65302a16b9
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+              value: sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-05T07:23:53Z"
+        client.knative.dev/updateTimestamp: "2026-07-05T07:55:20Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
           ports:
             - name: http1
               containerPort: 8181
@@ -414,11 +414,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1423-geb473c093
+              value: v0.596.0-1425-g2f3f77104
             - name: TORGHUT_COMMIT
-              value: eb473c093e120e52850e6cb9e2360e37424f8521
+              value: 2f3f7710437d89c1824a82b3813b6c65302a16b9
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+              value: sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f5a67f7b6bde4c97c426d98d5590a656f0f96f94ce63444178c47b79b5e2c930
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary

- Promote Torghut GitOps manifests to Nix-built image digest `sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6` from source commit `2f3f7710437d89c1824a82b3813b6c65302a16b9`.
- Update core Torghut, sim, migration, analysis workflow, repair cronjob, smoke job, and Hyperliquid runtime manifests to the same digest.
- This is a manual release PR because the automated `torghut-release` run was canceled while ARC arm64 scheduling was blocked; the image build and platform assertion were validated separately.

## Related Issues

None

## Testing

- `nix run .#assert-oci-platforms -- registry.ide-newton.ts.net/lab/torghut@sha256:ddcafb7f296e37503ed2e0808167e7a6c104b06d31e0a3f6f15ef53b5aa8e3a6 linux/amd64 linux/arm64`
- `kustomize build argocd/applications/torghut >/tmp/torghut-release-kustomize.yaml`
- `git diff --check`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
