### PR TITLE
ci(nix): migrate jangar image build

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -4,151 +4,70 @@ permissions:
   contents: read
 
 on:
+  pull_request:
+    paths:
+      - 'services/jangar/**'
+      - 'services/bumba/**'
+      - 'packages/agent-contracts/**'
+      - 'packages/codex/**'
+      - 'packages/cx-tools/**'
+      - 'packages/design/**'
+      - 'packages/discord/**'
+      - 'packages/otel/**'
+      - 'packages/temporal-bun-sdk/**'
+      - 'bun.lock'
+      - 'tsconfig.base.json'
+      - 'flake.lock'
+      - 'nix/images/jangar.nix'
+      - 'nix/images/openai-codex-cli.nix'
+      - 'nix/images/bun-workspace-service.nix'
+      - 'nix/packages.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
   push:
     branches:
       - main
     paths:
       - 'services/jangar/**'
-      - 'packages/scripts/src/jangar/build-image.ts'
-      - 'packages/scripts/src/shared/cli.ts'
-      - 'packages/scripts/src/shared/docker.ts'
-      - 'packages/scripts/src/shared/git.ts'
+      - 'services/bumba/**'
       - 'packages/agent-contracts/**'
       - 'packages/codex/**'
       - 'packages/cx-tools/**'
+      - 'packages/design/**'
+      - 'packages/discord/**'
       - 'packages/otel/**'
       - 'packages/temporal-bun-sdk/**'
-      - 'skills/**'
       - 'bun.lock'
+      - 'tsconfig.base.json'
+      - 'flake.lock'
+      - 'nix/images/jangar.nix'
+      - 'nix/images/openai-codex-cli.nix'
+      - 'nix/images/bun-workspace-service.nix'
+      - 'nix/packages.nix'
+      - 'nix/cache-push.sh'
+      - 'nix/ci-nix-oci-summary.sh'
+      - 'nix/ci-run-timed.sh'
+      - 'nix/oci-inspect-archive.sh'
+      - 'nix/oci-push.sh'
+      - 'nix/oci-release-contract.sh'
   workflow_dispatch:
 
 concurrency:
-  group: jangar-build-${{ github.ref }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: arc-arm64
-    timeout-minutes: 60
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          cache-binary: false
-
-      - name: Resolve image tag
-        id: meta
-        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts --filter @proompteng/jangar
-
-      - name: Prepare pruned build context
-        id: prune
-        shell: bash
-        run: |
-          set -euo pipefail
-          PRUNE_DIR="$(mktemp -d)"
-          bunx turbo prune --scope=@proompteng/jangar --docker --out-dir="$PRUNE_DIR"
-          cp tsconfig.base.json "$PRUNE_DIR/tsconfig.base.json"
-          if [ -d skills ]; then
-            cp -R skills "$PRUNE_DIR/skills"
-          fi
-          if [ -d packages/cx-tools ]; then
-            mkdir -p "$PRUNE_DIR/full/packages" "$PRUNE_DIR/json/packages"
-            cp -R packages/cx-tools "$PRUNE_DIR/full/packages/cx-tools"
-            cp -R packages/cx-tools "$PRUNE_DIR/json/packages/cx-tools"
-          fi
-          echo "context=$PRUNE_DIR" >> "$GITHUB_OUTPUT"
-
-      - name: Prebuild jangar output (pruned context)
-        if: ${{ vars.JANGAR_PREBUILD_ENABLED == 'true' }}
-        continue-on-error: true
-        shell: bash
-        env:
-          NODE_OPTIONS: --max-old-space-size=4096
-          CI: 'true'
-          JANGAR_BUILD_MINIFY: '0'
-          JANGAR_BUILD_SOURCEMAP: '0'
-        run: |
-          set -euo pipefail
-          PRUNE_DIR="${{ steps.prune.outputs.context }}"
-          # turbo prune --docker emits package manifests into full/json (not the prune root).
-          if [ -f "$PRUNE_DIR/bun.lock" ]; then
-            cp "$PRUNE_DIR/bun.lock" "$PRUNE_DIR/full/bun.lock"
-          fi
-          if [ -f "$PRUNE_DIR/tsconfig.base.json" ]; then
-            cp "$PRUNE_DIR/tsconfig.base.json" "$PRUNE_DIR/full/tsconfig.base.json"
-          fi
-          bun install --cwd "$PRUNE_DIR/full" --ignore-scripts --filter @proompteng/otel --filter @proompteng/temporal-bun-sdk --filter @proompteng/jangar
-          bun run --cwd "$PRUNE_DIR/full" --filter @proompteng/otel build
-          bun run --cwd "$PRUNE_DIR/full" --filter @proompteng/temporal-bun-sdk build
-          if ! timeout 8m bun --cwd "$PRUNE_DIR/full/services/jangar" run build; then
-            echo "Prebuild failed or timed out; continuing with Docker image build."
-          fi
-
-      - name: Build and push jangar image
-        env:
-          JANGAR_BUILD_CONTEXT: ${{ steps.prune.outputs.context }}
-          JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
-          JANGAR_IMAGE_PLATFORMS: linux/arm64
-          JANGAR_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/jangar:buildcache
-          JANGAR_BUILD_CACHE_MODE: max
-          JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
-          JANGAR_BUILD_SOURCEMAP: '0'
-          JANGAR_BUILD_CI: 'true'
-          JANGAR_BUILD_LOG_LEVEL: warn
-          DOCKER_BUILD_PROVENANCE: max
-          DOCKER_BUILD_SBOM: 'true'
-        run: bun run packages/scripts/src/jangar/build-image.ts
-
-      - name: Resolve pushed image digest
-        id: digest
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE="registry.ide-newton.ts.net/lab/jangar"
-          TAG="${{ steps.meta.outputs.tag }}"
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
-          if [ -z "${DIGEST}" ]; then
-            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
-            exit 1
-          fi
-          echo "${DIGEST}" > jangar-image-digest.txt
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-      - name: Write release contract artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          bun run packages/scripts/src/jangar/release-contract.ts write \
-            --path jangar-release-contract.json \
-            --source-sha "${GITHUB_SHA}" \
-            --tag "${{ steps.meta.outputs.tag }}" \
-            --digest "${{ steps.digest.outputs.digest }}" \
-            --image "registry.ide-newton.ts.net/lab/jangar"
-
-      - name: Upload release contract artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: jangar-release-contract
-          path: jangar-release-contract.json
-          if-no-files-found: error
-          retention-days: 3
-
-      - name: Update latest tag
-        run: |
-          set -euo pipefail
-          IMAGE="registry.ide-newton.ts.net/lab/jangar"
-          TAG="${{ steps.meta.outputs.tag }}"
-          docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${TAG}"
-          docker buildx imagetools inspect "${IMAGE}:${TAG}"
-          docker buildx imagetools inspect "${IMAGE}:latest"
+  nix-image:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: jangar
+      package_attr: jangar-image
+      tag: sha-${{ github.sha }}
+      latest: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
+      release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'jangar-release-contract' || '' }}
+    secrets: inherit

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -44,17 +44,21 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Set up Nix toolchain
+        uses: ./.github/actions/setup-nix-toolchain
         with:
-          bun-version: 1.3.14
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-preinstalled: 'true'
+          install-ci-toolchain: 'true'
+          extra-nix-config: |
+            experimental-features = nix-command flakes
+            substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
+            extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
+            fallback = true
 
       - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: jangar-release-contract
           path: .artifacts/jangar
@@ -102,15 +106,7 @@ jobs:
           elif [ -n "${CONTRACT_DIGEST}" ]; then
             DIGEST="${CONTRACT_DIGEST}"
           else
-            DIGEST="$(
-              bun --eval "
-                import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
-                const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
-                const repoDigest = inspectImageDigest(image)
-                const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
-                console.log(digest)
-              "
-            )"
+            DIGEST="$(crane digest "${IMAGE_NAME}:${IMAGE_TAG}")"
           fi
 
           DIGEST="${DIGEST#*@}"
@@ -120,6 +116,20 @@ jobs:
           fi
 
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify image digest and platforms
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if ! [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Invalid Jangar digest: ${DIGEST}" >&2
+            exit 2
+          fi
+          nix run .#assert-oci-platforms -- "${IMAGE}@${DIGEST}" linux/amd64 linux/arm64
 
       - name: Update Jangar manifests
         if: steps.meta.outputs.promote == 'true'

--- a/flake.nix
+++ b/flake.nix
@@ -263,6 +263,17 @@
               repoRoot = ./.;
               bun = exact.bun;
             };
+            "jangar-image" = import ./nix/images/jangar.nix {
+              inherit
+                pkgs
+                lib
+                nodejs
+                exact
+                repoRevision
+                ;
+              repoRoot = ./.;
+              bun = exact.bun;
+            };
             "torghut-image" = import ./nix/images/torghut.nix {
               inherit pkgs lib;
               repoRoot = ./.;

--- a/nix/images/jangar.nix
+++ b/nix/images/jangar.nix
@@ -1,0 +1,174 @@
+{
+  pkgs,
+  lib,
+  repoRoot,
+  bun,
+  nodejs,
+  exact,
+  repoRevision ? "dirty",
+}:
+
+let
+  codexCli = import ./openai-codex-cli.nix { inherit pkgs; };
+  kubectl = exact.kubectl or pkgs.kubectl;
+
+  scriptWrapper =
+    name: target:
+    pkgs.writeShellScriptBin name ''
+      exec ${bun}/bin/bun ${target} "$@"
+    '';
+
+  cxTools = [
+    (scriptWrapper "codex-nats-publish" "/app/packages/cx-tools/dist/codex-nats-publish.js")
+    (scriptWrapper "codex-nats-soak" "/app/packages/cx-tools/dist/codex-nats-soak.js")
+    (scriptWrapper "cx-codex-run" "/app/packages/cx-tools/dist/cx-codex-run.js")
+    (scriptWrapper "cx-workflow-cancel" "/app/packages/cx-tools/dist/cx-workflow-cancel.js")
+    (scriptWrapper "cx-workflow-query" "/app/packages/cx-tools/dist/cx-workflow-query.js")
+    (scriptWrapper "cx-workflow-signal" "/app/packages/cx-tools/dist/cx-workflow-signal.js")
+    (scriptWrapper "cx-workflow-start" "/app/packages/cx-tools/dist/cx-workflow-start.js")
+  ];
+
+  entrypoint = pkgs.writeShellScriptBin "jangar-entrypoint" ''
+    set -euo pipefail
+
+    mkdir -p "''${VSCODE_DATA_DIR:-/workspace/.ovscode}" "''${VSCODE_DEFAULT_FOLDER:-/workspace/lab}"
+
+    if command -v openvscode-server >/dev/null 2>&1; then
+      openvscode-server \
+        --host 0.0.0.0 \
+        --port "''${VSCODE_PORT:-8081}" \
+        --disable-telemetry \
+        --without-connection-token \
+        --user-data-dir "''${VSCODE_DATA_DIR:-/workspace/.ovscode}" \
+        --extensions-dir "''${VSCODE_DATA_DIR:-/workspace/.ovscode}/extensions" \
+        --default-folder "''${VSCODE_DEFAULT_FOLDER:-/workspace/lab}" &
+      vscode_pid="$!"
+      trap 'kill "$vscode_pid" 2>/dev/null || true' EXIT
+    fi
+
+    cd /app/services/jangar
+    exec ${bun}/bin/bun run .output/server/index.mjs
+  '';
+in
+import ./bun-workspace-service.nix {
+  inherit pkgs lib repoRoot bun nodejs;
+  serviceName = "jangar";
+  packageName = "@proompteng/jangar";
+  depsHash = {
+    x86_64-linux = "sha256-qT9oNXW4rDnQD/YVGb6oKK0cfbSzMFUuWdFEnM8P1sM=";
+    aarch64-linux = "sha256-tCsbYTGtLtJfKYC3sULqwYj4AOGYmf9lyGt2cDcAeqk=";
+  };
+  dependencyClosure = "bunCache";
+  installFilters = [
+    "@proompteng/agent-contracts"
+    "@proompteng/bumba"
+    "@proompteng/codex"
+    "@proompteng/cx-tools"
+    "@proompteng/design"
+    "@proompteng/discord"
+    "@proompteng/jangar"
+    "@proompteng/otel"
+    "@proompteng/temporal-bun-sdk"
+  ];
+  sourcePaths = [
+    "packages/agent-contracts"
+    "packages/codex"
+    "packages/cx-tools"
+    "packages/design"
+    "packages/discord"
+    "packages/otel"
+    "packages/temporal-bun-sdk"
+    "services/bumba"
+    "services/jangar"
+  ];
+  buildCommands = [
+    "patchShebangs --build node_modules"
+    "bun --cwd=packages/agent-contracts run build"
+    "bun --cwd=packages/codex run build"
+    "bun --cwd=packages/otel run build"
+    "bun --cwd=packages/temporal-bun-sdk run build"
+    "bun --cwd=packages/cx-tools run build"
+    "NODE_OPTIONS=--max-old-space-size=4096 CI=true JANGAR_BUILD_MINIFY=0 JANGAR_BUILD_SOURCEMAP=0 JANGAR_BUILD_LOG_LEVEL=warn bun --cwd=services/jangar run build"
+  ];
+  runtimeInstallPhase = ''
+    mkdir -p "$out/app/packages" "$out/app/services/jangar"
+
+    cp -R "$TMPDIR/work/node_modules" "$out/app/node_modules"
+
+    for package in agent-contracts codex cx-tools otel temporal-bun-sdk; do
+      cp -R "$TMPDIR/work/packages/$package" "$out/app/packages/$package"
+    done
+
+    cp "$TMPDIR/work/services/jangar/package.json" "$out/app/services/jangar/package.json"
+    cp -R "$TMPDIR/work/services/jangar/.output" "$out/app/services/jangar/.output"
+    mkdir -p "$out/app/services/jangar/src"
+    cp -R "$TMPDIR/work/services/jangar/src/worker.ts" "$out/app/services/jangar/src/worker.ts"
+    mkdir -p "$out/app/services/jangar/src/server"
+    cp -R "$TMPDIR/work/services/jangar/src/server/runtime-entry-config.ts" "$out/app/services/jangar/src/server/runtime-entry-config.ts"
+    cp -R "$TMPDIR/work/services/jangar/src/server/runtime-tooling-config.ts" "$out/app/services/jangar/src/server/runtime-tooling-config.ts"
+
+    cp -R "$TMPDIR/work/services/bumba" "$out/app/services/bumba"
+    rm -rf "$out/app/services/bumba/node_modules"
+    ln -s /app/node_modules "$out/app/services/bumba/node_modules"
+
+    chmod +x "$out/app/packages/cx-tools/dist/"*.js
+  '';
+  command = [
+    "${pkgs.tini}/bin/tini"
+    "--"
+    "${entrypoint}/bin/jangar-entrypoint"
+  ];
+  workingDir = "/app/services/jangar";
+  env = [
+    "PORT=8080"
+    "UI_PORT=8080"
+    "WORKER_PORT=8070"
+    "VSCODE_PORT=8081"
+    "VSCODE_DATA_DIR=/workspace/.ovscode"
+    "VSCODE_DEFAULT_FOLDER=/workspace/lab"
+    "CODEX_CWD=/workspace/lab"
+    "CODEX_REPO_SLUG=proompteng/lab"
+    "CODEX_REPO_URL=https://github.com/proompteng/lab.git"
+    "CODEX_BOOTSTRAP_REPO=1"
+    "JANGAR_VERSION=${repoRevision}"
+    "JANGAR_COMMIT=${repoRevision}"
+    "JAVA_HOME=${pkgs.jdk25_headless}"
+    "GRADLE_HOME=${pkgs.gradle_9}"
+    "GOROOT=${pkgs.go}/share/go"
+  ];
+  extraContents = [
+    codexCli
+    entrypoint
+    kubectl
+    nodejs
+    pkgs.bash
+    pkgs.curl
+    pkgs.docker-buildx
+    pkgs.docker-client
+    pkgs.gh
+    pkgs.git
+    pkgs.go
+    pkgs.gradle_9
+    pkgs.jdk25_headless
+    pkgs.jq
+    pkgs.kn
+    pkgs.kubectl-cnpg
+    pkgs.natscli
+    pkgs.neovim
+    pkgs.openssh
+    pkgs.openvscode-server
+    pkgs.python3
+    pkgs.ripgrep
+    pkgs.tmux
+    pkgs.tini
+    pkgs.unzip
+    pkgs.uv
+    pkgs.zoxide
+  ] ++ cxTools;
+  exposedPorts = {
+    "8070/tcp" = { };
+    "8080/tcp" = { };
+    "8081/tcp" = { };
+  };
+  maxLayers = 32;
+}

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "symphony:deploy": "bun run packages/scripts/src/symphony/deploy-service.ts",
     "bumba:enrich-file": "bun run packages/scripts/src/bumba/enrich-file.ts",
     "jangar:cleanup-worktrees": "bun run packages/scripts/src/jangar/cleanup-worktrees.ts",
+    "jangar:deploy": "bun run packages/scripts/src/jangar/deploy-service.ts",
     "flamingo:benchmark": "bun run scripts/jangar/benchmark-flamingo-vllm.ts",
     "flink:build": "bun run packages/scripts/src/dorvud/build-and-push.ts",
     "smoke:torghut-ws": "bun run packages/scripts/src/torghut/ws-smoke.ts",

--- a/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
+++ b/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
@@ -78,7 +78,7 @@ describe('resolve-release-metadata', () => {
     expect(dddToBfDocsOnlyFiles.some((filePath) => __private.isBuildTriggerPath(filePath))).toBe(false)
   })
 
-  it('does not block Jangar promotion for Agents Codex runtime-only package changes', () => {
+  it('blocks Jangar promotion when newer main has Codex package image inputs', () => {
     const decision = __private.evaluateWorkflowRunStaleness({
       sourceSha: ddd07d2f,
       mainHead: bf889391,
@@ -91,8 +91,8 @@ describe('resolve-release-metadata', () => {
     })
 
     expect(decision).toEqual({
-      promote: true,
-      reason: 'newer-main-non-jangar-only',
+      promote: false,
+      reason: 'newer-main-has-jangar-changes',
     })
   })
 

--- a/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
@@ -123,6 +123,22 @@ describe('updateJangarManifests', () => {
     rmSync(fixture.dir, { recursive: true, force: true })
   })
 
+  it('requires an explicit image digest', () => {
+    const fixture = createFixture()
+
+    expect(() =>
+      updateJangarManifests({
+        imageName,
+        tag: 'missing-digest',
+        rolloutTimestamp: '2026-02-20T06:46:00.000Z',
+        kustomizationPath: relative(repoRoot, fixture.kustomizationPath),
+        serviceManifestPath: relative(repoRoot, fixture.serviceManifestPath),
+      }),
+    ).toThrow('explicit image digest')
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+
   it('updates source rollout truth env when revision metadata is provided', () => {
     const fixture = createFixture()
     const sourceHeadSha = '9e7b87d813d9732d44586e213d9f47ec178f705a'

--- a/packages/scripts/src/jangar/build-image.ts
+++ b/packages/scripts/src/jangar/build-image.ts
@@ -1,12 +1,7 @@
 #!/usr/bin/env bun
 
-import { copyFileSync, cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { resolve } from 'node:path'
-
-import { ensureCli, repoRoot, run } from '../shared/cli'
-import { buildAndPushDockerImage, type DockerCacheMode } from '../shared/docker'
 import { execGit } from '../shared/git'
+import { buildAndPushNixImage } from '../shared/nix-oci-deploy'
 
 export type BuildImageOptions = {
   registry?: string
@@ -20,160 +15,76 @@ export type BuildImageOptions = {
   codexAuthPath?: string
   cacheRef?: string
   platforms?: string[]
-  cacheMode?: DockerCacheMode
+  cacheMode?: string
+  dryRun?: boolean
 }
 
-const parsePlatforms = (value: string | undefined): string[] | undefined => {
-  if (!value) return undefined
-  const platforms = value
-    .split(',')
-    .map((platform) => platform.trim())
-    .filter(Boolean)
+const dockerOnlyEnvNames = [
+  'JANGAR_BUILD_CONTEXT',
+  'JANGAR_DOCKERFILE',
+  'JANGAR_DOCKER_TARGET',
+  'JANGAR_BUILD_CACHE_REF',
+  'JANGAR_BUILD_CACHE_MODE',
+  'JANGAR_IMAGE_PLATFORMS',
+  'DOCKER_IMAGE_PLATFORMS',
+  'DOCKER_BUILD_PROVENANCE',
+  'DOCKER_BUILD_SBOM',
+]
 
-  return platforms.length > 0 ? platforms : undefined
-}
+const rejectDockerOnlyOptions = (options: BuildImageOptions) => {
+  const optionNames = [
+    ['context', options.context],
+    ['dockerfile', options.dockerfile],
+    ['target', options.target],
+    ['codexAuthPath', options.codexAuthPath],
+    ['cacheRef', options.cacheRef],
+    ['platforms', options.platforms],
+    ['cacheMode', options.cacheMode],
+  ] as const
 
-const parseCacheMode = (value: string | undefined): DockerCacheMode | undefined => {
-  if (!value) return undefined
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'min') return 'min'
-  if (normalized === 'max') return 'max'
-  return undefined
-}
-
-const createPrunedContext = async (): Promise<{ dir: string; cleanup: () => void }> => {
-  ensureCli('bunx')
-
-  const dir = mkdtempSync(resolve(tmpdir(), 'jangar-prune-'))
-  const cleanup = () => rmSync(dir, { recursive: true, force: true })
-
-  try {
-    await run('bunx', ['turbo', 'prune', '--scope=@proompteng/jangar', '--docker', `--out-dir=${dir}`], {
-      cwd: repoRoot,
-    })
-
-    // `turbo prune --docker` doesn't currently include this file, but our TS configs extend it.
-    copyFileSync(resolve(repoRoot, 'tsconfig.base.json'), resolve(dir, 'tsconfig.base.json'))
-    const skillsSource = resolve(repoRoot, 'skills')
-    if (existsSync(skillsSource)) {
-      cpSync(skillsSource, resolve(dir, 'skills'), { recursive: true })
-    }
-    const cxToolsSource = resolve(repoRoot, 'packages/cx-tools')
-    if (existsSync(cxToolsSource)) {
-      cpSync(cxToolsSource, resolve(dir, 'full/packages/cx-tools'), { recursive: true })
-      cpSync(cxToolsSource, resolve(dir, 'json/packages/cx-tools'), { recursive: true })
-    }
-    // By default we do NOT copy a locally-built `.output` into the Docker build context.
-    // Copying `.output` can silently ship stale server bundles if the local build was done on a different commit.
-    // If you really need the faster path, opt in explicitly.
-    if (process.env.JANGAR_USE_PREBUILT_OUTPUT?.trim().toLowerCase() === 'true') {
-      const outputSource = resolve(repoRoot, 'services/jangar/.output')
-      const outputEntry = resolve(outputSource, 'server/index.mjs')
-      if (existsSync(outputEntry)) {
-        cpSync(outputSource, resolve(dir, 'full/services/jangar/.output'), { recursive: true })
-      } else if (existsSync(outputSource)) {
-        console.warn('Skipping prebuilt .output: missing services/jangar/.output/server/index.mjs')
-      }
-    }
-    return { dir, cleanup }
-  } catch (error) {
-    cleanup()
-    throw error
+  const providedOptions = optionNames.filter(([, value]) => value !== undefined).map(([name]) => name)
+  const providedEnv = dockerOnlyEnvNames.filter((name) => process.env[name]?.trim())
+  if (providedOptions.length > 0 || providedEnv.length > 0) {
+    throw new Error(
+      `Jangar image builds are Nix OCI only; remove Docker-only inputs: ${[...providedOptions, ...providedEnv].join(', ')}`,
+    )
   }
 }
 
 export const buildImage = async (options: BuildImageOptions = {}) => {
+  rejectDockerOnlyOptions(options)
+
   const registry = options.registry ?? process.env.JANGAR_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = options.repository ?? process.env.JANGAR_IMAGE_REPOSITORY ?? 'lab/jangar'
   const tag = options.tag ?? process.env.JANGAR_IMAGE_TAG ?? execGit(['rev-parse', '--short', 'HEAD'])
-  const usePrune = options.context === undefined && process.env.JANGAR_BUILD_CONTEXT === undefined
-
-  const dockerfile = resolve(
-    repoRoot,
-    options.dockerfile ?? process.env.JANGAR_DOCKERFILE ?? 'services/jangar/Dockerfile',
-  )
-  const target = options.target ?? process.env.JANGAR_DOCKER_TARGET ?? undefined
-  const version = options.version ?? process.env.JANGAR_VERSION ?? tag
   const commit = options.commit ?? process.env.JANGAR_COMMIT ?? execGit(['rev-parse', 'HEAD'])
-  const codexAuthPath =
-    options.codexAuthPath ?? process.env.CODEX_AUTH_PATH ?? resolve(process.env.HOME ?? '', '.codex/auth.json')
-  const cacheRef = options.cacheRef ?? process.env.JANGAR_BUILD_CACHE_REF ?? `${registry}/${repository}:buildcache`
-  const cacheMode = options.cacheMode ?? parseCacheMode(process.env.JANGAR_BUILD_CACHE_MODE)
-  const platforms =
-    options.platforms ??
-    parsePlatforms(process.env.JANGAR_IMAGE_PLATFORMS) ??
-    parsePlatforms(process.env.DOCKER_IMAGE_PLATFORMS)
+  const version = options.version ?? process.env.JANGAR_VERSION ?? tag
 
-  let context: string
-  let pruneCleanup: (() => void) | undefined
+  const result = await buildAndPushNixImage({
+    service: 'jangar',
+    imageName: 'jangar',
+    packageAttr: 'jangar-image',
+    registry,
+    repository,
+    tag,
+    sourceSha: commit,
+    latestTag: 'latest',
+    dryRun: options.dryRun,
+  })
 
-  try {
-    if (usePrune) {
-      const pruned = await createPrunedContext()
-      context = pruned.dir
-      pruneCleanup = pruned.cleanup
-    } else {
-      context = resolve(repoRoot, options.context ?? process.env.JANGAR_BUILD_CONTEXT ?? '.')
-    }
-
-    const codexAuthPathForDocker = existsSync(codexAuthPath) ? codexAuthPath : undefined
-    if (!codexAuthPathForDocker) {
-      console.warn(`Codex auth not found at ${codexAuthPath}; build will proceed without it.`)
-    }
-
-    const buildArgs: Record<string, string> = {
-      JANGAR_VERSION: version,
-      JANGAR_COMMIT: commit,
-    }
-    const buildNodeOptions = process.env.JANGAR_BUILD_NODE_OPTIONS?.trim()
-    if (buildNodeOptions) {
-      buildArgs.JANGAR_BUILD_NODE_OPTIONS = buildNodeOptions
-    }
-    const buildMinify = process.env.JANGAR_BUILD_MINIFY?.trim()
-    if (buildMinify) {
-      buildArgs.JANGAR_BUILD_MINIFY = buildMinify
-    }
-    const buildSourceMap = process.env.JANGAR_BUILD_SOURCEMAP?.trim()
-    if (buildSourceMap) {
-      buildArgs.JANGAR_BUILD_SOURCEMAP = buildSourceMap
-    }
-    const buildCi = process.env.JANGAR_BUILD_CI?.trim()
-    if (buildCi) {
-      buildArgs.JANGAR_BUILD_CI = buildCi
-    }
-    const buildLogLevel = process.env.JANGAR_BUILD_LOG_LEVEL?.trim()
-    if (buildLogLevel) {
-      buildArgs.JANGAR_BUILD_LOG_LEVEL = buildLogLevel
-    }
-    if (process.env.BUILDX_VERSION) {
-      buildArgs.BUILDX_VERSION = process.env.BUILDX_VERSION
-    }
-
-    const result = await buildAndPushDockerImage({
-      registry,
-      repository,
-      tag,
-      context,
-      dockerfile,
-      target,
-      buildArgs,
-      codexAuthPath: codexAuthPathForDocker,
-      cacheRef,
-      cacheMode,
-      platforms,
-    })
-
-    return { ...result, version, commit }
-  } finally {
-    pruneCleanup?.()
-  }
+  return { image: `${registry}/${repository}:${tag}`, digest: result.reference, version, commit }
 }
 
 if (import.meta.main) {
-  buildImage().catch((error) => {
+  const args = process.argv.slice(2)
+  const cliTag = args[0]?.trim() && !args[0]?.startsWith('-') ? args[0] : undefined
+  buildImage({ tag: cliTag, dryRun: args.includes('--dry-run') }).catch((error) => {
     console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
   })
 }
 
-export const __private = { execGit }
+export const __private = {
+  execGit,
+  rejectDockerOnlyOptions,
+}

--- a/packages/scripts/src/jangar/deploy-service.ts
+++ b/packages/scripts/src/jangar/deploy-service.ts
@@ -6,7 +6,6 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
 import { buildImage } from './build-image'
 import { updateJangarManifests } from './update-manifests'
@@ -163,6 +162,10 @@ const resolveDeploymentNames = () => {
 }
 
 export const main = async (options: DeployOptions = {}) => {
+  const args = new Set(process.argv.slice(2))
+  const dryRun = args.has('--dry-run')
+  const noApply = dryRun || args.has('--no-apply')
+
   ensureCli('kubectl')
   ensureCli('curl')
   ensureCli('tar')
@@ -172,13 +175,15 @@ export const main = async (options: DeployOptions = {}) => {
   const sourceHeadSha = execGit(['rev-parse', 'HEAD'])
   const tag = options.tag ?? process.env.JANGAR_IMAGE_TAG ?? defaultTag
   const imageName = `${registry}/${repository}`
-  const image = `${registry}/${repository}:${tag}`
 
-  await buildImage({ registry, repository, tag })
+  const imageResult = await buildImage({ registry, repository, tag, dryRun })
+  const digest = imageResult.digest
+  console.log(`Image digest: ${digest}`)
 
-  const repoDigest = inspectImageDigest(image)
-  const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
-  console.log(`Image digest: ${repoDigest}`)
+  if (dryRun) {
+    console.log('Dry run complete; manifests and cluster state were not changed.')
+    return
+  }
 
   const kustomizePath = resolve(
     repoRoot,
@@ -203,6 +208,11 @@ export const main = async (options: DeployOptions = {}) => {
     serviceManifestPath: serviceManifest,
     workerManifestPath: workerManifest,
   })
+
+  if (noApply) {
+    console.log('Skipping kubectl apply because --no-apply was requested.')
+    return
+  }
 
   const { helmDir, helmBinary, cleanup } = writeHelmShim()
   const kubectl = Bun.which('kubectl')

--- a/packages/scripts/src/jangar/resolve-release-metadata.ts
+++ b/packages/scripts/src/jangar/resolve-release-metadata.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
 
@@ -8,11 +8,11 @@ import { fatal, repoRoot } from '../shared/cli'
 import { execGit } from '../shared/git'
 import { readReleaseContract } from './release-contract'
 
-const defaultContractPath = '.artifacts/jangar/jangar-release-contract.json'
+const defaultContractPath = '.artifacts/jangar/release-contract.json'
 const defaultImage = 'registry.ide-newton.ts.net/lab/jangar'
 
 const buildTriggerPathRegex =
-  /^(services\/jangar\/|packages\/scripts\/src\/jangar\/|packages\/scripts\/src\/shared\/|packages\/otel\/|packages\/temporal-bun-sdk\/|bun\.lock$)/
+  /^(services\/jangar\/|services\/bumba\/|packages\/(agent-contracts|codex|cx-tools|design|discord|otel|temporal-bun-sdk)\/|nix\/images\/jangar\.nix$|nix\/images\/openai-codex-cli\.nix$|nix\/images\/bun-workspace-service\.nix$|nix\/packages\.nix$|nix\/cache-push\.sh$|nix\/ci-nix-oci-summary\.sh$|nix\/ci-run-timed\.sh$|nix\/oci-inspect-archive\.sh$|nix\/oci-push\.sh$|nix\/oci-release-contract\.sh$|flake\.lock$|bun\.lock$|tsconfig\.base\.json$)/
 
 type CliOptions = {
   eventName?: string
@@ -108,6 +108,19 @@ const commitExists = (sha: string): boolean => {
   return result.exitCode === 0
 }
 
+const assertReleaseContractIdentity = (path: string) => {
+  const parsed = JSON.parse(readFileSync(resolvePath(path), 'utf8')) as {
+    service?: unknown
+    packageAttr?: unknown
+  }
+  if (typeof parsed.service === 'string' && parsed.service !== 'jangar') {
+    throw new Error(`Release contract service mismatch: expected jangar, got ${parsed.service}`)
+  }
+  if (typeof parsed.packageAttr === 'string' && parsed.packageAttr !== 'jangar-image') {
+    throw new Error(`Release contract packageAttr mismatch: expected jangar-image, got ${parsed.packageAttr}`)
+  }
+}
+
 const evaluateWorkflowRunStaleness = (input: WorkflowRunStalenessInput): WorkflowRunStalenessDecision => {
   if (input.sourceSha === input.mainHead) {
     return { promote: true, reason: 'head-current' }
@@ -201,6 +214,7 @@ const resolveReleaseMetadata = (options: ResolveReleaseMetadataOptions): Release
   let reason = 'eligible'
 
   if (eventName === 'workflow_run') {
+    assertReleaseContractIdentity(options.contractPath)
     const contract = readReleaseContract(options.contractPath)
     sourceSha = contract.sourceSha
     tag = contract.tag
@@ -301,6 +315,7 @@ if (import.meta.main) {
 }
 
 export const __private = {
+  assertReleaseContractIdentity,
   buildTriggerPathRegex,
   commitExists,
   evaluateWorkflowRunStaleness,

--- a/packages/scripts/src/jangar/update-manifests.ts
+++ b/packages/scripts/src/jangar/update-manifests.ts
@@ -4,7 +4,6 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { fatal, repoRoot } from '../shared/cli'
-import { inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
 import {
   updateKustomizationImage,
@@ -66,6 +65,14 @@ const normalizeOptional = (value: string | undefined): string | undefined => {
   return trimmed ? trimmed : undefined
 }
 
+const requireDigest = (digest: string | undefined): string => {
+  const normalized = normalizeOptional(digest)
+  if (!normalized) {
+    throw new Error('Jangar manifest updates require an explicit image digest from the release contract')
+  }
+  return normalized
+}
+
 type SourceServingProofEnv = {
   sourceHeadSha?: string
   gitopsRevision?: string
@@ -106,7 +113,7 @@ export const updateJangarManifests = (options: UpdateManifestsOptions) => {
   const kustomizationPath = resolvePath(options.kustomizationPath ?? defaultKustomizationPath)
   const serviceManifestPath = resolvePath(options.serviceManifestPath ?? defaultServiceManifestPath)
   const workerManifestPath = options.workerManifestPath ? resolvePath(options.workerManifestPath) : null
-  const digest = normalizeDigest(options.digest ?? inspectImageDigest(`${options.imageName}:${options.tag}`))
+  const digest = normalizeDigest(requireDigest(options.digest))
   const manifestImageDigest = normalizeOptional(options.manifestImageDigest) ?? digest
   const servingBuildCommit = normalizeOptional(options.servingBuildCommit) ?? normalizeOptional(options.sourceHeadSha)
   const servingImageDigest = normalizeOptional(options.servingImageDigest) ?? digest

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -71,6 +71,7 @@ describe('enabled app inventory', () => {
       'attic',
       'sag',
       'symphony',
+      'jangar',
       'torghut',
       'torghut-hyperliquid-feed',
       'torghut-hyperliquid-runtime',
@@ -94,6 +95,7 @@ describe('enabled app inventory', () => {
     expect(entry('arc').nixImageAttr).toBe('arc-runner-image')
     expect(entry('sag').nixImageAttr).toBe('sag-image')
     expect(entry('symphony').nixImageAttr).toBe('symphony-image')
+    expect(entry('jangar').nixImageAttr).toBe('jangar-image')
     expect(entry('torghut').nixImageAttr).toBe('torghut-image')
     expect(entry('torghut-hyperliquid-feed').nixImageAttr).toBe('torghut-hyperliquid-feed-image')
     expect(entry('torghut-hyperliquid-runtime').nixImageAttr).toBe('torghut-image')
@@ -130,6 +132,16 @@ describe('enabled app inventory', () => {
     expect(entry('froussard').workflowPaths).toContain('.github/workflows/froussard-ci.yml')
   })
 
+  it('tracks Jangar through both GitHub Actions and manual Nix image paths', () => {
+    expect(entry('jangar')).toMatchObject({
+      class: 'nix-image',
+      nixImageAttr: 'jangar-image',
+      buildScriptPath: 'packages/scripts/src/jangar/build-image.ts',
+      deployScriptPath: 'packages/scripts/src/jangar/deploy-service.ts',
+    })
+    expect(entry('jangar').workflowPaths).toContain('.github/workflows/jangar-build-push.yaml')
+  })
+
   it('tracks Torghut-family enabled apps through explicit Nix image ownership paths', () => {
     expect(entry('torghut-hyperliquid-feed')).toMatchObject({
       class: 'nix-image',
@@ -161,7 +173,7 @@ describe('enabled app inventory', () => {
   })
 
   it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
-    for (const name of ['jangar', 'symphony-jangar', 'symphony-torghut']) {
+    for (const name of ['symphony-jangar', 'symphony-torghut']) {
       expect(entry(name).class).toBe('deferred')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
       expect(entry(name).deferredReason).toBeTruthy()

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -30,10 +30,12 @@ const agentsCiWorkflow = readRepoFile('.github/workflows/agents-ci.yml')
 const arcRunnerBuildWorkflow = readRepoFile('.github/workflows/arc-runner-build-push.yml')
 const arcRunnerReleaseWorkflow = readRepoFile('.github/workflows/arc-runner-release.yml')
 const jangarBuildWorkflow = readRepoFile('.github/workflows/jangar-build-push.yaml')
+const jangarReleaseWorkflow = readRepoFile('.github/workflows/jangar-release.yml')
 const symphonyBuildWorkflow = readRepoFile('.github/workflows/symphony-build-push.yaml')
 const symphonyCiWorkflow = readRepoFile('.github/workflows/symphony-ci.yml')
 const symphonyReleaseWorkflow = readRepoFile('.github/workflows/symphony-release.yml')
 const symphonyReleaseMetadataScript = readRepoFile('packages/scripts/src/symphony/resolve-release-metadata.ts')
+const jangarReleaseMetadataScript = readRepoFile('packages/scripts/src/jangar/resolve-release-metadata.ts')
 const sagBuildWorkflow = readRepoFile('.github/workflows/sag-build-push.yaml')
 const sagReleaseWorkflow = readRepoFile('.github/workflows/sag-release.yml')
 const sagPostDeployVerifyWorkflow = readRepoFile('.github/workflows/sag-post-deploy-verify.yml')
@@ -66,6 +68,7 @@ const allNixImageModules = readdirSync(new URL('nix/images/', repoRoot))
   .map((name) => [name, readRepoFile(`nix/images/${name}`)] as const)
 const symphonyImageModule = readRepoFile('nix/images/symphony.nix')
 const sagImageModule = readRepoFile('nix/images/sag.nix')
+const jangarImageModule = readRepoFile('nix/images/jangar.nix')
 const torghutImageModule = readRepoFile('nix/images/torghut.nix')
 const torghutTaImageModule = readRepoFile('nix/images/torghut-ta.nix')
 const torghutWsImageModule = readRepoFile('nix/images/torghut-ws.nix')
@@ -82,6 +85,9 @@ const symphonyBuildScript = readRepoFile('packages/scripts/src/symphony/build-im
 const symphonyDeployScript = readRepoFile('packages/scripts/src/symphony/deploy-service.ts')
 const sagBuildScript = readRepoFile('packages/scripts/src/sag/build-image.ts')
 const sagDeployScript = readRepoFile('packages/scripts/src/sag/deploy-service.ts')
+const jangarBuildScript = readRepoFile('packages/scripts/src/jangar/build-image.ts')
+const jangarDeployScript = readRepoFile('packages/scripts/src/jangar/deploy-service.ts')
+const jangarUpdateScript = readRepoFile('packages/scripts/src/jangar/update-manifests.ts')
 const agentsBuildScript = readRepoFile('packages/scripts/src/agents/build-image.ts')
 const agentsDeployScript = readRepoFile('packages/scripts/src/agents/deploy-service.ts')
 const arcRunnerBuildScript = readRepoFile('packages/scripts/src/arc-runner/build-image.ts')
@@ -512,10 +518,10 @@ describe('native OCI build workflows', () => {
 
     for (const workflow of [jangarBuildWorkflow]) {
       expect(workflow).not.toContain("'packages/scripts/src/jangar/**'")
-      expect(workflow).toContain("'packages/scripts/src/jangar/build-image.ts'")
-      expect(workflow).toContain("'packages/scripts/src/shared/cli.ts'")
-      expect(workflow).toContain("'packages/scripts/src/shared/docker.ts'")
-      expect(workflow).toContain("'packages/scripts/src/shared/git.ts'")
+      expect(workflow).not.toContain("'packages/scripts/src/shared/docker.ts'")
+      expect(workflow).not.toContain("'packages/scripts/src/shared/nix-oci-deploy.ts'")
+      expect(workflow).toContain("'nix/images/jangar.nix'")
+      expect(workflow).toContain("'nix/images/bun-workspace-service.nix'")
     }
     expect(symphonyBuildWorkflow).not.toContain("'packages/scripts/src/symphony/**'")
     expect(symphonyBuildWorkflow).not.toContain("'packages/scripts/src/shared/cli.ts'")
@@ -554,6 +560,13 @@ describe('native OCI build workflows', () => {
     for (const helperInput of nixImageHelperInputs) {
       expect(symphonyReleaseMetadataScript).toContain(helperInput.replaceAll('/', '\\/').replaceAll('.', '\\.'))
     }
+
+    expect(jangarReleaseMetadataScript).not.toContain('.github\\/workflows\\/')
+    expect(jangarReleaseMetadataScript).not.toContain('setup-nix-toolchain')
+    expect(jangarReleaseMetadataScript).toContain('images\\/jangar\\.nix')
+    for (const helperInput of nixImageHelperInputs) {
+      expect(jangarReleaseMetadataScript).toContain(helperInput.replaceAll('/', '\\/').replaceAll('.', '\\.'))
+    }
   })
 
   it('does not fan out migrated image builds on workflow-only changes', () => {
@@ -564,6 +577,7 @@ describe('native OCI build workflows', () => {
       froussardWorkflow,
       productNixWorkflow,
       agentsBuildWorkflow,
+      jangarBuildWorkflow,
       symphonyBuildWorkflow,
       sagBuildWorkflow,
       torghutTaBuildWorkflow,
@@ -594,6 +608,7 @@ describe('native OCI build workflows', () => {
       froussardWorkflow,
       productNixWorkflow,
       agentsBuildWorkflow,
+      jangarBuildWorkflow,
       symphonyBuildWorkflow,
       sagBuildWorkflow,
     ]) {
@@ -614,6 +629,7 @@ describe('native OCI build workflows', () => {
       froussardWorkflow,
       productNixWorkflow,
       agentsBuildWorkflow,
+      jangarBuildWorkflow,
       sagBuildWorkflow,
     ]) {
       expect(workflow).toContain("- 'flake.lock'")
@@ -653,6 +669,8 @@ describe('native OCI build workflows', () => {
       productNixWorkflow,
       enabledProductReleaseWorkflow,
       agentsBuildWorkflow,
+      jangarBuildWorkflow,
+      jangarReleaseWorkflow,
       symphonyBuildWorkflow,
       symphonyReleaseWorkflow,
       sagBuildWorkflow,
@@ -731,6 +749,7 @@ describe('native OCI build workflows', () => {
       [froussardWorkflow, 'froussard-release-contract'],
       [sagBuildWorkflow, 'sag-release-contract'],
       [symphonyBuildWorkflow, 'symphony-release-contract'],
+      [jangarBuildWorkflow, 'jangar-release-contract'],
       [torghutBuildWorkflow, 'torghut-release-contract'],
       [torghutTaBuildWorkflow, 'torghut-ta-release-contract'],
       [torghutWsBuildWorkflow, 'torghut-ws-release-contract'],
@@ -801,6 +820,34 @@ describe('native OCI build workflows', () => {
     expect(sagReleaseWorkflow).not.toContain('docker buildx')
     expect(sagPostDeployVerifyWorkflow).toContain('kubectl -n sag rollout status deployment/sag')
     expect(sagPostDeployVerifyWorkflow).toContain('desired_replicas=')
+  })
+
+  it('routes the enabled Jangar image through a real Nix OCI attr', () => {
+    expect(flake).toContain('"jangar-image"')
+    expect(repoFileExists('nix/images/jangar.nix')).toBe(true)
+    expect(jangarImageModule).toContain('dependencyClosure = "bunCache";')
+    expect(jangarImageModule).toContain('"@proompteng/jangar"')
+    expect(jangarImageModule).toContain('"@proompteng/cx-tools"')
+    expect(jangarImageModule).toContain('import ./openai-codex-cli.nix')
+    expect(jangarImageModule).toContain('openvscode-server')
+    expect(jangarImageModule).toContain('import ./bun-workspace-service.nix')
+    expect(jangarImageModule).not.toContain('created = "now"')
+    expect(jangarImageModule).not.toContain('docker build')
+
+    expect(jangarBuildWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
+    expect(jangarBuildWorkflow).toContain('image_name: jangar')
+    expect(jangarBuildWorkflow).toContain('package_attr: jangar-image')
+    expect(jangarBuildWorkflow).toContain('jangar-release-contract')
+    expect(jangarBuildWorkflow).toContain('tag: sha-${{ github.sha }}')
+    expect(jangarBuildWorkflow).not.toContain('image_build_timeout:')
+    expect(jangarBuildWorkflow).not.toContain('oven-sh/setup-bun')
+    expect(jangarBuildWorkflow).not.toContain('docker/setup-buildx-action')
+
+    expect(jangarReleaseWorkflow).toContain('uses: ./.github/actions/setup-nix-toolchain')
+    expect(jangarReleaseWorkflow).toContain('crane digest "${IMAGE_NAME}:${IMAGE_TAG}"')
+    expect(jangarReleaseWorkflow).toContain('nix run .#assert-oci-platforms -- "${IMAGE}@${DIGEST}"')
+    expect(jangarReleaseWorkflow).not.toContain('docker buildx')
+    expect(jangarReleaseWorkflow).not.toContain('docker/setup-buildx-action')
   })
 
   it('routes the enabled Torghut family images through real Nix OCI attrs', () => {
@@ -984,6 +1031,7 @@ describe('native OCI build workflows', () => {
       froussardBuildScript,
       symphonyBuildScript,
       sagBuildScript,
+      jangarBuildScript,
       agentsBuildScript,
       agentsDeployScript,
       torghutImageBuildersScript,
@@ -1029,6 +1077,14 @@ describe('native OCI build workflows', () => {
     expect(sagDeployScript).toContain('dryRun')
     expect(sagDeployScript).toContain('noApply')
     expect(sagDeployScript).toContain('digest:')
+    expect(jangarDeployScript).not.toContain("from '../shared/docker'")
+    expect(jangarDeployScript).not.toContain('inspectImageDigest')
+    expect(jangarDeployScript).toContain('dryRun')
+    expect(jangarDeployScript).toContain('noApply')
+    expect(jangarDeployScript).toContain('digest:')
+    expect(jangarUpdateScript).not.toContain("from '../shared/docker'")
+    expect(jangarUpdateScript).not.toContain('inspectImageDigest')
+    expect(jangarUpdateScript).toContain('requireDigest')
     expect(agentsDeployScript).not.toContain("from '../shared/docker'")
     expect(agentsDeployScript).not.toContain('inspectImageDigest')
     expect(agentsDeployScript).toContain("from '../shared/nix-oci-deploy'")

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -45,6 +45,7 @@ const earlyNixImageApps = new Set([
   'bumba',
   'docs',
   'froussard',
+  'jangar',
   'oirat',
   'olden',
   'proompteng',
@@ -58,7 +59,6 @@ const earlyNixImageApps = new Set([
 ])
 
 const deferredApps = new Map<string, string>([
-  ['jangar', 'complex service plus OpenWebUI chart; requires a dedicated derivation and rollout proof'],
   ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
   ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
   ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
@@ -71,6 +71,7 @@ const appToNixAttr = new Map<string, string>([
   ['bumba', 'bumba-image'],
   ['docs', 'docs-image'],
   ['froussard', 'froussard-image'],
+  ['jangar', 'jangar-image'],
   ['oirat', 'oirat-image'],
   ['olden', 'olden-image'],
   ['proompteng', 'proompteng-image'],


### PR DESCRIPTION
## Summary

- Migrates the enabled Jangar image build from Docker Buildx to the shared real Nix OCI workflow and `.#jangar-image`.
- Adds the Jangar Nix image derivation, fixed Bun dependency closure hashes for amd64/arm64, and digest release contract checks.
- Moves `bun run jangar:deploy` onto the shared Nix image builder and requires manifest updates to use the explicit release digest.
- Extends enabled-app and OCI contract tests so Jangar counts only as a root-enabled Nix image migration.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/jangar/__tests__/update-manifests.test.ts packages/scripts/src/jangar/__tests__/release-contract.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/jangar/build-image.ts packages/scripts/src/jangar/deploy-service.ts packages/scripts/src/jangar/update-manifests.ts packages/scripts/src/jangar/resolve-release-metadata.ts packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/jangar/__tests__/update-manifests.test.ts`
- `nix eval --raw .#packages.x86_64-linux.jangar-image.drvPath`
- `nix eval --raw .#packages.aarch64-linux.jangar-image.drvPath`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
