### PR TITLE
ci(nix): create release prs with app token

### DIFF
--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -160,6 +160,7 @@ jobs:
         if: steps.meta.outputs.promote == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/arc-runner-release-${{ steps.meta.outputs.tag }}
           title: 'chore(arc): promote runner image ${{ steps.meta.outputs.tag }}'
           commit-message: 'chore(arc): promote runner image ${{ steps.meta.outputs.tag }}'

--- a/.github/workflows/attic-release.yml
+++ b/.github/workflows/attic-release.yml
@@ -101,6 +101,7 @@ jobs:
         if: steps.meta.outputs.promote == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/attic-release-${{ steps.meta.outputs.tag }}
           title: 'chore(attic): promote image ${{ steps.meta.outputs.tag }}'
           commit-message: 'chore(attic): promote image ${{ steps.meta.outputs.tag }}'

--- a/.github/workflows/enabled-product-nix-release.yml
+++ b/.github/workflows/enabled-product-nix-release.yml
@@ -194,6 +194,7 @@ jobs:
         if: steps.promote.outputs.promoted == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/product-nix-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha }}
           title: 'chore(product): promote nix product images'
           commit-message: 'chore(product): promote nix product images'

--- a/.github/workflows/enabled-simple-nix-release.yml
+++ b/.github/workflows/enabled-simple-nix-release.yml
@@ -203,6 +203,7 @@ jobs:
         if: steps.meta.outputs.promote == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/${{ steps.meta.outputs.service }}-nix-release-${{ steps.meta.outputs.tag }}
           title: 'chore(${{ steps.meta.outputs.service }}): promote nix image ${{ steps.meta.outputs.tag }}'
           commit-message: 'chore(${{ steps.meta.outputs.service }}): promote nix image ${{ steps.meta.outputs.tag }}'

--- a/.github/workflows/headlamp-release.yml
+++ b/.github/workflows/headlamp-release.yml
@@ -161,6 +161,7 @@ jobs:
         if: steps.meta.outputs.promote == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/headlamp-nix-release-${{ steps.meta.outputs.tag }}
           title: 'chore(headlamp): promote nix image ${{ steps.meta.outputs.tag }}'
           commit-message: 'chore(headlamp): promote nix image ${{ steps.meta.outputs.tag }}'

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -188,6 +188,7 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerReleaseWorkflow).not.toContain('docker buildx')
     expect(arcRunnerReleaseWorkflow).not.toContain('docker/setup-buildx-action')
     expect(arcRunnerReleaseWorkflow).toContain('peter-evans/create-pull-request@v7')
+    expect(arcRunnerReleaseWorkflow).toContain('token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}')
     expect(arcRunnerReleaseWorkflow).toContain('argocd/applications/arc/application.yaml')
     expect(arcRunnerReleaseWorkflow).toContain('nix-oci')
   })

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -9,6 +9,7 @@ const repoRoot = new URL('../../../../../', import.meta.url)
 const readRepoFile = (path: string): string => readFileSync(new URL(path, repoRoot), 'utf8')
 const repoFileExists = (path: string): boolean => existsSync(new URL(path, repoRoot))
 const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const releasePrTokenInput = 'token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}'
 const expectNixListBlock = (source: string, assignment: string): string => {
   const match = source.match(new RegExp(`${escapeRegex(assignment)}\\s*=\\s*\\[([\\s\\S]*?)\\];`, 'm'))
   expect(match?.[1]).toBeDefined()
@@ -39,6 +40,7 @@ const productNixWorkflow = readRepoFile('.github/workflows/product-nix-images.ym
 const bunWorkspaceServiceModule = readRepoFile('nix/images/bun-workspace-service.nix')
 const enabledProductReleaseWorkflow = readRepoFile('.github/workflows/enabled-product-nix-release.yml')
 const agentsBuildWorkflow = readRepoFile('.github/workflows/agents-build-push.yml')
+const agentsReleaseWorkflow = readRepoFile('.github/workflows/agents-release.yml')
 const agentsCiWorkflow = readRepoFile('.github/workflows/agents-ci.yml')
 const arcRunnerBuildWorkflow = readRepoFile('.github/workflows/arc-runner-build-push.yml')
 const arcRunnerReleaseWorkflow = readRepoFile('.github/workflows/arc-runner-release.yml')
@@ -381,6 +383,29 @@ describe('createOciIndex', () => {
 })
 
 describe('native OCI build workflows', () => {
+  it('creates generated release PRs with an app token fallback so automerge can run', () => {
+    for (const [name, workflow] of [
+      ['agents', agentsReleaseWorkflow],
+      ['arc-runner', arcRunnerReleaseWorkflow],
+      ['attic', atticReleaseWorkflow],
+      ['enabled-product', enabledProductReleaseWorkflow],
+      ['enabled-simple', enabledSimpleReleaseWorkflow],
+      ['headlamp', headlampReleaseWorkflow],
+      ['jangar', jangarReleaseWorkflow],
+      ['sag', sagReleaseWorkflow],
+      ['symphony', symphonyReleaseWorkflow],
+      ['torghut', torghutReleaseWorkflow],
+      ['torghut-hyperliquid-feed', torghutHyperliquidFeedReleaseWorkflow],
+      ['torghut-ta', torghutTaReleaseWorkflow],
+      ['torghut-ws', torghutWsReleaseWorkflow],
+    ]) {
+      expect(workflow, `${name} must open generated release PRs through create-pull-request`).toContain(
+        'peter-evans/create-pull-request@',
+      )
+      expect(workflow, `${name} release PRs must not be authored only by GITHUB_TOKEN`).toContain(releasePrTokenInput)
+    }
+  })
+
   it('routes the live Attic image through real Nix OCI builds', () => {
     expect(atticWorkflow).toContain('uses: ./.github/workflows/nix-oci-build-common.yml')
     expect(atticWorkflow).toContain('package_attr: atticd-image')


### PR DESCRIPTION
## Summary

- Make Nix/GitOps release PR creators use `AGENTS_SPLIT_TOKEN` with `GITHUB_TOKEN` fallback so downstream `pull_request_target` automerge workflows can fire automatically.
- Cover ARC runner, Attic, enabled simple/product Nix image releases, and Headlamp release PR creation.
- Add workflow contract tests so generated release PRs cannot regress to default Actions-token authorship only.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' -ignore 'SC2016' .github/workflows/arc-runner-release.yml .github/workflows/attic-release.yml .github/workflows/enabled-simple-nix-release.yml .github/workflows/enabled-product-nix-release.yml .github/workflows/headlamp-release.yml .github/workflows/release-pr-automerge.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
