### PR TITLE
ci(nix): bound image cache warm time

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -60,6 +60,7 @@ jobs:
       ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
       ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
       NIX_IMAGE_BUILD_ATTIC_TIMEOUT: 8m
+      NIX_IMAGE_CACHE_WARM_TIMEOUT: 2m
       NIX_OCI_LOG_DIR: /tmp/nix-oci-logs-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
     steps:
       - name: Start checkout timer
@@ -210,7 +211,7 @@ jobs:
           status_file="${NIX_OCI_LOG_DIR}/image-cache-push-status-${ARCH}.txt"
           set +e
           bash nix/ci-run-timed.sh "push-image-archive-output-${ARCH}" "${NIX_OCI_LOG_DIR}/cache-push-image-${ARCH}.log" \
-            bash nix/cache-push.sh "${image_paths[@]}"
+            timeout --kill-after=30s "${NIX_IMAGE_CACHE_WARM_TIMEOUT}" bash nix/cache-push.sh "${image_paths[@]}"
           status="$?"
           set -e
           if [[ "${status}" -ne 0 ]]; then

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -382,7 +382,10 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('Warm Nix image archive output in Attic')
     expect(nixOciWorkflow).toContain('mapfile -t image_paths < "${NIX_OCI_LOG_DIR}/image-paths-${ARCH}.txt"')
     expect(nixOciWorkflow).toContain("ATTIC_PUSH_NO_CLOSURE: 'true'")
-    expect(nixOciWorkflow).toContain('bash nix/cache-push.sh "${image_paths[@]}"')
+    expect(nixOciWorkflow).toContain('NIX_IMAGE_CACHE_WARM_TIMEOUT: 2m')
+    expect(nixOciWorkflow).toContain(
+      'timeout --kill-after=30s "${NIX_IMAGE_CACHE_WARM_TIMEOUT}" bash nix/cache-push.sh "${image_paths[@]}"',
+    )
     expect(nixOciWorkflow).toContain(
       'Attic image output push failed for ${ARCH}; registry image push remains authoritative.',
     )


### PR DESCRIPTION
## Summary

- Adds a hard 2-minute timeout around the Nix image archive Attic warm step so cache pushes cannot occupy ARC runners indefinitely after registry push succeeds.
- Keeps registry image push authoritative and preserves the existing warning path when optional cache warming fails.
- Adds a workflow contract test for the cache warm timeout.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This only bounds optional Attic warming after image push.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
