### PR TITLE
chore(torghut): promote image sha-3bb79292a54325dd55285ae0e1cc11589dc955d5

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -52,7 +52,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: ee8e4610ef674e74e020f44e8a4a3c18db5f6ae3
+              value: 3bb79292a54325dd55285ae0e1cc11589dc955d5
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: ee8e4610ef674e74e020f44e8a4a3c18db5f6ae3
+              value: 3bb79292a54325dd55285ae0e1cc11589dc955d5
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T01:40:09Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T02:06:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -539,9 +539,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1578-gee8e4610e
+              value: v0.596.0-1581-g3bb79292a
             - name: TORGHUT_COMMIT
-              value: ee8e4610ef674e74e020f44e8a4a3c18db5f6ae3
+              value: 3bb79292a54325dd55285ae0e1cc11589dc955d5
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T01:40:09Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T02:06:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -418,9 +418,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1578-gee8e4610e
+              value: v0.596.0-1581-g3bb79292a
             - name: TORGHUT_COMMIT
-              value: ee8e4610ef674e74e020f44e8a4a3c18db5f6ae3
+              value: 3bb79292a54325dd55285ae0e1cc11589dc955d5
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `3bb79292a54325dd55285ae0e1cc11589dc955d5`
- Image tag: `sha-3bb79292a54325dd55285ae0e1cc11589dc955d5`
- Image digest: `sha256:302c0aac25b8464cb3f2bb5e1c5c3f8887891575234d96472a585495be8ccd81`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher