### PR TITLE
fix(saigak): address gpu migration review drift guards

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -164,6 +164,13 @@ spec:
                       - /metadata/annotations
                       - /spec/volumeMode
                       - /spec/volumeName
+                  - group: ""
+                    kind: PersistentVolumeClaim
+                    name: saigak-altra-data
+                    jsonPointers:
+                      - /metadata/annotations
+                      - /spec/volumeMode
+                      - /spec/volumeName
                   - group: apps
                     kind: StatefulSet
                     name: saigak

--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -60,6 +60,10 @@ function filesWith(contentByPath: Partial<Record<string, string>> = {}): FileCon
   ]
 }
 
+test('accepts the valid Saigak migration fixture', () => {
+  expect(validateActiveSaigakMigrationContent(filesWith())).toEqual([])
+})
+
 test('requires SAIGAK_REQUIRE_GPU_RESIDENCY value to be true on the same env var entry', () => {
   const failures = validateActiveSaigakMigrationContent(
     filesWith({
@@ -71,6 +75,26 @@ test('requires SAIGAK_REQUIRE_GPU_RESIDENCY value to be true on the same env var
         .replace(
           'name: embedding-proxy\n          env:',
           'name: embedding-proxy\n          env:\n            - name: UNRELATED_FLAG\n              value: "true"',
+        ),
+    }),
+  )
+
+  expect(failures).toContain(
+    'argocd/applications/saigak/statefulset.yaml: Saigak must set SAIGAK_REQUIRE_GPU_RESIDENCY=true on the embedding proxy',
+  )
+})
+
+test('does not accept SAIGAK_REQUIRE_GPU_RESIDENCY from a non-proxy container', () => {
+  const failures = validateActiveSaigakMigrationContent(
+    filesWith({
+      'argocd/applications/saigak/statefulset.yaml': validSaigakStatefulSet
+        .replace(
+          'name: embedding-proxy\n          env:\n            - name: SAIGAK_REQUIRE_GPU_RESIDENCY\n              value: "true"',
+          'name: embedding-proxy\n          env:\n            - name: SAIGAK_REQUIRE_GPU_RESIDENCY\n              value: "false"',
+        )
+        .replace(
+          'name: ollama\n          resources:',
+          'name: ollama\n          env:\n            - name: SAIGAK_REQUIRE_GPU_RESIDENCY\n              value: "true"\n          resources:',
         ),
     }),
   )

--- a/scripts/jangar/validate-flamingo-hard-migration.test.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from 'bun:test'
+
+import { type FileContent, validateActiveSaigakMigrationContent } from './validate-flamingo-hard-migration'
+
+const validSaigakStatefulSet = `
+apiVersion: apps/v1
+kind: StatefulSet
+spec:
+  replicas: 1
+  template:
+    spec:
+      runtimeClassName: nvidia
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        kubernetes.io/hostname: talos-192-168-1-85
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: ollama
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+        - name: embedding-proxy
+          env:
+            - name: SAIGAK_REQUIRE_GPU_RESIDENCY
+              value: "true"
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: saigak-altra-data
+`
+
+const validPlatform = `
+ignoreDifferences:
+  - group: ""
+    kind: PersistentVolumeClaim
+    name: saigak-data
+    jsonPointers:
+      - /metadata/annotations
+      - /spec/volumeMode
+      - /spec/volumeName
+  - group: ""
+    kind: PersistentVolumeClaim
+    name: saigak-altra-data
+    jsonPointers:
+      - /metadata/annotations
+      - /spec/volumeMode
+      - /spec/volumeName
+`
+
+function filesWith(contentByPath: Partial<Record<string, string>> = {}): FileContent[] {
+  return [
+    {
+      path: 'argocd/applications/saigak/statefulset.yaml',
+      content: contentByPath['argocd/applications/saigak/statefulset.yaml'] ?? validSaigakStatefulSet,
+    },
+    {
+      path: 'argocd/applicationsets/platform.yaml',
+      content: contentByPath['argocd/applicationsets/platform.yaml'] ?? validPlatform,
+    },
+  ]
+}
+
+test('requires SAIGAK_REQUIRE_GPU_RESIDENCY value to be true on the same env var entry', () => {
+  const failures = validateActiveSaigakMigrationContent(
+    filesWith({
+      'argocd/applications/saigak/statefulset.yaml': validSaigakStatefulSet
+        .replace(
+          'name: SAIGAK_REQUIRE_GPU_RESIDENCY\n              value: "true"',
+          'name: SAIGAK_REQUIRE_GPU_RESIDENCY\n              value: "false"',
+        )
+        .replace(
+          'name: embedding-proxy\n          env:',
+          'name: embedding-proxy\n          env:\n            - name: UNRELATED_FLAG\n              value: "true"',
+        ),
+    }),
+  )
+
+  expect(failures).toContain(
+    'argocd/applications/saigak/statefulset.yaml: Saigak must set SAIGAK_REQUIRE_GPU_RESIDENCY=true on the embedding proxy',
+  )
+})
+
+test('requires saigak-altra-data PVC bound-field diff ignore', () => {
+  const failures = validateActiveSaigakMigrationContent(
+    filesWith({
+      'argocd/applicationsets/platform.yaml': validPlatform.replace(
+        /\n  - group: ""\n    kind: PersistentVolumeClaim\n    name: saigak-altra-data\n    jsonPointers:\n      - \/metadata\/annotations\n      - \/spec\/volumeMode\n      - \/spec\/volumeName\n/,
+        '\n',
+      ),
+    }),
+  )
+
+  expect(failures).toContain(
+    'argocd/applicationsets/platform.yaml: Saigak must ignore bound local-path PVC drift for saigak-altra-data',
+  )
+})

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -102,6 +102,64 @@ function hasYamlEnvVarValue(content: string, name: string, value: string): boole
   return new RegExp(`^\\s*-\\s*name:\\s*${escapedName}\\s*\\n\\s*value:\\s*${valuePattern}\\s*$`, 'm').test(content)
 }
 
+function getYamlSectionBlock(content: string, sectionName: string): string | null {
+  const sectionPattern = new RegExp(`^(?<indent>\\s*)${escapeRegExp(sectionName)}:\\s*$`)
+  const lines = content.split('\n')
+
+  for (let index = 0; index < lines.length; index++) {
+    const match = sectionPattern.exec(lines[index])
+    const sectionIndent = match?.groups?.indent.length
+    if (sectionIndent === undefined) continue
+
+    let endIndex = lines.length
+    for (let nextIndex = index + 1; nextIndex < lines.length; nextIndex++) {
+      if (lines[nextIndex].trim() === '') continue
+
+      const nextIndent = lines[nextIndex].match(/^(\s*)\S/)?.[1].length ?? 0
+      if (nextIndent <= sectionIndent) {
+        endIndex = nextIndex
+        break
+      }
+    }
+
+    return lines.slice(index, endIndex).join('\n')
+  }
+
+  return null
+}
+
+function getYamlListItemBlock(content: string, name: string): string | null {
+  const itemPattern = new RegExp(`^(?<indent>\\s*)-\\s*name:\\s*${escapeRegExp(name)}\\s*$`)
+  const lines = content.split('\n')
+
+  for (let index = 0; index < lines.length; index++) {
+    const match = itemPattern.exec(lines[index])
+    const itemIndent = match?.groups?.indent.length
+    if (itemIndent === undefined) continue
+
+    let endIndex = lines.length
+    for (let nextIndex = index + 1; nextIndex < lines.length; nextIndex++) {
+      if (lines[nextIndex].trim() === '') continue
+
+      const nextIndent = lines[nextIndex].match(/^(\s*)\S/)?.[1].length ?? 0
+      if (nextIndent <= itemIndent) {
+        endIndex = nextIndex
+        break
+      }
+    }
+
+    return lines.slice(index, endIndex).join('\n')
+  }
+
+  return null
+}
+
+function hasContainerEnvVarValue(content: string, containerName: string, name: string, value: string): boolean {
+  const containers = getYamlSectionBlock(content, 'containers')
+  const container = containers ? getYamlListItemBlock(containers, containerName) : null
+  return container ? hasYamlEnvVarValue(container, name, value) : false
+}
+
 function hasPvcBoundFieldDiffIgnore(content: string, name: string): boolean {
   const match = new RegExp(
     `kind:\\s*PersistentVolumeClaim\\s*\\n\\s*name:\\s*${escapeRegExp(name)}\\s*\\n\\s*jsonPointers:\\s*\\n(?<pointers>(?:\\s*-\\s*/[^\\n]+\\n?)+)`,
@@ -212,7 +270,7 @@ export function validateActiveSaigakMigrationContent(files: FileContent[]): stri
         )
       }
     }
-    if (!hasYamlEnvVarValue(saigakStatefulSet, 'SAIGAK_REQUIRE_GPU_RESIDENCY', 'true')) {
+    if (!hasContainerEnvVarValue(saigakStatefulSet, 'embedding-proxy', 'SAIGAK_REQUIRE_GPU_RESIDENCY', 'true')) {
       failures.push(
         'argocd/applications/saigak/statefulset.yaml: Saigak must set SAIGAK_REQUIRE_GPU_RESIDENCY=true on the embedding proxy',
       )

--- a/scripts/jangar/validate-flamingo-hard-migration.ts
+++ b/scripts/jangar/validate-flamingo-hard-migration.ts
@@ -91,6 +91,28 @@ function hasSaigakCompletionUrl(content: string): boolean {
   )
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function hasYamlEnvVarValue(content: string, name: string, value: string): boolean {
+  const escapedName = escapeRegExp(name)
+  const escapedValue = escapeRegExp(value)
+  const valuePattern = `(?:"${escapedValue}"|'${escapedValue}'|${escapedValue})`
+  return new RegExp(`^\\s*-\\s*name:\\s*${escapedName}\\s*\\n\\s*value:\\s*${valuePattern}\\s*$`, 'm').test(content)
+}
+
+function hasPvcBoundFieldDiffIgnore(content: string, name: string): boolean {
+  const match = new RegExp(
+    `kind:\\s*PersistentVolumeClaim\\s*\\n\\s*name:\\s*${escapeRegExp(name)}\\s*\\n\\s*jsonPointers:\\s*\\n(?<pointers>(?:\\s*-\\s*/[^\\n]+\\n?)+)`,
+    'm',
+  ).exec(content)
+  const pointers = match?.groups?.pointers ?? ''
+  return ['/metadata/annotations', '/spec/volumeMode', '/spec/volumeName'].every((pointer) =>
+    pointers.includes(`- ${pointer}`),
+  )
+}
+
 export function validateActiveSaigakMigrationContent(files: FileContent[]): string[] {
   const failures: string[] = []
   const byPath = new Map(files.map((file) => [file.path, file.content]))
@@ -153,6 +175,11 @@ export function validateActiveSaigakMigrationContent(files: FileContent[]): stri
   if (platform?.includes('namespace: saigak\n          name: saigak')) {
     failures.push('argocd/applicationsets/platform.yaml: Saigak must not keep VirtualMachine diff-ignore desired state')
   }
+  if (platform && !hasPvcBoundFieldDiffIgnore(platform, 'saigak-altra-data')) {
+    failures.push(
+      'argocd/applicationsets/platform.yaml: Saigak must ignore bound local-path PVC drift for saigak-altra-data',
+    )
+  }
 
   const saigakService = byPath.get('argocd/applications/saigak/service.yaml')
   if (saigakService?.includes('kubevirt.io/domain')) {
@@ -177,8 +204,6 @@ export function validateActiveSaigakMigrationContent(files: FileContent[]): stri
       'kubernetes.io/hostname: talos-192-168-1-85',
       'nvidia.com/gpu.present: "true"',
       'nvidia.com/gpu: "1"',
-      'SAIGAK_REQUIRE_GPU_RESIDENCY',
-      'value: "true"',
       'claimName: saigak-altra-data',
     ]) {
       if (!saigakStatefulSet.includes(term)) {
@@ -186,6 +211,11 @@ export function validateActiveSaigakMigrationContent(files: FileContent[]): stri
           `argocd/applications/saigak/statefulset.yaml: Saigak must run embeddings on the Altra RTX 3090, missing "${term}"`,
         )
       }
+    }
+    if (!hasYamlEnvVarValue(saigakStatefulSet, 'SAIGAK_REQUIRE_GPU_RESIDENCY', 'true')) {
+      failures.push(
+        'argocd/applications/saigak/statefulset.yaml: Saigak must set SAIGAK_REQUIRE_GPU_RESIDENCY=true on the embedding proxy',
+      )
     }
     for (const term of ['ollama pull qwen3:30b-a3b', 'ollama create qwen3-main-saigak']) {
       if (saigakStatefulSet.includes(term)) {


### PR DESCRIPTION
## Summary

- Adds the `saigak-altra-data` local-path PVC to Saigak Argo CD diff ignores so bound controller fields do not create drift or immutable PVC patch attempts.
- Tightens the Flamingo/Saigak migration lint so `SAIGAK_REQUIRE_GPU_RESIDENCY` must have its own adjacent `value: "true"` entry.
- Adds regression tests covering the GPU-residency env-var guard and the new PVC diff-ignore guard.

## Related Issues

Follow-up to review feedback on https://github.com/proompteng/lab/pull/11947#pullrequestreview-4631072238

## Testing

- `bun test scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `bun run lint:flamingo-hard-migration`
- `kubectl kustomize argocd/applications/saigak >/tmp/saigak-kubectl-kustomize.yaml`
- `node ./node_modules/oxfmt/bin/oxfmt --check ./scripts/jangar/validate-flamingo-hard-migration.ts ./scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json scripts/jangar/validate-flamingo-hard-migration.ts scripts/jangar/validate-flamingo-hard-migration.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.