### PR TITLE
ci(nix): add enabled rollout report audit

### DIFF
--- a/docs/nix-enabled-app-build-performance-rollout-plan.md
+++ b/docs/nix-enabled-app-build-performance-rollout-plan.md
@@ -151,11 +151,16 @@ Same commit plus same lockfiles should reproduce the same Nix output path and OC
 
 7. **PR 7: Final Rollout Report**
    - Record PRs, workflow run IDs, before/after timings, cache-hit counts, output paths, digests, Argo revisions, and smoke outputs.
+   - Generate the root-enabled app/image-build audit with
+     `bun run packages/scripts/src/shared/nix-rollout-report.ts`; pass `--contracts-dir <path> --require-contracts`
+     when collected release-contract artifacts are available.
    - Prove faster warm builds, deterministic rebuilds, digest-pinned releases, and no fake jobs/apps counted.
 
 ## Test Plan
 
 - `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/arc-runner.test.ts`
+- `bun test packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts`
+- `bun run packages/scripts/src/shared/nix-rollout-report.ts --json`
 - `nix flake check --print-build-logs`
 - Build each migrated image attr on both required platforms.
 - Inspect image archives and pushed registry indexes for OCI media types and `linux/amd64` plus `linux/arm64`.

--- a/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
+++ b/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { EnabledAppInventory, EnabledAppInventoryEntry } from '../enabled-apps'
+import {
+  buildNixRolloutReport,
+  formatNixRolloutReportMarkdown,
+  type NixRolloutReleaseContract,
+} from '../nix-rollout-report'
+
+const entry = (overrides: Partial<EnabledAppInventoryEntry>): EnabledAppInventoryEntry => ({
+  name: overrides.name ?? 'app',
+  path: overrides.path ?? `argocd/applications/${overrides.name ?? 'app'}`,
+  repoURL: overrides.repoURL ?? 'https://github.com/proompteng/lab.git',
+  sourceFile: overrides.sourceFile ?? 'argocd/applicationsets/platform.yaml',
+  sourceKind: overrides.sourceKind ?? 'applicationset-element',
+  class: overrides.class ?? 'nix-image',
+  enabled: overrides.enabled ?? true,
+  hasHelmChart: overrides.hasHelmChart ?? false,
+  repoImages: overrides.repoImages ?? [`registry.ide-newton.ts.net/lab/${overrides.name ?? 'app'}`],
+  buildScriptPath: overrides.buildScriptPath,
+  deployScriptPath: overrides.deployScriptPath,
+  workflowPaths: overrides.workflowPaths ?? [],
+  nixImageAttr: overrides.nixImageAttr,
+  deferredReason: overrides.deferredReason,
+})
+
+const inventory = (entries: EnabledAppInventoryEntry[]): EnabledAppInventory => ({
+  entries,
+  applicationSetEntryCount: entries.length,
+  directApplicationCount: 0,
+})
+
+const validContract = (overrides: Partial<NixRolloutReleaseContract> = {}): NixRolloutReleaseContract => ({
+  service: overrides.service ?? 'app',
+  image: overrides.image ?? 'registry.ide-newton.ts.net/lab/app',
+  tag: overrides.tag ?? 'sha-123',
+  digest: overrides.digest ?? 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  reference:
+    overrides.reference ??
+    'registry.ide-newton.ts.net/lab/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  sourceSha: overrides.sourceSha ?? '1234567890abcdef',
+  packageAttr: overrides.packageAttr ?? 'app-image',
+  platforms: overrides.platforms ?? ['linux/amd64', 'linux/arm64'],
+  builder: overrides.builder ?? 'nix-dockerTools-skopeo',
+  invocation: overrides.invocation ?? 'github-actions',
+  path: overrides.path ?? '.artifacts/app/release-contract.json',
+})
+
+describe('Nix rollout report', () => {
+  it('audits live enabled-app inventory without counting manifest-only Tigresse as deferred', () => {
+    const report = buildNixRolloutReport({})
+    const tigresse = report.manifestOnlyImageApps.find((candidate) => candidate.name === 'tigresse')
+
+    expect(report.nixImages.length).toBeGreaterThan(0)
+    expect(report.deferredApps).toEqual([])
+    expect(report.missingBuildContracts).toEqual([])
+    expect(tigresse?.deferredReason).toContain('proompteng/tigresse')
+  })
+
+  it('reports missing build contract pieces for Nix image apps', () => {
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'broken',
+          class: 'nix-image',
+          repoImages: ['registry.ide-newton.ts.net/lab/broken'],
+        }),
+      ]),
+    })
+
+    expect(report.missingBuildContracts).toEqual([
+      'broken: missing nix attr, manual build script, manual deploy script, workflow',
+    ])
+  })
+
+  it('validates provided release contracts and maps them to Nix image apps when required', () => {
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'app',
+          class: 'nix-image',
+          nixImageAttr: 'app-image',
+          buildScriptPath: 'packages/scripts/src/app/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/app/deploy-service.ts',
+          workflowPaths: ['.github/workflows/product-nix-images.yml'],
+        }),
+      ]),
+      releaseContracts: [validContract()],
+      requireContracts: true,
+    })
+
+    expect(report.releaseContracts).toMatchObject({
+      provided: 1,
+      valid: 1,
+      invalid: [],
+      missingForNixImages: [],
+    })
+  })
+
+  it('flags invalid release contracts and missing required contract coverage', () => {
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'app',
+          class: 'nix-image',
+          nixImageAttr: 'app-image',
+          buildScriptPath: 'packages/scripts/src/app/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/app/deploy-service.ts',
+          workflowPaths: ['.github/workflows/product-nix-images.yml'],
+        }),
+      ]),
+      releaseContracts: [
+        validContract({
+          service: 'other',
+          image: 'registry.ide-newton.ts.net/lab/other',
+          reference:
+            'registry.ide-newton.ts.net/lab/other@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          packageAttr: 'other-image',
+          platforms: ['linux/amd64'],
+          path: '.artifacts/other/release-contract.json',
+        }),
+      ],
+      requireContracts: true,
+    })
+
+    expect(report.releaseContracts.valid).toBe(0)
+    expect(report.releaseContracts.invalid[0]).toContain('missing platform linux/arm64')
+    expect(report.releaseContracts.missingForNixImages).toEqual(['app'])
+  })
+
+  it('formats a markdown report with inventory and gate sections', () => {
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'app',
+          class: 'nix-image',
+          nixImageAttr: 'app-image',
+          buildScriptPath: 'packages/scripts/src/app/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/app/deploy-service.ts',
+          workflowPaths: ['.github/workflows/product-nix-images.yml'],
+        }),
+      ]),
+    })
+
+    const markdown = formatNixRolloutReportMarkdown(report)
+
+    expect(markdown).toContain('# Nix Enabled-App Rollout Report')
+    expect(markdown).toContain('## Nix Image Apps')
+    expect(markdown).toContain('| app | app-image |')
+    expect(markdown).toContain('Missing Nix image build contracts: None')
+  })
+})

--- a/packages/scripts/src/shared/nix-rollout-report.ts
+++ b/packages/scripts/src/shared/nix-rollout-report.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env bun
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { fatal, repoRoot } from './cli'
+import { type EnabledAppInventory, type EnabledAppInventoryEntry, loadEnabledAppInventory } from './enabled-apps'
+import type { NixOciPlatform } from './nix-oci'
+
+type JsonRecord = Record<string, unknown>
+
+export type NixRolloutReleaseContract = {
+  service: string
+  image: string
+  tag: string
+  digest: string
+  reference: string
+  sourceSha: string
+  packageAttr: string
+  platforms: NixOciPlatform[]
+  builder: string
+  invocation?: string
+  path: string
+}
+
+export type NixRolloutReport = {
+  totals: {
+    entries: number
+    applicationSetEntries: number
+    directApplications: number
+    byClass: Record<string, number>
+  }
+  nixImages: EnabledAppInventoryEntry[]
+  manifestOnlyImageApps: EnabledAppInventoryEntry[]
+  deferredApps: EnabledAppInventoryEntry[]
+  missingBuildContracts: string[]
+  releaseContracts: {
+    provided: number
+    valid: number
+    invalid: string[]
+    missingForNixImages: string[]
+  }
+}
+
+const requiredPlatforms: NixOciPlatform[] = ['linux/amd64', 'linux/arm64']
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined)
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((item) => typeof item === 'string') : []
+
+const listJsonFiles = (path: string): string[] => {
+  if (!existsSync(path)) return []
+  const stat = statSync(path)
+  if (stat.isFile()) return path.endsWith('.json') ? [path] : []
+
+  const files: string[] = []
+  for (const name of readdirSync(path)) {
+    files.push(...listJsonFiles(join(path, name)))
+  }
+  return files.sort()
+}
+
+const parseReleaseContract = (path: string): NixRolloutReleaseContract | undefined => {
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown
+  if (!isRecord(parsed)) return undefined
+
+  const platforms = asStringArray(parsed.platforms)
+  const contract = {
+    service: asString(parsed.service) ?? '',
+    image: asString(parsed.image) ?? '',
+    tag: asString(parsed.tag) ?? '',
+    digest: asString(parsed.digest) ?? '',
+    reference: asString(parsed.reference) ?? '',
+    sourceSha: asString(parsed.sourceSha) ?? '',
+    packageAttr: asString(parsed.packageAttr) ?? '',
+    platforms: platforms as NixOciPlatform[],
+    builder: asString(parsed.builder) ?? '',
+    invocation: asString(parsed.invocation),
+    path,
+  }
+
+  return contract
+}
+
+export const loadNixRolloutReleaseContracts = (contractsPath: string): NixRolloutReleaseContract[] =>
+  listJsonFiles(contractsPath)
+    .map((path) => parseReleaseContract(path))
+    .filter((contract): contract is NixRolloutReleaseContract => contract !== undefined)
+
+const validateReleaseContract = (contract: NixRolloutReleaseContract): string[] => {
+  const errors: string[] = []
+  for (const field of ['service', 'image', 'tag', 'digest', 'reference', 'sourceSha', 'packageAttr'] as const) {
+    if (!contract[field]) errors.push(`${field} is missing`)
+  }
+  if (!contract.digest.startsWith('sha256:')) errors.push(`digest is not sha256: ${contract.digest}`)
+  if (contract.builder !== 'nix-dockerTools-skopeo') errors.push(`builder is not nix-dockerTools-skopeo`)
+  for (const platform of requiredPlatforms) {
+    if (!contract.platforms.includes(platform)) errors.push(`missing platform ${platform}`)
+  }
+  return errors
+}
+
+const contractCoversEntry = (contract: NixRolloutReleaseContract, entry: EnabledAppInventoryEntry): boolean =>
+  contract.service === entry.name ||
+  contract.packageAttr === entry.nixImageAttr ||
+  entry.repoImages.some((image) => contract.image === image || contract.reference.startsWith(`${image}@`))
+
+const countByClass = (entries: EnabledAppInventoryEntry[]): Record<string, number> =>
+  entries.reduce<Record<string, number>>((counts, entry) => {
+    counts[entry.class] = (counts[entry.class] ?? 0) + 1
+    return counts
+  }, {})
+
+export const buildNixRolloutReport = (input: {
+  inventory?: EnabledAppInventory
+  releaseContracts?: NixRolloutReleaseContract[]
+  requireContracts?: boolean
+}): NixRolloutReport => {
+  const inventory = input.inventory ?? loadEnabledAppInventory()
+  const releaseContracts = input.releaseContracts ?? []
+  const nixImages = inventory.entries.filter((entry) => entry.class === 'nix-image')
+  const manifestOnlyImageApps = inventory.entries.filter(
+    (entry) => entry.class === 'vendor-manifest' && entry.repoImages.length > 0,
+  )
+  const deferredApps = inventory.entries.filter((entry) => entry.class === 'deferred')
+  const missingBuildContracts = nixImages.flatMap((entry) => {
+    const missing = []
+    if (!entry.nixImageAttr) missing.push('nix attr')
+    if (!entry.buildScriptPath) missing.push('manual build script')
+    if (!entry.deployScriptPath) missing.push('manual deploy script')
+    if (entry.workflowPaths.length === 0) missing.push('workflow')
+    return missing.length > 0 ? [`${entry.name}: missing ${missing.join(', ')}`] : []
+  })
+  const invalidContracts = releaseContracts.flatMap((contract) => {
+    const errors = validateReleaseContract(contract)
+    return errors.length > 0 ? [`${contract.path}: ${errors.join('; ')}`] : []
+  })
+  const missingForNixImages = input.requireContracts
+    ? nixImages
+        .filter((entry) => !releaseContracts.some((contract) => contractCoversEntry(contract, entry)))
+        .map((entry) => entry.name)
+    : []
+
+  return {
+    totals: {
+      entries: inventory.entries.length,
+      applicationSetEntries: inventory.applicationSetEntryCount,
+      directApplications: inventory.directApplicationCount,
+      byClass: countByClass(inventory.entries),
+    },
+    nixImages,
+    manifestOnlyImageApps,
+    deferredApps,
+    missingBuildContracts,
+    releaseContracts: {
+      provided: releaseContracts.length,
+      valid: releaseContracts.length - invalidContracts.length,
+      invalid: invalidContracts,
+      missingForNixImages,
+    },
+  }
+}
+
+const formatList = (values: string[]): string => (values.length > 0 ? values.join(', ') : 'None')
+
+export const formatNixRolloutReportMarkdown = (report: NixRolloutReport): string => {
+  const lines = [
+    '# Nix Enabled-App Rollout Report',
+    '',
+    '## Inventory',
+    '',
+    `- Enabled ApplicationSet entries: ${report.totals.applicationSetEntries}`,
+    `- Direct root-managed Applications: ${report.totals.directApplications}`,
+    `- Total enabled entries: ${report.totals.entries}`,
+    `- Classes: ${Object.entries(report.totals.byClass)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, count]) => `${name}=${count}`)
+      .join(', ')}`,
+    '',
+    '## Nix Image Apps',
+    '',
+    '| App | Nix Attr | Manual Build | Manual Deploy | Workflows |',
+    '| --- | --- | --- | --- | --- |',
+    ...report.nixImages.map((entry) =>
+      [
+        `| ${entry.name}`,
+        entry.nixImageAttr ?? '',
+        entry.buildScriptPath ?? '',
+        entry.deployScriptPath ?? '',
+        `${entry.workflowPaths.join('<br>')} |`,
+      ].join(' | '),
+    ),
+    '',
+    '## Manifest-Only Repo Image References',
+    '',
+    '| App | Images | Reason |',
+    '| --- | --- | --- |',
+    ...report.manifestOnlyImageApps.map(
+      (entry) => `| ${entry.name} | ${entry.repoImages.join('<br>')} | ${entry.deferredReason ?? ''} |`,
+    ),
+    '',
+    '## Gates',
+    '',
+    `- Deferred apps: ${formatList(report.deferredApps.map((entry) => entry.name))}`,
+    `- Missing Nix image build contracts: ${formatList(report.missingBuildContracts)}`,
+    `- Release contracts provided: ${report.releaseContracts.provided}`,
+    `- Valid release contracts: ${report.releaseContracts.valid}`,
+    `- Invalid release contracts: ${formatList(report.releaseContracts.invalid)}`,
+    `- Nix image apps missing release contracts: ${formatList(report.releaseContracts.missingForNixImages)}`,
+    '',
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+const readCliArgs = () => {
+  const args = process.argv.slice(2)
+  const contractsIndex = args.indexOf('--contracts-dir')
+  const contractsDir = contractsIndex >= 0 ? args[contractsIndex + 1] : undefined
+  if (contractsIndex >= 0 && !contractsDir) {
+    throw new Error('--contracts-dir requires a path')
+  }
+  return {
+    json: args.includes('--json'),
+    contractsDir,
+    requireContracts: args.includes('--require-contracts'),
+  }
+}
+
+const runCli = (): void => {
+  const args = readCliArgs()
+  const releaseContracts = args.contractsDir
+    ? loadNixRolloutReleaseContracts(resolve(repoRoot, args.contractsDir))
+    : undefined
+  const report = buildNixRolloutReport({ releaseContracts, requireContracts: args.requireContracts })
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2))
+    return
+  }
+  console.log(formatNixRolloutReportMarkdown(report))
+}
+
+if (import.meta.main) {
+  try {
+    runCli()
+  } catch (error) {
+    fatal('Failed to build Nix rollout report', error)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `packages/scripts/src/shared/nix-rollout-report.ts` to generate a root-enabled Nix rollout audit from the enabled-app inventory.
- Validates migrated `nix-image` apps have Nix attrs, manual build/deploy scripts, and workflow coverage, with optional release-contract artifact validation.
- Updates the canonical Nix rollout plan to use the report generator for the final evidence path.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/nix-oci.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/shared/nix-rollout-report.ts packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/nix-rollout-report.ts packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts`
- `git diff --check`
- `bun run packages/scripts/src/shared/nix-rollout-report.ts --json | jq '{classes:.totals.byClass, nixImages:(.nixImages|length), manifestOnly:(.manifestOnlyImageApps|map(.name)), deferred:(.deferredApps|map(.name)), missingBuildContracts:.missingBuildContracts}'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
