### PR TITLE
fix(dorvud): accept live options websocket events

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
@@ -11,6 +11,9 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 /** Maps raw Alpaca JSON message into our envelope + channel name. */
 object AlpacaMapper {
@@ -139,7 +142,7 @@ object AlpacaMapper {
     isFinal: Boolean,
     source: String = "ws",
   ): Envelope<JsonElement>? {
-    val parsedEventTs = runCatching { Instant.parse(eventTs) }.getOrNull() ?: return null
+    val parsedEventTs = parseAlpacaEventInstant(eventTs) ?: return null
     return Envelope(
       ingestTs = Instant.now(),
       eventTs = parsedEventTs,
@@ -151,5 +154,23 @@ object AlpacaMapper {
       isFinal = isFinal,
       source = source,
     )
+  }
+}
+
+internal fun parseAlpacaEventInstant(eventTs: String): Instant? {
+  val normalized = eventTs.trim().takeIf { it.isNotEmpty() } ?: return null
+  return runCatching { Instant.parse(normalized) }.getOrNull()
+    ?: runCatching { OffsetDateTime.parse(normalized).toInstant() }.getOrNull()
+    ?: runCatching { LocalDateTime.parse(normalized).toInstant(ZoneOffset.UTC) }.getOrNull()
+    ?: parseEpochTimestamp(normalized)
+}
+
+private fun parseEpochTimestamp(value: String): Instant? {
+  val timestamp = value.toLongOrNull()?.takeIf { it >= 0 } ?: return null
+  return when (value.length) {
+    in 1..10 -> Instant.ofEpochSecond(timestamp)
+    in 11..13 -> Instant.ofEpochMilli(timestamp)
+    in 14..16 -> Instant.ofEpochSecond(timestamp / 1_000_000, (timestamp % 1_000_000) * 1_000)
+    else -> Instant.ofEpochSecond(timestamp / 1_000_000_000, timestamp % 1_000_000_000)
   }
 }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -803,6 +803,17 @@ class ForwarderApp(
                 throw RuntimeException("alpaca error code=${msg.code} msg=${msg.msg}")
               }
               else -> {
+                val observed = observedMarketDataMessage(msg)
+                if (observed != null) {
+                  metrics.recordProviderMessage(config.alpacaMarketType, observed.channel)
+                  marketDataChannelFreshness.recordProviderEvent(observed.channel, observed.symbol)
+                  if (config.alpacaMarketType == AlpacaMarketType.OPTIONS && observed.isQuoteOrTrade) {
+                    lastOptionsMarketDataEventAt.set(Instant.ofEpochMilli(nowMs()))
+                    starvationStatusPublished.set(false)
+                    metrics.setOptionsEventStarvation(false)
+                    updateWsReady()
+                  }
+                }
                 val channel = handleMessage(msg, producer, seq, tradesDedup, quotesDedup, barsDedup)
                 if (config.alpacaMarketType == AlpacaMarketType.OPTIONS && channel in setOf("trade", "trades", "quote", "quotes")) {
                   lastOptionsMarketDataEventAt.set(Instant.ofEpochMilli(nowMs()))
@@ -1387,8 +1398,6 @@ class ForwarderApp(
 
     val env = AlpacaMapper.toEnvelope(msg, config.alpacaMarketType, config.alpacaFeed) { symbol -> seq.next(symbol) } ?: return null
     recordLag(env)
-    metrics.recordProviderMessage(config.alpacaMarketType, env.channel)
-    marketDataChannelFreshness.recordProviderEvent(env.channel, env.symbol)
 
     val topic =
       when (env.channel) {
@@ -1758,6 +1767,23 @@ internal fun optionsEventStarved(
   val lastHealthyEvent = lastEventAt ?: subscribedSince ?: return false
   return Duration.between(lastHealthyEvent, now) >= grace
 }
+
+internal data class ObservedMarketDataMessage(
+  val channel: String,
+  val symbol: String,
+) {
+  val isQuoteOrTrade: Boolean
+    get() = channel == "trade" || channel == "trades" || channel == "quote" || channel == "quotes"
+}
+
+internal fun observedMarketDataMessage(message: AlpacaMessage): ObservedMarketDataMessage? =
+  when (message) {
+    is AlpacaTrade -> ObservedMarketDataMessage("trade", message.symbol)
+    is AlpacaQuote -> ObservedMarketDataMessage("quote", message.symbol)
+    is AlpacaBar -> ObservedMarketDataMessage("bars", message.symbol)
+    is AlpacaUpdatedBar -> ObservedMarketDataMessage("updatedBars", message.symbol)
+    else -> null
+  }
 
 internal fun isRegularMarketSession(
   now: Instant,

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
@@ -127,6 +127,30 @@ class AlpacaMapperTest {
   }
 
   @Test
+  fun `maps options timestamps without explicit zone as UTC`() {
+    val msg =
+      """{"T":"q","S":"NVDA260717C00160000","bp":1.1,"bs":12,"ap":1.2,"as":10,"t":"2026-07-08T14:52:03.192533568"}"""
+    val decoded = AlpacaMapper.decode(msg)
+
+    val env = AlpacaMapper.toEnvelope(decoded, AlpacaMarketType.OPTIONS, "indicative") { 1 }
+
+    assertNotNull(env)
+    assertEquals("2026-07-08T14:52:03.192533568Z", env.eventTs.toString())
+  }
+
+  @Test
+  fun `maps numeric epoch nanosecond timestamps`() {
+    val msg =
+      """{"T":"t","S":"NVDA260717C00160000","p":1.15,"s":1,"x":"N","t":"1783522323192533568"}"""
+    val decoded = AlpacaMapper.decode(msg)
+
+    val env = AlpacaMapper.toEnvelope(decoded, AlpacaMarketType.OPTIONS, "indicative") { 1 }
+
+    assertNotNull(env)
+    assertEquals("2026-07-08T14:52:03.192533568Z", env.eventTs.toString())
+  }
+
+  @Test
   fun `drops malformed options status frame instead of throwing`() {
     val msg =
       """{"T":"s","S":"AAPL260618C00100000","statusCode":"error","statusMessage":"bad symbol","t":"[ERROR: (java.lang.IllegalStateException) 'gen' is expected to be a string]"}"""

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
@@ -166,6 +166,35 @@ class ForwarderSubscriptionTest {
   }
 
   @Test
+  fun `observed market data messages expose raw provider quote and trade frames`() {
+    assertEquals(
+      ObservedMarketDataMessage("trade", "NVDA260717C00160000"),
+      observedMarketDataMessage(
+        AlpacaTrade(
+          symbol = "NVDA260717C00160000",
+          price = 1.15,
+          size = 1.0,
+          timestamp = "2026-07-08T14:52:03Z",
+        ),
+      ),
+    )
+    assertEquals(
+      ObservedMarketDataMessage("quote", "NVDA260717C00160000"),
+      observedMarketDataMessage(
+        AlpacaQuote(
+          symbol = "NVDA260717C00160000",
+          bidPrice = 1.1,
+          bidSize = 12.0,
+          askPrice = 1.2,
+          askSize = 10.0,
+          timestamp = "2026-07-08T14:52:03Z",
+        ),
+      ),
+    )
+    assertEquals(null, observedMarketDataMessage(AlpacaSuccess(msg = "authenticated")))
+  }
+
+  @Test
   fun `options event starvation requires options subscriptions during regular market hours`() {
     val now = Instant.parse("2026-06-18T15:00:00Z")
     val stale = now.minusSeconds(120)


### PR DESCRIPTION
## Summary

- Records raw Alpaca option quote/trade observations before dedup and envelope filtering so websocket liveness is not hidden by valid duplicate or rejected frames.
- Keeps Kafka success as the downstream market-data channel readiness proof while making provider-message and starvation diagnostics reflect actual provider traffic.
- Accepts Alpaca event timestamps without an explicit zone and numeric epoch timestamps so live option frames can still materialize into envelopes.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.AlpacaMapperTest' --tests 'ai.proompteng.dorvud.ws.ForwarderSubscriptionTest' --tests 'ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest'`
- `cd services/dorvud && ./gradlew :websockets:test`
- `cd services/dorvud && ./gradlew :websockets:ktlintCheck`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
