### PR TITLE
fix(jangar): include workspace runtime dependencies in nix image

### DIFF
--- a/nix/images/jangar.nix
+++ b/nix/images/jangar.nix
@@ -95,11 +95,12 @@ import ./bun-workspace-service.nix {
 
     cp -R "$TMPDIR/work/node_modules" "$out/app/node_modules"
 
-    for package in agent-contracts codex cx-tools otel temporal-bun-sdk; do
+    for package in agent-contracts codex cx-tools design discord otel temporal-bun-sdk; do
       cp -R "$TMPDIR/work/packages/$package" "$out/app/packages/$package"
     done
 
     cp "$TMPDIR/work/services/jangar/package.json" "$out/app/services/jangar/package.json"
+    cp -R "$TMPDIR/work/services/jangar/node_modules" "$out/app/services/jangar/node_modules"
     cp -R "$TMPDIR/work/services/jangar/.output" "$out/app/services/jangar/.output"
     mkdir -p "$out/app/services/jangar/src"
     cp -R "$TMPDIR/work/services/jangar/src/worker.ts" "$out/app/services/jangar/src/worker.ts"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -828,6 +828,10 @@ describe('native OCI build workflows', () => {
     expect(jangarImageModule).toContain('dependencyClosure = "bunCache";')
     expect(jangarImageModule).toContain('"@proompteng/jangar"')
     expect(jangarImageModule).toContain('"@proompteng/cx-tools"')
+    expect(jangarImageModule).toContain(
+      'for package in agent-contracts codex cx-tools design discord otel temporal-bun-sdk',
+    )
+    expect(jangarImageModule).toContain('cp -R "$TMPDIR/work/services/jangar/node_modules"')
     expect(jangarImageModule).toContain('import ./openai-codex-cli.nix')
     expect(jangarImageModule).toContain('openvscode-server')
     expect(jangarImageModule).toContain('import ./bun-workspace-service.nix')


### PR DESCRIPTION
## Summary

- Fixes the live Jangar Nix image crash where Bun could not resolve the direct `effect` dependency from the server bundle.
- Preserves `services/jangar/node_modules` in the image runtime root so Bun isolated-linker workspace dependencies resolve at runtime.
- Adds a contract assertion so the Jangar image keeps copying workspace runtime dependencies.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `nix eval --raw .#packages.x86_64-linux.jangar-image.drvPath`
- `nix eval --raw .#packages.aarch64-linux.jangar-image.drvPath`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
