### PR TITLE
fix(ci): allow bumba release env updates

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -17,6 +17,7 @@ on:
       - 'argocd/applications/app/kustomization.yaml'
       - 'argocd/applications/attic/deployment.yaml'
       - 'argocd/applications/attic/gc-cronjob.yaml'
+      - 'argocd/applications/bumba/deployment.yaml'
       - 'argocd/applications/bumba/kustomization.yaml'
       - 'argocd/applications/docs/kustomization.yaml'
       - 'argocd/applications/froussard/knative-service.yaml'
@@ -95,6 +96,7 @@ jobs:
             "argocd/applications/app/kustomization.yaml"
             "argocd/applications/attic/deployment.yaml"
             "argocd/applications/attic/gc-cronjob.yaml"
+            "argocd/applications/bumba/deployment.yaml"
             "argocd/applications/bumba/kustomization.yaml"
             "argocd/applications/docs/kustomization.yaml"
             "argocd/applications/froussard/knative-service.yaml"

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1394,6 +1394,7 @@ describe('native OCI build workflows', () => {
       'argocd/applications/app/kustomization.yaml',
       'argocd/applications/attic/deployment.yaml',
       'argocd/applications/attic/gc-cronjob.yaml',
+      'argocd/applications/bumba/deployment.yaml',
       'argocd/applications/bumba/kustomization.yaml',
       'argocd/applications/docs/kustomization.yaml',
       'argocd/applications/froussard/knative-service.yaml',


### PR DESCRIPTION
## Summary

- Add `argocd/applications/bumba/deployment.yaml` to the release PR automerge trigger paths.
- Add the same deployment file to the Nix OCI release allowlist so Bumba digest PRs can also update `TEMPORAL_WORKER_BUILD_ID`.
- Extend the workflow contract test to keep the allowlist aligned with Bumba release output.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `actionlint .github/workflows/release-pr-automerge.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
