### PR TITLE
fix(nix): harden arc runner image rollout

### DIFF
--- a/packages/scripts/src/arc-runner/__tests__/build-image.test.ts
+++ b/packages/scripts/src/arc-runner/__tests__/build-image.test.ts
@@ -2,15 +2,52 @@ import { describe, expect, it } from 'bun:test'
 
 import { __private } from '../build-image'
 
+const localRef =
+  'registry.example/lab/arc-runner@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const armRef = 'registry.example/lab/arc-runner@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
 describe('arc-runner build-image helpers', () => {
-  it('uses the same architecture tags as the ARC runner OCI workflow before publishing the index', () => {
+  it('uses explicit prebuilt arch references plus the local platform build before publishing the index', () => {
     expect(__private.platformTag('sha-123', 'linux/amd64')).toBe('sha-123-amd64')
     expect(__private.platformTag('sha-123', 'linux/arm64')).toBe('sha-123-arm64')
 
-    expect(__private.platformIndexTags('sha-123')).toEqual([
-      { platform: 'linux/amd64', tag: 'sha-123-amd64' },
-      { platform: 'linux/arm64', tag: 'sha-123-arm64' },
+    expect(
+      __private.platformIndexTags({
+        tag: 'sha-123',
+        buildPlatform: 'linux/amd64',
+        localImageRef: localRef,
+        prebuiltRefs: { 'linux/arm64': armRef },
+      }),
+    ).toEqual([
+      { platform: 'linux/amd64', tag: localRef },
+      { platform: 'linux/arm64', tag: armRef },
     ])
+  })
+
+  it('fails before building when the opposite platform reference is missing', () => {
+    expect(__private.missingPrebuiltPlatforms('linux/amd64', {})).toEqual(['linux/arm64'])
+    expect(() => __private.assertPrebuiltPlatformRefs('sha-123', 'linux/amd64', {})).toThrow(
+      'requires prebuilt image reference(s) for linux/arm64',
+    )
+    expect(() =>
+      __private.assertPrebuiltPlatformRefs('sha-123', 'linux/amd64', { 'linux/arm64': armRef }),
+    ).not.toThrow()
+  })
+
+  it('parses explicit prebuilt architecture references', () => {
+    expect(
+      __private.parseArgs([
+        '--tag',
+        'sha-123',
+        '--amd64-image-ref',
+        'registry.example/lab/arc-runner:sha-123-amd64',
+        '--arm64-image-ref=registry.example/lab/arc-runner:sha-123-arm64',
+      ]),
+    ).toMatchObject({
+      tag: 'sha-123',
+      amd64ImageRef: 'registry.example/lab/arc-runner:sha-123-amd64',
+      arm64ImageRef: 'registry.example/lab/arc-runner:sha-123-arm64',
+    })
   })
 
   it('keeps platform suffixes registry-safe for variant platforms', () => {

--- a/packages/scripts/src/arc-runner/build-image.ts
+++ b/packages/scripts/src/arc-runner/build-image.ts
@@ -15,6 +15,8 @@ export type BuildImageOptions = {
   version?: string
   commit?: string
   dryRun?: boolean
+  amd64ImageRef?: string
+  arm64ImageRef?: string
 }
 
 const service = 'arc-runner'
@@ -22,9 +24,12 @@ const imageName = 'arc-runner'
 const packageAttr = 'arc-runner-image'
 const requiredPlatforms = ['linux/amd64', 'linux/arm64'] as const
 
+type RequiredPlatform = (typeof requiredPlatforms)[number]
+type PlatformRefs = Partial<Record<RequiredPlatform, string>>
+
 const readEnv = (name: string) => process.env[name]?.trim()
 
-const localPlatform = (): (typeof requiredPlatforms)[number] => {
+const localPlatform = (): RequiredPlatform => {
   if (process.arch === 'x64') return 'linux/amd64'
   if (process.arch === 'arm64') return 'linux/arm64'
   throw new Error(`Unsupported ARC runner image build architecture: ${process.arch}`)
@@ -34,8 +39,58 @@ const platformSuffix = (platform: string): string => platform.replace(/^linux\//
 
 const platformTag = (tag: string, platform: string): string => `${tag}-${platformSuffix(platform)}`
 
-const platformIndexTags = (tag: string): OciArchTag[] =>
-  requiredPlatforms.map((platform) => ({ platform, tag: platformTag(tag, platform) }))
+const platformRefEnvName = (platform: RequiredPlatform): string =>
+  `ARC_RUNNER_${platformSuffix(platform).toUpperCase()}_IMAGE_REF`
+
+const platformRefFlagName = (platform: RequiredPlatform): string =>
+  `--${platformSuffix(platform).replaceAll('_', '-')}-image-ref`
+
+const platformRefsFromOptions = (options: BuildImageOptions): PlatformRefs => ({
+  'linux/amd64': options.amd64ImageRef ?? readEnv(platformRefEnvName('linux/amd64')),
+  'linux/arm64': options.arm64ImageRef ?? readEnv(platformRefEnvName('linux/arm64')),
+})
+
+const assertPlatformDigestsInclude = (
+  platformDigests: readonly OciPlatformDigest[],
+  required: readonly string[],
+  imageRef: string,
+): OciPlatformDigest[] => {
+  const observed = new Set(platformDigests.map((entry) => entry.platform))
+  const missing = required.filter((platform) => !observed.has(platform))
+  if (missing.length > 0) {
+    const observedText = [...observed].sort().join(', ') || 'none'
+    throw new Error(
+      `ARC runner image ${imageRef} does not satisfy platform requirement: ${missing.join(', ')}; observed: ${observedText}`,
+    )
+  }
+  return [...platformDigests]
+}
+
+const missingPrebuiltPlatforms = (buildPlatform: RequiredPlatform, platformRefs: PlatformRefs): RequiredPlatform[] =>
+  requiredPlatforms.filter((platform) => platform !== buildPlatform && !platformRefs[platform]?.trim())
+
+const assertPrebuiltPlatformRefs = (tag: string, buildPlatform: RequiredPlatform, platformRefs: PlatformRefs): void => {
+  const missing = missingPrebuiltPlatforms(buildPlatform, platformRefs)
+  if (missing.length === 0) return
+
+  const requirements = missing
+    .map((platform) => `${platform} via ${platformRefFlagName(platform)} or ${platformRefEnvName(platform)}`)
+    .join(', ')
+  throw new Error(
+    `ARC runner manual multi-arch image build for ${tag} requires prebuilt image reference(s) for ${requirements}; refusing to build ${buildPlatform} before the OCI index can be completed.`,
+  )
+}
+
+const platformIndexTags = (options: {
+  tag: string
+  buildPlatform: RequiredPlatform
+  localImageRef: string
+  prebuiltRefs: PlatformRefs
+}): OciArchTag[] =>
+  requiredPlatforms.map((platform) => ({
+    platform,
+    tag: platform === options.buildPlatform ? options.localImageRef : options.prebuiltRefs[platform]!,
+  }))
 
 const platformDigestRecord = (platformDigests: OciPlatformDigest[]): Record<string, string> =>
   Object.fromEntries(platformDigests.map((entry) => [entry.platform, entry.digest]))
@@ -110,6 +165,24 @@ const parseArgs = (args: string[]): BuildImageOptions => {
       options.registry = arg.slice('--registry='.length)
       continue
     }
+    if (arg === '--amd64-image-ref') {
+      options.amd64ImageRef = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--amd64-image-ref=')) {
+      options.amd64ImageRef = arg.slice('--amd64-image-ref='.length)
+      continue
+    }
+    if (arg === '--arm64-image-ref') {
+      options.arm64ImageRef = args[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--arm64-image-ref=')) {
+      options.arm64ImageRef = arg.slice('--arm64-image-ref='.length)
+      continue
+    }
     if (arg === '--dry-run') {
       options.dryRun = true
       continue
@@ -154,6 +227,9 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
   }
 
   const buildPlatform = localPlatform()
+  const prebuiltRefs = platformRefsFromOptions(options)
+  assertPrebuiltPlatformRefs(tag, buildPlatform, prebuiltRefs)
+
   const localPlatformTag = platformTag(tag, buildPlatform)
   const result = await buildAndPushNixImage({
     service,
@@ -171,10 +247,20 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
     )
   }
 
-  const indexResult = createOciIndex({ image, tag, latest: true, archTags: platformIndexTags(tag) })
+  const indexResult = createOciIndex({
+    image,
+    tag,
+    latest: false,
+    archTags: platformIndexTags({ tag, buildPlatform, localImageRef: result.reference, prebuiltRefs }),
+  })
+  const indexPlatforms = assertPlatformDigestsInclude(
+    indexResult.platformDigests,
+    requiredPlatforms,
+    indexResult.reference,
+  )
   writeIndexReleaseContract(result, indexResult, commit)
 
-  const platforms = indexResult.platformDigests.map((entry) => entry.platform)
+  const platforms = indexPlatforms.map((entry) => entry.platform)
 
   return {
     image: `${image}:${tag}`,
@@ -194,9 +280,14 @@ if (import.meta.main) {
 }
 
 export const __private = {
+  assertPrebuiltPlatformRefs,
   localPlatform,
+  missingPrebuiltPlatforms,
   parseArgs,
   platformIndexTags,
+  platformRefEnvName,
+  platformRefFlagName,
+  platformRefsFromOptions,
   platformSuffix,
   platformTag,
 }

--- a/packages/scripts/src/arc-runner/deploy-service.ts
+++ b/packages/scripts/src/arc-runner/deploy-service.ts
@@ -14,6 +14,8 @@ type CliOptions = {
   repository?: string
   tag?: string
   applicationPath: string
+  amd64ImageRef?: string
+  arm64ImageRef?: string
 }
 
 const defaultApplicationPath = 'argocd/applications/arc/application.yaml'
@@ -65,6 +67,24 @@ const parseArgs = (argv: string[]): Partial<CliOptions> => {
       options.repository = arg.slice('--repository='.length)
       continue
     }
+    if (arg === '--amd64-image-ref') {
+      options.amd64ImageRef = argv[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--amd64-image-ref=')) {
+      options.amd64ImageRef = arg.slice('--amd64-image-ref='.length)
+      continue
+    }
+    if (arg === '--arm64-image-ref') {
+      options.arm64ImageRef = argv[index + 1]
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--arm64-image-ref=')) {
+      options.arm64ImageRef = arg.slice('--arm64-image-ref='.length)
+      continue
+    }
     if (arg === '--application-path') {
       options.applicationPath = argv[index + 1]
       index += 1
@@ -92,6 +112,8 @@ const resolveOptions = (argv = process.argv.slice(2)): CliOptions => {
     repository: parsed.repository ?? readEnv('ARC_RUNNER_IMAGE_REPOSITORY') ?? 'lab/arc-runner',
     tag: parsed.tag ?? readEnv('ARC_RUNNER_IMAGE_TAG') ?? execGit(['rev-parse', '--short', 'HEAD']),
     applicationPath: parsed.applicationPath ?? readEnv('ARC_RUNNER_APPLICATION_PATH') ?? defaultApplicationPath,
+    amd64ImageRef: parsed.amd64ImageRef ?? readEnv('ARC_RUNNER_AMD64_IMAGE_REF'),
+    arm64ImageRef: parsed.arm64ImageRef ?? readEnv('ARC_RUNNER_ARM64_IMAGE_REF'),
   }
 }
 
@@ -155,6 +177,8 @@ export const main = async (argv = process.argv.slice(2)) => {
     repository: options.repository,
     tag: options.tag,
     dryRun: options.dryRun,
+    amd64ImageRef: options.amd64ImageRef,
+    arm64ImageRef: options.arm64ImageRef,
   })
   console.log(`Image digest: ${imageResult.digest}`)
   console.log(`Image platforms: ${imageResult.platforms.join(', ') || 'none'}`)


### PR DESCRIPTION
## Summary

- Make the Nix dockerTools ARC runner image provision writable Nix store/state directories for the `runner` user and keep single-user Nix config explicit.
- Return platform metadata from the ARC image builder and fail closed before GitOps manifest updates unless the image digest is deployable for both `linux/amd64` and `linux/arm64`.
- Harden manual ARC image rollout so it does not assume both architecture suffix tags exist: it requires an explicit prebuilt reference for the non-local architecture, builds/pushes only the local architecture tag, then creates the multi-arch OCI index from the local digest plus the explicit prebuilt reference.
- Add regression coverage for the deploy gate, manual multi-arch image-reference helpers, and writable Nix store image invariants.

## Related Issues

Follow-up to #11958 Codex review comments. Supersedes #12015, whose PR head became stale after branch recreation.

## Testing

- `bun test packages/scripts/src/arc-runner/__tests__/build-image.test.ts`
- `bun test packages/scripts/src/arc-runner/__tests__/*.test.ts`
- `bun test packages/scripts/src/shared/__tests__/arc-*.test.ts`
- `bun test packages/scripts/src/shared/__tests__/nix-oci-deploy.test.ts`
- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
