### PR TITLE
ci(torghut): squash merge generated release prs

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -421,7 +421,7 @@ jobs:
             sleep 10
           done
 
-      - name: Enable squash auto-merge
+      - name: Squash merge release PR
         if: steps.gates.outputs.eligible == 'true'
         shell: bash
         env:
@@ -430,14 +430,30 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          auto_merge_enabled="$(
+
+          pr_state="$(
             gh pr view "${PR_NUMBER}" \
               -R "${GH_REPO}" \
-              --json autoMergeRequest \
-              --jq '.autoMergeRequest != null'
+              --json state,mergeStateStatus,isDraft \
+              --jq '[.state, .mergeStateStatus, (.isDraft|tostring)] | @tsv'
           )"
-          if [ "${auto_merge_enabled}" = 'true' ]; then
-            echo "Auto-merge already enabled for PR #${PR_NUMBER}"
+          IFS=$'\t' read -r state merge_state is_draft <<< "${pr_state}"
+
+          if [ "${state}" != 'OPEN' ]; then
+            echo "PR #${PR_NUMBER} is not open: ${state}"
             exit 0
           fi
-          gh pr merge "${PR_NUMBER}" -R "${GH_REPO}" --auto --squash
+          if [ "${is_draft}" = 'true' ]; then
+            echo "PR #${PR_NUMBER} is draft; skipping merge."
+            exit 0
+          fi
+          case "${merge_state}" in
+            CLEAN | UNSTABLE)
+              ;;
+            *)
+              echo "PR #${PR_NUMBER} is not mergeable after required checks passed: ${merge_state}"
+              exit 1
+              ;;
+          esac
+
+          gh pr merge "${PR_NUMBER}" -R "${GH_REPO}" --squash

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -106,6 +106,14 @@ describe('torghut-deploy-automerge workflow', () => {
     expect(deployAutomergeWorkflow).not.toContain('deadline=$((SECONDS + 2700))')
   })
 
+  test('squash-merges generated release PRs after explicit gates instead of enabling brittle automerge', () => {
+    expect(deployAutomergeWorkflow).toContain('name: Squash merge release PR')
+    expect(deployAutomergeWorkflow).toContain('--json state,mergeStateStatus,isDraft')
+    expect(deployAutomergeWorkflow).toContain('CLEAN | UNSTABLE)')
+    expect(deployAutomergeWorkflow).toContain('gh pr merge "${PR_NUMBER}" -R "${GH_REPO}" --squash')
+    expect(deployAutomergeWorkflow).not.toContain('gh pr merge "${PR_NUMBER}" -R "${GH_REPO}" --auto --squash')
+  })
+
   test('allowlists hyperliquid feed image promotion PRs with a feed digest gate', () => {
     const manifestPath = 'argocd/applications/torghut-hyperliquid-feed/deployment.yaml'
 


### PR DESCRIPTION
## Summary

- Replace brittle Torghut release `--auto --squash` enablement with a guarded direct squash merge after the workflow's allowlist, digest, platform, and required-check gates pass.
- Keep generated release PRs automatic without waiting for a manual workflow dispatch when GitHub reports `enablePullRequestAutoMerge` as unstable.
- Add a regression test for the generated release PR merge behavior.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts packages/scripts/src/shared/__tests__/oci.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts`
- `actionlint -ignore 'label "arc-amd64" is unknown' -ignore 'SC2016' .github/workflows/torghut-deploy-automerge.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
