### PR TITLE
fix(torghut): address merged review feedback

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -602,6 +602,8 @@ jobs:
           MARKET_DATA_FRESHNESS_MODE: auto
           MARKET_DATA_MAX_LAG_SECONDS: '300'
           MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS: '300'
+          MARKET_DATA_HOLIDAYS: '2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25'
+          KAFKA_TOPIC_PARTITIONS: '0,1,2'
         run: |
           set -euo pipefail
           bun run smoke:torghut-market-data

--- a/argocd/applications/agents-ci/kustomization.yaml
+++ b/argocd/applications/agents-ci/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: agents-ci
 resources:
   - runner-rbac-cluster.yaml
   - runner-rbac.yaml

--- a/argocd/applications/agents-ci/runner-rbac-cluster.yaml
+++ b/argocd/applications/agents-ci/runner-rbac-cluster.yaml
@@ -165,9 +165,10 @@ roleRef:
   name: agents-ci-runner-torghut-post-deploy-read
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: agents-ci-runner-torghut-market-data-read
+  namespace: torghut
 rules:
   - apiGroups:
       - ''
@@ -185,24 +186,40 @@ rules:
       - torghut-ta-config
     verbs:
       - get
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/exec
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: agents-ci-runner-torghut-market-data-read
+  namespace: torghut
 subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
     namespace: arc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: agents-ci-runner-torghut-market-data-read
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: agents-ci-runner-kafka-tail
+  namespace: kafka
 rules:
   - apiGroups:
       - ''
@@ -220,14 +237,15 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: agents-ci-runner-kafka-tail
+  namespace: kafka
 subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
     namespace: arc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: agents-ci-runner-kafka-tail

--- a/argocd/applications/torghut-options/ws/configmap.yaml
+++ b/argocd/applications/torghut-options/ws/configmap.yaml
@@ -9,7 +9,7 @@ data:
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
   ALPACA_MARKET_DATA_CHANNELS: "trades,quotes"
-  OPTIONS_MARKET_HOLIDAYS: "2026-07-03"
+  OPTIONS_MARKET_HOLIDAYS: "2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25"
   JANGAR_SYMBOLS_URL: "http://torghut-options-catalog.torghut.svc.cluster.local/v1/options/hot-set"
   SYMBOLS: ""
   SYMBOLS_POLL_INTERVAL_MS: "30000"

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - codex-auth-externalsecret.yaml
   - postgres-cluster.yaml
+  - torghut-db-ca-prune-tombstone.yaml
   - torghut-db-ca-reflector-rbac.yaml
   - torghut-db-ca-prune-guard-job.yaml
   - torghut-db-ca-reflector-job.yaml

--- a/argocd/applications/torghut/torghut-db-ca-prune-tombstone.yaml
+++ b/argocd/applications/torghut/torghut-db-ca-prune-tombstone.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torghut-db-ca
+  namespace: torghut
+  annotations:
+    argocd.argoproj.io/hook: Skip
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    proompteng.ai/tombstone-reason: cnpg-ca-prune-migration-20260707
+type: Opaque

--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -15,6 +15,7 @@ data:
   # Full market-data mode (quotes enabled) must stay within account subscription constraints.
   # Keep universe size capped at 12 to preserve headroom and avoid 405 symbol-limit failures.
   ALPACA_MARKET_DATA_CHANNELS: "trades,quotes,bars,updatedBars"
+  OPTIONS_MARKET_HOLIDAYS: "2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25"
   # Static executable universe; the live trading loop must not depend on Jangar.
   SYMBOLS: "NVDA,AVGO,AMD,MU,MRVL,CRDO,COHR,LITE,SNDK,WDC"
   SYMBOLS_ALLOWLIST: "NVDA,AVGO,AMD,MU,MRVL,CRDO,COHR,LITE,SNDK,WDC"

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -154,19 +154,33 @@ describe('Torghut manifest scheduling', () => {
     const kustomization = parseManifest('argocd/applications/torghut/kustomization.yaml')
     const resources = kustomization.resources
     expect(Array.isArray(resources)).toBe(true)
+    expect(resources).toContain('torghut-db-ca-prune-tombstone.yaml')
     expect(resources).toContain('torghut-db-ca-reflector-rbac.yaml')
     expect(resources).toContain('torghut-db-ca-prune-guard-job.yaml')
     expect(resources).toContain('torghut-db-ca-reflector-job.yaml')
     expect(resources).not.toContain('torghut-db-ca-reflector-source.yaml')
+
+    const tombstone = parseManifest('argocd/applications/torghut/torghut-db-ca-prune-tombstone.yaml')
+    expect(tombstone.kind).toBe('Secret')
+    expect(getAtPath(tombstone, ['metadata']).name).toBe('torghut-db-ca')
+    expect(getAtPath(tombstone, ['metadata', 'annotations'])).toMatchObject({
+      'argocd.argoproj.io/hook': 'Skip',
+      'argocd.argoproj.io/sync-options': 'Prune=false,Delete=false',
+      'argocd.argoproj.io/compare-options': 'IgnoreExtraneous',
+    })
+    expect('data' in tombstone).toBe(false)
+    expect('stringData' in tombstone).toBe(false)
 
     for (const path of collectYamlFiles('argocd/applications/torghut')) {
       for (const manifest of parseManifestDocuments(path)) {
         if (!manifest) {
           continue
         }
-        expect(manifest.kind === 'Secret' && getAtPath(manifest, ['metadata']).name === 'torghut-db-ca', path).toBe(
-          false,
-        )
+        if (manifest.kind === 'Secret' && getAtPath(manifest, ['metadata']).name === 'torghut-db-ca') {
+          expect(getAtPath(manifest, ['metadata', 'annotations'])['argocd.argoproj.io/hook'], path).toBe('Skip')
+          expect('data' in manifest, path).toBe(false)
+          expect('stringData' in manifest, path).toBe(false)
+        }
       }
     }
 
@@ -508,5 +522,18 @@ describe('Torghut manifest scheduling', () => {
     const deployment = parseManifest('argocd/applications/torghut/ta/flinkdeployment.yaml')
     const spec = getAtPath(deployment, ['spec'])
     expect(spec.restartNonce).toBeGreaterThanOrEqual(20)
+  })
+
+  it('configures 2026 US market holidays for Torghut market-data freshness gates', () => {
+    const expectedHolidays =
+      '2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25'
+
+    for (const path of [
+      'argocd/applications/torghut/ws/configmap.yaml',
+      'argocd/applications/torghut-options/ws/configmap.yaml',
+    ]) {
+      const config = parseManifest(path)
+      expect(getAtPath(config, ['data']).OPTIONS_MARKET_HOLIDAYS, path).toBe(expectedHolidays)
+    }
   })
 })

--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -1,6 +1,10 @@
+import { readFileSync } from 'node:fs'
+
 import { describe, expect, it } from 'bun:test'
 
-import { evaluateMarketDataSmoke, marketSessionState } from '../market-data-smoke'
+import { evaluateMarketDataSmoke, marketSessionState, selectLatestKafkaRecord } from '../market-data-smoke'
+
+const marketDataSmokeSource = readFileSync(new URL('../market-data-smoke.ts', import.meta.url), 'utf8')
 
 const freshWsReadyz = {
   market_data_channels: [
@@ -314,7 +318,40 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.ok).toBe(false)
     expect(result.failures.join('\n')).toContain('ta_flink_zero_source_records')
     expect(result.failures.join('\n')).toContain('ta_flink_zero_signal_records')
-    expect(result.summaryLines.join('\n')).toContain('source_read_records=`0`')
+    expect(result.summaryLines.join('\n')).toContain('source_write_records=`0`')
+  })
+
+  it('uses Flink source output counters when current-rate metrics are missing', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: freshWsReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: {
+        ...freshTaFlinkJob,
+        vertices: freshTaFlinkJob.vertices.map((vertex) =>
+          vertex.name.startsWith('Source: ta-')
+            ? {
+                ...vertex,
+                metrics: { 'read-records': 0, 'write-records': 5 },
+              }
+            : vertex,
+        ),
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.failures.join('\n')).not.toContain('ta_flink_zero_source_records')
+    expect(result.summaryLines.join('\n')).toContain('source_write_records=`15`')
   })
 
   it('uses Flink current-rate metrics over lifetime counters when detecting current stalls', () => {
@@ -364,5 +401,27 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.enforceFreshness).toBe(false)
     expect(result.ok).toBe(false)
     expect(result.failures.join('\n')).toContain('ta_flink_not_running')
+  })
+
+  it('selects the freshest Kafka record across sampled partitions', () => {
+    expect(
+      selectLatestKafkaRecord([
+        { topic: 'torghut.trades.v1', partition: 0, eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        { topic: 'torghut.trades.v1', partition: 1, eventTs: '2026-07-07T17:00:10Z', symbol: 'AMD' },
+        { topic: 'torghut.trades.v1', partition: 2, eventTs: 'invalid', symbol: 'AVGO' },
+      ]),
+    ).toMatchObject({
+      partition: 1,
+      eventTs: '2026-07-07T17:00:10Z',
+      symbol: 'AMD',
+    })
+  })
+
+  it('does not depend on execing into the distroless websocket container', () => {
+    expect(marketDataSmokeSource).not.toContain('TORGHUT_WS_EXEC_TARGET')
+    expect(marketDataSmokeSource).not.toContain('fetchJsonViaWsPod')
+    expect(marketDataSmokeSource).toContain('const wsReadyz = await fetchJson(settings.wsReadyzUrl)')
+    expect(marketDataSmokeSource).toContain('http://torghut-ws.torghut.svc.cluster.local/readyz')
+    expect(marketDataSmokeSource).toContain('KAFKA_TOPIC_PARTITIONS')
   })
 })

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -165,6 +165,71 @@ const baseReadyz = {
   },
 }
 
+const acceptedSourceStaleDigest = {
+  ...baseDigest,
+  blockers: [{ reason: 'accepted_ta_signal_stale' }, { reason: 'hypothesis_not_promotion_eligible' }],
+  capital: {
+    ...baseDigest.capital,
+    capital_stage: 'operational_blocked',
+    live_submission_reason: 'accepted_ta_signal_stale',
+  },
+  health: {
+    ...baseDigest.health,
+    readyz_status: 'ok',
+    readyz_ok: true,
+    dependency_failures: [
+      { name: 'live_submission_gate', detail: 'accepted_ta_signal_stale' },
+      { name: 'profitability_proof_floor', detail: 'repair_only' },
+    ],
+  },
+  repair_queue: [{ code: 'repair_accepted_ta_signal_stale', reason: 'accepted_ta_signal_stale' }],
+}
+
+const acceptedSourceStaleTradingStatus = {
+  ...baseTradingStatus,
+  live_submission_gate: {
+    ...baseTradingStatus.live_submission_gate,
+    allowed: false,
+    reason: 'accepted_ta_signal_stale',
+    blocked_reasons: ['accepted_ta_signal_stale'],
+    capital_stage: 'operational_blocked',
+    capital_state: 'blocked',
+    clickhouse_ta_freshness: {
+      accepted_sources: ['ta'],
+      latest_accepted_event_at: '2026-06-30T20:54:52Z',
+      accepted_lag_seconds: 615152,
+      accepted_max_lag_seconds: 120,
+      accepted_source_state: 'stale',
+      blocking_reason: 'accepted_ta_signal_stale',
+      excluded_fresher_sources: [
+        {
+          source: 'rest',
+          excluded_reason: 'source_not_allowed_for_live_runtime',
+          latest_signal_at: '2026-07-02T20:32:00Z',
+        },
+      ],
+    },
+    live_submit_activation: baseLiveSubmitActivation,
+  },
+  operational_submission_gate: {
+    allowed: false,
+    blocked_reasons: ['accepted_ta_signal_stale'],
+    reason: 'accepted_ta_signal_stale',
+  },
+  submission_authority: {
+    schema_version: 'torghut.submission-authority.v1',
+    authority_scope: 'none',
+    effective_submit_mode: 'blocked',
+    can_submit_now: false,
+    reason: 'accepted_ta_signal_stale',
+    operational_submission_gate: {
+      allowed: false,
+      blocked_reasons: ['accepted_ta_signal_stale'],
+      reason: 'accepted_ta_signal_stale',
+    },
+  },
+}
+
 const coreDependenciesOnlyReadyz = {
   status: 'degraded',
   reason_codes: ['alpaca_degraded'],
@@ -275,74 +340,30 @@ describe('validatePostDeployEvidence', () => {
     const result = validatePostDeployEvidence({
       readyzHttpStatus: '200',
       readyz: { status: 'ok' },
-      revenueRepairDigest: {
-        ...baseDigest,
-        blockers: [{ reason: 'accepted_ta_signal_stale' }, { reason: 'hypothesis_not_promotion_eligible' }],
-        capital: {
-          ...baseDigest.capital,
-          capital_stage: 'operational_blocked',
-          live_submission_reason: 'accepted_ta_signal_stale',
-        },
-        health: {
-          ...baseDigest.health,
-          readyz_status: 'ok',
-          readyz_ok: true,
-          dependency_failures: [
-            { name: 'live_submission_gate', detail: 'accepted_ta_signal_stale' },
-            { name: 'profitability_proof_floor', detail: 'repair_only' },
-          ],
-        },
-        repair_queue: [{ code: 'repair_accepted_ta_signal_stale', reason: 'accepted_ta_signal_stale' }],
-      },
-      tradingStatus: {
-        ...baseTradingStatus,
-        live_submission_gate: {
-          ...baseTradingStatus.live_submission_gate,
-          allowed: false,
-          reason: 'accepted_ta_signal_stale',
-          blocked_reasons: ['accepted_ta_signal_stale'],
-          capital_stage: 'operational_blocked',
-          capital_state: 'blocked',
-          clickhouse_ta_freshness: {
-            accepted_sources: ['ta'],
-            latest_accepted_event_at: '2026-06-30T20:54:52Z',
-            accepted_lag_seconds: 615152,
-            accepted_max_lag_seconds: 120,
-            accepted_source_state: 'stale',
-            blocking_reason: 'accepted_ta_signal_stale',
-            excluded_fresher_sources: [
-              {
-                source: 'rest',
-                excluded_reason: 'source_not_allowed_for_live_runtime',
-                latest_signal_at: '2026-07-02T20:32:00Z',
-              },
-            ],
-          },
-          live_submit_activation: baseLiveSubmitActivation,
-        },
-        operational_submission_gate: {
-          allowed: false,
-          blocked_reasons: ['accepted_ta_signal_stale'],
-          reason: 'accepted_ta_signal_stale',
-        },
-        submission_authority: {
-          schema_version: 'torghut.submission-authority.v1',
-          authority_scope: 'none',
-          effective_submit_mode: 'blocked',
-          can_submit_now: false,
-          reason: 'accepted_ta_signal_stale',
-          operational_submission_gate: {
-            allowed: false,
-            blocked_reasons: ['accepted_ta_signal_stale'],
-            reason: 'accepted_ta_signal_stale',
-          },
-        },
-      },
+      revenueRepairDigest: acceptedSourceStaleDigest,
+      tradingStatus: acceptedSourceStaleTradingStatus,
     })
 
     expect(result.readyzAcceptedReason).toBe('repair_only_zero_notional')
     expect(result.liveSubmitContract).toBe('accepted_source_stale_zero_notional')
     expect(result.summaryLines.join('\n')).toContain('Live submit contract: `accepted_source_stale_zero_notional`')
+  })
+
+  it('rejects accepted TA stale contract with malformed submission authority schema', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: acceptedSourceStaleDigest,
+        tradingStatus: {
+          ...acceptedSourceStaleTradingStatus,
+          submission_authority: {
+            ...acceptedSourceStaleTradingStatus.submission_authority,
+            schema_version: 'torghut.submission-authority.v0',
+          },
+        },
+      }),
+    ).toThrow('submission_authority.schema_version')
   })
 
   it('accepts 2xx readyz with operational submission ready but capital still zero-notional repair-only', () => {

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -77,6 +77,10 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('MARKET_DATA_FRESHNESS_MODE: auto')
     expect(workflow).toContain("MARKET_DATA_MAX_LAG_SECONDS: '300'")
     expect(workflow).toContain("MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS: '300'")
+    expect(workflow).toContain(
+      "MARKET_DATA_HOLIDAYS: '2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25'",
+    )
+    expect(workflow).toContain("KAFKA_TOPIC_PARTITIONS: '0,1,2'")
     expect(workflow).toContain('bun run smoke:torghut-market-data')
   })
 
@@ -186,15 +190,26 @@ describe('torghut post-deploy verifier workflow', () => {
 
   it('grants the ARC runner only the extra Kubernetes access needed for market-data smoke', () => {
     expect(agentsCiClusterRbac).toContain('agents-ci-runner-torghut-market-data-read')
-    expect(agentsCiClusterRbac).toContain('kind: ClusterRole')
-    expect(agentsCiClusterRbac).toContain('kind: ClusterRoleBinding')
+    expect(agentsCiClusterRbac).toContain('kind: Role')
+    expect(agentsCiClusterRbac).toContain('kind: RoleBinding')
+    expect(agentsCiClusterRbac).toContain('namespace: torghut')
     expect(agentsCiClusterRbac).toContain('resourceNames:\n      - torghut-ws')
     expect(agentsCiClusterRbac).toContain('resources:\n      - configmaps')
     expect(agentsCiClusterRbac).toContain('resourceNames:\n      - torghut-ta-config')
-    expect(agentsCiClusterRbac).toContain('agents-ci-runner-kafka-tail')
+    expect(agentsCiClusterRbac).toContain('resources:\n      - pods')
     expect(agentsCiClusterRbac).toContain('resources:\n      - pods/exec')
-    expect(agentsCiClusterRbac).not.toContain('namespace: torghut')
-    expect(agentsCiClusterRbac).not.toContain('namespace: kafka')
+    expect(agentsCiClusterRbac).toContain('agents-ci-runner-kafka-tail')
+    expect(agentsCiClusterRbac).toContain('namespace: kafka')
+    expect(agentsCiClusterRbac).not.toContain('kind: ClusterRole\nmetadata:\n  name: agents-ci-runner-kafka-tail')
+    expect(agentsCiClusterRbac).not.toContain(
+      'kind: ClusterRoleBinding\nmetadata:\n  name: agents-ci-runner-kafka-tail',
+    )
+    expect(agentsCiClusterRbac).not.toContain(
+      'kind: ClusterRole\nmetadata:\n  name: agents-ci-runner-torghut-market-data-read',
+    )
+    expect(agentsCiClusterRbac).not.toContain(
+      'kind: ClusterRoleBinding\nmetadata:\n  name: agents-ci-runner-torghut-market-data-read',
+    )
   })
 
   it('runs arm64 workflows with the kube-mode service account that receives post-deploy RBAC', () => {

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -12,6 +12,7 @@ type MarketSessionState = 'pre' | 'regular' | 'post' | 'closed' | 'weekend' | 'h
 
 type KafkaTopicRecord = {
   topic: string
+  partition?: number
   eventTs?: string
   channel?: string
   symbol?: string
@@ -91,6 +92,14 @@ const parsePositiveNumber = (raw: string | undefined, fallback: number, label: s
     fatal(`${label} must be a positive number`)
   }
   return parsed
+}
+
+const parsePartitions = (raw: string | undefined): number[] => {
+  const values = parseList(raw, ['0', '1', '2']).map((item) => Number(item))
+  if (values.length === 0 || values.some((value) => !Number.isInteger(value) || value < 0)) {
+    fatal('KAFKA_TOPIC_PARTITIONS must be a comma-separated list of non-negative integers')
+  }
+  return [...new Set(values)].sort((left, right) => left - right)
 }
 
 const parseMode = (raw: string | undefined): SmokeMode => {
@@ -265,10 +274,23 @@ const summarizeKafkaRole = (
   return {
     line:
       `- Kafka ${role}: latest=\`${latest}\`, lag_seconds=\`${lag}\`, ` +
-      `symbol=\`${record.symbol ?? 'unknown'}\`, topic=\`${record.topic}\``,
+      `symbol=\`${record.symbol ?? 'unknown'}\`, topic=\`${record.topic}\`, ` +
+      `partition=\`${record.partition ?? 'unknown'}\``,
     stale: lag > maxLagSeconds,
     detail: `${role} latest event lag ${lag}s exceeds ${maxLagSeconds}s`,
   }
+}
+
+export const selectLatestKafkaRecord = (records: KafkaTopicRecord[]): KafkaTopicRecord | undefined => {
+  let latest: KafkaTopicRecord | undefined
+  let latestTs = -1
+  for (const record of records) {
+    const ts = parseTimestampMs(record.eventTs)
+    if (ts === undefined || ts < latestTs) continue
+    latest = record
+    latestTs = ts
+  }
+  return latest
 }
 
 export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketDataSmokeResult => {
@@ -298,12 +320,12 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
   }
 
   const taFlinkJob = getTaFlinkJobSnapshot(input.taFlinkJob)
-  const sourceReadRecords = sumRecords(
+  const sourceWriteRecords = sumRecords(
     taFlinkJob.vertices,
     (vertex) => vertex.name.startsWith('Source: ta-'),
-    'readRecords',
+    'writeRecords',
   )
-  const sourceReadRate = sumOptionalRecords(
+  const sourceWriteRate = sumOptionalRecords(
     taFlinkJob.vertices,
     (vertex) => vertex.name.startsWith('Source: ta-'),
     'writeRecordsPerSecond',
@@ -341,9 +363,9 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
   const nonRunningVertices = taFlinkJob.vertices.filter((vertex) => vertex.status !== 'RUNNING')
   summaryLines.push(
     `- TA Flink: state=\`${taFlinkJob.state}\`, job_id=\`${taFlinkJob.jobId}\`, ` +
-      `source_read_records=\`${sourceReadRecords}\`, microbar_records=\`${microbarRecords}\`, ` +
+      `source_write_records=\`${sourceWriteRecords}\`, microbar_records=\`${microbarRecords}\`, ` +
       `signal_records=\`${signalRecords}\`, status_records=\`${statusRecords}\`, ` +
-      `source_records_per_second=\`${sourceReadRate ?? 'missing'}\`, ` +
+      `source_records_per_second=\`${sourceWriteRate ?? 'missing'}\`, ` +
       `signal_records_per_second=\`${signalRate ?? 'missing'}\``,
   )
   if (taFlinkJob.state !== 'RUNNING') {
@@ -357,13 +379,13 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
       `ta_flink_vertices_not_running: ${nonRunningVertices.map((vertex) => `${vertex.name}=${vertex.status}`).join(', ')}`,
     )
   }
-  if ((sourceReadRate ?? sourceReadRecords) <= 0) {
+  if ((sourceWriteRate ?? sourceWriteRecords) <= 0) {
     pushFinding(
       enforceFreshness,
       failures,
       warnings,
       'ta_flink_zero_source_records',
-      'TA Flink source vertices report zero current records',
+      'TA Flink source vertices report zero current output records',
     )
   }
   if ((microbarRate ?? microbarRecords) <= 0) {
@@ -524,11 +546,13 @@ const execCapture = async (
   return stdout
 }
 
-const tailArgs = (topic: string, format: 'summary' | 'json', settings: RuntimeSettings) => [
+const tailArgs = (topic: string, format: 'summary' | 'json', settings: RuntimeSettings, partition: number) => [
   'run',
   'packages/scripts/src/kafka/tail-topic.ts',
   '--topic',
   topic,
+  '--partition',
+  String(partition),
   '--tail',
   settings.tail,
   '--timeout-ms',
@@ -550,24 +574,26 @@ const captureLatestKafkaRecord = async (
   topic: string,
   settings: RuntimeSettings,
 ): Promise<KafkaTopicRecord | undefined> => {
-  const stdout = await execCapture('bun', tailArgs(topic, 'json', settings), { cwd: repoRoot })
-  const parsed = JSON.parse(stdout) as unknown
-  if (!Array.isArray(parsed)) {
-    fatal(`Kafka tail for ${topic} did not return a JSON array`)
-  }
-  const records = parsed.filter(isObject)
-  for (let index = records.length - 1; index >= 0; index -= 1) {
-    const record = records[index]
-    const eventTs = asString(record.eventTs)
-    if (!eventTs) continue
-    return {
-      topic,
-      eventTs,
-      channel: asString(record.channel) ?? role,
-      symbol: asString(record.symbol),
+  const records: KafkaTopicRecord[] = []
+  for (const partition of settings.kafkaPartitions) {
+    const stdout = await execCapture('bun', tailArgs(topic, 'json', settings, partition), { cwd: repoRoot })
+    const parsed = JSON.parse(stdout) as unknown
+    if (!Array.isArray(parsed)) {
+      fatal(`Kafka tail for ${topic} partition ${partition} did not return a JSON array`)
+    }
+    for (const record of parsed.filter(isObject)) {
+      const eventTs = asString(record.eventTs)
+      if (!eventTs) continue
+      records.push({
+        topic,
+        partition,
+        eventTs,
+        channel: asString(record.channel) ?? role,
+        symbol: asString(record.symbol),
+      })
     }
   }
-  return undefined
+  return selectLatestKafkaRecord(records)
 }
 
 const fetchJsonViaPod = async (target: string, url: string, settings: RuntimeSettings): Promise<unknown> => {
@@ -584,8 +610,13 @@ const fetchJsonViaPod = async (target: string, url: string, settings: RuntimeSet
   return JSON.parse(stdout) as unknown
 }
 
-const fetchJsonViaWsPod = async (url: string, settings: RuntimeSettings): Promise<unknown> =>
-  fetchJsonViaPod(settings.wsExecTarget, url, settings)
+const fetchJson = async (url: string): Promise<unknown> => {
+  const response = await fetch(url)
+  if (!response.ok) {
+    fatal(`GET ${url} failed with HTTP ${response.status}`)
+  }
+  return (await response.json()) as unknown
+}
 
 type RuntimeSettings = {
   topics: string[]
@@ -595,6 +626,7 @@ type RuntimeSettings = {
   passwordSecretName: string
   passwordSecretKey: string
   tail: string
+  kafkaPartitions: number[]
   timeoutMs: string
   mode: SmokeMode
   maxKafkaLagSeconds: number
@@ -603,7 +635,6 @@ type RuntimeSettings = {
   now: Date
   printSummaries: boolean
   torghutNamespace: string
-  wsExecTarget: string
   wsReadyzUrl: string
   tradingStatusUrl: string
   taConfigMapName: string
@@ -623,6 +654,7 @@ const runtimeSettings = (): RuntimeSettings => ({
   passwordSecretName: process.env.KAFKA_PASSWORD_SECRET_NAME ?? 'torghut-ws',
   passwordSecretKey: process.env.KAFKA_PASSWORD_SECRET_KEY ?? 'password',
   tail: process.env.TAIL ?? '1',
+  kafkaPartitions: parsePartitions(process.env.KAFKA_TOPIC_PARTITIONS),
   timeoutMs: process.env.TIMEOUT_MS ?? '8000',
   mode: parseMode(process.env.MARKET_DATA_FRESHNESS_MODE),
   maxKafkaLagSeconds: parsePositiveNumber(process.env.MARKET_DATA_MAX_LAG_SECONDS, 300, 'MARKET_DATA_MAX_LAG_SECONDS'),
@@ -635,8 +667,7 @@ const runtimeSettings = (): RuntimeSettings => ({
   now: process.env.MARKET_DATA_NOW ? new Date(process.env.MARKET_DATA_NOW) : new Date(),
   printSummaries: process.env.MARKET_DATA_PRINT_SUMMARIES !== 'false',
   torghutNamespace: process.env.TORGHUT_NAMESPACE ?? 'torghut',
-  wsExecTarget: process.env.TORGHUT_WS_EXEC_TARGET ?? 'deploy/torghut-ws',
-  wsReadyzUrl: process.env.TORGHUT_WS_READYZ_URL ?? 'http://127.0.0.1:8080/readyz',
+  wsReadyzUrl: process.env.TORGHUT_WS_READYZ_URL ?? 'http://torghut-ws.torghut.svc.cluster.local/readyz',
   tradingStatusUrl: process.env.TORGHUT_STATUS_URL ?? 'http://torghut.torghut.svc.cluster.local/trading/status',
   taConfigMapName: process.env.TORGHUT_TA_CONFIGMAP ?? 'torghut-ta-config',
   taFlinkExecTarget: process.env.TORGHUT_TA_FLINK_EXEC_TARGET ?? 'deploy/torghut-ta',
@@ -751,7 +782,7 @@ const main = async () => {
 
   if (settings.printSummaries) {
     for (const topic of settings.topics) {
-      await run('bun', tailArgs(topic, 'summary', settings), { cwd: repoRoot })
+      await run('bun', tailArgs(topic, 'summary', settings, 0), { cwd: repoRoot })
     }
   }
 
@@ -760,8 +791,8 @@ const main = async () => {
     latestKafkaByRole[role] = await captureLatestKafkaRecord(role, settings.topicByRole[role], settings)
   }
 
-  const wsReadyz = await fetchJsonViaWsPod(settings.wsReadyzUrl, settings)
-  const tradingStatus = await fetchJsonViaWsPod(settings.tradingStatusUrl, settings)
+  const wsReadyz = await fetchJson(settings.wsReadyzUrl)
+  const tradingStatus = await fetchJson(settings.tradingStatusUrl)
   const taRuntimeConfig = await fetchConfigMapData(settings.torghutNamespace, settings.taConfigMapName)
   const taFlinkJob = await fetchTaFlinkJob(settings)
   const result = evaluateMarketDataSmoke({

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -559,6 +559,11 @@ const assertAcceptedSourceStaleZeroNotionalContract = (status: JsonObject, diges
     ACCEPTED_SOURCE_STALE_REASON,
     'torghut operational_submission_gate.blocked_reasons',
   )
+  requireScalarValue(
+    submissionAuthority.schema_version,
+    'torghut.submission-authority.v1',
+    'torghut submission_authority.schema_version',
+  )
   requireScalarValue(submissionAuthority.authority_scope, 'none', 'torghut submission_authority.authority_scope')
   requireScalarValue(
     submissionAuthority.effective_submit_mode,

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
@@ -76,8 +76,8 @@ internal object ReadinessClassifier {
     if (ready) return null
     return when {
       !gates.alpacaWs -> alpacaErrorClass ?: ReadinessErrorClass.Unknown
-      !gates.marketDataChannels -> marketDataChannelErrorClass ?: ReadinessErrorClass.MarketDataChannelStarvation
       !gates.kafka -> kafkaErrorClass ?: ReadinessErrorClass.Unknown
+      !gates.marketDataChannels -> marketDataChannelErrorClass ?: ReadinessErrorClass.MarketDataChannelStarvation
       !gates.tradeUpdates -> tradeUpdatesErrorClass ?: ReadinessErrorClass.Unknown
       else -> fallbackErrorClass ?: ReadinessErrorClass.Unknown
     }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
@@ -146,6 +146,29 @@ class ReadinessClassifierTest {
   }
 
   @Test
+  fun `readiness error reports kafka before derived market data starvation`() {
+    val gates =
+      ReadinessGates(
+        alpacaWs = true,
+        kafka = false,
+        tradeUpdates = true,
+        marketDataChannels = false,
+      )
+    assertEquals(
+      ReadinessErrorClass.KafkaAuth,
+      ReadinessClassifier.readinessErrorClassForGates(
+        ready = false,
+        gates = gates,
+        alpacaErrorClass = null,
+        kafkaErrorClass = ReadinessErrorClass.KafkaAuth,
+        tradeUpdatesErrorClass = null,
+        fallbackErrorClass = ReadinessErrorClass.Unknown,
+        marketDataChannelErrorClass = ReadinessErrorClass.MarketDataChannelStarvation,
+      ),
+    )
+  }
+
+  @Test
   fun `readiness error uses trade updates class when trade gate is false`() {
     val gates =
       ReadinessGates(

--- a/services/torghut/app/trading/submission_council/quant_health.py
+++ b/services/torghut/app/trading/submission_council/quant_health.py
@@ -202,7 +202,7 @@ def runtime_window_import_continuity_signal(
     clickhouse_ta_status: Mapping[str, Any] | None = None,
 ) -> tuple[str, str, str]:
     persisted_signal = fresh_clickhouse_signal_continuity(clickhouse_ta_status)
-    if persisted_signal is not None and persisted_signal[0] == "true":
+    if persisted_signal is not None:
         return persisted_signal
 
     state_text = _safe_attr_text(state, "last_signal_continuity_state")
@@ -226,8 +226,6 @@ def runtime_window_import_continuity_signal(
         return "true", "signal_continuity", state_text
     if actionable is False and state_text:
         return "true", "signal_continuity", state_text
-    if persisted_signal is not None:
-        return persisted_signal
     return "false", "missing", "signal_continuity_missing"
 
 

--- a/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from app.trading.submission_council.quant_health import (
+    runtime_window_import_continuity_signal,
+)
 from tests.submission_council.support import (
     SimpleNamespace,
     SubmissionCouncilTestCase,
@@ -65,4 +68,25 @@ class TestLiveSubmissionGateClickHouseFreshness(SubmissionCouncilTestCase):
         self.assertEqual(
             result["clickhouse_ta_freshness"]["accepted_source_state"],
             "stale",
+        )
+
+    def test_clickhouse_stale_status_overrides_cached_runtime_ready_state(self) -> None:
+        result = runtime_window_import_continuity_signal(
+            SimpleNamespace(
+                last_signal_continuity_state="signals_present",
+                last_signal_continuity_reason="signals_present",
+                last_signal_continuity_actionable=False,
+                signal_continuity_alert_active=False,
+            ),
+            clickhouse_ta_status={
+                "state": "current",
+                "latest_signal_at": datetime.now(timezone.utc).isoformat(),
+                "accepted_source_state": "stale",
+                "blocking_reason": None,
+            },
+        )
+
+        self.assertEqual(
+            result,
+            ("false", "clickhouse_ta_status", "accepted_ta_signal_stale"),
         )


### PR DESCRIPTION
## Summary

- Addresses actionable unresolved review feedback from Torghut PRs merged today, including #12074, #12076, #12078, #12083, #12087, #12088, #12091, #12092, #12093, #12095, and #12097.
- Narrows the ARC runner smoke permissions to namespace-scoped Roles for Torghut secret/configmap reads and Kafka pod exec, and removes the agents-ci namespace transformer that would corrupt cross-namespace RBAC.
- Protects the CNPG-managed `torghut-db-ca` secret with a skipped no-prune tombstone while keeping runtime CA reflection patching intact.
- Hardens post-deploy market-data proof by sampling required Kafka topics across partitions, using cluster HTTP instead of websocket pod exec, requiring submission-authority schema evidence, and configuring maintained 2026 US market holidays.
- Preserves fail-closed runtime behavior by making persisted ClickHouse stale signals override cached ready state, reporting Kafka outages before derived market-data starvation, and using TA Flink source output counters for missing-rate fallbacks.

## Related Issues

Review follow-up for:

- #12074 review comments r3540200857 and r3540253121
- #12076 review comment r3540308940
- #12078 review comment r3540362606
- #12083 review comment r3540539354
- #12087 review comments r3540566801, r3540566804, and r3540566808
- #12088 review comment r3540571516
- #12091 review comment r3540610033
- #12092 review comments r3540615956 and r3540615957
- #12093 review comment r3540656973
- #12095 review comment r3540689627
- #12097 review comment r3540748541
- #12096 review comments r3540769848 and r3540809930

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run --filter @proompteng/scripts lint` passed with three pre-existing warnings in unrelated files.
- `bun run lint:argocd`
- `git diff --check`
- `cd services/torghut && uv run --frozen pytest tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council/quant_health.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council/quant_health.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/dorvud && ./gradlew :websockets:build`
- `kustomize build argocd/applications/agents-ci` confirmed namespace-scoped smoke Roles for `torghut` and `kafka`.
- `@codex review` posted on #12096 and the returned holiday-calendar and torghut TA exec RBAC findings were addressed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
