### PR TITLE
fix(torghut): enforce live market data freshness

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -578,6 +578,16 @@ jobs:
             run_post_deploy_evidence_validator
           fi
 
+      - name: Verify market-data freshness
+        shell: bash
+        env:
+          MARKET_DATA_FRESHNESS_MODE: auto
+          MARKET_DATA_MAX_LAG_SECONDS: '300'
+          MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS: '300'
+        run: |
+          set -euo pipefail
+          bun run smoke:torghut-market-data
+
       - name: Upload revenue repair evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/argocd/applications/agents-ci/runner-rbac-cluster.yaml
+++ b/argocd/applications/agents-ci/runner-rbac-cluster.yaml
@@ -163,3 +163,67 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: agents-ci-runner-torghut-post-deploy-read
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agents-ci-runner-torghut-market-data-secret-read
+  namespace: torghut
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    resourceNames:
+      - torghut-ws
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agents-ci-runner-torghut-market-data-secret-read
+  namespace: torghut
+subjects:
+  - kind: ServiceAccount
+    name: arc-arm64-gha-rs-kube-mode
+    namespace: arc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agents-ci-runner-torghut-market-data-secret-read
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agents-ci-runner-kafka-tail
+  namespace: kafka
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/exec
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agents-ci-runner-kafka-tail
+  namespace: kafka
+subjects:
+  - kind: ServiceAccount
+    name: arc-arm64-gha-rs-kube-mode
+    namespace: arc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agents-ci-runner-kafka-tail

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -218,7 +218,7 @@ spec:
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS
               value: "1000"
             - name: TRADING_SIGNAL_ALLOWED_SOURCES
-              value: ta,rest
+              value: ta
             - name: TRADING_SIGNAL_LOOKBACK_MINUTES
               value: "15"
             - name: TRADING_PLANNED_DECISION_TIMEOUT_SECONDS

--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'bun:test'
+
+import { evaluateMarketDataSmoke, marketSessionState } from '../market-data-smoke'
+
+const freshWsReadyz = {
+  market_data_channels: [
+    {
+      channel: 'trades',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 10,
+      latest_kafka_success_at_ms: 1783447200000,
+      reason: 'market_data_channel_fresh',
+    },
+    {
+      channel: 'quotes',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 10,
+      latest_kafka_success_at_ms: 1783447200000,
+      reason: 'market_data_channel_fresh',
+    },
+    {
+      channel: 'bars',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 10,
+      latest_kafka_success_at_ms: 1783447200000,
+      reason: 'market_data_channel_fresh',
+    },
+    {
+      channel: 'updatedBars',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 10,
+      latest_kafka_success_at_ms: 1783447200000,
+      reason: 'market_data_channel_fresh',
+    },
+  ],
+}
+
+const staleWsReadyz = {
+  market_data_channels: [
+    {
+      channel: 'trades',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 0,
+      latest_kafka_success_at_ms: null,
+      reason: 'market_data_channel_gate_inactive',
+    },
+    {
+      channel: 'quotes',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 0,
+      latest_kafka_success_at_ms: null,
+      reason: 'market_data_channel_gate_inactive',
+    },
+    {
+      channel: 'bars',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 0,
+      latest_kafka_success_at_ms: null,
+      reason: 'market_data_channel_gate_inactive',
+    },
+    {
+      channel: 'updatedBars',
+      ready: true,
+      subscribed_symbol_count: 10,
+      observed_symbol_count: 0,
+      latest_kafka_success_at_ms: null,
+      reason: 'market_data_channel_gate_inactive',
+    },
+  ],
+}
+
+const tradingStatusWithFreshAcceptedTa = {
+  live_submission_gate: {
+    clickhouse_ta_freshness: {
+      accepted_sources: ['ta'],
+      latest_accepted_event_at: '2026-07-07T17:00:00Z',
+      accepted_lag_seconds: 0,
+      accepted_max_lag_seconds: 300,
+      accepted_source_state: 'fresh',
+      blocking_reason: null,
+    },
+  },
+}
+
+const tradingStatusWithStaleAcceptedTa = {
+  live_submission_gate: {
+    clickhouse_ta_freshness: {
+      accepted_sources: ['ta'],
+      latest_accepted_event_at: '2026-06-30T20:59:27Z',
+      accepted_lag_seconds: 604000,
+      accepted_max_lag_seconds: 300,
+      accepted_source_state: 'stale',
+      blocking_reason: 'accepted_ta_signal_stale',
+      excluded_fresher_sources: [{ source: 'rest', excluded_reason: 'source_not_allowed_for_live_runtime' }],
+    },
+  },
+}
+
+const tradingStatusWithRestAcceptedBackfill = {
+  live_submission_gate: {
+    clickhouse_ta_freshness: {
+      ...tradingStatusWithStaleAcceptedTa.live_submission_gate.clickhouse_ta_freshness,
+      accepted_sources: ['rest', 'ta'],
+    },
+  },
+}
+
+describe('market data smoke freshness evaluation', () => {
+  it('identifies regular US equity market session', () => {
+    expect(marketSessionState(new Date('2026-07-07T17:00:00Z'))).toBe('regular')
+    expect(marketSessionState(new Date('2026-07-07T22:00:00Z'))).toBe('post')
+  })
+
+  it('fails in auto mode during regular market hours when accepted TA and source topics are stale', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:00Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-06-30T20:54:58Z', symbol: 'SNDK' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-06-30T20:33:55Z', symbol: 'SNDK' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T16:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: staleWsReadyz,
+      tradingStatus: tradingStatusWithStaleAcceptedTa,
+    })
+
+    expect(result.enforceFreshness).toBe(true)
+    expect(result.ok).toBe(false)
+    expect(result.failures.join('\n')).toContain('accepted_ta_signal_stale')
+    expect(result.failures.join('\n')).toContain('kafka_trades_stale')
+    expect(result.failures.join('\n')).toContain('ws_trades_missing_kafka_success')
+  })
+
+  it('observes the same stale data after hours without claiming market-session proof', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T22:00:00Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-06-30T20:54:58Z', symbol: 'SNDK' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-06-30T20:33:55Z', symbol: 'SNDK' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T19:59:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: staleWsReadyz,
+      tradingStatus: tradingStatusWithRestAcceptedBackfill,
+    })
+
+    expect(result.sessionState).toBe('post')
+    expect(result.enforceFreshness).toBe(false)
+    expect(result.ok).toBe(true)
+    expect(result.warnings.join('\n')).toContain('accepted_ta_signal_stale')
+    expect(result.warnings.join('\n')).toContain('accepted_source_contains_backfill')
+  })
+
+  it('passes during regular market hours when WS topics and accepted TA are fresh', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: freshWsReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+    })
+
+    expect(result.sessionState).toBe('regular')
+    expect(result.enforceFreshness).toBe(true)
+    expect(result.ok).toBe(true)
+    expect(result.failures).toEqual([])
+  })
+})

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -56,6 +56,14 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).not.toContain('Torghut /readyz returned HTTP')
   })
 
+  it('runs market-data freshness verification after deploy evidence is accepted', () => {
+    expect(workflow).toContain('Verify market-data freshness')
+    expect(workflow).toContain('MARKET_DATA_FRESHNESS_MODE: auto')
+    expect(workflow).toContain("MARKET_DATA_MAX_LAG_SECONDS: '300'")
+    expect(workflow).toContain("MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS: '300'")
+    expect(workflow).toContain('bun run smoke:torghut-market-data')
+  })
+
   it('retries database-timeout readyz 503 payloads until they match an accepted readyz contract', () => {
     expect(workflow).toContain('fetch_readyz_json()')
     expect(workflow).toContain('packages/scripts/src/torghut/readyz-contract.ts')
@@ -158,6 +166,15 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(agentsCiClusterRbac).toContain('serving.knative.dev')
     expect(agentsCiClusterRbac).toContain('resources:\n      - pods')
     expect(agentsCiClusterRbac).toContain('arc-arm64-gha-rs-kube-mode')
+  })
+
+  it('grants the ARC runner only the extra Kubernetes access needed for market-data Kafka smoke', () => {
+    expect(agentsCiClusterRbac).toContain('agents-ci-runner-torghut-market-data-secret-read')
+    expect(agentsCiClusterRbac).toContain('namespace: torghut')
+    expect(agentsCiClusterRbac).toContain('resourceNames:\n      - torghut-ws')
+    expect(agentsCiClusterRbac).toContain('agents-ci-runner-kafka-tail')
+    expect(agentsCiClusterRbac).toContain('namespace: kafka')
+    expect(agentsCiClusterRbac).toContain('resources:\n      - pods/exec')
   })
 
   it('runs arm64 workflows with the kube-mode service account that receives post-deploy RBAC', () => {

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -1,6 +1,60 @@
 #!/usr/bin/env bun
 
-import { ensureCli, fatal, run } from '../shared/cli'
+import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
+
+type JsonObject = Record<string, unknown>
+
+type KafkaRole = 'trades' | 'quotes' | 'bars'
+
+type SmokeMode = 'auto' | 'enforce' | 'observe'
+
+type MarketSessionState = 'pre' | 'regular' | 'post' | 'closed' | 'weekend' | 'holiday'
+
+type KafkaTopicRecord = {
+  topic: string
+  eventTs?: string
+  channel?: string
+  symbol?: string
+}
+
+type MarketDataSmokeInput = {
+  now: Date
+  mode: SmokeMode
+  holidays: Set<string>
+  maxKafkaLagSeconds: number
+  acceptedMaxLagSeconds: number
+  latestKafkaByRole: Partial<Record<KafkaRole, KafkaTopicRecord>>
+  wsReadyz: unknown
+  tradingStatus: unknown
+}
+
+export type MarketDataSmokeResult = {
+  ok: boolean
+  enforceFreshness: boolean
+  sessionState: MarketSessionState
+  failures: string[]
+  warnings: string[]
+  summaryLines: string[]
+}
+
+const DEFAULT_SUMMARY_TOPICS = [
+  'torghut.trades.v1',
+  'torghut.quotes.v1',
+  'torghut.bars.1m.v1',
+  'torghut.ta.bars.1s.v1',
+  'torghut.ta.signals.v1',
+  'torghut.ta.status.v1',
+]
+
+const DEFAULT_TOPIC_BY_ROLE: Record<KafkaRole, string> = {
+  trades: 'torghut.trades.v1',
+  quotes: 'torghut.quotes.v1',
+  bars: 'torghut.bars.1m.v1',
+}
+
+const REQUIRED_WS_CHANNELS = ['trades', 'quotes', 'bars', 'updatedBars']
+const REQUIRED_KAFKA_ROLES: KafkaRole[] = ['trades', 'quotes', 'bars']
+const ACCEPTED_SOURCE_STALE_REASON = 'accepted_ta_signal_stale'
 
 const parseList = (raw: string | undefined, fallback: string[]) =>
   raw
@@ -8,45 +62,423 @@ const parseList = (raw: string | undefined, fallback: string[]) =>
     .map((item) => item.trim())
     .filter((item) => item.length > 0) ?? fallback
 
+const parsePositiveNumber = (raw: string | undefined, fallback: number, label: string): number => {
+  if (raw === undefined || raw.trim() === '') return fallback
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    fatal(`${label} must be a positive number`)
+  }
+  return parsed
+}
+
+const parseMode = (raw: string | undefined): SmokeMode => {
+  const mode = (raw ?? 'auto').trim().toLowerCase()
+  if (mode === 'auto' || mode === 'enforce' || mode === 'observe') return mode
+  fatal('MARKET_DATA_FRESHNESS_MODE must be auto, enforce, or observe')
+}
+
+const isObject = (value: unknown): value is JsonObject =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined)
+
+const asNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+const parseTimestampMs = (value: unknown): number | undefined => {
+  const raw = asString(value)
+  if (!raw) return undefined
+  const parsed = Date.parse(raw)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+const lagSeconds = (now: Date, timestamp: unknown): number | undefined => {
+  const tsMs = parseTimestampMs(timestamp)
+  if (tsMs === undefined) return undefined
+  return Math.max(0, Math.floor((now.getTime() - tsMs) / 1_000))
+}
+
+const nyParts = (now: Date): Record<string, string> =>
+  Object.fromEntries(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/New_York',
+      weekday: 'short',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+      .formatToParts(now)
+      .map((part) => [part.type, part.value]),
+  )
+
+export const marketSessionState = (now: Date, holidays: Set<string> = new Set()): MarketSessionState => {
+  const parts = nyParts(now)
+  const dateKey = `${parts.year}-${parts.month}-${parts.day}`
+  if (holidays.has(dateKey)) return 'holiday'
+  if (parts.weekday === 'Sat' || parts.weekday === 'Sun') return 'weekend'
+
+  const hour = Number(parts.hour) % 24
+  const minute = Number(parts.minute)
+  const minuteOfDay = hour * 60 + minute
+  if (minuteOfDay >= 4 * 60 && minuteOfDay < 9 * 60 + 30) return 'pre'
+  if (minuteOfDay >= 9 * 60 + 30 && minuteOfDay < 16 * 60) return 'regular'
+  if (minuteOfDay >= 16 * 60 && minuteOfDay < 20 * 60) return 'post'
+  return 'closed'
+}
+
+const shouldEnforceFreshness = (mode: SmokeMode, sessionState: MarketSessionState): boolean =>
+  mode === 'enforce' || (mode === 'auto' && sessionState === 'regular')
+
+const getWsChannels = (readyz: unknown): Map<string, JsonObject> => {
+  const root = isObject(readyz) ? readyz : {}
+  const channels = Array.isArray(root.market_data_channels) ? root.market_data_channels : []
+  return new Map(
+    channels
+      .filter(isObject)
+      .map((channel) => [asString(channel.channel) ?? '', channel])
+      .filter(([channel]) => channel.length > 0),
+  )
+}
+
+const getAcceptedFreshness = (status: unknown): JsonObject | undefined => {
+  if (!isObject(status)) return undefined
+  const liveSubmissionGate = isObject(status.live_submission_gate) ? status.live_submission_gate : undefined
+  if (liveSubmissionGate && isObject(liveSubmissionGate.clickhouse_ta_freshness)) {
+    return liveSubmissionGate.clickhouse_ta_freshness
+  }
+  if (isObject(status.clickhouse_ta_freshness)) return status.clickhouse_ta_freshness
+  return undefined
+}
+
+const pushFinding = (enforce: boolean, failures: string[], warnings: string[], code: string, detail: string) => {
+  const line = `${code}: ${detail}`
+  if (enforce) {
+    failures.push(line)
+  } else {
+    warnings.push(line)
+  }
+}
+
+const summarizeKafkaRole = (
+  now: Date,
+  role: KafkaRole,
+  record: KafkaTopicRecord | undefined,
+  maxLagSeconds: number,
+): { line: string; stale: boolean; detail: string } => {
+  const latest = record?.eventTs
+  const lag = lagSeconds(now, latest)
+  if (!record || !latest || lag === undefined) {
+    return {
+      line: `- Kafka ${role}: latest=\`missing\` topic=\`${record?.topic ?? DEFAULT_TOPIC_BY_ROLE[role]}\``,
+      stale: true,
+      detail: `${role} has no parseable latest event timestamp`,
+    }
+  }
+  return {
+    line:
+      `- Kafka ${role}: latest=\`${latest}\`, lag_seconds=\`${lag}\`, ` +
+      `symbol=\`${record.symbol ?? 'unknown'}\`, topic=\`${record.topic}\``,
+    stale: lag > maxLagSeconds,
+    detail: `${role} latest event lag ${lag}s exceeds ${maxLagSeconds}s`,
+  }
+}
+
+export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketDataSmokeResult => {
+  const sessionState = marketSessionState(input.now, input.holidays)
+  const enforceFreshness = shouldEnforceFreshness(input.mode, sessionState)
+  const failures: string[] = []
+  const warnings: string[] = []
+  const summaryLines = [
+    `- Market session: \`${sessionState}\``,
+    `- Freshness mode: \`${input.mode}\`, enforced=\`${enforceFreshness}\``,
+  ]
+
+  const wsChannels = getWsChannels(input.wsReadyz)
+  for (const channel of REQUIRED_WS_CHANNELS) {
+    const status = wsChannels.get(channel)
+    const ready = status?.ready === true
+    const subscribed = asNumber(status?.subscribed_symbol_count) ?? 0
+    const observed = asNumber(status?.observed_symbol_count) ?? 0
+    const reason = asString(status?.reason) ?? 'missing'
+    summaryLines.push(
+      `- WS ${channel}: ready=\`${ready}\`, subscribed=\`${subscribed}\`, observed=\`${observed}\`, reason=\`${reason}\``,
+    )
+    if (!ready || subscribed <= 0) {
+      pushFinding(
+        enforceFreshness,
+        failures,
+        warnings,
+        `ws_${channel}_not_ready`,
+        `WS channel ${channel} ready=${ready} subscribed_symbol_count=${subscribed} reason=${reason}`,
+      )
+    }
+    if (enforceFreshness && status?.latest_kafka_success_at_ms === null) {
+      failures.push(`ws_${channel}_missing_kafka_success: WS channel ${channel} has no Kafka success timestamp`)
+    }
+  }
+
+  for (const role of REQUIRED_KAFKA_ROLES) {
+    const summary = summarizeKafkaRole(input.now, role, input.latestKafkaByRole[role], input.maxKafkaLagSeconds)
+    summaryLines.push(summary.line)
+    if (summary.stale) {
+      pushFinding(enforceFreshness, failures, warnings, `kafka_${role}_stale`, summary.detail)
+    }
+  }
+
+  const freshness = getAcceptedFreshness(input.tradingStatus)
+  const acceptedState = asString(freshness?.accepted_source_state) ?? 'missing'
+  const blockingReason = asString(freshness?.blocking_reason) ?? 'missing'
+  const latestAccepted = asString(freshness?.latest_accepted_event_at)
+  const acceptedLag = asNumber(freshness?.accepted_lag_seconds) ?? lagSeconds(input.now, latestAccepted)
+  const acceptedMaxLag = asNumber(freshness?.accepted_max_lag_seconds) ?? input.acceptedMaxLagSeconds
+  const acceptedSources = Array.isArray(freshness?.accepted_sources)
+    ? freshness.accepted_sources.map((source) => asString(source) ?? '').filter(Boolean)
+    : []
+  summaryLines.push(
+    `- Accepted TA: state=\`${acceptedState}\`, latest=\`${latestAccepted ?? 'missing'}\`, ` +
+      `lag_seconds=\`${acceptedLag ?? 'missing'}\`, max_lag_seconds=\`${acceptedMaxLag}\`, ` +
+      `blocking_reason=\`${blockingReason}\`, sources=\`${acceptedSources.join(',') || 'missing'}\``,
+  )
+
+  if (!acceptedSources.includes('ta')) {
+    pushFinding(
+      enforceFreshness,
+      failures,
+      warnings,
+      'accepted_ta_source_missing',
+      'accepted_sources does not include ta',
+    )
+  }
+  const unexpectedAcceptedSources = acceptedSources.filter((source) => source !== 'ta')
+  if (unexpectedAcceptedSources.length > 0) {
+    pushFinding(
+      enforceFreshness,
+      failures,
+      warnings,
+      'accepted_source_contains_backfill',
+      `accepted_sources includes non-live source(s): ${unexpectedAcceptedSources.join(',')}`,
+    )
+  }
+  if (!latestAccepted || acceptedLag === undefined) {
+    pushFinding(
+      enforceFreshness,
+      failures,
+      warnings,
+      'accepted_ta_timestamp_missing',
+      'accepted TA freshness has no parseable latest_accepted_event_at',
+    )
+  } else if (acceptedLag > acceptedMaxLag) {
+    pushFinding(
+      enforceFreshness,
+      failures,
+      warnings,
+      'accepted_ta_stale',
+      `accepted TA lag ${acceptedLag}s exceeds ${acceptedMaxLag}s`,
+    )
+  }
+  if (acceptedState === 'stale' || blockingReason === ACCEPTED_SOURCE_STALE_REASON) {
+    pushFinding(
+      enforceFreshness,
+      failures,
+      warnings,
+      ACCEPTED_SOURCE_STALE_REASON,
+      `accepted_source_state=${acceptedState} blocking_reason=${blockingReason}`,
+    )
+  }
+
+  return {
+    ok: failures.length === 0,
+    enforceFreshness,
+    sessionState,
+    failures,
+    warnings,
+    summaryLines,
+  }
+}
+
+const execCapture = async (
+  command: string,
+  args: string[],
+  options: { cwd?: string; stdin?: string; env?: Record<string, string | undefined> } = {},
+) => {
+  const subprocess = Bun.spawn([command, ...args], {
+    cwd: options.cwd,
+    stdin: options.stdin ? 'pipe' : 'inherit',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: options.env ? { ...process.env, ...options.env } : process.env,
+  })
+
+  if (options.stdin !== undefined) {
+    void subprocess.stdin.write(options.stdin)
+    void subprocess.stdin.end()
+  }
+
+  const stdout = await new Response(subprocess.stdout).text()
+  const stderr = await new Response(subprocess.stderr).text()
+  const exitCode = await subprocess.exited
+  if (exitCode !== 0) {
+    fatal(`Command failed (${exitCode}): ${command} ${args.join(' ')}`.trim(), stderr || stdout)
+  }
+  return stdout
+}
+
+const tailArgs = (topic: string, format: 'summary' | 'json', settings: RuntimeSettings) => [
+  'run',
+  'packages/scripts/src/kafka/tail-topic.ts',
+  '--topic',
+  topic,
+  '--tail',
+  settings.tail,
+  '--timeout-ms',
+  settings.timeoutMs,
+  '--username',
+  settings.username,
+  '--password-secret-namespace',
+  settings.passwordSecretNamespace,
+  '--password-secret-name',
+  settings.passwordSecretName,
+  '--password-secret-key',
+  settings.passwordSecretKey,
+  '--format',
+  format,
+]
+
+const captureLatestKafkaRecord = async (
+  role: KafkaRole,
+  topic: string,
+  settings: RuntimeSettings,
+): Promise<KafkaTopicRecord | undefined> => {
+  const stdout = await execCapture('bun', tailArgs(topic, 'json', settings), { cwd: repoRoot })
+  const parsed = JSON.parse(stdout) as unknown
+  if (!Array.isArray(parsed)) {
+    fatal(`Kafka tail for ${topic} did not return a JSON array`)
+  }
+  const records = parsed.filter(isObject)
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index]
+    const eventTs = asString(record.eventTs)
+    if (!eventTs) continue
+    return {
+      topic,
+      eventTs,
+      channel: asString(record.channel) ?? role,
+      symbol: asString(record.symbol),
+    }
+  }
+  return undefined
+}
+
+const fetchJsonViaWsPod = async (url: string, settings: RuntimeSettings): Promise<unknown> => {
+  const stdout = await execCapture('kubectl', [
+    'exec',
+    '-n',
+    settings.torghutNamespace,
+    settings.wsExecTarget,
+    '--',
+    'wget',
+    '-qO-',
+    url,
+  ])
+  return JSON.parse(stdout) as unknown
+}
+
+type RuntimeSettings = {
+  topics: string[]
+  topicByRole: Record<KafkaRole, string>
+  username: string
+  passwordSecretNamespace: string
+  passwordSecretName: string
+  passwordSecretKey: string
+  tail: string
+  timeoutMs: string
+  mode: SmokeMode
+  maxKafkaLagSeconds: number
+  acceptedMaxLagSeconds: number
+  holidays: Set<string>
+  now: Date
+  printSummaries: boolean
+  torghutNamespace: string
+  wsExecTarget: string
+  wsReadyzUrl: string
+  tradingStatusUrl: string
+}
+
+const runtimeSettings = (): RuntimeSettings => ({
+  topics: parseList(process.env.TORGHUT_MARKET_DATA_TOPICS, DEFAULT_SUMMARY_TOPICS),
+  topicByRole: {
+    trades: process.env.TORGHUT_TRADES_TOPIC ?? DEFAULT_TOPIC_BY_ROLE.trades,
+    quotes: process.env.TORGHUT_QUOTES_TOPIC ?? DEFAULT_TOPIC_BY_ROLE.quotes,
+    bars: process.env.TORGHUT_BARS_TOPIC ?? DEFAULT_TOPIC_BY_ROLE.bars,
+  },
+  username: process.env.KAFKA_USERNAME ?? 'torghut-ws',
+  passwordSecretNamespace: process.env.KAFKA_PASSWORD_SECRET_NAMESPACE ?? 'torghut',
+  passwordSecretName: process.env.KAFKA_PASSWORD_SECRET_NAME ?? 'torghut-ws',
+  passwordSecretKey: process.env.KAFKA_PASSWORD_SECRET_KEY ?? 'password',
+  tail: process.env.TAIL ?? '1',
+  timeoutMs: process.env.TIMEOUT_MS ?? '8000',
+  mode: parseMode(process.env.MARKET_DATA_FRESHNESS_MODE),
+  maxKafkaLagSeconds: parsePositiveNumber(process.env.MARKET_DATA_MAX_LAG_SECONDS, 300, 'MARKET_DATA_MAX_LAG_SECONDS'),
+  acceptedMaxLagSeconds: parsePositiveNumber(
+    process.env.MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS,
+    300,
+    'MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS',
+  ),
+  holidays: new Set(parseList(process.env.MARKET_DATA_HOLIDAYS, [])),
+  now: process.env.MARKET_DATA_NOW ? new Date(process.env.MARKET_DATA_NOW) : new Date(),
+  printSummaries: process.env.MARKET_DATA_PRINT_SUMMARIES !== 'false',
+  torghutNamespace: process.env.TORGHUT_NAMESPACE ?? 'torghut',
+  wsExecTarget: process.env.TORGHUT_WS_EXEC_TARGET ?? 'deploy/torghut-ws',
+  wsReadyzUrl: process.env.TORGHUT_WS_READYZ_URL ?? 'http://127.0.0.1:8080/readyz',
+  tradingStatusUrl: process.env.TORGHUT_STATUS_URL ?? 'http://torghut.torghut.svc.cluster.local/trading/status',
+})
+
 const main = async () => {
   ensureCli('kubectl')
 
-  const topics = parseList(process.env.TORGHUT_MARKET_DATA_TOPICS, [
-    'torghut.trades.v1',
-    'torghut.quotes.v1',
-    'torghut.bars.1m.v1',
-    'torghut.ta.bars.1s.v1',
-    'torghut.ta.signals.v1',
-    'torghut.ta.status.v1',
-  ])
-  const username = process.env.KAFKA_USERNAME ?? 'torghut-ws'
-  const passwordSecretNamespace = process.env.KAFKA_PASSWORD_SECRET_NAMESPACE ?? 'torghut'
-  const passwordSecretName = process.env.KAFKA_PASSWORD_SECRET_NAME ?? 'torghut-ws'
-  const passwordSecretKey = process.env.KAFKA_PASSWORD_SECRET_KEY ?? 'password'
-  const tail = process.env.TAIL ?? '1'
-  const timeoutMs = process.env.TIMEOUT_MS ?? '8000'
+  const settings = runtimeSettings()
+  if (Number.isNaN(settings.now.getTime())) {
+    fatal('MARKET_DATA_NOW must be a parseable timestamp when set')
+  }
 
-  for (const topic of topics) {
-    await run('bun', [
-      'run',
-      'packages/scripts/src/kafka/tail-topic.ts',
-      '--topic',
-      topic,
-      '--tail',
-      tail,
-      '--timeout-ms',
-      timeoutMs,
-      '--username',
-      username,
-      '--password-secret-namespace',
-      passwordSecretNamespace,
-      '--password-secret-name',
-      passwordSecretName,
-      '--password-secret-key',
-      passwordSecretKey,
-      '--format',
-      'summary',
-    ])
+  if (settings.printSummaries) {
+    for (const topic of settings.topics) {
+      await run('bun', tailArgs(topic, 'summary', settings), { cwd: repoRoot })
+    }
+  }
+
+  const latestKafkaByRole: Partial<Record<KafkaRole, KafkaTopicRecord>> = {}
+  for (const role of REQUIRED_KAFKA_ROLES) {
+    latestKafkaByRole[role] = await captureLatestKafkaRecord(role, settings.topicByRole[role], settings)
+  }
+
+  const wsReadyz = await fetchJsonViaWsPod(settings.wsReadyzUrl, settings)
+  const tradingStatus = await fetchJsonViaWsPod(settings.tradingStatusUrl, settings)
+  const result = evaluateMarketDataSmoke({
+    now: settings.now,
+    mode: settings.mode,
+    holidays: settings.holidays,
+    maxKafkaLagSeconds: settings.maxKafkaLagSeconds,
+    acceptedMaxLagSeconds: settings.acceptedMaxLagSeconds,
+    latestKafkaByRole,
+    wsReadyz,
+    tradingStatus,
+  })
+
+  console.log('Torghut market-data freshness evidence:')
+  for (const line of result.summaryLines) console.log(line)
+  for (const warning of result.warnings) console.warn(`warning: ${warning}`)
+  if (!result.ok) {
+    fatal(`Torghut market-data freshness check failed\n${result.failures.join('\n')}`)
   }
 }
 

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -37,6 +37,11 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
         self.assertEqual(settings.trading_mode, "live")
         self.assertEqual(settings.trading_pipeline_mode, "simple")
         self.assertEqual(settings.trading_universe_source, "static")
+        self.assertEqual(
+            _csv_values(env.get("TRADING_SIGNAL_ALLOWED_SOURCES")),
+            {"ta"},
+            "live runtime must fail closed on accepted TA and must not promote REST backfill into live accepted sources",
+        )
         self.assertNotIn("TRADING_STRATEGY_SCHEDULER_ENABLED", env)
         self.assertFalse(settings.trading_autonomy_enabled)
         self.assertFalse(settings.trading_autonomy_allow_live_promotion)


### PR DESCRIPTION
## Summary

- Restores live Torghut accepted signal sources to `ta` only so REST backfill cannot mask stale accepted TA data.
- Adds an authenticated Torghut market-data smoke verifier that checks Kafka trades, quotes, bars, websocket readiness, and `/trading/status` accepted-source freshness with market-hours enforcement.
- Wires the post-deploy workflow to run the market-data smoke and grants the ARC runner the narrow Kubernetes access needed to read the existing Kafka/Strimzi secret path.
- Adds regression coverage for market-session enforcement, stale accepted TA, REST backfill rejection, workflow wiring, RBAC, and the live Knative manifest contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `cd services/torghut && uv run --frozen pytest tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py -k 'safe_live_defaults or runtime_symbol_sources_use_live_signal_universe'`
- `bunx oxfmt --check packages/scripts/src/torghut/market-data-smoke.ts packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts .github/workflows/torghut-post-deploy-verify.yml argocd/applications/agents-ci/runner-rbac-cluster.yaml`
- `bun run --cwd packages/scripts lint:oxlint:type` (passes with 0 errors; existing warnings remain outside this change)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `MARKET_DATA_PRINT_SUMMARIES=false MARKET_DATA_FRESHNESS_MODE=auto TIMEOUT_MS=10000 bun run smoke:torghut-market-data` (after-hours live smoke exits 0 while reporting stale Kafka/accepted TA and the current live `rest,ta` accepted-source violation that this PR removes)

## Screenshots

N/A

## Breaking Changes

Live Torghut returns to `TRADING_SIGNAL_ALLOWED_SOURCES=ta`; REST backfill remains excluded from accepted live signal freshness and can no longer make the runtime appear fresher.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.