### PR TITLE
fix(torghut): require per-channel ws subscriptions

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -658,26 +658,31 @@ class ForwarderApp(
                 return@forEach
               }
               is AlpacaSubscription -> {
-                val actualSubscribed = msg.subscribedSymbolsForChannels(alpacaMarketDataChannels(config))
-                val missing = missingDesiredSymbols(symbolsTracker.current(), actualSubscribed)
+                val channels = alpacaMarketDataChannels(config)
+                val actualSubscribedByChannel = msg.subscribedSymbolsByChannel(channels)
+                val actualSubscribed = actualSubscribedByChannel.values.flatten().toSet()
+                val missingByChannel = missingDesiredSymbolsByChannel(symbolsTracker.current(), actualSubscribedByChannel, channels)
+                val missing = missingByChannel.values.flatten().distinct()
                 subscribedLock.withLock {
                   subscribedSymbols.clear()
                   subscribedSymbols.addAll(actualSubscribed)
                 }
                 if (actualSubscribed.isNotEmpty()) {
                   subscribedSince.compareAndSet(null, Instant.ofEpochMilli(nowMs()))
-                  marketDataChannelFreshness.recordSubscription(actualSubscribed)
+                  marketDataChannelFreshness.recordSubscriptionByChannel(actualSubscribedByChannel)
                 } else {
                   subscribedSince.set(null)
                   lastOptionsMarketDataEventAt.set(null)
                   marketDataChannelFreshness.clearSubscription()
                 }
-                subscribedOk = actualSubscribed.isNotEmpty() && missing.isEmpty()
+                subscribedOk = actualSubscribed.isNotEmpty() && missingByChannel.isEmpty()
                 updateWsReady()
-                if (missing.isNotEmpty()) {
+                if (missingByChannel.isNotEmpty()) {
                   logger.warn {
-                    "alpaca subscription missing desired symbols count=${missing.size} symbols=$missing " +
-                      "subscribed_count=${actualSubscribed.size}"
+                    val missingSummary = missingByChannel.mapValues { (_, symbols) -> symbols.size }
+                    val subscribedSummary = actualSubscribedByChannel.mapValues { (_, symbols) -> symbols.size }
+                    "alpaca subscription missing desired symbols channels=$missingSummary symbols=$missing " +
+                      "subscribed_channels=$subscribedSummary subscribed_count=${actualSubscribed.size}"
                   }
                   applySubscribe(missing)
                 }
@@ -1506,15 +1511,22 @@ class ForwarderApp(
   }
 }
 
-internal fun AlpacaSubscription.subscribedSymbolsForChannels(channels: Collection<String>): Set<String> {
-  val normalizedChannels = channels.map { it.trim() }.filter { it.isNotEmpty() }.toSet()
-  val subscribed = mutableSetOf<String>()
-  if ("trades" in normalizedChannels) subscribed.addAll(trades)
-  if ("quotes" in normalizedChannels) subscribed.addAll(quotes)
-  if ("bars" in normalizedChannels) subscribed.addAll(bars1m)
-  if ("updatedBars" in normalizedChannels) subscribed.addAll(updatedBars)
-  if ("dailyBars" in normalizedChannels) subscribed.addAll(dailyBars)
-  return subscribed.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.toSet()
+internal fun AlpacaSubscription.subscribedSymbolsForChannels(channels: Collection<String>): Set<String> =
+  subscribedSymbolsByChannel(channels).values.flatten().toSet()
+
+internal fun AlpacaSubscription.subscribedSymbolsByChannel(channels: Collection<String>): Map<String, Set<String>> {
+  val normalizedChannels = channels.mapNotNull(::canonicalMarketDataChannel).toSet()
+  return normalizedChannels.associateWith { channel ->
+    val subscribed =
+      when (channel) {
+        "trades" -> trades
+        "quotes" -> quotes
+        "bars" -> bars1m
+        "updatedBars" -> updatedBars
+        else -> emptyList()
+      }
+    subscribed.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.toSet()
+  }
 }
 
 internal fun missingDesiredSymbols(
@@ -1523,6 +1535,22 @@ internal fun missingDesiredSymbols(
 ): List<String> {
   val normalizedSubscribed = subscribed.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.toSet()
   return desired.map { it.trim().uppercase() }.filter { it.isNotEmpty() && it !in normalizedSubscribed }.distinct()
+}
+
+internal fun missingDesiredSymbolsByChannel(
+  desired: Collection<String>,
+  subscribedByChannel: Map<String, Set<String>>,
+  channels: Collection<String>,
+): Map<String, List<String>> {
+  val normalizedDesired = desired.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.distinct()
+  return channels
+    .mapNotNull(::canonicalMarketDataChannel)
+    .distinct()
+    .mapNotNull { channel ->
+      val subscribed = subscribedByChannel[channel].orEmpty()
+      val missing = normalizedDesired.filter { it !in subscribed }
+      if (missing.isEmpty()) null else channel to missing
+    }.toMap()
 }
 
 internal enum class SubscriptionAction {

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
@@ -35,13 +35,29 @@ internal class MarketDataChannelFreshnessTracker(
 ) {
   private val requiredChannels = requiredChannels.mapNotNull(::canonicalMarketDataChannel).distinct()
   private val latestByChannel = ConcurrentHashMap<String, ChannelFreshnessState>()
-  private val subscribedSymbols = AtomicReference<Set<String>>(emptySet())
+  private val subscribedSymbolsByChannel = AtomicReference<Map<String, Set<String>>>(emptyMap())
   private val subscribedSinceMs = AtomicLong(0)
 
   fun recordSubscription(symbols: Collection<String>) {
-    val normalized = symbols.map { it.trim().uppercase() }.filter { it.isNotEmpty() }.toSet()
-    subscribedSymbols.set(normalized)
-    if (normalized.isEmpty()) {
+    recordSubscriptionByChannel(requiredChannels.associateWith { symbols })
+  }
+
+  fun recordSubscriptionByChannel(symbolsByChannel: Map<String, Collection<String>>) {
+    val inputByCanonical =
+      symbolsByChannel.entries.groupBy(
+        keySelector = { (channel, _) -> canonicalMarketDataChannel(channel) },
+        valueTransform = { (_, symbols) -> symbols },
+      )
+    val normalizedByChannel =
+      requiredChannels.associateWith { channel ->
+        inputByCanonical[channel]
+          ?.flatten()
+          ?.mapNotNull(::normalizeSymbol)
+          ?.toSet()
+          .orEmpty()
+      }
+    subscribedSymbolsByChannel.set(normalizedByChannel)
+    if (normalizedByChannel.values.all { it.isEmpty() }) {
       subscribedSinceMs.set(0)
       return
     }
@@ -49,7 +65,7 @@ internal class MarketDataChannelFreshnessTracker(
   }
 
   fun clearSubscription() {
-    subscribedSymbols.set(emptySet())
+    subscribedSymbolsByChannel.set(emptyMap())
     subscribedSinceMs.set(0)
   }
 
@@ -80,13 +96,15 @@ internal class MarketDataChannelFreshnessTracker(
   fun snapshot(): List<MarketDataChannelReadiness> {
     val now = nowMs()
     val subscribedAt = subscribedSinceMs.get()
-    val symbols = subscribedSymbols.get()
+    val symbolsByChannel = subscribedSymbolsByChannel.get()
+    val hasAnySubscribedSymbols = symbolsByChannel.values.any { it.isNotEmpty() }
     val gateActive =
-      symbols.isNotEmpty() &&
+      hasAnySubscribedSymbols &&
         subscribedAt > 0 &&
         now - subscribedAt >= warmupMs &&
         marketSessionActive(Instant.ofEpochMilli(now))
     return requiredChannels.map { channel ->
+      val channelSymbols = symbolsByChannel[channel].orEmpty()
       val state = latestByChannel[channel]
       val latestKafkaSuccessAt = state?.latestKafkaSuccessAtMs?.get()?.takeIf { it > 0 }
       val latestProviderAt = state?.latestProviderEventAtMs?.get()?.takeIf { it > 0 }
@@ -101,6 +119,7 @@ internal class MarketDataChannelFreshnessTracker(
       val ready =
         when {
           !gateActive -> true
+          channelSymbols.isEmpty() -> false
           latestKafkaSuccessAt == null -> false
           lagMs == null -> false
           else -> lagMs <= maxLagMs
@@ -113,7 +132,7 @@ internal class MarketDataChannelFreshnessTracker(
         latestSerializedAtMs = latestSerializedAt,
         latestKafkaSuccessAtMs = latestKafkaSuccessAt,
         latestSymbol = state?.latestSymbol?.get(),
-        subscribedSymbolCount = symbols.size,
+        subscribedSymbolCount = channelSymbols.size,
         observedSymbolCount = observedSymbols.size,
         observedSymbols = observedSymbols,
         lagMs = lagMs,
@@ -122,6 +141,7 @@ internal class MarketDataChannelFreshnessTracker(
           when {
             ready && !gateActive -> "market_data_channel_gate_inactive"
             ready -> "market_data_channel_fresh"
+            channelSymbols.isEmpty() -> "market_data_channel_not_subscribed"
             latestKafkaSuccessAt == null -> "market_data_channel_missing_kafka_success"
             else -> "market_data_channel_stale"
           },

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
@@ -27,6 +27,15 @@ class ForwarderSubscriptionTest {
       setOf("NVDA", "AMZN"),
       ack.subscribedSymbolsForChannels(listOf("quotes")),
     )
+    assertEquals(
+      mapOf(
+        "trades" to setOf("NVDA", "AAPL"),
+        "quotes" to setOf("NVDA", "AMZN"),
+        "bars" to setOf("AVGO"),
+        "updatedBars" to setOf("AMD"),
+      ),
+      ack.subscribedSymbolsByChannel(listOf("trades", "quotes", "bars", "updatedBars")),
+    )
   }
 
   @Test
@@ -41,6 +50,24 @@ class ForwarderSubscriptionTest {
       ).subscribedSymbolsForChannels(listOf("trades", "quotes", "bars", "updatedBars"))
 
     assertEquals(listOf("AAPL", "AMZN", "GOOGL", "ORCL"), missingDesiredSymbols(desired, actual))
+  }
+
+  @Test
+  fun `missing desired symbols are evaluated for every requested channel`() {
+    val desired = listOf("NVDA", "AMD")
+    val actual =
+      AlpacaSubscription(
+        bars1m = listOf("NVDA", "AMD"),
+      ).subscribedSymbolsByChannel(listOf("trades", "quotes", "bars", "updatedBars"))
+
+    assertEquals(
+      mapOf(
+        "trades" to listOf("NVDA", "AMD"),
+        "quotes" to listOf("NVDA", "AMD"),
+        "updatedBars" to listOf("NVDA", "AMD"),
+      ),
+      missingDesiredSymbolsByChannel(desired, actual, listOf("trades", "quotes", "bars", "updatedBars")),
+    )
   }
 
   @Test

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -53,4 +53,41 @@ class MarketDataChannelFreshnessTrackerTest {
       tracker.snapshot().first { it.channel == "trades" }.reason,
     )
   }
+
+  @Test
+  fun `subscription coverage is tracked per market data channel`() {
+    val nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("trades", "quotes", "bars", "updatedBars"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.EQUITY,
+      )
+
+    tracker.recordSubscriptionByChannel(
+      mapOf(
+        "trades" to emptyList(),
+        "quotes" to emptyList(),
+        "bars" to listOf("NVDA", "AMD"),
+        "updatedBars" to emptyList(),
+      ),
+    )
+    tracker.recordProviderEvent("bars", "NVDA")
+    tracker.recordSerializedEvent("bars", "NVDA")
+    tracker.recordKafkaSuccess("bars", "NVDA")
+
+    val byChannel = tracker.snapshot().associateBy { it.channel }
+
+    assertFalse(tracker.ready())
+    assertTrue(byChannel.getValue("bars").ready)
+    assertEquals(2, byChannel.getValue("bars").subscribedSymbolCount)
+    assertFalse(byChannel.getValue("trades").ready)
+    assertEquals(0, byChannel.getValue("trades").subscribedSymbolCount)
+    assertEquals(
+      "market_data_channel_not_subscribed",
+      byChannel.getValue("trades").reason,
+    )
+  }
 }


### PR DESCRIPTION
## Summary

- Tracks Alpaca market-data subscription acknowledgements per required channel instead of flattening them into one symbol union.
- Requires every configured WS channel to acknowledge the configured symbol universe before the WS session can report subscription-ready.
- Adds readiness/test coverage for bars-only acknowledgements so trades, quotes, and updatedBars cannot be masked by bar subscriptions.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest' --tests 'ai.proompteng.dorvud.ws.ForwarderSubscriptionTest'`
- `cd services/dorvud && ./gradlew :websockets:test :websockets:ktlintCheck`

## Screenshots (if applicable)

N/A

## Breaking Changes

Operational fail-closed behavior: during active market-data freshness gates, WS readiness now fails if Alpaca acknowledges only a subset of required channels for the configured symbols.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
