### PR TITLE
fix(headlamp): mount writable tmp for nix image

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -10,6 +10,12 @@ persistentVolumeClaim:
   enabled: false
 podSecurityContext:
   fsGroup: 101
+volumeMounts:
+  - name: headlamp-tmp
+    mountPath: /tmp
+volumes:
+  - name: headlamp-tmp
+    emptyDir: {}
 config:
   oidc:
     secret:

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -57,6 +57,7 @@ const bumbaWorkflow = readRepoFile('.github/workflows/bumba-ci.yml')
 const froussardWorkflow = readRepoFile('.github/workflows/froussard-ci.yml')
 const headlampWorkflow = readRepoFile('.github/workflows/headlamp-ci.yml')
 const headlampReleaseWorkflow = readRepoFile('.github/workflows/headlamp-release.yml')
+const headlampValues = readRepoFile('argocd/applications/headlamp/values.yaml')
 const froussardKnativeService = readRepoFile('argocd/applications/froussard/knative-service.yaml')
 const appImageModule = readRepoFile('nix/images/app.nix')
 const productImageModules = [
@@ -815,6 +816,9 @@ describe('native OCI build workflows', () => {
     expect(headlampImageModule).not.toContain('cp prometheus/main.js prometheus/package.json')
     expect(headlampImageModule).not.toContain('created = "now"')
     expect(headlampImageModule).not.toContain('docker build')
+    expect(headlampValues).toContain('name: headlamp-tmp')
+    expect(headlampValues).toContain('mountPath: /tmp')
+    expect(headlampValues).toContain('emptyDir: {}')
 
     expect(headlampWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
     expect(headlampWorkflow).toContain('image_name: headlamp')


### PR DESCRIPTION
## Summary

- Mount an `emptyDir` at `/tmp` for Headlamp so the non-root Nix image runtime can create its temporary frontend files.
- Add a contract test that keeps the Headlamp GitOps values aligned with the Nix image runtime requirement.
- Keep the promoted Nix-built image digest unchanged; this is a GitOps runtime fix only.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `nix run .#render-headlamp`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
