### PR TITLE
fix(torghut): tolerate finished bounded flink source

### DIFF
--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -377,6 +377,41 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.summaryLines.join('\n')).toContain('source_records_per_second=`0`')
   })
 
+  it('allows a finished bounded collection source inside a running Flink job after market close', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-08T02:47:00Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 120,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T20:54:01Z', symbol: 'SNDK' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T20:53:01Z', symbol: 'MU' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T20:13:00Z', symbol: 'SNDK' },
+      },
+      wsReadyz: staleWsReadyz,
+      tradingStatus: tradingStatusWithStaleAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: {
+        ...freshTaFlinkJob,
+        vertices: [
+          {
+            name: 'Source: Collection Source',
+            status: 'FINISHED',
+            metrics: { 'read-records': 1, 'write-records': 1 },
+          },
+          ...freshTaFlinkJob.vertices,
+        ],
+      },
+    })
+
+    expect(result.sessionState).toBe('closed')
+    expect(result.enforceFreshness).toBe(false)
+    expect(result.ok).toBe(true)
+    expect(result.failures.join('\n')).not.toContain('ta_flink_vertices_not_running')
+    expect(result.warnings.join('\n')).toContain('accepted_ta_signal_stale')
+  })
+
   it('fails regardless of market session when the Flink job is not running', () => {
     const result = evaluateMarketDataSmoke({
       now: new Date('2026-07-07T22:00:00Z'),

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -256,6 +256,9 @@ const sumOptionalRecords = (
   return matching.reduce((total, value) => total + value, 0)
 }
 
+const isFinishedBoundedCollectionSource = (vertex: TaFlinkVertexSnapshot): boolean =>
+  vertex.status === 'FINISHED' && vertex.name === 'Source: Collection Source'
+
 const summarizeKafkaRole = (
   now: Date,
   role: KafkaRole,
@@ -360,7 +363,9 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
     (vertex) => vertex.name.includes('ta-status') || vertex.name.includes('sink-status'),
     'readRecordsPerSecond',
   )
-  const nonRunningVertices = taFlinkJob.vertices.filter((vertex) => vertex.status !== 'RUNNING')
+  const nonRunningVertices = taFlinkJob.vertices.filter(
+    (vertex) => vertex.status !== 'RUNNING' && !isFinishedBoundedCollectionSource(vertex),
+  )
   summaryLines.push(
     `- TA Flink: state=\`${taFlinkJob.state}\`, job_id=\`${taFlinkJob.jobId}\`, ` +
       `source_write_records=\`${sourceWriteRecords}\`, microbar_records=\`${microbarRecords}\`, ` +


### PR DESCRIPTION
## Summary

- Fixes the post-deploy market-data smoke failure from `torghut-post-deploy-verify` on commit `f812087b`.
- Treats `Source: Collection Source=FINISHED` as a tolerated bounded setup/source vertex inside an otherwise running TA Flink job.
- Keeps hard failures for a non-running Flink job and keeps current-rate/source-output freshness warnings or failures unchanged.
- Adds a regression test using the closed-market failure shape from the live verifier logs.

## Related Issues

Follow-up for #12096 rollout verification failure: `torghut-post-deploy-verify` run `28913662291`.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run --filter @proompteng/scripts lint` passed with three pre-existing warnings in unrelated files.
- `git diff --check`
- Attempted live local `bun run smoke:torghut-market-data`; it could not resolve in-cluster service DNS from the local worktree, which is expected outside the ARC runner path.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
