### PR TITLE
ci(nix): classify tigresse as manifest-only

### DIFF
--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -22,6 +22,9 @@ Current inventory from the repo guardrail:
   is a build-owning migration target because the live chart values pin `lab/headlamp`.
 - Derived apps that reuse a migrated repo image, such as `symphony-jangar` and `symphony-torghut`, are tracked as
   `nix-image` consumers of that shared image rather than deferred migration proof gaps.
+- `tigresse` is not an in-repo Nix migration gap: this repo vendors the Helm chart and pins
+  `registry.ide-newton.ts.net/lab/tigresse`, but the operator source/build ownership is the separate private
+  `proompteng/tigresse` repository.
 
 Hard exclusions:
 

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -194,14 +194,8 @@ describe('enabled app inventory', () => {
     expect(entry('torghut-options').workflowPaths).toContain('.github/workflows/torghut-ta-build-push.yaml')
   })
 
-  it('defers complex repo-image apps without supported build ownership instead of counting them as rollout proof', () => {
-    expect(entry('tigresse').class).toBe('deferred')
-    expect(entry('tigresse').repoImages.length).toBeGreaterThan(0)
-    expect(entry('tigresse').deferredReason).toBeTruthy()
-  })
-
   it('keeps repo-image apps without local build ownership out of Nix migration state', () => {
-    for (const name of ['analysis', 'bilig']) {
+    for (const name of ['analysis', 'bilig', 'tigresse']) {
       expect(entry(name).class).toBe('vendor-manifest')
       expect(entry(name).repoImages.length).toBeGreaterThan(0)
       expect(entry(name).buildScriptPath).toBeUndefined()
@@ -209,6 +203,15 @@ describe('enabled app inventory', () => {
       expect(entry(name).nixImageAttr).toBeUndefined()
       expect(entry(name).deferredReason).toBeTruthy()
     }
+  })
+
+  it('tracks Tigresse as a vendored external-operator chart, not an in-repo image build gap', () => {
+    expect(entry('tigresse')).toMatchObject({
+      class: 'vendor-manifest',
+      hasHelmChart: true,
+      repoImages: ['registry.ide-newton.ts.net/lab/tigresse'],
+    })
+    expect(entry('tigresse').deferredReason).toContain('proompteng/tigresse')
   })
 
   it('passes the no-build-for-chart-and-vendor guardrail', () => {

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -62,10 +62,6 @@ const earlyNixImageApps = new Set([
   'torghut-options',
 ])
 
-const deferredApps = new Map<string, string>([
-  ['tigresse', 'chart-rendered app references a lab image but has no supported build/deploy path yet'],
-])
-
 const appToNixAttr = new Map<string, string>([
   ['app', 'app-image'],
   ['arc', 'arc-runner-image'],
@@ -126,6 +122,10 @@ const appToWorkflowPaths = new Map<string, string[]>([
 const manifestOnlyRepoImageApps = new Map<string, string>([
   ['analysis', 'repo image is tracked by image updater, but no local source build/deploy path exists in this repo'],
   ['bilig', 'repo image is produced outside this checkout; this app is GitOps/image-updater managed here'],
+  [
+    'tigresse',
+    'operator source lives in the private proompteng/tigresse repository; lab only vendors the chart and pins its image digest',
+  ],
 ])
 
 const uniqueSorted = (values: Iterable<string>): string[] => [...new Set(values)].sort()
@@ -318,11 +318,6 @@ const classify = (entry: EnabledAppInventoryEntry): EnabledAppInventoryEntry => 
   const manifestOnlyReason = manifestOnlyRepoImageApps.get(entry.name)
   if (manifestOnlyReason) {
     return { ...entry, class: 'vendor-manifest', deferredReason: manifestOnlyReason }
-  }
-
-  const deferredReason = deferredApps.get(entry.name)
-  if (deferredReason) {
-    return { ...entry, class: 'deferred', deferredReason }
   }
 
   if (entry.repoImages.length > 0) {


### PR DESCRIPTION
## Summary

- Reclassifies `tigresse` as a documented manifest-only exception instead of a deferred in-repo Nix image migration gap.
- Records that lab vendors the Tigresse chart and pins its image digest, while image build ownership lives in the separate private `proompteng/tigresse` repo.
- Extends enabled-app inventory tests so `tigresse` cannot be counted as chart-only or as unfinished lab image-build rollout proof.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bun run packages/scripts/src/shared/enabled-apps.ts --assert`
- `bun run packages/scripts/src/shared/enabled-apps.ts --json | jq '{total:(.entries|length), byClass:(.entries|group_by(.class)|map({class:.[0].class,count:length})), deferred:(.entries|map(select(.class=="deferred")|.name)), tigresse:(.entries|map(select(.name=="tigresse")|{class,hasHelmChart,repoImages,buildScriptPath,deployScriptPath,nixImageAttr,deferredReason})|.[0])}'`
- `bunx oxfmt --check packages/scripts/src/shared/enabled-apps.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
