### PR TITLE
fix(nix): refresh oirat dependency hashes

### DIFF
--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-b7gVdCguIM7nTpTtFVCB5XtQa8gTlpYCbBXZirSxzRM=";
-    aarch64-linux = "sha256-QQZr97O1Ux7zqCrk3UaeMRL43ALxn+1I6AzgrpkL7Tc=";
+    x86_64-linux = "sha256-bNAJstmwJ+1p2iZpop6zGONyOp8hEfgfrOML5kTASVo=";
+    aarch64-linux = "sha256-vkXEfzpeFgruwUyn5bzdvBG8TGfWaCVzZ/OsUjm3dCM=";
   };
   installFilters = [
     "@proompteng/discord"


### PR DESCRIPTION
## Summary

- Refresh the fixed-output Bun dependency hashes for the enabled Oirat Nix image on amd64 and arm64.
- Use the hashes reported by the failed main Oirat Nix OCI proof run 28755585769.
- Keep the change limited to the Oirat image derivation so the real ARC Linux image build can prove the fix.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `nix eval --raw .#packages.x86_64-linux.oirat-image.drvPath`
- `nix eval --raw .#packages.aarch64-linux.oirat-image.drvPath`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
