### PR TITLE
fix(torghut): normalize hyperliquid order prices

### DIFF
--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -26,6 +26,8 @@ from .universe import execution_universe_status
 
 _METADATA_REFRESH_SECONDS = 300
 _SUPPORTED_LIMIT_TIFS = {"Ioc"}
+_PERP_MAX_PRICE_DECIMALS = 6
+_MAX_PRICE_SIGNIFICANT_FIGURES = 5
 
 
 class HyperliquidExecutionExchange(Protocol):
@@ -313,7 +315,11 @@ class HyperliquidSdkExecutionExchange:
         if size_decimals is not None:
             quant = Decimal("1").scaleb(-size_decimals)
             size = intent.size.quantize(quant, rounding=ROUND_DOWN)
-        price = _normalize_price(intent.limit_price, side=intent.side)
+        price = _normalize_price(
+            intent.limit_price,
+            side=intent.side,
+            size_decimals=size_decimals,
+        )
         notional_usd = (price * size).quantize(Decimal("0.000001"))
         if (
             notional_usd < self._config.min_order_notional_usd
@@ -710,9 +716,48 @@ def _spot_usdc_balances(payload: Mapping[str, object]) -> list[Mapping[str, obje
     return usdc_balances
 
 
-def _normalize_price(price: Decimal, *, side: str) -> Decimal:
+def _normalize_price(
+    price: Decimal,
+    *,
+    side: str,
+    size_decimals: int | None,
+) -> Decimal:
+    if price <= Decimal("0"):
+        raise ValueError("order_price_must_be_positive")
     rounding = ROUND_DOWN if side == "buy" else ROUND_UP
-    return price.quantize(Decimal("0.000001"), rounding=rounding)
+    max_decimals = _PERP_MAX_PRICE_DECIMALS
+    if size_decimals is not None:
+        max_decimals = max(0, _PERP_MAX_PRICE_DECIMALS - size_decimals)
+    rounded = _quantize_decimal_places(price, max_decimals, rounding)
+    if rounded <= Decimal("0"):
+        raise ValueError("order_price_below_exchange_precision")
+    if rounded == rounded.to_integral_value():
+        return rounded
+    normalized = _quantize_significant_figures(
+        rounded,
+        _MAX_PRICE_SIGNIFICANT_FIGURES,
+        rounding,
+    )
+    return normalized
+
+
+def _quantize_decimal_places(
+    value: Decimal,
+    decimals: int,
+    rounding: str,
+) -> Decimal:
+    quantum = Decimal("1").scaleb(-decimals)
+    return value.quantize(quantum, rounding=rounding)
+
+
+def _quantize_significant_figures(
+    value: Decimal,
+    figures: int,
+    rounding: str,
+) -> Decimal:
+    exponent = value.adjusted() - figures + 1
+    quantum = Decimal("1").scaleb(exponent)
+    return value.quantize(quantum, rounding=rounding)
 
 
 def _sdk_dex(dex: str) -> str:

--- a/services/torghut/app/hyperliquid_execution/models.py
+++ b/services/torghut/app/hyperliquid_execution/models.py
@@ -142,7 +142,7 @@ class RiskVerdict:
 
 @dataclass(frozen=True)
 class OrderIntent:
-    """Maker-first Hyperliquid limit order intent."""
+    """Hyperliquid limit order intent."""
 
     market_id: str
     coin: str

--- a/services/torghut/app/hyperliquid_execution/order_policy.py
+++ b/services/torghut/app/hyperliquid_execution/order_policy.py
@@ -21,7 +21,7 @@ def build_order_intent(
     signal_id: str,
     now: datetime | None = None,
 ) -> OrderIntent:
-    """Create an order intent for the active restore policy."""
+    """Create an order intent for the active execution policy."""
 
     if not verdict.allowed:
         raise ValueError(f"risk_verdict_blocked:{verdict.reason}")

--- a/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
+++ b/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
@@ -11,7 +11,7 @@ from app.hyperliquid_execution.exchange import HyperliquidSdkExecutionExchange
 from app.hyperliquid_execution.models import ExecutionMarket, OpenOrder, OrderIntent
 
 
-def test_exchange_submits_ioc_restore_order() -> None:
+def test_exchange_submits_ioc_order() -> None:
     sdk = _FakeSdk()
     sdk.next_order_response = {
         "response": {"data": {"statuses": [{"filled": {"oid": 123}}]}}

--- a/services/torghut/tests/hyperliquid_execution/test_exchange_price_normalization.py
+++ b/services/torghut/tests/hyperliquid_execution/test_exchange_price_normalization.py
@@ -1,0 +1,119 @@
+"""Exchange price normalization regressions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.hyperliquid_execution.config import HyperliquidExecutionConfig
+from app.hyperliquid_execution.exchange import (
+    HyperliquidSdkExecutionExchange,
+    _normalize_price,
+)
+from app.hyperliquid_execution.models import ExecutionMarket, OrderIntent, OrderSide
+
+
+def test_exchange_normalizes_perp_price_to_hyperliquid_tick_rules() -> None:
+    sdk = _FakeSdk()
+    exchange = _FakeExchange(
+        HyperliquidExecutionConfig.from_env(
+            {
+                "HYPERLIQUID_EXECUTION_API_WALLET_PRIVATE_KEY": "0x1",
+                "HYPERLIQUID_EXECUTION_ACCOUNT_ADDRESS": "0xabc",
+            }
+        ),
+        sdk=sdk,
+    )
+    exchange.filter_supported_markets((_market("SOL"), _market("BTC")))
+
+    sol = exchange.submit_order(_intent("SOL", limit_price=Decimal("82.164061")))
+    btc_buy = exchange.submit_order(_intent("BTC", limit_price=Decimal("63369.669123")))
+    btc_sell = exchange.submit_order(
+        _intent("BTC", side="sell", limit_price=Decimal("63306.331123"))
+    )
+
+    assert sol.status == "accepted"
+    assert btc_buy.status == "accepted"
+    assert btc_sell.status == "accepted"
+    assert sdk.orders[0]["limit_px"] == 82.164
+    assert sdk.orders[1]["limit_px"] == 63369.0
+    assert sdk.orders[2]["limit_px"] == 63307.0
+
+
+def test_exchange_rejects_non_positive_order_price() -> None:
+    with pytest.raises(ValueError, match="order_price_must_be_positive"):
+        _normalize_price(Decimal("0"), side="buy", size_decimals=2)
+
+
+def test_exchange_rejects_price_below_exchange_precision() -> None:
+    with pytest.raises(ValueError, match="order_price_below_exchange_precision"):
+        _normalize_price(Decimal("0.1"), side="buy", size_decimals=6)
+
+
+class _FakeSdk:
+    def __init__(self) -> None:
+        self.orders: list[dict[str, object]] = []
+
+    def order(self, **kwargs: object) -> dict[str, object]:
+        self.orders.append(dict(kwargs))
+        return {"response": {"data": {"statuses": [{"resting": {"oid": 123}}]}}}
+
+
+class _FakeInfo:
+    def meta(self, *, dex: str = "") -> dict[str, object]:
+        return {
+            "universe": [
+                {"name": "SOL", "szDecimals": 2, "maxLeverage": 10},
+                {"name": "BTC", "szDecimals": 3, "maxLeverage": 40},
+            ]
+        }
+
+
+class _FakeExchange(HyperliquidSdkExecutionExchange):
+    def __init__(self, config: HyperliquidExecutionConfig, *, sdk: _FakeSdk) -> None:
+        super().__init__(config)
+        self._sdk = sdk
+        self._fake_info = _FakeInfo()
+
+    def _exchange(self) -> _FakeSdk:
+        return self._sdk
+
+    def _info(self) -> _FakeInfo:
+        return self._fake_info
+
+    def _cloid(self, raw: str) -> str:
+        return raw
+
+
+def _intent(
+    coin: str,
+    *,
+    side: OrderSide = "buy",
+    limit_price: Decimal,
+) -> OrderIntent:
+    return OrderIntent(
+        market_id=f"hl:perp:default:{coin}",
+        coin=coin,
+        dex="default",
+        side=side,
+        size=Decimal("0.1234"),
+        limit_price=limit_price,
+        notional_usd=Decimal("12.34"),
+        cloid="0xabc",
+        tif="Ioc",
+        reduce_only=False,
+        signal_id="signal",
+        expires_at=datetime.now(timezone.utc),
+    )
+
+
+def _market(coin: str) -> ExecutionMarket:
+    return ExecutionMarket(
+        market_id=f"hl:perp:default:{coin}",
+        coin=coin,
+        dex="default",
+        network="mainnet",
+        day_notional_volume_usd=Decimal("1000"),
+    )


### PR DESCRIPTION
## Summary

- Normalize Hyperliquid perp limit prices using exchange metadata before submitting IOC orders.
- Enforce the documented perp price constraints: 5 significant figures, integer-price allowance, and `6 - szDecimals` decimal places.
- Add a regression covering SOL-style decimal prices and BTC integer-price normalization.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/hyperliquid_execution -q`
- `uv run --frozen ruff check app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen ruff format --check app/hyperliquid_execution tests/hyperliquid_execution`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
