### PR TITLE
ci(torghut): run release checks on amd64 arc

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -131,7 +131,7 @@ jobs:
     name: Release manifest changes
     # The digest contract check inspects registry.ide-newton.ts.net, which is only
     # reachable from ARC runners on the lab network.
-    runs-on: arc-arm64
+    runs-on: arc-amd64
     needs:
       - changes
     if: ${{ needs.changes.outputs.service != 'true' && needs.changes.outputs.manifests == 'true' }}

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -59,7 +59,7 @@ jobs:
       }}
     # The private registry is only reachable from the ARC runners on the lab network.
     # This pull_request_target job checks out trusted base code only, never pull request code.
-    runs-on: arc-arm64
+    runs-on: arc-amd64
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Move Torghut release-manifest verification from `arc-arm64` to `arc-amd64`.
- Move Torghut deploy automerge eligibility from `arc-arm64` to `arc-amd64`.
- Keep both jobs on ARC because they need lab-network access to `registry.ide-newton.ts.net`, but they do not need an arm64 runner to inspect multi-arch OCI manifests.

## Related Issues

None

## Testing

- `rg -n "runs-on: arc-(arm64|amd64)" .github/workflows/torghut-ci.yml .github/workflows/torghut-deploy-automerge.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
