### PR TITLE
test(torghut): assert bash runtime image contract

### DIFF
--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -8,6 +8,19 @@ const originalWhich = Bun.which
 const repoRoot = new URL('../../../../../', import.meta.url)
 const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
 const repoFileExists = (path: string): boolean => existsSync(new URL(path, repoRoot))
+const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const expectNixListBlock = (source: string, assignment: string): string => {
+  const match = source.match(new RegExp(`${escapeRegex(assignment)}\\s*=\\s*\\[([\\s\\S]*?)\\];`, 'm'))
+  expect(match?.[1]).toBeDefined()
+  return match?.[1] ?? ''
+}
+const expectNixMakeBinPathBlock = (source: string, assignment: string): string => {
+  const match = source.match(
+    new RegExp(`${escapeRegex(assignment)}\\s*=\\s*lib\\.makeBinPath\\s*\\[([\\s\\S]*?)\\];`, 'm'),
+  )
+  expect(match?.[1]).toBeDefined()
+  return match?.[1] ?? ''
+}
 
 const atticWorkflow = readRepoFile('.github/workflows/attic-build-push.yaml')
 const atticReleaseWorkflow = readRepoFile('.github/workflows/attic-release.yml')
@@ -981,8 +994,11 @@ describe('native OCI build workflows', () => {
     ]) {
       expect(flake).toContain(`"${packageAttr}"`)
     }
+    const torghutRuntimeContents = expectNixListBlock(torghutImageModule, 'contents')
+    const torghutRuntimePath = expectNixMakeBinPathBlock(torghutImageModule, 'runtimePath')
     expect(torghutImageModule).toContain('pkgs.uv')
-    expect(torghutImageModule).toContain('pkgs.bash')
+    expect(torghutRuntimeContents).toContain('pkgs.bash')
+    expect(torghutRuntimePath).toContain('pkgs.bash')
     expect(torghutImageModule).toContain('pkgs.stdenv.cc.cc.lib')
     expect(torghutImageModule).toContain('"LD_LIBRARY_PATH=${runtimeLibraryPath}"')
     expect(torghutImageModule).toContain('"PYTHONPATH=/app"')


### PR DESCRIPTION
## Summary

- Tighten the Torghut OCI regression test so bash must be present in the runtime contents list.
- Assert the runtime PATH source so build-only nativeBuildInputs bash no longer satisfies the check.
- Add reusable Nix list helpers for scoped assertions in OCI workflow tests.

## Related Issues

None

## Testing

- `bun install --frozen-lockfile --ignore-scripts`
- `node node_modules/oxfmt/bin/oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts -t 'routes the enabled Torghut family images through real Nix OCI attrs'`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
