### PR TITLE
fix(attic): harden release selector cleanup

### DIFF
--- a/.github/workflows/attic-release.yml
+++ b/.github/workflows/attic-release.yml
@@ -93,7 +93,7 @@ jobs:
           export IMAGE_REF="${IMAGE}@${DIGEST}"
           for path in argocd/applications/attic/deployment.yaml argocd/applications/attic/gc-cronjob.yaml; do
             perl -0pi -e 's#image:\s+registry\.ide-newton\.ts\.net/lab/attic(?::latest|@sha256:[0-9a-f]{64})#image: $ENV{IMAGE_REF}#g' "${path}"
-            perl -0pi -e 's#\\n[( ]*)nodeSelector:\\n\\1  kubernetes\\.io/arch: (?:amd64|arm64)\\n#\\n#g' "${path}"
+            perl -0pi -e 's#\n([ ]*)nodeSelector:\n\1  kubernetes\.io/arch: (?:amd64|arm64)\n#\n#g' "${path}"
             grep -F "image: ${IMAGE_REF}" "${path}" >/dev/null
           done
 


### PR DESCRIPTION
## Summary

- Fix the Attic release workflow selector-cleanup regex so it compiles and does not stop promotion before `create-pull-request`.
- Preserve the existing Attic image promotion behavior while clearing stale `kubernetes.io/arch` node selectors for verified multi-arch releases.
- Keep the Attic deploy regression coverage that verifies stale architecture selector cleanup.

## Related Issues

Follow-up to Codex review feedback on #12005.

## Testing

- `node node_modules/.bun/oxfmt@0.48.0/node_modules/oxfmt/bin/oxfmt --check .github/workflows/attic-release.yml packages/scripts/src/attic/build-image.ts packages/scripts/src/attic/deploy-service.ts packages/scripts/src/attic/__tests__/build-image.test.ts packages/scripts/src/attic/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `node node_modules/.bun/oxlint@1.63.0+f3bfc1478e9cbe2b/node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts/src/attic packages/scripts/src/shared/__tests__/oci.test.ts`
- `bun test packages/scripts/src/attic/__tests__/build-image.test.ts packages/scripts/src/attic/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/nix-oci-deploy.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A — workflow and deploy-script test coverage only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
