### PR TITLE
fix(torghut): decode ta status heartbeat in smoke

### DIFF
--- a/packages/scripts/src/kafka/tail-topic.ts
+++ b/packages/scripts/src/kafka/tail-topic.ts
@@ -17,7 +17,7 @@ type Args = {
   passwordSecretKey: string
   kafkaNamespace: string
   kafkaPod?: string
-  format: 'raw' | 'summary' | 'json'
+  format: 'raw' | 'summary' | 'json' | 'base64'
 }
 
 const usage = () =>
@@ -44,7 +44,7 @@ Options:
   --kafka-namespace <ns>              Namespace that contains the Kafka broker pod (default: kafka)
   --kafka-pod <pod>                   Kafka broker pod to exec into (default: auto-detect)
 
-  --format raw|summary|json           Output format (default: summary)
+  --format raw|summary|json|base64    Output format (default: summary)
 
 Examples:
   KAFKA_USERNAME=torghut-ws KAFKA_PASSWORD=$(kubectl -n torghut get secret torghut-ws -o jsonpath='{.data.password}' | base64 -d) \\
@@ -246,7 +246,7 @@ const main = async () => {
   }
 
   args.format = args.format ?? 'summary'
-  if (!['raw', 'summary', 'json'].includes(args.format)) {
+  if (!['raw', 'summary', 'json', 'base64'].includes(args.format)) {
     fatal(`Invalid --format: ${String(args.format)}`)
   }
 
@@ -284,7 +284,13 @@ const main = async () => {
     'if [ -z "$end_offset" ]; then end_offset=0; fi',
     'start_offset=$(( end_offset - TAIL ))',
     'if [ "$start_offset" -lt 0 ]; then start_offset=0; fi',
-    '/opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server "$BOOTSTRAP" --consumer.config "$CLIENT" --topic "$TOPIC" --partition "$PARTITION" --offset "$start_offset" --max-messages "$TAIL" --timeout-ms "$TIMEOUT_MS"',
+    'consumer_args=(--bootstrap-server "$BOOTSTRAP" --command-config "$CLIENT" --topic "$TOPIC" --partition "$PARTITION" --offset "$start_offset" --max-messages "$TAIL" --timeout-ms "$TIMEOUT_MS")',
+    'if [ "$FORMAT" = "base64" ]; then',
+    '  /opt/kafka/bin/kafka-console-consumer.sh "${consumer_args[@]}" | base64 | tr -d "\\n"',
+    '  printf "\\n"',
+    'else',
+    '  /opt/kafka/bin/kafka-console-consumer.sh "${consumer_args[@]}"',
+    'fi',
   ].join('\n')
 
   const stdout = await execCapture(
@@ -305,12 +311,19 @@ const main = async () => {
       `SECURITY_PROTOCOL=${args.securityProtocol}`,
       `SASL_MECHANISM=${args.saslMechanism}`,
       `KAFKA_USERNAME=${args.username}`,
+      `FORMAT=${args.format}`,
       'bash',
       '-lc',
       remoteScript,
     ],
     { stdin: `${args.password}\n` },
   )
+
+  if (args.format === 'base64') {
+    const encoded = stdout.trim()
+    process.stdout.write(encoded.length > 0 ? `${encoded}\n` : '')
+    return
+  }
 
   const lines = stdout
     .split('\n')

--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'bun:test'
 
 import { evaluateMarketDataSmoke, marketSessionState, selectLatestKafkaRecord } from '../market-data-smoke'
+import { decodeTaStatusHeartbeatAvro } from '../ta-status-heartbeat'
 
 const marketDataSmokeSource = readFileSync(new URL('../market-data-smoke.ts', import.meta.url), 'utf8')
 
@@ -121,6 +122,61 @@ const liveTaRuntimeConfig = {
   autoOffsetReset: 'latest',
 }
 
+const freshTaStatusHeartbeat = {
+  topic: 'torghut.ta.status.v1',
+  partition: 0,
+  ingestTs: '2026-07-07T17:00:20Z',
+  eventTs: '2026-07-07T17:00:20Z',
+  symbol: 'ta',
+  seq: 10,
+  isFinal: true,
+  source: 'ta',
+  watermarkLagMs: 5_000,
+  sourceLagMs: 20_000,
+  lastEventTs: '2026-07-07T17:00:00Z',
+  lastInputEventTs: '2026-07-07T17:00:00Z',
+  lastOutputEventTs: '2026-07-07T17:00:00Z',
+  inputEventCount: 240,
+  outputEventCount: 120,
+  currentInputEventCount: 20,
+  currentOutputEventCount: 10,
+  currentRecordCount: 30,
+  inputRatePerSecond: 2,
+  outputRatePerSecond: 1,
+  microbarEventCount: 240,
+  signalEventCount: 120,
+  microbarRatePerSecond: 2,
+  signalRatePerSecond: 1,
+  clickhouseSinkEnabled: true,
+  perSymbolLatestEventTs: {
+    NVDA: '2026-07-07T17:00:00Z',
+    AMD: '2026-07-07T17:00:00Z',
+  },
+  marketSessionState: 'regular',
+  status: 'ok',
+  heartbeat: true,
+  version: 1,
+}
+
+const staleTaStatusHeartbeat = {
+  ...freshTaStatusHeartbeat,
+  ingestTs: '2026-07-07T17:00:20Z',
+  eventTs: '2026-07-07T17:00:20Z',
+  sourceLagMs: 610_000,
+  lastEventTs: '2026-07-07T16:50:00Z',
+  lastInputEventTs: '2026-07-07T16:50:00Z',
+  lastOutputEventTs: '2026-07-07T16:50:00Z',
+  currentInputEventCount: 0,
+  currentOutputEventCount: 0,
+  currentRecordCount: 0,
+  inputRatePerSecond: 0,
+  outputRatePerSecond: 0,
+  microbarRatePerSecond: 0,
+  signalRatePerSecond: 0,
+  statusReason: 'zero_current_records_during_regular_session',
+  status: 'degraded',
+}
+
 const freshTaFlinkJob = {
   jid: 'job-live',
   state: 'RUNNING',
@@ -188,7 +244,136 @@ const stalledRateTaFlinkJob = {
   })),
 }
 
+const testTextEncoder = new TextEncoder()
+
+const concatBytes = (chunks: Uint8Array[]): Buffer => Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)))
+
+const encodeLong = (value: number): Buffer => {
+  let raw = BigInt(value)
+  raw = (raw << 1n) ^ (raw >> 63n)
+  const out: number[] = []
+  while ((raw & ~0x7fn) !== 0n) {
+    out.push(Number((raw & 0x7fn) | 0x80n))
+    raw >>= 7n
+  }
+  out.push(Number(raw))
+  return Buffer.from(out)
+}
+
+const encodeString = (value: string): Buffer => {
+  const bytes = testTextEncoder.encode(value)
+  return concatBytes([encodeLong(bytes.length), bytes])
+}
+
+const encodeDouble = (value: number): Buffer => {
+  const buffer = Buffer.alloc(8)
+  buffer.writeDoubleLE(value)
+  return buffer
+}
+
+const encodeBoolean = (value: boolean): Buffer => Buffer.from([value ? 1 : 0])
+
+const encodeNullableLong = (value: number | undefined): Buffer =>
+  value === undefined ? encodeLong(0) : concatBytes([encodeLong(1), encodeLong(value)])
+
+const encodeNullableDouble = (value: number | undefined): Buffer =>
+  value === undefined ? encodeLong(0) : concatBytes([encodeLong(1), encodeDouble(value)])
+
+const encodeNullableString = (value: string | undefined): Buffer =>
+  value === undefined ? encodeLong(0) : concatBytes([encodeLong(1), encodeString(value)])
+
+const encodeNullableBoolean = (value: boolean | undefined): Buffer =>
+  value === undefined ? encodeLong(0) : concatBytes([encodeLong(1), encodeBoolean(value)])
+
+const encodeNullableStringMap = (value: Record<string, string> | undefined): Buffer => {
+  if (value === undefined) return encodeLong(0)
+  const entries = Object.entries(value)
+  return concatBytes([
+    encodeLong(1),
+    encodeLong(entries.length),
+    ...entries.flatMap(([key, item]) => [encodeString(key), encodeString(item)]),
+    encodeLong(0),
+  ])
+}
+
+const encodeNullableVersion = (value: number | undefined): Buffer =>
+  value === undefined ? encodeLong(1) : concatBytes([encodeLong(0), encodeLong(value)])
+
+const encodeTaStatusFixture = (heartbeat: typeof freshTaStatusHeartbeat & { statusReason?: string }): Buffer =>
+  concatBytes([
+    encodeString(heartbeat.ingestTs),
+    encodeString(heartbeat.eventTs),
+    encodeString(heartbeat.symbol),
+    encodeLong(heartbeat.seq),
+    encodeNullableBoolean(heartbeat.isFinal),
+    encodeNullableString(heartbeat.source),
+    encodeLong(0),
+    encodeNullableLong(heartbeat.watermarkLagMs),
+    encodeNullableLong(heartbeat.sourceLagMs),
+    encodeNullableString(heartbeat.lastEventTs),
+    encodeNullableString(heartbeat.lastInputEventTs),
+    encodeNullableString(heartbeat.lastOutputEventTs),
+    encodeNullableLong(heartbeat.inputEventCount),
+    encodeNullableLong(heartbeat.outputEventCount),
+    encodeNullableLong(heartbeat.currentInputEventCount),
+    encodeNullableLong(heartbeat.currentOutputEventCount),
+    encodeNullableLong(heartbeat.currentRecordCount),
+    encodeNullableDouble(heartbeat.inputRatePerSecond),
+    encodeNullableDouble(heartbeat.outputRatePerSecond),
+    encodeNullableLong(heartbeat.microbarEventCount),
+    encodeNullableLong(heartbeat.signalEventCount),
+    encodeNullableDouble(heartbeat.microbarRatePerSecond),
+    encodeNullableDouble(heartbeat.signalRatePerSecond),
+    encodeNullableBoolean(heartbeat.clickhouseSinkEnabled),
+    encodeNullableStringMap(heartbeat.perSymbolLatestEventTs),
+    encodeNullableString(heartbeat.marketSessionState),
+    encodeNullableString(heartbeat.statusReason),
+    encodeString(heartbeat.status),
+    encodeNullableBoolean(heartbeat.heartbeat),
+    encodeNullableVersion(heartbeat.version),
+  ])
+
 describe('market data smoke freshness evaluation', () => {
+  it('decodes TA status heartbeat Avro evidence from Kafka bytes', () => {
+    const encoded = encodeTaStatusFixture(freshTaStatusHeartbeat)
+    const decoded = decodeTaStatusHeartbeatAvro(encoded, {
+      topic: 'torghut.ta.status.v1',
+      partition: 2,
+    })
+    const prefixed = decodeTaStatusHeartbeatAvro(concatBytes([Buffer.from([0, 0, 0, 0, 7]), encoded]), {
+      topic: 'torghut.ta.status.v1',
+      partition: 2,
+    })
+
+    expect(decoded).toMatchObject({
+      topic: 'torghut.ta.status.v1',
+      partition: 2,
+      eventTs: '2026-07-07T17:00:20Z',
+      symbol: 'ta',
+      seq: 10,
+      sourceLagMs: 20_000,
+      currentRecordCount: 30,
+      currentInputEventCount: 20,
+      currentOutputEventCount: 10,
+      clickhouseSinkEnabled: true,
+      marketSessionState: 'regular',
+      status: 'ok',
+      heartbeat: true,
+      version: 1,
+    })
+    expect(prefixed).toMatchObject({
+      topic: 'torghut.ta.status.v1',
+      partition: 2,
+      eventTs: '2026-07-07T17:00:20Z',
+      status: 'ok',
+      version: 1,
+    })
+    expect(decoded.perSymbolLatestEventTs).toEqual({
+      NVDA: '2026-07-07T17:00:00Z',
+      AMD: '2026-07-07T17:00:00Z',
+    })
+  })
+
   it('identifies regular US equity market session', () => {
     expect(marketSessionState(new Date('2026-07-07T17:00:00Z'))).toBe('regular')
     expect(marketSessionState(new Date('2026-07-07T22:00:00Z'))).toBe('post')
@@ -210,6 +395,7 @@ describe('market data smoke freshness evaluation', () => {
       tradingStatus: tradingStatusWithStaleAcceptedTa,
       taRuntimeConfig: liveTaRuntimeConfig,
       taFlinkJob: zeroCurrentTaFlinkJob,
+      taStatusHeartbeat: staleTaStatusHeartbeat,
     })
 
     expect(result.enforceFreshness).toBe(true)
@@ -217,6 +403,8 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.failures.join('\n')).toContain('accepted_ta_signal_stale')
     expect(result.failures.join('\n')).toContain('kafka_trades_stale')
     expect(result.failures.join('\n')).toContain('ws_trades_missing_kafka_success')
+    expect(result.failures.join('\n')).toContain('ta_status_degraded')
+    expect(result.failures.join('\n')).toContain('ta_status_source_lag_stale')
   })
 
   it('observes the same stale data after hours without claiming market-session proof', () => {
@@ -235,6 +423,7 @@ describe('market data smoke freshness evaluation', () => {
       tradingStatus: tradingStatusWithRestAcceptedBackfill,
       taRuntimeConfig: liveTaRuntimeConfig,
       taFlinkJob: zeroCurrentTaFlinkJob,
+      taStatusHeartbeat: staleTaStatusHeartbeat,
     })
 
     expect(result.sessionState).toBe('post')
@@ -243,6 +432,7 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.warnings.join('\n')).toContain('accepted_ta_signal_stale')
     expect(result.warnings.join('\n')).toContain('accepted_source_contains_backfill')
     expect(result.warnings.join('\n')).toContain('ta_flink_zero_source_records')
+    expect(result.warnings.join('\n')).toContain('ta_status_degraded')
   })
 
   it('passes during regular market hours when WS topics and accepted TA are fresh', () => {
@@ -261,12 +451,36 @@ describe('market data smoke freshness evaluation', () => {
       tradingStatus: tradingStatusWithFreshAcceptedTa,
       taRuntimeConfig: liveTaRuntimeConfig,
       taFlinkJob: freshTaFlinkJob,
+      taStatusHeartbeat: freshTaStatusHeartbeat,
     })
 
     expect(result.sessionState).toBe('regular')
     expect(result.enforceFreshness).toBe(true)
     expect(result.ok).toBe(true)
     expect(result.failures).toEqual([])
+  })
+
+  it('fails during regular market hours when TA status heartbeat is missing', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: freshWsReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: freshTaFlinkJob,
+    })
+
+    expect(result.enforceFreshness).toBe(true)
+    expect(result.ok).toBe(false)
+    expect(result.failures.join('\n')).toContain('ta_status_heartbeat_missing')
   })
 
   it('fails even after hours when production TA is left in replay mode', () => {
@@ -288,6 +502,7 @@ describe('market data smoke freshness evaluation', () => {
         autoOffsetReset: 'earliest',
       },
       taFlinkJob: freshTaFlinkJob,
+      taStatusHeartbeat: freshTaStatusHeartbeat,
     })
 
     expect(result.enforceFreshness).toBe(false)
@@ -312,6 +527,7 @@ describe('market data smoke freshness evaluation', () => {
       tradingStatus: tradingStatusWithFreshAcceptedTa,
       taRuntimeConfig: liveTaRuntimeConfig,
       taFlinkJob: zeroCurrentTaFlinkJob,
+      taStatusHeartbeat: staleTaStatusHeartbeat,
     })
 
     expect(result.enforceFreshness).toBe(true)
@@ -347,6 +563,7 @@ describe('market data smoke freshness evaluation', () => {
             : vertex,
         ),
       },
+      taStatusHeartbeat: freshTaStatusHeartbeat,
     })
 
     expect(result.ok).toBe(true)
@@ -380,6 +597,7 @@ describe('market data smoke freshness evaluation', () => {
           },
         ],
       },
+      taStatusHeartbeat: freshTaStatusHeartbeat,
     })
 
     expect(result.ok).toBe(true)
@@ -407,6 +625,7 @@ describe('market data smoke freshness evaluation', () => {
           vertex.name.startsWith('Source: ta-trades-source') ? { ...vertex, status: 'FINISHED' } : vertex,
         ),
       },
+      taStatusHeartbeat: freshTaStatusHeartbeat,
     })
 
     expect(result.ok).toBe(false)
@@ -429,6 +648,7 @@ describe('market data smoke freshness evaluation', () => {
       tradingStatus: tradingStatusWithFreshAcceptedTa,
       taRuntimeConfig: liveTaRuntimeConfig,
       taFlinkJob: stalledRateTaFlinkJob,
+      taStatusHeartbeat: freshTaStatusHeartbeat,
     })
 
     expect(result.ok).toBe(false)
@@ -455,6 +675,7 @@ describe('market data smoke freshness evaluation', () => {
         ...freshTaFlinkJob,
         state: 'FAILED',
       },
+      taStatusHeartbeat: freshTaStatusHeartbeat,
     })
 
     expect(result.enforceFreshness).toBe(false)

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env bun
 
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
+import {
+  decodeTaStatusHeartbeatAvro,
+  evaluateTaStatusHeartbeat,
+  type TaStatusHeartbeatRecord,
+} from './ta-status-heartbeat'
 
 type JsonObject = Record<string, unknown>
 
@@ -29,6 +34,7 @@ type MarketDataSmokeInput = {
   tradingStatus: unknown
   taRuntimeConfig?: TaRuntimeConfig
   taFlinkJob?: unknown
+  taStatusHeartbeat?: TaStatusHeartbeatRecord
 }
 
 export type MarketDataSmokeResult = {
@@ -75,6 +81,7 @@ const DEFAULT_TOPIC_BY_ROLE: Record<KafkaRole, string> = {
   bars: 'torghut.bars.1m.v1',
 }
 
+const DEFAULT_TA_STATUS_TOPIC = 'torghut.ta.status.v1'
 const REQUIRED_WS_CHANNELS = ['trades', 'quotes', 'bars', 'updatedBars']
 const REQUIRED_KAFKA_ROLES: KafkaRole[] = ['trades', 'quotes', 'bars']
 const ACCEPTED_SOURCE_STALE_REASON = 'accepted_ta_signal_stale'
@@ -421,6 +428,17 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
     )
   }
 
+  const taStatusEvaluation = evaluateTaStatusHeartbeat({
+    now: input.now,
+    enforceFreshness,
+    maxLagSeconds: input.maxKafkaLagSeconds,
+    topic: input.taStatusHeartbeat?.topic ?? DEFAULT_TA_STATUS_TOPIC,
+    heartbeat: input.taStatusHeartbeat,
+  })
+  summaryLines.push(taStatusEvaluation.summaryLine)
+  failures.push(...taStatusEvaluation.failures)
+  warnings.push(...taStatusEvaluation.warnings)
+
   const wsChannels = getWsChannels(input.wsReadyz)
   for (const channel of REQUIRED_WS_CHANNELS) {
     const status = wsChannels.get(channel)
@@ -551,7 +569,13 @@ const execCapture = async (
   return stdout
 }
 
-const tailArgs = (topic: string, format: 'summary' | 'json', settings: RuntimeSettings, partition: number) => [
+const tailArgs = (
+  topic: string,
+  format: 'summary' | 'json' | 'base64',
+  settings: RuntimeSettings,
+  partition: number,
+  tail = settings.tail,
+) => [
   'run',
   'packages/scripts/src/kafka/tail-topic.ts',
   '--topic',
@@ -559,7 +583,7 @@ const tailArgs = (topic: string, format: 'summary' | 'json', settings: RuntimeSe
   '--partition',
   String(partition),
   '--tail',
-  settings.tail,
+  tail,
   '--timeout-ms',
   settings.timeoutMs,
   '--username',
@@ -601,6 +625,36 @@ const captureLatestKafkaRecord = async (
   return selectLatestKafkaRecord(records)
 }
 
+const selectLatestTaStatusHeartbeat = (heartbeats: TaStatusHeartbeatRecord[]): TaStatusHeartbeatRecord | undefined => {
+  let latest: TaStatusHeartbeatRecord | undefined
+  let latestTs = -1
+  for (const heartbeat of heartbeats) {
+    const ts = parseTimestampMs(heartbeat.eventTs)
+    if (ts === undefined || ts < latestTs) continue
+    latest = heartbeat
+    latestTs = ts
+  }
+  return latest
+}
+
+const captureLatestTaStatusHeartbeat = async (
+  topic: string,
+  settings: RuntimeSettings,
+): Promise<TaStatusHeartbeatRecord | undefined> => {
+  const heartbeats: TaStatusHeartbeatRecord[] = []
+  for (const partition of settings.kafkaPartitions) {
+    const stdout = await execCapture('bun', tailArgs(topic, 'base64', settings, partition, '1'), { cwd: repoRoot })
+    const encoded = stdout.trim()
+    if (!encoded) continue
+    try {
+      heartbeats.push(decodeTaStatusHeartbeatAvro(Buffer.from(encoded, 'base64'), { topic, partition }))
+    } catch (err) {
+      fatal(`Failed to decode TA status heartbeat from ${topic} partition ${partition}`, err)
+    }
+  }
+  return selectLatestTaStatusHeartbeat(heartbeats)
+}
+
 const fetchJsonViaPod = async (target: string, url: string, settings: RuntimeSettings): Promise<unknown> => {
   const stdout = await execCapture('kubectl', [
     'exec',
@@ -626,6 +680,7 @@ const fetchJson = async (url: string): Promise<unknown> => {
 type RuntimeSettings = {
   topics: string[]
   topicByRole: Record<KafkaRole, string>
+  taStatusTopic: string
   username: string
   passwordSecretNamespace: string
   passwordSecretName: string
@@ -654,6 +709,7 @@ const runtimeSettings = (): RuntimeSettings => ({
     quotes: process.env.TORGHUT_QUOTES_TOPIC ?? DEFAULT_TOPIC_BY_ROLE.quotes,
     bars: process.env.TORGHUT_BARS_TOPIC ?? DEFAULT_TOPIC_BY_ROLE.bars,
   },
+  taStatusTopic: process.env.TORGHUT_TA_STATUS_TOPIC ?? DEFAULT_TA_STATUS_TOPIC,
   username: process.env.KAFKA_USERNAME ?? 'torghut-ws',
   passwordSecretNamespace: process.env.KAFKA_PASSWORD_SECRET_NAMESPACE ?? 'torghut',
   passwordSecretName: process.env.KAFKA_PASSWORD_SECRET_NAME ?? 'torghut-ws',
@@ -795,6 +851,7 @@ const main = async () => {
   for (const role of REQUIRED_KAFKA_ROLES) {
     latestKafkaByRole[role] = await captureLatestKafkaRecord(role, settings.topicByRole[role], settings)
   }
+  const taStatusHeartbeat = await captureLatestTaStatusHeartbeat(settings.taStatusTopic, settings)
 
   const wsReadyz = await fetchJson(settings.wsReadyzUrl)
   const tradingStatus = await fetchJson(settings.tradingStatusUrl)
@@ -811,6 +868,7 @@ const main = async () => {
     tradingStatus,
     taRuntimeConfig,
     taFlinkJob,
+    taStatusHeartbeat,
   })
 
   console.log('Torghut market-data freshness evidence:')

--- a/packages/scripts/src/torghut/ta-status-heartbeat.ts
+++ b/packages/scripts/src/torghut/ta-status-heartbeat.ts
@@ -1,0 +1,417 @@
+export type TaStatusHeartbeatRecord = {
+  topic: string
+  partition?: number
+  ingestTs: string
+  eventTs: string
+  symbol: string
+  seq: number
+  isFinal?: boolean
+  source?: string
+  watermarkLagMs?: number
+  sourceLagMs?: number
+  lastEventTs?: string
+  lastInputEventTs?: string
+  lastOutputEventTs?: string
+  inputEventCount?: number
+  outputEventCount?: number
+  currentInputEventCount?: number
+  currentOutputEventCount?: number
+  currentRecordCount?: number
+  inputRatePerSecond?: number
+  outputRatePerSecond?: number
+  microbarEventCount?: number
+  signalEventCount?: number
+  microbarRatePerSecond?: number
+  signalRatePerSecond?: number
+  clickhouseSinkEnabled?: boolean
+  perSymbolLatestEventTs?: Record<string, string>
+  marketSessionState?: string
+  statusReason?: string
+  status: string
+  heartbeat?: boolean
+  version?: number
+}
+
+type TaStatusHeartbeatEvaluationInput = {
+  now: Date
+  enforceFreshness: boolean
+  maxLagSeconds: number
+  topic: string
+  heartbeat?: TaStatusHeartbeatRecord
+}
+
+export type TaStatusHeartbeatEvaluation = {
+  summaryLine: string
+  failures: string[]
+  warnings: string[]
+}
+
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true })
+
+const parseTimestampMs = (value: string | undefined): number | undefined => {
+  if (!value) return undefined
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+const lagSeconds = (now: Date, timestamp: string | undefined): number | undefined => {
+  const tsMs = parseTimestampMs(timestamp)
+  if (tsMs === undefined) return undefined
+  return Math.max(0, Math.floor((now.getTime() - tsMs) / 1_000))
+}
+
+const stripSchemaRegistryPrefix = (bytes: Uint8Array): Uint8Array => {
+  if (bytes.length >= 5 && bytes[0] === 0) {
+    return bytes.subarray(5)
+  }
+  return bytes
+}
+
+const pushFinding = (enforce: boolean, failures: string[], warnings: string[], code: string, detail: string) => {
+  const line = `${code}: ${detail}`
+  if (enforce) {
+    failures.push(line)
+  } else {
+    warnings.push(line)
+  }
+}
+
+class AvroStatusReader {
+  private offset = 0
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  readString(label: string): string {
+    const length = this.readLong(`${label}.length`)
+    if (length < 0) throw new Error(`${label} length is negative`)
+    const end = this.offset + length
+    if (end > this.bytes.length) throw new Error(`${label} exceeds Avro payload length`)
+    const value = utf8Decoder.decode(this.bytes.slice(this.offset, end))
+    this.offset = end
+    return value
+  }
+
+  readLong(label: string): number {
+    let raw = 0n
+    let shift = 0n
+    for (let i = 0; i < 10; i += 1) {
+      const byte = this.readByte(label)
+      raw |= BigInt(byte & 0x7f) << shift
+      if ((byte & 0x80) === 0) {
+        const decoded = (raw >> 1n) ^ -(raw & 1n)
+        if (decoded > BigInt(Number.MAX_SAFE_INTEGER) || decoded < BigInt(Number.MIN_SAFE_INTEGER)) {
+          throw new Error(`${label} is outside the JavaScript safe integer range`)
+        }
+        return Number(decoded)
+      }
+      shift += 7n
+    }
+    throw new Error(`${label} Avro varint is too long`)
+  }
+
+  readInt(label: string): number {
+    return this.readLong(label)
+  }
+
+  readBoolean(label: string): boolean {
+    const byte = this.readByte(label)
+    if (byte === 0) return false
+    if (byte === 1) return true
+    throw new Error(`${label} is not an Avro boolean`)
+  }
+
+  readDouble(label: string): number {
+    this.requireBytes(label, 8)
+    const view = new DataView(this.bytes.buffer, this.bytes.byteOffset + this.offset, 8)
+    const value = view.getFloat64(0, true)
+    this.offset += 8
+    return value
+  }
+
+  readNullableBoolean(label: string): boolean | undefined {
+    const branch = this.readUnionBranch(label)
+    if (branch === 0) return undefined
+    if (branch === 1) return this.readBoolean(label)
+    throw new Error(`${label} has unsupported Avro union branch ${branch}`)
+  }
+
+  readNullableLong(label: string): number | undefined {
+    const branch = this.readUnionBranch(label)
+    if (branch === 0) return undefined
+    if (branch === 1) return this.readLong(label)
+    throw new Error(`${label} has unsupported Avro union branch ${branch}`)
+  }
+
+  readNullableDouble(label: string): number | undefined {
+    const branch = this.readUnionBranch(label)
+    if (branch === 0) return undefined
+    if (branch === 1) return this.readDouble(label)
+    throw new Error(`${label} has unsupported Avro union branch ${branch}`)
+  }
+
+  readNullableString(label: string): string | undefined {
+    const branch = this.readUnionBranch(label)
+    if (branch === 0) return undefined
+    if (branch === 1) return this.readString(label)
+    throw new Error(`${label} has unsupported Avro union branch ${branch}`)
+  }
+
+  readNullableWindow(label: string): void {
+    const branch = this.readUnionBranch(label)
+    if (branch === 0) return
+    if (branch !== 1) throw new Error(`${label} has unsupported Avro union branch ${branch}`)
+    this.readString(`${label}.size`)
+    this.readNullableString(`${label}.step`)
+    this.readNullableString(`${label}.start`)
+    this.readNullableString(`${label}.end`)
+  }
+
+  readNullableStringMap(label: string): Record<string, string> | undefined {
+    const branch = this.readUnionBranch(label)
+    if (branch === 0) return undefined
+    if (branch !== 1) throw new Error(`${label} has unsupported Avro union branch ${branch}`)
+
+    const output: Record<string, string> = {}
+    while (true) {
+      let blockCount = this.readLong(`${label}.block_count`)
+      if (blockCount === 0) return output
+      if (blockCount < 0) {
+        blockCount = -blockCount
+        this.readLong(`${label}.block_size`)
+      }
+      for (let i = 0; i < blockCount; i += 1) {
+        const key = this.readString(`${label}.key`)
+        output[key] = this.readString(`${label}.${key}`)
+      }
+    }
+  }
+
+  readNullableVersion(label: string): number | undefined {
+    const branch = this.readUnionBranch(label)
+    if (branch === 0) return this.readInt(label)
+    if (branch === 1) return undefined
+    throw new Error(`${label} has unsupported Avro union branch ${branch}`)
+  }
+
+  private readUnionBranch(label: string): number {
+    return this.readLong(`${label}.union_branch`)
+  }
+
+  private readByte(label: string): number {
+    this.requireBytes(label, 1)
+    const value = this.bytes[this.offset]
+    this.offset += 1
+    return value
+  }
+
+  private requireBytes(label: string, length: number) {
+    if (this.offset + length > this.bytes.length) {
+      throw new Error(`${label} exceeds Avro payload length`)
+    }
+  }
+}
+
+export const decodeTaStatusHeartbeatAvro = (
+  bytes: Uint8Array,
+  metadata: { topic: string; partition?: number },
+): TaStatusHeartbeatRecord => {
+  const reader = new AvroStatusReader(stripSchemaRegistryPrefix(bytes))
+  const ingestTs = reader.readString('ingest_ts')
+  const eventTs = reader.readString('event_ts')
+  const symbol = reader.readString('symbol')
+  const seq = reader.readLong('seq')
+  const isFinal = reader.readNullableBoolean('is_final')
+  const source = reader.readNullableString('source')
+  reader.readNullableWindow('window')
+  const watermarkLagMs = reader.readNullableLong('watermark_lag_ms')
+  const sourceLagMs = reader.readNullableLong('source_lag_ms')
+  const lastEventTs = reader.readNullableString('last_event_ts')
+  const lastInputEventTs = reader.readNullableString('last_input_event_ts')
+  const lastOutputEventTs = reader.readNullableString('last_output_event_ts')
+  const inputEventCount = reader.readNullableLong('input_event_count')
+  const outputEventCount = reader.readNullableLong('output_event_count')
+  const currentInputEventCount = reader.readNullableLong('current_input_event_count')
+  const currentOutputEventCount = reader.readNullableLong('current_output_event_count')
+  const currentRecordCount = reader.readNullableLong('current_record_count')
+  const inputRatePerSecond = reader.readNullableDouble('input_rate_per_second')
+  const outputRatePerSecond = reader.readNullableDouble('output_rate_per_second')
+  const microbarEventCount = reader.readNullableLong('microbar_event_count')
+  const signalEventCount = reader.readNullableLong('signal_event_count')
+  const microbarRatePerSecond = reader.readNullableDouble('microbar_rate_per_second')
+  const signalRatePerSecond = reader.readNullableDouble('signal_rate_per_second')
+  const clickhouseSinkEnabled = reader.readNullableBoolean('clickhouse_sink_enabled')
+  const perSymbolLatestEventTs = reader.readNullableStringMap('per_symbol_latest_event_ts')
+  const marketSessionState = reader.readNullableString('market_session_state')
+  const statusReason = reader.readNullableString('status_reason')
+  const status = reader.readString('status')
+  const heartbeat = reader.readNullableBoolean('heartbeat')
+  const version = reader.readNullableVersion('version')
+
+  return {
+    topic: metadata.topic,
+    partition: metadata.partition,
+    ingestTs,
+    eventTs,
+    symbol,
+    seq,
+    isFinal,
+    source,
+    watermarkLagMs,
+    sourceLagMs,
+    lastEventTs,
+    lastInputEventTs,
+    lastOutputEventTs,
+    inputEventCount,
+    outputEventCount,
+    currentInputEventCount,
+    currentOutputEventCount,
+    currentRecordCount,
+    inputRatePerSecond,
+    outputRatePerSecond,
+    microbarEventCount,
+    signalEventCount,
+    microbarRatePerSecond,
+    signalRatePerSecond,
+    clickhouseSinkEnabled,
+    perSymbolLatestEventTs,
+    marketSessionState,
+    statusReason,
+    status,
+    heartbeat,
+    version,
+  }
+}
+
+export const evaluateTaStatusHeartbeat = (input: TaStatusHeartbeatEvaluationInput): TaStatusHeartbeatEvaluation => {
+  const failures: string[] = []
+  const warnings: string[] = []
+  const heartbeat = input.heartbeat
+  if (!heartbeat) {
+    return {
+      summaryLine: `- TA status heartbeat: latest=\`missing\`, topic=\`${input.topic}\``,
+      failures: input.enforceFreshness
+        ? [`ta_status_heartbeat_missing: no decodeable heartbeat found on ${input.topic}`]
+        : [],
+      warnings: input.enforceFreshness
+        ? []
+        : [`ta_status_heartbeat_missing: no decodeable heartbeat found on ${input.topic}`],
+    }
+  }
+
+  const heartbeatLag = lagSeconds(input.now, heartbeat.eventTs)
+  const sourceLagSeconds = heartbeat.sourceLagMs === undefined ? undefined : Math.floor(heartbeat.sourceLagMs / 1_000)
+  const summaryLine =
+    `- TA status heartbeat: status=\`${heartbeat.status}\`, reason=\`${heartbeat.statusReason ?? 'ok'}\`, ` +
+    `latest=\`${heartbeat.eventTs}\`, lag_seconds=\`${heartbeatLag ?? 'missing'}\`, ` +
+    `source_lag_ms=\`${heartbeat.sourceLagMs ?? 'missing'}\`, ` +
+    `last_input=\`${heartbeat.lastInputEventTs ?? 'missing'}\`, ` +
+    `last_output=\`${heartbeat.lastOutputEventTs ?? 'missing'}\`, ` +
+    `current_records=\`${heartbeat.currentRecordCount ?? 'missing'}\`, ` +
+    `current_input=\`${heartbeat.currentInputEventCount ?? 'missing'}\`, ` +
+    `current_output=\`${heartbeat.currentOutputEventCount ?? 'missing'}\`, ` +
+    `microbar_rate=\`${heartbeat.microbarRatePerSecond ?? 'missing'}\`, ` +
+    `signal_rate=\`${heartbeat.signalRatePerSecond ?? 'missing'}\`, ` +
+    `clickhouse_sink_enabled=\`${heartbeat.clickhouseSinkEnabled ?? 'missing'}\`, ` +
+    `session=\`${heartbeat.marketSessionState ?? 'missing'}\`, ` +
+    `partition=\`${heartbeat.partition ?? 'unknown'}\``
+
+  if (heartbeatLag === undefined) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_heartbeat_timestamp_missing',
+      'TA status heartbeat has no parseable event_ts',
+    )
+  } else if (heartbeatLag > input.maxLagSeconds) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_heartbeat_stale',
+      `TA status heartbeat lag ${heartbeatLag}s exceeds ${input.maxLagSeconds}s`,
+    )
+  }
+  if (heartbeat.status !== 'ok') {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_degraded',
+      `TA status heartbeat status=${heartbeat.status} reason=${heartbeat.statusReason ?? 'missing'}`,
+    )
+  }
+  if ((heartbeat.currentRecordCount ?? 0) <= 0) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_zero_current_records',
+      'TA status heartbeat reports zero current input/output records',
+    )
+  }
+  if ((heartbeat.currentInputEventCount ?? 0) <= 0) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_zero_current_input_records',
+      'TA status heartbeat reports zero current input records',
+    )
+  }
+  if ((heartbeat.currentOutputEventCount ?? 0) <= 0) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_zero_current_output_records',
+      'TA status heartbeat reports zero current output records',
+    )
+  }
+  if (sourceLagSeconds === undefined) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_source_lag_missing',
+      'TA status heartbeat has no source_lag_ms',
+    )
+  } else if (sourceLagSeconds > input.maxLagSeconds) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_source_lag_stale',
+      `TA status source lag ${sourceLagSeconds}s exceeds ${input.maxLagSeconds}s`,
+    )
+  }
+  if (!heartbeat.lastInputEventTs) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_last_input_missing',
+      'TA status heartbeat has no last_input_event_ts',
+    )
+  }
+  if (!heartbeat.lastOutputEventTs) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_last_output_missing',
+      'TA status heartbeat has no last_output_event_ts',
+    )
+  }
+  if (heartbeat.clickhouseSinkEnabled !== true) {
+    pushFinding(
+      input.enforceFreshness,
+      failures,
+      warnings,
+      'ta_status_clickhouse_sink_disabled',
+      `TA status heartbeat clickhouse_sink_enabled=${heartbeat.clickhouseSinkEnabled ?? 'missing'}`,
+    )
+  }
+
+  return { summaryLine, failures, warnings }
+}


### PR DESCRIPTION
## Summary

- Decode `torghut.ta.status.v1` heartbeat payloads in the Torghut market-data smoke, including schema-registry-prefixed Avro bytes from the live Kafka topic.
- Add a binary-safe `base64` mode to the Kafka tail helper and switch the remote consumer to `--command-config` so stdout stays message-only.
- Fail/warn on missing, stale, degraded, zero-current-record, missing source-lag, and disabled ClickHouse-sink heartbeat evidence through the existing smoke evaluator.
- Keep `market-data-smoke.ts` under the 1000-line ceiling by moving the TA heartbeat contract into `ta-status-heartbeat.ts`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bun run --cwd packages/scripts lint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `bun test packages/scripts/src`
- `git diff --check`
- `bun run packages/scripts/src/kafka/tail-topic.ts --topic torghut.ta.status.v1 --partition 0 --tail 1 --timeout-ms 8000 --username torghut-ws --password-secret-namespace torghut --password-secret-name torghut-ws --password-secret-key password --format base64 | head -c 80`
- `MARKET_DATA_FRESHNESS_MODE=observe TORGHUT_WS_READYZ_URL=http://127.0.0.1:18082/readyz TORGHUT_STATUS_URL=http://127.0.0.1:18081/trading/status bun run packages/scripts/src/torghut/market-data-smoke.ts`

Live smoke evidence: decoded TA status heartbeat reported `status=ok`, latest `2026-07-08T10:43:27.487115324Z`, `lag_seconds=0`, `clickhouse_sink_enabled=true`, `session=outside_regular_session`, with pre-market warnings for zero current records and stale accepted TA/source topics.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
