### PR TITLE
fix(torghut): wait for knative readiness in post-deploy

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -233,42 +233,60 @@ jobs:
             done
           done
 
-          set +e
-          KNSVC_READY="$(kubectl get ksvc torghut -n torghut -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /tmp/torghut-ksvc-ready.err)"
-          KNSVC_READY_STATUS=$?
-          set -e
-          if [ "${KNSVC_READY_STATUS}" -ne 0 ]; then
-            if grep -qi 'not found' /tmp/torghut-ksvc-ready.err; then
-              echo "Knative Service torghut was not found"
-              cat /tmp/torghut-ksvc-ready.err
-              exit 1
-            else
-              echo "Failed to read Knative Service torghut"
-              cat /tmp/torghut-ksvc-ready.err
-              exit 1
-            fi
-          elif [ "${KNSVC_READY}" != 'True' ]; then
-            echo "Knative Service torghut is not Ready"
-            exit 1
-          fi
-          set +e
-          SIM_KNSVC_READY="$(kubectl get ksvc torghut-sim -n torghut -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /tmp/torghut-sim-ksvc-ready.err)"
-          SIM_KNSVC_READY_STATUS=$?
-          set -e
-          if [ "${SIM_KNSVC_READY_STATUS}" -ne 0 ]; then
-            if grep -qi 'not found' /tmp/torghut-sim-ksvc-ready.err; then
-              echo "Knative Service torghut-sim was not found"
-              cat /tmp/torghut-sim-ksvc-ready.err
-              exit 1
-            else
-              echo "Failed to read Knative Service torghut-sim"
-              cat /tmp/torghut-sim-ksvc-ready.err
-              exit 1
-            fi
-          elif [ "${SIM_KNSVC_READY}" != 'True' ]; then
-            echo "Knative Service torghut-sim is not Ready"
-            exit 1
-          fi
+          KNSVC_READY_ATTEMPTS=60
+          KNSVC_READY_INTERVAL_SECONDS=2
+
+          wait_knative_service_ready() {
+            local service="$1"
+            local attempt
+            local status
+            local ready
+            local latest_ready
+            local latest_created
+            local output
+            local error_path="/tmp/${service}-ksvc-ready.err"
+
+            for attempt in $(seq 1 "${KNSVC_READY_ATTEMPTS}"); do
+              set +e
+              output="$(
+                kubectl get ksvc "${service}" -n torghut \
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status} {.status.latestReadyRevisionName} {.status.latestCreatedRevisionName}' \
+                  2> "${error_path}"
+              )"
+              status=$?
+              set -e
+
+              if [ "${status}" -ne 0 ]; then
+                if grep -qi 'not found' "${error_path}"; then
+                  echo "Knative Service ${service} was not found"
+                  cat "${error_path}"
+                  exit 1
+                fi
+                echo "Failed to read Knative Service ${service}"
+                cat "${error_path}"
+                exit 1
+              fi
+
+              ready="$(echo "${output}" | awk '{print $1}')"
+              latest_ready="$(echo "${output}" | awk '{print $2}')"
+              latest_created="$(echo "${output}" | awk '{print $3}')"
+              if [ "${ready}" = 'True' ]; then
+                return 0
+              fi
+
+              if [ "${attempt}" -eq "${KNSVC_READY_ATTEMPTS}" ]; then
+                echo "Knative Service ${service} did not become Ready after bounded retry window"
+                kubectl get ksvc "${service}" -n torghut -o yaml || true
+                exit 1
+              fi
+
+              echo "Attempt ${attempt}: Knative Service ${service} ready=${ready:-empty} latestReady=${latest_ready:-empty} latestCreated=${latest_created:-empty}"
+              sleep "${KNSVC_READY_INTERVAL_SECONDS}"
+            done
+          }
+
+          wait_knative_service_ready torghut
+          wait_knative_service_ready torghut-sim
 
           for deployment in \
             torghut-options-catalog \

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -22,11 +22,27 @@ const arcKubeModeServiceAccount = readFileSync(
 describe('torghut post-deploy verifier workflow', () => {
   it('does not skip Knative Service readiness when the runner lacks RBAC', () => {
     expect(workflow).not.toContain('Skipping Knative Service readiness check')
-    expect(workflow).toContain('Failed to read Knative Service torghut')
+    expect(workflow).toContain('Failed to read Knative Service ${service}')
+  })
+
+  it('polls Knative Service readiness after Argo applies a new revision', () => {
+    expect(workflow).toContain('wait_knative_service_ready()')
+    expect(workflow).toContain('KNSVC_READY_ATTEMPTS=60')
+    expect(workflow).toContain('KNSVC_READY_INTERVAL_SECONDS=2')
+    expect(workflow).toContain('wait_knative_service_ready torghut')
+    expect(workflow).toContain('wait_knative_service_ready torghut-sim')
+    expect(workflow).toContain(
+      'Attempt ${attempt}: Knative Service ${service} ready=${ready:-empty} latestReady=${latest_ready:-empty} latestCreated=${latest_created:-empty}',
+    )
+    expect(workflow).toContain('Knative Service ${service} did not become Ready after bounded retry window')
+    expect(workflow).not.toContain('KNSVC_READY_STATUS=$?')
+    expect(workflow).not.toContain('SIM_KNSVC_READY_STATUS=$?')
   })
 
   it('uses a shell-safe jsonpath for Knative Service readiness', () => {
-    expect(workflow).toContain(`jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`)
+    expect(workflow).toContain(
+      `jsonpath='{.status.conditions[?(@.type=="Ready")].status} {.status.latestReadyRevisionName} {.status.latestCreatedRevisionName}'`,
+    )
     expect(workflow).not.toContain(`jsonpath='{.status.conditions[?(@.type==\\"Ready\\")].status}'`)
   })
 
@@ -95,7 +111,7 @@ describe('torghut post-deploy verifier workflow', () => {
   })
 
   it('verifies torghut-sim paper-route target mirroring after deploy', () => {
-    expect(workflow).toContain('Knative Service torghut-sim is not Ready')
+    expect(workflow).toContain('wait_knative_service_ready torghut-sim')
     expect(workflow).toContain('http://torghut.torghut.svc.cluster.local/trading/proofs')
     expect(workflow).toContain('http://torghut-sim.torghut.svc.cluster.local/trading/proofs')
     expect(workflow).toContain('TORGHUT_SIM_PAPER_ROUTE_EVIDENCE')


### PR DESCRIPTION
## Summary

- Replaces the one-shot Torghut Knative Service readiness reads in post-deploy verification with a bounded readiness poll.
- Reports live/latest revision names while waiting, and dumps service diagnostics only after the retry window expires.
- Adds regression assertions so future verifier changes cannot reintroduce the race that failed the `2440cfac7` post-deploy run.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check .github/workflows/torghut-post-deploy-verify.yml packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type` (passes with 0 errors; existing warnings remain outside this change)
- Live readback after PR #12087 rollout settled: Argo `torghut` and `agents-ci` are `Synced Healthy` at `2440cfac7eebb4c1a82c3c9d4e20f084a000855d`; live `torghut` Knative Service is ready on `torghut-01392` with `TRADING_SIGNAL_ALLOWED_SOURCES=ta`.
- `MARKET_DATA_PRINT_SUMMARIES=false MARKET_DATA_FRESHNESS_MODE=auto TIMEOUT_MS=10000 bun run smoke:torghut-market-data` (after-hours live smoke exits 0, no longer reports REST backfill acceptance, and still reports stale Kafka/accepted TA as warnings)

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
