### PR TITLE
fix(torghut): make TA freshness session aware

### DIFF
--- a/services/torghut/app/config/service_fields.py
+++ b/services/torghut/app/config/service_fields.py
@@ -581,7 +581,7 @@ class CoreSettingsFields(BaseSettings):
     )
 
     trading_feature_max_staleness_ms: int = Field(
-        default=120000,
+        default=300000,
         alias="TRADING_FEATURE_MAX_STALENESS_MS",
         description="Maximum allowed p95 feature staleness in milliseconds per batch.",
     )

--- a/services/torghut/app/trading/ingest/clickhouse_signal_source_freshness.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_source_freshness.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TypeAlias
+from zoneinfo import ZoneInfo
 
 from ..clickhouse import to_datetime64
 from .clickhouse_signal_ingestor_market_support import (
@@ -21,8 +22,13 @@ ColumnResolver: TypeAlias = Callable[[], set[str] | None]
 SourceWhereClause: TypeAlias = Callable[[], str | None]
 
 _DIAGNOSTIC_EXCEPTIONS = (RuntimeError, OSError, ValueError, TypeError)
+_EASTERN_TZ = ZoneInfo("America/New_York")
 
 logger = logging.getLogger("app.trading.ingest")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 @dataclass(frozen=True)
@@ -35,6 +41,14 @@ class ClickHouseSignalFreshnessContext:
     query_clickhouse: ClickHouseQuery
     resolve_columns: ColumnResolver
     source_where_clause: SourceWhereClause
+    now: Callable[[], datetime] = _utc_now
+
+
+@dataclass(frozen=True)
+class _AcceptedSourceFreshnessGate:
+    state: str
+    blocking_reason: str | None
+    reason_codes: tuple[str, ...] = ()
 
 
 def build_accepted_source_freshness_contract(
@@ -43,12 +57,18 @@ def build_accepted_source_freshness_contract(
     time_column: str,
     latest_signal_at: datetime,
 ) -> dict[str, object]:
-    now = datetime.now(timezone.utc)
+    now = context.now().astimezone(timezone.utc)
     max_age_seconds = max(1, int(context.max_staleness_ms) // 1000)
     accepted_lag_seconds = max(0, int((now - latest_signal_at).total_seconds()))
     accepted_sources = accepted_signal_sources(context.allowed_sources_raw)
-    stale = accepted_lag_seconds > max_age_seconds and not context.simulation_mode
-    reason_codes: list[str] = []
+    market_session = regular_market_session_state(now)
+    freshness_gate = _accepted_source_freshness_gate(
+        lag_seconds=accepted_lag_seconds,
+        max_age_seconds=max_age_seconds,
+        regular_session_open=market_session["regular_session_open"] is True,
+        simulation_mode=context.simulation_mode,
+    )
+    reason_codes = list(freshness_gate.reason_codes)
     excluded_fresher_sources: list[dict[str, object]] = []
     per_symbol_coverage: list[dict[str, object]] = []
     try:
@@ -77,13 +97,54 @@ def build_accepted_source_freshness_contract(
         "latest_accepted_event_at": latest_signal_at,
         "accepted_lag_seconds": accepted_lag_seconds,
         "accepted_max_lag_seconds": max_age_seconds,
-        "accepted_source_state": "stale" if stale else "current",
-        "blocking_reason": "accepted_ta_signal_stale" if stale else None,
+        "accepted_source_state": freshness_gate.state,
+        "blocking_reason": freshness_gate.blocking_reason,
         "fresh_until": latest_signal_at + timedelta(seconds=max_age_seconds),
         "excluded_fresher_sources": excluded_fresher_sources,
         "per_symbol_coverage": per_symbol_coverage,
-        "market_session_state": "not_evaluated",
+        **market_session,
         "freshness_reason_codes": reason_codes,
+    }
+
+
+def _accepted_source_freshness_gate(
+    *,
+    lag_seconds: int,
+    max_age_seconds: int,
+    regular_session_open: bool,
+    simulation_mode: bool,
+) -> _AcceptedSourceFreshnessGate:
+    if lag_seconds <= max_age_seconds or simulation_mode:
+        return _AcceptedSourceFreshnessGate(state="current", blocking_reason=None)
+    if regular_session_open:
+        return _AcceptedSourceFreshnessGate(
+            state="stale",
+            blocking_reason="accepted_ta_signal_stale",
+        )
+    return _AcceptedSourceFreshnessGate(
+        state="outside_regular_session",
+        blocking_reason=None,
+        reason_codes=("accepted_ta_signal_outside_regular_session",),
+    )
+
+
+def regular_market_session_state(now: datetime) -> dict[str, object]:
+    current = now.astimezone(_EASTERN_TZ)
+    session_open = current.replace(hour=9, minute=30, second=0, microsecond=0)
+    session_close = current.replace(hour=16, minute=0, second=0, microsecond=0)
+    if current.weekday() >= 5:
+        state = "weekend_closed"
+    elif current < session_open:
+        state = "pre_market"
+    elif current < session_close:
+        state = "regular_open"
+    else:
+        state = "after_market_close"
+    return {
+        "market_session_state": state,
+        "regular_session_open": state == "regular_open",
+        "regular_session_open_at": session_open.astimezone(timezone.utc),
+        "regular_session_close_at": session_close.astimezone(timezone.utc),
     }
 
 
@@ -240,4 +301,5 @@ __all__ = [
     "ClickHouseSignalFreshnessContext",
     "excluded_fresher_sources_after_accepted_latest",
     "latest_signal_readiness_counts",
+    "regular_market_session_state",
 ]

--- a/services/torghut/app/trading/submission_council/quant_health.py
+++ b/services/torghut/app/trading/submission_council/quant_health.py
@@ -174,6 +174,12 @@ def fresh_clickhouse_signal_continuity(
     )
     if accepted_source_state == "stale":
         return "false", "clickhouse_ta_status", "accepted_ta_signal_stale"
+    if accepted_source_state == "outside_regular_session":
+        market_session_state = _safe_text(
+            clickhouse_ta_status.get("market_session_state")
+        )
+        reason = market_session_state or "outside_regular_session"
+        return "true", "clickhouse_ta_status", f"accepted_ta_signal_{reason}"
     state = _safe_text(clickhouse_ta_status.get("state"))
     latest_signal_at = _coerce_aware_datetime(
         clickhouse_ta_status.get("latest_signal_at")

--- a/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
@@ -90,3 +90,31 @@ class TestLiveSubmissionGateClickHouseFreshness(SubmissionCouncilTestCase):
             result,
             ("false", "clickhouse_ta_status", "accepted_ta_signal_stale"),
         )
+
+    def test_clickhouse_after_hours_accepted_lag_does_not_emit_stale_blocker(
+        self,
+    ) -> None:
+        result = runtime_window_import_continuity_signal(
+            SimpleNamespace(
+                last_signal_continuity_state="signals_present",
+                last_signal_continuity_reason="signals_present",
+                last_signal_continuity_actionable=False,
+                signal_continuity_alert_active=False,
+            ),
+            clickhouse_ta_status={
+                "state": "current",
+                "latest_signal_at": "2026-07-07T20:47:05+00:00",
+                "accepted_source_state": "outside_regular_session",
+                "blocking_reason": None,
+                "market_session_state": "after_market_close",
+            },
+        )
+
+        self.assertEqual(
+            result,
+            (
+                "true",
+                "clickhouse_ta_status",
+                "accepted_ta_signal_after_market_close",
+            ),
+        )

--- a/services/torghut/tests/test_signal_readiness_status.py
+++ b/services/torghut/tests/test_signal_readiness_status.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
 
 from app.trading.ingest import ClickHouseSignalIngestor
+from app.trading.ingest.clickhouse_signal_source_freshness import (
+    ClickHouseSignalFreshnessContext,
+)
 from app.trading.ingest.shared_context import coerce_count
 
 
@@ -53,14 +57,23 @@ class SourceFreshnessIngestor(SourceFilteredReadinessIngestor):
         *args: object,
         source_rows: list[dict[str, object]],
         coverage_rows: list[dict[str, object]],
+        now: datetime | None = None,
         **kwargs: object,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.source_rows = source_rows
         self.coverage_rows = coverage_rows
+        self.now = now
 
     def _accepted_signal_sources(self) -> tuple[str, ...]:
         return ("ta",)
+
+    def _signal_freshness_context(self) -> ClickHouseSignalFreshnessContext:
+        context = super()._signal_freshness_context()
+        now = self.now
+        if now is None:
+            return context
+        return replace(context, now=lambda: now)
 
     def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
         self.queries.append(query)
@@ -142,8 +155,9 @@ def test_latest_signal_readiness_counts_include_source_filter() -> None:
 def test_latest_signal_status_blocks_stale_accepted_source_and_reports_excluded_fresher_source() -> (
     None
 ):
-    latest = datetime(2026, 5, 13, 20, 56, 16, tzinfo=timezone.utc)
-    rest_latest = datetime(2026, 5, 13, 21, 4, 16, tzinfo=timezone.utc)
+    now = datetime(2026, 5, 13, 15, 30, tzinfo=timezone.utc)
+    latest = now - timedelta(minutes=10)
+    rest_latest = now - timedelta(minutes=2)
     ingestor = SourceFreshnessIngestor(
         schema="envelope",
         table="torghut.ta_signals",
@@ -172,6 +186,7 @@ def test_latest_signal_status_blocks_stale_accepted_source_and_reports_excluded_
                 "signal_rows": "3",
             }
         ],
+        now=now,
     )
 
     status = ingestor.latest_signal_status()
@@ -179,6 +194,8 @@ def test_latest_signal_status_blocks_stale_accepted_source_and_reports_excluded_
     assert status["accepted_sources"] == ["ta"]
     assert status["accepted_source_state"] == "stale"
     assert status["blocking_reason"] == "accepted_ta_signal_stale"
+    assert status["market_session_state"] == "regular_open"
+    assert status["regular_session_open"] is True
     assert status["excluded_fresher_sources"] == [
         {
             "source": "rest",
@@ -196,4 +213,54 @@ def test_latest_signal_status_blocks_stale_accepted_source_and_reports_excluded_
             "lag_seconds": 0,
             "signal_rows": 3,
         }
+    ]
+
+
+def test_latest_signal_status_does_not_hard_block_stale_accepted_source_after_close() -> (
+    None
+):
+    now = datetime(2026, 7, 7, 22, 0, tzinfo=timezone.utc)
+    latest = datetime(2026, 7, 7, 20, 47, 5, tzinfo=timezone.utc)
+    rest_latest = datetime(2026, 7, 7, 20, 59, tzinfo=timezone.utc)
+    ingestor = SourceFreshnessIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="http://example",
+        latest_signal_ts=latest,
+        signal_rows=12,
+        symbol_count=6,
+        source_rows=[
+            {
+                "source": "rest",
+                "latest_signal_ts": rest_latest.isoformat(),
+                "signal_rows": "40",
+                "symbol_count": "10",
+            },
+            {
+                "source": "ta",
+                "latest_signal_ts": latest.isoformat(),
+                "signal_rows": "12",
+                "symbol_count": "6",
+            },
+        ],
+        coverage_rows=[
+            {
+                "symbol": "NVDA",
+                "latest_signal_ts": latest.isoformat(),
+                "signal_rows": "3",
+            }
+        ],
+        now=now,
+    )
+
+    status = ingestor.latest_signal_status()
+
+    assert status["accepted_sources"] == ["ta"]
+    assert status["accepted_lag_seconds"] > status["accepted_max_lag_seconds"]
+    assert status["accepted_source_state"] == "outside_regular_session"
+    assert status["blocking_reason"] is None
+    assert status["market_session_state"] == "after_market_close"
+    assert status["regular_session_open"] is False
+    assert status["freshness_reason_codes"] == [
+        "accepted_ta_signal_outside_regular_session"
     ]


### PR DESCRIPTION
## Summary

- Makes accepted-source TA freshness session-aware so stale TA during regular market hours still fails closed, while after-hours/pre-market lag is reported as outside the regular session instead of a false hard blocker.
- Carries `market_session_state`, regular-session open/close timestamps, and `regular_session_open` through the ClickHouse TA freshness contract.
- Updates the submission continuity fallback so `outside_regular_session` remains diagnostic and does not become `signal_lag_exceeded`.
- Aligns the default feature freshness budget with the production recovery plan at 300 seconds.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_signal_readiness_status.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen ruff check app tests`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app tests`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
