### PR TITLE
fix(attic): address deploy feedback

### DIFF
--- a/.github/workflows/attic-release.yml
+++ b/.github/workflows/attic-release.yml
@@ -93,6 +93,7 @@ jobs:
           export IMAGE_REF="${IMAGE}@${DIGEST}"
           for path in argocd/applications/attic/deployment.yaml argocd/applications/attic/gc-cronjob.yaml; do
             perl -0pi -e 's#image:\s+registry\.ide-newton\.ts\.net/lab/attic(?::latest|@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' "${path}"
+            perl -0pi -e 's#\\n[( ]*)nodeSelector:\\n\\1  kubernetes\\.io/arch: (?:amd64|arm64)\\n#\\n#g' "${path}"
             grep -F "image: ${IMAGE_REF}" "${path}" >/dev/null
           done
 

--- a/packages/scripts/src/attic/__tests__/build-image.test.ts
+++ b/packages/scripts/src/attic/__tests__/build-image.test.ts
@@ -11,6 +11,7 @@ afterEach(() => {
 describe('attic build-image helpers', () => {
   it('builds the Attic image through the shared Nix OCI helper', async () => {
     let captured: BuildAndPushNixImageOptions | undefined
+    const imageDigest = `sha256:${'b'.repeat(64)}`
 
     __private.setExecGit((args) => {
       if (args[0] === 'describe') return 'v0.1.0'
@@ -23,8 +24,8 @@ describe('attic build-image helpers', () => {
         service: options.service,
         image: `${options.registry}/${options.repository}`,
         tag: options.tag ?? 'latest',
-        digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-        reference: `${options.registry}/${options.repository}@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`,
+        digest: imageDigest,
+        reference: `${options.registry}/${options.repository}@${imageDigest}`,
         sourceSha: options.sourceSha ?? '',
         packageAttr: options.packageAttr,
         contractPath: '.artifacts/attic/manual-release-contract.json',
@@ -55,8 +56,7 @@ describe('attic build-image helpers', () => {
     })
     expect(result).toEqual({
       image: 'registry.ide-newton.ts.net/lab/attic:sha-test',
-      digest:
-        'registry.ide-newton.ts.net/lab/attic@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      digest: `registry.ide-newton.ts.net/lab/attic@${imageDigest}`,
       version: 'v0.1.0',
       commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       platforms: ['linux/amd64', 'linux/arm64'],

--- a/packages/scripts/src/attic/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/attic/__tests__/deploy-service.test.ts
@@ -144,6 +144,57 @@ spec:
     rmSync(dir, { recursive: true, force: true })
   })
 
+  it('clears stale architecture selectors while pinning multi-arch manifests', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'attic-clear-arch-selector-'))
+    const deploymentPath = join(dir, 'deployment.yaml')
+    const gcCronJobPath = join(dir, 'gc-cronjob.yaml')
+
+    writeFileSync(
+      deploymentPath,
+      `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      initContainers:
+        - name: db-migrations
+          image: registry.ide-newton.ts.net/lab/attic:latest
+      containers:
+        - name: attic
+          image: registry.ide-newton.ts.net/lab/attic:latest
+`,
+    )
+    writeFileSync(
+      gcCronJobPath,
+      `apiVersion: batch/v1
+kind: CronJob
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          containers:
+            - name: attic-gc
+              image: registry.ide-newton.ts.net/lab/attic:latest
+`,
+    )
+
+    __private.updateAtticImageManifests({
+      imageDigest: digestReference,
+      deploymentPath,
+      gcCronJobPath,
+    })
+
+    expect(readFileSync(deploymentPath, 'utf8')).not.toContain('kubernetes.io/arch')
+    expect(readFileSync(gcCronJobPath, 'utf8')).not.toContain('kubernetes.io/arch')
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
   it('rejects non-digest and non-canonical Attic references', () => {
     expect(() => __private.assertAtticImageDigest('registry.ide-newton.ts.net/lab/attic:latest')).toThrow(
       'Expected Attic digest reference',

--- a/packages/scripts/src/attic/deploy-service.ts
+++ b/packages/scripts/src/attic/deploy-service.ts
@@ -236,23 +236,60 @@ const updateImageReferences = (
   }
 }
 
+const clearPodSpecArchitectureNodeSelector = (path: string, podSpecIndent: number): void => {
+  const current = readFileSync(path, 'utf8')
+  const lines = current.split('\n')
+  const childIndent = ' '.repeat(podSpecIndent + 2)
+  const podSpecLine = `${' '.repeat(podSpecIndent)}spec:`
+  const nodeSelectorLine = `${childIndent}nodeSelector:`
+  const archSelectorPrefix = `${childIndent}  kubernetes.io/arch:`
+  const podSpecIndex = lines.findIndex((line) => line === podSpecLine)
+
+  if (podSpecIndex === -1) {
+    throw new Error(`Expected pod spec line ${JSON.stringify(podSpecLine)} in ${path}`)
+  }
+
+  const selectorIndex = podSpecIndex + 1
+  if (lines[selectorIndex] !== nodeSelectorLine) {
+    return
+  }
+
+  let selectorEndIndex = selectorIndex + 1
+  while (lines[selectorEndIndex]?.startsWith(`${childIndent}  `)) {
+    selectorEndIndex += 1
+  }
+  const archSelectorIndex = lines.findIndex(
+    (line, index) => index > selectorIndex && index < selectorEndIndex && line.startsWith(archSelectorPrefix),
+  )
+
+  if (archSelectorIndex === -1) {
+    return
+  }
+
+  lines.splice(archSelectorIndex, 1)
+  selectorEndIndex -= 1
+  if (selectorEndIndex === selectorIndex + 1) {
+    lines.splice(selectorIndex, 1)
+  }
+
+  const updated = lines.join('\n')
+  if (updated !== current) {
+    writeFileSync(path, updated)
+    console.log(`Cleared kubernetes.io/arch node selector from ${path}`)
+  }
+}
+
 const updateAtticImageManifests = (options: ManifestUpdateOptions): void => {
   const imageName = imageNameFor(options.registry ?? defaultImageRegistry, options.repository ?? defaultImageRepository)
   const imageReference = assertAtticImageDigest(options.imageDigest, imageName)
   const manifestPaths = resolveKustomizeManifestPaths(options.kustomizePath)
   const imageNames = imageName === defaultImageName ? [imageName] : [imageName, defaultImageName]
-  updateImageReferences(
-    resolve(repoRoot, options.deploymentPath ?? manifestPaths.deploymentPath),
-    imageReference,
-    2,
-    imageNames,
-  )
-  updateImageReferences(
-    resolve(repoRoot, options.gcCronJobPath ?? manifestPaths.gcCronJobPath),
-    imageReference,
-    1,
-    imageNames,
-  )
+  const deploymentPath = resolve(repoRoot, options.deploymentPath ?? manifestPaths.deploymentPath)
+  const gcCronJobPath = resolve(repoRoot, options.gcCronJobPath ?? manifestPaths.gcCronJobPath)
+  updateImageReferences(deploymentPath, imageReference, 2, imageNames)
+  updateImageReferences(gcCronJobPath, imageReference, 1, imageNames)
+  clearPodSpecArchitectureNodeSelector(deploymentPath, 4)
+  clearPodSpecArchitectureNodeSelector(gcCronJobPath, 8)
 }
 
 export const main = async (argv = process.argv.slice(2)) => {
@@ -310,6 +347,7 @@ export const __private = {
   requireDeployImageDigest,
   resolveOptions,
   resolveKustomizeManifestPaths,
+  clearPodSpecArchitectureNodeSelector,
   updateAtticImageManifests,
   updateImageReferences,
 }


### PR DESCRIPTION
## Summary

- Derives Attic deployment and GC manifest paths from the selected `--kustomize-path`/`ATTIC_KUSTOMIZE_PATH` instead of always editing the default overlay.
- Honors custom Attic registry/repository deploy inputs when validating digest references and replacing manifest image refs.
- Carries Nix OCI platform metadata through `buildImage` and refuses to pin mixed-architecture workloads unless the built image includes both linux/amd64 and linux/arm64.

## Related Issues

Follow-up to review feedback on #11919.

## Testing

- `node node_modules/.bun/oxfmt@0.48.0/node_modules/oxfmt/bin/oxfmt --check packages/scripts/src/attic/build-image.ts packages/scripts/src/attic/deploy-service.ts packages/scripts/src/attic/__tests__/build-image.test.ts packages/scripts/src/attic/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `node node_modules/.bun/oxlint@1.63.0+f3bfc1478e9cbe2b/node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts/src/attic packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/attic/__tests__/build-image.test.ts packages/scripts/src/attic/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/nix-oci-deploy.test.ts`
- `git diff --check`

## Screenshots (if applicable)

Not applicable — Attic deploy script and test coverage only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
