### PR TITLE
fix(agents): address nix image review feedback

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths:
       - 'bun.lock'
+      - 'nix/images/agents.nix'
+      - 'nix/images/bun-workspace-service.nix'
+      - 'nix/images/openai-codex-cli.nix'
+      - 'nix/packages.nix'
       - 'argocd/applications/argo-workflows/**'
       - 'argocd/applications/agents/**'
       - 'charts/agents/**'
@@ -23,6 +27,7 @@ on:
       - 'packages/scripts/src/shared/cli.ts'
       - 'packages/scripts/src/shared/docker.ts'
       - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
       - 'packages/scripts/src/shared/__tests__/docker.test.ts'
       - 'packages/temporal-bun-sdk/**'
       - 'services/agents/**'
@@ -33,6 +38,10 @@ on:
       - main
     paths:
       - 'bun.lock'
+      - 'nix/images/agents.nix'
+      - 'nix/images/bun-workspace-service.nix'
+      - 'nix/images/openai-codex-cli.nix'
+      - 'nix/packages.nix'
       - 'argocd/applications/argo-workflows/**'
       - 'argocd/applications/agents/**'
       - 'charts/agents/**'
@@ -48,6 +57,7 @@ on:
       - 'packages/scripts/src/shared/cli.ts'
       - 'packages/scripts/src/shared/docker.ts'
       - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/nix-oci-deploy.ts'
       - 'packages/scripts/src/shared/__tests__/docker.test.ts'
       - 'packages/temporal-bun-sdk/**'
       - 'services/agents/**'

--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -13,6 +13,7 @@ const envKeys = [
   'AGENTS_IMAGE_REPOSITORY',
   'AGENTS_IMAGE_TAG',
   'AGENTS_IMAGE_TARGET',
+  'AGENTS_DOCKER_TARGET',
   'AGENTS_NIX_IMAGE_TARGET',
   'AGENTS_RUNNER_IMAGE_REPOSITORY',
   'AGENTS_SHELL_IMAGE_REPOSITORY',
@@ -83,6 +84,50 @@ describe('agents build-image helpers', () => {
     })
   })
 
+  it('honors generic repository overrides for explicit runner and shell targets', () => {
+    process.env.AGENTS_IMAGE_REPOSITORY = 'lab/custom-agents-runtime'
+
+    expect(
+      __private.resolveBuildConfiguration({
+        target: 'runner',
+        tag: 'abc123',
+        commit: 'abcdef',
+      }),
+    ).toMatchObject({
+      repository: 'lab/custom-agents-runtime',
+      target: 'runner',
+      packageAttr: 'agents-codex-runner-image',
+    })
+    expect(
+      __private.resolveBuildConfiguration({
+        target: 'agents-shell',
+        tag: 'abc123',
+        commit: 'abcdef',
+      }),
+    ).toMatchObject({
+      repository: 'lab/custom-agents-runtime',
+      target: 'agents-shell',
+      packageAttr: 'agents-shell-image',
+    })
+  })
+
+  it('prefers target-specific repository overrides over the generic override', () => {
+    process.env.AGENTS_IMAGE_REPOSITORY = 'lab/generic-agents-runtime'
+    process.env.AGENTS_RUNNER_IMAGE_REPOSITORY = 'lab/custom-agents-runner'
+
+    expect(
+      __private.resolveBuildConfiguration({
+        target: 'runner',
+        tag: 'abc123',
+        commit: 'abcdef',
+      }),
+    ).toMatchObject({
+      repository: 'lab/custom-agents-runner',
+      target: 'runner',
+      packageAttr: 'agents-codex-runner-image',
+    })
+  })
+
   it('can infer the target from a canonical repository override', () => {
     expect(
       __private.resolveBuildConfiguration({
@@ -94,6 +139,17 @@ describe('agents build-image helpers', () => {
       target: 'controller',
       packageAttr: 'agents-controller-image',
     })
+  })
+
+  it('rejects the legacy Docker target env var instead of silently defaulting', () => {
+    process.env.AGENTS_DOCKER_TARGET = 'controller'
+
+    expect(() =>
+      __private.resolveBuildConfiguration({
+        tag: 'abc123',
+        commit: 'abcdef',
+      }),
+    ).toThrow('AGENTS_DOCKER_TARGET')
   })
 
   it('rejects old Docker-only build options instead of silently falling back', () => {
@@ -197,6 +253,39 @@ describe('agents build-image helpers', () => {
       'registry.ide-newton.ts.net/lab/agents-control-plane:abc123',
       'registry.ide-newton.ts.net/lab/agents-shell:abc123',
     ])
+  })
+
+  it('parses removed Docker CLI flags so Nix option rejection catches them', () => {
+    const options = __private.parseArgs([
+      '--dockerfile',
+      'services/agents/Dockerfile',
+      '--context=.',
+      '--cache-ref',
+      'registry.example/cache',
+      '--platforms=linux/amd64,linux/arm64',
+      '--target',
+      'runner',
+      '--tag',
+      'abc123',
+    ])
+
+    expect(options).toEqual({
+      dockerfile: 'services/agents/Dockerfile',
+      context: '.',
+      cacheRef: 'registry.example/cache',
+      platforms: ['linux/amd64', 'linux/arm64'],
+      target: 'runner',
+      tag: 'abc123',
+    })
+    expect(() => __private.resolveBuildConfiguration({ ...options, commit: 'abcdef' })).toThrow(
+      'Docker-only option(s): context, dockerfile, cacheRef, platforms',
+    )
+  })
+
+  it('rejects unknown or malformed manual CLI flags before they can be consumed as tags', () => {
+    expect(() => __private.parseArgs(['--unknown'])).toThrow('Unsupported Agents build-image CLI flag: --unknown')
+    expect(() => __private.parseArgs(['--target'])).toThrow('Missing value for --target')
+    expect(() => __private.parseArgs(['abc123', 'extra'])).toThrow('Unexpected positional argument: extra')
   })
 
   it('parses the manual CLI target, tag, repository, registry, and dry-run flags', () => {

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -122,13 +122,17 @@ describe('classifyAgentsImageMode', () => {
   it('builds a local image for Agents Nix image input changes', () => {
     const result = classifyAgentsImageMode([
       'nix/images/agents.nix',
+      'nix/images/bun-workspace-service.nix',
       'nix/images/openai-codex-cli.nix',
+      'nix/packages.nix',
       'packages/scripts/src/shared/nix-oci-deploy.ts',
     ])
     expect(result.mode).toBe('build-local-image')
     expect(result.matchedPaths).toEqual([
       'nix/images/agents.nix',
+      'nix/images/bun-workspace-service.nix',
       'nix/images/openai-codex-cli.nix',
+      'nix/packages.nix',
       'packages/scripts/src/shared/nix-oci-deploy.ts',
     ])
   })
@@ -199,6 +203,20 @@ describe('agents-ci workflow local Agents image build', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 
     expect(workflow).toContain('git diff --name-only "${BASE_SHA}...${HEAD_SHA}"')
+  })
+
+  it('triggers Agents CI for local Nix image inputs that the classifier can build', () => {
+    const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
+
+    for (const path of [
+      'nix/images/agents.nix',
+      'nix/images/bun-workspace-service.nix',
+      'nix/images/openai-codex-cli.nix',
+      'nix/packages.nix',
+      'packages/scripts/src/shared/nix-oci-deploy.ts',
+    ]) {
+      expect(workflow).toContain(`      - '${path}'`)
+    }
   })
 
   it('builds local kind smoke images when the published registry is unreachable', () => {

--- a/packages/scripts/src/agents/build-image.ts
+++ b/packages/scripts/src/agents/build-image.ts
@@ -70,7 +70,7 @@ const imagePlans: AgentsImagePlan[] = [
     imageName: 'agents-shell',
     packageAttr: 'agents-shell-image',
     defaultRepository: 'lab/agents-shell',
-    repositoryEnvKeys: ['AGENTS_SHELL_IMAGE_REPOSITORY'],
+    repositoryEnvKeys: ['AGENTS_SHELL_IMAGE_REPOSITORY', 'AGENTS_IMAGE_REPOSITORY'],
   },
   {
     target: 'runner',
@@ -79,7 +79,7 @@ const imagePlans: AgentsImagePlan[] = [
     imageName: 'agents-codex-runner',
     packageAttr: 'agents-codex-runner-image',
     defaultRepository: 'lab/agents-codex-runner',
-    repositoryEnvKeys: ['AGENTS_RUNNER_IMAGE_REPOSITORY'],
+    repositoryEnvKeys: ['AGENTS_RUNNER_IMAGE_REPOSITORY', 'AGENTS_IMAGE_REPOSITORY'],
   },
 ]
 
@@ -95,6 +95,14 @@ let buildAndPushNixImageImpl = buildAndPushNixImage
 let execGitImpl = execGit
 
 const readEnv = (name: string) => process.env[name]?.trim()
+
+const requireArgValue = (args: string[], index: number, option: string): string => {
+  const value = args[index + 1]
+  if (!value || value.startsWith('-')) {
+    throw new Error(`Missing value for ${option}`)
+  }
+  return value
+}
 
 const resolveTarget = (value: string | undefined, fallback: AgentsImageTarget): AgentsImageTarget => {
   const normalized = value?.trim().toLowerCase()
@@ -119,6 +127,14 @@ const rejectDockerOptions = (options: BuildImageOptions): void => {
   const present = dockerOnlyOptionNames.filter((name) => options[name] !== undefined)
   if (present.length > 0) {
     throw new Error(`Agents Nix image builds do not accept Docker-only option(s): ${present.join(', ')}`)
+  }
+
+  const legacyDockerTarget = readEnv('AGENTS_DOCKER_TARGET')
+  if (legacyDockerTarget) {
+    throw new Error(
+      'Agents Nix image builds do not accept legacy Docker target env var AGENTS_DOCKER_TARGET; ' +
+        'use AGENTS_IMAGE_TARGET or AGENTS_NIX_IMAGE_TARGET',
+    )
   }
 }
 
@@ -202,7 +218,7 @@ const parseArgs = (args: string[]): BuildImageOptions => {
     if (!arg) continue
 
     if (arg === '--target') {
-      options.target = args[i + 1]
+      options.target = requireArgValue(args, i, arg)
       i += 1
       continue
     }
@@ -211,7 +227,7 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       continue
     }
     if (arg === '--tag') {
-      options.tag = args[i + 1]
+      options.tag = requireArgValue(args, i, arg)
       i += 1
       continue
     }
@@ -220,7 +236,7 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       continue
     }
     if (arg === '--repository') {
-      options.repository = args[i + 1]
+      options.repository = requireArgValue(args, i, arg)
       i += 1
       continue
     }
@@ -229,7 +245,7 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       continue
     }
     if (arg === '--registry') {
-      options.registry = args[i + 1]
+      options.registry = requireArgValue(args, i, arg)
       i += 1
       continue
     }
@@ -241,9 +257,76 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       options.dryRun = true
       continue
     }
-    if (!arg.startsWith('-') && options.tag === undefined) {
-      options.tag = arg
+    if (arg === '--context') {
+      options.context = requireArgValue(args, i, arg)
+      i += 1
+      continue
     }
+    if (arg.startsWith('--context=')) {
+      options.context = arg.slice('--context='.length)
+      continue
+    }
+    if (arg === '--dockerfile') {
+      options.dockerfile = requireArgValue(args, i, arg)
+      i += 1
+      continue
+    }
+    if (arg.startsWith('--dockerfile=')) {
+      options.dockerfile = arg.slice('--dockerfile='.length)
+      continue
+    }
+    if (arg === '--codex-auth-path') {
+      options.codexAuthPath = requireArgValue(args, i, arg)
+      i += 1
+      continue
+    }
+    if (arg.startsWith('--codex-auth-path=')) {
+      options.codexAuthPath = arg.slice('--codex-auth-path='.length)
+      continue
+    }
+    if (arg === '--cache-ref') {
+      options.cacheRef = requireArgValue(args, i, arg)
+      i += 1
+      continue
+    }
+    if (arg.startsWith('--cache-ref=')) {
+      options.cacheRef = arg.slice('--cache-ref='.length)
+      continue
+    }
+    if (arg === '--platforms') {
+      options.platforms = requireArgValue(args, i, arg)
+        .split(',')
+        .map((platform) => platform.trim())
+        .filter(Boolean)
+      i += 1
+      continue
+    }
+    if (arg.startsWith('--platforms=')) {
+      options.platforms = arg
+        .slice('--platforms='.length)
+        .split(',')
+        .map((platform) => platform.trim())
+        .filter(Boolean)
+      continue
+    }
+    if (arg === '--cache-mode') {
+      options.cacheMode = requireArgValue(args, i, arg)
+      i += 1
+      continue
+    }
+    if (arg.startsWith('--cache-mode=')) {
+      options.cacheMode = arg.slice('--cache-mode='.length)
+      continue
+    }
+    if (arg.startsWith('-')) {
+      throw new Error(`Unsupported Agents build-image CLI flag: ${arg}`)
+    }
+    if (options.tag === undefined) {
+      options.tag = arg
+      continue
+    }
+
+    throw new Error(`Unexpected positional argument: ${arg}`)
   }
   return options
 }


### PR DESCRIPTION
## Summary

- Add `agents-ci` path triggers for local Nix Agents image inputs so classifier-relevant image changes actually run the workflow.
- Reject legacy Docker-era manual image configuration, including `AGENTS_DOCKER_TARGET` and removed Docker CLI flags, instead of silently defaulting or treating flags as tags.
- Preserve generic `AGENTS_IMAGE_REPOSITORY` overrides for runner and shell image targets while keeping target-specific overrides higher precedence.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check HEAD~1..HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
