### PR TITLE
fix(arc): restore previous runner image digest

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -53,7 +53,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:107cc79380317e577118aa220bf55d8cdc171ee209fefc270d791d3ce55d2aba
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -64,7 +64,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:107cc79380317e577118aa220bf55d8cdc171ee209fefc270d791d3ce55d2aba
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |
@@ -174,7 +174,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:107cc79380317e577118aa220bf55d8cdc171ee209fefc270d791d3ce55d2aba
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -185,7 +185,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:107cc79380317e577118aa220bf55d8cdc171ee209fefc270d791d3ce55d2aba
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |
@@ -298,7 +298,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:107cc79380317e577118aa220bf55d8cdc171ee209fefc270d791d3ce55d2aba
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -309,7 +309,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:107cc79380317e577118aa220bf55d8cdc171ee209fefc270d791d3ce55d2aba
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |


### PR DESCRIPTION
## Summary

- Restore ARC runner, init, and analysis runner image pins to the last known-good digest.
- Unblock ARC runner creation after the Nix-built runner image failed in `init-dind-externals`.
- Keep this restore isolated from the forward Nix image fix.

## Related Issues

None

## Testing

- `rg -n 'arc-runner@sha256' argocd/applications/arc/application.yaml`
- `git diff --check`
- Live readback before restore showed new Nix image pods failing in `init-dind-externals` and ARC runners stuck pending.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
