### PR TITLE
fix(torghut): isolate ta clickhouse migration path

### DIFF
--- a/argocd/applications/torghut/clickhouse/ta-replicated-table-migration-job.yaml
+++ b/argocd/applications/torghut/clickhouse/ta-replicated-table-migration-job.yaml
@@ -150,7 +150,7 @@ spec:
                     vwap Nullable(Float64),
                     count UInt64
                   )
-                  ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/ta_microbars', '{replica}', ingest_ts)
+                  ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/${table}', '{replica}', ingest_ts)
                   PARTITION BY toDate(event_ts)
                   ORDER BY (symbol, event_ts, seq)
                   TTL toDateTime(event_ts) + INTERVAL 35 DAY
@@ -192,7 +192,7 @@ spec:
                     vol_realized_w60s Nullable(Float64),
                     microstructure_signal_v1 Nullable(String)
                   )
-                  ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/ta_signals', '{replica}', ingest_ts)
+                  ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/${table}', '{replica}', ingest_ts)
                   PARTITION BY toDate(event_ts)
                   ORDER BY (symbol, event_ts, seq)
                   TTL toDateTime(event_ts) + INTERVAL 35 DAY
@@ -201,7 +201,7 @@ spec:
 
               migrate_table() {
                 local table="$1"
-                local shadow="${table}__replicated_migration_v1"
+                local shadow="${table}__replicated_migration_v2"
                 local host cutoff cutoff_literal
                 declare -A cutoffs=()
 


### PR DESCRIPTION
## Summary

- Updates the Torghut ClickHouse TA migration hook to create replicated shadow tables under the shadow table Keeper path instead of the final public table path.
- Fixes the live `ta_signals` migration failure where stale Keeper replica znodes already existed at `/clickhouse/tables/default/0/ta_signals`.
- Keeps the public table names unchanged after `EXCHANGE TABLES`; only the migration shadow path changes.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_stream(File.read("argocd/applications/torghut/clickhouse/ta-replicated-table-migration-job.yaml")); puts "yaml ok"'`
- Extracted the migration script from the Job manifest and ran `bash -n` against it.
- `kustomize build --enable-helm argocd/applications/torghut/clickhouse`
- `git diff --check`
- Live hook evidence: PR #12136 migrated `ta_microbars`, then failed creating `ta_signals__replicated_migration_v1` because ClickHouse Keeper already had stale `/clickhouse/tables/default/0/ta_signals/replicas/...` znodes.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This only changes the internal Keeper path used by temporary replicated migration shadow tables.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
