### PR TITLE
fix(torghut): guard cnpg ca from argo prune

### DIFF
--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - codex-auth-externalsecret.yaml
   - postgres-cluster.yaml
   - torghut-db-ca-reflector-rbac.yaml
+  - torghut-db-ca-prune-guard-job.yaml
   - torghut-db-ca-reflector-job.yaml
   - cnpg-torghut-db-objectbucketclaim.yaml
   - postgres-scheduled-backup.yaml

--- a/argocd/applications/torghut/torghut-db-ca-prune-guard-job.yaml
+++ b/argocd/applications/torghut/torghut-db-ca-prune-guard-job.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: torghut-db-ca-prune-guard
+  namespace: torghut
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 120
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: torghut-db-ca-prune-guard
+        app.kubernetes.io/part-of: torghut
+    spec:
+      restartPolicy: Never
+      serviceAccountName: torghut-db-ca-reflector
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: protect
+          image: bitnami/kubectl@sha256:a67b11e95e953f550f020a41970185ccc5f83d78b86b8c575d02c904aa0f9cd7
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              if ! kubectl -n torghut get secret torghut-db-ca >/dev/null 2>&1; then
+                echo "CNPG CA secret is absent; nothing to protect from Argo prune"
+                exit 0
+              fi
+
+              if ! kubectl -n torghut get secret torghut-db-ca \
+                -o jsonpath='{.data.ca\.crt}{" "}{.data.ca\.key}' | grep -Eq '^[^[:space:]]+ [^[:space:]]+$'; then
+                echo "existing torghut-db-ca lacks CNPG CA data; leaving it pruneable for CNPG recovery"
+                exit 0
+              fi
+
+              kubectl -n torghut annotate secret torghut-db-ca \
+                argocd.argoproj.io/sync-options=Prune=false \
+                --overwrite
+              kubectl -n torghut annotate secret torghut-db-ca \
+                argocd.argoproj.io/tracking-id- || true
+              echo "protected existing CNPG-managed torghut-db-ca from Argo prune"

--- a/argocd/applications/torghut/torghut-db-ca-reflector-job.yaml
+++ b/argocd/applications/torghut/torghut-db-ca-reflector-job.yaml
@@ -45,11 +45,14 @@ spec:
                 if kubectl -n torghut get secret torghut-db-ca \
                   -o jsonpath='{.data.ca\.crt}{" "}{.data.ca\.key}' | grep -Eq '^[^[:space:]]+ [^[:space:]]+$'; then
                   kubectl -n torghut annotate secret torghut-db-ca \
+                    argocd.argoproj.io/sync-options=Prune=false \
                     reflector.v1.k8s.emberstack.com/reflection-allowed=true \
                     reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces=pgadmin,jangar,argo-workflows \
                     reflector.v1.k8s.emberstack.com/reflection-auto-enabled=true \
                     reflector.v1.k8s.emberstack.com/reflection-auto-namespaces=pgadmin,jangar,argo-workflows \
                     --overwrite
+                  kubectl -n torghut annotate secret torghut-db-ca \
+                    argocd.argoproj.io/tracking-id- || true
                   echo "annotated existing CNPG-managed torghut-db-ca secret for reflection"
                   exit 0
                 fi

--- a/argocd/applications/torghut/torghut-db-ca-reflector-rbac.yaml
+++ b/argocd/applications/torghut/torghut-db-ca-reflector-rbac.yaml
@@ -3,12 +3,16 @@ kind: ServiceAccount
 metadata:
   name: torghut-db-ca-reflector
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: torghut-db-ca-reflector
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -20,6 +24,8 @@ kind: RoleBinding
 metadata:
   name: torghut-db-ca-reflector
   namespace: torghut
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
 subjects:
   - kind: ServiceAccount
     name: torghut-db-ca-reflector

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -150,6 +150,64 @@ describe('Torghut manifest scheduling', () => {
     expect(resources).not.toContain('whitepaper-autoresearch-replay-materialization-cronworkflow.yaml')
   })
 
+  it('protects the CNPG-managed Torghut CA secret from Argo prune without creating it', () => {
+    const kustomization = parseManifest('argocd/applications/torghut/kustomization.yaml')
+    const resources = kustomization.resources
+    expect(Array.isArray(resources)).toBe(true)
+    expect(resources).toContain('torghut-db-ca-reflector-rbac.yaml')
+    expect(resources).toContain('torghut-db-ca-prune-guard-job.yaml')
+    expect(resources).toContain('torghut-db-ca-reflector-job.yaml')
+    expect(resources).not.toContain('torghut-db-ca-reflector-source.yaml')
+
+    for (const path of collectYamlFiles('argocd/applications/torghut')) {
+      for (const manifest of parseManifestDocuments(path)) {
+        if (!manifest) {
+          continue
+        }
+        expect(manifest.kind === 'Secret' && getAtPath(manifest, ['metadata']).name === 'torghut-db-ca', path).toBe(
+          false,
+        )
+      }
+    }
+
+    const rbac = parseManifestDocuments('argocd/applications/torghut/torghut-db-ca-reflector-rbac.yaml')
+    for (const manifest of rbac) {
+      expect(getAtPath(manifest, ['metadata', 'annotations'])['argocd.argoproj.io/sync-wave']).toBe('-20')
+    }
+    const role = rbac.find((manifest) => manifest.kind === 'Role')
+    expect(role).toBeDefined()
+    expect(getAtPath(role, ['rules', 0])).toMatchObject({
+      apiGroups: [''],
+      resources: ['secrets'],
+      resourceNames: ['torghut-db-ca'],
+      verbs: ['get', 'patch'],
+    })
+
+    const pruneGuard = parseManifest('argocd/applications/torghut/torghut-db-ca-prune-guard-job.yaml')
+    expect(getAtPath(pruneGuard, ['metadata', 'annotations'])).toMatchObject({
+      'argocd.argoproj.io/hook': 'Sync',
+      'argocd.argoproj.io/hook-delete-policy': 'BeforeHookCreation,HookSucceeded',
+      'argocd.argoproj.io/sync-wave': '-10',
+    })
+    expect(getAtPath(pruneGuard, ['spec'])).toMatchObject({
+      backoffLimit: 2,
+      activeDeadlineSeconds: 120,
+      ttlSecondsAfterFinished: 300,
+    })
+    expect(getAtPath(pruneGuard, ['spec', 'template', 'spec']).serviceAccountName).toBe('torghut-db-ca-reflector')
+    const pruneCommand = String(getAtPath(pruneGuard, ['spec', 'template', 'spec', 'containers', 0]).command)
+    expect(pruneCommand).toContain('argocd.argoproj.io/sync-options=Prune=false')
+    expect(pruneCommand).toContain('argocd.argoproj.io/tracking-id-')
+    expect(pruneCommand).toContain('existing torghut-db-ca lacks CNPG CA data; leaving it pruneable')
+    expect(pruneCommand).toContain('protected existing CNPG-managed torghut-db-ca from Argo prune')
+
+    const reflector = parseManifest('argocd/applications/torghut/torghut-db-ca-reflector-job.yaml')
+    const reflectorCommand = String(getAtPath(reflector, ['spec', 'template', 'spec', 'containers', 0]).command)
+    expect(reflectorCommand).toContain('argocd.argoproj.io/sync-options=Prune=false')
+    expect(reflectorCommand).toContain('argocd.argoproj.io/tracking-id-')
+    expect(reflectorCommand).toContain('reflector.v1.k8s.emberstack.com/reflection-allowed=true')
+  })
+
   it('bounds Hyperliquid ClickHouse schema hooks so Argo syncs cannot hang on distributed DDL', () => {
     const job = parseManifest('argocd/applications/torghut-hyperliquid-feed/clickhouse-schema-job.yaml')
     const container = getAtPath(job, ['spec', 'template', 'spec', 'containers', 0])


### PR DESCRIPTION
## Summary

- Add a Sync hook that protects an existing valid CNPG-managed `torghut-db-ca` secret from Argo prune before the reflector PostSync hook runs.
- Keep bootstrap safe by exiting without creating the secret when it is absent and leaving an invalid empty secret pruneable for CNPG recovery.
- Extend the reflector hook to keep `Prune=false` and remove stale Argo tracking metadata after valid CA data exists.
- Add a Torghut manifest regression test proving there is no desired `Secret/torghut-db-ca` manifest and the prune guard contract stays present.

## Related Issues

Addresses the P1 review thread on https://github.com/proompteng/lab/pull/12088#discussion_r3540571516.
Follow-up to #12083 and #12088.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`
- Live break-glass validation: patched `secret/torghut-db-ca` to remove stale `argocd.argoproj.io/tracking-id`, add `argocd.argoproj.io/sync-options=Prune=false`, and verified the secret still has CNPG ownerReference plus `ca.crt`/`ca.key` without printing secret data.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This is a migration guard for an already existing CNPG-owned secret; it does not create or rotate the CA.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
