### PR TITLE
chore(bumba): promote nix image sha-1af79b6fcd3cbb7a4d5a4db64ac8f85012fcf6cf

### DIFF
--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:18e059b5f4dbb1c2c1e4279a556f819cf095093aee2787a23ceaac421b6b9916
+    digest: sha256:64016e7e06dfb9dbc1ed25a336f7ac742b98856fa8e203eca42dcf00508e74dd
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:64016e7e06dfb9dbc1ed25a336f7ac742b98856fa8e203eca42dcf00508e74dd`.
- Source commit: `1af79b6fcd3cbb7a4d5a4db64ac8f85012fcf6cf`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:64016e7e06dfb9dbc1ed25a336f7ac742b98856fa8e203eca42dcf00508e74dd" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.