### PR TITLE
fix(torghut): stop stale target plan entry rejects

### DIFF
--- a/services/torghut/app/trading/scheduler/source_collection/source_decisions.py
+++ b/services/torghut/app/trading/scheduler/source_collection/source_decisions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, cast
 
@@ -38,6 +38,7 @@ from ..target_plan_helpers import (
     target_plan_has_active_bounded_sim_collection_owner as _target_plan_has_active_bounded_sim_collection_owner,
     target_probe_action as _target_probe_action,
     target_probe_cap as _target_probe_cap,
+    target_probe_exit_minute_after_open as _target_probe_exit_minute_after_open,
     target_probe_symbol_actions as _target_probe_symbol_actions,
     target_probe_symbol_quantities as _target_probe_symbol_quantities,
     target_probe_window as _target_probe_window,
@@ -249,6 +250,12 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
             return None
         if window is None or not source_collection_window_active(window, state.now):
             return None
+        if self._paper_route_target_entry_window_elapsed(
+            target,
+            window=window,
+            state=state,
+        ):
+            return None
         if target_cap is None or target_cap <= 0 or strategy is None:
             return None
 
@@ -278,6 +285,29 @@ class SimplePipelineSourceCollectionDecisionMixin(SourceCollectionRuntimeMixin):
         ):
             return None
         return context
+
+    def _paper_route_target_entry_window_elapsed(
+        self,
+        target: Mapping[str, Any],
+        *,
+        window: tuple[datetime, datetime],
+        state: SourceCollectionState,
+    ) -> bool:
+        exit_minute, _ = _target_probe_exit_minute_after_open(target)
+        if exit_minute is None:
+            return False
+        window_start, window_end = window
+        window_minutes = max(1, int((window_end - window_start).total_seconds() // 60))
+        effective_exit_minute = min(exit_minute, window_minutes - 1)
+        exit_due_at = window_start + timedelta(minutes=effective_exit_minute)
+        if state.now < exit_due_at:
+            return False
+        self._record_bounded_target_plan_blocker(
+            reason="target_plan_entry_window_closed",
+            symbols=state.target_symbols,
+            targets=[target],
+        )
+        return True
 
     def _live_bounded_paper_route_source_collection_blocker(
         self,

--- a/services/torghut/app/trading/scheduler/submission_preparation/quote_sizing.py
+++ b/services/torghut/app/trading/scheduler/submission_preparation/quote_sizing.py
@@ -461,7 +461,7 @@ class SimplePipelineSubmissionQuoteSizingMixin(TradingPipelineBase):
         event_ts: datetime,
         exit_due_at: datetime,
     ) -> StrategyDecision:
-        reason = "bounded_paper_route_target_exit_window_elapsed"
+        reason = "target_plan_entry_window_closed"
         audit = {
             "schema_version": "torghut.bounded-paper-route-exit-window.v1",
             "state": "rejected",
@@ -515,7 +515,7 @@ class SimplePipelineSubmissionQuoteSizingMixin(TradingPipelineBase):
             event_ts=event_ts,
             exit_due_at=exit_due_at,
         )
-        return updated, "bounded_paper_route_target_exit_window_elapsed"
+        return updated, "target_plan_entry_window_closed"
 
     @staticmethod
     def _apply_bounded_collection_target_sizing_audit(

--- a/services/torghut/tests/pipeline/test_trading_pipeline_paper_route_quote_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_paper_route_quote_b.py
@@ -419,12 +419,10 @@ class TestTradingPipelinePaperRouteQuoteB(TradingPipelineTestCaseBase):
         self.assertEqual(row.status, "rejected")
         self.assertEqual(
             row_json["reject_reason_atomic"],
-            ["bounded_paper_route_target_exit_window_elapsed"],
+            ["target_plan_entry_window_closed"],
         )
         self.assertEqual(price_fetcher.snapshot_requests, 0)
-        self.assertEqual(
-            exit_window["reason"], "bounded_paper_route_target_exit_window_elapsed"
-        )
+        self.assertEqual(exit_window["reason"], "target_plan_entry_window_closed")
         self.assertEqual(exit_window["event_ts"], now.isoformat())
         self.assertEqual(exit_window["exit_due_at"], exit_due_at.isoformat())
         self.assertEqual(

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -238,6 +238,86 @@ def test_live_bounded_paper_route_target_generates_capped_source_decisions(
         settings.trading_allow_shorts = allow_shorts_before
 
 
+def test_live_bounded_paper_route_target_stops_entries_after_exit_due_at(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings, "trading_mode", "live")
+    monkeypatch.setattr(settings, "trading_simple_paper_route_probe_enabled", True)
+    monkeypatch.setattr(
+        settings, "trading_simple_paper_route_probe_allow_live_mode", True
+    )
+    monkeypatch.setattr(settings, "trading_simple_submit_enabled", True)
+    monkeypatch.setattr(
+        settings, "trading_live_submit_activation_expires_at", "2026-06-17T20:05:00Z"
+    )
+    monkeypatch.setattr(settings, "trading_simple_paper_route_probe_max_notional", 100)
+    monkeypatch.setattr(settings, "trading_allow_shorts", True)
+    now = datetime(2026, 6, 17, 19, 50, tzinfo=timezone.utc)
+    target = _bounded_hpairs_target(
+        account_label="TORGHUT_REPLAY",
+        source_account_label="TORGHUT_REPLAY",
+        paper_account_label="TORGHUT_REPLAY",
+        execution_account_label="TORGHUT_REPLAY",
+        target_notional="500",
+        paper_route_probe_next_session_max_notional="500",
+        paper_route_probe_window_start="2026-06-17T13:30:00+00:00",
+        paper_route_probe_window_end="2026-06-17T20:00:00+00:00",
+        paper_route_probe_symbol_quantities={},
+        source_kind="runtime_ledger_source_collection_candidate",
+    )
+    strategy = Strategy(
+        name="microbar-cross-sectional-pairs-v1",
+        description="metadata fixture",
+        enabled=True,
+        base_timeframe="1Sec",
+        universe_type="static",
+        universe_symbols=["AAPL", "AMZN"],
+    )
+    blockers: list[dict[str, object]] = []
+    pipeline = object.__new__(SimpleTradingPipeline)
+    pipeline.account_label = "PA3SX7FYNUTF"
+    pipeline.price_fetcher = SimpleNamespace(
+        fetch_market_snapshot=lambda signal: MarketSnapshot(
+            symbol=signal.symbol,
+            as_of=signal.event_ts,
+            price=Decimal("25"),
+            spread=Decimal("0"),
+            source="fixture",
+            bid=Decimal("25"),
+            ask=Decimal("25"),
+        )
+    )
+    pipeline._is_market_session_open = lambda _now: True
+    pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+        {"AAPL", "AMZN"},
+        None,
+        [target],
+    )
+    pipeline._record_bounded_target_plan_blocker = lambda **kwargs: blockers.append(
+        kwargs
+    )
+    monkeypatch.setattr(
+        "app.trading.scheduler.simple_pipeline.trading_now",
+        lambda account_label=None: now,
+    )
+
+    decisions = pipeline._paper_route_target_source_decisions(
+        strategies=[strategy],
+        allowed_symbols={"AAPL", "AMZN"},
+        positions=[],
+        session=None,
+    )
+
+    assert decisions == []
+    elapsed_blockers = [
+        blocker
+        for blocker in blockers
+        if blocker["reason"] == "target_plan_entry_window_closed"
+    ]
+    assert len(elapsed_blockers) == 1
+    assert elapsed_blockers[0]["symbols"] == {"AAPL", "AMZN"}
+
+
 def test_live_bounded_source_collection_skips_unactionable_short_open_leg(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Stop source-collection from generating target-plan entry decisions after the plan's exit time has passed.
- Replace stale internal reason names with the clearer `target_plan_entry_window_closed` code.
- Add regression coverage for live bounded target plans and stale pre-submit decisions.

## Related Issues

None

## Testing

- `nix develop -c uv run --frozen pytest tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/pipeline/test_trading_pipeline_paper_route_quote_b.py`
- `nix develop -c uv run --frozen pyright --project pyrightconfig.json`
- `nix develop -c uv run --frozen pyright --project pyrightconfig.alpha.json`
- `nix develop -c uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
