### PR TITLE
chore(torghut): promote image sha-6a10312c7204319e73bfe7fff9095df0148b336d

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -52,7 +52,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: 6a10312c7204319e73bfe7fff9095df0148b336d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b5b68a06cfbc8b14ea8eb55406aecdcf31c971e1cd8ad1fc2585f8fcb1580c7a
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: 6a10312c7204319e73bfe7fff9095df0148b336d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b5b68a06cfbc8b14ea8eb55406aecdcf31c971e1cd8ad1fc2585f8fcb1580c7a
             - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T02:38:39Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T03:09:13Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -539,9 +539,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1584-g88789b673
+              value: v0.596.0-1588-g6a10312c7
             - name: TORGHUT_COMMIT
-              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: 6a10312c7204319e73bfe7fff9095df0148b336d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b5b68a06cfbc8b14ea8eb55406aecdcf31c971e1cd8ad1fc2585f8fcb1580c7a
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T02:38:39Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T03:09:13Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -418,9 +418,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1584-g88789b673
+              value: v0.596.0-1588-g6a10312c7
             - name: TORGHUT_COMMIT
-              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: 6a10312c7204319e73bfe7fff9095df0148b336d
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:b5b68a06cfbc8b14ea8eb55406aecdcf31c971e1cd8ad1fc2585f8fcb1580c7a
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `6a10312c7204319e73bfe7fff9095df0148b336d`
- Image tag: `sha-6a10312c7204319e73bfe7fff9095df0148b336d`
- Image digest: `sha256:b5b68a06cfbc8b14ea8eb55406aecdcf31c971e1cd8ad1fc2585f8fcb1580c7a`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher