### PR TITLE
ci(nix): expose headlamp repo image gap

### DIFF
--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -18,6 +18,8 @@ Current inventory from the repo guardrail:
 - Vendor/static manifest apps do not receive image builds unless this repo owns their image build path.
 - External-source apps are not repo image migration targets.
 - Repo-image apps must be either `nix-image`, explicitly `deferred`, or a documented manifest-only exception.
+- Helm values that override chart images with `registry.ide-newton.ts.net/lab/...` count as repo-image references. `headlamp`
+  is therefore deferred until its Docker-backed workflow is migrated or intentionally retired.
 
 Hard exclusions:
 
@@ -136,6 +138,8 @@ Same commit plus same lockfiles should reproduce the same Nix output path and OC
 6. **PR 6: Docker Quarantine And Removal**
    - Remove Docker Buildx/CLI build-push paths from migrated enabled apps.
    - Rename remaining Docker helpers as Docker-backed transitional paths.
+   - Migrate or retire `headlamp-ci.yml`; the live Helm release currently overrides the upstream chart with a repo-built
+     `lab/headlamp` image, so it cannot be counted as chart-only.
    - Disabled and non-owned apps cannot count as rollout proof.
 
 7. **PR 7: Final Rollout Report**

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -36,16 +36,7 @@ describe('enabled app inventory', () => {
   })
 
   it('keeps chart-only apps out of Nix image migration state', () => {
-    for (const name of [
-      'headlamp',
-      'temporal',
-      'observability',
-      'nats',
-      'kafka',
-      'traefik',
-      'tailscale',
-      'cert-manager',
-    ]) {
+    for (const name of ['temporal', 'observability', 'nats', 'kafka', 'traefik', 'tailscale', 'cert-manager']) {
       expect(entry(name)).toMatchObject({
         class: 'helm-chart',
         hasHelmChart: true,
@@ -54,6 +45,18 @@ describe('enabled app inventory', () => {
       expect(entry(name).nixImageAttr).toBeUndefined()
       expect(entry(name).buildScriptPath).toBeUndefined()
     }
+  })
+
+  it('does not hide repo-owned Helm image overrides as chart-only apps', () => {
+    expect(entry('headlamp')).toMatchObject({
+      class: 'deferred',
+      hasHelmChart: true,
+      repoImages: ['registry.ide-newton.ts.net/lab/headlamp@sha256'],
+      deferredReason:
+        'Helm chart is overridden to run a repo-built lab/headlamp image; migrate the Docker workflow separately',
+    })
+    expect(entry('headlamp').nixImageAttr).toBeUndefined()
+    expect(entry('headlamp').buildScriptPath).toBeUndefined()
   })
 
   it('marks only approved early build-owning apps as Nix image candidates', () => {

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -36,6 +36,7 @@ type JsonRecord = Record<string, unknown>
 
 const labRepoURL = 'https://github.com/proompteng/lab.git'
 const labImagePrefix = 'registry.ide-newton.ts.net/lab/'
+const labImageRegistry = 'registry.ide-newton.ts.net'
 
 const earlyNixImageApps = new Set([
   'agents',
@@ -59,6 +60,10 @@ const earlyNixImageApps = new Set([
 ])
 
 const deferredApps = new Map<string, string>([
+  [
+    'headlamp',
+    'Helm chart is overridden to run a repo-built lab/headlamp image; migrate the Docker workflow separately',
+  ],
   ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
   ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
   ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
@@ -232,8 +237,12 @@ const collectRepoImages = (yamlPath: string, document: unknown): string[] => {
     const image = asString(record.image)
     if (image?.startsWith(labImagePrefix)) images.add(image)
 
+    const registry = asString(record.registry)
     const repository = asString(record.repository)
     if (repository?.startsWith(labImagePrefix)) images.add(repository)
+    if (registry === labImageRegistry && repository?.startsWith('lab/')) {
+      images.add(`${registry}/${repository}`)
+    }
 
     if (basename(yamlPath) === 'kustomization.yaml' && Array.isArray(record.images)) {
       for (const entry of record.images) {


### PR DESCRIPTION
## Summary

- Detect Helm values that split repo-owned images across `image.registry` and `image.repository`.
- Classify Headlamp as a deferred repo-image app instead of chart-only because GitOps points at `registry.ide-newton.ts.net/lab/headlamp`.
- Update the Nix rollout plan to keep Headlamp in the Docker quarantine/migration backlog.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun packages/scripts/src/shared/enabled-apps.ts --assert --json | jq -r '.entries[] | select(.name=="headlamp") | [.class,.name,(.repoImages|join(",")),(.deferredReason // "")] | @tsv'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
