### PR TITLE
fix(torghut): align live gate freshness surfaces

### DIFF
--- a/services/torghut/app/api/readiness_helpers/evaluate_trading_health_payload_bounded.py
+++ b/services/torghut/app/api/readiness_helpers/evaluate_trading_health_payload_bounded.py
@@ -53,6 +53,7 @@ def _cached_result_from_entry(
         return None
     payload = deepcopy(cast(dict[str, object], cache_entry["payload"]))
     dependencies = payload.get("dependencies")
+    readiness_dependency_reasons: list[str] = []
     if isinstance(dependencies, Mapping):
         from .evaluate_trading_health_payload import (
             runtime_dependencies_for_health_surface,
@@ -89,15 +90,14 @@ def _cached_result_from_entry(
                     "readiness_dependency_guard_reasons": readiness_dependency_reasons,
                 }
                 payload["dependencies"] = dependencies_payload
-    status_value = cache_entry.get("status_code")
-    status_code = status_value if isinstance(status_value, int) else 503
-    return (
-        cast(
+    if readiness_dependency_reasons:
+        payload = cast(
             dict[str, object],
             _strip_promotion_authority_claims_for_readiness(payload),
-        ),
-        status_code,
-    )
+        )
+    status_value = cache_entry.get("status_code")
+    status_code = status_value if isinstance(status_value, int) else 503
+    return payload, status_code
 
 
 def _start_refresh_locked(

--- a/services/torghut/app/api/readiness_helpers/readiness_surface.py
+++ b/services/torghut/app/api/readiness_helpers/readiness_surface.py
@@ -588,10 +588,12 @@ def _evaluate_core_readiness_payload(
         "readiness_surface": "core_dependencies_and_live_submission_gate",
         "live_submission_gate": live_submission_gate,
     }
-    return cast(
-        dict[str, object],
-        strip_promotion_authority_claims_for_readiness(payload),
-    ), 200 if overall_ok else 503
+    if readiness_dependency_reasons:
+        payload = cast(
+            dict[str, object],
+            strip_promotion_authority_claims_for_readiness(payload),
+        )
+    return payload, 200 if overall_ok else 503
 
 
 def trading_health_surface_cache_key(

--- a/services/torghut/app/api/readiness_helpers/trading_health_proof_lane.py
+++ b/services/torghut/app/api/readiness_helpers/trading_health_proof_lane.py
@@ -32,12 +32,19 @@ def build_trading_health_proof_lane(
         dependencies=dict(dependency_snapshot.dependencies),
         deps=deps,
     )
+    _add_clickhouse_ta_status(proof_lane)
     _add_alpha_readiness(proof_lane)
     _add_live_gate_and_proof_floor(proof_lane)
     _add_primary_payloads(proof_lane)
     add_repair_payloads(proof_lane)
     add_dependency_statuses(proof_lane)
     return proof_lane
+
+
+def _add_clickhouse_ta_status(proof_lane: TradingHealthProofLane) -> None:
+    proof_lane.payloads["clickhouse_ta_status"] = (
+        proof_lane.deps.load_clickhouse_ta_status(proof_lane.context.scheduler)
+    )
 
 
 def _add_alpha_readiness(proof_lane: TradingHealthProofLane) -> None:
@@ -59,6 +66,7 @@ def _add_alpha_readiness(proof_lane: TradingHealthProofLane) -> None:
                 scheduler,
                 tca_summary=payload(payloads, "tca_summary"),
                 market_context_status=market_context_status,
+                feature_readiness=payload(payloads, "clickhouse_ta_status"),
             )
         )
     except (SQLAlchemyError, RuntimeError, ValueError, KeyError, TypeError) as exc:
@@ -111,6 +119,7 @@ def _add_live_gate_and_proof_floor(proof_lane: TradingHealthProofLane) -> None:
             empirical_jobs_status=empirical_jobs,
             dspy_runtime_status=dspy_runtime,
             quant_health_status=quant_evidence,
+            clickhouse_ta_status=payload(payloads, "clickhouse_ta_status"),
         )
     payloads["proof_floor"] = deps.build_profitability_proof_floor_payload(
         state=scheduler.state,

--- a/services/torghut/tests/api/test_trading_api_health_contract.py
+++ b/services/torghut/tests/api/test_trading_api_health_contract.py
@@ -1,11 +1,119 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from tests.api.trading_api_support import (
+    SimpleNamespace,
     TradingApiTestCaseBase,
+    TradingScheduler,
+    _mark_static_universe_loaded,
+    app,
     datetime,
     patch,
     timezone,
 )
+
+
+def _current_clickhouse_ta_status() -> dict[str, object]:
+    return {
+        "accepted_sources": ["ta"],
+        "latest_accepted_event_at": "2026-07-08T12:07:15Z",
+        "accepted_lag_seconds": 150,
+        "accepted_source_state": "current",
+        "blocking_reason": None,
+    }
+
+
+def _healthy_dependency_snapshot(
+    checked_at: datetime,
+) -> tuple[dict[str, object], datetime, bool]:
+    return (
+        {
+            "postgres": {"ok": True, "detail": "ok"},
+            "clickhouse": {"ok": True, "detail": "ok"},
+            "alpaca": {"ok": True, "detail": "ok"},
+            "tigerbeetle": {"ok": True, "detail": "ok"},
+        },
+        checked_at,
+        False,
+    )
+
+
+def _recording_hypothesis_runtime_builder(
+    calls: list[dict[str, object]],
+) -> Callable[..., tuple[dict[str, object], dict[str, object], SimpleNamespace]]:
+    def _build_hypothesis_runtime(
+        *_args: object, **kwargs: object
+    ) -> tuple[dict[str, object], dict[str, object], SimpleNamespace]:
+        calls.append(dict(kwargs))
+        summary = {
+            "promotion_eligible_total": 1,
+            "capital_stage_totals": {"shadow": 1},
+            "dependency_quorum": {
+                "decision": "allow",
+                "reasons": [],
+                "message": "ready",
+            },
+        }
+        return (
+            {
+                "registry_loaded": True,
+                "registry_path": "test",
+                "registry_errors": [],
+                "dependency_quorum": summary["dependency_quorum"],
+                "summary": summary,
+                "items": [],
+            },
+            summary,
+            SimpleNamespace(
+                decision="allow",
+                as_payload=lambda: summary["dependency_quorum"],
+            ),
+        )
+
+    return _build_hypothesis_runtime
+
+
+def _recording_live_gate_builder(
+    calls: list[dict[str, object]],
+) -> Callable[..., dict[str, object]]:
+    def _build_gate(_state: object, **kwargs: object) -> dict[str, object]:
+        calls.append(dict(kwargs))
+        return {
+            "allowed": True,
+            "reason": "operational_submission_ready",
+            "blocked_reasons": [],
+            "reason_codes": [],
+            "read_model_unavailable": False,
+            "promotion_authority": True,
+            "promotion_authority_ok": True,
+            "final_authority_ok": True,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "capital_stage": "live",
+            "capital_state": "live",
+            "clickhouse_ta_freshness": kwargs["clickhouse_ta_status"],
+        }
+
+    return _build_gate
+
+
+def _install_running_scheduler() -> object | None:
+    original_scheduler = getattr(app.state, "trading_scheduler", None)
+    scheduler = TradingScheduler()
+    scheduler.state.running = True
+    scheduler.state.last_run_at = datetime.now(timezone.utc)
+    _mark_static_universe_loaded(scheduler)
+    app.state.trading_scheduler = scheduler
+    return original_scheduler
+
+
+def _restore_scheduler(original_scheduler: object | None) -> None:
+    if original_scheduler is None:
+        if hasattr(app.state, "trading_scheduler"):
+            del app.state.trading_scheduler
+    else:
+        app.state.trading_scheduler = original_scheduler
 
 
 class TestTradingApiHealthContract(TradingApiTestCaseBase):
@@ -82,3 +190,73 @@ class TestTradingApiHealthContract(TradingApiTestCaseBase):
         self.assertFalse(gate["final_authority_ok"])
         self.assertFalse(gate["final_promotion_allowed"])
         self.assertTrue(gate["readiness_dependency_guard_active"])
+
+    def test_trading_health_uses_one_current_clickhouse_ta_status_for_gate(
+        self,
+    ) -> None:
+        original_scheduler = _install_running_scheduler()
+        checked_at = datetime.now(timezone.utc)
+        clickhouse_ta_status = _current_clickhouse_ta_status()
+        hypothesis_calls: list[dict[str, object]] = []
+        gate_calls: list[dict[str, object]] = []
+
+        try:
+            with (
+                patch(
+                    "app.api.readiness_helpers.evaluate_trading_health_payload._readiness_dependency_snapshot",
+                    side_effect=(
+                        lambda *_args, **_kwargs: _healthy_dependency_snapshot(
+                            checked_at
+                        )
+                    ),
+                ),
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.load_clickhouse_ta_status",
+                    return_value=clickhouse_ta_status,
+                ),
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.load_tca_summary",
+                    return_value={},
+                ),
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.build_hypothesis_runtime_payload",
+                    side_effect=_recording_hypothesis_runtime_builder(hypothesis_calls),
+                ),
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.empirical_jobs_status",
+                    return_value={"ready": True, "status": "healthy"},
+                ),
+                patch(
+                    "app.api.readiness_helpers.evaluate_trading_health_payload.load_quant_evidence_status",
+                    return_value={
+                        "required": True,
+                        "ok": True,
+                        "status": "healthy",
+                        "reason": "ready",
+                        "blocking_reasons": [],
+                        "account": "paper",
+                        "window": "15m",
+                    },
+                ),
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.build_api_live_submission_gate_payload",
+                    side_effect=_recording_live_gate_builder(gate_calls),
+                ),
+            ):
+                response = self.client.get("/trading/health")
+
+            self.assertIn(response.status_code, {200, 503})
+            self.assertEqual(
+                hypothesis_calls[0]["feature_readiness"],
+                clickhouse_ta_status,
+            )
+            self.assertEqual(
+                gate_calls[0]["clickhouse_ta_status"],
+                clickhouse_ta_status,
+            )
+            self.assertEqual(
+                response.json()["live_submission_gate"]["clickhouse_ta_freshness"],
+                clickhouse_ta_status,
+            )
+        finally:
+            _restore_scheduler(original_scheduler)

--- a/services/torghut/tests/api/test_trading_api_readyz_contract.py
+++ b/services/torghut/tests/api/test_trading_api_readyz_contract.py
@@ -45,6 +45,7 @@ def _operational_ready_gate() -> dict[str, object]:
         "final_promotion_authorized": False,
         "blocked_reasons": [],
         "reason_codes": ["operational_submission_ready"],
+        "dependency_quorum_decision": "allow",
         "capital_stage": "live",
         "capital_state": "live",
         "read_model_evaluated": False,
@@ -140,8 +141,12 @@ class TestTradingApiReadyzContract(TradingApiTestCaseBase):
             live_submission_gate = payload["live_submission_gate"]
             self.assertTrue(live_submission_gate["allowed"])
             self.assertFalse(live_submission_gate["promotion_authority"])
-            self.assertFalse(live_submission_gate["final_authority_ok"])
+            self.assertTrue(live_submission_gate["final_authority_ok"])
             self.assertFalse(live_submission_gate["final_promotion_allowed"])
+            self.assertEqual(
+                live_submission_gate["dependency_quorum_decision"],
+                "allow",
+            )
             self.assertEqual(
                 live_submission_gate["reason"],
                 "operational_submission_ready",


### PR DESCRIPTION
## Summary

- Loads ClickHouse TA freshness once in the `/trading/health` proof lane and reuses that same payload for hypothesis runtime and live-submission gate construction.
- Preserves the shared live-submission gate on healthy `/readyz` and cached health surfaces instead of rewriting authority/quorum fields when readiness dependencies are healthy.
- Adds regression coverage proving `/trading/health` passes current ClickHouse TA status into both the hypothesis runtime and live gate, and `/readyz` preserves the shared gate result while still failing closed on degraded dependencies.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_health_contract.py -k clickhouse_ta_status -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_health_contract.py -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_live_gate_llm.py -k 'matches_status_health_and_readyz' -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_readyz_contract.py -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_health_contract.py tests/api/test_trading_api_live_gate_llm.py tests/api/test_trading_api_readyz_contract.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app/api/readiness_helpers/trading_health_proof_lane.py app/api/readiness_helpers/readiness_surface.py app/api/readiness_helpers/evaluate_trading_health_payload_bounded.py tests/api/test_trading_api_health_contract.py tests/api/test_trading_api_readyz_contract.py`
- `cd services/torghut && uv run --frozen python -m compileall app/api/readiness_helpers/trading_health_proof_lane.py app/api/readiness_helpers/readiness_surface.py app/api/readiness_helpers/evaluate_trading_health_payload_bounded.py tests/api/test_trading_api_health_contract.py tests/api/test_trading_api_readyz_contract.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines app/api/readiness_helpers/trading_health_proof_lane.py app/api/readiness_helpers/readiness_surface.py app/api/readiness_helpers/evaluate_trading_health_payload_bounded.py tests/api/test_trading_api_health_contract.py tests/api/test_trading_api_readyz_contract.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/api/readiness_helpers/trading_health_proof_lane.py app/api/readiness_helpers/readiness_surface.py app/api/readiness_helpers/evaluate_trading_health_payload_bounded.py tests/api/test_trading_api_health_contract.py tests/api/test_trading_api_readyz_contract.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
