### PR TITLE
perf(rook-ceph): raise recovery pacing

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -40,12 +40,12 @@ cephClusterSpec:
       # zero misplaced objects and zero remapped/backfilling PGs.
       osd_mclock_profile: "high_recovery_ops"
       osd_mclock_override_recovery_settings: "true"
-      osd_max_backfills: "3"
-      osd_recovery_max_active_hdd: "6"
+      osd_max_backfills: "6"
+      osd_recovery_max_active_hdd: "12"
       osd_recovery_sleep_hdd: "0"
       # Temporary recovery-surge capacity model. The steady-state client posture
       # should return this to 275 after the PG split is clean.
-      osd_mclock_max_capacity_iops_hdd: "500"
+      osd_mclock_max_capacity_iops_hdd: "750"
       # Seagate Exos X24 24TB HDDs advertise 285 MB/s / 272 MiB/s sustained transfer.
       # Keep the mClock HDD bandwidth model explicit so client/recovery QoS is not based on the conservative default.
       osd_mclock_max_sequential_bandwidth_hdd: "285212672"
@@ -54,9 +54,12 @@ cephClusterSpec:
       osd_scrub_auto_repair: "true"
       osd_scrub_auto_repair_num_errors: "5"
     mgr:
-      # Keep capacity balancing conservative during client hours and tighten PG shard
-      # deviation without enabling read-primary balancing while pre-Reef clients exist.
-      target_max_misplaced_ratio: "0.03"
+      # Temporary recovery-surge ceiling for the hot-pool PG split. The previous
+      # 3% ceiling was deliberately pacing pgp_num progress; use 10% during the
+      # maintenance recovery window, then return to 3% for steady client ops.
+      target_max_misplaced_ratio: "0.10"
+      # Keep PG shard deviation tight without enabling read-primary balancing while
+      # pre-Reef clients exist.
       mgr/balancer/upmap_max_deviation: "1"
 
   dataDirHostPath: /var/lib/rook

--- a/docs/runbooks/rook-ceph-client-ops-performance.md
+++ b/docs/runbooks/rook-ceph-client-ops-performance.md
@@ -88,36 +88,40 @@ Durable GitOps settings for recovery surge:
 
 ```yaml
 osd_mclock_profile: "high_recovery_ops"
-osd_mclock_max_capacity_iops_hdd: "500"
+osd_mclock_max_capacity_iops_hdd: "750"
 osd_mclock_override_recovery_settings: "true"
-osd_max_backfills: "3"
-osd_recovery_max_active_hdd: "6"
+osd_max_backfills: "6"
+osd_recovery_max_active_hdd: "12"
 osd_recovery_sleep_hdd: "0"
+target_max_misplaced_ratio: "0.10"
 ```
 
 Live command equivalent:
 
 ```bash
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_profile high_recovery_ops
-kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_max_capacity_iops_hdd 500
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_max_capacity_iops_hdd 750
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_override_recovery_settings true
-kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_max_backfills 3
-kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_recovery_max_active_hdd 6
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_max_backfills 6
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_recovery_max_active_hdd 12
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_recovery_sleep_hdd 0
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set mgr target_max_misplaced_ratio 0.10
 ```
 
 Why these knobs:
 
 1. `high_recovery_ops` is Ceph's built-in mClock profile for prioritizing recovery and backfill over client ops.
-1. `osd_mclock_max_capacity_iops_hdd=500` temporarily prevents the scheduler from under-modeling recovery capacity
+1. `osd_mclock_max_capacity_iops_hdd=750` temporarily prevents the scheduler from under-modeling recovery capacity
    during the surge. The steady-state client setting remains `275`, based on local OSD bench samples.
 1. With mClock active, Ceph resets or ignores legacy recovery/backfill concurrency changes unless
    `osd_mclock_override_recovery_settings=true`.
-1. `osd_max_backfills=3` is a bounded surge value that increases per-OSD backfill reservations beyond the default
-   `1` without using unbounded concurrency.
-1. `osd_recovery_max_active_hdd=6` doubles the HDD active recovery limit from the default `3`.
+1. `osd_max_backfills=6` is an aggressive maintenance value that raises per-OSD backfill reservations beyond the
+   default `1` without using unbounded concurrency.
+1. `osd_recovery_max_active_hdd=12` raises the HDD active recovery limit for the maintenance window.
 1. `osd_recovery_sleep_hdd=0` removes the default HDD sleep between recovery/backfill operations for the
    maintenance window.
+1. `target_max_misplaced_ratio=0.10` lets Ceph expose more of a large PG split at once. This directly addresses the
+   `Too many objects (... > 0.030000) are misplaced; try again later` gate during urgent recovery.
 
 Monitor every 30-60 seconds:
 
@@ -135,6 +139,7 @@ single known OSD:
 ```bash
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_profile high_client_ops
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set osd osd_mclock_max_capacity_iops_hdd 275
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config set mgr target_max_misplaced_ratio 0.03
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config rm osd osd_mclock_override_recovery_settings
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config rm osd osd_max_backfills
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config rm osd osd_recovery_max_active_hdd
@@ -147,6 +152,7 @@ in GitOps:
 ```yaml
 osd_mclock_profile: "high_client_ops"
 osd_mclock_max_capacity_iops_hdd: "275"
+target_max_misplaced_ratio: "0.03"
 ```
 
 Remove the recovery override keys from GitOps at the same time:


### PR DESCRIPTION
## Summary

- Raises temporary Rook-Ceph recovery-surge backfill concurrency from 3/6 to 6/12 for the active hot-pool PG split.
- Raises temporary `target_max_misplaced_ratio` from 3% to 10% so Ceph can advance `pgp_num` instead of waiting at the old pacing ceiling.
- Updates the Ceph performance runbook with the live commands, rationale, rollback command, and steady-state revert target.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applications/rook-ceph/cluster-values.yaml docs/runbooks/rook-ceph-client-ops-performance.md`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-recovery-pacing.render.yaml`
- `rg -n 'osd_mclock_profile|osd_mclock_max_capacity_iops_hdd|osd_mclock_override_recovery_settings|osd_max_backfills|osd_recovery_max_active_hdd|osd_recovery_sleep_hdd|target_max_misplaced_ratio' /tmp/rook-ceph-recovery-pacing.render.yaml`
- `bun run lint:argocd`
- Live readback: `ceph config dump` shows `target_max_misplaced_ratio=0.100000`, `osd_max_backfills=6`, `osd_recovery_max_active_hdd=12`, and `osd_mclock_max_capacity_iops_hdd=750`.
- Live effect: hot pools advanced from `pgp_num=120/128` to `128/128`, active backfilling increased from 9 to 18 PGs, and balancer status changed from the 3% misplaced gate to a successful optimization result.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a temporary recovery-window posture. It intentionally prioritizes remap/backfill over client latency and must be reverted to `high_client_ops`, `target_max_misplaced_ratio=0.03`, and `osd_mclock_max_capacity_iops_hdd=275` after the cluster reaches zero misplaced objects and zero remapped/backfilling PGs.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
