### PR TITLE
fix(saigak): restore altra gpu embeddings

### DIFF
--- a/argocd/applications/saigak/kustomization.yaml
+++ b/argocd/applications/saigak/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: saigak
 resources:
   - configmap.yaml
+  - pvc-altra.yaml
   - pvc.yaml
   - statefulset.yaml
   - service.yaml

--- a/argocd/applications/saigak/pvc-altra.yaml
+++ b/argocd/applications/saigak/pvc-altra.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: saigak-altra-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 200Gi

--- a/argocd/applications/saigak/statefulset.yaml
+++ b/argocd/applications/saigak/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: embeddings
 spec:
   serviceName: saigak
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: saigak
@@ -18,11 +18,16 @@ spec:
         app.kubernetes.io/name: saigak
         app.kubernetes.io/component: embeddings
     spec:
+      runtimeClassName: nvidia
       nodeSelector:
         kubernetes.io/arch: amd64
-        kubernetes.io/hostname: turin
+        kubernetes.io/hostname: talos-192-168-1-85
+        nvidia.com/gpu.present: "true"
       tolerations:
         - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
       terminationGracePeriodSeconds: 120
@@ -97,6 +102,10 @@ spec:
               value: 30m
             - name: OLLAMA_MAX_LOADED_MODELS
               value: "1"
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: compute,utility
           livenessProbe:
             exec:
               command:
@@ -110,9 +119,11 @@ spec:
             requests:
               cpu: "8"
               memory: 32Gi
+              nvidia.com/gpu: "1"
             limits:
               cpu: "32"
               memory: 64Gi
+              nvidia.com/gpu: "1"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -137,7 +148,7 @@ spec:
             - name: SAIGAK_PROXY_TIMEOUT_SECONDS
               value: "120"
             - name: SAIGAK_REQUIRE_GPU_RESIDENCY
-              value: "false"
+              value: "true"
           ports:
             - name: http
               containerPort: 11434
@@ -187,5 +198,5 @@ spec:
             name: saigak-runtime
         - name: model-cache
           persistentVolumeClaim:
-            claimName: saigak-data
+            claimName: saigak-altra-data
       restartPolicy: Always

--- a/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
+++ b/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
@@ -8,12 +8,12 @@ This runbook records the hard migration where completion traffic moves to the
 
 `saigak` is a Kubernetes `StatefulSet` serving Ollama through an embeddings-only
 proxy on port `11434`; it must not expose chat completion endpoints. Its current
-PVC is local-path storage selected on `turin`, so the immediate safe deconflict
-is CPU-only residency on `turin` with no `runtimeClassName: nvidia`, no
-`nvidia.com/gpu` request or limit, and no NVIDIA runtime environment. A real move
-to the Altra RTX 3090 requires both an allocatable Altra GPU and a storage
-migration off the Turin local-path PVC; only that later GPU-backed mode should
-set `SAIGAK_REQUIRE_GPU_RESIDENCY=true`.
+active PVC is `saigak-altra-data`, a local-path cache that binds on first
+consumer to the Altra node (`talos-192-168-1-85`) so the old Turin-bound
+`saigak-data` cache cannot pin the pod away from the RTX 3090. The pod must use
+`runtimeClassName: nvidia`, request and limit `nvidia.com/gpu: "1"`, and keep
+`SAIGAK_REQUIRE_GPU_RESIDENCY=true` so readiness fails unless the 4096-dimensional
+embedding model is resident in GPU VRAM.
 
 `flamingo` is a normal Kubernetes Deployment pinned to Turin's Blackwell GPU. It
 serves a vLLM OpenAI-compatible API on:
@@ -155,8 +155,7 @@ Do not treat completion migration as complete until all of these are true:
 - No completion consumer depends on Saigak's Ollama model store.
 - OpenWebUI, Jangar, Bumba, Agents, Torghut, and Synthesis configs have been audited.
 - Saigak rejects `/v1/chat/completions` and `/api/generate`.
-- Saigak `/v1/embeddings` returns 4096 dimensions. `/api/ps` showing GPU VRAM
-  residency is required only after Altra advertises allocatable `nvidia.com/gpu`
-  and Saigak storage has migrated off Turin local-path storage; until then,
-  CPU-only Turin residency is acceptable and Blackwell GPU residency is not.
+- Saigak `/v1/embeddings` returns 4096 dimensions, and `/api/ps` shows the
+  embedding model with non-zero `size_vram` on the Altra RTX 3090. CPU-only
+  residency is not an acceptable steady state.
 - A stability window has passed with Flamingo stable under normal agent load.

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -163,18 +163,26 @@ export function validateActiveSaigakMigrationContent(files: FileContent[]): stri
 
   const saigakStatefulSet = byPath.get('argocd/applications/saigak/statefulset.yaml')
   if (saigakStatefulSet) {
-    for (const term of [
-      'runtimeClassName: nvidia',
-      'nvidia.com/gpu:',
-      'OLLAMA_FLASH_ATTENTION',
-      'NVIDIA_VISIBLE_DEVICES',
-      'NVIDIA_DRIVER_CAPABILITIES',
-      'RTX PRO 6000',
-      'Blackwell',
-    ]) {
+    for (const term of ['kubernetes.io/hostname: turin', 'RTX PRO 6000', 'Blackwell']) {
       if (saigakStatefulSet.includes(term)) {
         failures.push(
           `argocd/applications/saigak/statefulset.yaml: Saigak must not consume Turin Blackwell GPU resources, found "${term}"`,
+        )
+      }
+    }
+    for (const term of [
+      'replicas: 1',
+      'runtimeClassName: nvidia',
+      'kubernetes.io/hostname: talos-192-168-1-85',
+      'nvidia.com/gpu.present: "true"',
+      'nvidia.com/gpu: "1"',
+      'SAIGAK_REQUIRE_GPU_RESIDENCY',
+      'value: "true"',
+      'claimName: saigak-altra-data',
+    ]) {
+      if (!saigakStatefulSet.includes(term)) {
+        failures.push(
+          `argocd/applications/saigak/statefulset.yaml: Saigak must run embeddings on the Altra RTX 3090, missing "${term}"`,
         )
       }
     }


### PR DESCRIPTION
## Summary

- Restores `saigak` to one embeddings-only replica on Altra (`talos-192-168-1-85`) with the NVIDIA runtime and `nvidia.com/gpu: "1"`.
- Adds a new Altra-local model-cache PVC so the old Turin-bound local-path PVC does not pin Saigak away from the RTX 3090.
- Updates the Flamingo/Saigak migration guard and runbook to require GPU-backed Saigak embeddings while keeping completions on Flamingo.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/saigak`
- `bun run lint:flamingo-hard-migration`
- `bun test services/jangar/src/server/__tests__/memory-config.test.ts services/jangar/src/server/__tests__/embedding-client.test.ts`
- `bun test services/bumba/src/activities/index.test.ts -t embeddings`
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Saigak now requires Altra to advertise an allocatable NVIDIA GPU and readiness requires the embedding model to be resident in GPU VRAM.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
