### PR TITLE
fix(torghut): align readyz dependency quorum

### DIFF
--- a/services/torghut/app/api/readiness_helpers/readiness_surface.py
+++ b/services/torghut/app/api/readiness_helpers/readiness_surface.py
@@ -297,9 +297,14 @@ def guard_live_submission_gate_for_readiness(
     gate["reason"] = guard_reason
 
     blocked_reasons = list(cast(Sequence[object], gate.get("blocked_reasons") or []))
-    gate["blocked_reasons"] = append_unique_reason(blocked_reasons, guard_reason)
     reason_codes = list(cast(Sequence[object], gate.get("reason_codes") or []))
-    gate["reason_codes"] = append_unique_reason(reason_codes, guard_reason)
+    append_unique_reason(blocked_reasons, guard_reason)
+    append_unique_reason(reason_codes, guard_reason)
+    for dependency_reason in readiness_dependency_reasons:
+        append_unique_reason(blocked_reasons, dependency_reason)
+        append_unique_reason(reason_codes, dependency_reason)
+    gate["blocked_reasons"] = blocked_reasons
+    gate["reason_codes"] = reason_codes
 
     plan = gate.get("runtime_ledger_paper_probation_import_plan")
     if isinstance(plan, Mapping):
@@ -379,12 +384,26 @@ def core_readiness_live_submission_gate() -> dict[str, object]:
     }
 
 
-def _readiness_hypothesis_summary() -> dict[str, object]:
-    dependency_quorum = {
-        "decision": "unknown",
-        "reasons": ["readyz_bounded_read_model"],
-        "message": "readyz evaluates the shared live-submission gate without the full status read model",
-    }
+def _readiness_hypothesis_summary(
+    *,
+    readiness_dependency_reasons: Sequence[str],
+) -> dict[str, object]:
+    reason_codes = [str(reason) for reason in readiness_dependency_reasons]
+    if reason_codes:
+        dependency_quorum = {
+            "decision": "block",
+            "reasons": reason_codes,
+            "message": "readyz core dependencies are degraded",
+        }
+    else:
+        dependency_quorum = {
+            "decision": "allow",
+            "reasons": ["readyz_core_dependencies_healthy"],
+            "message": (
+                "readyz core dependencies are healthy; full status read model "
+                "is intentionally skipped"
+            ),
+        }
     return {
         "registry_loaded": False,
         "registry_path": None,
@@ -449,7 +468,9 @@ def readiness_live_submission_gate(
         gate = status_dependencies.build_api_live_submission_gate_payload(
             scheduler.state,
             session=None,
-            hypothesis_summary=_readiness_hypothesis_summary(),
+            hypothesis_summary=_readiness_hypothesis_summary(
+                readiness_dependency_reasons=readiness_dependency_reasons,
+            ),
             empirical_jobs_status=status_dependencies.empirical_jobs_status(),
             dspy_runtime_status=_readiness_dspy_runtime_status(scheduler),
             quant_health_status=None,

--- a/services/torghut/tests/api/test_trading_api_readyz_contract.py
+++ b/services/torghut/tests/api/test_trading_api_readyz_contract.py
@@ -53,6 +53,41 @@ def _operational_ready_gate() -> dict[str, object]:
     }
 
 
+def _live_submission_settings_snapshot() -> dict[str, object]:
+    return {
+        "trading_mode": settings.trading_mode,
+        "trading_enabled": settings.trading_enabled,
+        "trading_kill_switch_enabled": settings.trading_kill_switch_enabled,
+        "trading_simple_submit_enabled": settings.trading_simple_submit_enabled,
+        "trading_live_submit_enabled": settings.trading_live_submit_enabled,
+        "trading_testnet_after_hours_enabled": (
+            settings.trading_testnet_after_hours_enabled
+        ),
+    }
+
+
+def _enable_live_submission_settings() -> None:
+    settings.trading_mode = "live"
+    settings.trading_enabled = True
+    settings.trading_kill_switch_enabled = False
+    settings.trading_simple_submit_enabled = True
+    settings.trading_live_submit_enabled = True
+    settings.trading_testnet_after_hours_enabled = True
+
+
+def _restore_live_submission_settings(snapshot: dict[str, object]) -> None:
+    settings.trading_mode = str(snapshot["trading_mode"])
+    settings.trading_enabled = bool(snapshot["trading_enabled"])
+    settings.trading_kill_switch_enabled = bool(snapshot["trading_kill_switch_enabled"])
+    settings.trading_simple_submit_enabled = bool(
+        snapshot["trading_simple_submit_enabled"]
+    )
+    settings.trading_live_submit_enabled = bool(snapshot["trading_live_submit_enabled"])
+    settings.trading_testnet_after_hours_enabled = bool(
+        snapshot["trading_testnet_after_hours_enabled"]
+    )
+
+
 class TestTradingApiReadyzContract(TradingApiTestCaseBase):
     @patch(
         "app.api.health_checks.build_tigerbeetle_ledger_status",
@@ -271,6 +306,66 @@ class TestTradingApiReadyzLiveGateContract(TradingApiTestCaseBase):
         )
         self.assertFalse(gate["read_model_evaluated"])
         self.assertIn("live_submit_activation", gate)
+
+    def test_readiness_live_submission_gate_allows_healthy_core_dependency_quorum(
+        self,
+    ) -> None:
+        original = _live_submission_settings_snapshot()
+        scheduler = TradingScheduler()
+        try:
+            _enable_live_submission_settings()
+            with (
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.load_clickhouse_ta_status",
+                    return_value=_fresh_clickhouse_ta_status(),
+                ),
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.empirical_jobs_status",
+                    return_value={"ready": True, "status": "healthy"},
+                ),
+            ):
+                gate = readiness_surface_helpers.readiness_live_submission_gate(
+                    scheduler,
+                    readiness_dependency_reasons=[],
+                )
+        finally:
+            _restore_live_submission_settings(original)
+
+        self.assertEqual(gate["dependency_quorum_decision"], "allow")
+        self.assertEqual(
+            gate["readiness_surface"],
+            "core_dependencies_and_live_submission_gate",
+        )
+        self.assertFalse(gate["read_model_evaluated"])
+
+    def test_readiness_live_submission_gate_blocks_degraded_core_dependency_quorum(
+        self,
+    ) -> None:
+        original = _live_submission_settings_snapshot()
+        scheduler = TradingScheduler()
+        try:
+            _enable_live_submission_settings()
+            with (
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.load_clickhouse_ta_status",
+                    return_value=_fresh_clickhouse_ta_status(),
+                ),
+                patch(
+                    "app.api.readiness_helpers.status_dependencies.empirical_jobs_status",
+                    return_value={"ready": True, "status": "healthy"},
+                ),
+            ):
+                gate = readiness_surface_helpers.readiness_live_submission_gate(
+                    scheduler,
+                    readiness_dependency_reasons=["clickhouse_dependency_degraded"],
+                )
+        finally:
+            _restore_live_submission_settings(original)
+
+        self.assertFalse(gate["allowed"])
+        self.assertEqual(gate["dependency_quorum_decision"], "block")
+        self.assertIn("clickhouse_dependency_degraded", gate["reason_codes"])
+        self.assertTrue(gate["readiness_dependency_guard_active"])
 
     def test_core_readyz_creates_scheduler_when_app_state_is_empty(self) -> None:
         original = {


### PR DESCRIPTION
## Summary

- Make the bounded `/readyz` hypothesis summary report dependency quorum `allow` when core readiness dependencies are healthy instead of `unknown`.
- Report dependency quorum `block` with concrete dependency reason codes when core readiness dependencies are degraded.
- Add regressions for healthy and degraded readyz live-submission gate quorum behavior.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_readyz_contract.py -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_live_gate_llm.py -k 'matches_status_health_and_readyz' -q`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines app/api/readiness_helpers/readiness_surface.py tests/api/test_trading_api_readyz_contract.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/api/readiness_helpers/readiness_surface.py tests/api/test_trading_api_readyz_contract.py`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
