### PR TITLE
fix(headlamp): make nix frontend copy writable

### DIFF
--- a/nix/images/headlamp.nix
+++ b/nix/images/headlamp.nix
@@ -117,6 +117,7 @@ let
       mkdir -p "$out/headlamp/plugins" "$out/headlamp/static-plugins"
       cp ${backend}/bin/headlamp-server "$out/headlamp/headlamp-server"
       cp -R ${frontend}/frontend "$out/headlamp/frontend"
+      chmod -R u+w "$out/headlamp/frontend"
       cp -R ${prometheusPlugin}/static-plugins/. "$out/headlamp/static-plugins/"
       runHook postInstall
     '';

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -813,6 +813,7 @@ describe('native OCI build workflows', () => {
     expect(headlampImageModule).toContain('etc/ssl/certs/ca-certificates.crt')
     expect(headlampImageModule).toContain('export HOME="$TMPDIR/home"')
     expect(headlampImageModule).toContain('cp main.js package.json "$out/static-plugins/prometheus/"')
+    expect(headlampImageModule).toContain('chmod -R u+w "$out/headlamp/frontend"')
     expect(headlampImageModule).not.toContain('cp prometheus/main.js prometheus/package.json')
     expect(headlampImageModule).not.toContain('created = "now"')
     expect(headlampImageModule).not.toContain('docker build')


### PR DESCRIPTION
## Summary

- Make the packaged Headlamp frontend tree user-writable inside the Nix image runtime root.
- Preserve the existing Nix image flow and `/tmp` runtime mount; this fixes Headlamp's startup rewrite of `index.html`.
- Add a contract assertion so the Headlamp image does not regress to read-only copied frontend assets.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `nix build .#packages.x86_64-linux.headlamp-image --dry-run --print-build-logs`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
