### PR TITLE
fix(nix): keep bumba image digest stable

### DIFF
--- a/.github/workflows/enabled-simple-nix-release.yml
+++ b/.github/workflows/enabled-simple-nix-release.yml
@@ -189,6 +189,9 @@ jobs:
               path="argocd/applications/bumba/kustomization.yaml"
               perl -0pi -e 's#(-\s*name:\s+registry\.ide-newton\.ts\.net/lab/bumba\s*\n\s*)(?:newTag|digest):\s*.*#$1digest: $ENV{DIGEST}#g' "${path}"
               grep -F "digest: ${DIGEST}" "${path}"
+              deployment_path="argocd/applications/bumba/deployment.yaml"
+              perl -0pi -e 's#(-\s*name:\s+TEMPORAL_WORKER_BUILD_ID\s*\n\s*value:\s*).*#$1bumba@$ENV{SOURCE_SHA}#g' "${deployment_path}"
+              grep -F "value: bumba@${SOURCE_SHA}" "${deployment_path}"
               ;;
             froussard)
               image_ref="${IMAGE}@${DIGEST}"

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: default
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
+            - name: TEMPORAL_WORKER_BUILD_ID
+              value: bumba@1af79b6fcd3cbb7a4d5a4db64ac8f85012fcf6cf
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "64"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/flake.nix
+++ b/flake.nix
@@ -219,7 +219,7 @@
               bun = exact.bun;
             };
             "bumba-image" = import ./nix/images/bumba.nix {
-              inherit pkgs lib nodejs repoRevision;
+              inherit pkgs lib nodejs;
               repoRoot = ./.;
               bun = exact.bun;
             };

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -4,7 +4,6 @@
   repoRoot,
   bun,
   nodejs,
-  repoRevision,
 }:
 
 import ./bun-workspace-service.nix {
@@ -29,9 +28,6 @@ import ./bun-workspace-service.nix {
   command = [
     "bun"
     "services/bumba/src/worker.ts"
-  ];
-  env = [
-    "TEMPORAL_WORKER_BUILD_ID=bumba@${repoRevision}"
   ];
   extraContents = [
     pkgs.git

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -89,6 +89,7 @@ const allNixImageModules = readdirSync(new URL('nix/images/', repoRoot))
 const symphonyImageModule = readRepoFile('nix/images/symphony.nix')
 const sagImageModule = readRepoFile('nix/images/sag.nix')
 const jangarImageModule = readRepoFile('nix/images/jangar.nix')
+const bumbaImageModule = readRepoFile('nix/images/bumba.nix')
 const headlampImageModule = readRepoFile('nix/images/headlamp.nix')
 const torghutImageModule = readRepoFile('nix/images/torghut.nix')
 const torghutTaImageModule = readRepoFile('nix/images/torghut-ta.nix')
@@ -1327,10 +1328,22 @@ describe('native OCI build workflows', () => {
     }
     expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/oirat/kustomization.yaml')
     expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/bumba/kustomization.yaml')
+    expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/bumba/deployment.yaml')
+    expect(enabledSimpleReleaseWorkflow).toContain('TEMPORAL_WORKER_BUILD_ID')
+    expect(enabledSimpleReleaseWorkflow).toContain('value: bumba@${SOURCE_SHA}')
     expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/froussard/knative-service.yaml')
     expect(enabledSimpleReleaseWorkflow).toContain('\\@sha256:[0-9a-f]{64}')
     expect(enabledSimpleReleaseWorkflow).toContain('peter-evans/create-pull-request@v7')
     expect(enabledSimpleReleaseWorkflow).not.toContain('docker buildx')
+  })
+
+  it('keeps Bumba image content independent from GitOps-only release commits', () => {
+    expect(bumbaImageModule).not.toContain('repoRevision')
+    expect(bumbaImageModule).not.toContain('TEMPORAL_WORKER_BUILD_ID')
+    expect(flake).not.toContain(
+      'inherit pkgs lib nodejs repoRevision;\n              repoRoot = ./.;\n              bun = exact.bun;',
+    )
+    expect(readRepoFile('argocd/applications/bumba/deployment.yaml')).toContain('TEMPORAL_WORKER_BUILD_ID')
   })
 
   it('opens digest-pinning release PRs for enabled product app Nix builds', () => {


### PR DESCRIPTION
## Summary

- Move Bumba `TEMPORAL_WORKER_BUILD_ID` out of the Nix image config so GitOps-only release commits do not change image contents.
- Have the enabled simple release workflow update the Bumba Deployment worker build ID to `bumba@<source-sha>` when promoting a digest.
- Add a regression test that blocks reintroducing Bumba repo revision into the image derivation.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `nix eval --raw .#packages.x86_64-linux.bumba-image.drvPath`
- `nix eval --raw .#packages.aarch64-linux.bumba-image.drvPath`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/enabled-simple-nix-release.yml`
- `kustomize build argocd/applications/bumba`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
