### PR TITLE
perf(nix): warm exact image outputs in attic

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -192,29 +192,30 @@ jobs:
           fi
           bash nix/ci-run-timed.sh "push-platform-image-${ARCH}" "${NIX_OCI_LOG_DIR}/oci-push-${ARCH}.log" "${args[@]}"
 
-      - name: Warm Nix image archive closure in Attic
+      - name: Warm Nix image archive output in Attic
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         env:
           ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
           ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
+          ATTIC_PUSH_NO_CLOSURE: 'true'
           ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
           test -n "${ATTIC_TOKEN}"
           mapfile -t image_paths < "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"
           if [[ "${#image_paths[@]}" -eq 0 ]]; then
-            echo "No Nix image closure paths were captured." >&2
+            echo "No Nix image output paths were captured." >&2
             exit 2
           fi
           status_file="${NIX_OCI_LOG_DIR}/image-cache-push-status-${ARCH}.txt"
           set +e
-          bash nix/ci-run-timed.sh "push-image-archive-closure-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-image-${ARCH}.log" \
+          bash nix/ci-run-timed.sh "push-image-archive-output-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-image-${ARCH}.log" \
             bash nix/cache-push.sh "${image_paths[@]}"
           status="$?"
           set -e
           if [[ "${status}" -ne 0 ]]; then
             printf 'failed\t%s\n' "${status}" > "${status_file}"
-            echo "::warning title=Attic image closure warm failed::Attic image closure push failed for ${ARCH}; registry image push remains authoritative. See cache-push-image-${ARCH}.log."
+            echo "::warning title=Attic image output warm failed::Attic image output push failed for ${ARCH}; registry image push remains authoritative. See cache-push-image-${ARCH}.log."
             exit 0
           fi
           printf 'succeeded\t0\n' > "${status_file}"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -375,11 +375,12 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('printf \'%s\\n\' "${image_tar}" > "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
     expect(nixOciWorkflow).not.toContain('Prime OCI helper closures')
     expect(nixOciWorkflow).not.toContain('Push build platform helper closures to Attic')
-    expect(nixOciWorkflow).toContain('Warm Nix image archive closure in Attic')
+    expect(nixOciWorkflow).toContain('Warm Nix image archive output in Attic')
     expect(nixOciWorkflow).toContain('mapfile -t image_paths < "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
+    expect(nixOciWorkflow).toContain("ATTIC_PUSH_NO_CLOSURE: 'true'")
     expect(nixOciWorkflow).toContain('bash nix/cache-push.sh "${image_paths[@]}"')
     expect(nixOciWorkflow).toContain(
-      'Attic image closure push failed for ${ARCH}; registry image push remains authoritative.',
+      'Attic image output push failed for ${ARCH}; registry image push remains authoritative.',
     )
     expect(nixOciWorkflow).not.toContain('cache_paths=("${helper_paths[@]}" "${image_paths[@]}")')
     expect(nixOciWorkflow).not.toContain('nix run .#cache-push')
@@ -402,7 +403,7 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).not.toContain('helper_attrs=')
     expect(nixOciWorkflow).not.toContain('helper_paths')
     expect(nixOciWorkflow).not.toContain('No build-platform helper closure paths were captured.')
-    expect(nixOciWorkflow).toContain('No Nix image closure paths were captured.')
+    expect(nixOciWorkflow).toContain('No Nix image output paths were captured.')
     expect(nixOciWorkflow).not.toContain('No index helper closure paths were captured.')
     expect(nixOciWorkflow).toContain('Start checkout timer')
     expect(nixOciWorkflow).toContain('Record checkout timing')
@@ -711,7 +712,7 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain("github.event_name == 'workflow_dispatch'")
     expect(nixOciWorkflow).toContain("github.ref == 'refs/heads/main' || inputs.publish_on_dispatch")
     expect(nixOciWorkflow).toContain('name: Push platform image without Docker')
-    expect(nixOciWorkflow).toContain('name: Warm Nix image archive closure in Attic')
+    expect(nixOciWorkflow).toContain('name: Warm Nix image archive output in Attic')
     expect(nixOciWorkflow).toContain('publish-index:')
 
     for (const [workflow, artifact] of [


### PR DESCRIPTION
## Summary

- Warm only the exact Nix image archive output path in Attic from the per-platform OCI matrix.
- Set `ATTIC_PUSH_NO_CLOSURE=true` for that step to avoid repeatedly pushing shared dependency/runtime closures for every image and architecture.
- Update OCI workflow contract tests so the output-only cache warm behavior is intentional.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `shellcheck nix/cache-push.sh nix/oci-push.sh nix/ci-nix-oci-summary.sh`
- `git diff --check`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
