### PR TITLE
fix(torghut): respect conditional updated bars readiness

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
@@ -14,6 +14,9 @@ data class MarketDataChannelReadiness(
   val channel: String,
   val ready: Boolean,
   @SerialName("required") val required: Boolean,
+  @SerialName("readiness_mode") val readinessMode: String = "continuous",
+  @SerialName("freshness_required") val freshnessRequired: Boolean = true,
+  @SerialName("symbol_coverage_required") val symbolCoverageRequired: Boolean = true,
   @SerialName("latest_provider_event_at_ms") val latestProviderEventAtMs: Long? = null,
   @SerialName("latest_serialized_at_ms") val latestSerializedAtMs: Long? = null,
   @SerialName("latest_kafka_success_at_ms") val latestKafkaSuccessAtMs: Long? = null,
@@ -122,10 +125,14 @@ internal class MarketDataChannelFreshnessTracker(
         marketSessionActive(Instant.ofEpochMilli(now))
     return requiredChannels.map { channel ->
       val channelSymbols = symbolsByChannel[channel].orEmpty()
+      val readinessMode = readinessModeFor(channel)
+      val freshnessRequired = readinessMode == MarketDataChannelReadinessMode.CONTINUOUS
+      val symbolCoverageRequired = readinessMode == MarketDataChannelReadinessMode.CONTINUOUS
       val state = latestByChannel[channel]
       val latestKafkaSuccessAt = state?.latestKafkaSuccessAtMs?.get()?.takeIf { it > 0 }
       val latestProviderAt = state?.latestProviderEventAtMs?.get()?.takeIf { it > 0 }
       val latestSerializedAt = state?.latestSerializedAtMs?.get()?.takeIf { it > 0 }
+      val latestObservedInputAt = listOfNotNull(latestProviderAt, latestSerializedAt).maxOrNull()
       val latestSubscriptionAckAt = latestSubscriptionAckAtMsByChannel[channel]?.get()?.takeIf { it > 0 }
       val symbolLastSeen = state?.latestKafkaSuccessAtMsBySymbol?.mapValues { (_, seenAt) -> seenAt.get() }.orEmpty()
       val subscribedSymbols = channelSymbols.sorted()
@@ -143,21 +150,41 @@ internal class MarketDataChannelFreshnessTracker(
           }.toMap()
       val subscriptionAckLagMs = latestSubscriptionAckAt?.let { (now - it).coerceAtLeast(0) }
       val freshSymbols =
-        channelSymbols
-          .filter { symbol -> symbolLagMs[symbol]?.let { it <= maxLagMs } == true }
-          .sorted()
+        if (symbolCoverageRequired) {
+          channelSymbols
+            .filter { symbol -> symbolLagMs[symbol]?.let { it <= maxLagMs } == true }
+            .sorted()
+        } else {
+          observedSymbols
+            .filter { symbol -> symbolLagMs[symbol]?.let { it <= maxLagMs } == true }
+            .sorted()
+        }
       val missingSymbols =
-        channelSymbols
-          .filter { symbol -> symbol !in symbolLastSeen }
-          .sorted()
+        if (symbolCoverageRequired) {
+          channelSymbols
+            .filter { symbol -> symbol !in symbolLastSeen }
+            .sorted()
+        } else {
+          emptyList()
+        }
       val staleSymbols =
-        channelSymbols
-          .filter { symbol -> symbolLastSeen.containsKey(symbol) && symbol !in freshSymbols }
-          .sorted()
+        if (symbolCoverageRequired) {
+          channelSymbols
+            .filter { symbol -> symbolLastSeen.containsKey(symbol) && symbol !in freshSymbols }
+            .sorted()
+        } else {
+          emptyList()
+        }
+      val conditionalKafkaSuccessMissing =
+        !freshnessRequired &&
+          latestObservedInputAt != null &&
+          (latestKafkaSuccessAt == null || latestKafkaSuccessAt < latestObservedInputAt) &&
+          now - latestObservedInputAt > maxLagMs
       val ready =
         when {
           !gateActive -> true
           channelSymbols.isEmpty() -> false
+          !freshnessRequired -> !conditionalKafkaSuccessMissing
           latestKafkaSuccessAt == null -> false
           missingSymbols.isNotEmpty() -> false
           staleSymbols.isNotEmpty() -> false
@@ -168,6 +195,9 @@ internal class MarketDataChannelFreshnessTracker(
         channel = channel,
         ready = ready,
         required = true,
+        readinessMode = readinessMode.id,
+        freshnessRequired = freshnessRequired,
+        symbolCoverageRequired = symbolCoverageRequired,
         latestProviderEventAtMs = latestProviderAt,
         latestSerializedAtMs = latestSerializedAt,
         latestKafkaSuccessAtMs = latestKafkaSuccessAt,
@@ -188,8 +218,12 @@ internal class MarketDataChannelFreshnessTracker(
         reason =
           when {
             ready && !gateActive -> "market_data_channel_gate_inactive"
+            ready && !freshnessRequired && latestObservedInputAt == null -> "market_data_channel_conditional_no_events"
+            ready && !freshnessRequired && latestKafkaSuccessAt == null -> "market_data_channel_conditional_pending_kafka_success"
+            ready && !freshnessRequired -> "market_data_channel_conditional_observed"
             ready -> "market_data_channel_fresh"
             channelSymbols.isEmpty() -> "market_data_channel_not_subscribed"
+            conditionalKafkaSuccessMissing -> "market_data_channel_conditional_missing_kafka_success"
             latestKafkaSuccessAt == null -> "market_data_channel_missing_kafka_success"
             missingSymbols.isNotEmpty() -> "market_data_channel_missing_symbol_coverage"
             staleSymbols.isNotEmpty() -> "market_data_channel_stale_symbol_coverage"
@@ -252,6 +286,19 @@ internal class MarketDataChannelFreshnessTracker(
     }
   }
 }
+
+private enum class MarketDataChannelReadinessMode(
+  val id: String,
+) {
+  CONTINUOUS("continuous"),
+  CONDITIONAL("conditional"),
+}
+
+private fun readinessModeFor(channel: String): MarketDataChannelReadinessMode =
+  when (canonicalMarketDataChannel(channel)) {
+    "updatedBars" -> MarketDataChannelReadinessMode.CONDITIONAL
+    else -> MarketDataChannelReadinessMode.CONTINUOUS
+  }
 
 internal fun canonicalMarketDataChannel(channel: String): String? =
   when (val normalized = channel.trim().lowercase()) {

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -8,6 +8,88 @@ import kotlin.test.assertTrue
 
 class MarketDataChannelFreshnessTrackerTest {
   @Test
+  fun `conditional updated bars do not block readiness when no late-trade corrections arrive`() {
+    val nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("trades", "quotes", "bars", "updatedBars"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.EQUITY,
+      )
+
+    tracker.recordSubscriptionByChannel(
+      mapOf(
+        "trades" to listOf("NVDA", "AMD"),
+        "quotes" to listOf("NVDA", "AMD"),
+        "bars" to listOf("NVDA", "AMD"),
+        "updatedBars" to listOf("NVDA", "AMD"),
+      ),
+    )
+    listOf("trades", "quotes", "bars").forEach { channel ->
+      listOf("NVDA", "AMD").forEach { symbol ->
+        tracker.recordProviderEvent(channel, symbol)
+        tracker.recordSerializedEvent(channel, symbol)
+        tracker.recordKafkaSuccess(channel, symbol)
+      }
+    }
+
+    val byChannel = tracker.snapshot().associateBy { it.channel }
+    val updatedBars = byChannel.getValue("updatedBars")
+
+    assertTrue(tracker.ready())
+    assertTrue(updatedBars.ready)
+    assertFalse(updatedBars.freshnessRequired)
+    assertFalse(updatedBars.symbolCoverageRequired)
+    assertEquals("conditional", updatedBars.readinessMode)
+    assertEquals("market_data_channel_conditional_no_events", updatedBars.reason)
+    assertEquals(emptyList(), updatedBars.missingSymbols)
+  }
+
+  @Test
+  fun `conditional updated bars fail only when observed corrections do not reach kafka`() {
+    var nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("updatedBars"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.EQUITY,
+      )
+
+    tracker.recordSubscriptionByChannel(mapOf("updatedBars" to listOf("NVDA", "AMD")))
+    tracker.recordProviderEvent("updatedBars", "NVDA")
+    tracker.recordSerializedEvent("updatedBars", "NVDA")
+
+    assertTrue(tracker.ready())
+    assertEquals(
+      "market_data_channel_conditional_pending_kafka_success",
+      tracker.snapshot().single().reason,
+    )
+
+    nowMs += 61_000
+
+    val missingKafka = tracker.snapshot().single()
+    assertFalse(tracker.ready())
+    assertEquals("market_data_channel_conditional_missing_kafka_success", missingKafka.reason)
+    assertEquals(emptyList(), missingKafka.missingSymbols)
+
+    tracker.recordKafkaSuccess("updatedBars", "NVDA")
+
+    assertTrue(tracker.ready())
+
+    nowMs += 61_000
+
+    val staleButValid = tracker.snapshot().single()
+    assertTrue(tracker.ready())
+    assertEquals("market_data_channel_conditional_observed", staleButValid.reason)
+    assertEquals(listOf("NVDA"), staleButValid.observedSymbols)
+    assertEquals(emptyList(), staleButValid.staleSymbols)
+  }
+
+  @Test
   fun `required equity channels are not ready when only bars are producing`() {
     var nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
     val tracker =


### PR DESCRIPTION
## Summary

- Fixes the live `torghut-ws` readiness kill loop caused by treating Alpaca `updatedBars` as a continuous freshness channel.
- Keeps `updatedBars` subscribed and visible in `/readyz`, but marks it as a conditional correction channel that does not require continuous symbol coverage.
- Preserves strict freshness and per-symbol coverage gates for continuous channels: trades, quotes, and minute bars.
- Adds regression tests for no conditional `updatedBars` events, pending Kafka callback handling, and missing Kafka success after an observed correction.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest'`
- `cd services/dorvud && ./gradlew :websockets:test`
- `cd services/dorvud && ./gradlew ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test :technical-analysis:test :technical-analysis-flink:test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
