### PR TITLE
test(jangar): guard deploy script stale promotions

### DIFF
--- a/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
+++ b/packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts
@@ -126,6 +126,22 @@ describe('resolve-release-metadata', () => {
     expect(__private.isBuildTriggerPath('.github/workflows/jangar-build-push.yaml')).toBe(false)
   })
 
+  it('does not treat Jangar deploy script changes as image build changes', () => {
+    const decision = __private.evaluateWorkflowRunStaleness({
+      sourceSha: ddd07d2f,
+      mainHead: bf889391,
+      isAncestor: true,
+      changedMainFiles: ['packages/scripts/src/jangar/update-manifests.ts'],
+    })
+
+    expect(decision).toEqual({
+      promote: true,
+      reason: 'newer-main-non-jangar-only',
+    })
+    expect(__private.isBuildTriggerPath('packages/scripts/src/jangar/update-manifests.ts')).toBe(false)
+    expect(__private.isBuildTriggerPath('packages/scripts/src/jangar/deploy-service.ts')).toBe(false)
+  })
+
   it('regression from git history fixture: blocks f22a8cbc promotion when newer main has jangar changes', () => {
     const decision = __private.evaluateWorkflowRunStaleness({
       sourceSha: f22a8cbc,

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -585,6 +585,8 @@ describe('native OCI build workflows', () => {
 
     expect(jangarReleaseMetadataScript).not.toContain('.github\\/workflows\\/')
     expect(jangarReleaseMetadataScript).not.toContain('setup-nix-toolchain')
+    expect(jangarReleaseMetadataScript).not.toContain('packages\\/scripts\\/src\\/jangar')
+    expect(jangarReleaseMetadataScript).not.toContain('packages\\/scripts\\/src\\/shared')
     expect(jangarReleaseMetadataScript).toContain('images\\/jangar\\.nix')
     for (const helperInput of nixImageHelperInputs) {
       expect(jangarReleaseMetadataScript).toContain(helperInput.replaceAll('/', '\\/').replaceAll('.', '\\.'))


### PR DESCRIPTION
## Summary

- Adds a Jangar release metadata regression test for the PR #11922 review case: newer `packages/scripts/src/jangar/update-manifests.ts` changes must not mark an older successful image build as stale.
- Asserts Jangar deploy-only script paths remain non-build-triggering in the stale-promotion guard.
- Extends the OCI workflow guardrail test so Jangar release metadata cannot reintroduce broad `packages/scripts/src/jangar` or shared-script regex triggers.

## Related Issues

Follow-up for review feedback on #11922.

## Testing

- `bun test packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun /workspace/lab/node_modules/oxfmt/dist/cli.js --check packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun /workspace/lab/node_modules/oxlint/dist/cli.js --config .oxlintrc.json packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`

## Screenshots (if applicable)

N/A — test-only CI guardrail change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
