### PR TITLE
fix(dorvud): preserve options msgpack timestamps

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -5,7 +5,9 @@ import ai.proompteng.dorvud.platform.Envelope
 import ai.proompteng.dorvud.platform.Metrics
 import ai.proompteng.dorvud.platform.SeqTracker
 import ai.proompteng.dorvud.platform.buildProducer
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.POJONode
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
@@ -1660,30 +1662,31 @@ class ForwarderApp(
   }
 
   private fun decodeMarketDataFrame(frame: Frame): JsonElement? {
-    val text =
-      try {
-        when (frame) {
-          is Frame.Text -> frame.readText()
-          is Frame.Binary ->
-            if (config.alpacaMarketType == AlpacaMarketType.OPTIONS) {
-              msgPackMapper.readTree(frame.readBytes()).toString()
-            } else {
-              frame.readBytes().decodeToString()
-            }
-          else -> return null
+    try {
+      when (frame) {
+        is Frame.Text -> return parseMarketDataJson(frame.readText())
+        is Frame.Binary -> {
+          val bytes = frame.readBytes()
+          if (config.alpacaMarketType == AlpacaMarketType.OPTIONS) {
+            return jsonElementFromJacksonNode(msgPackMapper.readTree(bytes))
+          }
+          return parseMarketDataJson(bytes.decodeToString())
         }
-      } catch (e: Exception) {
-        logger.warn(e) { "failed to decode alpaca frame; dropping" }
-        return null
+        else -> return null
       }
+    } catch (e: Exception) {
+      logger.warn(e) { "failed to decode alpaca frame; dropping" }
+      return null
+    }
+  }
 
-    return try {
+  private fun parseMarketDataJson(text: String): JsonElement? =
+    try {
       json.parseToJsonElement(text)
     } catch (e: SerializationException) {
       logger.warn(e) { "failed to parse alpaca frame as JSON; dropping" }
       null
     }
-  }
 
   private fun extractSymbols(element: JsonElement?): List<String> =
     when (element) {
@@ -1802,6 +1805,34 @@ internal fun observedMarketDataMessage(message: AlpacaMessage): ObservedMarketDa
     is AlpacaBar -> ObservedMarketDataMessage("bars", message.symbol)
     is AlpacaUpdatedBar -> ObservedMarketDataMessage("updatedBars", message.symbol)
     else -> null
+  }
+
+internal fun jsonElementFromJacksonNode(node: JsonNode): JsonElement =
+  when {
+    node.isObject -> {
+      buildJsonObject {
+        val fields = node.fields()
+        while (fields.hasNext()) {
+          val entry = fields.next()
+          put(entry.key, jsonElementFromJacksonNode(entry.value))
+        }
+      }
+    }
+    node.isArray -> {
+      buildJsonArray {
+        val elements = node.elements()
+        while (elements.hasNext()) {
+          add(jsonElementFromJacksonNode(elements.next()))
+        }
+      }
+    }
+    node.isTextual -> JsonPrimitive(node.textValue())
+    node.isNumber -> JsonPrimitive(node.numberValue())
+    node.isBoolean -> JsonPrimitive(node.booleanValue())
+    node.isNull || node.isMissingNode -> JsonNull
+    node is POJONode -> node.pojo?.toString()?.let(::JsonPrimitive) ?: JsonNull
+    node.isBinary -> JsonPrimitive(node.asText())
+    else -> JsonPrimitive(node.asText())
   }
 
 internal fun marketDataEnvelopeDropReason(message: AlpacaMessage): String {

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
@@ -1,11 +1,18 @@
 package ai.proompteng.dorvud.ws
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.node.POJONode
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ForwarderSubscriptionTest {
@@ -222,6 +229,33 @@ class ForwarderSubscriptionTest {
         ),
       ),
     )
+  }
+
+  @Test
+  fun `messagepack timestamp nodes are preserved as parseable option event timestamps`() {
+    val frame = JsonNodeFactory.instance.objectNode()
+    frame.put("T", "q")
+    frame.put("S", "NVDA260717C00160000")
+    frame.put("bp", 1.1)
+    frame.put("bs", 12.0)
+    frame.put("ap", 1.2)
+    frame.put("as", 10.0)
+    frame.set<JsonNode>("t", POJONode(Instant.parse("2026-07-08T14:52:03.192533568Z")))
+
+    val element = jsonElementFromJacksonNode(frame)
+
+    assertEquals("2026-07-08T14:52:03.192533568Z", element.jsonObject["t"]?.jsonPrimitive?.contentOrNull)
+    val message = AlpacaMapper.decode(element.toString())
+    val envelope =
+      assertNotNull(
+        AlpacaMapper.toEnvelope(
+          message = message,
+          marketType = AlpacaMarketType.OPTIONS,
+          feed = "indicative",
+          seqProvider = { 1 },
+        ),
+      )
+    assertEquals("2026-07-08T14:52:03.192533568Z", envelope.eventTs.toString())
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Preserve Jackson MessagePack-decoded option frames as kotlinx JSON instead of stringifying the Jackson tree.
- Convert POJO timestamp extension nodes to their timestamp text so option quote/trade event timestamps remain parseable.
- Add regression coverage for option quote envelope creation from a MessagePack-style timestamp node.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.ForwarderSubscriptionTest' --tests 'ai.proompteng.dorvud.ws.AlpacaMapperTest' --tests 'ai.proompteng.dorvud.ws.ForwarderMetricsTest'`
- `cd services/dorvud && ./gradlew :websockets:ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
