### PR TITLE
fix(headlamp): make nix image runtime writable

### DIFF
--- a/nix/images/headlamp.nix
+++ b/nix/images/headlamp.nix
@@ -132,8 +132,9 @@ pkgs.dockerTools.buildLayeredImage {
     pkgs.cacert
   ];
   extraCommands = ''
-    mkdir -p tmp var/tmp
+    mkdir -p tmp var/tmp etc/ssl/certs
     chmod 1777 tmp var/tmp
+    ln -s ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt etc/ssl/certs/ca-certificates.crt
   '';
   config = {
     Entrypoint = [
@@ -145,6 +146,7 @@ pkgs.dockerTools.buildLayeredImage {
     ];
     Env = [
       "PATH=${lib.makeBinPath [ pkgs.busybox ]}"
+      "HOME=/tmp"
       "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
       "HEADLAMP_STATIC_PLUGINS_DIR=/headlamp/static-plugins"
     ];

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -808,6 +808,8 @@ describe('native OCI build workflows', () => {
     expect(headlampImageModule).toContain('pkgs.dockerTools.buildLayeredImage')
     expect(headlampImageModule).toContain('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER')
     expect(headlampImageModule).toContain('"HEADLAMP_STATIC_PLUGINS_DIR=/headlamp/static-plugins"')
+    expect(headlampImageModule).toContain('"HOME=/tmp"')
+    expect(headlampImageModule).toContain('etc/ssl/certs/ca-certificates.crt')
     expect(headlampImageModule).toContain('export HOME="$TMPDIR/home"')
     expect(headlampImageModule).toContain('cp main.js package.json "$out/static-plugins/prometheus/"')
     expect(headlampImageModule).not.toContain('cp prometheus/main.js prometheus/package.json')


### PR DESCRIPTION
## Summary

- Fixes the Nix-built Headlamp runtime image by setting `HOME=/tmp` for non-root config/plugin writes.
- Adds the `/etc/ssl/certs/ca-certificates.crt` compatibility path expected by the existing Headlamp OIDC args.
- Adds OCI contract assertions so the runtime env and CA path do not regress.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `nix build .#packages.x86_64-linux.headlamp-image --dry-run --print-build-logs`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
