### PR TITLE
fix(agents): bootstrap memory provider schema

### DIFF
--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -145,11 +145,11 @@ jobs:
           if [[ "${build_status}" -ne 0 ]]; then
             rm -f "${out_link}"
             echo "::warning title=Nix image archive build retried without Attic::Attic substitution or build timed out/failed for ${PACKAGE_ATTR} on ${ARCH}; retrying with cache.nixos.org only so the runner does not hang on a final image archive copy."
-            fallback_nix_config=$'experimental-features = nix-command flakes\nsubstituters = https://cache.nixos.org/\nfallback = true\nconnect-timeout = 10\nstalled-download-timeout = 60\ndownload-attempts = 1'
+            fallback_nix_config=$'experimental-features = nix-command flakes\nsubstituters = https://cache.nixos.org/\nfallback = true\nconnect-timeout = 10\nstalled-download-timeout = 60\ndownload-attempts = 1\nbuild-users-group ='
             env NIX_CONFIG="${fallback_nix_config}" \
               bash nix/ci-run-timed.sh "build-image-${ARCH}-cache-nixos-fallback" "${NIX_OCI_LOG_DIR}/build-image-${ARCH}-cache-nixos-fallback.log" \
               timeout --kill-after=30s "${NIX_IMAGE_BUILD_ATTIC_TIMEOUT}" \
-              nix build ".#${PACKAGE_ATTR}" --print-build-logs --out-link "${out_link}"
+              nix build ".#${PACKAGE_ATTR}" --print-build-logs --out-link "${out_link}" --option build-users-group ''
           fi
           image_tar="$(readlink -f "${out_link}")"
           if [ ! -f "${image_tar}" ]; then

--- a/services/agents/src/server/memory-provider-schema.test.ts
+++ b/services/agents/src/server/memory-provider-schema.test.ts
@@ -7,7 +7,7 @@ import {
   type MemoryProviderQueryable,
 } from './memory-provider-schema'
 
-const makeQueryable = (options: { hasEmbeddings?: boolean; extensions?: string[] } = {}) => {
+const makeQueryable = (options: { embeddingRows?: number; extensions?: string[] } = {}) => {
   const calls: { sql: string; params?: unknown[] }[] = []
   const query = vi.fn(async (sql: string, params?: unknown[]) => {
     calls.push({ sql, params })
@@ -15,8 +15,8 @@ const makeQueryable = (options: { hasEmbeddings?: boolean; extensions?: string[]
     if (normalized.includes('select extname from pg_extension')) {
       return { rows: (options.extensions ?? ['vector', 'pgcrypto']).map((extname) => ({ extname })) }
     }
-    if (normalized.includes('select exists') && normalized.includes('memory_embeddings')) {
-      return { rows: [{ has_rows: options.hasEmbeddings ?? false }] }
+    if (normalized.includes('select count(*)') && normalized.includes('memory_embeddings')) {
+      return { rows: [{ row_count: options.embeddingRows ?? 0 }] }
     }
     return { rows: [] }
   })
@@ -44,8 +44,8 @@ describe('memory provider schema bootstrap', () => {
     expect(sqlText).not.toContain('using ivfflat')
   })
 
-  it('does not create the ANN index before embeddings exist', async () => {
-    const { calls, db } = makeQueryable({ hasEmbeddings: false })
+  it('does not create the ANN index before enough embeddings exist', async () => {
+    const { calls, db } = makeQueryable({ embeddingRows: 99_999 })
 
     await expect(createMemoryProviderAnnIndexIfReady(db, { schema: 'public', embeddingDimension: 3 })).resolves.toBe(
       false,
@@ -54,13 +54,14 @@ describe('memory provider schema bootstrap', () => {
     expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(false)
   })
 
-  it('creates the ANN index after embeddings exist', async () => {
-    const { calls, db } = makeQueryable({ hasEmbeddings: true })
+  it('creates the ANN index after there are enough embeddings to train it', async () => {
+    const { calls, db } = makeQueryable({ embeddingRows: 100_000 })
     await expect(createMemoryProviderAnnIndexIfReady(db, { schema: 'public', embeddingDimension: 3 })).resolves.toBe(
       true,
     )
 
     expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(true)
+    expect(calls.some((call) => call.sql.toLowerCase().includes('with (lists = 100)'))).toBe(true)
   })
 
   it('fails fast when the provider database is missing required extensions', async () => {

--- a/services/agents/src/server/memory-provider-schema.test.ts
+++ b/services/agents/src/server/memory-provider-schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createMemoryProviderAnnIndexIfReady,
+  ensureMemoryProviderSchema,
+  getMemoryProviderSchemaStatements,
+  type MemoryProviderQueryable,
+} from './memory-provider-schema'
+
+const makeQueryable = (options: { hasEmbeddings?: boolean; extensions?: string[] } = {}) => {
+  const calls: { sql: string; params?: unknown[] }[] = []
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    calls.push({ sql, params })
+    const normalized = sql.toLowerCase()
+    if (normalized.includes('select extname from pg_extension')) {
+      return { rows: (options.extensions ?? ['vector', 'pgcrypto']).map((extname) => ({ extname })) }
+    }
+    if (normalized.includes('select exists') && normalized.includes('memory_embeddings')) {
+      return { rows: [{ has_rows: options.hasEmbeddings ?? false }] }
+    }
+    return { rows: [] }
+  })
+
+  return { calls, db: { query } as unknown as MemoryProviderQueryable }
+}
+
+describe('memory provider schema bootstrap', () => {
+  it('creates provider tables and base indexes without creating an IVFFlat index', async () => {
+    const { calls, db } = makeQueryable()
+
+    await ensureMemoryProviderSchema(db, { schema: 'public', embeddingDimension: 3 })
+
+    const sqlText = calls.map((call) => call.sql.toLowerCase()).join('\n')
+    expect(sqlText).toContain('create table if not exists "public"."memory_events"')
+    expect(sqlText).toContain('create table if not exists "public"."memory_kv"')
+    expect(sqlText).toContain('create table if not exists "public"."memory_embeddings"')
+    expect(sqlText).not.toContain('using ivfflat')
+  })
+
+  it('keeps the migration statement set free of the deferred ANN index', () => {
+    const sqlText = getMemoryProviderSchemaStatements(3, 'public').join('\n').toLowerCase()
+
+    expect(sqlText).toContain('memory_embeddings')
+    expect(sqlText).not.toContain('using ivfflat')
+  })
+
+  it('does not create the ANN index before embeddings exist', async () => {
+    const { calls, db } = makeQueryable({ hasEmbeddings: false })
+
+    await expect(createMemoryProviderAnnIndexIfReady(db, { schema: 'public', embeddingDimension: 3 })).resolves.toBe(
+      false,
+    )
+
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(false)
+  })
+
+  it('creates the ANN index after embeddings exist', async () => {
+    const { calls, db } = makeQueryable({ hasEmbeddings: true })
+    await expect(createMemoryProviderAnnIndexIfReady(db, { schema: 'public', embeddingDimension: 3 })).resolves.toBe(
+      true,
+    )
+
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(true)
+  })
+
+  it('fails fast when the provider database is missing required extensions', async () => {
+    const { db } = makeQueryable({ extensions: [] })
+
+    await expect(ensureMemoryProviderSchema(db, { schema: 'public', embeddingDimension: 3 })).rejects.toThrow(
+      /missing required Postgres extensions in Memory provider database/i,
+    )
+  })
+})

--- a/services/agents/src/server/memory-provider-schema.ts
+++ b/services/agents/src/server/memory-provider-schema.ts
@@ -10,6 +10,9 @@ export type MemoryProviderSchemaConnection = {
 export type MemoryProviderQueryable = Pick<Pool, 'query'>
 
 const REQUIRED_EXTENSIONS = ['vector', 'pgcrypto'] as const
+const PREFERRED_IVFFLAT_LISTS = 100
+const PREFERRED_IVFFLAT_ROWS_PER_LIST = 1000
+const MIN_IVFFLAT_INDEX_ROWS = PREFERRED_IVFFLAT_LISTS * PREFERRED_IVFFLAT_ROWS_PER_LIST
 
 const quoteIdentifier = (identifier: string) => {
   const normalized = identifier.trim()
@@ -70,11 +73,17 @@ export const getMemoryProviderSchemaStatements = (dimension: number, schema: str
   ]
 }
 
-const getMemoryProviderAnnIndexStatement = (dimension: number, schema: string) => {
+const getMemoryProviderAnnIndexStatement = (dimension: number, schema: string, lists: number) => {
   normalizeEmbeddingDimension(dimension)
+  const normalizedLists = Math.max(1, Math.floor(lists))
   const embeddingsTable = qualifyMemoryProviderTable(schema, 'memory_embeddings')
   return `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_embeddings_embedding_idx')}
-    ON ${embeddingsTable} USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);`
+    ON ${embeddingsTable} USING ivfflat (embedding vector_cosine_ops) WITH (lists = ${normalizedLists});`
+}
+
+const estimateIvfflatLists = (rowCount: number) => {
+  if (rowCount < 1_000_000) return Math.max(1, Math.floor(rowCount / PREFERRED_IVFFLAT_ROWS_PER_LIST))
+  return Math.max(1, Math.floor(Math.sqrt(rowCount)))
 }
 
 export const ensureMemoryProviderExtensions = async (db: MemoryProviderQueryable) => {
@@ -119,12 +128,19 @@ export const createMemoryProviderAnnIndexIfReady = async (
   }
 
   const embeddingsTable = qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')
-  const { rows } = await db.query<{ has_rows: boolean }>(
-    `SELECT EXISTS (SELECT 1 FROM ${embeddingsTable} LIMIT 1) AS has_rows`,
+  const { rows } = await db.query<{ row_count: string | number }>(
+    `SELECT COUNT(*)::bigint AS row_count FROM ${embeddingsTable}`,
   )
-  if (!rows[0]?.has_rows) return false
+  const rowCount = Number(rows[0]?.row_count ?? 0)
+  if (!Number.isFinite(rowCount) || rowCount < MIN_IVFFLAT_INDEX_ROWS) return false
 
-  await db.query(getMemoryProviderAnnIndexStatement(connection.embeddingDimension, connection.schema))
+  await db.query(
+    getMemoryProviderAnnIndexStatement(
+      connection.embeddingDimension,
+      connection.schema,
+      estimateIvfflatLists(rowCount),
+    ),
+  )
   return true
 }
 

--- a/services/agents/src/server/memory-provider-schema.ts
+++ b/services/agents/src/server/memory-provider-schema.ts
@@ -1,0 +1,134 @@
+import type { Pool } from 'pg'
+
+import { MAX_PGVECTOR_ANN_DIMENSION, supportsPgvectorAnnIndex } from './pgvector-indexing'
+
+export type MemoryProviderSchemaConnection = {
+  schema: string
+  embeddingDimension: number
+}
+
+export type MemoryProviderQueryable = Pick<Pool, 'query'>
+
+const REQUIRED_EXTENSIONS = ['vector', 'pgcrypto'] as const
+
+const quoteIdentifier = (identifier: string) => {
+  const normalized = identifier.trim()
+  if (!normalized) throw new Error('Postgres identifier cannot be empty')
+  if (normalized.includes('\0')) throw new Error('Postgres identifier cannot contain a NUL byte')
+  return `"${normalized.replace(/"/g, '""')}"`
+}
+
+const normalizeEmbeddingDimension = (dimension: number) => {
+  if (!Number.isFinite(dimension) || dimension <= 0) {
+    throw new Error(`memory embedding dimension must be a positive integer; got ${dimension}`)
+  }
+  return Math.floor(dimension)
+}
+
+export const qualifyMemoryProviderTable = (schema: string, table: string) =>
+  `${quoteIdentifier(schema)}.${quoteIdentifier(table)}`
+
+export const getMemoryProviderSchemaStatements = (dimension: number, schema: string) => {
+  const embeddingDimension = normalizeEmbeddingDimension(dimension)
+  const eventsTable = qualifyMemoryProviderTable(schema, 'memory_events')
+  const kvTable = qualifyMemoryProviderTable(schema, 'memory_kv')
+  const embeddingsTable = qualifyMemoryProviderTable(schema, 'memory_embeddings')
+
+  return [
+    `CREATE TABLE IF NOT EXISTS ${eventsTable} (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload JSONB NOT NULL DEFAULT '{}'::JSONB
+    );`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_events_dataset_created_at_idx')}
+    ON ${eventsTable} (dataset, created_at DESC);`,
+    `CREATE TABLE IF NOT EXISTS ${kvTable} (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value JSONB NOT NULL DEFAULT '{}'::JSONB,
+      CONSTRAINT ${quoteIdentifier('memory_kv_dataset_key_key')} UNIQUE (dataset, key)
+    );`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_kv_dataset_key_idx')}
+    ON ${kvTable} (dataset, key);`,
+    `CREATE TABLE IF NOT EXISTS ${embeddingsTable} (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      key TEXT NOT NULL,
+      embedding vector(${embeddingDimension}) NOT NULL,
+      metadata JSONB NOT NULL DEFAULT '{}'::JSONB
+    );`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_embeddings_dataset_key_idx')}
+    ON ${embeddingsTable} (dataset, key);`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_embeddings_metadata_idx')}
+    ON ${embeddingsTable} USING GIN (metadata JSONB_PATH_OPS);`,
+  ]
+}
+
+const getMemoryProviderAnnIndexStatement = (dimension: number, schema: string) => {
+  normalizeEmbeddingDimension(dimension)
+  const embeddingsTable = qualifyMemoryProviderTable(schema, 'memory_embeddings')
+  return `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_embeddings_embedding_idx')}
+    ON ${embeddingsTable} USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);`
+}
+
+export const ensureMemoryProviderExtensions = async (db: MemoryProviderQueryable) => {
+  const { rows } = await db.query<{ extname: string }>(
+    'SELECT extname FROM pg_extension WHERE extname = ANY($1::text[])',
+    [[...REQUIRED_EXTENSIONS]],
+  )
+
+  const installed = new Set(rows.map((row) => row.extname))
+  const missing = REQUIRED_EXTENSIONS.filter((ext) => !installed.has(ext))
+  if (missing.length > 0) {
+    throw new Error(
+      `missing required Postgres extensions in Memory provider database: ${missing.join(', ')}. ` +
+        'Install them as a privileged user (e.g. `CREATE EXTENSION vector; CREATE EXTENSION pgcrypto;`) ' +
+        'before using postgres Memory providers.',
+    )
+  }
+}
+
+export const ensureMemoryProviderSchema = async (
+  db: MemoryProviderQueryable,
+  connection: MemoryProviderSchemaConnection,
+) => {
+  await ensureMemoryProviderExtensions(db)
+  for (const statement of getMemoryProviderSchemaStatements(connection.embeddingDimension, connection.schema)) {
+    await db.query(statement)
+  }
+}
+
+export const createMemoryProviderAnnIndexIfReady = async (
+  db: MemoryProviderQueryable,
+  connection: MemoryProviderSchemaConnection,
+) => {
+  if (!supportsPgvectorAnnIndex(connection.embeddingDimension)) {
+    console.log('[agents:pgvector]', {
+      event: 'skip_ann_index',
+      context: `${connection.schema}.memory_embeddings`,
+      dimension: connection.embeddingDimension,
+      maxSupportedDimension: MAX_PGVECTOR_ANN_DIMENSION,
+    })
+    return false
+  }
+
+  const embeddingsTable = qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')
+  const { rows } = await db.query<{ has_rows: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM ${embeddingsTable} LIMIT 1) AS has_rows`,
+  )
+  if (!rows[0]?.has_rows) return false
+
+  await db.query(getMemoryProviderAnnIndexStatement(connection.embeddingDimension, connection.schema))
+  return true
+}
+
+export const __test__ = {
+  getMemoryProviderAnnIndexStatement,
+  quoteIdentifier,
+}

--- a/services/agents/src/server/memory-provider.test.ts
+++ b/services/agents/src/server/memory-provider.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { __test__, queryMemory, writeMemoryEmbedding, writeMemoryEvent } from './memory-provider'
+import type { MemoryProviderQueryable } from './memory-provider-schema'
+
+const connection = {
+  dataset: 'agent-memory',
+  schema: 'public',
+  embeddingDimension: 3,
+  connectionString: 'postgresql://provider-db',
+}
+
+const makePool = (options: { hasEmbeddings?: boolean } = {}) => {
+  const calls: { sql: string; params?: unknown[] }[] = []
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    calls.push({ sql, params })
+    const normalized = sql.toLowerCase()
+    if (normalized.includes('select extname from pg_extension')) {
+      return { rows: [{ extname: 'vector' }, { extname: 'pgcrypto' }] }
+    }
+    if (normalized.includes('select exists') && normalized.includes('memory_embeddings')) {
+      return { rows: [{ has_rows: options.hasEmbeddings ?? true }] }
+    }
+    if (normalized.includes('from "public"."memory_embeddings"') && normalized.includes('embedding <=>')) {
+      return { rows: [{ key: 'note-1', score: 0.9, metadata: { source: 'test' } }] }
+    }
+    return { rows: [] }
+  })
+
+  return { calls, pool: { query } as unknown as MemoryProviderQueryable }
+}
+
+describe('memory provider operations', () => {
+  const previousEnv: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of ['NODE_ENV', 'OPENAI_API_KEY', 'OPENAI_EMBEDDING_DIMENSION']) {
+      previousEnv[key] = process.env[key]
+    }
+    process.env.NODE_ENV = 'test'
+    delete process.env.OPENAI_API_KEY
+    process.env.OPENAI_EMBEDDING_DIMENSION = '3'
+  })
+
+  afterEach(() => {
+    __test__.resetMemoryProviderState()
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  })
+
+  it('bootstraps the resolved provider database before writing events', async () => {
+    const { calls, pool } = makePool()
+    __test__.setMemoryProviderPoolFactory(() => pool)
+
+    await writeMemoryEvent(connection, 'sync-started', { ok: true })
+
+    const createTableIndex = calls.findIndex((call) => call.sql.toLowerCase().includes('create table if not exists'))
+    const insertIndex = calls.findIndex((call) =>
+      call.sql.toLowerCase().includes('insert into "public"."memory_events"'),
+    )
+    expect(createTableIndex).toBeGreaterThanOrEqual(0)
+    expect(insertIndex).toBeGreaterThan(createTableIndex)
+    expect(calls[insertIndex]?.params).toEqual(['agent-memory', 'sync-started', { ok: true }])
+  })
+
+  it('defers the ANN index until an embedding write has inserted data', async () => {
+    const { calls, pool } = makePool({ hasEmbeddings: true })
+    __test__.setMemoryProviderPoolFactory(() => pool)
+
+    await writeMemoryEmbedding(connection, 'note-1', 'hello world', { source: 'test' })
+
+    const insertIndex = calls.findIndex((call) =>
+      call.sql.toLowerCase().includes('insert into "public"."memory_embeddings"'),
+    )
+    const annIndex = calls.findIndex((call) => call.sql.toLowerCase().includes('using ivfflat'))
+    expect(insertIndex).toBeGreaterThanOrEqual(0)
+    expect(annIndex).toBeGreaterThan(insertIndex)
+  })
+
+  it('creates the ANN index lazily on query only when embeddings already exist', async () => {
+    const { calls, pool } = makePool({ hasEmbeddings: true })
+    __test__.setMemoryProviderPoolFactory(() => pool)
+
+    await expect(queryMemory(connection, 'hello', 1)).resolves.toEqual([
+      { key: 'note-1', score: 0.9, metadata: { source: 'test' } },
+    ])
+
+    const annIndex = calls.findIndex((call) => call.sql.toLowerCase().includes('using ivfflat'))
+    const queryIndex = calls.findIndex(
+      (call) =>
+        call.sql.toLowerCase().includes('from "public"."memory_embeddings"') &&
+        call.sql.toLowerCase().includes('embedding <=>'),
+    )
+    expect(annIndex).toBeGreaterThanOrEqual(0)
+    expect(queryIndex).toBeGreaterThan(annIndex)
+  })
+})

--- a/services/agents/src/server/memory-provider.test.ts
+++ b/services/agents/src/server/memory-provider.test.ts
@@ -10,16 +10,13 @@ const connection = {
   connectionString: 'postgresql://provider-db',
 }
 
-const makePool = (options: { hasEmbeddings?: boolean } = {}) => {
+const makePool = () => {
   const calls: { sql: string; params?: unknown[] }[] = []
   const query = vi.fn(async (sql: string, params?: unknown[]) => {
     calls.push({ sql, params })
     const normalized = sql.toLowerCase()
     if (normalized.includes('select extname from pg_extension')) {
       return { rows: [{ extname: 'vector' }, { extname: 'pgcrypto' }] }
-    }
-    if (normalized.includes('select exists') && normalized.includes('memory_embeddings')) {
-      return { rows: [{ has_rows: options.hasEmbeddings ?? true }] }
     }
     if (normalized.includes('from "public"."memory_embeddings"') && normalized.includes('embedding <=>')) {
       return { rows: [{ key: 'note-1', score: 0.9, metadata: { source: 'test' } }] }
@@ -78,8 +75,8 @@ describe('memory provider operations', () => {
     expect(calls[insertIndex]?.params).toEqual(['agent-memory', 'sync-started', { ok: true }])
   })
 
-  it('defers the ANN index until an embedding write has inserted data', async () => {
-    const { calls, pool } = makePool({ hasEmbeddings: true })
+  it('does not create the IVFFlat index in the embedding write path', async () => {
+    const { calls, pool } = makePool()
     __test__.setMemoryProviderPoolFactory(() => pool)
 
     await writeMemoryEmbedding(connection, 'note-1', 'hello world', { source: 'test' })
@@ -87,26 +84,24 @@ describe('memory provider operations', () => {
     const insertIndex = calls.findIndex((call) =>
       call.sql.toLowerCase().includes('insert into "public"."memory_embeddings"'),
     )
-    const annIndex = calls.findIndex((call) => call.sql.toLowerCase().includes('using ivfflat'))
     expect(insertIndex).toBeGreaterThanOrEqual(0)
-    expect(annIndex).toBeGreaterThan(insertIndex)
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(false)
   })
 
-  it('creates the ANN index lazily on query only when embeddings already exist', async () => {
-    const { calls, pool } = makePool({ hasEmbeddings: true })
+  it('queries memory without creating an online IVFFlat index', async () => {
+    const { calls, pool } = makePool()
     __test__.setMemoryProviderPoolFactory(() => pool)
 
     await expect(queryMemory(connection, 'hello', 1)).resolves.toEqual([
       { key: 'note-1', score: 0.9, metadata: { source: 'test' } },
     ])
 
-    const annIndex = calls.findIndex((call) => call.sql.toLowerCase().includes('using ivfflat'))
     const queryIndex = calls.findIndex(
       (call) =>
         call.sql.toLowerCase().includes('from "public"."memory_embeddings"') &&
         call.sql.toLowerCase().includes('embedding <=>'),
     )
-    expect(annIndex).toBeGreaterThanOrEqual(0)
-    expect(queryIndex).toBeGreaterThan(annIndex)
+    expect(queryIndex).toBeGreaterThanOrEqual(0)
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(false)
   })
 })

--- a/services/agents/src/server/memory-provider.test.ts
+++ b/services/agents/src/server/memory-provider.test.ts
@@ -34,11 +34,21 @@ describe('memory provider operations', () => {
   const previousEnv: Record<string, string | undefined> = {}
 
   beforeEach(() => {
-    for (const key of ['NODE_ENV', 'OPENAI_API_KEY', 'OPENAI_EMBEDDING_DIMENSION']) {
+    for (const key of [
+      'NODE_ENV',
+      'OPENAI_API_KEY',
+      'OPENAI_EMBEDDING_API_BASE_URL',
+      'OPENAI_API_BASE_URL',
+      'OPENAI_API_BASE',
+      'OPENAI_EMBEDDING_DIMENSION',
+    ]) {
       previousEnv[key] = process.env[key]
     }
     process.env.NODE_ENV = 'test'
     delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_EMBEDDING_API_BASE_URL
+    delete process.env.OPENAI_API_BASE_URL
+    delete process.env.OPENAI_API_BASE
     process.env.OPENAI_EMBEDDING_DIMENSION = '3'
   })
 

--- a/services/agents/src/server/memory-provider.ts
+++ b/services/agents/src/server/memory-provider.ts
@@ -4,6 +4,12 @@ import { Pool } from 'pg'
 
 import { type KubernetesClient, RESOURCE_MAP } from './kube-types'
 import { resolveEmbeddingConfig } from './memory-config'
+import {
+  createMemoryProviderAnnIndexIfReady,
+  ensureMemoryProviderSchema,
+  qualifyMemoryProviderTable,
+  type MemoryProviderQueryable,
+} from './memory-provider-schema'
 import { asRecord, asString, readNested } from './primitives'
 
 export type MemoryConnection = {
@@ -24,7 +30,10 @@ type EnvSource = Record<string, string | undefined>
 const DEFAULT_MEMORY_DATABASE_POOL_MAX = 2
 
 const globalState = globalThis as typeof globalThis & {
+  __agentsMemoryProviderAnnReady?: Map<string, Promise<boolean>>
+  __agentsMemoryProviderPoolFactory?: (connectionString: string) => MemoryProviderQueryable
   __agentsMemoryProviderPools?: Map<string, Pool>
+  __agentsMemoryProviderSchemaReady?: Map<string, Promise<void>>
 }
 
 const parsePositiveInt = (value: string | undefined, fallback: number) => {
@@ -85,7 +94,10 @@ const getPoolCache = () => {
   return globalState.__agentsMemoryProviderPools
 }
 
-const getMemoryPool = (connectionString: string) => {
+const getMemoryPool = (connectionString: string): MemoryProviderQueryable => {
+  const testPoolFactory = globalState.__agentsMemoryProviderPoolFactory
+  if (testPoolFactory) return testPoolFactory(connectionString)
+
   const pools = getPoolCache()
   const existing = pools.get(connectionString)
   if (existing) return existing
@@ -99,10 +111,65 @@ const getMemoryPool = (connectionString: string) => {
   return created
 }
 
+const getSchemaReadyCache = () => {
+  if (!globalState.__agentsMemoryProviderSchemaReady) {
+    globalState.__agentsMemoryProviderSchemaReady = new Map<string, Promise<void>>()
+  }
+  return globalState.__agentsMemoryProviderSchemaReady
+}
+
+const getAnnReadyCache = () => {
+  if (!globalState.__agentsMemoryProviderAnnReady) {
+    globalState.__agentsMemoryProviderAnnReady = new Map<string, Promise<boolean>>()
+  }
+  return globalState.__agentsMemoryProviderAnnReady
+}
+
+const memoryProviderSchemaCacheKey = (connection: MemoryConnection) =>
+  `${connection.connectionString}\0${connection.schema}\0${connection.embeddingDimension}`
+
+const ensureProviderSchemaReady = async (connection: MemoryConnection, pool: MemoryProviderQueryable) => {
+  const cache = getSchemaReadyCache()
+  const key = memoryProviderSchemaCacheKey(connection)
+  let ready = cache.get(key)
+  if (!ready) {
+    ready = ensureMemoryProviderSchema(pool, connection)
+    cache.set(key, ready)
+  }
+
+  try {
+    await ready
+  } catch (error) {
+    cache.delete(key)
+    throw error
+  }
+}
+
+const ensureProviderAnnIndexReady = async (connection: MemoryConnection, pool: MemoryProviderQueryable) => {
+  const cache = getAnnReadyCache()
+  const key = memoryProviderSchemaCacheKey(connection)
+  let ready = cache.get(key)
+  if (!ready) {
+    ready = createMemoryProviderAnnIndexIfReady(pool, connection)
+    cache.set(key, ready)
+  }
+
+  try {
+    const created = await ready
+    if (!created) cache.delete(key)
+    return created
+  } catch (error) {
+    cache.delete(key)
+    throw error
+  }
+}
+
 export const closeMemoryProviderPools = async () => {
   const pools = getPoolCache()
   const activePools = [...pools.values()]
   pools.clear()
+  globalState.__agentsMemoryProviderSchemaReady?.clear()
+  globalState.__agentsMemoryProviderAnnReady?.clear()
   await Promise.all(activePools.map((pool) => pool.end()))
 }
 
@@ -230,16 +297,19 @@ export const writeMemoryEvent = async (
   payload: Record<string, unknown>,
 ) => {
   const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
   await pool.query(
-    `INSERT INTO ${connection.schema}.memory_events (dataset, event_type, payload) VALUES ($1, $2, $3)`,
+    `INSERT INTO ${qualifyMemoryProviderTable(connection.schema, 'memory_events')} (dataset, event_type, payload)
+     VALUES ($1, $2, $3)`,
     [connection.dataset, eventType, payload],
   )
 }
 
 export const writeMemoryKv = async (connection: MemoryConnection, key: string, value: Record<string, unknown>) => {
   const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
   await pool.query(
-    `INSERT INTO ${connection.schema}.memory_kv (dataset, key, value)
+    `INSERT INTO ${qualifyMemoryProviderTable(connection.schema, 'memory_kv')} (dataset, key, value)
      VALUES ($1, $2, $3)
      ON CONFLICT (dataset, key)
      DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
@@ -256,11 +326,13 @@ export const writeMemoryEmbedding = async (
   const embedding = await embedText(text, connection.embeddingDimension)
   const vector = vectorToPg(embedding)
   const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
   await pool.query(
-    `INSERT INTO ${connection.schema}.memory_embeddings (dataset, key, embedding, metadata)
+    `INSERT INTO ${qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')} (dataset, key, embedding, metadata)
      VALUES ($1, $2, $3::vector, $4)`,
     [connection.dataset, key, vector, metadata],
   )
+  await ensureProviderAnnIndexReady(connection, pool)
 }
 
 export const queryMemory = async (
@@ -271,17 +343,30 @@ export const queryMemory = async (
   const embedding = await embedText(query, connection.embeddingDimension)
   const vector = vectorToPg(embedding)
   const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
+  await ensureProviderAnnIndexReady(connection, pool)
   const { rows } = await pool.query(
     `SELECT key, metadata, (1 - (embedding <=> $1::vector)) as score
-     FROM ${connection.schema}.memory_embeddings
+     FROM ${qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')}
      WHERE dataset = $2
      ORDER BY embedding <=> $1::vector
      LIMIT $3`,
     [vector, connection.dataset, limit],
   )
-  return rows.map((row: { key: string; score: number | null; metadata: Record<string, unknown> }) => ({
+  return rows.map((row) => ({
     key: row.key,
     score: row.score,
     metadata: row.metadata ?? {},
   }))
+}
+
+export const __test__ = {
+  resetMemoryProviderState: () => {
+    delete globalState.__agentsMemoryProviderPoolFactory
+    globalState.__agentsMemoryProviderSchemaReady?.clear()
+    globalState.__agentsMemoryProviderAnnReady?.clear()
+  },
+  setMemoryProviderPoolFactory: (factory: (connectionString: string) => MemoryProviderQueryable) => {
+    globalState.__agentsMemoryProviderPoolFactory = factory
+  },
 }

--- a/services/agents/src/server/memory-provider.ts
+++ b/services/agents/src/server/memory-provider.ts
@@ -5,6 +5,7 @@ import { Pool } from 'pg'
 import { type KubernetesClient, RESOURCE_MAP } from './kube-types'
 import { resolveEmbeddingConfig } from './memory-config'
 import {
+  createMemoryProviderAnnIndexIfReady,
   ensureMemoryProviderSchema,
   qualifyMemoryProviderTable,
   type MemoryProviderQueryable,
@@ -327,6 +328,12 @@ export const queryMemory = async (
     score: row.score,
     metadata: row.metadata ?? {},
   }))
+}
+
+export const createMemoryEmbeddingIndexIfReady = async (connection: MemoryConnection) => {
+  const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
+  return createMemoryProviderAnnIndexIfReady(pool, connection)
 }
 
 export const __test__ = {

--- a/services/agents/src/server/memory-provider.ts
+++ b/services/agents/src/server/memory-provider.ts
@@ -5,7 +5,6 @@ import { Pool } from 'pg'
 import { type KubernetesClient, RESOURCE_MAP } from './kube-types'
 import { resolveEmbeddingConfig } from './memory-config'
 import {
-  createMemoryProviderAnnIndexIfReady,
   ensureMemoryProviderSchema,
   qualifyMemoryProviderTable,
   type MemoryProviderQueryable,
@@ -30,7 +29,6 @@ type EnvSource = Record<string, string | undefined>
 const DEFAULT_MEMORY_DATABASE_POOL_MAX = 2
 
 const globalState = globalThis as typeof globalThis & {
-  __agentsMemoryProviderAnnReady?: Map<string, Promise<boolean>>
   __agentsMemoryProviderPoolFactory?: (connectionString: string) => MemoryProviderQueryable
   __agentsMemoryProviderPools?: Map<string, Pool>
   __agentsMemoryProviderSchemaReady?: Map<string, Promise<void>>
@@ -118,13 +116,6 @@ const getSchemaReadyCache = () => {
   return globalState.__agentsMemoryProviderSchemaReady
 }
 
-const getAnnReadyCache = () => {
-  if (!globalState.__agentsMemoryProviderAnnReady) {
-    globalState.__agentsMemoryProviderAnnReady = new Map<string, Promise<boolean>>()
-  }
-  return globalState.__agentsMemoryProviderAnnReady
-}
-
 const memoryProviderSchemaCacheKey = (connection: MemoryConnection) =>
   `${connection.connectionString}\0${connection.schema}\0${connection.embeddingDimension}`
 
@@ -145,31 +136,11 @@ const ensureProviderSchemaReady = async (connection: MemoryConnection, pool: Mem
   }
 }
 
-const ensureProviderAnnIndexReady = async (connection: MemoryConnection, pool: MemoryProviderQueryable) => {
-  const cache = getAnnReadyCache()
-  const key = memoryProviderSchemaCacheKey(connection)
-  let ready = cache.get(key)
-  if (!ready) {
-    ready = createMemoryProviderAnnIndexIfReady(pool, connection)
-    cache.set(key, ready)
-  }
-
-  try {
-    const created = await ready
-    if (!created) cache.delete(key)
-    return created
-  } catch (error) {
-    cache.delete(key)
-    throw error
-  }
-}
-
 export const closeMemoryProviderPools = async () => {
   const pools = getPoolCache()
   const activePools = [...pools.values()]
   pools.clear()
   globalState.__agentsMemoryProviderSchemaReady?.clear()
-  globalState.__agentsMemoryProviderAnnReady?.clear()
   await Promise.all(activePools.map((pool) => pool.end()))
 }
 
@@ -332,7 +303,6 @@ export const writeMemoryEmbedding = async (
      VALUES ($1, $2, $3::vector, $4)`,
     [connection.dataset, key, vector, metadata],
   )
-  await ensureProviderAnnIndexReady(connection, pool)
 }
 
 export const queryMemory = async (
@@ -344,7 +314,6 @@ export const queryMemory = async (
   const vector = vectorToPg(embedding)
   const pool = getMemoryPool(connection.connectionString)
   await ensureProviderSchemaReady(connection, pool)
-  await ensureProviderAnnIndexReady(connection, pool)
   const { rows } = await pool.query(
     `SELECT key, metadata, (1 - (embedding <=> $1::vector)) as score
      FROM ${qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')}
@@ -364,7 +333,6 @@ export const __test__ = {
   resetMemoryProviderState: () => {
     delete globalState.__agentsMemoryProviderPoolFactory
     globalState.__agentsMemoryProviderSchemaReady?.clear()
-    globalState.__agentsMemoryProviderAnnReady?.clear()
   },
   setMemoryProviderPoolFactory: (factory: (connectionString: string) => MemoryProviderQueryable) => {
     globalState.__agentsMemoryProviderPoolFactory = factory

--- a/services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts
+++ b/services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts
@@ -2,70 +2,14 @@ import { type Kysely, sql } from 'kysely'
 
 import type { AgentsDatabase } from '../db'
 import { resolveEmbeddingConfig } from '../memory-config'
-import { createPgvectorAnnIndexIfSupported } from '../pgvector-indexing'
+import { getMemoryProviderSchemaStatements } from '../memory-provider-schema'
 
 const resolveEmbeddingDimension = () => resolveEmbeddingConfig(process.env).dimension
 
 export const up = async (db: Kysely<AgentsDatabase>) => {
   const embeddingDimension = resolveEmbeddingDimension()
 
-  await sql`
-    CREATE TABLE IF NOT EXISTS memory_events (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      dataset TEXT NOT NULL,
-      event_type TEXT NOT NULL,
-      payload JSONB NOT NULL DEFAULT '{}'::JSONB
-    );
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_events_dataset_created_at_idx
-    ON memory_events (dataset, created_at DESC);
-  `.execute(db)
-
-  await sql`
-    CREATE TABLE IF NOT EXISTS memory_kv (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      dataset TEXT NOT NULL,
-      key TEXT NOT NULL,
-      value JSONB NOT NULL DEFAULT '{}'::JSONB,
-      CONSTRAINT memory_kv_dataset_key_key UNIQUE (dataset, key)
-    );
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_kv_dataset_key_idx
-    ON memory_kv (dataset, key);
-  `.execute(db)
-
-  await sql`
-    CREATE TABLE IF NOT EXISTS memory_embeddings (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      dataset TEXT NOT NULL,
-      key TEXT NOT NULL,
-      embedding vector(${sql.raw(String(embeddingDimension))}) NOT NULL,
-      metadata JSONB NOT NULL DEFAULT '{}'::JSONB
-    );
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_embeddings_dataset_key_idx
-    ON memory_embeddings (dataset, key);
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_embeddings_metadata_idx
-    ON memory_embeddings USING GIN (metadata JSONB_PATH_OPS);
-  `.execute(db)
-
-  await createPgvectorAnnIndexIfSupported(
-    db,
-    embeddingDimension,
-    'CREATE INDEX IF NOT EXISTS memory_embeddings_embedding_idx ON memory_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);',
-    'memory_embeddings',
-  )
+  for (const statement of getMemoryProviderSchemaStatements(embeddingDimension, 'public')) {
+    await sql.raw(statement).execute(db)
+  }
 }

--- a/services/agents/src/server/v1/memory-operations.test.ts
+++ b/services/agents/src/server/v1/memory-operations.test.ts
@@ -102,6 +102,39 @@ describe('memory operations API', () => {
     expect(queryMemory).toHaveBeenCalledWith(connection, 'find notes', 5)
   })
 
+  it('runs embedding index maintenance through the leader-gated operation path', async () => {
+    const connection = {
+      dataset: 'agent-memory',
+      schema: 'public',
+      embeddingDimension: 1536,
+      connectionString: 'postgresql://agents-memory',
+    }
+    const requireLeaderForMutation = vi.fn(() => null)
+    const createMemoryEmbeddingIndexIfReady = vi.fn(async () => true)
+
+    const response = await postMemoryOperationsHandler(
+      request({
+        memoryRef: 'agent-memory',
+        namespace: 'agents',
+        operation: 'embedding-index',
+      }),
+      {
+        kubeClient: {} as never,
+        requireLeaderForMutation,
+        resolveMemoryConnection: vi.fn(async () => connection),
+        createMemoryEmbeddingIndexIfReady,
+      },
+    )
+
+    await expect(json(response)).resolves.toMatchObject({
+      ok: true,
+      operation: 'embedding-index',
+      created: true,
+    })
+    expect(requireLeaderForMutation).toHaveBeenCalled()
+    expect(createMemoryEmbeddingIndexIfReady).toHaveBeenCalledWith(connection)
+  })
+
   it('gates memory mutations on the elected Agents leader', async () => {
     const response = await postMemoryOperationsHandler(
       request({

--- a/services/agents/src/server/v1/memory-operations.ts
+++ b/services/agents/src/server/v1/memory-operations.ts
@@ -1,4 +1,5 @@
 import {
+  createMemoryEmbeddingIndexIfReady as defaultCreateMemoryEmbeddingIndexIfReady,
   queryMemory as defaultQueryMemory,
   resolveMemoryConnection as defaultResolveMemoryConnection,
   writeMemoryEmbedding as defaultWriteMemoryEmbedding,
@@ -18,6 +19,7 @@ export type MemoryOperationsApiDependencies = {
   writeMemoryKv?: typeof defaultWriteMemoryKv
   writeMemoryEmbedding?: typeof defaultWriteMemoryEmbedding
   queryMemory?: typeof defaultQueryMemory
+  createMemoryEmbeddingIndexIfReady?: typeof defaultCreateMemoryEmbeddingIndexIfReady
 }
 
 type MemoryOperationPayload =
@@ -49,6 +51,11 @@ type MemoryOperationPayload =
       namespace: string
       query: string
       limit?: number
+    }
+  | {
+      operation: 'embedding-index'
+      memoryRef: string
+      namespace: string
     }
 
 const getKubeClient = (deps: MemoryOperationsApiDependencies) =>
@@ -125,7 +132,11 @@ export const parseMemoryOperationPayload = (payload: Record<string, unknown>): M
     }
   }
 
-  throw new Error('operation must be one of event, kv, embedding, query')
+  if (operation === 'embedding-index') {
+    return { operation, memoryRef, namespace }
+  }
+
+  throw new Error('operation must be one of event, kv, embedding, query, embedding-index')
 }
 
 export const postMemoryOperationsHandler = async (request: Request, deps: MemoryOperationsApiDependencies = {}) => {
@@ -173,6 +184,19 @@ export const postMemoryOperationsHandler = async (request: Request, deps: Memory
         operation: parsed.operation,
         memoryRef: parsed.memoryRef,
         namespace: parsed.namespace,
+      })
+    }
+
+    if (parsed.operation === 'embedding-index') {
+      const created = await (deps.createMemoryEmbeddingIndexIfReady ?? defaultCreateMemoryEmbeddingIndexIfReady)(
+        connection,
+      )
+      return okResponse({
+        ok: true,
+        operation: parsed.operation,
+        memoryRef: parsed.memoryRef,
+        namespace: parsed.namespace,
+        created,
       })
     }
 


### PR DESCRIPTION
## Summary

- Bootstraps Memory provider tables and base indexes on the database resolved from each postgres Memory secret before provider reads or writes.
- Shares the Memory provider base schema DDL between the service migration and provider bootstrap path.
- Keeps IVFFlat creation out of provider write/query paths; the explicit index helper now requires enough rows to train and sizes lists from row count before creating the index.
- Hardens the shared Nix OCI cache fallback so arm64 image retries preserve the blank build-users-group override.

## Related Issues

Follow-up to Codex review comments on #11950.

## Testing

- `bun run --filter @proompteng/agents test -- src/server/memory-provider-schema.test.ts src/server/memory-provider.test.ts src/server/v1/memory-operations.test.ts src/server/kysely-migrations.test.ts`
- `node /workspace/lab/node_modules/.bun/oxfmt@0.48.0/node_modules/oxfmt/bin/oxfmt --check src scripts` from `services/agents`; direct Node entrypoint used because this container has no `/usr/bin/env` for `bunx`
- `bun run scripts/generate-control-plane-registry.ts` from `services/agents`
- `node /workspace/lab/node_modules/.bun/oxfmt@0.48.0/node_modules/oxfmt/bin/oxfmt src/control-plane/primitive-registry.generated.ts`
- `node /workspace/lab/node_modules/.bun/typescript@6.0.3/node_modules/typescript/bin/tsc --noEmit -p tsconfig.json`
- `node /workspace/lab/node_modules/.bun/oxlint@1.63.0+f3bfc1478e9cbe2b/node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/agents/src/server/memory-provider.ts services/agents/src/server/memory-provider-schema.ts services/agents/src/server/memory-provider.test.ts services/agents/src/server/memory-provider-schema.test.ts services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts`
- Inspected failed arm64 image job logs from run `28753120194`; the workflow fallback now preserves `build-users-group =` via `NIX_CONFIG` and `--option build-users-group ''`
- `bun run --filter @proompteng/agents test` fails on an unrelated local harness issue: `src/runner/codex-app-server.test.ts` cannot spawn `scripts/codex/fake-app-server.ts` because this container lacks `/usr/bin/env`; the file exists in the worktree

## Screenshots (if applicable)

N/A

## Breaking Changes

N/A

## Checklist

- Filled from the repository pull request template.
- Added regression coverage for provider-database schema bootstrap and offline/deferred ANN index creation.
- Validated the touched TypeScript paths with targeted tests, formatting, type-checking, and linting.
- Tracked and fixed the CI-only Nix fallback failure observed while making this PR green.
