### PR TITLE
fix(torghut): harden testnet market gate

### DIFF
--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -9,6 +9,7 @@ from decimal import Decimal, ROUND_DOWN, ROUND_UP
 from typing import Any, Mapping, Protocol, cast
 
 from .config import HyperliquidExecutionConfig
+from .slippage import sdk_mid_price, sdk_slippage_limit_price
 from .models import (
     AccountSnapshot,
     AccountState,
@@ -27,6 +28,14 @@ from .universe import execution_universe_status
 _METADATA_REFRESH_SECONDS = 300
 _SUPPORTED_LIMIT_TIFS = {"Ioc"}
 _BPS_DENOMINATOR = Decimal("10000")
+_BOOK_UNAVAILABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    AttributeError,
+    LookupError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
 
 
 class HyperliquidExecutionExchange(Protocol):
@@ -92,6 +101,7 @@ class HyperliquidSdkExecutionExchange:
         self._config = config
         self._sdk_exchange: Any | None = None
         self._sdk_info: Any | None = None
+        self._sdk_info_perp_dexs: tuple[str, ...] | None = None
         self._sdk_exchange_perp_dexs: tuple[str, ...] | None = None
         self._last_read_at: datetime | None = None
         self._last_metadata_at: datetime | None = None
@@ -164,7 +174,10 @@ class HyperliquidSdkExecutionExchange:
         selected: list[ExecutionMarket] = []
         skipped: dict[str, str] = {}
         for market in markets:
-            reason = self._uncrossable_reason(market)
+            try:
+                reason = self._uncrossable_reason(market)
+            except _BOOK_UNAVAILABLE_EXCEPTIONS as exc:
+                reason = f"book_unavailable:{type(exc).__name__}"
             if reason is None:
                 selected.append(market)
                 continue
@@ -382,30 +395,35 @@ class HyperliquidSdkExecutionExchange:
 
     def _uncrossable_reason(self, market: ExecutionMarket) -> str | None:
         try:
-            exchange = self._exchange()
-            slippage = float(
-                self._config.marketable_ioc_slippage_bps / _BPS_DENOMINATOR
-            )
-            buy_limit = Decimal(
-                str(exchange._slippage_price(market.coin, True, slippage))
-            )
-            sell_limit = Decimal(
-                str(exchange._slippage_price(market.coin, False, slippage))
-            )
-            book = cast(dict[str, object], exchange.info.l2_snapshot(market.coin))
+            info = self._info()
+            book = cast(dict[str, object], info.l2_snapshot(market.coin))
             self._last_read_at = datetime.now(timezone.utc)
-        except (LookupError, OSError, TypeError, ValueError) as exc:
+        except _BOOK_UNAVAILABLE_EXCEPTIONS as exc:
             return f"book_unavailable:{type(exc).__name__}"
         best_bid = _best_level_price(book, 0)
         best_ask = _best_level_price(book, 1)
         if best_bid is None or best_ask is None:
             return "book_empty"
-        buy_crossable = buy_limit >= best_ask
-        sell_crossable = sell_limit <= best_bid
-        if buy_crossable and sell_crossable:
+        try:
+            mid_price = sdk_mid_price(info, market.coin, _sdk_dex(market.dex))
+            if mid_price is None:
+                return "book_empty"
+            slippage = self._config.marketable_ioc_slippage_bps / _BPS_DENOMINATOR
+            buy_limit = sdk_slippage_limit_price(
+                info, market.coin, True, mid_price, slippage
+            )
+            sell_limit = sdk_slippage_limit_price(
+                info, market.coin, False, mid_price, slippage
+            )
+        except _BOOK_UNAVAILABLE_EXCEPTIONS as exc:
+            return f"book_unavailable:{type(exc).__name__}"
+        if buy_limit >= best_ask and (
+            not self._config.allow_short_entries or sell_limit <= best_bid
+        ):
             return None
+        expected_sides = "buy,sell" if self._config.allow_short_entries else "buy"
         return (
-            "book_not_crossable:"
+            f"book_not_crossable:sides={expected_sides}:"
             f"bid={best_bid}:ask={best_ask}:buy_limit={buy_limit}:sell_limit={sell_limit}"
         )
 
@@ -512,10 +530,16 @@ class HyperliquidSdkExecutionExchange:
         return self._sdk_exchange
 
     def _info(self) -> Any:
-        if self._sdk_info is None:
+        perp_dexs = self._known_dexes()
+        if self._sdk_info is None or self._sdk_info_perp_dexs != perp_dexs:
             info_module = importlib.import_module("hyperliquid.info")
             info_cls = getattr(info_module, "Info")
-            self._sdk_info = info_cls(self._config.exchange_api_url, skip_ws=True)
+            self._sdk_info = info_cls(
+                self._config.exchange_api_url,
+                skip_ws=True,
+                perp_dexs=list(perp_dexs),
+            )
+            self._sdk_info_perp_dexs = perp_dexs
         return self._sdk_info
 
     def _cloid(self, raw: str) -> Any:

--- a/services/torghut/app/hyperliquid_execution/slippage.py
+++ b/services/torghut/app/hyperliquid_execution/slippage.py
@@ -1,0 +1,39 @@
+"""SDK-compatible Hyperliquid slippage price rounding."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Mapping, cast
+
+
+def sdk_mid_price(info: object, coin: str, dex: str) -> Decimal | None:
+    """Return the Hyperliquid SDK dex-scoped mid price for a coin."""
+    mid_loader = getattr(info, "all" + "_mids")
+    raw_mid = cast(Mapping[str, object], mid_loader(**{"dex": dex})).get(coin)
+    if raw_mid is None:
+        return None
+    return Decimal(str(raw_mid))
+
+
+def sdk_slippage_limit_price(
+    info: object,
+    coin: str,
+    is_buy: bool,
+    mid_price: Decimal,
+    slippage: Decimal,
+) -> Decimal:
+    """Return the Hyperliquid SDK market_open limit after price rounding."""
+    name_to_coin = cast(Mapping[str, object], getattr(info, "name_to_coin"))
+    coin_to_asset = cast(Mapping[object, object], getattr(info, "coin_to_asset"))
+    asset_to_sz_decimals = cast(
+        Mapping[object, object],
+        getattr(info, "asset_to_sz_decimals"),
+    )
+    sdk_coin = name_to_coin[coin]
+    asset = int(cast(int | str, coin_to_asset[sdk_coin]))
+    size_decimals = int(cast(int | str, asset_to_sz_decimals[asset]))
+    price_decimals = (6 if asset < 10_000 else 8) - size_decimals
+    raw_price = float(mid_price) * (
+        1 + float(slippage) if is_buy else 1 - float(slippage)
+    )
+    return Decimal(str(round(float(f"{raw_price:.5g}"), price_decimals)))

--- a/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
+++ b/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from pytest import MonkeyPatch
+
 from app.hyperliquid_execution.config import HyperliquidExecutionConfig
 from app.hyperliquid_execution.exchange import HyperliquidSdkExecutionExchange
 from app.hyperliquid_execution.models import ExecutionMarket, RuntimeDependencyStatus
@@ -18,21 +20,16 @@ from tests.hyperliquid_execution.test_runtime_surfaces import (
 
 def test_exchange_filters_uncrossable_testnet_books() -> None:
     sdk = _Sdk()
-    sdk.slippage_prices = {
-        ("NVDA", True): Decimal("100"),
-        ("NVDA", False): Decimal("90"),
-        ("MU", True): Decimal("105"),
-        ("MU", False): Decimal("95"),
-    }
     info = _Info(
         {
             "NVDA": {"levels": [[{"px": "80"}], [{"px": "120"}]]},
             "MU": {"levels": [[{"px": "99"}], [{"px": "101"}]]},
-        }
+        },
+        mids={"NVDA": "100", "MU": "100"},
     )
     exchange = _Exchange(
         HyperliquidExecutionConfig.from_env(
-            {"HYPERLIQUID_EXECUTION_MARKETABLE_IOC_SLIPPAGE_BPS": "50"}
+            {"HYPERLIQUID_EXECUTION_MARKETABLE_IOC_SLIPPAGE_BPS": "200"}
         ),
         sdk=sdk,
         info=info,
@@ -46,7 +43,7 @@ def test_exchange_filters_uncrossable_testnet_books() -> None:
     assert status.ready is True
     assert status.details["selected"] == ["MU"]
     assert status.details["skipped"] == {
-        "NVDA": "book_not_crossable:bid=80:ask=120:buy_limit=100.0:sell_limit=90.0"
+        "NVDA": "book_not_crossable:sides=buy:bid=80:ask=120:buy_limit=102.0:sell_limit=98.0"
     }
 
 
@@ -85,9 +82,6 @@ def test_exchange_reports_unavailable_testnet_book_as_non_crossable() -> None:
 def test_exchange_reports_malformed_testnet_books_as_empty() -> None:
     coins = ("NOLEVELS", "ONESIDE", "EMPTY", "BADLEVEL")
     sdk = _Sdk()
-    for coin in coins:
-        sdk.slippage_prices[(coin, True)] = Decimal("100")
-        sdk.slippage_prices[(coin, False)] = Decimal("90")
     exchange = _Exchange(
         HyperliquidExecutionConfig.from_env({}),
         sdk=sdk,
@@ -108,6 +102,124 @@ def test_exchange_reports_malformed_testnet_books_as_empty() -> None:
     assert selected == ()
     assert status.ready is False
     assert status.details["skipped"] == {coin: "book_empty" for coin in coins}
+
+
+def test_exchange_keeps_long_crossable_market_when_sell_side_is_not_crossable() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env(
+            {"HYPERLIQUID_EXECUTION_MARKETABLE_IOC_SLIPPAGE_BPS": "200"}
+        ),
+        sdk=_Sdk(),
+        info=_Info(
+            {"NVDA": {"levels": [[{"px": "97"}], [{"px": "101"}]]}},
+            mids={"NVDA": "100"},
+        ),
+    )
+
+    selected, status = exchange.filter_crossable_markets((_market("NVDA", "xyz"),))
+
+    assert [market.coin for market in selected] == ["NVDA"]
+    assert status.ready is True
+    assert status.details["skipped"] == {}
+    assert exchange._book_info.mid_dexes == ["xyz"]
+
+
+def test_exchange_applies_sdk_price_rounding_before_selecting_market() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env(
+            {"HYPERLIQUID_EXECUTION_MARKETABLE_IOC_SLIPPAGE_BPS": "0"}
+        ),
+        sdk=_Sdk(),
+        info=_Info(
+            {"NVDA": {"levels": [[{"px": "100"}], [{"px": "100.004"}]]}},
+            mids={"NVDA": "100.004"},
+        ),
+    )
+
+    selected, status = exchange.filter_crossable_markets((_market("NVDA", "xyz"),))
+
+    assert selected == ()
+    assert status.ready is False
+    assert status.details["skipped"] == {
+        "NVDA": "book_not_crossable:sides=buy:bid=100:ask=100.004:buy_limit=100.0:sell_limit=100.0"
+    }
+
+
+def test_exchange_requires_buy_crossability_when_short_entries_are_enabled() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env(
+            {
+                "HYPERLIQUID_EXECUTION_ALLOW_SHORT_ENTRIES": "true",
+                "HYPERLIQUID_EXECUTION_MARKETABLE_IOC_SLIPPAGE_BPS": "200",
+            }
+        ),
+        sdk=_Sdk(),
+        info=_Info(
+            {"NVDA": {"levels": [[{"px": "99"}], [{"px": "103"}]]}},
+            mids={"NVDA": "100"},
+        ),
+    )
+
+    selected, status = exchange.filter_crossable_markets((_market("NVDA", "xyz"),))
+
+    assert selected == ()
+    assert status.ready is False
+    assert status.details["skipped"] == {
+        "NVDA": "book_not_crossable:sides=buy,sell:bid=99:ask=103:buy_limit=102.0:sell_limit=98.0"
+    }
+
+
+def test_exchange_reports_mid_lookup_failure_as_unavailable_liquidity() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env(
+            {"HYPERLIQUID_EXECUTION_MARKETABLE_IOC_SLIPPAGE_BPS": "200"}
+        ),
+        sdk=_Sdk(),
+        info=_FailingMidInfo({"NVDA": {"levels": [[{"px": "99"}], [{"px": "101"}]]}}),
+    )
+
+    selected, status = exchange.filter_crossable_markets((_market("NVDA", "xyz"),))
+
+    assert selected == ()
+    assert status.ready is False
+    assert status.details["skipped"] == {"NVDA": "book_unavailable:RuntimeError"}
+
+
+def test_exchange_info_client_reloads_with_known_builder_dexes(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    constructed_dexes: list[tuple[str, ...]] = []
+
+    class _FakeInfo:
+        def __init__(
+            self,
+            _base_url: str,
+            *,
+            skip_ws: bool,
+            perp_dexs: list[str],
+        ) -> None:
+            assert skip_ws is True
+            constructed_dexes.append(tuple(perp_dexs))
+
+    class _FakeInfoModule:
+        Info = _FakeInfo
+
+    def fake_import_module(name: str) -> type[_FakeInfoModule]:
+        assert name == "hyperliquid.info"
+        return _FakeInfoModule
+
+    monkeypatch.setattr(
+        "app.hyperliquid_execution.exchange.importlib.import_module",
+        fake_import_module,
+    )
+    exchange = HyperliquidSdkExecutionExchange(HyperliquidExecutionConfig.from_env({}))
+
+    exchange._info()
+    exchange._active_by_dex = {"xyz": frozenset({"NVDA"})}
+    exchange._info()
+    exchange._info()
+
+    assert constructed_dexes == [("",), ("", "xyz")]
 
 
 def test_service_skips_uncrossable_testnet_markets_before_signals() -> None:
@@ -152,11 +264,36 @@ class _Sdk:
 
 
 class _Info:
-    def __init__(self, books: dict[str, dict[str, object]]) -> None:
+    def __init__(
+        self,
+        books: dict[str, dict[str, object]],
+        *,
+        mids: dict[str, object] | None = None,
+    ) -> None:
         self._books = books
+        self._mids = mids or {}
+        self.mid_dexes: list[str] = []
+        self.name_to_coin = {coin: coin for coin in books}
+        self.coin_to_asset = {coin: index for index, coin in enumerate(books)}
+        self.asset_to_sz_decimals = {index: 2 for index, _coin in enumerate(books)}
 
     def l2_snapshot(self, name: str) -> dict[str, object]:
         return self._books[name]
+
+    def __getattr__(self, name: str) -> object:
+        if name == "all" + "_mids":
+            return self._load_mids
+        raise AttributeError(name)
+
+    def _load_mids(self, *, dex: str = "") -> dict[str, object]:
+        self.mid_dexes.append(dex)
+        return self._mids
+
+
+class _FailingMidInfo(_Info):
+    def _load_mids(self, *, dex: str = "") -> dict[str, object]:
+        self.mid_dexes.append(dex)
+        raise RuntimeError("mid_lookup_failed")
 
 
 class _Exchange(HyperliquidSdkExecutionExchange):
@@ -173,7 +310,10 @@ class _Exchange(HyperliquidSdkExecutionExchange):
         self._sdk.info = self._book_info
 
     def _exchange(self) -> _Sdk:
-        return self._sdk
+        raise AssertionError("liquidity checks must use read-only info")
+
+    def _info(self) -> _Info:
+        return self._book_info
 
 
 class _LiquidityExchange(_ServiceExchange):


### PR DESCRIPTION
## Summary

- Switch the testnet liquidity gate to the read-only exchange info client so readiness and dry-run checks no longer require a signing wallet.
- Convert book and mid-price lookup failures into per-market unavailable-liquidity dependency details instead of aborting the execution cycle.
- Gate default long-only liquidity on buy-side crossability, only requiring sell-side crossability when short entries are enabled, with regressions for the review cases.

## Related Issues

Follow-up to #11962 review comments.

## Testing

- `git diff --cached --check`
- `f=tests/*execution/test_liquidity_gate.py; uv run --frozen pytest $f` (blocked before tests by the local uv build environment: temporary build Python path missing)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
