### PR TITLE
fix(torghut): expose live gate in proofs

### DIFF
--- a/services/torghut/app/trading/proofs/schemas.py
+++ b/services/torghut/app/trading/proofs/schemas.py
@@ -121,6 +121,10 @@ class ProofSummaryPayload(TypedDict):
     ready_count: int
     import_due_count: int
     blocked_count: int
+    live_submission_allowed: bool
+    live_submission_reason: str | None
+    accepted_source_state: str | None
+    accepted_lag_seconds: float | None
 
 
 class ProofsPayload(TypedDict):
@@ -128,6 +132,7 @@ class ProofsPayload(TypedDict):
     generated_at: str
     kind: ProofKind
     window: dict[str, object]
+    live_submission_gate: dict[str, object]
     proofs: list[ProofPayload]
     summary: ProofSummaryPayload
     promotion_authority: PromotionAuthorityPayload

--- a/services/torghut/app/trading/proofs/service.py
+++ b/services/torghut/app/trading/proofs/service.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from decimal import Decimal
+from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -42,8 +43,8 @@ from .targets import (
 def build_proofs_payload(
     session: Session,
     *,
-    live_submission_gate: Mapping[str, Any],
-    route_reacquisition_book: Mapping[str, Any],
+    live_submission_gate: Mapping[str, object],
+    route_reacquisition_book: Mapping[str, object],
     generated_at: datetime | None = None,
     kind: ProofKind = "runtime_window",
     limit: int = DEFAULT_PROOFS_LIMIT,
@@ -81,6 +82,8 @@ def build_proofs_payload(
     blocker_counts: Counter[str] = Counter()
     for proof in proofs:
         blocker_counts.update(proof["blockers"])
+    gate_payload = _live_submission_gate_payload(live_submission_gate)
+    gate_freshness = _live_submission_gate_freshness(gate_payload)
     return {
         "schema_version": PROOFS_SCHEMA_VERSION,
         "generated_at": isoformat(resolved_generated_at),
@@ -90,6 +93,7 @@ def build_proofs_payload(
             generated_at=resolved_generated_at,
             proofs=proofs,
         ),
+        "live_submission_gate": gate_payload,
         "proofs": proofs,
         "summary": {
             "target_count": len(targets),
@@ -99,6 +103,14 @@ def build_proofs_payload(
             "ready_count": state_counts.get("proof_ready", 0),
             "import_due_count": state_counts.get("import_due", 0),
             "blocked_count": state_counts.get("blocked", 0),
+            "live_submission_allowed": bool(gate_payload.get("allowed")),
+            "live_submission_reason": _text_or_none(gate_payload.get("reason")),
+            "accepted_source_state": _text_or_none(
+                gate_freshness.get("accepted_source_state")
+            ),
+            "accepted_lag_seconds": _float_or_none(
+                gate_freshness.get("accepted_lag_seconds")
+            ),
         },
         "promotion_authority": {
             "allowed": False,
@@ -109,11 +121,52 @@ def build_proofs_payload(
     }
 
 
+def _live_submission_gate_payload(
+    live_submission_gate: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        str(key): value
+        for key, value in live_submission_gate.items()
+        if str(key).strip()
+    }
+
+
+def _live_submission_gate_freshness(
+    live_submission_gate: Mapping[str, object],
+) -> Mapping[str, object]:
+    freshness = live_submission_gate.get("clickhouse_ta_freshness")
+    if isinstance(freshness, Mapping):
+        return cast(Mapping[str, object], freshness)
+    return {}
+
+
+def _text_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _float_or_none(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float, Decimal)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
 def _load_strategy_universe_by_name(
     session: Session,
     *,
-    live_submission_gate: Mapping[str, Any],
-    route_reacquisition_book: Mapping[str, Any],
+    live_submission_gate: Mapping[str, object],
+    route_reacquisition_book: Mapping[str, object],
 ) -> dict[str, object]:
     names = proof_target_strategy_lookup_names_from_payloads(
         live_submission_gate=live_submission_gate,
@@ -138,7 +191,7 @@ def _build_proof(
     generated_at: datetime,
     full_audit: bool,
     target_account_audit_available: bool,
-    live_submission_gate: Mapping[str, Any],
+    live_submission_gate: Mapping[str, object],
 ) -> ProofPayload:
     window_closed = generated_at >= target.window_end
     source_counts = load_source_activity_counts(session, target)

--- a/services/torghut/tests/api/test_trading_api_live_gate_llm.py
+++ b/services/torghut/tests/api/test_trading_api_live_gate_llm.py
@@ -14,6 +14,73 @@ from tests.api.trading_api_support import (
 )
 
 
+def _shared_blocked_live_gate() -> dict[str, object]:
+    return {
+        "allowed": False,
+        "reason": "promotion_certificate_missing",
+        "blocked_reasons": [
+            "promotion_certificate_missing",
+            "hypothesis_window_evidence_missing",
+        ],
+        "certificate_id": None,
+        "capital_stage": "shadow",
+        "capital_state": "observe",
+        "issued_at": None,
+        "expires_at": None,
+        "reason_codes": [
+            "promotion_certificate_missing",
+            "hypothesis_window_evidence_missing",
+        ],
+        "clickhouse_ta_freshness": {
+            "accepted_sources": ["ta"],
+            "latest_accepted_event_at": "2026-03-20T09:54:00Z",
+            "accepted_lag_seconds": 360,
+            "accepted_source_state": "stale",
+            "blocking_reason": "accepted_ta_signal_stale",
+        },
+        "segment_summary": {
+            "segments": {
+                "execution": {"state": "ok", "reason_codes": []},
+                "empirical": {"state": "ok", "reason_codes": []},
+                "llm-review": {"state": "ok", "reason_codes": []},
+                "market-context": {"state": "ok", "reason_codes": []},
+                "ta-core": {"state": "ok", "reason_codes": []},
+            },
+            "evaluated_hypotheses": [],
+        },
+        "quant_health_ref": {
+            "account": "paper",
+            "window": "15m",
+            "status": "healthy",
+            "source_url": "http://torghut.test/quant/health",
+            "latest_metrics_updated_at": "2026-03-20T10:00:00Z",
+        },
+        "market_context_ref": {"last_freshness_seconds": 30},
+        "evidence_tuple": {
+            "hypothesis_id": None,
+            "candidate_id": None,
+            "strategy_id": None,
+            "account": "paper",
+            "window": "15m",
+            "capital_state": "observe",
+        },
+        "lineage_ref": {
+            "status": "unverified",
+            "candidate_id": None,
+            "hypothesis_id": None,
+            "dataset_snapshot_count": 0,
+            "dataset_snapshot_id": None,
+            "dataset_snapshot_ref": None,
+            "dataset_snapshot_run_id": None,
+            "strategy_hypothesis_count": 0,
+            "strategy_hypothesis_id": None,
+            "lane_id": None,
+            "strategy_family": None,
+        },
+        "evaluated_tuples": [],
+    }
+
+
 class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
     def test_trading_status_includes_llm_evaluation(self) -> None:
         with patch("app.api.trading_status.SessionLocal", self.session_local):
@@ -340,63 +407,7 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
             scheduler.state.last_run_at = datetime.now(timezone.utc)
             _mark_static_universe_loaded(scheduler)
             app.state.trading_scheduler = scheduler
-            shared_gate = {
-                "allowed": False,
-                "reason": "promotion_certificate_missing",
-                "blocked_reasons": [
-                    "promotion_certificate_missing",
-                    "hypothesis_window_evidence_missing",
-                ],
-                "certificate_id": None,
-                "capital_stage": "shadow",
-                "capital_state": "observe",
-                "issued_at": None,
-                "expires_at": None,
-                "reason_codes": [
-                    "promotion_certificate_missing",
-                    "hypothesis_window_evidence_missing",
-                ],
-                "segment_summary": {
-                    "segments": {
-                        "execution": {"state": "ok", "reason_codes": []},
-                        "empirical": {"state": "ok", "reason_codes": []},
-                        "llm-review": {"state": "ok", "reason_codes": []},
-                        "market-context": {"state": "ok", "reason_codes": []},
-                        "ta-core": {"state": "ok", "reason_codes": []},
-                    },
-                    "evaluated_hypotheses": [],
-                },
-                "quant_health_ref": {
-                    "account": "paper",
-                    "window": "15m",
-                    "status": "healthy",
-                    "source_url": "http://torghut.test/quant/health",
-                    "latest_metrics_updated_at": "2026-03-20T10:00:00Z",
-                },
-                "market_context_ref": {"last_freshness_seconds": 30},
-                "evidence_tuple": {
-                    "hypothesis_id": None,
-                    "candidate_id": None,
-                    "strategy_id": None,
-                    "account": "paper",
-                    "window": "15m",
-                    "capital_state": "observe",
-                },
-                "lineage_ref": {
-                    "status": "unverified",
-                    "candidate_id": None,
-                    "hypothesis_id": None,
-                    "dataset_snapshot_count": 0,
-                    "dataset_snapshot_id": None,
-                    "dataset_snapshot_ref": None,
-                    "dataset_snapshot_run_id": None,
-                    "strategy_hypothesis_count": 0,
-                    "strategy_hypothesis_id": None,
-                    "lane_id": None,
-                    "strategy_family": None,
-                },
-                "evaluated_tuples": [],
-            }
+            shared_gate = _shared_blocked_live_gate()
 
             with (
                 patch(
@@ -471,16 +482,60 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
                     "app.api.runtime_profitability._build_live_submission_gate_payload",
                     return_value=shared_gate,
                 ),
+                patch(
+                    "app.api.proofs._empirical_jobs_status",
+                    return_value={"ready": True, "status": "healthy"},
+                ),
+                patch(
+                    "app.api.proofs.load_quant_evidence_status",
+                    return_value={
+                        "required": True,
+                        "ok": True,
+                        "status": "healthy",
+                        "reason": "ready",
+                        "blocking_reasons": [],
+                        "account": "paper",
+                        "window": "15m",
+                    },
+                ),
+                patch(
+                    "app.api.proofs._build_live_submission_gate_payload",
+                    return_value=shared_gate,
+                ),
+                patch(
+                    "app.api.proofs._merge_external_paper_route_target_plan",
+                    side_effect=lambda gate: gate,
+                ),
+                patch(
+                    "app.api.proofs._build_simple_lane_status_payload",
+                    return_value={},
+                ),
+                patch(
+                    "app.api.proofs._with_configured_paper_collection_targets",
+                    side_effect=(
+                        lambda live_submission_gate, *, simple_lane_status, session: (
+                            live_submission_gate
+                        )
+                    ),
+                ),
+                patch(
+                    "app.api.proofs._paper_route_probe_book_from_target_plan",
+                    return_value={},
+                ),
             ):
                 status_response = self.client.get("/trading/status")
                 health_response = self.client.get("/trading/health")
                 ready_response = self.client.get("/readyz")
                 runtime_response = self.client.get("/trading/profitability/runtime")
+                proofs_response = self.client.get(
+                    "/trading/proofs?kind=runtime_window&window=next&limit=1"
+                )
 
             self.assertEqual(status_response.status_code, 200)
             self.assertEqual(health_response.status_code, 503)
             self.assertEqual(ready_response.status_code, 503)
             self.assertEqual(runtime_response.status_code, 200)
+            self.assertEqual(proofs_response.status_code, 200)
             self.assertEqual(
                 status_response.json()["live_submission_gate"], shared_gate
             )
@@ -491,6 +546,17 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
                 runtime_response.json()["live_submission_gate"],
                 shared_gate,
             )
+            proofs_payload = proofs_response.json()
+            self.assertEqual(proofs_payload["live_submission_gate"], shared_gate)
+            self.assertEqual(
+                proofs_payload["summary"]["live_submission_reason"],
+                "promotion_certificate_missing",
+            )
+            self.assertEqual(
+                proofs_payload["summary"]["accepted_source_state"],
+                "stale",
+            )
+            self.assertEqual(proofs_payload["summary"]["accepted_lag_seconds"], 360.0)
             ready_gate = ready_response.json()["live_submission_gate"]
             self.assertEqual(
                 ready_gate,

--- a/services/torghut/tests/test_proofs_service.py
+++ b/services/torghut/tests/test_proofs_service.py
@@ -51,10 +51,21 @@ def _target(window_start: datetime, window_end: datetime) -> dict[str, object]:
 
 
 def _gate(
-    target: dict[str, object], blockers: list[str] | None = None
+    target: dict[str, object],
+    blockers: list[str] | None = None,
+    accepted_lag_seconds: object = 420.5,
 ) -> dict[str, object]:
     return {
+        "allowed": False,
+        "reason": "accepted_ta_signal_stale",
         "blocked_reasons": blockers or [],
+        "clickhouse_ta_freshness": {
+            "accepted_sources": ["ta"],
+            "latest_accepted_event_at": "2026-06-08T13:29:00+00:00",
+            "accepted_lag_seconds": accepted_lag_seconds,
+            "accepted_source_state": "stale",
+            "blocking_reason": "accepted_ta_signal_stale",
+        },
         "runtime_ledger_paper_probation_import_plan": {
             "target_count": 1,
             "targets": [target],
@@ -68,10 +79,13 @@ def _build(
     generated_at: datetime,
     target: dict[str, object] | None = None,
     blockers: list[str] | None = None,
+    accepted_lag_seconds: object = 420.5,
 ) -> dict[str, object]:
     return build_proofs_payload(
         session,
-        live_submission_gate=_gate(target, blockers) if target else {},
+        live_submission_gate=(
+            _gate(target, blockers, accepted_lag_seconds) if target else {}
+        ),
         route_reacquisition_book={},
         generated_at=generated_at,
         window="auto",
@@ -89,6 +103,56 @@ def test_build_proofs_payload_reports_no_target() -> None:
     assert payload["proofs"] == []
     assert payload["summary"]["target_count"] == 0
     assert payload["promotion_authority"]["allowed"] is False
+
+
+def test_build_proofs_payload_exposes_live_submission_gate_and_freshness_summary() -> (
+    None
+):
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    window_end = datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc)
+    target = _target(window_start, window_end)
+    with _session() as session:
+        payload = _build(
+            session,
+            target=target,
+            generated_at=window_start - timedelta(minutes=1),
+        )
+
+    assert payload["live_submission_gate"]["allowed"] is False
+    assert payload["live_submission_gate"]["reason"] == "accepted_ta_signal_stale"
+    assert payload["summary"]["live_submission_allowed"] is False
+    assert payload["summary"]["live_submission_reason"] == "accepted_ta_signal_stale"
+    assert payload["summary"]["accepted_source_state"] == "stale"
+    assert payload["summary"]["accepted_lag_seconds"] == 420.5
+    assert payload["promotion_authority"] == {
+        "allowed": False,
+        "final_promotion_allowed": False,
+        "reason": "proof_collection_only",
+        "blockers": ["live_runtime_ledger_authority_required"],
+    }
+
+
+def test_build_proofs_payload_normalizes_invalid_accepted_lag_summary() -> None:
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    window_end = datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc)
+    target = _target(window_start, window_end)
+    cases: list[tuple[object, float | None]] = [
+        ("421.75", 421.75),
+        (True, None),
+        ({"lag": 421}, None),
+        ("not-a-number", None),
+    ]
+
+    for raw_lag, expected_lag in cases:
+        with _session() as session:
+            payload = _build(
+                session,
+                target=target,
+                generated_at=window_start - timedelta(minutes=1),
+                accepted_lag_seconds=raw_lag,
+            )
+
+        assert payload["summary"]["accepted_lag_seconds"] == expected_lag
 
 
 def test_build_proofs_payload_fills_missing_symbols_from_strategy_universe() -> None:

--- a/services/torghut/tests/test_trading_proofs_api.py
+++ b/services/torghut/tests/test_trading_proofs_api.py
@@ -18,6 +18,16 @@ def _payload() -> dict[str, object]:
             "end": "2026-06-08T20:00:00+00:00",
             "closed": True,
         },
+        "live_submission_gate": {
+            "allowed": False,
+            "reason": "accepted_ta_signal_stale",
+            "clickhouse_ta_freshness": {
+                "accepted_sources": ["ta"],
+                "accepted_lag_seconds": 900,
+                "accepted_source_state": "stale",
+                "blocking_reason": "accepted_ta_signal_stale",
+            },
+        },
         "proofs": [],
         "summary": {
             "target_count": 0,
@@ -27,6 +37,10 @@ def _payload() -> dict[str, object]:
             "ready_count": 0,
             "import_due_count": 0,
             "blocked_count": 0,
+            "live_submission_allowed": False,
+            "live_submission_reason": "accepted_ta_signal_stale",
+            "accepted_source_state": "stale",
+            "accepted_lag_seconds": 900,
         },
         "promotion_authority": {
             "allowed": False,
@@ -47,7 +61,10 @@ def test_trading_proofs_endpoint_uses_canonical_contract() -> None:
         )
 
     assert response.status_code == 200
-    assert response.json()["schema_version"] == "torghut.proofs.v1"
+    payload = response.json()
+    assert payload["schema_version"] == "torghut.proofs.v1"
+    assert payload["live_submission_gate"]["reason"] == "accepted_ta_signal_stale"
+    assert payload["summary"]["accepted_source_state"] == "stale"
     build.assert_called_once_with(
         kind="runtime_window",
         limit=2,


### PR DESCRIPTION
## Summary

- Exposes the shared Torghut live submission gate at the top level of `/trading/proofs`.
- Adds proof summary fields for live submission allowance, gate reason, accepted-source state, and accepted-source lag.
- Extends service, endpoint, and cross-endpoint tests so status, health, readyz, runtime profitability, and proofs share the same operational gate contract.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_live_gate_llm.py::TestTradingApiLiveGateLlm::test_live_submission_gate_matches_status_health_and_readyz tests/test_proofs_service.py tests/test_trading_proofs_api.py --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.xml --cov-report=`
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/proofs/service.py app/trading/proofs/schemas.py tests/test_proofs_service.py tests/test_trading_proofs_api.py tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/proofs/service.py app/trading/proofs/schemas.py tests/test_proofs_service.py tests/test_trading_proofs_api.py tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/proofs/service.py app/trading/proofs/schemas.py tests/test_proofs_service.py tests/test_trading_proofs_api.py tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `cd services/torghut && uv run --frozen python -m compileall app/trading/proofs app/api/proofs.py tests/test_proofs_service.py tests/test_trading_proofs_api.py tests/api/test_trading_api_live_gate_llm.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
