### PR TITLE
fix(torghut): require ws symbol freshness coverage

### DIFF
--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -14,6 +14,9 @@ const freshWsReadyz = {
       ready: true,
       subscribed_symbol_count: 10,
       observed_symbol_count: 10,
+      fresh_symbol_count: 10,
+      missing_symbols: [],
+      stale_symbols: [],
       latest_kafka_success_at_ms: 1783447200000,
       reason: 'market_data_channel_fresh',
     },
@@ -22,6 +25,9 @@ const freshWsReadyz = {
       ready: true,
       subscribed_symbol_count: 10,
       observed_symbol_count: 10,
+      fresh_symbol_count: 10,
+      missing_symbols: [],
+      stale_symbols: [],
       latest_kafka_success_at_ms: 1783447200000,
       reason: 'market_data_channel_fresh',
     },
@@ -30,6 +36,9 @@ const freshWsReadyz = {
       ready: true,
       subscribed_symbol_count: 10,
       observed_symbol_count: 10,
+      fresh_symbol_count: 10,
+      missing_symbols: [],
+      stale_symbols: [],
       latest_kafka_success_at_ms: 1783447200000,
       reason: 'market_data_channel_fresh',
     },
@@ -38,6 +47,9 @@ const freshWsReadyz = {
       ready: true,
       subscribed_symbol_count: 10,
       observed_symbol_count: 10,
+      fresh_symbol_count: 10,
+      missing_symbols: [],
+      stale_symbols: [],
       latest_kafka_success_at_ms: 1783447200000,
       reason: 'market_data_channel_fresh',
     },
@@ -79,6 +91,19 @@ const staleWsReadyz = {
       reason: 'market_data_channel_gate_inactive',
     },
   ],
+}
+
+const partialCoverageWsReadyz = {
+  market_data_channels: freshWsReadyz.market_data_channels.map((channel) =>
+    channel.channel === 'trades'
+      ? {
+          ...channel,
+          fresh_symbol_count: 9,
+          missing_symbols: ['AMD'],
+          reason: 'market_data_channel_missing_symbol_coverage',
+        }
+      : channel,
+  ),
 }
 
 const tradingStatusWithFreshAcceptedTa = {
@@ -458,6 +483,30 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.enforceFreshness).toBe(true)
     expect(result.ok).toBe(true)
     expect(result.failures).toEqual([])
+  })
+
+  it('fails during regular market hours when WS symbol coverage is incomplete', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: partialCoverageWsReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: freshTaFlinkJob,
+      taStatusHeartbeat: freshTaStatusHeartbeat,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures.join('\n')).toContain('ws_trades_symbol_coverage_gap')
+    expect(result.summaryLines.join('\n')).toContain('missing=`AMD`')
   })
 
   it('fails during regular market hours when TA status heartbeat is missing', () => {

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -120,6 +120,9 @@ const isObject = (value: unknown): value is JsonObject =>
 
 const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined)
 
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map((item) => asString(item) ?? '').filter((item) => item.length > 0) : []
+
 const asNumber = (value: unknown): number | undefined => {
   if (typeof value === 'number' && Number.isFinite(value)) return value
   if (typeof value === 'string' && value.trim() !== '') {
@@ -445,9 +448,14 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
     const ready = status?.ready === true
     const subscribed = asNumber(status?.subscribed_symbol_count) ?? 0
     const observed = asNumber(status?.observed_symbol_count) ?? 0
+    const fresh = asNumber(status?.fresh_symbol_count)
+    const missingSymbols = asStringArray(status?.missing_symbols)
+    const staleSymbols = asStringArray(status?.stale_symbols)
     const reason = asString(status?.reason) ?? 'missing'
     summaryLines.push(
-      `- WS ${channel}: ready=\`${ready}\`, subscribed=\`${subscribed}\`, observed=\`${observed}\`, reason=\`${reason}\``,
+      `- WS ${channel}: ready=\`${ready}\`, subscribed=\`${subscribed}\`, observed=\`${observed}\`, ` +
+        `fresh=\`${fresh ?? 'missing'}\`, missing=\`${missingSymbols.join(',') || 'none'}\`, ` +
+        `stale=\`${staleSymbols.join(',') || 'none'}\`, reason=\`${reason}\``,
     )
     if (!ready || subscribed <= 0) {
       pushFinding(
@@ -456,6 +464,20 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
         warnings,
         `ws_${channel}_not_ready`,
         `WS channel ${channel} ready=${ready} subscribed_symbol_count=${subscribed} reason=${reason}`,
+      )
+    }
+    if (
+      missingSymbols.length > 0 ||
+      staleSymbols.length > 0 ||
+      (fresh !== undefined && subscribed > 0 && fresh < subscribed)
+    ) {
+      pushFinding(
+        enforceFreshness,
+        failures,
+        warnings,
+        `ws_${channel}_symbol_coverage_gap`,
+        `WS channel ${channel} fresh_symbol_count=${fresh ?? 'missing'} subscribed_symbol_count=${subscribed} ` +
+          `missing_symbols=${missingSymbols.join(',') || 'none'} stale_symbols=${staleSymbols.join(',') || 'none'}`,
       )
     }
     if (enforceFreshness && status?.latest_kafka_success_at_ms === null) {

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -1116,7 +1116,7 @@ class ForwarderApp(
               source = "rest",
             )
           recordLag(env)
-          sendKafka(producer, config.topics.trades, env, "trades")
+          sendKafka(producer, config.topics.trades, env)
         }
     } catch (e: Exception) {
       tradesBackfillDone.set(false)
@@ -1405,7 +1405,7 @@ class ForwarderApp(
           recordKafkaFailure(exception, topic)
         } else {
           metrics.recordKafkaProduceSuccess(topic)
-          marketDataChannelFreshness.recordKafkaSuccess(marketDataChannel, env.symbol)
+          marketDataChannelFreshness.recordKafkaSuccess(marketDataFreshnessChannelFor(env, marketDataChannel), env.symbol)
           recordKafkaSuccess()
         }
       }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderMetrics.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderMetrics.kt
@@ -243,6 +243,21 @@ internal class ForwarderMetrics(
         field = "observed_symbol_count",
         value = channel.observedSymbolCount.toLong(),
       )
+      setMarketDataChannelGauge(
+        channel = channel.channel,
+        field = "fresh_symbol_count",
+        value = channel.freshSymbolCount.toLong(),
+      )
+      setMarketDataChannelGauge(
+        channel = channel.channel,
+        field = "missing_symbol_count",
+        value = channel.missingSymbols.size.toLong(),
+      )
+      setMarketDataChannelGauge(
+        channel = channel.channel,
+        field = "stale_symbol_count",
+        value = channel.staleSymbols.size.toLong(),
+      )
     }
   }
 

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
@@ -1,5 +1,6 @@
 package ai.proompteng.dorvud.ws
 
+import ai.proompteng.dorvud.platform.Envelope
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.Instant
@@ -20,6 +21,11 @@ data class MarketDataChannelReadiness(
   @SerialName("subscribed_symbol_count") val subscribedSymbolCount: Int = 0,
   @SerialName("observed_symbol_count") val observedSymbolCount: Int = 0,
   @SerialName("observed_symbols") val observedSymbols: List<String> = emptyList(),
+  @SerialName("fresh_symbol_count") val freshSymbolCount: Int = 0,
+  @SerialName("fresh_symbols") val freshSymbols: List<String> = emptyList(),
+  @SerialName("missing_symbols") val missingSymbols: List<String> = emptyList(),
+  @SerialName("stale_symbols") val staleSymbols: List<String> = emptyList(),
+  @SerialName("symbol_lag_ms") val symbolLagMs: Map<String, Long> = emptyMap(),
   @SerialName("lag_ms") val lagMs: Long? = null,
   @SerialName("max_lag_ms") val maxLagMs: Long,
   @SerialName("reason") val reason: String,
@@ -109,18 +115,38 @@ internal class MarketDataChannelFreshnessTracker(
       val latestKafkaSuccessAt = state?.latestKafkaSuccessAtMs?.get()?.takeIf { it > 0 }
       val latestProviderAt = state?.latestProviderEventAtMs?.get()?.takeIf { it > 0 }
       val latestSerializedAt = state?.latestSerializedAtMs?.get()?.takeIf { it > 0 }
+      val symbolLastSeen = state?.latestKafkaSuccessAtMsBySymbol?.mapValues { (_, seenAt) -> seenAt.get() }.orEmpty()
       val observedSymbols =
-        state
-          ?.kafkaSuccessSymbols
-          ?.toList()
-          ?.sorted()
-          .orEmpty()
+        symbolLastSeen
+          .keys
+          .filter { symbol -> symbol in channelSymbols }
+          .sorted()
       val lagMs = latestKafkaSuccessAt?.let { (now - it).coerceAtLeast(0) }
+      val symbolLagMs =
+        channelSymbols
+          .mapNotNull { symbol ->
+            val seenAt = symbolLastSeen[symbol]?.takeIf { it > 0 } ?: return@mapNotNull null
+            symbol to (now - seenAt).coerceAtLeast(0)
+          }.toMap()
+      val freshSymbols =
+        channelSymbols
+          .filter { symbol -> symbolLagMs[symbol]?.let { it <= maxLagMs } == true }
+          .sorted()
+      val missingSymbols =
+        channelSymbols
+          .filter { symbol -> symbol !in symbolLastSeen }
+          .sorted()
+      val staleSymbols =
+        channelSymbols
+          .filter { symbol -> symbolLastSeen.containsKey(symbol) && symbol !in freshSymbols }
+          .sorted()
       val ready =
         when {
           !gateActive -> true
           channelSymbols.isEmpty() -> false
           latestKafkaSuccessAt == null -> false
+          missingSymbols.isNotEmpty() -> false
+          staleSymbols.isNotEmpty() -> false
           lagMs == null -> false
           else -> lagMs <= maxLagMs
         }
@@ -135,6 +161,11 @@ internal class MarketDataChannelFreshnessTracker(
         subscribedSymbolCount = channelSymbols.size,
         observedSymbolCount = observedSymbols.size,
         observedSymbols = observedSymbols,
+        freshSymbolCount = freshSymbols.size,
+        freshSymbols = freshSymbols,
+        missingSymbols = missingSymbols,
+        staleSymbols = staleSymbols,
+        symbolLagMs = symbolLagMs,
         lagMs = lagMs,
         maxLagMs = maxLagMs,
         reason =
@@ -143,6 +174,8 @@ internal class MarketDataChannelFreshnessTracker(
             ready -> "market_data_channel_fresh"
             channelSymbols.isEmpty() -> "market_data_channel_not_subscribed"
             latestKafkaSuccessAt == null -> "market_data_channel_missing_kafka_success"
+            missingSymbols.isNotEmpty() -> "market_data_channel_missing_symbol_coverage"
+            staleSymbols.isNotEmpty() -> "market_data_channel_stale_symbol_coverage"
             else -> "market_data_channel_stale"
           },
       )
@@ -166,7 +199,7 @@ internal class MarketDataChannelFreshnessTracker(
     val latestSerializedAtMs = AtomicLong(0)
     val latestKafkaSuccessAtMs = AtomicLong(0)
     val latestSymbol = AtomicReference<String?>(null)
-    val kafkaSuccessSymbols: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    val latestKafkaSuccessAtMsBySymbol = ConcurrentHashMap<String, AtomicLong>()
 
     fun recordProviderEvent(
       atMs: Long,
@@ -191,7 +224,9 @@ internal class MarketDataChannelFreshnessTracker(
       latestKafkaSuccessAtMs.set(atMs)
       updateSymbol(symbol)
       val normalized = normalizeSymbol(symbol) ?: return
-      kafkaSuccessSymbols.add(normalized)
+      latestKafkaSuccessAtMsBySymbol
+        .computeIfAbsent(normalized) { AtomicLong(0) }
+        .set(atMs)
     }
 
     private fun updateSymbol(symbol: String?) {
@@ -209,6 +244,14 @@ internal fun canonicalMarketDataChannel(channel: String): String? =
     "updatedbars" -> "updatedBars"
     else -> null
   }
+
+internal fun marketDataFreshnessChannelFor(
+  env: Envelope<*>,
+  marketDataChannel: String?,
+): String? {
+  if (!env.source.equals("ws", ignoreCase = true)) return null
+  return marketDataChannel
+}
 
 private fun normalizeSymbol(symbol: String?): String? =
   symbol

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderEndpointsTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderEndpointsTest.kt
@@ -1,8 +1,10 @@
 package ai.proompteng.dorvud.ws
 
+import ai.proompteng.dorvud.platform.Envelope
 import ai.proompteng.dorvud.platform.KafkaAuth
 import ai.proompteng.dorvud.platform.KafkaProducerSettings
 import ai.proompteng.dorvud.platform.KafkaTls
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import java.time.Instant
 import kotlin.test.Test
@@ -174,5 +176,25 @@ class ForwarderEndpointsTest {
 
     assertEquals(null, query.feed)
     assertEquals(null, query.pageToken)
+  }
+
+  @Test
+  fun `only websocket envelopes can satisfy live market-data freshness`() {
+    val wsEnvelope =
+      Envelope(
+        ingestTs = Instant.parse("2026-07-07T14:00:00Z"),
+        eventTs = Instant.parse("2026-07-07T14:00:00Z"),
+        feed = "iex",
+        channel = "trades",
+        symbol = "NVDA",
+        seq = 1,
+        payload = JsonPrimitive("payload"),
+        source = "ws",
+      )
+    val restEnvelope = wsEnvelope.copy(source = "rest")
+
+    assertEquals("trades", marketDataFreshnessChannelFor(wsEnvelope, "trades"))
+    assertEquals(null, marketDataFreshnessChannelFor(restEnvelope, "trades"))
+    assertEquals(null, marketDataFreshnessChannelFor(wsEnvelope, null))
   }
 }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -27,10 +27,11 @@ class MarketDataChannelFreshnessTrackerTest {
     val byChannel = tracker.snapshot().associateBy { it.channel }
 
     assertFalse(tracker.ready())
-    assertTrue(byChannel.getValue("bars").ready)
+    assertFalse(byChannel.getValue("bars").ready)
     assertEquals(2, byChannel.getValue("bars").subscribedSymbolCount)
     assertEquals(1, byChannel.getValue("bars").observedSymbolCount)
     assertEquals(listOf("NVDA"), byChannel.getValue("bars").observedSymbols)
+    assertEquals(listOf("AMD"), byChannel.getValue("bars").missingSymbols)
     assertFalse(byChannel.getValue("trades").ready)
     assertEquals(
       "market_data_channel_missing_kafka_success",
@@ -43,13 +44,25 @@ class MarketDataChannelFreshnessTrackerTest {
       tracker.recordKafkaSuccess(channel, "NVDA")
     }
 
+    assertFalse(tracker.ready())
+    assertEquals(
+      "market_data_channel_missing_symbol_coverage",
+      tracker.snapshot().first { it.channel == "trades" }.reason,
+    )
+
+    listOf("trades", "quotes", "bars", "updatedBars").forEach { channel ->
+      tracker.recordProviderEvent(channel, "AMD")
+      tracker.recordSerializedEvent(channel, "AMD")
+      tracker.recordKafkaSuccess(channel, "AMD")
+    }
+
     assertTrue(tracker.ready())
 
     nowMs += 61_000
 
     assertFalse(tracker.ready())
     assertEquals(
-      "market_data_channel_stale",
+      "market_data_channel_stale_symbol_coverage",
       tracker.snapshot().first { it.channel == "trades" }.reason,
     )
   }
@@ -81,13 +94,52 @@ class MarketDataChannelFreshnessTrackerTest {
     val byChannel = tracker.snapshot().associateBy { it.channel }
 
     assertFalse(tracker.ready())
-    assertTrue(byChannel.getValue("bars").ready)
+    assertFalse(byChannel.getValue("bars").ready)
     assertEquals(2, byChannel.getValue("bars").subscribedSymbolCount)
+    assertEquals(listOf("AMD"), byChannel.getValue("bars").missingSymbols)
     assertFalse(byChannel.getValue("trades").ready)
     assertEquals(0, byChannel.getValue("trades").subscribedSymbolCount)
     assertEquals(
       "market_data_channel_not_subscribed",
       byChannel.getValue("trades").reason,
     )
+  }
+
+  @Test
+  fun `regular-session readiness requires fresh coverage for every subscribed symbol`() {
+    var nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("trades"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.EQUITY,
+      )
+
+    tracker.recordSubscriptionByChannel(mapOf("trades" to listOf("NVDA", "AMD")))
+    tracker.recordProviderEvent("trades", "NVDA")
+    tracker.recordSerializedEvent("trades", "NVDA")
+    tracker.recordKafkaSuccess("trades", "NVDA")
+
+    val missingCoverage = tracker.snapshot().single()
+    assertFalse(tracker.ready())
+    assertEquals("market_data_channel_missing_symbol_coverage", missingCoverage.reason)
+    assertEquals(listOf("AMD"), missingCoverage.missingSymbols)
+    assertEquals(listOf("NVDA"), missingCoverage.freshSymbols)
+
+    nowMs += 10_000
+    tracker.recordProviderEvent("trades", "AMD")
+    tracker.recordSerializedEvent("trades", "AMD")
+    tracker.recordKafkaSuccess("trades", "AMD")
+
+    assertTrue(tracker.ready())
+
+    nowMs += 55_000
+    val staleCoverage = tracker.snapshot().single()
+    assertFalse(tracker.ready())
+    assertEquals("market_data_channel_stale_symbol_coverage", staleCoverage.reason)
+    assertEquals(listOf("NVDA"), staleCoverage.staleSymbols)
+    assertEquals(listOf("AMD"), staleCoverage.freshSymbols)
   }
 }


### PR DESCRIPTION
## Summary

- Requires websocket market-data readiness to prove fresh symbol coverage for every subscribed symbol on each required channel during regular sessions.
- Prevents REST backfill envelopes from satisfying the live websocket freshness gate.
- Adds fresh, missing, and stale symbol coverage fields to WS readyz/metrics, and teaches the Torghut market-data smoke proof to surface and enforce those fields when present.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest' --tests 'ai.proompteng.dorvud.ws.ForwarderEndpointsTest'`
- `cd services/dorvud && ./gradlew :websockets:test :websockets:ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test :technical-analysis:test :technical-analysis-flink:test ktlintCheck`
- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bun run --cwd packages/scripts lint` (passes with existing warning-only findings in unrelated files)
- `bun test packages/scripts/src`
- `bun run --cwd packages/scripts lint:oxlint:type` (passes with existing warning-only findings in unrelated files)
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
