### PR TITLE
perf(rook-ceph): restore client ops profile

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -35,17 +35,10 @@ cephClusterSpec:
       rbd_default_map_options: "ms_mode=prefer-crc"
     osd:
       bluestore_cache_autotune: "true"
-      # Temporary recovery-surge mode for the 32 -> 128 hot-pool PG split.
-      # Revert to high_client_ops and remove the override keys after ceph -s shows
-      # zero misplaced objects and zero remapped/backfilling PGs.
-      osd_mclock_profile: "high_recovery_ops"
-      osd_mclock_override_recovery_settings: "true"
-      osd_max_backfills: "6"
-      osd_recovery_max_active_hdd: "12"
-      osd_recovery_sleep_hdd: "0"
-      # Temporary recovery-surge capacity model. The steady-state client posture
-      # should return this to 275 after the PG split is clean.
-      osd_mclock_max_capacity_iops_hdd: "750"
+      # Steady-state client-ops posture. Temporary recovery-surge overrides belong
+      # only in an active maintenance window and must be removed after recovery is clean.
+      osd_mclock_profile: "high_client_ops"
+      osd_mclock_max_capacity_iops_hdd: "275"
       # Seagate Exos X24 24TB HDDs advertise 285 MB/s / 272 MiB/s sustained transfer.
       # Keep the mClock HDD bandwidth model explicit so client/recovery QoS is not based on the conservative default.
       osd_mclock_max_sequential_bandwidth_hdd: "285212672"
@@ -54,12 +47,9 @@ cephClusterSpec:
       osd_scrub_auto_repair: "true"
       osd_scrub_auto_repair_num_errors: "5"
     mgr:
-      # Temporary recovery-surge ceiling for the hot-pool PG split. The previous
-      # 3% ceiling was deliberately pacing pgp_num progress; use 10% during the
-      # maintenance recovery window, then return to 3% for steady client ops.
-      target_max_misplaced_ratio: "0.10"
-      # Keep PG shard deviation tight without enabling read-primary balancing while
-      # pre-Reef clients exist.
+      # Keep PG movement conservative during normal client operations and keep PG
+      # shard deviation tight without enabling read-primary balancing while pre-Reef clients exist.
+      target_max_misplaced_ratio: "0.03"
       mgr/balancer/upmap_max_deviation: "1"
 
   dataDirHostPath: /var/lib/rook

--- a/docs/runbooks/rook-ceph-client-ops-performance.md
+++ b/docs/runbooks/rook-ceph-client-ops-performance.md
@@ -79,12 +79,31 @@ cephfs-data0 pg_num=128 pgp_num=128
 objectstore.rgw.buckets.data pg_num=128 pgp_num=128
 ```
 
+## Normal Client-Ops State
+
+Normal operation should prefer client IO after recovery/backfill is clean:
+
+```yaml
+osd_mclock_profile: "high_client_ops"
+osd_mclock_max_capacity_iops_hdd: "275"
+target_max_misplaced_ratio: "0.03"
+```
+
+The recovery override keys must be absent in normal operation:
+
+```yaml
+osd_mclock_override_recovery_settings
+osd_max_backfills
+osd_recovery_max_active_hdd
+osd_recovery_sleep_hdd
+```
+
 ## Temporary Recovery-Surge Mode
 
 If the hot-pool PG split remains active for many hours, switch from client-biased QoS to recovery-biased QoS until
 the split completes. This is temporary maintenance mode, not the final client-ops posture.
 
-Durable GitOps settings for recovery surge:
+Temporary GitOps patch for recovery surge:
 
 ```yaml
 osd_mclock_profile: "high_recovery_ops"


### PR DESCRIPTION
## Summary

- Restores Rook-Ceph GitOps to the normal `high_client_ops` mClock profile after recovery/backfill reached clean state.
- Removes the temporary recovery-surge override keys from the rendered CephCluster.
- Documents the normal client-ops state separately from the temporary recovery-surge playbook.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applications/rook-ceph/cluster-values.yaml docs/runbooks/rook-ceph-client-ops-performance.md`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-client-ops-restore.render.yaml`
- `rg -n 'osd_mclock_profile|osd_mclock_max_capacity_iops_hdd|osd_mclock_override_recovery_settings|osd_max_backfills|osd_recovery_max_active_hdd|osd_recovery_sleep_hdd|target_max_misplaced_ratio' /tmp/rook-ceph-client-ops-restore.render.yaml`
- `bun run lint:argocd`
- Live readback after direct config change: `ceph config dump` shows `osd_mclock_profile=high_client_ops`, `osd_mclock_max_capacity_iops_hdd=275.000000`, `target_max_misplaced_ratio=0.030000`, and no recovery override keys.
- Live Ceph state before GitOps revert: `6 up / 6 in`, no remapped/backfilling PGs, scrub activity only, with the existing `osd.0` BlueStore slow-op warning.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This restores the normal client-ops posture after the temporary recovery maintenance window.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
