### PR TITLE
fix(saigak): target altra arm64 node

### DIFF
--- a/argocd/applications/saigak/statefulset.yaml
+++ b/argocd/applications/saigak/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       runtimeClassName: nvidia
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
         kubernetes.io/hostname: talos-192-168-1-85
         nvidia.com/gpu.present: "true"
       tolerations:

--- a/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
+++ b/docs/jangar/saigak-to-flamingo-gpu-pod-migration.md
@@ -9,7 +9,7 @@ This runbook records the hard migration where completion traffic moves to the
 `saigak` is a Kubernetes `StatefulSet` serving Ollama through an embeddings-only
 proxy on port `11434`; it must not expose chat completion endpoints. Its current
 active PVC is `saigak-altra-data`, a local-path cache that binds on first
-consumer to the Altra node (`talos-192-168-1-85`) so the old Turin-bound
+consumer to the ARM64 Altra node (`talos-192-168-1-85`) so the old Turin-bound
 `saigak-data` cache cannot pin the pod away from the RTX 3090. The pod must use
 `runtimeClassName: nvidia`, request and limit `nvidia.com/gpu: "1"`, and keep
 `SAIGAK_REQUIRE_GPU_RESIDENCY=true` so readiness fails unless the 4096-dimensional

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -173,6 +173,7 @@ export function validateActiveSaigakMigrationContent(files: FileContent[]): stri
     for (const term of [
       'replicas: 1',
       'runtimeClassName: nvidia',
+      'kubernetes.io/arch: arm64',
       'kubernetes.io/hostname: talos-192-168-1-85',
       'nvidia.com/gpu.present: "true"',
       'nvidia.com/gpu: "1"',


### PR DESCRIPTION
## Summary

- Corrects the Saigak Altra node selector to `kubernetes.io/arch: arm64`.
- Updates the migration guard to require the ARM64 Altra selector.
- Updates the runbook text to state that Saigak binds to the ARM64 Altra node.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/saigak`
- `bun run lint:flamingo-hard-migration`
- `bunx oxfmt --check scripts/jangar/validate-flamingo-hard-migration.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
