### PR TITLE
test(froussard): guard compact webhook goal expectation

### DIFF
--- a/apps/froussard/src/routes/webhooks.test.ts
+++ b/apps/froussard/src/routes/webhooks.test.ts
@@ -123,7 +123,19 @@ const expectAgentRunSubmission = (
     'x-agents-client': 'froussard',
   })
 
+  const expectedGoalObjective = [
+    `Implement GitHub issue owner/repo#${options.issueNumber}: ${options.issueTitle}.`,
+    `Issue URL: ${options.issueUrl}.`,
+    'Base branch: main.',
+    'Head branch: codex/issue-1-test.',
+    'Use implementation.text for the full issue body, requirements, and acceptance criteria.',
+  ].join('\n')
+
   const payload = JSON.parse(String(init.body)) as Record<string, unknown>
+  const goal = payload.goal as { objective?: unknown } | undefined
+  expect(goal?.objective).toBe(expectedGoalObjective)
+  expect(goal?.objective).not.toBe('PROMPT')
+
   expect(payload).toMatchObject({
     namespace: 'agents',
     agentRef: { name: 'codex-agent' },
@@ -132,13 +144,7 @@ const expectAgentRunSubmission = (
       source: { provider: 'github', externalId: `owner/repo#${options.issueNumber}` },
     },
     goal: {
-      objective: [
-        `Implement GitHub issue owner/repo#${options.issueNumber}: ${options.issueTitle}.`,
-        `Issue URL: ${options.issueUrl}.`,
-        'Base branch: main.',
-        'Head branch: codex/issue-1-test.',
-        'Use implementation.text for the full issue body, requirements, and acceptance criteria.',
-      ].join('\n'),
+      objective: expectedGoalObjective,
       tokenBudget: 250000,
     },
     runtime: { type: 'job', config: { serviceAccountName: 'agents-sa' } },

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-kJ3EYa/VBjZdlSwCYq/7suUohBFxxoghZoDalfTOiY8=";
-    aarch64-linux = "sha256-ft1Zcx/6ocKrRQbUs15r0d2Vu2aA7+leb6N7Qd/V28g=";
+    x86_64-linux = "sha256-AtfWR7smSXB2V+2M6Sz8W8JqA7jkh5OvJf5Eq0OltQw=";
+    aarch64-linux = "sha256-NQv5zTeCZcVjziyTqY4m7n4zJOQOjuZAMt8vvF33uuE=";
   };
   installFilters = [
     "@proompteng/agent-contracts"


### PR DESCRIPTION
## Summary

- Adds an explicit regression assertion that Froussard webhook AgentRun submissions use the compact GitHub metadata goal objective.
- Keeps the full Codex prompt assertion on `implementation.text`, making the compact goal and full implementation payload expectations distinct.
- Updates the Froussard Nix dependency hashes for both amd64 and arm64 so the image jobs pass on this PR.

## Related Issues

Addresses review feedback from #11909.

## Testing

- `node node_modules/vitest/vitest.mjs run src/routes/webhooks.test.ts src/services/agents.test.ts --config vitest.config.ts`
- `git diff --check`
- GitHub Actions on PR #11937: Froussard test, amd64 image, arm64 image, lint, validate, argocd-lint, changed-files, semantic commit/title checks all passing.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
