### PR TITLE
chore(oirat): promote nix image sha-4404a90ac83d6643b78a6f847e5a34b0416ae3bd

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:6f27e320843034987a571d156cd7968decce0eee2c7be9bd2e4fc2fb0762d187
+    digest: sha256:ea89bc7c66cb89373661d09162bd046e0f70c8ada356bfb1773833dfd20a7214


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:ea89bc7c66cb89373661d09162bd046e0f70c8ada356bfb1773833dfd20a7214`.
- Source commit: `4404a90ac83d6643b78a6f847e5a34b0416ae3bd`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:ea89bc7c66cb89373661d09162bd046e0f70c8ada356bfb1773833dfd20a7214" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.