### PR TITLE
fix(dorvud): decode options msgpack timestamp extensions

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -57,7 +57,10 @@ import kotlinx.serialization.json.put
 import mu.KotlinLogging
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.msgpack.jackson.dataformat.MessagePackExtensionType
 import org.msgpack.jackson.dataformat.MessagePackFactory
+import org.msgpack.jackson.dataformat.TimestampExtensionModule
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.time.Instant
@@ -74,6 +77,9 @@ private val marketSessionZoneId: ZoneId = ZoneId.of("America/New_York")
 private const val DEFAULT_ALPACA_BARS_BACKFILL_LOOKBACK_HOURS = 12L
 private const val ALPACA_BARS_BACKFILL_LIMIT = 10_000
 private const val ALPACA_TRADES_BACKFILL_LIMIT = 10_000
+private const val MESSAGE_PACK_TIMESTAMP_32_UNSIGNED_MASK = 0xffffffffL
+private const val MESSAGE_PACK_TIMESTAMP_64_NANO_SHIFT = 34
+private const val MESSAGE_PACK_TIMESTAMP_64_SECONDS_MASK = 0x00000003ffffffffL
 
 internal fun alpacaMarketDataStreamUrl(config: ForwarderConfig): String =
   when (config.alpacaMarketType) {
@@ -1830,10 +1836,41 @@ internal fun jsonElementFromJacksonNode(node: JsonNode): JsonElement =
     node.isNumber -> JsonPrimitive(node.numberValue())
     node.isBoolean -> JsonPrimitive(node.booleanValue())
     node.isNull || node.isMissingNode -> JsonNull
-    node is POJONode -> node.pojo?.toString()?.let(::JsonPrimitive) ?: JsonNull
+    node is POJONode -> jsonElementFromPojo(node.pojo)
     node.isBinary -> JsonPrimitive(node.asText())
     else -> JsonPrimitive(node.asText())
   }
+
+private fun jsonElementFromPojo(pojo: Any?): JsonElement =
+  when (pojo) {
+    null -> JsonNull
+    is Instant -> JsonPrimitive(pojo.toString())
+    is MessagePackExtensionType -> messagePackTimestampInstant(pojo)?.toString()?.let(::JsonPrimitive) ?: JsonPrimitive(pojo.toString())
+    else -> JsonPrimitive(pojo.toString())
+  }
+
+private fun messagePackTimestampInstant(extension: MessagePackExtensionType): Instant? {
+  if (extension.type != TimestampExtensionModule.EXT_TYPE) return null
+  val data = extension.data
+  return runCatching {
+    when (data.size) {
+      4 -> Instant.ofEpochSecond(ByteBuffer.wrap(data).int.toLong() and MESSAGE_PACK_TIMESTAMP_32_UNSIGNED_MASK)
+      8 -> {
+        val packed = ByteBuffer.wrap(data).long
+        val nanos = packed ushr MESSAGE_PACK_TIMESTAMP_64_NANO_SHIFT
+        val seconds = packed and MESSAGE_PACK_TIMESTAMP_64_SECONDS_MASK
+        Instant.ofEpochSecond(seconds, nanos)
+      }
+      12 -> {
+        val buffer = ByteBuffer.wrap(data)
+        val nanos = buffer.int.toLong() and MESSAGE_PACK_TIMESTAMP_32_UNSIGNED_MASK
+        val seconds = buffer.long
+        Instant.ofEpochSecond(seconds, nanos)
+      }
+      else -> null
+    }
+  }.getOrNull()
+}
 
 internal fun marketDataEnvelopeDropReason(message: AlpacaMessage): String {
   val timestamp = alpacaEventTimestamp(message) ?: return "unsupported_message"

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderSubscriptionTest.kt
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.databind.node.POJONode
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.msgpack.jackson.dataformat.MessagePackExtensionType
+import org.msgpack.jackson.dataformat.TimestampExtensionModule
+import org.msgpack.value.ValueFactory
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -232,7 +235,8 @@ class ForwarderSubscriptionTest {
   }
 
   @Test
-  fun `messagepack timestamp nodes are preserved as parseable option event timestamps`() {
+  fun `messagepack extension timestamp nodes are preserved as parseable option event timestamps`() {
+    val timestamp = Instant.parse("2026-07-08T14:52:03.192533568Z")
     val frame = JsonNodeFactory.instance.objectNode()
     frame.put("T", "q")
     frame.put("S", "NVDA260717C00160000")
@@ -240,11 +244,19 @@ class ForwarderSubscriptionTest {
     frame.put("bs", 12.0)
     frame.put("ap", 1.2)
     frame.put("as", 10.0)
-    frame.set<JsonNode>("t", POJONode(Instant.parse("2026-07-08T14:52:03.192533568Z")))
+    frame.set<JsonNode>(
+      "t",
+      POJONode(
+        MessagePackExtensionType(
+          TimestampExtensionModule.EXT_TYPE,
+          ValueFactory.newTimestamp(timestamp).data,
+        ),
+      ),
+    )
 
     val element = jsonElementFromJacksonNode(frame)
 
-    assertEquals("2026-07-08T14:52:03.192533568Z", element.jsonObject["t"]?.jsonPrimitive?.contentOrNull)
+    assertEquals(timestamp.toString(), element.jsonObject["t"]?.jsonPrimitive?.contentOrNull)
     val message = AlpacaMapper.decode(element.toString())
     val envelope =
       assertNotNull(
@@ -255,7 +267,7 @@ class ForwarderSubscriptionTest {
           seqProvider = { 1 },
         ),
       )
-    assertEquals("2026-07-08T14:52:03.192533568Z", envelope.eventTs.toString())
+    assertEquals(timestamp, envelope.eventTs)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Decode Jackson `MessagePackExtensionType` timestamp nodes into RFC3339 instants instead of falling back to class-name strings.
- Handle MessagePack timestamp extension payloads for 32-bit, 64-bit, and 96-bit encodings.
- Update the options quote regression to use the same MessagePack extension class seen in live frames.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.ForwarderSubscriptionTest' --tests 'ai.proompteng.dorvud.ws.AlpacaMapperTest' --tests 'ai.proompteng.dorvud.ws.ForwarderMetricsTest'`
- `cd services/dorvud && ./gradlew :websockets:ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
