### PR TITLE
fix(torghut): type hyperliquid fill dedup binds

### DIFF
--- a/services/torghut/app/hyperliquid_execution/repository.py
+++ b/services/torghut/app/hyperliquid_execution/repository.py
@@ -428,7 +428,7 @@ class HyperliquidExecutionRepository:
                     SELECT id
                     FROM hyperliquid_execution_orders
                     WHERE execution_network = 'testnet'
-                      AND exchange_order_id = :exchange_order_id
+                      AND exchange_order_id = CAST(:exchange_order_id AS text)
                     ORDER BY created_at DESC
                     LIMIT 1
                   ), order_id),
@@ -440,7 +440,7 @@ class HyperliquidExecutionRepository:
                   notional_usd = :notional_usd,
                   fee_usd = :fee_usd,
                   closed_pnl_usd = :closed_pnl_usd,
-                  exchange_order_id = COALESCE(:exchange_order_id, exchange_order_id),
+                  exchange_order_id = COALESCE(CAST(:exchange_order_id AS text), exchange_order_id),
                   event_ts = :event_ts,
                   raw_payload = raw_payload || CAST(:raw_payload AS jsonb)
                 WHERE execution_network = 'testnet'
@@ -448,8 +448,8 @@ class HyperliquidExecutionRepository:
                   AND coin = :coin
                   AND (
                     exchange_order_id IS NULL
-                    OR :exchange_order_id IS NULL
-                    OR exchange_order_id = :exchange_order_id
+                    OR CAST(:exchange_order_id AS text) IS NULL
+                    OR exchange_order_id = CAST(:exchange_order_id AS text)
                   )
                   AND NOT EXISTS (
                     SELECT 1
@@ -470,8 +470,8 @@ class HyperliquidExecutionRepository:
                   AND coin = :coin
                   AND (
                     exchange_order_id IS NULL
-                    OR :exchange_order_id IS NULL
-                    OR exchange_order_id = :exchange_order_id
+                    OR CAST(:exchange_order_id AS text) IS NULL
+                    OR exchange_order_id = CAST(:exchange_order_id AS text)
                   )
                   AND EXISTS (
                     SELECT 1

--- a/services/torghut/tests/hyperliquid_execution/test_repository_fill_identity.py
+++ b/services/torghut/tests/hyperliquid_execution/test_repository_fill_identity.py
@@ -32,6 +32,10 @@ def test_repository_deduplicates_legacy_hash_fill_before_tid_insert() -> None:
     assert "UPDATE hyperliquid_execution_fills" in fill_calls[0][0]
     assert "DELETE FROM hyperliquid_execution_fills" in fill_calls[1][0]
     assert "INSERT INTO hyperliquid_execution_fills" in fill_calls[2][0]
+    assert "CAST(:exchange_order_id AS text) IS NULL" in fill_calls[0][0]
+    assert "CAST(:exchange_order_id AS text) IS NULL" in fill_calls[1][0]
+    assert "OR :exchange_order_id IS NULL" not in fill_calls[0][0]
+    assert "OR :exchange_order_id IS NULL" not in fill_calls[1][0]
     assert fill_calls[0][1] is not None
     assert fill_calls[0][1]["legacy_fill_hash"] == "order-hash"
     assert fill_calls[1][1] is not None


### PR DESCRIPTION
## Summary

- Cast Hyperliquid legacy fill dedup `exchange_order_id` bind sites to `text` so PostgreSQL can type-check `IS NULL` predicates.
- Keep the legacy hash-to-`tid` migration path intact without double-counting fills.
- Add a regression assertion that rejects the untyped `:exchange_order_id IS NULL` SQL shape that broke live readiness.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/hyperliquid_execution/test_repository_fill_identity.py tests/hyperliquid_execution/test_exchange_fill_identity.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff format --check app/hyperliquid_execution/repository.py tests/hyperliquid_execution/test_repository_fill_identity.py`
- `uv run --frozen ruff check app/hyperliquid_execution/repository.py tests/hyperliquid_execution/test_repository_fill_identity.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
