### PR TITLE
fix(torghut): persist normalized hyperliquid intents

### DIFF
--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -182,6 +182,9 @@ class HyperliquidSdkExecutionExchange:
             },
         )
 
+    def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
+        return self._normalize_order_intent(intent)
+
     def submit_order(self, intent: OrderIntent) -> OrderResult:
         if intent.tif not in _SUPPORTED_LIMIT_TIFS:
             return OrderResult(
@@ -204,7 +207,7 @@ class HyperliquidSdkExecutionExchange:
                 raw_response={"error": "reduce_only_entry_orders_unsupported"},
                 rejection_reason="reduce_only_entry_orders_unsupported",
             )
-        normalized = self._normalize_order_intent(intent)
+        normalized = self.normalize_order_intent(intent)
         response = cast(
             dict[str, object],
             self._exchange().market_open(

--- a/services/torghut/app/hyperliquid_execution/service.py
+++ b/services/torghut/app/hyperliquid_execution/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Protocol, cast
@@ -17,6 +18,7 @@ from .models import (
     ExecutionMarket,
     FeatureSnapshot,
     OpenOrder,
+    OrderIntent,
     RiskState,
     RuntimeDependencyStatus,
 )
@@ -194,6 +196,7 @@ class HyperliquidExecutionService:
                     signal_id=signal_id,
                     now=context.started_at,
                 )
+                intent = _normalize_order_intent(self._exchange, intent)
                 result = self._exchange.submit_order(intent)
             except Exception as exc:
                 counts.record_order_error(type(exc).__name__)
@@ -318,6 +321,16 @@ class HyperliquidExecutionService:
             observed_at=observed_at,
             details={"open_order_coins": sorted(open_coins)},
         )
+
+
+def _normalize_order_intent(
+    exchange: HyperliquidExecutionExchange,
+    intent: OrderIntent,
+) -> OrderIntent:
+    normalize = getattr(exchange, "normalize_order_intent", None)
+    if not callable(normalize):
+        return intent
+    return cast(Callable[[OrderIntent], OrderIntent], normalize)(intent)
 
 
 def runtime_readiness(

--- a/services/torghut/tests/hyperliquid_execution/test_service_normalized_intents.py
+++ b/services/torghut/tests/hyperliquid_execution/test_service_normalized_intents.py
@@ -1,0 +1,76 @@
+"""Service regressions for persisted exchange-normalized order intents."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+from app.hyperliquid_execution.config import HyperliquidExecutionConfig
+from app.hyperliquid_execution.models import OrderIntent, OrderResult
+from app.hyperliquid_execution.service import HyperliquidExecutionService
+from tests.hyperliquid_execution.test_runtime_surfaces import (
+    _FakeSession,
+    _ServiceExchange,
+    _ServiceFeed,
+    _now,
+)
+
+
+def test_service_persists_exchange_normalized_order_intent() -> None:
+    now = _now()
+    config = HyperliquidExecutionConfig.from_env(
+        {
+            "HYPERLIQUID_EXECUTION_TRADING_ENABLED": "true",
+            "HYPERLIQUID_EXECUTION_API_WALLET_PRIVATE_KEY": "0x1",
+            "HYPERLIQUID_EXECUTION_ACCOUNT_ADDRESS": "0xabc",
+            "HYPERLIQUID_EXECUTION_TRADE_COINS": "xyz:NVDA",
+        }
+    )
+    session = _FakeSession()
+    exchange = _NormalizingServiceExchange(now)
+    service = HyperliquidExecutionService(
+        config=config,
+        feed=_ServiceFeed(now),
+        exchange=exchange,
+    )
+
+    result = service.run_once(session)
+
+    assert result.orders_submitted == 1
+    assert exchange.submitted_intents[0].size == Decimal("0.2")
+    assert exchange.submitted_intents[0].limit_price == Decimal("101.000000")
+    assert exchange.submitted_intents[0].notional_usd == Decimal("20.200000")
+    order_params = next(
+        params
+        for sql, params in session.calls
+        if "INSERT INTO hyperliquid_execution_orders" in sql
+    )
+    assert order_params is not None
+    assert order_params["size"] == "0.2"
+    assert order_params["limit_price"] == "101.000000"
+    assert order_params["notional_usd"] == "20.200000"
+    multifactor_params = next(
+        params
+        for sql, params in session.calls
+        if "INSERT INTO multifactor_execution_intents" in sql
+    )
+    assert multifactor_params is not None
+    assert multifactor_params["notional_usd"] == "20.200000"
+
+
+class _NormalizingServiceExchange(_ServiceExchange):
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.submitted_intents: list[OrderIntent] = []
+
+    def normalize_order_intent(self, intent: OrderIntent) -> OrderIntent:
+        return replace(
+            intent,
+            size=Decimal("0.2"),
+            limit_price=Decimal("101.000000"),
+            notional_usd=Decimal("20.200000"),
+        )
+
+    def submit_order(self, intent: OrderIntent) -> OrderResult:
+        self.submitted_intents.append(intent)
+        return super().submit_order(intent)


### PR DESCRIPTION
## Summary

- Add an exchange-adapter normalization hook so the service can persist the exact Hyperliquid intent that will be submitted.
- Normalize the order intent before submission in `HyperliquidExecutionService`, so `hyperliquid_execution_orders` and `multifactor_execution_intents` store the submitted size, limit price, and notional.
- Add a focused regression that forces exchange-side intent normalization and verifies both persistence surfaces receive the normalized notional.

## Related Issues

Follow-up for Codex review on #11953.

## Testing

- `uv sync --frozen --no-install-project` with `UV_PYTHON=/tmp/python3.12-loader` (local container workaround; full `uv sync --frozen --extra dev` is blocked because the uv-managed CPython binary requires a glibc loader path not present in the shell image).
- `python -m pytest tests/hyperliquid_execution/test_service_normalized_intents.py tests/hyperliquid_execution/test_runtime_surfaces.py::test_service_cycle_cancels_reconciles_submits_and_records_cycle tests/hyperliquid_execution/test_feed_readiness_gate.py -q` (via the same local Python loader workaround): 8 passed.
- `python -m pytest tests/hyperliquid_execution -q` (via the same local Python loader workaround): 71 passed.
- `ruff check app/hyperliquid_execution tests/hyperliquid_execution`: passed.
- `ruff format --check app/hyperliquid_execution tests/hyperliquid_execution`: 31 files already formatted.
- `git diff --check`: passed.
- Local Pyright was not runnable in this shell: direct `uv run --frozen pyright ...` invocations were blocked by the shell safety layer / nonstandard Python loader. GitHub Actions Pyright passed on the first PR head before the test-file split and will be checked again on the updated head.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
