### PR TITLE
docs(rook-ceph): harden RBD nodeplugin inventory

### DIFF
--- a/docs/runbooks/rook-ceph-client-ops-performance.md
+++ b/docs/runbooks/rook-ceph-client-ops-performance.md
@@ -559,7 +559,9 @@ too old. Ceph's read-primary balancer uses `pg-upmap-primary`, and current Ceph 
 not support those mappings. For this cluster, enabling `upmap-read` while the default `rook-ceph-block` class is
 used by production KRBD mounts can hang or break RBD IO. Do not force `set-require-min-compat-client reef`.
 
-Inventory commands:
+Inventory commands. Select RBD nodeplugin pods by their `app` label and verify the `csi-rbdplugin` container exists before
+running `rbd showmapped`; this avoids silently skipping KRBD inventory when pod names differ across Ceph-CSI/Rook
+deployments.
 
 ```bash
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph features
@@ -568,9 +570,21 @@ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph tell mon.e sessions --f
   jq -r '.[] | select(.entity_name=="client.csi-rbd-node") |
     [.global_id, .con_features_release, .socket_addr.addr, (.remote_host // "-")] | @tsv'
 
-kubectl -n rook-ceph get pods -o wide | rg 'rook-ceph\.rbd\.csi\.ceph\.com-nodeplugin'
+RBD_NODEPLUGIN_SELECTOR='app in (rook-ceph.rbd.csi.ceph.com-nodeplugin,csi-rbdplugin)'
 
-for pod in $(kubectl -n rook-ceph get pods -o name | rg 'rook-ceph\.rbd\.csi\.ceph\.com-nodeplugin'); do
+kubectl -n rook-ceph get pods -l "${RBD_NODEPLUGIN_SELECTOR}" -o wide
+
+rbd_nodeplugins="$(kubectl -n rook-ceph get pods -l "${RBD_NODEPLUGIN_SELECTOR}" -o json | \
+  jq -r '.items[] |
+    select(any(.spec.containers[]?; .name=="csi-rbdplugin")) |
+    "pod/" + .metadata.name')"
+
+if [ -z "${rbd_nodeplugins}" ]; then
+  echo "No RBD CSI nodeplugin pods found with selector: ${RBD_NODEPLUGIN_SELECTOR}" >&2
+  exit 1
+fi
+
+for pod in ${rbd_nodeplugins}; do
   node="$(kubectl -n rook-ceph get "$pod" -o jsonpath='{.spec.nodeName}')"
   count="$(kubectl -n rook-ceph exec "${pod#pod/}" -c csi-rbdplugin -- rbd showmapped --format json | jq length)"
   printf '%s\t%s\t%s\n' "$node" "$pod" "$count"

--- a/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+
+it('selects RBD CSI nodeplugin pods by label without silently skipping mapped KRBD checks', () => {
+  const runbook = readFileSync(join(repoRoot, 'docs/runbooks/rook-ceph-client-ops-performance.md'), 'utf8')
+
+  expect(runbook).toContain("RBD_NODEPLUGIN_SELECTOR='app in (rook-ceph.rbd.csi.ceph.com-nodeplugin,csi-rbdplugin)'")
+  expect(runbook).toContain('select(any(.spec.containers[]?; .name=="csi-rbdplugin"))')
+  expect(runbook).toContain('No RBD CSI nodeplugin pods found with selector')
+  expect(runbook).toContain('-c csi-rbdplugin -- rbd showmapped --format json')
+  expect(runbook).not.toContain("rg 'rook-ceph\\.rbd\\.csi\\.ceph\\.com-nodeplugin'")
+})


### PR DESCRIPTION
## Summary

- Select RBD CSI nodeplugin pods with supported `app` labels instead of matching generated pod names.
- Verify candidates contain the `csi-rbdplugin` container and fail loudly when no nodeplugin pods are found before inventorying mapped KRBD devices.
- Add a Bun regression test that prevents the runbook from drifting back to brittle pod-name matching.

## Related Issues

None. This is a follow-up to review feedback on #12073.

## Testing

- `bun test packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check origin/main...HEAD`
- Live `rook-ceph` validation selected all three RBD nodeplugin pods and returned mapped-device counts of 31, 42, and 7 from their `csi-rbdplugin` containers.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
