### PR TITLE
ci(nix): track symphony derivative image consumers

### DIFF
--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -20,6 +20,8 @@ Current inventory from the repo guardrail:
 - Repo-image apps must be either `nix-image`, explicitly `deferred`, or a documented manifest-only exception.
 - Helm values that override chart images with `registry.ide-newton.ts.net/lab/...` count as repo-image references. `headlamp`
   is a build-owning migration target because the live chart values pin `lab/headlamp`.
+- Derived apps that reuse a migrated repo image, such as `symphony-jangar` and `symphony-torghut`, are tracked as
+  `nix-image` consumers of that shared image rather than deferred migration proof gaps.
 
 Hard exclusions:
 
@@ -123,6 +125,8 @@ Same commit plus same lockfiles should reproduce the same Nix output path and OC
    - Package `agents-codex-runner` runtime dependencies through Nix.
    - Remove Docker image build paths for enabled Agents service images once the runner image is migrated.
    - Smoke only the root-enabled Agents app.
+   - Treat derived deployments as Nix-covered only when the shared image release/deploy path updates their manifests
+     together; do not create duplicate image builds for those apps.
 
 4. **PR 4: Torghut-Family Nix Migration**
    - Add uv/Nix derivations for `torghut`, `torghut-hyperliquid-feed`, `torghut-hyperliquid-runtime`, and `torghut-options`.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -75,6 +75,8 @@ describe('enabled app inventory', () => {
       'attic',
       'sag',
       'symphony',
+      'symphony-jangar',
+      'symphony-torghut',
       'jangar',
       'torghut',
       'torghut-hyperliquid-feed',
@@ -100,6 +102,8 @@ describe('enabled app inventory', () => {
     expect(entry('arc').nixImageAttr).toBe('arc-runner-image')
     expect(entry('sag').nixImageAttr).toBe('sag-image')
     expect(entry('symphony').nixImageAttr).toBe('symphony-image')
+    expect(entry('symphony-jangar').nixImageAttr).toBe('symphony-image')
+    expect(entry('symphony-torghut').nixImageAttr).toBe('symphony-image')
     expect(entry('jangar').nixImageAttr).toBe('jangar-image')
     expect(entry('torghut').nixImageAttr).toBe('torghut-image')
     expect(entry('torghut-hyperliquid-feed').nixImageAttr).toBe('torghut-hyperliquid-feed-image')
@@ -147,6 +151,19 @@ describe('enabled app inventory', () => {
     expect(entry('jangar').workflowPaths).toContain('.github/workflows/jangar-build-push.yaml')
   })
 
+  it('tracks Symphony derivative apps through the shared Symphony Nix image path', () => {
+    for (const name of ['symphony-jangar', 'symphony-torghut']) {
+      expect(entry(name)).toMatchObject({
+        class: 'nix-image',
+        nixImageAttr: 'symphony-image',
+        buildScriptPath: 'packages/scripts/src/symphony/build-image.ts',
+        deployScriptPath: 'packages/scripts/src/symphony/deploy-service.ts',
+      })
+      expect(entry(name).workflowPaths).toContain('.github/workflows/symphony-build-push.yaml')
+      expect(entry(name).deferredReason).toBeUndefined()
+    }
+  })
+
   it('tracks Torghut-family enabled apps through explicit Nix image ownership paths', () => {
     expect(entry('torghut-hyperliquid-feed')).toMatchObject({
       class: 'nix-image',
@@ -177,12 +194,10 @@ describe('enabled app inventory', () => {
     expect(entry('torghut-options').workflowPaths).toContain('.github/workflows/torghut-ta-build-push.yaml')
   })
 
-  it('defers complex or unhealthy repo-image apps instead of counting them as rollout proof', () => {
-    for (const name of ['symphony-jangar', 'symphony-torghut']) {
-      expect(entry(name).class).toBe('deferred')
-      expect(entry(name).repoImages.length).toBeGreaterThan(0)
-      expect(entry(name).deferredReason).toBeTruthy()
-    }
+  it('defers complex repo-image apps without supported build ownership instead of counting them as rollout proof', () => {
+    expect(entry('tigresse').class).toBe('deferred')
+    expect(entry('tigresse').repoImages.length).toBeGreaterThan(0)
+    expect(entry('tigresse').deferredReason).toBeTruthy()
   })
 
   it('keeps repo-image apps without local build ownership out of Nix migration state', () => {

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -53,6 +53,8 @@ const earlyNixImageApps = new Set([
   'proompteng',
   'sag',
   'symphony',
+  'symphony-jangar',
+  'symphony-torghut',
   'synthesis',
   'torghut',
   'torghut-hyperliquid-feed',
@@ -61,8 +63,6 @@ const earlyNixImageApps = new Set([
 ])
 
 const deferredApps = new Map<string, string>([
-  ['symphony-jangar', 'derived deployment using the symphony image; migrate with symphony'],
-  ['symphony-torghut', 'derived deployment using the symphony image; migrate with symphony'],
   ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
 ])
 
@@ -80,6 +80,8 @@ const appToNixAttr = new Map<string, string>([
   ['proompteng', 'proompteng-image'],
   ['sag', 'sag-image'],
   ['symphony', 'symphony-image'],
+  ['symphony-jangar', 'symphony-image'],
+  ['symphony-torghut', 'symphony-image'],
   ['synthesis', 'synthesis-image'],
   ['agents', 'agents-codex-runner-image'],
   ['torghut', 'torghut-image'],
@@ -90,6 +92,8 @@ const appToNixAttr = new Map<string, string>([
 
 const appToBuildScriptPath = new Map<string, string>([
   ['arc', 'packages/scripts/src/arc-runner/build-image.ts'],
+  ['symphony-jangar', 'packages/scripts/src/symphony/build-image.ts'],
+  ['symphony-torghut', 'packages/scripts/src/symphony/build-image.ts'],
   ['torghut-hyperliquid-feed', 'packages/scripts/src/torghut/build-hyperliquid-feed-image.ts'],
   ['torghut-hyperliquid-runtime', 'packages/scripts/src/torghut/build-image.ts'],
   ['torghut-options', 'packages/scripts/src/torghut/build-image.ts'],
@@ -97,12 +101,16 @@ const appToBuildScriptPath = new Map<string, string>([
 
 const appToDeployScriptPath = new Map<string, string>([
   ['arc', 'packages/scripts/src/arc-runner/deploy-service.ts'],
+  ['symphony-jangar', 'packages/scripts/src/symphony/deploy-service.ts'],
+  ['symphony-torghut', 'packages/scripts/src/symphony/deploy-service.ts'],
   ['torghut-hyperliquid-feed', 'packages/scripts/src/torghut/update-hyperliquid-feed-manifest.ts'],
   ['torghut-hyperliquid-runtime', 'packages/scripts/src/torghut/update-manifests.ts'],
   ['torghut-options', 'packages/scripts/src/torghut/update-manifests.ts'],
 ])
 
 const appToWorkflowPaths = new Map<string, string[]>([
+  ['symphony-jangar', ['.github/workflows/symphony-build-push.yaml']],
+  ['symphony-torghut', ['.github/workflows/symphony-build-push.yaml']],
   ['torghut-hyperliquid-feed', ['.github/workflows/torghut-hyperliquid-feed-build-push.yaml']],
   ['torghut-hyperliquid-runtime', ['.github/workflows/torghut-build-push.yaml']],
   [


### PR DESCRIPTION
## Summary

- Classify `symphony-jangar` and `symphony-torghut` as consumers of the migrated shared `symphony-image` instead of deferred apps.
- Map those derived deployments to the existing Symphony Nix build/deploy scripts and `symphony-build-push` workflow.
- Update the rollout plan and inventory guardrails so derived apps do not require duplicate image builds.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bun run packages/scripts/src/shared/enabled-apps.ts --assert`
- `bun run packages/scripts/src/shared/enabled-apps.ts --json | jq '{total:(.entries|length), byClass:(.entries|group_by(.class)|map({class:.[0].class,count:length})), deferred:[.entries[]|select(.class=="deferred")|{name,deferredReason}], symphony:[.entries[]|select(.name|test("^symphony"))|{name,class,nixImageAttr,buildScriptPath,deployScriptPath,workflowPaths}]}'`
- `bunx oxfmt --check packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
