### PR TITLE
perf(rook-ceph): surge backfill recovery

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -35,13 +35,17 @@ cephClusterSpec:
       rbd_default_map_options: "ms_mode=prefer-crc"
     osd:
       bluestore_cache_autotune: "true"
-      # Prioritize client IO after the Turin BlueStore DB migration has recovered.
-      # Recovery/backfill overrides are intentionally omitted so the built-in mClock profile controls QoS.
-      osd_mclock_profile: "high_client_ops"
-      # Fresh 2026-07-06 OSD bench samples measured HDD random-write service capacity
-      # around 280 IOPS median. Keep the mClock HDD capacity model conservative and
-      # remove any per-OSD live overrides that would mask this cluster-wide value.
-      osd_mclock_max_capacity_iops_hdd: "275"
+      # Temporary recovery-surge mode for the 32 -> 128 hot-pool PG split.
+      # Revert to high_client_ops and remove the override keys after ceph -s shows
+      # zero misplaced objects and zero remapped/backfilling PGs.
+      osd_mclock_profile: "high_recovery_ops"
+      osd_mclock_override_recovery_settings: "true"
+      osd_max_backfills: "3"
+      osd_recovery_max_active_hdd: "6"
+      osd_recovery_sleep_hdd: "0"
+      # Temporary recovery-surge capacity model. The steady-state client posture
+      # should return this to 275 after the PG split is clean.
+      osd_mclock_max_capacity_iops_hdd: "500"
       # Seagate Exos X24 24TB HDDs advertise 285 MB/s / 272 MiB/s sustained transfer.
       # Keep the mClock HDD bandwidth model explicit so client/recovery QoS is not based on the conservative default.
       osd_mclock_max_sequential_bandwidth_hdd: "285212672"

--- a/docs/runbooks/rook-ceph-client-ops-performance.md
+++ b/docs/runbooks/rook-ceph-client-ops-performance.md
@@ -79,6 +79,85 @@ cephfs-data0 pg_num=128 pgp_num=128
 objectstore.rgw.buckets.data pg_num=128 pgp_num=128
 ```
 
+## Temporary Recovery-Surge Mode
+
+If the hot-pool PG split remains active for many hours, switch from client-biased QoS to recovery-biased QoS until
+the split completes. This is temporary maintenance mode, not the final client-ops posture.
+
+Durable GitOps settings for recovery surge:
+
+```yaml
+osd_mclock_profile: "high_recovery_ops"
+osd_mclock_max_capacity_iops_hdd: "500"
+osd_mclock_override_recovery_settings: "true"
+osd_max_backfills: "3"
+osd_recovery_max_active_hdd: "6"
+osd_recovery_sleep_hdd: "0"
+```
+
+Live command equivalent:
+
+```bash
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_profile high_recovery_ops
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_max_capacity_iops_hdd 500
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_override_recovery_settings true
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_max_backfills 3
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_recovery_max_active_hdd 6
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_recovery_sleep_hdd 0
+```
+
+Why these knobs:
+
+1. `high_recovery_ops` is Ceph's built-in mClock profile for prioritizing recovery and backfill over client ops.
+1. `osd_mclock_max_capacity_iops_hdd=500` temporarily prevents the scheduler from under-modeling recovery capacity
+   during the surge. The steady-state client setting remains `275`, based on local OSD bench samples.
+1. With mClock active, Ceph resets or ignores legacy recovery/backfill concurrency changes unless
+   `osd_mclock_override_recovery_settings=true`.
+1. `osd_max_backfills=3` is a bounded surge value that increases per-OSD backfill reservations beyond the default
+   `1` without using unbounded concurrency.
+1. `osd_recovery_max_active_hdd=6` doubles the HDD active recovery limit from the default `3`.
+1. `osd_recovery_sleep_hdd=0` removes the default HDD sleep between recovery/backfill operations for the
+   maintenance window.
+
+Monitor every 30-60 seconds:
+
+```bash
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd perf
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd pool ls detail | \
+  rg 'replicapool|cephfs-data0|objectstore.rgw.buckets.data'
+```
+
+Rollback the surge immediately if OSDs start flapping, client mounts fail, or BlueStore slow ops expand beyond a
+single known OSD:
+
+```bash
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_profile high_client_ops
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_max_capacity_iops_hdd 275
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config rm osd osd_mclock_override_recovery_settings
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config rm osd osd_max_backfills
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config rm osd osd_recovery_max_active_hdd
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config rm osd osd_recovery_sleep_hdd
+```
+
+After `ceph -s` reports zero misplaced objects and zero remapped/backfilling/backfill-wait PGs, restore client mode
+in GitOps:
+
+```yaml
+osd_mclock_profile: "high_client_ops"
+osd_mclock_max_capacity_iops_hdd: "275"
+```
+
+Remove the recovery override keys from GitOps at the same time:
+
+```yaml
+osd_mclock_override_recovery_settings
+osd_max_backfills
+osd_recovery_max_active_hdd
+osd_recovery_sleep_hdd
+```
+
 Benchmark sequence after clean:
 
 ```bash


### PR DESCRIPTION
"## Summary\n\n- Temporarily switches Rook-Ceph OSD mClock from `high_client_ops` to `high_recovery_ops` for the long-running hot-pool PG split.\n- Persists bounded recovery overrides: `osd_mclock_max_capacity_iops_hdd=500`, `osd_max_backfills=3`, `osd_recovery_max_active_hdd=6`, and `osd_recovery_sleep_hdd=0`.\n- Documents the recovery-surge playbook, live commands, monitoring, rollback, and required revert back to client mode after the split is clean.\n\n## Related Issues\n\nNone\n\n## Testing\n\n- `git diff --check -- argocd/applications/rook-ceph/cluster-values.yaml docs/runbooks/rook-ceph-client-ops-performance.md`\n- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-recovery-surge.render.yaml`\n- `rg -n 'osd_mclock_profile: high_recovery_ops|osd_mclock_max_capacity_iops_hdd: \"500\"|osd_mclock_override_recovery_settings: \"true\"|osd_max_backfills: \"3\"|osd_recovery_max_active_hdd: \"6\"|osd_recovery_sleep_hdd: \"0\"|v19\\.2\\.3|v1\\.19\\.5|balancerMode: upmap|pg_num_min: \"128\"|bulk: \"true\"' /tmp/rook-ceph-recovery-surge.render.yaml`\n- `bun run lint:argocd`\n- Live readback before GitOps PR: `ceph config dump` showed the recovery-surge settings active.\n- Live readback after surge: `ceph -s` showed the PG split advancing from `pgp_num=118` to `pgp_num=120` for `replicapool` and `cephfs-data0`.\n\n## Screenshots (if applicable)\n\nN/A\n\n## Breaking Changes\n\nTemporary operational mode. This intentionally prioritizes recovery/backfill over client IO until `ceph -s` shows zero misplaced objects and zero remapped/backfilling PGs. Revert to `high_client_ops` after the split is clean.\n\n## Checklist\n\n- [x] Testing section documents the exact validation performed.\n- [x] Screenshots and Breaking Changes sections are handled appropriately.\n- [x] Documentation, release notes, and follow-ups are updated or tracked.\n"