### PR TITLE
fix(torghut): accept fail-closed post-deploy evidence

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -271,6 +271,80 @@ describe('validatePostDeployEvidence', () => {
     expect(result.summaryLines.join('\n')).toContain('Live submit contract: `shadow_zero_notional_gate_closed`')
   })
 
+  it('accepts 2xx readyz with accepted TA stale fail-closed at zero notional', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '200',
+      readyz: { status: 'ok' },
+      revenueRepairDigest: {
+        ...baseDigest,
+        blockers: [{ reason: 'accepted_ta_signal_stale' }, { reason: 'hypothesis_not_promotion_eligible' }],
+        capital: {
+          ...baseDigest.capital,
+          capital_stage: 'operational_blocked',
+          live_submission_reason: 'accepted_ta_signal_stale',
+        },
+        health: {
+          ...baseDigest.health,
+          readyz_status: 'ok',
+          readyz_ok: true,
+          dependency_failures: [
+            { name: 'live_submission_gate', detail: 'accepted_ta_signal_stale' },
+            { name: 'profitability_proof_floor', detail: 'repair_only' },
+          ],
+        },
+        repair_queue: [{ code: 'repair_accepted_ta_signal_stale', reason: 'accepted_ta_signal_stale' }],
+      },
+      tradingStatus: {
+        ...baseTradingStatus,
+        live_submission_gate: {
+          ...baseTradingStatus.live_submission_gate,
+          allowed: false,
+          reason: 'accepted_ta_signal_stale',
+          blocked_reasons: ['accepted_ta_signal_stale'],
+          capital_stage: 'operational_blocked',
+          capital_state: 'blocked',
+          clickhouse_ta_freshness: {
+            accepted_sources: ['ta'],
+            latest_accepted_event_at: '2026-06-30T20:54:52Z',
+            accepted_lag_seconds: 615152,
+            accepted_max_lag_seconds: 120,
+            accepted_source_state: 'stale',
+            blocking_reason: 'accepted_ta_signal_stale',
+            excluded_fresher_sources: [
+              {
+                source: 'rest',
+                excluded_reason: 'source_not_allowed_for_live_runtime',
+                latest_signal_at: '2026-07-02T20:32:00Z',
+              },
+            ],
+          },
+          live_submit_activation: baseLiveSubmitActivation,
+        },
+        operational_submission_gate: {
+          allowed: false,
+          blocked_reasons: ['accepted_ta_signal_stale'],
+          reason: 'accepted_ta_signal_stale',
+        },
+        submission_authority: {
+          schema_version: 'torghut.submission-authority.v1',
+          authority_scope: 'none',
+          effective_submit_mode: 'blocked',
+          can_submit_now: false,
+          reason: 'accepted_ta_signal_stale',
+          operational_submission_gate: {
+            allowed: false,
+            blocked_reasons: ['accepted_ta_signal_stale'],
+            reason: 'accepted_ta_signal_stale',
+          },
+        },
+      },
+    })
+
+    expect(result.readyzAcceptedReason).toBe('repair_only_zero_notional')
+    expect(result.liveSubmitContract).toBe('accepted_source_stale_zero_notional')
+    expect(result.summaryLines.join('\n')).toContain('Live submit contract: `accepted_source_stale_zero_notional`')
+  })
+
   it('accepts 2xx readyz with operational submission ready but capital still zero-notional repair-only', () => {
     const result = validatePostDeployEvidence({
       readyzHttpStatus: '200',

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -9,6 +9,7 @@ const PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = 'torghut.paper-route-evidence.v1'
 const PAPER_ROUTE_TARGETS_SCHEMA_VERSION = 'torghut.next-paper-route-runtime-window-targets.v1'
 const RUNTIME_WINDOW_IMPORT_HEALTH_GATE_SCHEMA_VERSION = 'torghut.runtime-window-import-health-gate.v1'
 const RUNTIME_WINDOW_IMPORT_HEALTH_GATE_SUMMARY_SCHEMA_VERSION = 'torghut.runtime-window-import-health-gate-summary.v1'
+const ACCEPTED_SOURCE_STALE_REASON = 'accepted_ta_signal_stale'
 
 type JsonObject = Record<string, unknown>
 
@@ -28,6 +29,7 @@ type PostDeployEvidenceInput = {
 }
 
 type LiveSubmitContract =
+  | 'accepted_source_stale_zero_notional'
   | 'bounded_live_submit_active'
   | 'expired_activation_blocked'
   | 'operational_zero_notional_repair'
@@ -89,6 +91,9 @@ const requireArrayIncludes = (value: unknown, expected: string, label: string) =
     throw new Error(`${label} must include ${expected}`)
   }
 }
+
+const arrayIncludesScalar = (value: unknown, expected: string): boolean =>
+  Array.isArray(value) && value.map((item) => formatScalar(item, '')).includes(expected)
 
 const parseHttpStatus = (value: string): number => {
   if (!/^[0-9]{3}$/.test(value)) {
@@ -477,6 +482,118 @@ const assertOperationalZeroNotionalRepairContract = (status: JsonObject, digest:
   return 'operational_zero_notional_repair'
 }
 
+const isAcceptedSourceStaleZeroNotionalCandidate = (status: JsonObject, digest: JsonObject): boolean => {
+  const capital =
+    digest.capital && typeof digest.capital === 'object' && !Array.isArray(digest.capital)
+      ? (digest.capital as JsonObject)
+      : {}
+  const liveSubmissionGate =
+    status.live_submission_gate &&
+    typeof status.live_submission_gate === 'object' &&
+    !Array.isArray(status.live_submission_gate)
+      ? (status.live_submission_gate as JsonObject)
+      : {}
+  const activation =
+    liveSubmissionGate.live_submit_activation &&
+    typeof liveSubmissionGate.live_submit_activation === 'object' &&
+    !Array.isArray(liveSubmissionGate.live_submit_activation)
+      ? (liveSubmissionGate.live_submit_activation as JsonObject)
+      : {}
+  return (
+    digest.business_state === 'repair_only' &&
+    digest.revenue_ready === false &&
+    capital.live_submission_allowed === false &&
+    capital.live_submission_reason === ACCEPTED_SOURCE_STALE_REASON &&
+    capital.capital_state === 'zero_notional' &&
+    formatScalar(capital.max_notional, '') === '0' &&
+    liveSubmissionGate.allowed === false &&
+    activation.configured === true &&
+    arrayIncludesScalar(liveSubmissionGate.blocked_reasons, ACCEPTED_SOURCE_STALE_REASON)
+  )
+}
+
+const assertAcceptedSourceStaleZeroNotionalContract = (status: JsonObject, digest: JsonObject): LiveSubmitContract => {
+  assertRepairOnlyZeroNotionalDigest(digest)
+
+  const capital = requireObject(digest.capital, 'torghut revenue repair digest capital')
+  requireScalarValue(
+    capital.live_submission_reason,
+    ACCEPTED_SOURCE_STALE_REASON,
+    'torghut revenue repair digest capital.live_submission_reason',
+  )
+
+  const liveSubmissionGate = requireObject(status.live_submission_gate, 'torghut status live_submission_gate')
+  const operationalSubmissionGate = requireObject(
+    status.operational_submission_gate,
+    'torghut status operational_submission_gate',
+  )
+  const submissionAuthority = requireObject(status.submission_authority, 'torghut status submission_authority')
+  const freshness = requireObject(
+    liveSubmissionGate.clickhouse_ta_freshness,
+    'torghut status live_submission_gate.clickhouse_ta_freshness',
+  )
+
+  if (requireBoolean(status.autonomy_enabled, 'torghut status autonomy_enabled') !== false) {
+    throw new Error('torghut status autonomy_enabled must be false for accepted-source stale repair rollout')
+  }
+  if (requireBoolean(liveSubmissionGate.allowed, 'torghut status live_submission_gate.allowed') !== false) {
+    throw new Error('accepted-source stale repair rollout requires live_submission_gate.allowed=false')
+  }
+  requireArrayIncludes(
+    liveSubmissionGate.blocked_reasons,
+    ACCEPTED_SOURCE_STALE_REASON,
+    'torghut live_submission_gate.blocked_reasons',
+  )
+  if (
+    requireBoolean(operationalSubmissionGate.allowed, 'torghut status operational_submission_gate.allowed') !== false
+  ) {
+    throw new Error('accepted-source stale repair rollout requires operational_submission_gate.allowed=false')
+  }
+  requireScalarValue(
+    operationalSubmissionGate.reason,
+    ACCEPTED_SOURCE_STALE_REASON,
+    'torghut status operational_submission_gate.reason',
+  )
+  requireArrayIncludes(
+    operationalSubmissionGate.blocked_reasons,
+    ACCEPTED_SOURCE_STALE_REASON,
+    'torghut operational_submission_gate.blocked_reasons',
+  )
+  requireScalarValue(submissionAuthority.authority_scope, 'none', 'torghut submission_authority.authority_scope')
+  requireScalarValue(
+    submissionAuthority.effective_submit_mode,
+    'blocked',
+    'torghut submission_authority.effective_submit_mode',
+  )
+  requireScalarValue(submissionAuthority.reason, ACCEPTED_SOURCE_STALE_REASON, 'torghut submission_authority.reason')
+  if (requireBoolean(submissionAuthority.can_submit_now, 'torghut submission_authority.can_submit_now') !== false) {
+    throw new Error('accepted-source stale repair rollout requires submission_authority.can_submit_now=false')
+  }
+  requireScalarValue(
+    freshness.accepted_source_state,
+    'stale',
+    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_source_state',
+  )
+  requireScalarValue(
+    freshness.blocking_reason,
+    ACCEPTED_SOURCE_STALE_REASON,
+    'torghut live_submission_gate.clickhouse_ta_freshness.blocking_reason',
+  )
+  requireArrayIncludes(
+    freshness.accepted_sources,
+    'ta',
+    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_sources',
+  )
+  assertLiveSubmitActivationContract(
+    requireObject(
+      liveSubmissionGate.live_submit_activation,
+      'torghut status live_submission_gate.live_submit_activation',
+    ),
+  )
+
+  return 'accepted_source_stale_zero_notional'
+}
+
 const isRepairOnlyZeroNotionalCandidate = (status: JsonObject, digest: JsonObject): boolean => {
   const capital =
     digest.capital && typeof digest.capital === 'object' && !Array.isArray(digest.capital)
@@ -502,6 +619,7 @@ const isRepairOnlyZeroNotionalCandidate = (status: JsonObject, digest: JsonObjec
     ((capital.live_submission_allowed === false &&
       liveSubmissionGate.allowed === false &&
       activation.configured === false) ||
+      isAcceptedSourceStaleZeroNotionalCandidate(status, digest) ||
       (capital.live_submission_allowed === true &&
         liveSubmissionGate.allowed === true &&
         activation.configured === true))
@@ -853,7 +971,9 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
       liveSubmitContract =
         capital.live_submission_allowed === true
           ? assertOperationalZeroNotionalRepairContract(status, digest)
-          : assertShadowZeroNotionalGateClosedContract(status, digest)
+          : isAcceptedSourceStaleZeroNotionalCandidate(status, digest)
+            ? assertAcceptedSourceStaleZeroNotionalContract(status, digest)
+            : assertShadowZeroNotionalGateClosedContract(status, digest)
       readyzAcceptedReason = 'repair_only_zero_notional'
     } else {
       liveSubmitContract = assertBoundedLiveSubmitContract(status)


### PR DESCRIPTION
## Summary

- Accept Torghut post-deploy evidence where the live runtime correctly fails closed on stale accepted TA data.
- Add an explicit `accepted_source_stale_zero_notional` contract for zero-notional repair-only rollouts.
- Cover the CI failure shape with a regression test for `accepted_ta_signal_stale` blocking submission authority.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type`
- Replayed patched validator against failed run 28906440475 artifact: `TORGHUT_READYZ_HTTP_STATUS=200 ... bun run packages/scripts/src/torghut/post-deploy-evidence.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
