### PR TITLE
fix(torghut): allow bounded ta startup smoke vertex

### DIFF
--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -354,6 +354,65 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.summaryLines.join('\n')).toContain('source_write_records=`15`')
   })
 
+  it('allows the bounded startup heartbeat source to finish after emitting', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: freshWsReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: {
+        ...freshTaFlinkJob,
+        vertices: [
+          ...freshTaFlinkJob.vertices,
+          {
+            name: 'Source: Collection Source',
+            status: 'FINISHED',
+            metrics: { 'read-records': 0, 'write-records': 1 },
+          },
+        ],
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.failures.join('\n')).not.toContain('ta_flink_vertices_not_running')
+  })
+
+  it('still fails unexpected finished Flink vertices', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: freshWsReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: {
+        ...freshTaFlinkJob,
+        vertices: freshTaFlinkJob.vertices.map((vertex) =>
+          vertex.name.startsWith('Source: ta-trades-source') ? { ...vertex, status: 'FINISHED' } : vertex,
+        ),
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures.join('\n')).toContain('ta_flink_vertices_not_running')
+  })
+
   it('uses Flink current-rate metrics over lifetime counters when detecting current stalls', () => {
     const result = evaluateMarketDataSmoke({
       now: new Date('2026-07-07T17:00:30Z'),

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -256,6 +256,9 @@ const sumOptionalRecords = (
   return matching.reduce((total, value) => total + value, 0)
 }
 
+const isExpectedFinishedTaFlinkVertex = (vertex: TaFlinkVertexSnapshot): boolean =>
+  vertex.name === 'Source: Collection Source' && vertex.status === 'FINISHED' && vertex.writeRecords > 0
+
 const summarizeKafkaRole = (
   now: Date,
   role: KafkaRole,
@@ -360,7 +363,9 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
     (vertex) => vertex.name.includes('ta-status') || vertex.name.includes('sink-status'),
     'readRecordsPerSecond',
   )
-  const nonRunningVertices = taFlinkJob.vertices.filter((vertex) => vertex.status !== 'RUNNING')
+  const nonRunningVertices = taFlinkJob.vertices.filter(
+    (vertex) => vertex.status !== 'RUNNING' && !isExpectedFinishedTaFlinkVertex(vertex),
+  )
   summaryLines.push(
     `- TA Flink: state=\`${taFlinkJob.state}\`, job_id=\`${taFlinkJob.jobId}\`, ` +
       `source_write_records=\`${sourceWriteRecords}\`, microbar_records=\`${microbarRecords}\`, ` +


### PR DESCRIPTION
## Summary

- Allow the Torghut market-data smoke verifier to treat the bounded TA startup heartbeat source as expected when it finishes after emitting a record.
- Keep unexpected non-running Flink vertices fatal, including finished long-running source vertices.
- Add regression coverage for the live Flink graph shape seen after the TA heartbeat rollout.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/market-data-smoke.ts packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/torghut/market-data-smoke.ts packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bun run --cwd packages/scripts lint` (passes with pre-existing warnings outside touched files)
- `TORGHUT_WS_READYZ_URL=http://127.0.0.1:19081/readyz TORGHUT_STATUS_URL=http://127.0.0.1:19080/trading/status MARKET_DATA_PRINT_SUMMARIES=false MARKET_DATA_FRESHNESS_MODE=observe TIMEOUT_MS=10000 bun run smoke:torghut-market-data`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
