### PR TITLE
fix(torghut): harden hyperliquid margin budgets

### DIFF
--- a/services/torghut/app/hyperliquid_execution/margin.py
+++ b/services/torghut/app/hyperliquid_execution/margin.py
@@ -95,11 +95,24 @@ def gross_margin_used_usd(state: RiskState) -> Decimal:
     """Estimate current margin used from exposure and per-symbol max leverage."""
 
     used = _ZERO
+    mapped_position_notional = _ZERO
+    position_exposure_by_coin = state.position_exposure_usd_by_coin
+    if position_exposure_by_coin is None:
+        position_exposure_by_coin = state.symbol_exposure_usd_by_coin
     for coin, exposure_usd in state.symbol_exposure_usd_by_coin.items():
         leverage = state.max_leverage_by_coin.get(coin, _ONE)
         if leverage <= _ZERO:
             leverage = _ONE
+        mapped_position_notional += abs(position_exposure_by_coin.get(coin, _ZERO))
         used += margin_for_notional(exposure_usd, leverage)
+
+    raw_gross_exposure = _quantize_usd(abs(state.gross_exposure_usd))
+    unmapped_notional = _nonnegative(raw_gross_exposure - mapped_position_notional)
+    if unmapped_notional > _ZERO:
+        used += margin_for_notional(
+            unmapped_notional,
+            _fallback_leverage_for_unmapped_exposure(state),
+        )
     return _quantize_usd(used)
 
 
@@ -121,9 +134,9 @@ def over_budget_coins(
     result: set[str] = set()
     for coin in state.symbol_exposure_usd_by_coin:
         budget, blocker = resolve_margin_budget(coin=coin, state=state, config=config)
-        if blocker == "margin_capacity_below_min_order" and budget is not None:
-            result.add(coin)
-        elif budget is not None and budget.over_budget:
+        if blocker == "symbol_margin_metadata_missing":
+            continue
+        if budget is not None and budget.over_budget:
             result.add(coin)
     return result
 
@@ -149,8 +162,6 @@ def _resolve_equity_basis(state: RiskState) -> tuple[_EquityBasis | None, str | 
     if equity_basis_usd <= _ZERO:
         return None, "account_equity_missing"
     withdrawable_usd = max(state.withdrawable_usd, _ZERO)
-    if withdrawable_usd <= _ZERO:
-        return None, "withdrawable_margin_missing"
     return (
         _EquityBasis(
             equity_basis_usd=_quantize_usd(equity_basis_usd),
@@ -172,9 +183,7 @@ def _resolve_margin_use(
         equity_basis.equity_basis_usd * config.target_margin_utilization
     )
     gross_used = gross_margin_used_usd(state)
-    remaining_gross = _nonnegative(
-        min(target_budget - gross_used, equity_basis.withdrawable_usd)
-    )
+    remaining_gross = _nonnegative(target_budget - gross_used)
     symbol_used = margin_for_notional(
         state.symbol_exposure_usd_by_coin.get(coin, _ZERO),
         max_leverage,
@@ -229,6 +238,15 @@ def _build_budget(
 
 def _nonnegative(value: Decimal) -> Decimal:
     return _quantize_usd(max(value, _ZERO))
+
+
+def _fallback_leverage_for_unmapped_exposure(state: RiskState) -> Decimal:
+    positive_leverages = [
+        leverage for leverage in state.max_leverage_by_coin.values() if leverage > _ZERO
+    ]
+    if not positive_leverages:
+        return _ONE
+    return min(positive_leverages)
 
 
 def _quantize_usd(value: Decimal) -> Decimal:

--- a/services/torghut/app/hyperliquid_execution/margin.py
+++ b/services/torghut/app/hyperliquid_execution/margin.py
@@ -241,12 +241,7 @@ def _nonnegative(value: Decimal) -> Decimal:
 
 
 def _fallback_leverage_for_unmapped_exposure(state: RiskState) -> Decimal:
-    positive_leverages = [
-        leverage for leverage in state.max_leverage_by_coin.values() if leverage > _ZERO
-    ]
-    if not positive_leverages:
-        return _ONE
-    return min(positive_leverages)
+    return _ONE
 
 
 def _quantize_usd(value: Decimal) -> Decimal:

--- a/services/torghut/app/hyperliquid_execution/models.py
+++ b/services/torghut/app/hyperliquid_execution/models.py
@@ -120,6 +120,7 @@ class RiskState:
     open_order_coins: frozenset[str]
     symbol_exposure_usd_by_coin: dict[str, Decimal]
     cooldown_reason_by_coin: dict[str, str]
+    position_exposure_usd_by_coin: dict[str, Decimal] | None = None
     account_value_usd: Decimal = Decimal("0")
     withdrawable_usd: Decimal = Decimal("0")
     max_leverage_by_coin: dict[str, Decimal] = field(default_factory=_empty_decimal_map)

--- a/services/torghut/app/hyperliquid_execution/repository_read_models.py
+++ b/services/torghut/app/hyperliquid_execution/repository_read_models.py
@@ -65,6 +65,16 @@ def risk_state(
             """
         )
     ).mappings()
+    position_exposure_rows = session.execute(
+        text(
+            """
+            SELECT coin, SUM(ABS(notional_usd)) AS exposure_usd
+            FROM hyperliquid_execution_positions
+            WHERE execution_network = 'testnet'
+            GROUP BY coin
+            """
+        )
+    ).mappings()
     cooldown_rows = session.execute(
         text(
             """
@@ -88,6 +98,10 @@ def risk_state(
         },
         cooldown_reason_by_coin={
             str(row["coin"]): str(row["cooldown_reason"]) for row in cooldown_rows
+        },
+        position_exposure_usd_by_coin={
+            str(row["coin"]): Decimal(str(row["exposure_usd"]))
+            for row in position_exposure_rows
         },
         max_leverage_by_coin=dict(max_leverage_by_coin or {}),
     )

--- a/services/torghut/tests/hyperliquid_execution/test_margin.py
+++ b/services/torghut/tests/hyperliquid_execution/test_margin.py
@@ -22,7 +22,7 @@ def test_gross_margin_use_counts_unmapped_raw_account_exposure() -> None:
         max_leverage_by_coin={"NVDA": Decimal("20")},
     )
 
-    assert gross_margin_used_usd(state) == Decimal("350.000000")
+    assert gross_margin_used_usd(state) == Decimal("6050.000000")
     assert gross_margin_over_budget(state=state, config=config)
 
 
@@ -35,7 +35,7 @@ def test_gross_margin_use_keeps_raw_position_offset_position_only() -> None:
         max_leverage_by_coin={"NVDA": Decimal("20")},
     )
 
-    assert gross_margin_used_usd(state) == Decimal("450.000000")
+    assert gross_margin_used_usd(state) == Decimal("6150.000000")
     assert gross_margin_over_budget(state=state, config=config)
 
 
@@ -48,7 +48,7 @@ def test_gross_margin_use_treats_empty_position_map_as_authoritative() -> None:
         max_leverage_by_coin={"NVDA": Decimal("20")},
     )
 
-    assert gross_margin_used_usd(state) == Decimal("500.000000")
+    assert gross_margin_used_usd(state) == Decimal("7150.000000")
     assert gross_margin_over_budget(state=state, config=config)
 
 

--- a/services/torghut/tests/hyperliquid_execution/test_margin.py
+++ b/services/torghut/tests/hyperliquid_execution/test_margin.py
@@ -1,0 +1,136 @@
+"""Regression tests for Hyperliquid execution margin budgeting."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.hyperliquid_execution.config import HyperliquidExecutionConfig
+from app.hyperliquid_execution.margin import (
+    gross_margin_over_budget,
+    gross_margin_used_usd,
+    over_budget_coins,
+    resolve_margin_budget,
+)
+from app.hyperliquid_execution.models import RiskState
+
+
+def test_gross_margin_use_counts_unmapped_raw_account_exposure() -> None:
+    config = HyperliquidExecutionConfig.from_env({})
+    state = _risk_state(
+        gross_exposure_usd=Decimal("7000"),
+        symbol_exposure_usd_by_coin={"NVDA": Decimal("1000")},
+        max_leverage_by_coin={"NVDA": Decimal("20")},
+    )
+
+    assert gross_margin_used_usd(state) == Decimal("350.000000")
+    assert gross_margin_over_budget(state=state, config=config)
+
+
+def test_gross_margin_use_keeps_raw_position_offset_position_only() -> None:
+    config = HyperliquidExecutionConfig.from_env({})
+    state = _risk_state(
+        gross_exposure_usd=Decimal("7000"),
+        symbol_exposure_usd_by_coin={"NVDA": Decimal("3000")},
+        position_exposure_usd_by_coin={"NVDA": Decimal("1000")},
+        max_leverage_by_coin={"NVDA": Decimal("20")},
+    )
+
+    assert gross_margin_used_usd(state) == Decimal("450.000000")
+    assert gross_margin_over_budget(state=state, config=config)
+
+
+def test_gross_margin_use_treats_empty_position_map_as_authoritative() -> None:
+    config = HyperliquidExecutionConfig.from_env({})
+    state = _risk_state(
+        gross_exposure_usd=Decimal("7000"),
+        symbol_exposure_usd_by_coin={"NVDA": Decimal("3000")},
+        position_exposure_usd_by_coin={},
+        max_leverage_by_coin={"NVDA": Decimal("20")},
+    )
+
+    assert gross_margin_used_usd(state) == Decimal("500.000000")
+    assert gross_margin_over_budget(state=state, config=config)
+
+
+def test_sub_min_residual_capacity_does_not_mark_symbol_over_budget() -> None:
+    config = HyperliquidExecutionConfig.from_env(
+        {"HYPERLIQUID_EXECUTION_MIN_ORDER_NOTIONAL_USD": "12"}
+    )
+    state = _risk_state(
+        gross_exposure_usd=Decimal("1589"),
+        symbol_exposure_usd_by_coin={"NVDA": Decimal("1589")},
+        max_leverage_by_coin={"NVDA": Decimal("20")},
+    )
+
+    budget, blocker = resolve_margin_budget(
+        coin="NVDA",
+        state=state,
+        config=config,
+    )
+
+    assert budget is not None
+    assert blocker == "margin_capacity_below_min_order"
+    assert budget.remaining_symbol_margin_usd == Decimal("0.550000")
+    assert budget.order_notional_capacity_usd == Decimal("11.000000")
+    assert not budget.over_budget
+    assert over_budget_coins(state=state, config=config) == set()
+
+
+def test_symbol_over_budget_is_detected_with_zero_withdrawable_margin() -> None:
+    config = HyperliquidExecutionConfig.from_env({})
+    under_symbol_cap = _risk_state(
+        withdrawable_usd=Decimal("0"),
+        gross_exposure_usd=Decimal("1000"),
+        symbol_exposure_usd_by_coin={"NVDA": Decimal("1000")},
+        max_leverage_by_coin={"NVDA": Decimal("20")},
+    )
+    over_symbol_cap = _risk_state(
+        withdrawable_usd=Decimal("0"),
+        gross_exposure_usd=Decimal("1700"),
+        symbol_exposure_usd_by_coin={"NVDA": Decimal("1700")},
+        max_leverage_by_coin={"NVDA": Decimal("20")},
+    )
+
+    under_budget, under_blocker = resolve_margin_budget(
+        coin="NVDA",
+        state=under_symbol_cap,
+        config=config,
+    )
+    over_budget, over_blocker = resolve_margin_budget(
+        coin="NVDA",
+        state=over_symbol_cap,
+        config=config,
+    )
+
+    assert under_budget is not None
+    assert under_blocker == "margin_capacity_below_min_order"
+    assert not under_budget.over_budget
+    assert over_budget_coins(state=under_symbol_cap, config=config) == set()
+
+    assert over_budget is not None
+    assert over_blocker == "margin_capacity_below_min_order"
+    assert over_budget.over_budget
+    assert over_budget_coins(state=over_symbol_cap, config=config) == {"NVDA"}
+
+
+def _risk_state(
+    *,
+    gross_exposure_usd: Decimal,
+    symbol_exposure_usd_by_coin: dict[str, Decimal],
+    max_leverage_by_coin: dict[str, Decimal],
+    withdrawable_usd: Decimal = Decimal("900"),
+    position_exposure_usd_by_coin: dict[str, Decimal] | None = None,
+) -> RiskState:
+    return RiskState(
+        trading_enabled=True,
+        dependencies=(),
+        gross_exposure_usd=gross_exposure_usd,
+        daily_realized_pnl_usd=Decimal("0"),
+        open_order_coins=frozenset(),
+        symbol_exposure_usd_by_coin=symbol_exposure_usd_by_coin,
+        cooldown_reason_by_coin={},
+        position_exposure_usd_by_coin=position_exposure_usd_by_coin,
+        account_value_usd=Decimal("1000"),
+        withdrawable_usd=withdrawable_usd,
+        max_leverage_by_coin=max_leverage_by_coin,
+    )

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
@@ -739,6 +739,8 @@ class _FakeSession:
             ]
         if "SELECT DISTINCT coin" in sql:
             return [{"coin": "NVDA"}] if self.risk_open_coin else []
+        if "SUM(ABS(notional_usd))" in sql:
+            return [{"coin": "NVDA", "exposure_usd": str(self.risk_exposure_usd)}]
         if "GROUP BY coin" in sql and "exposures" in sql:
             return [{"coin": "NVDA", "exposure_usd": str(self.risk_exposure_usd)}]
         if "cooldown_reason" in sql and "cooldown_until > now()" in sql:


### PR DESCRIPTION
## Summary

- Count raw account gross exposure that is not represented in the per-symbol exposure map when estimating used margin.
- Separate gross/symbol budget exhaustion from withdrawable free margin so zero withdrawable margin does not hide symbol cap breaches.
- Stop classifying sub-min residual order capacity as over-budget reduce-only maintenance.
- Add margin regressions covering the PR #11949 review scenarios; verified the current runtime image pin already descends from PR #11949.

## Related Issues

Follow-up to #11949 review comments.

## Testing

- `PYTHONPATH=app python3 - <<'PY' ... run tests/hyperliquid_execution/test_margin.py regression functions ... PY`
- `PYTHONPATH=app python3 - <<'PY' ... run focused strategy risk functions from tests/hyperliquid_execution/test_strategy_risk_universe.py ... PY`
- `PYTHONPATH=app python3 - <<'PY' ... run focused maintenance functions from tests/hyperliquid_execution/test_maintenance.py ... PY`
- `python3 -m compileall -q app/hyperliquid_execution tests/hyperliquid_execution/test_margin.py`
- `node /workspace/.agents-shell/home/.npm/_npx/54f2e868007e631e/node_modules/pyright/index.js app/hyperliquid_execution/margin.py tests/hyperliquid_execution/test_margin.py --pythonpath $(command -v python3)`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
