### PR TITLE
ci(arc): allow release after unrelated main changes

### DIFF
--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -95,9 +95,19 @@ jobs:
             exit 1
           fi
           if [[ "${source_sha}" != "$(git rev-parse HEAD)" ]]; then
-            echo "promote=false" >> "${GITHUB_OUTPUT}"
-            echo "Stale ARC runner build ${source_sha}; current main is $(git rev-parse HEAD)." >&2
-            exit 0
+            changed_paths="$(git diff --name-only "${source_sha}..HEAD")"
+            arc_image_input_changes="$(
+              printf '%s\n' "${changed_paths}" | grep -E \
+                '^(\.github/workflows/arc-runner-build-push\.yml|\.github/workflows/nix-oci-build-common\.yml|flake\.nix|flake\.lock|nix/images/arc-runner\.nix|nix/packages\.nix|nix/oci-push\.sh|nix/cache-push\.sh)$' || true
+            )"
+            if [[ -n "${arc_image_input_changes}" ]]; then
+              echo "promote=false" >> "${GITHUB_OUTPUT}"
+              echo "Stale ARC runner build ${source_sha}; current main is $(git rev-parse HEAD)." >&2
+              echo "ARC runner image inputs changed after the build:" >&2
+              printf '%s\n' "${arc_image_input_changes}" >&2
+              exit 0
+            fi
+            echo "ARC runner image inputs unchanged after ${source_sha}; promoting existing digest from current main." >&2
           fi
 
           {

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -128,6 +128,23 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerReleaseWorkflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
     expect(arcRunnerReleaseWorkflow).toContain("require-preinstalled: 'true'")
     expect(arcRunnerReleaseWorkflow).toContain('crane digest "${image}:${tag}"')
+    expect(arcRunnerReleaseWorkflow).toContain('changed_paths="$(git diff --name-only "${source_sha}..HEAD")"')
+    expect(arcRunnerReleaseWorkflow).toContain('arc_image_input_changes="$(')
+    expect(arcRunnerReleaseWorkflow).toContain('ARC runner image inputs changed after the build:')
+    expect(arcRunnerReleaseWorkflow).toContain('ARC runner image inputs unchanged after ${source_sha}')
+    for (const arcImageInput of [
+      '\\.github/workflows/arc-runner-build-push\\.yml',
+      '\\.github/workflows/nix-oci-build-common\\.yml',
+      'flake\\.nix',
+      'flake\\.lock',
+      'nix/images/arc-runner\\.nix',
+      'nix/packages\\.nix',
+      'nix/oci-push\\.sh',
+      'nix/cache-push\\.sh',
+    ]) {
+      expect(arcRunnerReleaseWorkflow).toContain(arcImageInput)
+    }
+    expect(arcRunnerReleaseWorkflow).not.toContain('\\.github/workflows/arc-runner-release\\.yml')
     expect(arcRunnerReleaseWorkflow).toContain('nix run .#assert-oci-platforms')
     expect(arcRunnerReleaseWorkflow).not.toContain('docker buildx')
     expect(arcRunnerReleaseWorkflow).not.toContain('docker/setup-buildx-action')


### PR DESCRIPTION
## Summary

- Allow ARC runner release promotion to reuse an already-built image when later `main` commits changed only unrelated files.
- Keep the release guard fail-closed when ARC runner image inputs changed after the build.
- Add a contract test covering the allowed/blocked stale-build paths.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
