### PR TITLE
chore(jangar): promote image sha-c4b0fee9ef3b91c10bf57b73540f4e04b3896a62

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-05T14:55:23Z
+    deploy.knative.dev/rollout: 2026-07-05T16:05:15Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
+              value: c4b0fee9ef3b91c10bf57b73540f4e04b3896a62
             - name: JANGAR_GITOPS_REVISION
-              value: 3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
+              value: c4b0fee9ef3b91c10bf57b73540f4e04b3896a62
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "28744710723"
+              value: "28746684382"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:cd113cb0d7f8b0741db969d282b96c164d29ac596d11aef79741d1b03d3079df
+              value: sha256:85dedfa3f1d6dc38be857647c2f530d6aee888ac57385180ca1ce8d1c06b28fa
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
+              value: c4b0fee9ef3b91c10bf57b73540f4e04b3896a62
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:cd113cb0d7f8b0741db969d282b96c164d29ac596d11aef79741d1b03d3079df
+              value: sha256:85dedfa3f1d6dc38be857647c2f530d6aee888ac57385180ca1ce8d1c06b28fa
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-3c56efdb18dd108c8bf884f209f3d9de8aa52a2d
-    digest: sha256:cd113cb0d7f8b0741db969d282b96c164d29ac596d11aef79741d1b03d3079df
+    newTag: sha-c4b0fee9ef3b91c10bf57b73540f4e04b3896a62
+    digest: sha256:85dedfa3f1d6dc38be857647c2f530d6aee888ac57385180ca1ce8d1c06b28fa


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `c4b0fee9ef3b91c10bf57b73540f4e04b3896a62`
- Image tag: `sha-c4b0fee9ef3b91c10bf57b73540f4e04b3896a62`
- Image digest: `sha256:85dedfa3f1d6dc38be857647c2f530d6aee888ac57385180ca1ce8d1c06b28fa`
- Source CI run: `28746684382`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates