### PR TITLE
fix(nix): refresh bumba dependency hashes

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -12,8 +12,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-r1MqBWNeGieUQque+vdJCPDGxMx3gOTmPOuTnzRQ+Pc=";
-    aarch64-linux = "sha256-r1MqBWNeGieUQque+vdJCPDGxMx3gOTmPOuTnzRQ+Pc=";
+    x86_64-linux = "sha256-xNgeqqGdtrwynJWfVAmzQiqGBqH+VvLHznZQQ7dapB8=";
+    aarch64-linux = "sha256-xNgeqqGdtrwynJWfVAmzQiqGBqH+VvLHznZQQ7dapB8=";
   };
   installFilters = [
     "@proompteng/bumba"


### PR DESCRIPTION
## Summary

- Refresh the fixed-output Bun dependency hashes for the enabled Bumba Nix image.
- Use the hash reported by failed main Bumba Nix OCI proof run 28756366554.
- Keep the change limited to the Bumba image derivation so ARC Linux builds prove the fix.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `nix eval --raw .#packages.x86_64-linux.bumba-image.drvPath`
- `nix eval --raw .#packages.aarch64-linux.bumba-image.drvPath`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
