### PR TITLE
test(torghut): expect amd64 release checks

### DIFF
--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -290,7 +290,7 @@ describe('torghut build-push workflow', () => {
     )
 
     expect(buildContractStep).toBeGreaterThan(releaseManifestJob)
-    expect(releaseManifestJobBody).toContain('runs-on: arc-arm64')
+    expect(releaseManifestJobBody).toContain('runs-on: arc-amd64')
     expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net, which is only')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/knative-service.yaml')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ta/flinkdeployment.yaml')

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -27,7 +27,7 @@ const countOccurrences = (haystack: string, needle: string): number => haystack.
 
 describe('torghut-deploy-automerge workflow', () => {
   test('runs registry digest validation where the private registry is reachable', () => {
-    expect(deployAutomergeWorkflow).toContain('runs-on: arc-arm64')
+    expect(deployAutomergeWorkflow).toContain('runs-on: arc-amd64')
     expect(deployAutomergeWorkflow).not.toContain('runs-on: ubuntu-latest')
     expect(deployAutomergeWorkflow).toContain(
       'This pull_request_target job checks out trusted base code only, never pull request code.',


### PR DESCRIPTION
## Summary

- Update Torghut release-manifest CI tests to expect `arc-amd64`.
- Update Torghut deploy-automerge workflow tests to expect `arc-amd64`.
- Keep the private-registry ARC coverage intact while removing the stale arm64-only assumption.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
