### PR TITLE
ci(jangar): remove rollback verifier automation

### DIFF
--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -21,8 +21,7 @@ jobs:
   verify:
     runs-on: arc-arm64
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -135,58 +134,3 @@ jobs:
             --deployment-name jangar-deployment \
             --migrate-stale-running \
             --allow-no-versioned-pollers
-
-      - name: Prepare rollback manifests
-        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        id: rollback
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          HEAD_MESSAGE="$(git log -1 --pretty=%s)"
-          if [[ "${HEAD_MESSAGE}" == rollback\(jangar\):* ]]; then
-            echo "Skipping rollback PR because current commit is already a rollback"
-            echo "should_rollback=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if ! git rev-parse --verify HEAD^ >/dev/null 2>&1; then
-            echo "No parent commit available for rollback"
-            echo "should_rollback=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git checkout --quiet HEAD^ -- \
-            argocd/applications/jangar/kustomization.yaml \
-            argocd/applications/jangar/deployment.yaml
-
-          if git diff --quiet -- \
-            argocd/applications/jangar/kustomization.yaml \
-            argocd/applications/jangar/deployment.yaml; then
-            echo "No rollback diff detected"
-            echo "should_rollback=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "should_rollback=true" >> "$GITHUB_OUTPUT"
-
-      - name: Open rollback pull request
-        if: failure() && steps.rollback.outputs.should_rollback == 'true'
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
-          branch: codex/jangar-rollback-${{ github.run_id }}-${{ github.run_attempt }}
-          base: main
-          title: 'rollback(jangar): revert failed promotion ${{ github.sha }}'
-          commit-message: 'rollback(jangar): revert failed promotion ${{ github.sha }}'
-          delete-branch: true
-          add-paths: |
-            argocd/applications/jangar/kustomization.yaml
-            argocd/applications/jangar/deployment.yaml
-          body: |
-            ## Summary
-            Automatic rollback created because `jangar-post-deploy-verify` failed on `main`.
-
-            - Failed commit: `${{ github.sha }}`
-            - Workflow run: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
-            - Rollback source: `HEAD^` manifests from the failed run checkout

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -31,6 +31,7 @@ const arcRunnerBuildWorkflow = readRepoFile('.github/workflows/arc-runner-build-
 const arcRunnerReleaseWorkflow = readRepoFile('.github/workflows/arc-runner-release.yml')
 const jangarBuildWorkflow = readRepoFile('.github/workflows/jangar-build-push.yaml')
 const jangarReleaseWorkflow = readRepoFile('.github/workflows/jangar-release.yml')
+const jangarPostDeployVerifyWorkflow = readRepoFile('.github/workflows/jangar-post-deploy-verify.yml')
 const symphonyBuildWorkflow = readRepoFile('.github/workflows/symphony-build-push.yaml')
 const symphonyCiWorkflow = readRepoFile('.github/workflows/symphony-ci.yml')
 const symphonyReleaseWorkflow = readRepoFile('.github/workflows/symphony-release.yml')
@@ -861,6 +862,20 @@ describe('native OCI build workflows', () => {
     expect(jangarReleaseWorkflow).toContain('nix run .#assert-oci-platforms -- "${IMAGE}@${DIGEST}"')
     expect(jangarReleaseWorkflow).not.toContain('docker buildx')
     expect(jangarReleaseWorkflow).not.toContain('docker/setup-buildx-action')
+  })
+
+  it('keeps Jangar post-deploy verification observe-only without rollback PR automation', () => {
+    expect(jangarPostDeployVerifyWorkflow).toContain('name: jangar-post-deploy-verify')
+    expect(jangarPostDeployVerifyWorkflow).toContain('contents: read')
+    expect(jangarPostDeployVerifyWorkflow).toContain('Verify deployment health and digest')
+    expect(jangarPostDeployVerifyWorkflow).toContain('Sync Temporal routing after rollout')
+    expect(jangarPostDeployVerifyWorkflow).not.toContain('contents: write')
+    expect(jangarPostDeployVerifyWorkflow).not.toContain('pull-requests: write')
+    expect(jangarPostDeployVerifyWorkflow).not.toContain('Prepare rollback manifests')
+    expect(jangarPostDeployVerifyWorkflow).not.toContain('Open rollback pull request')
+    expect(jangarPostDeployVerifyWorkflow).not.toContain('peter-evans/create-pull-request')
+    expect(jangarPostDeployVerifyWorkflow).not.toContain('codex/jangar-rollback')
+    expect(jangarPostDeployVerifyWorkflow).not.toContain('rollback(jangar)')
   })
 
   it('routes the enabled Torghut family images through real Nix OCI attrs', () => {


### PR DESCRIPTION
## Summary

- Remove Jangar post-deploy rollback PR creation from the verifier workflow.
- Reduce verifier permissions from write access to read-only contents.
- Add a contract test that blocks rollback automation from returning to the Jangar verifier.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`
- `actionlint -color -ignore 'label "arc-arm64" is unknown' .github/workflows/jangar-post-deploy-verify.yml .github/workflows/jangar-guardrails.yml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
