### PR TITLE
chore(torghut): promote image sha-2440cfac7eebb4c1a82c3c9d4e20f084a000855d

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -52,7 +52,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: e4cb3b36f18cd57e27551b1ca8f18b61730bfcfe
+              value: 2440cfac7eebb4c1a82c3c9d4e20f084a000855d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: e4cb3b36f18cd57e27551b1ca8f18b61730bfcfe
+              value: 2440cfac7eebb4c1a82c3c9d4e20f084a000855d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T00:01:52Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T01:07:16Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -539,9 +539,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1564-ge4cb3b36f
+              value: v0.596.0-1573-g2440cfac7
             - name: TORGHUT_COMMIT
-              value: e4cb3b36f18cd57e27551b1ca8f18b61730bfcfe
+              value: 2440cfac7eebb4c1a82c3c9d4e20f084a000855d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T00:01:52Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T01:07:16Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -418,9 +418,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1564-ge4cb3b36f
+              value: v0.596.0-1573-g2440cfac7
             - name: TORGHUT_COMMIT
-              value: e4cb3b36f18cd57e27551b1ca8f18b61730bfcfe
+              value: 2440cfac7eebb4c1a82c3c9d4e20f084a000855d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2440cfac7eebb4c1a82c3c9d4e20f084a000855d`
- Image tag: `sha-2440cfac7eebb4c1a82c3c9d4e20f084a000855d`
- Image digest: `sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher