### PR TITLE
fix(dorvud): expose options websocket envelope drops

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -158,7 +160,7 @@ object AlpacaMapper {
 }
 
 internal fun parseAlpacaEventInstant(eventTs: String): Instant? {
-  val normalized = eventTs.trim().takeIf { it.isNotEmpty() } ?: return null
+  val normalized = normalizeTimestampText(eventTs) ?: return null
   return runCatching { Instant.parse(normalized) }.getOrNull()
     ?: runCatching { OffsetDateTime.parse(normalized).toInstant() }.getOrNull()
     ?: runCatching { LocalDateTime.parse(normalized).toInstant(ZoneOffset.UTC) }.getOrNull()
@@ -166,6 +168,7 @@ internal fun parseAlpacaEventInstant(eventTs: String): Instant? {
 }
 
 private fun parseEpochTimestamp(value: String): Instant? {
+  if ('.' in value) return parseDecimalEpochSeconds(value)
   val timestamp = value.toLongOrNull()?.takeIf { it >= 0 } ?: return null
   return when (value.length) {
     in 1..10 -> Instant.ofEpochSecond(timestamp)
@@ -173,4 +176,32 @@ private fun parseEpochTimestamp(value: String): Instant? {
     in 14..16 -> Instant.ofEpochSecond(timestamp / 1_000_000, (timestamp % 1_000_000) * 1_000)
     else -> Instant.ofEpochSecond(timestamp / 1_000_000_000, timestamp % 1_000_000_000)
   }
+}
+
+private fun parseDecimalEpochSeconds(value: String): Instant? {
+  val timestamp = runCatching { BigDecimal(value) }.getOrNull()?.takeIf { it.signum() >= 0 } ?: return null
+  val seconds = timestamp.setScale(0, RoundingMode.DOWN)
+  val nanos =
+    timestamp
+      .subtract(seconds)
+      .movePointRight(9)
+      .setScale(0, RoundingMode.DOWN)
+      .toLong()
+  return Instant.ofEpochSecond(seconds.toLong(), nanos)
+}
+
+private fun normalizeTimestampText(raw: String): String? {
+  val trimmed =
+    raw
+      .trim()
+      .removeSurrounding("\"")
+      .takeIf { it.isNotEmpty() }
+      ?: return null
+  val withSeparator =
+    if (trimmed.length > 10 && trimmed[10] == ' ') {
+      trimmed.replaceRange(10, 11, "T")
+    } else {
+      trimmed
+    }
+  return withSeparator.replace(Regex("([+-]\\d{2})(\\d{2})$"), "$1:$2")
 }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -228,6 +228,7 @@ class ForwarderApp(
   private val kafkaErrorClass = AtomicReference<ReadinessErrorClass?>(null)
   private val reportedNotReadyClass = AtomicReference<ReadinessErrorClass?>(null)
   private val kafkaFailureCount = AtomicInteger(0)
+  private val envelopeDropLogged = AtomicBoolean(false)
   private val backfillDone = AtomicBoolean(false)
   private val tradesBackfillDone = AtomicBoolean(false)
   private val notReadyLivenessGate = NotReadyLivenessGate(config.healthNotReadyKillAfterMs, nowMs)
@@ -1396,7 +1397,12 @@ class ForwarderApp(
       else -> {}
     }
 
-    val env = AlpacaMapper.toEnvelope(msg, config.alpacaMarketType, config.alpacaFeed) { symbol -> seq.next(symbol) } ?: return null
+    val env =
+      AlpacaMapper.toEnvelope(msg, config.alpacaMarketType, config.alpacaFeed) { symbol -> seq.next(symbol) }
+        ?: run {
+          recordMarketDataEnvelopeDrop(msg)
+          return null
+        }
     recordLag(env)
 
     val topic =
@@ -1446,6 +1452,19 @@ class ForwarderApp(
   private fun recordLag(env: Envelope<*>) {
     val lagMs = Duration.between(env.eventTs, env.ingestTs).toMillis()
     metrics.recordLagMs(lagMs)
+  }
+
+  private fun recordMarketDataEnvelopeDrop(msg: AlpacaMessage) {
+    val observed = observedMarketDataMessage(msg) ?: return
+    val reason = marketDataEnvelopeDropReason(msg)
+    metrics.recordMarketDataDrop(config.alpacaMarketType, observed.channel, reason)
+    if (envelopeDropLogged.compareAndSet(false, true)) {
+      logger.warn {
+        "alpaca market-data frame dropped before envelope " +
+          "market_type=${config.alpacaMarketType.name.lowercase()} channel=${observed.channel} " +
+          "reason=$reason timestamp_shape=${timestampShape(alpacaEventTimestamp(msg))}"
+      }
+    }
   }
 
   private fun recordKafkaFailure(
@@ -1784,6 +1803,38 @@ internal fun observedMarketDataMessage(message: AlpacaMessage): ObservedMarketDa
     is AlpacaUpdatedBar -> ObservedMarketDataMessage("updatedBars", message.symbol)
     else -> null
   }
+
+internal fun marketDataEnvelopeDropReason(message: AlpacaMessage): String {
+  val timestamp = alpacaEventTimestamp(message) ?: return "unsupported_message"
+  return if (parseAlpacaEventInstant(timestamp) == null) {
+    "invalid_event_ts"
+  } else {
+    "envelope_mapping_failed"
+  }
+}
+
+internal fun alpacaEventTimestamp(message: AlpacaMessage): String? =
+  when (message) {
+    is AlpacaTrade -> message.timestamp
+    is AlpacaQuote -> message.timestamp
+    is AlpacaBar -> message.timestamp
+    is AlpacaUpdatedBar -> message.timestamp
+    is AlpacaStatus -> message.timestamp
+    else -> null
+  }
+
+private fun timestampShape(timestamp: String?): String {
+  val value = timestamp?.trim()?.takeIf { it.isNotEmpty() } ?: return "missing"
+  return listOf(
+    "len=${value.length}",
+    "has_t=${value.contains('T')}",
+    "has_space=${value.contains(' ')}",
+    "has_z=${value.endsWith('Z')}",
+    "has_dot=${value.contains('.')}",
+    "has_offset=${Regex("[+-]\\d{2}:?\\d{2}$").containsMatchIn(value)}",
+    "numeric=${value.all { it.isDigit() || it == '.' }}",
+  ).joinToString(",")
+}
 
 internal fun isRegularMarketSession(
   now: Instant,

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderMetrics.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderMetrics.kt
@@ -21,6 +21,7 @@ internal class ForwarderMetrics(
   private val kafkaMetadataErrorCounters = ConcurrentHashMap<String, Counter>()
   private val desiredSymbolsFetchFailureCounters = ConcurrentHashMap<String, Counter>()
   private val providerMessageCounters = ConcurrentHashMap<String, Counter>()
+  private val marketDataDropCounters = ConcurrentHashMap<String, Counter>()
   private val marketDataChannelGaugeValues = ConcurrentHashMap<String, AtomicLong>()
 
   private val readinessStatus = AtomicInteger(0)
@@ -198,6 +199,23 @@ internal class ForwarderMetrics(
           .builder("torghut_ws_provider_messages_total")
           .tag("market_type", parts[0].lowercase())
           .tag("channel", parts[1])
+          .register(registry)
+      }.increment()
+  }
+
+  fun recordMarketDataDrop(
+    marketType: AlpacaMarketType,
+    channel: String,
+    reason: String,
+  ) {
+    marketDataDropCounters
+      .computeIfAbsent("${marketType.name}|$channel|$reason") { key ->
+        val parts = key.split("|", limit = 3)
+        Counter
+          .builder("torghut_ws_market_data_drops_total")
+          .tag("market_type", parts[0].lowercase())
+          .tag("channel", parts[1])
+          .tag("reason", parts[2])
           .register(registry)
       }.increment()
   }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
@@ -151,6 +151,30 @@ class AlpacaMapperTest {
   }
 
   @Test
+  fun `maps decimal epoch second timestamps`() {
+    val msg =
+      """{"T":"q","S":"NVDA260717C00160000","bp":1.1,"bs":12,"ap":1.2,"as":10,"t":"1783522323.192533568"}"""
+    val decoded = AlpacaMapper.decode(msg)
+
+    val env = AlpacaMapper.toEnvelope(decoded, AlpacaMarketType.OPTIONS, "indicative") { 1 }
+
+    assertNotNull(env)
+    assertEquals("2026-07-08T14:52:03.192533568Z", env.eventTs.toString())
+  }
+
+  @Test
+  fun `maps timestamps with space separator and compact offset`() {
+    val msg =
+      """{"T":"q","S":"NVDA260717C00160000","bp":1.1,"bs":12,"ap":1.2,"as":10,"t":"2026-07-08 10:52:03.192533568-0400"}"""
+    val decoded = AlpacaMapper.decode(msg)
+
+    val env = AlpacaMapper.toEnvelope(decoded, AlpacaMarketType.OPTIONS, "indicative") { 1 }
+
+    assertNotNull(env)
+    assertEquals("2026-07-08T14:52:03.192533568Z", env.eventTs.toString())
+  }
+
+  @Test
   fun `drops malformed options status frame instead of throwing`() {
     val msg =
       """{"T":"s","S":"AAPL260618C00100000","statusCode":"error","statusMessage":"bad symbol","t":"[ERROR: (java.lang.IllegalStateException) 'gen' is expected to be a string]"}"""

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderMetricsTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderMetricsTest.kt
@@ -82,6 +82,7 @@ class ForwarderMetricsTest {
     val metrics = ForwarderMetrics(registry)
 
     metrics.recordProviderMessage(AlpacaMarketType.OPTIONS, "quote")
+    metrics.recordMarketDataDrop(AlpacaMarketType.OPTIONS, "quote", "invalid_event_ts")
     metrics.setOptionsEventStarvation(true)
 
     assertEquals(
@@ -90,6 +91,16 @@ class ForwarderMetricsTest {
         .find("torghut_ws_provider_messages_total")
         .tag("market_type", "options")
         .tag("channel", "quote")
+        .counter()
+        ?.count(),
+    )
+    assertEquals(
+      1.0,
+      registry
+        .find("torghut_ws_market_data_drops_total")
+        .tag("market_type", "options")
+        .tag("channel", "quote")
+        .tag("reason", "invalid_event_ts")
         .counter()
         ?.count(),
     )

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
@@ -195,6 +195,36 @@ class ForwarderSubscriptionTest {
   }
 
   @Test
+  fun `market data drop reason identifies invalid event timestamps`() {
+    assertEquals(
+      "invalid_event_ts",
+      marketDataEnvelopeDropReason(
+        AlpacaQuote(
+          symbol = "NVDA260717C00160000",
+          bidPrice = 1.1,
+          bidSize = 12.0,
+          askPrice = 1.2,
+          askSize = 10.0,
+          timestamp = "[ERROR: provider timestamp unavailable]",
+        ),
+      ),
+    )
+    assertEquals(
+      "envelope_mapping_failed",
+      marketDataEnvelopeDropReason(
+        AlpacaQuote(
+          symbol = "NVDA260717C00160000",
+          bidPrice = 1.1,
+          bidSize = 12.0,
+          askPrice = 1.2,
+          askSize = 10.0,
+          timestamp = "2026-07-08T14:52:03.192533568Z",
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun `options event starvation requires options subscriptions during regular market hours`() {
     val now = Instant.parse("2026-06-18T15:00:00Z")
     val stale = now.minusSeconds(120)


### PR DESCRIPTION
## Summary

- Harden Alpaca event timestamp parsing for decimal epoch seconds, space-separated timestamps, and compact timezone offsets.
- Add explicit `torghut_ws_market_data_drops_total` metrics for decoded market-data frames that fail before envelope creation.
- Add a one-time safe diagnostic log for pre-envelope drops that records only market type, channel, reason, and timestamp shape.
- Cover parser hardening, drop reason classification, and drop metric registration with websocket tests.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.AlpacaMapperTest' --tests 'ai.proompteng.dorvud.ws.ForwarderSubscriptionTest' --tests 'ai.proompteng.dorvud.ws.ForwarderMetricsTest' --tests 'ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest'`
- `cd services/dorvud && ./gradlew :websockets:ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
