### PR TITLE
fix(jangar): build node pty in nix image

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -68,6 +68,7 @@ jobs:
       image_name: jangar
       package_attr: jangar-image
       tag: sha-${{ github.sha }}
+      image_build_timeout: 12m
       latest: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
       release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'jangar-release-contract' || '' }}
     secrets: inherit

--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: string
         default: ''
+      image_build_timeout:
+        required: false
+        type: string
+        default: 8m
       publish_on_dispatch:
         required: false
         type: boolean
@@ -59,7 +63,7 @@ jobs:
     env:
       ATTIC_CACHE_ENDPOINT: http://attic.attic.svc.cluster.local
       ATTIC_PUBLIC_KEY: ${{ vars.ATTIC_PUBLIC_KEY }}
-      NIX_IMAGE_BUILD_ATTIC_TIMEOUT: 8m
+      NIX_IMAGE_BUILD_ATTIC_TIMEOUT: ${{ inputs.image_build_timeout }}
       NIX_IMAGE_CACHE_WARM_TIMEOUT: 2m
       NIX_OCI_LOG_DIR: /tmp/nix-oci-logs-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
     steps:

--- a/nix/images/jangar.nix
+++ b/nix/images/jangar.nix
@@ -83,6 +83,36 @@ import ./bun-workspace-service.nix {
   ];
   buildCommands = [
     "patchShebangs --build node_modules"
+    ''
+      set -eux
+      export PATH="${lib.makeBinPath [
+        pkgs.gnumake
+        pkgs.node-gyp
+        pkgs.python3
+        pkgs.stdenv.cc
+      ]}:$PATH"
+      node_pty_package_json="$(node -p "require.resolve('node-pty/package.json')" 2>/dev/null || (cd services/jangar && node -p "require.resolve('node-pty/package.json')"))"
+      node_pty_dir="$(dirname "$node_pty_package_json")"
+      cd "$node_pty_dir"
+      case "$(uname -m)" in
+        x86_64) node_arch=x64 ;;
+        aarch64) node_arch=arm64 ;;
+        *) node_arch="$(uname -m)" ;;
+      esac
+      export PYTHON="${pkgs.python3}/bin/python3"
+      export npm_config_build_from_source=true
+      export npm_config_nodedir="${nodejs}"
+      export npm_config_arch="$node_arch"
+      export npm_config_target="$(${nodejs}/bin/node -p 'process.versions.node')"
+      node-gyp rebuild
+      test -f build/Release/pty.node
+      mkdir -p "$TMPDIR/node-pty-artifacts"
+      cp build/Release/pty.node "$TMPDIR/node-pty-artifacts/pty.node"
+      rm -rf build
+      mkdir -p build/Release
+      cp "$TMPDIR/node-pty-artifacts/pty.node" build/Release/pty.node
+      cd "$TMPDIR/work"
+    ''
     "bun --cwd=packages/agent-contracts run build"
     "bun --cwd=packages/codex run build"
     "bun --cwd=packages/otel run build"
@@ -102,6 +132,21 @@ import ./bun-workspace-service.nix {
     cp "$TMPDIR/work/services/jangar/package.json" "$out/app/services/jangar/package.json"
     cp -R "$TMPDIR/work/services/jangar/node_modules" "$out/app/services/jangar/node_modules"
     cp -R "$TMPDIR/work/services/jangar/.output" "$out/app/services/jangar/.output"
+    node_pty_package_json="$(find "$out/app/node_modules/.bun" -path '*/node_modules/node-pty/package.json' -print -quit)"
+    if [ -z "$node_pty_package_json" ]; then
+      echo "node-pty package not found in runtime node_modules" >&2
+      exit 1
+    fi
+    node_pty_dir="$(dirname "$node_pty_package_json")"
+    if [ ! -f "$node_pty_dir/build/Release/pty.node" ]; then
+      echo "node-pty native module missing from runtime node_modules" >&2
+      exit 1
+    fi
+    mkdir -p "$out/app/services/jangar/.output/server/node_modules/node-pty"
+    cp -R "$node_pty_dir/build" "$out/app/services/jangar/.output/server/node_modules/node-pty/build"
+    if [ -d "$node_pty_dir/prebuilds" ]; then
+      cp -R "$node_pty_dir/prebuilds" "$out/app/services/jangar/.output/server/node_modules/node-pty/prebuilds"
+    fi
     mkdir -p "$out/app/services/jangar/src"
     cp -R "$TMPDIR/work/services/jangar/src/worker.ts" "$out/app/services/jangar/src/worker.ts"
     mkdir -p "$out/app/services/jangar/src/server"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -405,7 +405,9 @@ describe('native OCI build workflows', () => {
     expect(nixOciWorkflow).toContain('substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/')
     expect(nixOciWorkflow).toContain('fallback = true')
     expect(nixOciWorkflow).toContain('stalled-download-timeout = 60')
-    expect(nixOciWorkflow).toContain('NIX_IMAGE_BUILD_ATTIC_TIMEOUT: 8m')
+    expect(nixOciWorkflow).toContain('image_build_timeout:')
+    expect(nixOciWorkflow).toContain('default: 8m')
+    expect(nixOciWorkflow).toContain('NIX_IMAGE_BUILD_ATTIC_TIMEOUT: ${{ inputs.image_build_timeout }}')
     expect(nixOciWorkflow).toContain('timeout --kill-after=30s "${NIX_IMAGE_BUILD_ATTIC_TIMEOUT}"')
     expect(nixOciWorkflow).toContain('build-image-${ARCH}-cache-nixos-fallback')
     expect(nixOciWorkflow).toContain('timeout --kill-after=30s "${NIX_IMAGE_BUILD_ATTIC_TIMEOUT}" \\')
@@ -832,6 +834,13 @@ describe('native OCI build workflows', () => {
       'for package in agent-contracts codex cx-tools design discord otel temporal-bun-sdk',
     )
     expect(jangarImageModule).toContain('cp -R "$TMPDIR/work/services/jangar/node_modules"')
+    expect(jangarImageModule).toContain('node-gyp rebuild')
+    expect(jangarImageModule).toContain('test -f build/Release/pty.node')
+    expect(jangarImageModule).toContain('rm -rf build')
+    expect(jangarImageModule).toContain('node-pty native module missing from runtime node_modules')
+    expect(jangarImageModule).toContain(
+      'cp -R "$node_pty_dir/build" "$out/app/services/jangar/.output/server/node_modules/node-pty/build"',
+    )
     expect(jangarImageModule).toContain('import ./openai-codex-cli.nix')
     expect(jangarImageModule).toContain('openvscode-server')
     expect(jangarImageModule).toContain('import ./bun-workspace-service.nix')
@@ -843,7 +852,7 @@ describe('native OCI build workflows', () => {
     expect(jangarBuildWorkflow).toContain('package_attr: jangar-image')
     expect(jangarBuildWorkflow).toContain('jangar-release-contract')
     expect(jangarBuildWorkflow).toContain('tag: sha-${{ github.sha }}')
-    expect(jangarBuildWorkflow).not.toContain('image_build_timeout:')
+    expect(jangarBuildWorkflow).toContain('image_build_timeout: 12m')
     expect(jangarBuildWorkflow).not.toContain('oven-sh/setup-bun')
     expect(jangarBuildWorkflow).not.toContain('docker/setup-buildx-action')
 


### PR DESCRIPTION
## Summary

- Builds Jangar's `node-pty` native module during the Nix image build using pinned Nix toolchain inputs.
- Fails the image build if `build/Release/pty.node` is missing from runtime `node_modules`.
- Preserves the built `node-pty` artifacts in the server runtime tree and adds OCI contract coverage.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `nix eval --raw .#packages.x86_64-linux.jangar-image.drvPath`
- `nix eval --raw .#packages.aarch64-linux.jangar-image.drvPath`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
