### PR TITLE
fix(ci): allow generated release pr author

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -84,7 +84,7 @@ jobs:
             exit 0
           fi
 
-          allowed_authors=("app/github-actions" "github-actions[bot]")
+          allowed_authors=("app/github-actions" "github-actions[bot]" "gregkonush")
           legacy_release_paths=(
             "argocd/applications/khoshut/kustomization.yaml"
             "argocd/applications/analysis/kustomization.yaml"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1398,6 +1398,7 @@ describe('native OCI build workflows', () => {
     )
     expect(releasePrAutomergeWorkflow).toContain('[[ "$PR_HEAD_REF" =~ ^codex/product-nix-release-[0-9a-f]{40}$ ]]')
     expect(releasePrAutomergeWorkflow).toContain('for required_label in automated-pr nix-oci')
+    expect(releasePrAutomergeWorkflow).toContain('"gregkonush"')
     expect(releasePrAutomergeWorkflow).toContain('reason=eligible:${release_kind}')
   })
 


### PR DESCRIPTION
## Summary

- Allow generated release PRs authored by the repo automation token user to pass the existing release automerge author gate.
- Preserve the existing same-repo, branch-pattern, label, no-opt-out, and allowlisted changed-file checks.
- Add a workflow guardrail test for the observed generated PR author path.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts`
- `actionlint -ignore 'label "arc-arm64" is unknown' -ignore 'label "arc-amd64" is unknown' .github/workflows/release-pr-automerge.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
