### PR TITLE
fix(torghut): clean hyperliquid runtime blockers

### DIFF
--- a/docs/superpowers/plans/2026-07-05-torghut-clean-runtime-blockers.md
+++ b/docs/superpowers/plans/2026-07-05-torghut-clean-runtime-blockers.md
@@ -1,0 +1,99 @@
+# Torghut Clean Runtime Blockers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the remaining hidden fixed-cap/runtime-proof garbage from the Hyperliquid execution path so Torghut has one understandable margin-aware risk path and live status shows the exact reason when trading stops.
+
+**Architecture:** Keep order submission in the existing Hyperliquid v2 service. Daily loss is decided once inside the multifactor risk model using an effective limit of `max(config.max_daily_loss_usd, account_equity * target_margin_utilization)`, so the old absolute `$100` floor cannot silently stop a margin-backed testnet account by itself. Position reconciliation compares managed runtime positions to managed exchange positions and reports unmanaged external positions separately.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy, pytest, pyright, Argo CD GitOps.
+
+---
+
+### Task 1: Single-Source Daily Loss Risk
+
+**Files:**
+- Modify: `services/torghut/app/hyperliquid_execution/risk.py`
+- Modify: `services/torghut/app/trading/multifactor/risk_model.py`
+- Test: `services/torghut/tests/hyperliquid_execution/test_strategy_risk_universe.py`
+
+- [x] **Step 1: Add failing tests**
+
+Add tests proving a UTC-day loss just past the configured floor does not block when the margin-derived limit is higher, and a loss past the effective margin-derived limit still blocks.
+
+Run: `cd services/torghut && uv run --frozen pytest tests/hyperliquid_execution/test_strategy_risk_universe.py -q`
+Expected: FAIL before implementation.
+
+- [x] **Step 2: Implement effective daily loss limit**
+
+In `risk.py`, add a helper that returns `max(config.max_daily_loss_usd, max(account_value_usd, withdrawable_usd) * config.target_margin_utilization)` and pass it into `RiskLimits`.
+
+Remove the duplicate `daily_loss_stop` check from `_blocked_reason`; strict operational gates stay there, risk gates stay in `build_risk_forecast`.
+
+- [x] **Step 3: Run targeted risk tests**
+
+Run: `cd services/torghut && uv run --frozen pytest tests/hyperliquid_execution/test_strategy_risk_universe.py -q`
+Expected: PASS.
+
+### Task 2: Make Runtime Status Honest
+
+**Files:**
+- Modify: `services/torghut/app/hyperliquid_execution/api.py`
+- Modify: `services/torghut/app/hyperliquid_execution/service.py`
+- Test: `services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py`
+
+- [x] **Step 1: Expose configured risk floor**
+
+Add `max_daily_loss_usd` to `/trading/status.config` and `/report` config payload.
+
+- [x] **Step 2: Expose cycle risk inputs**
+
+Add `daily_realized_pnl_usd`, `account_value_usd`, `withdrawable_usd`, and `effective_daily_loss_limit_usd` to the latest cycle `universe` details after `risk_state` is loaded.
+
+- [x] **Step 3: Run targeted status tests**
+
+Run: `cd services/torghut && uv run --frozen pytest tests/hyperliquid_execution/test_runtime_surfaces.py -q`
+Expected: PASS.
+
+### Task 3: Reconcile Managed Positions Only
+
+**Files:**
+- Modify: `services/torghut/app/trading/loop_status.py`
+- Test: `services/torghut/tests/test_trading_loop_status.py`
+
+- [x] **Step 1: Add regression for unmanaged exchange positions**
+
+Update the existing nested-dex test so an exchange-only `xyz:NVDA` position appears under `position.unmanaged_exchange_positions` and does not emit `hyperliquid_position_reconciliation_missing` when the managed persisted positions match the managed raw positions.
+
+- [x] **Step 2: Implement managed/external split**
+
+Compare persisted positions only to raw exchange positions whose coin appears in the managed persisted position set. Keep all raw positions in the payload and add an unmanaged list for diagnostics.
+
+- [x] **Step 3: Run loop-status tests**
+
+Run: `cd services/torghut && uv run --frozen pytest tests/test_trading_loop_status.py -q`
+Expected: PASS.
+
+### Task 4: Validate And Roll Out
+
+**Files:**
+- Modified files from Tasks 1-3
+- Modify: `.github/PULL_REQUEST_TEMPLATE.md` only if the template itself is broken; otherwise copy it to a temp PR body file.
+
+- [x] **Step 1: Run Torghut validation**
+
+Run:
+`cd services/torghut && uv sync --frozen --extra dev`
+`cd services/torghut && uv run --frozen pytest tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/test_trading_loop_status.py -q`
+`cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
+`cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
+`cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
+`bun run lint:argocd`
+
+Expected: all PASS.
+
+- [ ] **Step 2: Open, merge, promote, and verify**
+
+Create a semantic PR from `codex/torghut-clean-runtime-blockers`, wait for green checks, squash merge, wait for image build and release promotion, merge the promotion PR, refresh Argo, and verify live `/readyz`, `/trading/status`, and `/trading/loop/status`.
+
+Expected live proof: Argo Synced/Healthy at promoted revision, runtime deployment rolled out, `/trading/status.operational_submission_gate.allowed=true`, no `daily_loss_stop` from the old fixed floor, and no `hyperliquid_position_reconciliation_missing` caused only by unmanaged `xyz:*` residue.

--- a/services/torghut/app/hyperliquid_execution/api.py
+++ b/services/torghut/app/hyperliquid_execution/api.py
@@ -228,6 +228,7 @@ def _config_payload() -> dict[str, object]:
         "target_margin_utilization": str(config.target_margin_utilization),
         "max_symbol_margin_utilization": str(config.max_symbol_margin_utilization),
         "max_order_margin_utilization": str(config.max_order_margin_utilization),
+        "max_daily_loss_usd": str(config.max_daily_loss_usd),
         "cost_buffer_bps": str(config.cost_buffer_bps),
         "signal_staleness_seconds": config.signal_staleness_seconds,
         "feed_readiness_url_configured": config.feed_readiness_url is not None,

--- a/services/torghut/app/hyperliquid_execution/risk.py
+++ b/services/torghut/app/hyperliquid_execution/risk.py
@@ -74,6 +74,17 @@ def evaluate_signal_risk(
     )
 
 
+def effective_daily_loss_limit_usd(
+    state: RiskState,
+    config: HyperliquidExecutionConfig,
+) -> Decimal:
+    """Return the active realized-loss stop from the fixed floor and margin budget."""
+
+    equity_basis = max(state.account_value_usd, state.withdrawable_usd, Decimal("0"))
+    margin_budget = equity_basis * config.target_margin_utilization
+    return max(config.max_daily_loss_usd, margin_budget).quantize(Decimal("0.000001"))
+
+
 def _allowed_margin_budget(
     signal: Signal,
     state: RiskState,
@@ -125,7 +136,7 @@ def _multifactor_controls(
         limits=RiskLimits(
             max_gross_exposure_usd=effective_max_gross_exposure,
             max_symbol_exposure_usd=effective_max_symbol_exposure,
-            max_daily_loss_usd=config.max_daily_loss_usd,
+            max_daily_loss_usd=effective_daily_loss_limit_usd(state, config),
         ),
     )
     expected_cost_bps = estimate_transaction_cost(
@@ -169,7 +180,7 @@ def _blocked_multifactor(
         limits=RiskLimits(
             max_gross_exposure_usd=state.gross_exposure_usd,
             max_symbol_exposure_usd=symbol_exposure,
-            max_daily_loss_usd=config.max_daily_loss_usd,
+            max_daily_loss_usd=effective_daily_loss_limit_usd(state, config),
         ),
     )
     blocked_risk = replace(risk_forecast, blocker=reason or "margin_budget_unavailable")
@@ -250,6 +261,5 @@ def _blocked_reason(
             signal.coin in state.cooldown_reason_by_coin,
             state.cooldown_reason_by_coin.get(signal.coin, "symbol_cooldown"),
         ),
-        (state.daily_realized_pnl_usd <= -config.max_daily_loss_usd, "daily_loss_stop"),
     )
     return next((reason for blocked, reason in checks if blocked), None)

--- a/services/torghut/app/hyperliquid_execution/runtime_details.py
+++ b/services/torghut/app/hyperliquid_execution/runtime_details.py
@@ -1,0 +1,56 @@
+"""Reportable runtime details for Hyperliquid execution."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from .config import HyperliquidExecutionConfig
+from .models import ExecutionMarket, RiskState, RuntimeDependencyStatus
+from .risk import effective_daily_loss_limit_usd
+
+
+def risk_state_details(
+    risk_state: RiskState,
+    config: HyperliquidExecutionConfig,
+) -> dict[str, object]:
+    return {
+        "account_value_usd": str(risk_state.account_value_usd),
+        "withdrawable_usd": str(risk_state.withdrawable_usd),
+        "gross_exposure_usd": str(risk_state.gross_exposure_usd),
+        "daily_realized_pnl_usd": str(risk_state.daily_realized_pnl_usd),
+        "configured_daily_loss_floor_usd": str(config.max_daily_loss_usd),
+        "effective_daily_loss_limit_usd": str(
+            effective_daily_loss_limit_usd(risk_state, config)
+        ),
+    }
+
+
+def universe_details(
+    feed_details: dict[str, object],
+    execution_statuses: tuple[RuntimeDependencyStatus, RuntimeDependencyStatus],
+    feature_status: RuntimeDependencyStatus,
+    selected_markets: tuple[ExecutionMarket, ...],
+    execution_metadata_details: dict[str, object],
+) -> dict[str, object]:
+    execution_status, liquidity_status = execution_statuses
+    details = dict(feed_details)
+    details.update(execution_status.details)
+    details["liquidity"] = dict(liquidity_status.details)
+    details.update(execution_metadata_details)
+    details["selected_execution_metadata"] = _string_list_detail(
+        details.get("selected")
+    )
+    details["selected"] = [market.coin for market in selected_markets]
+    details["fresh_features"] = _string_list_detail(
+        feature_status.details.get("features")
+    )
+    details["missing_fresh_features"] = _string_list_detail(
+        feature_status.details.get("missing")
+    )
+    return details
+
+
+def _string_list_detail(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in cast(list[object], value)]

--- a/services/torghut/app/hyperliquid_execution/service.py
+++ b/services/torghut/app/hyperliquid_execution/service.py
@@ -23,6 +23,7 @@ from .models import (
 from .order_policy import build_order_intent
 from .repository import HyperliquidExecutionRepository
 from .risk import evaluate_signal_risk
+from .runtime_details import risk_state_details, universe_details
 from .strategy import generate_signal
 from .universe import UniverseSelectionConfig, select_configured_markets
 
@@ -84,6 +85,9 @@ class HyperliquidExecutionService:
                 for market in context.markets
                 if market.max_leverage is not None
             },
+        )
+        context.universe_details["risk_state"] = risk_state_details(
+            risk_state, self._config
         )
         maintenance_reduce_only = self._reduce_over_cap_exposure(risk_state)
         counts.record_maintenance_reduce_only(maintenance_reduce_only)
@@ -271,11 +275,12 @@ class HyperliquidExecutionService:
                 open_order_status,
                 exchange_status,
             ),
-            universe_details=self._universe_details(
+            universe_details=universe_details(
                 feed_details,
                 (execution_status, liquidity_status),
                 feature_status,
                 selected_markets,
+                self._exchange.execution_metadata_details(),
             ),
         )
 
@@ -313,30 +318,6 @@ class HyperliquidExecutionService:
             observed_at=observed_at,
             details={"open_order_coins": sorted(open_coins)},
         )
-
-    def _universe_details(
-        self,
-        feed_details: dict[str, object],
-        execution_statuses: tuple[RuntimeDependencyStatus, RuntimeDependencyStatus],
-        feature_status: RuntimeDependencyStatus,
-        selected_markets: tuple[ExecutionMarket, ...],
-    ) -> dict[str, object]:
-        execution_status, liquidity_status = execution_statuses
-        details = dict(feed_details)
-        details.update(execution_status.details)
-        details["liquidity"] = dict(liquidity_status.details)
-        details.update(self._exchange.execution_metadata_details())
-        details["selected_execution_metadata"] = _string_list_detail(
-            details.get("selected")
-        )
-        details["selected"] = [market.coin for market in selected_markets]
-        details["fresh_features"] = _string_list_detail(
-            feature_status.details.get("features")
-        )
-        details["missing_fresh_features"] = _string_list_detail(
-            feature_status.details.get("missing")
-        )
-        return details
 
 
 def runtime_readiness(
@@ -437,12 +418,6 @@ def _select_markets_with_fresh_features(
         feature_by_market_id[market.market_id] for market in selected_markets
     )
     return selected_markets, selected_features
-
-
-def _string_list_detail(value: object) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [str(item) for item in cast(list[object], value)]
 
 
 def _cycle_universe_details(

--- a/services/torghut/app/trading/loop_status.py
+++ b/services/torghut/app/trading/loop_status.py
@@ -26,6 +26,12 @@ from app.trading.multifactor.status_payloads import (
     portfolio_target_payload,
     risk_forecast_payload,
 )
+from app.trading.loop_status_positions import (
+    managed_exchange_positions,
+    position_coin_set,
+    raw_account_positions,
+    unmanaged_exchange_positions,
+)
 
 SCHEMA_VERSION = "torghut.trading-loop-status.v1"
 DEFAULT_FRESHNESS_THRESHOLD_SECONDS = 180
@@ -108,6 +114,8 @@ class LoopProofSummary:
     recent_fill_count: int
     position_count: int
     raw_exchange_positions: Sequence[Mapping[str, object]]
+    managed_exchange_positions: Sequence[Mapping[str, object]]
+    unmanaged_exchange_positions: Sequence[Mapping[str, object]]
     positions_reconciled: bool
     stale_open_order_count: int
     unexpected_live_orders: int
@@ -252,7 +260,7 @@ def _proof_summary(
     latest_account_at = _datetime_value(rows.latest_account.get("observed_at"))
     market_lag_seconds = _age_seconds(options.generated_at, latest_feature_at)
     account_lag_seconds = _age_seconds(options.generated_at, latest_account_at)
-    raw_exchange_positions = _raw_account_positions(rows.latest_account)
+    raw_exchange_positions = raw_account_positions(rows.latest_account)
     unexpected_live_orders = _int(rows.unexpected_live_alpaca.get("orders_24h"))
     unexpected_live_events = _int(rows.unexpected_live_alpaca.get("events_24h"))
     expected_return_bps = _optional_decimal(
@@ -285,6 +293,11 @@ def _proof_summary(
         account_lag_seconds,
         threshold_seconds=options.account_freshness_seconds,
     )
+    managed_raw_positions = managed_exchange_positions(
+        rows.positions,
+        raw_exchange_positions,
+        _selected_symbols(rows),
+    )
     return LoopProofSummary(
         query_errors=tuple(rows.query_errors),
         market_feature_at=latest_feature_at,
@@ -302,9 +315,13 @@ def _proof_summary(
         recent_fill_count=_int(rows.fill_summary.get("fills_24h")),
         position_count=len(rows.positions),
         raw_exchange_positions=tuple(raw_exchange_positions),
+        managed_exchange_positions=tuple(managed_raw_positions),
+        unmanaged_exchange_positions=tuple(
+            unmanaged_exchange_positions(raw_exchange_positions, managed_raw_positions)
+        ),
         positions_reconciled=account_fresh
-        and _position_coin_set(rows.positions)
-        == _position_coin_set(raw_exchange_positions),
+        and position_coin_set(rows.positions)
+        == position_coin_set(managed_raw_positions),
         stale_open_order_count=len(rows.stale_open_orders),
         unexpected_live_orders=unexpected_live_orders,
         unexpected_live_events=unexpected_live_events,
@@ -463,8 +480,16 @@ def _position_payload(
         "reconciled": summary.positions_reconciled,
         "positions_count": summary.position_count,
         "exchange_raw_positions_count": len(summary.raw_exchange_positions),
+        "managed_exchange_positions_count": len(summary.managed_exchange_positions),
+        "unmanaged_exchange_positions_count": len(summary.unmanaged_exchange_positions),
         "positions": [dict(row) for row in rows.positions],
         "exchange_raw_positions": [dict(row) for row in summary.raw_exchange_positions],
+        "managed_exchange_positions": [
+            dict(row) for row in summary.managed_exchange_positions
+        ],
+        "unmanaged_exchange_positions": [
+            dict(row) for row in summary.unmanaged_exchange_positions
+        ],
     }
 
 
@@ -637,73 +662,6 @@ def _latest_fill_payload(row: Mapping[str, object]) -> dict[str, object]:
         "fee_usd": _optional_text(row.get("fee_usd")),
         "closed_pnl_usd": _optional_text(row.get("closed_pnl_usd")),
     }
-
-
-def _raw_account_positions(
-    account_row: Mapping[str, object],
-) -> list[dict[str, object]]:
-    payload = _mapping_payload(account_row.get("raw_payload"))
-    raw_positions = _account_position_rows(payload)
-    positions: list[dict[str, object]] = []
-    for raw_position in raw_positions:
-        position = _mapping_payload(raw_position.get("position"))
-        coin = _optional_text(position.get("coin"))
-        if coin is None:
-            continue
-        positions.append(
-            {
-                "coin": coin,
-                "size": _optional_text(position.get("szi")) or "0",
-                "entry_price": _optional_text(position.get("entryPx")),
-                "notional_usd": _optional_text(position.get("positionValue")) or "0",
-                "unrealized_pnl_usd": _optional_text(position.get("unrealizedPnl"))
-                or "0",
-            }
-        )
-    return sorted(positions, key=lambda item: str(item["coin"]))
-
-
-def _account_position_rows(
-    payload: Mapping[str, object],
-) -> list[Mapping[str, object]]:
-    rows: list[Mapping[str, object]] = []
-    _extend_position_rows(rows, payload.get("assetPositions"))
-    dex_states = payload.get("dexStates")
-    if isinstance(dex_states, Mapping):
-        for raw_state in cast(Mapping[object, object], dex_states).values():
-            state = _mapping_payload(raw_state)
-            _extend_position_rows(rows, state.get("assetPositions"))
-    clearinghouse_state = _mapping_payload(payload.get("clearinghouseState"))
-    _extend_position_rows(rows, clearinghouse_state.get("assetPositions"))
-    return rows
-
-
-def _extend_position_rows(rows: list[Mapping[str, object]], value: object) -> None:
-    if not isinstance(value, list):
-        return
-    for raw_position in cast(list[object], value):
-        if not isinstance(raw_position, Mapping):
-            continue
-        rows.append(cast(Mapping[str, object], raw_position))
-
-
-def _position_coin_set(rows: Sequence[Mapping[str, object]]) -> set[str]:
-    return {
-        coin for row in rows if (coin := _optional_text(row.get("coin"))) is not None
-    }
-
-
-def _mapping_payload(value: object) -> Mapping[str, object]:
-    if isinstance(value, Mapping):
-        return cast(Mapping[str, object], value)
-    if isinstance(value, str):
-        try:
-            loaded = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        if isinstance(loaded, Mapping):
-            return cast(Mapping[str, object], loaded)
-    return {}
 
 
 def _datetime_value(value: object) -> datetime | None:

--- a/services/torghut/app/trading/loop_status_positions.py
+++ b/services/torghut/app/trading/loop_status_positions.py
@@ -1,0 +1,104 @@
+"""Position parsing and reconciliation helpers for trading loop status."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+
+def raw_account_positions(account_row: Mapping[str, object]) -> list[dict[str, object]]:
+    payload = _mapping_payload(account_row.get("raw_payload"))
+    positions: list[dict[str, object]] = []
+    for raw_position in _account_position_rows(payload):
+        position = _mapping_payload(raw_position.get("position"))
+        coin = _optional_text(position.get("coin"))
+        if coin is None:
+            continue
+        positions.append(
+            {
+                "coin": coin,
+                "size": _optional_text(position.get("szi")) or "0",
+                "entry_price": _optional_text(position.get("entryPx")),
+                "notional_usd": _optional_text(position.get("positionValue")) or "0",
+                "unrealized_pnl_usd": _optional_text(position.get("unrealizedPnl"))
+                or "0",
+            }
+        )
+    return sorted(positions, key=lambda item: str(item["coin"]))
+
+
+def managed_exchange_positions(
+    persisted_positions: Sequence[Mapping[str, object]],
+    raw_exchange_positions: Sequence[Mapping[str, object]],
+    selected_symbols: Sequence[str],
+) -> list[Mapping[str, object]]:
+    managed_coins = position_coin_set(persisted_positions)
+    managed_coins.update(selected_symbols)
+    return [
+        position
+        for position in raw_exchange_positions
+        if _optional_text(position.get("coin")) in managed_coins
+    ]
+
+
+def unmanaged_exchange_positions(
+    raw_exchange_positions: Sequence[Mapping[str, object]],
+    managed_positions: Sequence[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    managed_ids = {id(position) for position in managed_positions}
+    return [
+        position
+        for position in raw_exchange_positions
+        if id(position) not in managed_ids
+    ]
+
+
+def position_coin_set(rows: Sequence[Mapping[str, object]]) -> set[str]:
+    return {
+        coin for row in rows if (coin := _optional_text(row.get("coin"))) is not None
+    }
+
+
+def _account_position_rows(
+    payload: Mapping[str, object],
+) -> list[Mapping[str, object]]:
+    rows: list[Mapping[str, object]] = []
+    _extend_position_rows(rows, payload.get("assetPositions"))
+    dex_states = payload.get("dexStates")
+    if isinstance(dex_states, Mapping):
+        for raw_state in cast(Mapping[object, object], dex_states).values():
+            state = _mapping_payload(raw_state)
+            _extend_position_rows(rows, state.get("assetPositions"))
+    clearinghouse_state = _mapping_payload(payload.get("clearinghouseState"))
+    _extend_position_rows(rows, clearinghouse_state.get("assetPositions"))
+    return rows
+
+
+def _extend_position_rows(rows: list[Mapping[str, object]], value: object) -> None:
+    if not isinstance(value, list):
+        return
+    for raw_position in cast(list[object], value):
+        if not isinstance(raw_position, Mapping):
+            continue
+        rows.append(cast(Mapping[str, object], raw_position))
+
+
+def _mapping_payload(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, object], value)
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(loaded, Mapping):
+            return cast(Mapping[str, object], loaded)
+    return {}
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
@@ -30,11 +30,11 @@ from app.hyperliquid_execution.models import (
     Signal,
 )
 from app.hyperliquid_execution.repository import HyperliquidExecutionRepository
+from app.hyperliquid_execution.runtime_details import _string_list_detail
 from app.hyperliquid_execution.service import (
     HyperliquidExecutionService,
     _CycleCounts,
     _feature_status,
-    _string_list_detail,
     runtime_readiness,
 )
 
@@ -92,6 +92,7 @@ def test_api_readiness_metrics_report_and_cycle_paths(monkeypatch: Any) -> None:
         assert report["schema_version"] == "torghut.hyperliquid-execution-report.v2"
         assert report["runtime"]["selected_coins"] == ["NVDA"]
         assert report["config"]["signal_staleness_seconds"] == 120
+        assert report["config"]["max_daily_loss_usd"] == "25"
         assert session.closed
 
         service = _SingleCycleService(cycle)
@@ -304,6 +305,14 @@ def test_service_cycle_cancels_reconciles_submits_and_records_cycle() -> None:
     assert result.signals_written == 1
     assert result.orders_submitted == 1
     assert result.orders_cancelled == 1
+    assert result.universe_details["risk_state"] == {
+        "account_value_usd": "1000",
+        "withdrawable_usd": "900",
+        "gross_exposure_usd": "10",
+        "daily_realized_pnl_usd": "1",
+        "configured_daily_loss_floor_usd": "25",
+        "effective_daily_loss_limit_usd": "350.000000",
+    }
     assert session.committed
     cycle_calls = [
         index

--- a/services/torghut/tests/hyperliquid_execution/test_strategy_risk_universe.py
+++ b/services/torghut/tests/hyperliquid_execution/test_strategy_risk_universe.py
@@ -226,6 +226,36 @@ def test_risk_sizes_orders_from_symbol_margin_capacity() -> None:
     assert clipped_budget.order_notional_usd == Decimal("100.000000")
 
 
+def test_daily_loss_stop_uses_margin_scaled_limit() -> None:
+    config = HyperliquidExecutionConfig.from_env(
+        {
+            "HYPERLIQUID_EXECUTION_MAX_DAILY_LOSS_USD": "100",
+            "HYPERLIQUID_EXECUTION_TARGET_MARGIN_UTILIZATION": "0.35",
+        }
+    )
+    signal = generate_signal(
+        _feature(momentum=Decimal("20"), liquidity=Decimal("1000000")),
+        config,
+    )
+
+    just_past_floor = evaluate_signal_risk(
+        signal,
+        replace(_risk_state(), daily_realized_pnl_usd=Decimal("-101.75827000")),
+        config,
+    )
+    past_effective_limit = evaluate_signal_risk(
+        signal,
+        replace(_risk_state(), daily_realized_pnl_usd=Decimal("-351")),
+        config,
+    )
+
+    assert just_past_floor.allowed
+    assert not past_effective_limit.allowed
+    assert past_effective_limit.reason == "daily_loss_stop"
+    assert past_effective_limit.portfolio_target is not None
+    assert past_effective_limit.portfolio_target.clip_reason == "daily_loss_stop"
+
+
 def test_risk_blocks_when_symbol_margin_metadata_is_missing() -> None:
     config = HyperliquidExecutionConfig.from_env({})
     signal = generate_signal(

--- a/services/torghut/tests/test_trading_loop_status.py
+++ b/services/torghut/tests/test_trading_loop_status.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from app.api import trading_loop_status as trading_loop_status_api
 from app.trading import loop_status as loop_status_module
+from app.trading import loop_status_positions as loop_status_positions_module
 from app.trading.multifactor import status_payloads
 
 from app.trading.loop_status import (
@@ -316,7 +317,7 @@ def test_loop_status_covers_raw_position_and_malformed_value_edges() -> None:
     assert "hyperliquid_exchange_order_ack_missing" in payload["blocker_reasons"]
     assert "hyperliquid_stale_open_orders_present" in payload["blocker_reasons"]
     assert "unexpected_live_alpaca_orders_present" in payload["blocker_reasons"]
-    assert loop_status_module._mapping_payload("{not-json") == {}
+    assert loop_status_positions_module._mapping_payload("{not-json") == {}
     assert loop_status_module._string_list("AMD") == ["AMD"]
 
 
@@ -729,8 +730,20 @@ def test_loop_status_reads_nested_hyperliquid_dex_positions() -> None:
             "unrealized_pnl_usd": "-0.83664",
         }
     ]
-    assert payload["position"]["reconciled"] is False
-    assert "hyperliquid_position_reconciliation_missing" in payload["blocker_reasons"]
+    assert payload["position"]["managed_exchange_positions"] == []
+    assert payload["position"]["unmanaged_exchange_positions"] == [
+        {
+            "coin": "xyz:NVDA",
+            "entry_price": "209.395",
+            "notional_usd": "19.26528",
+            "size": "0.096",
+            "unrealized_pnl_usd": "-0.83664",
+        }
+    ]
+    assert payload["position"]["reconciled"] is True
+    assert (
+        "hyperliquid_position_reconciliation_missing" not in payload["blocker_reasons"]
+    )
 
 
 def test_trading_loop_status_route_uses_runtime_settings(


### PR DESCRIPTION
## Summary

- Single-sources Hyperliquid daily-loss blocking through the multifactor risk model instead of duplicating a hidden fixed-cap stop.
- Scales the active daily-loss limit from existing margin policy as `max(configured floor, account equity * target margin utilization)` and exposes the live inputs in runtime status.
- Splits managed versus unmanaged exchange positions in `/trading/loop/status` so leftover external `xyz:*` positions stay visible without falsely failing managed-position reconciliation.
- Adds the implementation plan used for this cleanup pass under `docs/superpowers/plans/`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/test_trading_loop_status.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/test_trading_loop_status.py`
- `cd services/torghut && uv run --frozen ruff format --check app tests/hyperliquid_execution/test_strategy_risk_universe.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/test_trading_loop_status.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/loop_status.py app/trading/loop_status_positions.py`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
