### PR TITLE
chore(torghut): promote ws image sha-ce8192e36ec5770393ce85e5aefcf0daedd5dc21

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c63ee746755e351894ce07f360f16ae920fac80854f638e27a9e73be83fa640d
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c1a28c034f67014d17193305ff2ce0d7ad5ed80eee37c4c95da6242936be4755
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: main-sha-ce8192e36ec5770393ce85e5aefcf0daedd5dc21
             - name: TORGHUT_WS_COMMIT
-              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: ce8192e36ec5770393ce85e5aefcf0daedd5dc21
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c63ee746755e351894ce07f360f16ae920fac80854f638e27a9e73be83fa640d
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:c1a28c034f67014d17193305ff2ce0d7ad5ed80eee37c4c95da6242936be4755
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: main-sha-ce8192e36ec5770393ce85e5aefcf0daedd5dc21
             - name: TORGHUT_WS_COMMIT
-              value: 88789b6737f3a9ed6c99f6598f3732f9b5aa30f7
+              value: ce8192e36ec5770393ce85e5aefcf0daedd5dc21
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `ce8192e36ec5770393ce85e5aefcf0daedd5dc21`
- Image tag: `sha-ce8192e36ec5770393ce85e5aefcf0daedd5dc21`
- Image digest: `sha256:c1a28c034f67014d17193305ff2ce0d7ad5ed80eee37c4c95da6242936be4755`