### PR TITLE
fix(arc): restore stable runner image digest

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -53,7 +53,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:9a86a6ba8d9ce4aa03ede3fc8b5b7bb9559d3b79d1ee4b0520b75e0c7961d726
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -64,7 +64,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:9a86a6ba8d9ce4aa03ede3fc8b5b7bb9559d3b79d1ee4b0520b75e0c7961d726
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |
@@ -174,7 +174,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:9a86a6ba8d9ce4aa03ede3fc8b5b7bb9559d3b79d1ee4b0520b75e0c7961d726
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -185,7 +185,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:9a86a6ba8d9ce4aa03ede3fc8b5b7bb9559d3b79d1ee4b0520b75e0c7961d726
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |
@@ -298,7 +298,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:9a86a6ba8d9ce4aa03ede3fc8b5b7bb9559d3b79d1ee4b0520b75e0c7961d726
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -309,7 +309,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:9a86a6ba8d9ce4aa03ede3fc8b5b7bb9559d3b79d1ee4b0520b75e0c7961d726
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:4a5d57be68379792aee41ec2bf11048e2f0c4f732dfc7cbcc3d44bebdd9b47a4
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |


### PR DESCRIPTION
## Summary

- Restore ARC runner init and runner images to the last known-good digest after the Nix-built digest failed init copy.
- Keep the change limited to the ARC GitOps Application image pin.
- Leave the forward Nix image fix for a separate PR so runner capacity recovers first.

## Related Issues

None

## Testing

- `git diff --check`
- `rg -n "arc-runner@sha256" argocd/applications/arc/application.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
