### PR TITLE
ci(nix): auto-merge generated image release prs

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -13,6 +13,15 @@ on:
       - 'argocd/applications/khoshut/kustomization.yaml'
       - 'argocd/applications/analysis/kustomization.yaml'
       - 'argocd/applications/bilig/kustomization.yaml'
+      - 'argocd/applications/app/kustomization.yaml'
+      - 'argocd/applications/bumba/kustomization.yaml'
+      - 'argocd/applications/docs/kustomization.yaml'
+      - 'argocd/applications/froussard/knative-service.yaml'
+      - 'argocd/applications/headlamp/values.yaml'
+      - 'argocd/applications/oirat/kustomization.yaml'
+      - 'argocd/applications/olden/kustomization.yaml'
+      - 'argocd/applications/proompteng/kustomization.yaml'
+      - 'argocd/applications/synthesis/kustomization.yaml'
       - '.github/workflows/release-pr-automerge.yml'
   workflow_dispatch:
     inputs:
@@ -36,7 +45,13 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.pull_request.base.ref == 'main' &&
-          startsWith(github.event.pull_request.head.ref, 'release/') &&
+          (
+            startsWith(github.event.pull_request.head.ref, 'release/') ||
+            (
+              startsWith(github.event.pull_request.head.ref, 'codex/') &&
+              contains(github.event.pull_request.head.ref, '-nix-release-')
+            )
+          ) &&
           github.event.pull_request.draft == false
         )
       }}
@@ -64,10 +79,21 @@ jobs:
           fi
 
           allowed_authors=("app/github-actions" "github-actions[bot]")
-          allowed_paths=(
+          legacy_release_paths=(
             "argocd/applications/khoshut/kustomization.yaml"
             "argocd/applications/analysis/kustomization.yaml"
             "argocd/applications/bilig/kustomization.yaml"
+          )
+          nix_oci_release_paths=(
+            "argocd/applications/app/kustomization.yaml"
+            "argocd/applications/bumba/kustomization.yaml"
+            "argocd/applications/docs/kustomization.yaml"
+            "argocd/applications/froussard/knative-service.yaml"
+            "argocd/applications/headlamp/values.yaml"
+            "argocd/applications/oirat/kustomization.yaml"
+            "argocd/applications/olden/kustomization.yaml"
+            "argocd/applications/proompteng/kustomization.yaml"
+            "argocd/applications/synthesis/kustomization.yaml"
           )
 
           contains() {
@@ -103,7 +129,13 @@ jobs:
             exit 0
           fi
 
-          if [[ "$PR_HEAD_REF" != release/* ]]; then
+          release_kind=""
+          if [[ "$PR_HEAD_REF" == release/* ]]; then
+            release_kind="legacy-release"
+          elif [[ "$PR_HEAD_REF" =~ ^codex/(headlamp|oirat|bumba|froussard)-nix-release-sha-[0-9a-f]{40}$ ]] ||
+            [[ "$PR_HEAD_REF" =~ ^codex/product-nix-release-[0-9a-f]{40}$ ]]; then
+            release_kind="nix-oci-release"
+          else
             echo "reason=head-not-release-branch" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -135,6 +167,22 @@ jobs:
             exit 0
           fi
 
+          if [[ "$release_kind" == "nix-oci-release" ]]; then
+            for required_label in automated-pr nix-oci; do
+              has_required_label=$(
+                gh pr view "$PR_NUMBER" \
+                  -R "$GH_REPO" \
+                  --json labels \
+                  --jq 'any(.labels[]?; .name == "'"$required_label"'")'
+              )
+
+              if [[ "$has_required_label" != "true" ]]; then
+                echo "reason=missing-required-label:${required_label}" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            done
+          fi
+
           changed_files=()
           for attempt in 1 2 3; do
             mapfile -t changed_files < <(
@@ -156,14 +204,21 @@ jobs:
           fi
 
           for path in "${changed_files[@]}"; do
-            if ! contains "$path" "${allowed_paths[@]}"; then
-              echo "reason=changed-file-not-allowlisted:$path" >> "$GITHUB_OUTPUT"
-              exit 0
+            if [[ "$release_kind" == "legacy-release" ]]; then
+              if ! contains "$path" "${legacy_release_paths[@]}"; then
+                echo "reason=changed-file-not-allowlisted:$path" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              if ! contains "$path" "${nix_oci_release_paths[@]}"; then
+                echo "reason=changed-file-not-allowlisted:$path" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
             fi
           done
 
           echo "eligible=true" >> "$GITHUB_OUTPUT"
-          echo "reason=eligible" >> "$GITHUB_OUTPUT"
+          echo "reason=eligible:${release_kind}" >> "$GITHUB_OUTPUT"
 
       - name: Eligibility summary
         shell: bash

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1285,7 +1285,7 @@ describe('native OCI build workflows', () => {
     expect(enabledProductReleaseWorkflow).not.toContain('docker buildx')
   })
 
-  it('blocks stale Docker-era release PRs for migrated simple Nix image apps', () => {
+  it('blocks stale Docker-era release branches but auto-merges generated Nix OCI release PRs', () => {
     expect(autoPrReleaseBranchesWorkflow).toContain('migrated_nix_image_paths=(')
     for (const path of [
       'argocd/applications/app/kustomization.yaml',
@@ -1302,10 +1302,29 @@ describe('native OCI build workflows', () => {
       'argocd/applications/synthesis/kustomization.yaml',
     ]) {
       expect(autoPrReleaseBranchesWorkflow).toContain(`"${path}"`)
-      expect(releasePrAutomergeWorkflow).not.toContain(`'${path}'`)
-      expect(releasePrAutomergeWorkflow).not.toContain(`"${path}"`)
     }
     expect(autoPrReleaseBranchesWorkflow).toContain('reason="migrated-nix-image-app:${path}"')
+    expect(releasePrAutomergeWorkflow).toContain('nix_oci_release_paths=(')
+    expect(releasePrAutomergeWorkflow).toContain("contains(github.event.pull_request.head.ref, '-nix-release-')")
+    for (const path of [
+      'argocd/applications/app/kustomization.yaml',
+      'argocd/applications/bumba/kustomization.yaml',
+      'argocd/applications/docs/kustomization.yaml',
+      'argocd/applications/froussard/knative-service.yaml',
+      'argocd/applications/headlamp/values.yaml',
+      'argocd/applications/oirat/kustomization.yaml',
+      'argocd/applications/olden/kustomization.yaml',
+      'argocd/applications/proompteng/kustomization.yaml',
+      'argocd/applications/synthesis/kustomization.yaml',
+    ]) {
+      expect(releasePrAutomergeWorkflow).toContain(`"${path}"`)
+    }
+    expect(releasePrAutomergeWorkflow).toContain(
+      '[[ "$PR_HEAD_REF" =~ ^codex/(headlamp|oirat|bumba|froussard)-nix-release-sha-[0-9a-f]{40}$ ]]',
+    )
+    expect(releasePrAutomergeWorkflow).toContain('[[ "$PR_HEAD_REF" =~ ^codex/product-nix-release-[0-9a-f]{40}$ ]]')
+    expect(releasePrAutomergeWorkflow).toContain('for required_label in automated-pr nix-oci')
+    expect(releasePrAutomergeWorkflow).toContain('reason=eligible:${release_kind}')
   })
 
   it('keeps Froussard Knative digest rollouts from respecting ignored live annotations during apply', () => {


### PR DESCRIPTION
## Summary

- Enable `release-pr-automerge` for generated Nix OCI digest release PRs from `codex/*-nix-release-*` branches.
- Require same-repo bot-authored PRs, `automated-pr` and `nix-oci` labels, no `do-not-automerge`, and an allowlisted GitOps manifest path.
- Keep legacy `release/*` auto-merge behavior separate from the new Nix OCI release path.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `actionlint .github/workflows/release-pr-automerge.yml`
- `yq e '.jobs.enable.if' .github/workflows/release-pr-automerge.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
