### PR TITLE
chore(torghut): promote ws image sha-4d359b12ef806df8f6aa3d361e848e540bb15201

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:59ecb6f559263721ea658804a580452b4917d888e5755b3010304effdbb9f6f3
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6bcde3cf90998e53544778859b6dae682a8ae98bacf9df0227f3af5293d3989d
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-72a3901838f5586d65ae2b81f782683a9f51a398
+              value: main-sha-4d359b12ef806df8f6aa3d361e848e540bb15201
             - name: TORGHUT_WS_COMMIT
-              value: 72a3901838f5586d65ae2b81f782683a9f51a398
+              value: 4d359b12ef806df8f6aa3d361e848e540bb15201
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:59ecb6f559263721ea658804a580452b4917d888e5755b3010304effdbb9f6f3
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6bcde3cf90998e53544778859b6dae682a8ae98bacf9df0227f3af5293d3989d
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-72a3901838f5586d65ae2b81f782683a9f51a398
+              value: main-sha-4d359b12ef806df8f6aa3d361e848e540bb15201
             - name: TORGHUT_WS_COMMIT
-              value: 72a3901838f5586d65ae2b81f782683a9f51a398
+              value: 4d359b12ef806df8f6aa3d361e848e540bb15201
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `4d359b12ef806df8f6aa3d361e848e540bb15201`
- Image tag: `sha-4d359b12ef806df8f6aa3d361e848e540bb15201`
- Image digest: `sha256:6bcde3cf90998e53544778859b6dae682a8ae98bacf9df0227f3af5293d3989d`