### PR TITLE
chore(torghut): promote ws image sha-e02367c041c43f4e1c64f8973c949b915baf7aff

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6bcde3cf90998e53544778859b6dae682a8ae98bacf9df0227f3af5293d3989d
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:3e66387e822b9ef0c59b823706d8bd2efe77ff5b7882f05e38822c0475b41a34
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-4d359b12ef806df8f6aa3d361e848e540bb15201
+              value: main-sha-e02367c041c43f4e1c64f8973c949b915baf7aff
             - name: TORGHUT_WS_COMMIT
-              value: 4d359b12ef806df8f6aa3d361e848e540bb15201
+              value: e02367c041c43f4e1c64f8973c949b915baf7aff
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6bcde3cf90998e53544778859b6dae682a8ae98bacf9df0227f3af5293d3989d
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:3e66387e822b9ef0c59b823706d8bd2efe77ff5b7882f05e38822c0475b41a34
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-4d359b12ef806df8f6aa3d361e848e540bb15201
+              value: main-sha-e02367c041c43f4e1c64f8973c949b915baf7aff
             - name: TORGHUT_WS_COMMIT
-              value: 4d359b12ef806df8f6aa3d361e848e540bb15201
+              value: e02367c041c43f4e1c64f8973c949b915baf7aff
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `e02367c041c43f4e1c64f8973c949b915baf7aff`
- Image tag: `sha-e02367c041c43f4e1c64f8973c949b915baf7aff`
- Image digest: `sha256:3e66387e822b9ef0c59b823706d8bd2efe77ff5b7882f05e38822c0475b41a34`