### PR TITLE
fix(torghut): authorize db ca reflection

### DIFF
--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - codex-auth-externalsecret.yaml
   - postgres-cluster.yaml
+  - torghut-db-ca-reflector-source.yaml
   - cnpg-torghut-db-objectbucketclaim.yaml
   - postgres-scheduled-backup.yaml
   - strategy-configmap.yaml

--- a/argocd/applications/torghut/torghut-db-ca-reflector-source.yaml
+++ b/argocd/applications/torghut/torghut-db-ca-reflector-source.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torghut-db-ca
+  namespace: torghut
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pgadmin,jangar,argo-workflows"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pgadmin,jangar,argo-workflows"
+type: Opaque


### PR DESCRIPTION
## Summary

- Add a metadata-only GitOps manifest for `Secret/torghut-db-ca` so reflector authorization is durable on the CNPG-owned source secret.
- Keep reflected copies in `pgadmin`, `jangar`, and `argo-workflows` populated from the renewed Torghut CA instead of empty placeholders.
- Preserve CNPG-owned secret data while managing only reflection annotations through Argo.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`
- Live: annotated the source Torghut CA secret, confirmed `jangar/torghut-db-ca` regained `ca.crt`, and verified the certificate is valid through August 30, 2026.
- Live: restarted Jangar and confirmed quant health reports `status=ok`, fresh metrics, and zero pipeline lag.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
