### PR TITLE
chore(jangar): promote image sha-3c56efdb18dd108c8bf884f209f3d9de8aa52a2d

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-05T14:17:31Z
+    deploy.knative.dev/rollout: 2026-07-05T14:55:23Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 430653cf3c44923cee2c66e589fb5cd16b2dd75e
+              value: 3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
             - name: JANGAR_GITOPS_REVISION
-              value: 430653cf3c44923cee2c66e589fb5cd16b2dd75e
+              value: 3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28743680439"
+              value: "28744710723"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:fa0494182a11a8ba426117c0eab4bf3d57760379e71382febda9198193d067b5
+              value: sha256:cd113cb0d7f8b0741db969d282b96c164d29ac596d11aef79741d1b03d3079df
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 430653cf3c44923cee2c66e589fb5cd16b2dd75e
+              value: 3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:fa0494182a11a8ba426117c0eab4bf3d57760379e71382febda9198193d067b5
+              value: sha256:cd113cb0d7f8b0741db969d282b96c164d29ac596d11aef79741d1b03d3079df
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-430653cf3c44923cee2c66e589fb5cd16b2dd75e
-    digest: sha256:fa0494182a11a8ba426117c0eab4bf3d57760379e71382febda9198193d067b5
+    newTag: sha-3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
+    digest: sha256:cd113cb0d7f8b0741db969d282b96c164d29ac596d11aef79741d1b03d3079df


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `3c56efdb18dd108c8bf884f209f3d9de8aa52a2d`
- Image tag: `sha-3c56efdb18dd108c8bf884f209f3d9de8aa52a2d`
- Image digest: `sha256:cd113cb0d7f8b0741db969d282b96c164d29ac596d11aef79741d1b03d3079df`
- Source CI run: `28744710723`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates