### PR TITLE
fix(torghut): allow smoke verifier to read ta config

### DIFF
--- a/argocd/applications/agents-ci/runner-rbac-cluster.yaml
+++ b/argocd/applications/agents-ci/runner-rbac-cluster.yaml
@@ -167,7 +167,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: agents-ci-runner-torghut-market-data-secret-read
+  name: agents-ci-runner-torghut-market-data-read
 rules:
   - apiGroups:
       - ''
@@ -177,11 +177,19 @@ rules:
       - torghut-ws
     verbs:
       - get
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - torghut-ta-config
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: agents-ci-runner-torghut-market-data-secret-read
+  name: agents-ci-runner-torghut-market-data-read
 subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
@@ -189,7 +197,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: agents-ci-runner-torghut-market-data-secret-read
+  name: agents-ci-runner-torghut-market-data-read
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -184,11 +184,13 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(agentsCiClusterRbac).toContain('arc-arm64-gha-rs-kube-mode')
   })
 
-  it('grants the ARC runner only the extra Kubernetes access needed for market-data Kafka smoke', () => {
-    expect(agentsCiClusterRbac).toContain('agents-ci-runner-torghut-market-data-secret-read')
+  it('grants the ARC runner only the extra Kubernetes access needed for market-data smoke', () => {
+    expect(agentsCiClusterRbac).toContain('agents-ci-runner-torghut-market-data-read')
     expect(agentsCiClusterRbac).toContain('kind: ClusterRole')
     expect(agentsCiClusterRbac).toContain('kind: ClusterRoleBinding')
     expect(agentsCiClusterRbac).toContain('resourceNames:\n      - torghut-ws')
+    expect(agentsCiClusterRbac).toContain('resources:\n      - configmaps')
+    expect(agentsCiClusterRbac).toContain('resourceNames:\n      - torghut-ta-config')
     expect(agentsCiClusterRbac).toContain('agents-ci-runner-kafka-tail')
     expect(agentsCiClusterRbac).toContain('resources:\n      - pods/exec')
     expect(agentsCiClusterRbac).not.toContain('namespace: torghut')


### PR DESCRIPTION
## Summary
- Grant the ARC kube-mode runner read access to only the `torghut-ta-config` configmap used by the Torghut market-data smoke.
- Rename the narrow market-data read role from secret-only to market-data read, while keeping secret access scoped to `torghut-ws`.
- Extend the post-deploy workflow contract test so the TA config read permission is enforced in CI.

## Testing
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check argocd/applications/agents-ci/runner-rbac-cluster.yaml packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run lint:argocd`

## Rollout / Risk
- GitOps-only RBAC change for `agents-ci`; no runtime Torghut containers or trading config changed.
- Required to unblock the post-deploy market-data verifier after the smoke started checking live TA consumer config.
