### PR TITLE
fix(agents): add memory provider schema migration

### DIFF
--- a/services/agents/src/server/kysely-migrations.ts
+++ b/services/agents/src/server/kysely-migrations.ts
@@ -14,6 +14,7 @@ import * as agentsAgentRunRerunSubmissionsMigration from './migrations/20260520_
 import * as agentsCodexRunProjectionMigration from './migrations/20260520_agents_codex_run_projection'
 import * as agentsCodexLegacyBackfillMigration from './migrations/20260521_agents_codex_legacy_backfill'
 import * as agentsMemoryNotesMigration from './migrations/20260521_agents_memory_notes'
+import * as agentsMemoryProviderTablesMigration from './migrations/20260705_agents_memory_provider_tables'
 
 type MigrationMap = Record<string, Migration>
 
@@ -38,6 +39,7 @@ const migrations: MigrationMap = {
   '20260520_agents_codex_run_projection': agentsCodexRunProjectionMigration,
   '20260521_agents_codex_legacy_backfill': agentsCodexLegacyBackfillMigration,
   '20260521_agents_memory_notes': agentsMemoryNotesMigration,
+  '20260705_agents_memory_provider_tables': agentsMemoryProviderTablesMigration,
   '20260520_agents_comms_agent_run_identity': agentsCommsAgentRunIdentityMigration,
   '20260520_agents_comms_agent_run_name_lookup': agentsCommsAgentRunNameLookupMigration,
 }

--- a/services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts
+++ b/services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts
@@ -1,0 +1,71 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { AgentsDatabase } from '../db'
+import { resolveEmbeddingConfig } from '../memory-config'
+import { createPgvectorAnnIndexIfSupported } from '../pgvector-indexing'
+
+const resolveEmbeddingDimension = () => resolveEmbeddingConfig(process.env).dimension
+
+export const up = async (db: Kysely<AgentsDatabase>) => {
+  const embeddingDimension = resolveEmbeddingDimension()
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS memory_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload JSONB NOT NULL DEFAULT '{}'::JSONB
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS memory_events_dataset_created_at_idx
+    ON memory_events (dataset, created_at DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS memory_kv (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value JSONB NOT NULL DEFAULT '{}'::JSONB,
+      CONSTRAINT memory_kv_dataset_key_key UNIQUE (dataset, key)
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS memory_kv_dataset_key_idx
+    ON memory_kv (dataset, key);
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS memory_embeddings (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      key TEXT NOT NULL,
+      embedding vector(${sql.raw(String(embeddingDimension))}) NOT NULL,
+      metadata JSONB NOT NULL DEFAULT '{}'::JSONB
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS memory_embeddings_dataset_key_idx
+    ON memory_embeddings (dataset, key);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS memory_embeddings_metadata_idx
+    ON memory_embeddings USING GIN (metadata JSONB_PATH_OPS);
+  `.execute(db)
+
+  await createPgvectorAnnIndexIfSupported(
+    db,
+    embeddingDimension,
+    'CREATE INDEX IF NOT EXISTS memory_embeddings_embedding_idx ON memory_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);',
+    'memory_embeddings',
+  )
+}


### PR DESCRIPTION
## Summary

- Add an Agents DB migration for the memory provider tables used by `/v1/memory-operations`.
- Create `memory_events`, `memory_kv`, and `memory_embeddings` with the configured embedding vector dimension.
- Keep the migration registered with the Agents Kysely migration provider so future deploys preserve the live repair.

## Related Issues

None

## Testing

- `bun test services/agents/src/server/kysely-migrations.test.ts services/agents/src/server/v1/memory-operations.test.ts`
- `bunx oxfmt --check services/agents/src/server/kysely-migrations.ts services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts`
- `git diff --check`
- Live repair validation: created the same schema in the `agents` DB, then verified `/v1/memory-operations` embedding save and query both returned HTTP 200 with a 4096-dimensional Saigak embedding-backed result.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
