### PR TITLE
perf(ceph): add client ops optimization gates

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -35,6 +35,10 @@ cephClusterSpec:
       # Prioritize client IO after the Turin BlueStore DB migration has recovered.
       # Recovery/backfill overrides are intentionally omitted so the built-in mClock profile controls QoS.
       osd_mclock_profile: "high_client_ops"
+      # Fresh 2026-07-06 OSD bench samples measured HDD random-write service capacity
+      # around 280 IOPS median. Keep the mClock HDD capacity model conservative and
+      # remove any per-OSD live overrides that would mask this cluster-wide value.
+      osd_mclock_max_capacity_iops_hdd: "275"
       # Seagate Exos X24 24TB HDDs advertise 285 MB/s / 272 MiB/s sustained transfer.
       # Keep the mClock HDD bandwidth model explicit so client/recovery QoS is not based on the conservative default.
       osd_mclock_max_sequential_bandwidth_hdd: "285212672"
@@ -42,6 +46,11 @@ cephClusterSpec:
       # Automatically repair small scrub inconsistencies. Larger damage still requires operator review.
       osd_scrub_auto_repair: "true"
       osd_scrub_auto_repair_num_errors: "5"
+    mgr:
+      # Keep capacity balancing conservative during client hours and tighten PG shard
+      # deviation without enabling read-primary balancing while pre-Reef clients exist.
+      target_max_misplaced_ratio: "0.03"
+      mgr/balancer/upmap_max_deviation: "1"
 
   dataDirHostPath: /var/lib/rook
 
@@ -163,6 +172,7 @@ cephClusterSpec:
 # Disable chart-managed default block/filesystem classes to avoid duplicates.
 # Canonical classes are managed in storageclasses.yaml as:
 # - rook-ceph-block (RWO)
+# - rook-ceph-block-nbd-canary (RWO, non-default rbd-nbd proof lane)
 # - rook-cephfs (RWX, kernel-capable nodes only)
 # - rook-cephfs-fuse (RWX on Talos-compatible nodes)
 # - CephFilesystem details such as MDS resources

--- a/argocd/applications/rook-ceph/storageclasses.yaml
+++ b/argocd/applications/rook-ceph/storageclasses.yaml
@@ -31,6 +31,32 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
   csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
 ---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-block-nbd-canary
+  annotations:
+    storage.proompteng.ai/purpose: disposable-rbd-nbd-canary
+    storage.proompteng.ai/production-default: "false"
+provisioner: rook-ceph.rbd.csi.ceph.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  clusterID: rook-ceph
+  pool: replicapool
+  imageFeatures: layering
+  csi.storage.k8s.io/fstype: ext4
+  # Non-default canary for proving rbd-nbd mount behavior. Do not migrate durable
+  # production PVCs here until restart/remount tests pass.
+  mounter: rbd-nbd
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+---
 apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:

--- a/docs/runbooks/rook-ceph-client-ops-performance.md
+++ b/docs/runbooks/rook-ceph-client-ops-performance.md
@@ -1,0 +1,189 @@
+# Rook-Ceph Client-Ops Performance
+
+This runbook is the staged client-ops performance plan for the live `galactic` Rook-Ceph cluster.
+It is intentionally conservative: do the safe RBD and mClock work now, and do not enable read-primary balancing
+until the client compatibility gate is clean.
+
+## Current State
+
+Live evidence captured on 2026-07-06:
+
+1. `ceph -s` reported `HEALTH_OK`, `6 up / 6 in` OSDs, and `409 active+clean` PGs.
+1. `ceph balancer status --format json` reported `active=true`, `mode=upmap`, and no current upmap optimization plan.
+1. `ceph osd pool ls detail` showed high `read_balance_score` values, including `replicapool=1.50`,
+   `objectstore.rgw.buckets.index=3.00`, `cephfs-metadata=1.88`, and `cephfs-data0=1.88`.
+1. `ceph features` still showed three `client.csi-rbd-node` sessions at release `luminous`.
+1. `ceph osd get-require-min-compat-client` reported `luminous`.
+1. `ceph config dump` showed live per-OSD `osd_mclock_max_capacity_iops_hdd=1000` overrides, which were not in GitOps.
+
+That means read-primary balancing is a real performance opportunity, but it is not safe to enable yet.
+
+## Source Basis
+
+1. Ceph read balancer documentation: `read_balance_score > 1` means primary reads are imbalanced, but
+   `read` and `upmap-read` use `pg-upmap-primary` and require no pre-Reef clients.
+   <https://docs.ceph.com/en/latest/rados/operations/read-balancer/>
+1. Ceph balancer documentation: `upmap-read` combines capacity upmap balancing and read-primary balancing;
+   `target_max_misplaced_ratio=0.03` is a conservative convergence setting, and
+   `mgr/balancer/upmap_max_deviation=1` is described as reasonable and safe for most clusters.
+   <https://docs.ceph.com/en/latest/rados/operations/balancer/>
+1. Ceph mClock documentation: `high_client_ops` is a built-in profile, and
+   `osd_mclock_max_capacity_iops_hdd` models 4 KiB random-write IOPS capacity for rotational media.
+   <https://docs.ceph.com/en/latest/rados/configuration/mclock-config-ref/>
+1. Rook block storage documentation and local Rook examples support setting `mounter: rbd-nbd` in an RBD
+   `StorageClass`.
+   <https://rook.io/docs/rook/latest-release/Storage-Configuration/Block-Storage-RBD/block-storage/>
+1. Local Rook source under `~/github.com/rook` shows `balancerMode` supports `upmap-read`, but Rook sets
+   `set-require-min-compat-client reef` for `read` or `upmap-read`. Do not configure those modes while
+   luminous clients are connected.
+
+## Safe Changes Applied
+
+1. Keep `osd_mclock_profile=high_client_ops`.
+1. Set `osd_mclock_max_capacity_iops_hdd=275` in GitOps.
+1. Keep `osd_mclock_max_sequential_bandwidth_hdd=285212672`.
+1. Keep `osd_memory_target=8589934592`.
+1. Keep CSI read affinity enabled by `kubernetes.io/hostname`.
+1. Set conservative manager balancer convergence keys:
+   - `target_max_misplaced_ratio=0.03`
+   - `mgr/balancer/upmap_max_deviation=1`
+1. Add non-default `rook-ceph-block-nbd-canary`.
+1. Leave default `rook-ceph-block` unchanged.
+1. Leave live balancer mode at `upmap`, not `upmap-read`.
+
+The `275` IOPS value comes from two fresh `ceph tell osd.* bench` passes on 2026-07-06:
+
+| OSD | Run 1 IOPS | Run 2 IOPS |
+| --- | ---: | ---: |
+| osd.0 | 277.79 | 265.35 |
+| osd.1 | 257.05 | 218.57 |
+| osd.2 | 297.34 | 297.85 |
+| osd.3 | 249.30 | 259.06 |
+| osd.4 | 304.64 | 297.37 |
+| osd.5 | 282.49 | 284.30 |
+
+The full-sample median is about 280 IOPS. GitOps uses `275` to stay slightly conservative.
+
+## Live Drift Cleanup
+
+If live config still has per-OSD `1000` overrides, they mask the GitOps cluster-wide value. Remove them after the
+GitOps change is merged or during the same maintenance window:
+
+```bash
+for osd in 0 1 2 3 4 5; do
+  kubectl -n rook-ceph exec deploy/rook-ceph-tools -- \
+    ceph config rm "osd.${osd}" osd_mclock_max_capacity_iops_hdd
+done
+
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- \
+  ceph config set osd osd_mclock_max_capacity_iops_hdd 275
+
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- \
+  ceph config dump | rg 'mclock_max_capacity|mclock_profile|target_max_misplaced|upmap_max_deviation'
+```
+
+Acceptance:
+
+1. No `osd.N osd_mclock_max_capacity_iops_hdd 1000` rows remain.
+1. One `osd osd_mclock_max_capacity_iops_hdd 275` row exists.
+1. `ceph -s` remains `HEALTH_OK`.
+
+## RBD-NBD Canary
+
+`rook-ceph-block-nbd-canary` is non-default and must only be used for disposable proof:
+
+1. fio PVCs.
+1. Rebuildable caches.
+1. One low-risk workload after fio passes.
+
+Do not move production databases, Kafka, ClickHouse, registry canonical data, or Torghut durable state to the canary
+class.
+
+Apply the benchmark assets on demand:
+
+```bash
+kubectl apply -k kubernetes/rook-ceph-rbd-canary
+kubectl apply -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block.yaml
+kubectl apply -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary.yaml
+```
+
+Capture results:
+
+```bash
+kubectl -n rook-ceph-benchmarks logs -f job/rook-ceph-block-benchmark
+kubectl -n rook-ceph-benchmarks logs -f job/rook-ceph-block-nbd-canary-benchmark
+kubectl -n rook-ceph-benchmarks get pods -o wide
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd perf
+```
+
+Restart/remount proof for the canary class:
+
+```bash
+kubectl apply -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary-remount.yaml
+kubectl -n rook-ceph-benchmarks logs -f job/rook-ceph-block-nbd-canary-remount
+```
+
+The canary passes only if the pod mounts, fio completes, the pod can be recreated, data can be read back, and
+`ceph -s` remains healthy.
+
+The first live run on 2026-07-06 passed mount/fio/readback for both classes. Default KRBD was faster than the NBD
+canary in that sample, so the default class remains unchanged:
+
+| StorageClass | Randread IOPS | Randread p95 | Mixed read/write IOPS | Seq write BW |
+| --- | ---: | ---: | ---: | ---: |
+| `rook-ceph-block` | 76.57 | 115.9 ms | 34.85 / 15.64 | 7.28 MB/s |
+| `rook-ceph-block-nbd-canary` | 63.38 | 132.6 ms | 24.73 / 11.08 | 7.26 MB/s |
+
+## Read-Primary Balancer Gate
+
+Do not enable `upmap-read` until this command reports no pre-Reef clients:
+
+```bash
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph features
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph tell mon.* sessions --format json
+```
+
+When the luminous clients are gone:
+
+1. Confirm the connected clients are Reef or newer.
+1. Confirm no kernel client path still depends on unsupported `pg-upmap-primary` mappings.
+1. Set `ceph osd set-require-min-compat-client reef --yes-i-really-mean-it`.
+1. Change the Rook mgr balancer module to `balancerMode: upmap-read`.
+1. Let Rook reconcile.
+1. Verify:
+   - `ceph osd get-require-min-compat-client` is `reef`.
+   - `ceph balancer status` reports `mode=upmap-read`.
+   - `ceph osd dump | rg pg_upmap_primary` shows mappings only after the gate is accepted.
+   - hot-pool `read_balance_score` values improve toward `<=1.25`.
+   - RBD and CephFS mounts still work.
+
+Rollback if kernel or CSI mounts fail:
+
+```bash
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph balancer mode upmap
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd rm-pg-upmap-primary-all
+```
+
+Do not lower min compat after it has been raised for a feature rollout.
+
+## Validation Checklist
+
+Before merge:
+
+```bash
+mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph.render.yaml
+bun run lint:argocd
+```
+
+After sync:
+
+```bash
+kubectl get storageclass rook-ceph-block rook-ceph-block-nbd-canary
+kubectl get storageclass -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}{"\n"}{end}'
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config dump | rg 'mclock_max_capacity|mclock_profile|target_max_misplaced|upmap_max_deviation'
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph balancer status --format json
+```
+
+The default class must remain `rook-ceph-block`. The canary class must not be default.

--- a/kubernetes/rook-ceph-rbd-canary/README.md
+++ b/kubernetes/rook-ceph-rbd-canary/README.md
@@ -1,0 +1,34 @@
+# Rook-Ceph RBD Canary
+
+Apply-on-demand assets for comparing the default kernel RBD path with the non-default
+`rook-ceph-block-nbd-canary` StorageClass.
+
+Bootstrap the namespace, script, and PVCs:
+
+```bash
+kubectl apply -k kubernetes/rook-ceph-rbd-canary
+```
+
+Run the default RBD job:
+
+```bash
+kubectl apply -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block.yaml
+kubectl -n rook-ceph-benchmarks logs -f job/rook-ceph-block-benchmark
+```
+
+Run the NBD canary job:
+
+```bash
+kubectl apply -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary.yaml
+kubectl -n rook-ceph-benchmarks logs -f job/rook-ceph-block-nbd-canary-benchmark
+```
+
+Run the NBD remount/readback job after the NBD canary job has completed:
+
+```bash
+kubectl apply -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary-remount.yaml
+kubectl -n rook-ceph-benchmarks logs -f job/rook-ceph-block-nbd-canary-remount
+```
+
+The full workflow and gates live in
+`docs/runbooks/rook-ceph-client-ops-performance.md`.

--- a/kubernetes/rook-ceph-rbd-canary/configmap.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/configmap.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-ceph-rbd-canary-scripts
+  namespace: rook-ceph-benchmarks
+data:
+  run-rbd-canary.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    mount_dir="${1:?mount dir required}"
+    result_dir="${2:?result dir required}"
+    class_name="${3:?storage class required}"
+
+    mkdir -p "${mount_dir}" "${result_dir}"
+
+    echo "storageClass=${class_name}" | tee "${result_dir}/suite.info"
+    date -u +"startedAt=%Y-%m-%dT%H:%M:%SZ" | tee -a "${result_dir}/suite.info"
+
+    fio \
+      --name=randread \
+      --directory="${mount_dir}" \
+      --rw=randread \
+      --bs=4k \
+      --size=1g \
+      --numjobs=2 \
+      --iodepth=16 \
+      --direct=1 \
+      --runtime=45 \
+      --time_based=1 \
+      --group_reporting=1 \
+      --output-format=json \
+      --output="${result_dir}/fio-randread.json"
+
+    fio \
+      --name=randrw-mixed \
+      --directory="${mount_dir}" \
+      --rw=randrw \
+      --rwmixread=70 \
+      --bs=4k \
+      --size=1g \
+      --numjobs=2 \
+      --iodepth=16 \
+      --direct=1 \
+      --runtime=45 \
+      --time_based=1 \
+      --group_reporting=1 \
+      --output-format=json \
+      --output="${result_dir}/fio-randrw.json"
+
+    fio \
+      --name=seq-write \
+      --directory="${mount_dir}" \
+      --rw=write \
+      --bs=1m \
+      --size=1g \
+      --numjobs=1 \
+      --iodepth=8 \
+      --direct=1 \
+      --runtime=0 \
+      --group_reporting=1 \
+      --output-format=json \
+      --output="${result_dir}/fio-seq-write.json"
+
+    sync
+    echo "canary-readback-${class_name}" > "${mount_dir}/readback.txt"
+    test "$(cat "${mount_dir}/readback.txt")" = "canary-readback-${class_name}"
+
+    date -u +"finishedAt=%Y-%m-%dT%H:%M:%SZ" | tee -a "${result_dir}/suite.info"
+    ls -lah "${result_dir}"
+    for result in \
+      "${result_dir}/fio-randread.json" \
+      "${result_dir}/fio-randrw.json" \
+      "${result_dir}/fio-seq-write.json"; do
+      echo "==== ${result##*/} ===="
+      python3 - "${result}" <<'PY'
+    import json
+    import sys
+    from pathlib import Path
+
+    data = json.loads(Path(sys.argv[1]).read_text(encoding="ascii"))
+    job = data["jobs"][0]
+    read = job.get("read", {})
+    write = job.get("write", {})
+    print(json.dumps({
+      "job": job["jobname"],
+      "read_iops": read.get("iops"),
+      "read_bw_bytes": read.get("bw_bytes"),
+      "read_clat_ns_p95": read.get("clat_ns", {}).get("percentile", {}).get("95.000000"),
+      "read_clat_ns_p99": read.get("clat_ns", {}).get("percentile", {}).get("99.000000"),
+      "write_iops": write.get("iops"),
+      "write_bw_bytes": write.get("bw_bytes"),
+      "write_clat_ns_p95": write.get("clat_ns", {}).get("percentile", {}).get("95.000000"),
+      "write_clat_ns_p99": write.get("clat_ns", {}).get("percentile", {}).get("99.000000"),
+    }, indent=2))
+    PY
+    done

--- a/kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary-remount.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary-remount.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-ceph-block-nbd-canary-remount
+  namespace: rook-ceph-benchmarks
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: readback
+          image: debian:bookworm-slim
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              expected="canary-readback-rook-ceph-block-nbd-canary"
+              actual="$(cat /mnt/rbd/readback.txt)"
+              test "${actual}" = "${expected}"
+              date -u +"remountReadbackAt=%Y-%m-%dT%H:%M:%SZ"
+              echo "readback=${actual}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65532
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: benchmark-volume
+              mountPath: /mnt/rbd
+              readOnly: true
+      volumes:
+        - name: benchmark-volume
+          persistentVolumeClaim:
+            claimName: rook-ceph-block-nbd-canary-bench
+            readOnly: true

--- a/kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-ceph-block-nbd-canary-benchmark
+  namespace: rook-ceph-benchmarks
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: benchmark
+          image: debian:bookworm-slim
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+              apt-get update
+              apt-get install -y --no-install-recommends fio python3 ca-certificates
+              /scripts/run-rbd-canary.sh /mnt/rbd /results rook-ceph-block-nbd-canary
+          env:
+            - name: DEBIAN_FRONTEND
+              value: noninteractive
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          volumeMounts:
+            - name: benchmark-volume
+              mountPath: /mnt/rbd
+            - name: benchmark-results
+              mountPath: /results
+            - name: benchmark-scripts
+              mountPath: /scripts
+      volumes:
+        - name: benchmark-volume
+          persistentVolumeClaim:
+            claimName: rook-ceph-block-nbd-canary-bench
+        - name: benchmark-results
+          emptyDir: {}
+        - name: benchmark-scripts
+          configMap:
+            name: rook-ceph-rbd-canary-scripts
+            defaultMode: 0755

--- a/kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-ceph-block-benchmark
+  namespace: rook-ceph-benchmarks
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: benchmark
+          image: debian:bookworm-slim
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+              apt-get update
+              apt-get install -y --no-install-recommends fio python3 ca-certificates
+              /scripts/run-rbd-canary.sh /mnt/rbd /results rook-ceph-block
+          env:
+            - name: DEBIAN_FRONTEND
+              value: noninteractive
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          volumeMounts:
+            - name: benchmark-volume
+              mountPath: /mnt/rbd
+            - name: benchmark-results
+              mountPath: /results
+            - name: benchmark-scripts
+              mountPath: /scripts
+      volumes:
+        - name: benchmark-volume
+          persistentVolumeClaim:
+            claimName: rook-ceph-block-bench
+        - name: benchmark-results
+          emptyDir: {}
+        - name: benchmark-scripts
+          configMap:
+            name: rook-ceph-rbd-canary-scripts
+            defaultMode: 0755

--- a/kubernetes/rook-ceph-rbd-canary/kustomization.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - pvc-rook-ceph-block.yaml
+  - pvc-rook-ceph-block-nbd-canary.yaml

--- a/kubernetes/rook-ceph-rbd-canary/namespace.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph-benchmarks

--- a/kubernetes/rook-ceph-rbd-canary/pvc-rook-ceph-block-nbd-canary.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/pvc-rook-ceph-block-nbd-canary.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rook-ceph-block-nbd-canary-bench
+  namespace: rook-ceph-benchmarks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: rook-ceph-block-nbd-canary

--- a/kubernetes/rook-ceph-rbd-canary/pvc-rook-ceph-block.yaml
+++ b/kubernetes/rook-ceph-rbd-canary/pvc-rook-ceph-block.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rook-ceph-block-bench
+  namespace: rook-ceph-benchmarks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: rook-ceph-block


### PR DESCRIPTION
## Summary

- Calibrate Rook-Ceph client-ops GitOps with measured HDD mClock capacity, conservative balancer convergence settings, and no read-primary mode while pre-Reef clients remain connected.
- Add a non-default `rook-ceph-block-nbd-canary` StorageClass for disposable RBD-NBD proof without changing the default `rook-ceph-block` class.
- Document the staged client-ops optimization plan, source basis, live proof, cleanup commands, and the gated path to `upmap-read`.
- Add apply-on-demand RBD benchmark/remount manifests under `kubernetes/rook-ceph-rbd-canary`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph.render.yaml`
- Render inspection confirmed `rook-ceph-block` remains default, `rook-ceph-block-nbd-canary` renders non-default with `mounter: rbd-nbd`, and CephCluster renders `osd_mclock_max_capacity_iops_hdd=275`, `target_max_misplaced_ratio=0.03`, and `mgr/balancer/upmap_max_deviation=1`.
- `bun run lint:argocd`
- `kubectl apply --dry-run=client -k kubernetes/rook-ceph-rbd-canary`
- `kubectl apply --dry-run=client -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block.yaml`
- `kubectl apply --dry-run=client -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary.yaml`
- `kubectl apply --dry-run=client -f kubernetes/rook-ceph-rbd-canary/job-rook-ceph-block-nbd-canary-remount.yaml`
- `git diff --check`
- Live Ceph config cleanup: removed per-OSD `osd_mclock_max_capacity_iops_hdd=1000` overrides, set cluster-wide `osd_mclock_max_capacity_iops_hdd=275`, and set mgr balancer settings.
- Live canary proof: default KRBD and NBD canary PVCs provisioned, attached, mounted, completed fio, and the NBD canary remount/readback job read `canary-readback-rook-ceph-block-nbd-canary` at `2026-07-06T00:38:13Z`.
- Live post-proof cleanup deleted disposable benchmark jobs/PVCs/namespace; `rook-ceph-block-nbd-canary` StorageClass remains for GitOps adoption.
- Live health after proof: `ceph health detail` reported `HEALTH_OK`.

## Breaking Changes

None. The default `rook-ceph-block` StorageClass remains unchanged. `upmap-read` is intentionally not enabled because `ceph features` still reports three luminous clients.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
