### PR TITLE
test(torghut): guard amd64 workflow runner contracts

### DIFF
--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -291,6 +291,7 @@ describe('torghut build-push workflow', () => {
 
     expect(buildContractStep).toBeGreaterThan(releaseManifestJob)
     expect(releaseManifestJobBody).toContain('runs-on: arc-amd64')
+    expect(releaseManifestJobBody).not.toContain('runs-on: arc-arm64')
     expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net, which is only')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/knative-service.yaml')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ta/flinkdeployment.yaml')

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -28,6 +28,7 @@ const countOccurrences = (haystack: string, needle: string): number => haystack.
 describe('torghut-deploy-automerge workflow', () => {
   test('runs registry digest validation where the private registry is reachable', () => {
     expect(deployAutomergeWorkflow).toContain('runs-on: arc-amd64')
+    expect(deployAutomergeWorkflow).not.toContain('runs-on: arc-arm64')
     expect(deployAutomergeWorkflow).not.toContain('runs-on: ubuntu-latest')
     expect(deployAutomergeWorkflow).toContain(
       'This pull_request_target job checks out trusted base code only, never pull request code.',


### PR DESCRIPTION
## Summary

- Addresses PR #11940 review 4630967203 by tightening Torghut workflow runner contract tests around the amd64 ARC runner change.
- Adds stale-runner guards so the `release-manifests` CI job and deploy-automerge digest-validation workflow reject `runs-on: arc-arm64`.
- Keeps the existing positive `runs-on: arc-amd64` assertions in place.

## Related Issues

None. Follow-up for PR #11940 review 4630967203.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `cd packages/scripts && node ../../node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json .`
- `cd packages/scripts && node ../../node_modules/oxfmt/bin/oxfmt --check .`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
