### PR TITLE
perf(rook-ceph): calibrate mclock iops

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -38,6 +38,7 @@ cephClusterSpec:
       # Steady-state client-ops posture. Temporary recovery-surge overrides belong
       # only in an active maintenance window and must be removed after recovery is clean.
       osd_mclock_profile: "high_client_ops"
+      # Fallback for future HDD OSDs. Current OSDs have per-daemon measured overrides below.
       osd_mclock_max_capacity_iops_hdd: "275"
       # Seagate Exos X24 24TB HDDs advertise 285 MB/s / 272 MiB/s sustained transfer.
       # Keep the mClock HDD bandwidth model explicit so client/recovery QoS is not based on the conservative default.
@@ -46,6 +47,19 @@ cephClusterSpec:
       # Automatically repair small scrub inconsistencies. Larger damage still requires operator review.
       osd_scrub_auto_repair: "true"
       osd_scrub_auto_repair_num_errors: "5"
+    # Per-OSD mClock HDD IOPS capacity, measured with Ceph's documented 4 KiB OSD bench path on 2026-07-07.
+    osd.0:
+      osd_mclock_max_capacity_iops_hdd: "210"
+    osd.1:
+      osd_mclock_max_capacity_iops_hdd: "250"
+    osd.2:
+      osd_mclock_max_capacity_iops_hdd: "260"
+    osd.3:
+      osd_mclock_max_capacity_iops_hdd: "200"
+    osd.4:
+      osd_mclock_max_capacity_iops_hdd: "220"
+    osd.5:
+      osd_mclock_max_capacity_iops_hdd: "240"
     mgr:
       # Keep PG movement conservative during normal client operations and keep PG
       # shard deviation tight without enabling read-primary balancing while pre-Reef clients exist.

--- a/docs/runbooks/rook-ceph-client-ops-performance.md
+++ b/docs/runbooks/rook-ceph-client-ops-performance.md
@@ -89,6 +89,18 @@ osd_mclock_max_capacity_iops_hdd: "275"
 target_max_misplaced_ratio: "0.03"
 ```
 
+`osd_mclock_max_capacity_iops_hdd=275` is only the fallback for new HDD OSDs. Current OSDs use measured per-daemon
+overrides so the mClock scheduler does not overestimate slower disks:
+
+```yaml
+osd.0: 210
+osd.1: 250
+osd.2: 260
+osd.3: 200
+osd.4: 220
+osd.5: 240
+```
+
 The recovery override keys must be absent in normal operation:
 
 ```yaml
@@ -97,6 +109,41 @@ osd_max_backfills
 osd_recovery_max_active_hdd
 osd_recovery_sleep_hdd
 ```
+
+## mClock IOPS Calibration
+
+Ceph defines `osd_mclock_max_capacity_iops_hdd` as the max random-write IOPS capacity at 4 KiB block size for
+rotational media. The value is used by mClock to calculate QoS shares for client, recovery, scrub, snaptrim, and
+other OSD work. It is not a direct client IOPS throttle.
+
+Ceph's documented OSD-bench calibration command is:
+
+```bash
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph tell osd.N cache drop
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph tell osd.N bench 12288000 4096 4194304 100
+```
+
+Live sample from 2026-07-07, while the cluster was clean from recovery/backfill but still running scrub activity and
+showing the known `osd.0` BlueStore slow-op warning:
+
+| OSD | Measured IOPS | Durable mClock IOPS |
+| --- | ---: | ---: |
+| 0 | 210.51 | 210 |
+| 1 | 257.92 | 250 |
+| 2 | 264.48 | 260 |
+| 3 | 199.97 | 200 |
+| 4 | 219.71 | 220 |
+| 5 | 243.81 | 240 |
+
+Raw evidence file from the calibration run:
+
+```text
+/tmp/ceph-osd-4k-bench-20260706225632.jsonl
+```
+
+Re-run this calibration after the BlueStore slow-op warning clears and no scrub/deep-scrub is active. If the re-run
+materially changes the slowest OSD values, update the per-OSD overrides instead of replacing them with one broad
+cluster-wide number.
 
 ## Temporary Recovery-Surge Mode
 


### PR DESCRIPTION
## Summary

- Adds measured per-OSD `osd_mclock_max_capacity_iops_hdd` overrides for the six current HDD OSDs.
- Keeps `275` only as a fallback for future HDD OSDs instead of pretending one global value fits all current disks.
- Documents the Ceph OSD-bench calibration command, raw measured IOPS table, and the follow-up condition for rerunning after scrub/slow-op clears.

## Related Issues

None

## Testing

- `kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph tell osd.N cache drop`
- `kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph tell osd.N bench 12288000 4096 4194304 100`
- Live measured IOPS: osd.0 `210.51`, osd.1 `257.92`, osd.2 `264.48`, osd.3 `199.97`, osd.4 `219.71`, osd.5 `243.81`.
- Live config applied and verified with `ceph tell osd.N config get osd_mclock_max_capacity_iops_hdd`.
- `git diff --check -- argocd/applications/rook-ceph/cluster-values.yaml docs/runbooks/rook-ceph-client-ops-performance.md`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-mclock-iops.render.yaml`
- `rg -n 'osd_mclock_max_capacity_iops_hdd|osd\.0:|osd\.1:|osd\.2:|osd\.3:|osd\.4:|osd\.5:' /tmp/rook-ceph-mclock-iops.render.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This tunes mClock's per-OSD capacity model for existing OSDs; it does not change pools, data placement, or client storage classes.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
