### PR TITLE
chore(bumba): promote nix image sha-4b844e1b20b1b6b372487de2dddef00cbea8d663

### DIFF
--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:7fe7889d5c32133182f52c366ee5a1c682e8595152a631cb5d28a7ccb3e44a2b
+    digest: sha256:18e059b5f4dbb1c2c1e4279a556f819cf095093aee2787a23ceaac421b6b9916
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:18e059b5f4dbb1c2c1e4279a556f819cf095093aee2787a23ceaac421b6b9916`.
- Source commit: `4b844e1b20b1b6b372487de2dddef00cbea8d663`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:18e059b5f4dbb1c2c1e4279a556f819cf095093aee2787a23ceaac421b6b9916" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.