### PR TITLE
fix(froussard): reject stale docker build flags

### DIFF
--- a/packages/scripts/src/froussard/__tests__/build-image.test.ts
+++ b/packages/scripts/src/froussard/__tests__/build-image.test.ts
@@ -111,6 +111,36 @@ describe('froussard build-image helpers', () => {
     ).toThrow('context, platforms, cacheRef')
   })
 
+  it('parses stale Docker-only CLI flags for rejection before positional tag fallback', () => {
+    const dockerfileOptions = __private.parseArgs(['--dockerfile', 'Dockerfile'])
+
+    expect(dockerfileOptions).toEqual({ dockerfile: 'Dockerfile' })
+    expect(() => __private.resolveBuildConfiguration(dockerfileOptions)).toThrow(
+      'Froussard Nix image builds do not accept Docker-only option(s): dockerfile',
+    )
+
+    const multiOptionArgs = [
+      '--context',
+      '.',
+      '--platforms=linux/amd64,linux/arm64',
+      '--cache-ref',
+      'registry.example/cache',
+    ]
+
+    expect(__private.parseArgs(multiOptionArgs)).toEqual({
+      context: '.',
+      platforms: ['linux/amd64', 'linux/arm64'],
+      cacheRef: 'registry.example/cache',
+    })
+    expect(() => __private.resolveBuildConfiguration(__private.parseArgs(multiOptionArgs))).toThrow(
+      'context, platforms, cacheRef',
+    )
+  })
+
+  it('rejects unknown CLI flags before consuming the next positional value as a tag', () => {
+    expect(() => __private.parseArgs(['--unknown-flag', 'sha-test'])).toThrow('Unknown option: --unknown-flag')
+  })
+
   it('parses manual CLI tag, registry, repository, and dry-run flags', () => {
     expect(
       __private.parseArgs([

--- a/packages/scripts/src/froussard/build-image.ts
+++ b/packages/scripts/src/froussard/build-image.ts
@@ -47,6 +47,20 @@ const rejectDockerOptions = (options: BuildImageOptions): void => {
   }
 }
 
+const requireOptionValue = (args: string[], index: number, optionName: string): string => {
+  const value = args[index + 1]
+  if (value === undefined || value.startsWith('-')) {
+    throw new Error(`Missing value for ${optionName}`)
+  }
+  return value
+}
+
+const parsePlatforms = (value: string): string[] =>
+  value
+    .split(',')
+    .map((platform) => platform.trim())
+    .filter(Boolean)
+
 const resolveBuildConfiguration = (options: BuildImageOptions = {}): BuildConfiguration => {
   rejectDockerOptions(options)
 
@@ -66,7 +80,7 @@ const parseArgs = (args: string[]): BuildImageOptions => {
     if (!arg) continue
 
     if (arg === '--tag') {
-      options.tag = args[index + 1]
+      options.tag = requireOptionValue(args, index, arg)
       index += 1
       continue
     }
@@ -75,7 +89,7 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       continue
     }
     if (arg === '--repository') {
-      options.repository = args[index + 1]
+      options.repository = requireOptionValue(args, index, arg)
       index += 1
       continue
     }
@@ -84,7 +98,7 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       continue
     }
     if (arg === '--registry') {
-      options.registry = args[index + 1]
+      options.registry = requireOptionValue(args, index, arg)
       index += 1
       continue
     }
@@ -96,9 +110,52 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       options.dryRun = true
       continue
     }
+    if (arg === '--context') {
+      options.context = requireOptionValue(args, index, arg)
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--context=')) {
+      options.context = arg.slice('--context='.length)
+      continue
+    }
+    if (arg === '--dockerfile') {
+      options.dockerfile = requireOptionValue(args, index, arg)
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--dockerfile=')) {
+      options.dockerfile = arg.slice('--dockerfile='.length)
+      continue
+    }
+    if (arg === '--platforms') {
+      options.platforms = parsePlatforms(requireOptionValue(args, index, arg))
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--platforms=')) {
+      options.platforms = parsePlatforms(arg.slice('--platforms='.length))
+      continue
+    }
+    if (arg === '--cache-ref') {
+      options.cacheRef = requireOptionValue(args, index, arg)
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--cache-ref=')) {
+      options.cacheRef = arg.slice('--cache-ref='.length)
+      continue
+    }
+    if (arg.startsWith('-')) {
+      const optionName = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg
+      throw new Error(`Unknown option: ${optionName}`)
+    }
     if (!arg.startsWith('-') && options.tag === undefined) {
       options.tag = arg
+      continue
     }
+
+    throw new Error(`Unexpected positional argument: ${arg}`)
   }
   return options
 }


### PR DESCRIPTION
## Summary

- Parse stale Froussard Docker-only CLI flags (`--dockerfile`, `--context`, `--platforms`, `--cache-ref`) into rejectable options instead of allowing their values to become positional tags.
- Require values for Froussard CLI options that take arguments and fail unknown flags before consuming following positional values.
- Add regression coverage for Docker-only flag rejection and unknown flag handling.

## Related Issues

Follow-up to #11923 Codex review comment.

## Testing

- `bun test packages/scripts/src/froussard/__tests__/build-image.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts -t 'keeps manual migrated app deploy scripts on the shared Nix image helper'`
- `bun packages/scripts/src/froussard/build-image.ts --dockerfile Dockerfile --dry-run` exits with status 1 and reports `Froussard Nix image builds do not accept Docker-only option(s): dockerfile`
- `node -e 'process.argv=["node","oxfmt","--check","packages/scripts/src/froussard/build-image.ts","packages/scripts/src/froussard/__tests__/build-image.test.ts"]; import("./node_modules/oxfmt/dist/cli.js")'`
- `node -e 'process.argv=["node","oxlint","--config",".oxlintrc.json","packages/scripts/src/froussard/build-image.ts","packages/scripts/src/froussard/__tests__/build-image.test.ts"]; import("./node_modules/oxlint/dist/cli.js")'`
- `node -e 'process.argv=["node","oxlint","--config",".oxlintrc.json","--type-aware","--tsconfig","packages/scripts/tsconfig.json","packages/scripts/src/froussard/build-image.ts","packages/scripts/src/froussard/__tests__/build-image.test.ts"]; import("./node_modules/oxlint/dist/cli.js")'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
