### PR TITLE
chore(torghut): promote ws image sha-88789b6737f3a9ed6c99f6598f3732f9b5aa30f7

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:60e01c593170d71f77f963d10813e361443e2267de2d939cfbea9e52de2d84ae
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c63ee746755e351894ce07f360f16ae920fac80854f638e27a9e73be83fa640d
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-cccd20ac7535c8469b7829b46054a71a516ae7d9
+              value: main-sha-88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
             - name: TORGHUT_WS_COMMIT
-              value: cccd20ac7535c8469b7829b46054a71a516ae7d9
+              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:60e01c593170d71f77f963d10813e361443e2267de2d939cfbea9e52de2d84ae
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c63ee746755e351894ce07f360f16ae920fac80854f638e27a9e73be83fa640d
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-cccd20ac7535c8469b7829b46054a71a516ae7d9
+              value: main-sha-88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
             - name: TORGHUT_WS_COMMIT
-              value: cccd20ac7535c8469b7829b46054a71a516ae7d9
+              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `88789b6737f3a9ed6c99f6598f3732f9b5aa30f7`
- Image tag: `sha-88789b6737f3a9ed6c99f6598f3732f9b5aa30f7`
- Image digest: `sha256:c63ee746755e351894ce07f360f16ae920fac80854f638e27a9e73be83fa640d`