### PR TITLE
fix(registry): lower memory request

### DIFF
--- a/argocd/applications/registry/deployment.yaml
+++ b/argocd/applications/registry/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               memory: "1Gi"
             requests:
               cpu: "200m"
-              memory: "256Mi"
+              memory: "64Mi"
           ports:
             - containerPort: 5000
           volumeMounts:


### PR DESCRIPTION
## Summary

- Lower the registry Deployment memory request from `256Mi` to `64Mi`.
- Match the live request patch that restored registry scheduling when the cluster had pod and requested-memory pressure.
- Keep the limit at `1Gi`; no storage, PVC, Ceph, Rook, or Talos changes.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/registry >/tmp/registry-kustomize.yaml`
- `rg -n "memory: 64Mi|memory: \"64Mi\"|name: registry" /tmp/registry-kustomize.yaml | head -20`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
