### PR TITLE
ci(nix): auto-merge attic arc release prs

### DIFF
--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -178,6 +178,7 @@ jobs:
             - [x] Documentation, release notes, and follow-ups are updated or tracked.
           labels: |
             automated-pr
+            nix-oci
             arc
           add-paths: |
             argocd/applications/arc/application.yaml

--- a/.github/workflows/attic-release.yml
+++ b/.github/workflows/attic-release.yml
@@ -133,6 +133,7 @@ jobs:
             - [x] Documentation, release notes, and follow-ups are updated or tracked.
           labels: |
             automated-pr
+            nix-oci
             attic
           add-paths: |
             argocd/applications/attic/deployment.yaml

--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -13,7 +13,10 @@ on:
       - 'argocd/applications/khoshut/kustomization.yaml'
       - 'argocd/applications/analysis/kustomization.yaml'
       - 'argocd/applications/bilig/kustomization.yaml'
+      - 'argocd/applications/arc/application.yaml'
       - 'argocd/applications/app/kustomization.yaml'
+      - 'argocd/applications/attic/deployment.yaml'
+      - 'argocd/applications/attic/gc-cronjob.yaml'
       - 'argocd/applications/bumba/kustomization.yaml'
       - 'argocd/applications/docs/kustomization.yaml'
       - 'argocd/applications/froussard/knative-service.yaml'
@@ -49,7 +52,10 @@ jobs:
             startsWith(github.event.pull_request.head.ref, 'release/') ||
             (
               startsWith(github.event.pull_request.head.ref, 'codex/') &&
-              contains(github.event.pull_request.head.ref, '-nix-release-')
+              (
+                contains(github.event.pull_request.head.ref, '-nix-release-') ||
+                contains(github.event.pull_request.head.ref, '-release-')
+              )
             )
           ) &&
           github.event.pull_request.draft == false
@@ -85,7 +91,10 @@ jobs:
             "argocd/applications/bilig/kustomization.yaml"
           )
           nix_oci_release_paths=(
+            "argocd/applications/arc/application.yaml"
             "argocd/applications/app/kustomization.yaml"
+            "argocd/applications/attic/deployment.yaml"
+            "argocd/applications/attic/gc-cronjob.yaml"
             "argocd/applications/bumba/kustomization.yaml"
             "argocd/applications/docs/kustomization.yaml"
             "argocd/applications/froussard/knative-service.yaml"
@@ -132,7 +141,8 @@ jobs:
           release_kind=""
           if [[ "$PR_HEAD_REF" == release/* ]]; then
             release_kind="legacy-release"
-          elif [[ "$PR_HEAD_REF" =~ ^codex/(headlamp|oirat|bumba|froussard)-nix-release-sha-[0-9a-f]{40}$ ]] ||
+          elif [[ "$PR_HEAD_REF" =~ ^codex/(attic|arc-runner)-release-sha-[0-9a-f]{40}$ ]] ||
+            [[ "$PR_HEAD_REF" =~ ^codex/(headlamp|oirat|bumba|froussard)-nix-release-sha-[0-9a-f]{40}$ ]] ||
             [[ "$PR_HEAD_REF" =~ ^codex/product-nix-release-[0-9a-f]{40}$ ]]; then
             release_kind="nix-oci-release"
           else

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -158,6 +158,7 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerReleaseWorkflow).not.toContain('docker/setup-buildx-action')
     expect(arcRunnerReleaseWorkflow).toContain('peter-evans/create-pull-request@v7')
     expect(arcRunnerReleaseWorkflow).toContain('argocd/applications/arc/application.yaml')
+    expect(arcRunnerReleaseWorkflow).toContain('nix-oci')
   })
 
   it('uses a shared setup action so Nix jobs validate preinstalled tools before falling back', () => {

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1324,8 +1324,12 @@ describe('native OCI build workflows', () => {
     expect(autoPrReleaseBranchesWorkflow).toContain('reason="migrated-nix-image-app:${path}"')
     expect(releasePrAutomergeWorkflow).toContain('nix_oci_release_paths=(')
     expect(releasePrAutomergeWorkflow).toContain("contains(github.event.pull_request.head.ref, '-nix-release-')")
+    expect(releasePrAutomergeWorkflow).toContain("contains(github.event.pull_request.head.ref, '-release-')")
     for (const path of [
+      'argocd/applications/arc/application.yaml',
       'argocd/applications/app/kustomization.yaml',
+      'argocd/applications/attic/deployment.yaml',
+      'argocd/applications/attic/gc-cronjob.yaml',
       'argocd/applications/bumba/kustomization.yaml',
       'argocd/applications/docs/kustomization.yaml',
       'argocd/applications/froussard/knative-service.yaml',
@@ -1337,6 +1341,9 @@ describe('native OCI build workflows', () => {
     ]) {
       expect(releasePrAutomergeWorkflow).toContain(`"${path}"`)
     }
+    expect(releasePrAutomergeWorkflow).toContain(
+      '[[ "$PR_HEAD_REF" =~ ^codex/(attic|arc-runner)-release-sha-[0-9a-f]{40}$ ]]',
+    )
     expect(releasePrAutomergeWorkflow).toContain(
       '[[ "$PR_HEAD_REF" =~ ^codex/(headlamp|oirat|bumba|froussard)-nix-release-sha-[0-9a-f]{40}$ ]]',
     )
@@ -1365,6 +1372,7 @@ describe('native OCI build workflows', () => {
     expect(atticReleaseWorkflow).toContain('attic-release-contract')
     expect(atticReleaseWorkflow).toContain('argocd/applications/attic/deployment.yaml')
     expect(atticReleaseWorkflow).toContain('argocd/applications/attic/gc-cronjob.yaml')
+    expect(atticReleaseWorkflow).toContain('nix-oci')
     expect(atticReleaseWorkflow).toContain('nix run .#resolve-attic-release-metadata')
     expect(atticReleaseWorkflow).toContain('export IMAGE_REF="${IMAGE}@${DIGEST}"')
     expect(atticReleaseWorkflow).toContain('image: $ENV{IMAGE_REF}')


### PR DESCRIPTION
## Summary

- Adds Attic and ARC runner digest-pinning release PRs to the guarded Nix OCI release automerge path.
- Requires generated Attic and ARC release PRs to carry the same `automated-pr` and `nix-oci` labels used by other migrated Nix OCI release PRs.
- Keeps Torghut and other safety-sensitive release branches outside this generic automerge branch allowlist.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/release-pr-automerge.yml .github/workflows/attic-release.yml .github/workflows/arc-runner-release.yml`
- Bash regex smoke for Attic/ARC/Headlamp/Product generated release branches and Torghut exclusion
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
