### PR TITLE
fix(torghut): harden ta freshness gates

### DIFF
--- a/argocd/applications/torghut/ta/configmap.yaml
+++ b/argocd/applications/torghut/ta/configmap.yaml
@@ -28,6 +28,7 @@ data:
   # IEX quote cadence can be sparse for the capped chip universe; keep TA quotes
   # fresh enough for execution gates without admitting overnight/stale state.
   TA_QUOTE_STALE_AFTER_MS: "15000"
+  TA_SOURCE_LAG_DEGRADED_AFTER_MS: "300000"
   TA_PARALLELISM: "8"
   TA_VWAP_WINDOW_SECONDS: "300"
   TA_REALIZED_VOL_WINDOW: "60"

--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -404,6 +404,40 @@ describe('market data smoke freshness evaluation', () => {
     expect(marketSessionState(new Date('2026-07-07T22:00:00Z'))).toBe('post')
   })
 
+  it('does not enforce regular-session freshness on configured market holidays', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-03T17:00:00Z'),
+      mode: 'auto',
+      holidays: new Set(['2026-07-03']),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-02T20:54:58Z', symbol: 'SNDK' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-02T20:33:55Z', symbol: 'SNDK' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-02T20:59:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: staleWsReadyz,
+      tradingStatus: tradingStatusWithStaleAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: zeroCurrentTaFlinkJob,
+      taStatusHeartbeat: staleTaStatusHeartbeat,
+    })
+
+    expect(result.sessionState).toBe('holiday')
+    expect(result.enforceFreshness).toBe(false)
+    expect(result.ok).toBe(true)
+    expect(result.warnings.join('\n')).toContain('accepted_ta_signal_stale')
+    expect(result.warnings.join('\n')).toContain('ta_flink_zero_source_records')
+  })
+
+  it('ships 2026 US equity holidays as the smoke default calendar', () => {
+    expect(marketDataSmokeSource).toContain('DEFAULT_US_EQUITY_MARKET_HOLIDAYS')
+    expect(marketDataSmokeSource).toContain("'2026-07-03'")
+    expect(marketDataSmokeSource).toContain(
+      'holidays: new Set(parseList(process.env.MARKET_DATA_HOLIDAYS, DEFAULT_US_EQUITY_MARKET_HOLIDAYS))',
+    )
+  })
+
   it('fails in auto mode during regular market hours when accepted TA and source topics are stale', () => {
     const result = evaluateMarketDataSmoke({
       now: new Date('2026-07-07T17:00:00Z'),

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -85,6 +85,18 @@ const DEFAULT_TA_STATUS_TOPIC = 'torghut.ta.status.v1'
 const REQUIRED_WS_CHANNELS = ['trades', 'quotes', 'bars', 'updatedBars']
 const REQUIRED_KAFKA_ROLES: KafkaRole[] = ['trades', 'quotes', 'bars']
 const ACCEPTED_SOURCE_STALE_REASON = 'accepted_ta_signal_stale'
+const DEFAULT_US_EQUITY_MARKET_HOLIDAYS = [
+  '2026-01-01',
+  '2026-01-19',
+  '2026-02-16',
+  '2026-04-03',
+  '2026-05-25',
+  '2026-06-19',
+  '2026-07-03',
+  '2026-09-07',
+  '2026-11-26',
+  '2026-12-25',
+]
 
 const parseList = (raw: string | undefined, fallback: string[]) =>
   raw
@@ -748,7 +760,7 @@ const runtimeSettings = (): RuntimeSettings => ({
     300,
     'MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS',
   ),
-  holidays: new Set(parseList(process.env.MARKET_DATA_HOLIDAYS, [])),
+  holidays: new Set(parseList(process.env.MARKET_DATA_HOLIDAYS, DEFAULT_US_EQUITY_MARKET_HOLIDAYS)),
   now: process.env.MARKET_DATA_NOW ? new Date(process.env.MARKET_DATA_NOW) : new Date(),
   printSummaries: process.env.MARKET_DATA_PRINT_SUMMARIES !== 'false',
   torghutNamespace: process.env.TORGHUT_NAMESPACE ?? 'torghut',

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTaConfig.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTaConfig.kt
@@ -4,6 +4,8 @@ import org.apache.flink.connector.base.DeliveryGuarantee
 import java.io.Serializable
 import java.time.Duration
 
+internal const val DEFAULT_TA_SOURCE_LAG_DEGRADED_AFTER_MS: Long = 300_000
+
 data class FlinkTaConfig(
   val bootstrapServers: String,
   val tradesTopic: String,
@@ -26,6 +28,7 @@ data class FlinkTaConfig(
   val minPauseBetweenCheckpointsMs: Long,
   val maxOutOfOrderMs: Long,
   val quoteStaleAfterMs: Long,
+  val sourceLagDegradedAfterMs: Long,
   val parallelism: Int,
   val vwapWindow: Duration,
   val realizedVolWindow: Int,
@@ -94,6 +97,10 @@ data class FlinkTaConfig(
         env("TA_QUOTE_STALE_AFTER_MS")?.toLongOrNull()
           ?: env("TA_QUOTE_STALE_AFTER_SEC")?.toLongOrNull()?.times(1_000)
           ?: 2_000
+      val sourceLagDegradedAfterMs =
+        env("TA_SOURCE_LAG_DEGRADED_AFTER_MS")?.toLongOrNull()
+          ?: env("TA_SOURCE_LAG_DEGRADED_AFTER_SEC")?.toLongOrNull()?.times(1_000)
+          ?: DEFAULT_TA_SOURCE_LAG_DEGRADED_AFTER_MS
 
       return FlinkTaConfig(
         bootstrapServers = env("TA_KAFKA_BOOTSTRAP", "kafka-kafka-bootstrap.kafka:9092"),
@@ -117,6 +124,7 @@ data class FlinkTaConfig(
         minPauseBetweenCheckpointsMs = envLong("TA_CHECKPOINT_PAUSE_MS", 5_000),
         maxOutOfOrderMs = envLong("TA_MAX_OUT_OF_ORDER_MS", 2_000),
         quoteStaleAfterMs = quoteStaleAfterMs,
+        sourceLagDegradedAfterMs = sourceLagDegradedAfterMs,
         parallelism = parallelism,
         vwapWindow = Duration.ofSeconds(envLong("TA_VWAP_WINDOW_SECONDS", 300)),
         realizedVolWindow = envInt("TA_REALIZED_VOL_WINDOW", 60),

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
@@ -177,6 +177,7 @@ fun main() {
           StatusHeartbeatProcessFunction(
             intervalMs = statusIntervalMs,
             clickhouseSinkEnabled = !config.clickhouseUrl.isNullOrBlank(),
+            sourceLagDegradedAfterMs = config.sourceLagDegradedAfterMs,
           ),
         )
     statusHeartbeats
@@ -197,6 +198,8 @@ private const val STATUS_SYMBOL = "ta"
 private const val MARKET_SESSION_REGULAR = "regular"
 private const val MARKET_SESSION_OUTSIDE_REGULAR = "outside_regular_session"
 private const val ZERO_CURRENT_RECORDS_REASON = "zero_current_records_during_regular_session"
+private const val SOURCE_LAG_MISSING_REASON = "source_lag_missing_during_regular_session"
+private const val SOURCE_LAG_STALE_REASON = "source_lag_stale_during_regular_session"
 private val EQUITY_MARKET_ZONE: ZoneId = ZoneId.of("America/New_York")
 private val REGULAR_SESSION_OPEN: LocalTime = LocalTime.of(9, 30)
 private val REGULAR_SESSION_CLOSE: LocalTime = LocalTime.of(16, 0)
@@ -1005,6 +1008,7 @@ private class MicrobarProcessFunction : KeyedProcessFunction<String, TradeEnvelo
 private class StatusHeartbeatProcessFunction(
   private val intervalMs: Long,
   private val clickhouseSinkEnabled: Boolean,
+  private val sourceLagDegradedAfterMs: Long,
 ) : KeyedProcessFunction<String, StatusHeartbeatInput, Envelope<TaStatusPayload>>() {
   private lateinit var lastInputEventMsState: ValueState<Long>
   private lateinit var lastOutputEventMsState: ValueState<Long>
@@ -1147,6 +1151,7 @@ private class StatusHeartbeatProcessFunction(
         lastHeartbeatMs = lastHeartbeatMs,
         perSymbolLatestEventTs = perSymbolLatestEventTs,
         clickhouseSinkEnabled = clickhouseSinkEnabled,
+        sourceLagDegradedAfterMs = sourceLagDegradedAfterMs,
       )
     lastHeartbeatInputCountState.update(inputEventCount)
     lastHeartbeatOutputCountState.update(outputEventCount)
@@ -1193,6 +1198,7 @@ internal fun taStatusPayload(
   lastHeartbeatMs: Long?,
   perSymbolLatestEventTs: Map<String, String>,
   clickhouseSinkEnabled: Boolean = false,
+  sourceLagDegradedAfterMs: Long = DEFAULT_TA_SOURCE_LAG_DEGRADED_AFTER_MS,
 ): TaStatusPayload {
   val nowMs = now.toEpochMilli()
   val watermarkLagMs =
@@ -1211,6 +1217,8 @@ internal fun taStatusPayload(
   val currentInputEventCount = deltaSinceLastHeartbeat(inputEventCount, lastHeartbeatInputCount)
   val currentOutputEventCount = deltaSinceLastHeartbeat(outputEventCount, lastHeartbeatOutputCount)
   val currentRecordCount = currentInputEventCount + currentOutputEventCount
+  val lastEventMs = maxOfNullable(lastInputEventMs, lastOutputEventMs)
+  val sourceLagMs = lastEventMs?.let { (nowMs - it).coerceAtLeast(0) }
   val outputRatePerSecond =
     ratePerSecond(
       nowMs = nowMs,
@@ -1220,17 +1228,21 @@ internal fun taStatusPayload(
     )
   val marketSessionState = marketSessionState(now)
   val statusReason =
-    if (marketSessionState == MARKET_SESSION_REGULAR && currentRecordCount == 0L) {
+    if (marketSessionState != MARKET_SESSION_REGULAR) {
+      null
+    } else if (sourceLagMs == null) {
+      SOURCE_LAG_MISSING_REASON
+    } else if (sourceLagMs > sourceLagDegradedAfterMs) {
+      SOURCE_LAG_STALE_REASON
+    } else if (currentRecordCount == 0L) {
       ZERO_CURRENT_RECORDS_REASON
     } else {
       null
     }
   val status = if (statusReason == null) "ok" else "degraded"
-  val lastEventMs = maxOfNullable(lastInputEventMs, lastOutputEventMs)
   val lastEventTs = lastEventMs?.let { Instant.ofEpochMilli(it).toString() }
   val lastInputEventTs = lastInputEventMs?.let { Instant.ofEpochMilli(it).toString() }
   val lastOutputEventTs = lastOutputEventMs?.let { Instant.ofEpochMilli(it).toString() }
-  val sourceLagMs = lastEventMs?.let { (nowMs - it).coerceAtLeast(0) }
   return TaStatusPayload(
     watermarkLagMs = watermarkLagMs,
     sourceLagMs = sourceLagMs,

--- a/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisStatusHeartbeatTest.kt
+++ b/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisStatusHeartbeatTest.kt
@@ -47,7 +47,7 @@ class FlinkTechnicalAnalysisStatusHeartbeatTest {
     assertEquals(false, payload.clickhouseSinkEnabled)
     assertEquals(emptyMap(), payload.perSymbolLatestEventTs)
     assertEquals("regular", payload.marketSessionState)
-    assertEquals("zero_current_records_during_regular_session", payload.statusReason)
+    assertEquals("source_lag_missing_during_regular_session", payload.statusReason)
     assertEquals("degraded", payload.status)
   }
 
@@ -93,6 +93,35 @@ class FlinkTechnicalAnalysisStatusHeartbeatTest {
     assertNull(payload.statusReason)
     assertEquals("ok", payload.status)
     assertEquals(mapOf("NVDA" to lastOutputEvent.toString()), payload.perSymbolLatestEventTs)
+  }
+
+  @Test
+  fun `regular session heartbeat degrades on stale source lag even when counters moved`() {
+    val now = Instant.parse("2026-07-07T14:10:05Z")
+    val lastInputEvent = Instant.parse("2026-07-07T14:00:00Z")
+    val lastOutputEvent = Instant.parse("2026-07-07T14:00:05Z")
+
+    val payload =
+      taStatusPayload(
+        now = now,
+        watermark = lastOutputEvent.toEpochMilli(),
+        lastInputEventMs = lastInputEvent.toEpochMilli(),
+        lastOutputEventMs = lastOutputEvent.toEpochMilli(),
+        inputEventCount = 25,
+        outputEventCount = 15,
+        lastHeartbeatInputCount = 5,
+        lastHeartbeatOutputCount = 10,
+        lastHeartbeatMs = now.minusSeconds(10).toEpochMilli(),
+        perSymbolLatestEventTs = mapOf("NVDA" to lastOutputEvent.toString()),
+        clickhouseSinkEnabled = true,
+        sourceLagDegradedAfterMs = 300_000,
+      )
+
+    assertEquals(600_000, payload.sourceLagMs)
+    assertEquals(25, payload.currentRecordCount)
+    assertEquals("regular", payload.marketSessionState)
+    assertEquals("source_lag_stale_during_regular_session", payload.statusReason)
+    assertEquals("degraded", payload.status)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add the 2026 US equity holiday calendar as the default market-data smoke calendar.
- Add `TA_SOURCE_LAG_DEGRADED_AFTER_MS` for the equities TA Flink job and wire the live config to 300 seconds.
- Degrade TA status heartbeats during regular market hours when accepted-source lag is missing or stale, even if counters moved.
- Keep REST/backfill excluded from live accepted-source readiness.

## Related Issues

Follow-up to the Torghut production market-data freshness recovery rollout.

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bun run --cwd packages/scripts lint` passed with three pre-existing warnings in unrelated `src/app/*` files.
- `cd services/dorvud && ./gradlew :technical-analysis-flink:test --tests 'ai.proompteng.dorvud.ta.flink.FlinkTechnicalAnalysisStatusHeartbeatTest' :technical-analysis-flink:ktlintCheck`
- `cd services/dorvud && ./gradlew :technical-analysis-flink:test`
- `kubectl kustomize argocd/applications/torghut | rg -n 'TA_SOURCE_LAG_DEGRADED_AFTER_MS|name: torghut-ta-config'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
