### PR TITLE
fix(dorvud): treat options coverage as diagnostic

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
@@ -125,9 +125,11 @@ internal class MarketDataChannelFreshnessTracker(
         marketSessionActive(Instant.ofEpochMilli(now))
     return requiredChannels.map { channel ->
       val channelSymbols = symbolsByChannel[channel].orEmpty()
-      val readinessMode = readinessModeFor(channel)
+      val readinessMode = readinessModeFor(channel, marketType)
       val freshnessRequired = readinessMode == MarketDataChannelReadinessMode.CONTINUOUS
-      val symbolCoverageRequired = readinessMode == MarketDataChannelReadinessMode.CONTINUOUS
+      val symbolCoverageRequired =
+        readinessMode == MarketDataChannelReadinessMode.CONTINUOUS &&
+          marketType != AlpacaMarketType.OPTIONS
       val state = latestByChannel[channel]
       val latestKafkaSuccessAt = state?.latestKafkaSuccessAtMs?.get()?.takeIf { it > 0 }
       val latestProviderAt = state?.latestProviderEventAtMs?.get()?.takeIf { it > 0 }
@@ -294,9 +296,14 @@ private enum class MarketDataChannelReadinessMode(
   CONDITIONAL("conditional"),
 }
 
-private fun readinessModeFor(channel: String): MarketDataChannelReadinessMode =
-  when (canonicalMarketDataChannel(channel)) {
-    "updatedBars" -> MarketDataChannelReadinessMode.CONDITIONAL
+private fun readinessModeFor(
+  channel: String,
+  marketType: AlpacaMarketType,
+): MarketDataChannelReadinessMode =
+  when {
+    canonicalMarketDataChannel(channel) == "updatedBars" -> MarketDataChannelReadinessMode.CONDITIONAL
+    marketType == AlpacaMarketType.OPTIONS && canonicalMarketDataChannel(channel) == "trades" ->
+      MarketDataChannelReadinessMode.CONDITIONAL
     else -> MarketDataChannelReadinessMode.CONTINUOUS
   }
 

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -229,4 +229,75 @@ class MarketDataChannelFreshnessTrackerTest {
     assertEquals(listOf("NVDA"), staleCoverage.staleSymbols)
     assertEquals(listOf("AMD"), staleCoverage.freshSymbols)
   }
+
+  @Test
+  fun `options readiness does not require full symbol coverage for quote liveness`() {
+    val nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("quotes"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.OPTIONS,
+      )
+
+    tracker.recordSubscriptionByChannel(mapOf("quotes" to listOf("NVDA260717C00160000", "NVDA260717P00160000")))
+    tracker.recordProviderEvent("quotes", "NVDA260717C00160000")
+    tracker.recordSerializedEvent("quotes", "NVDA260717C00160000")
+    tracker.recordKafkaSuccess("quotes", "NVDA260717C00160000")
+
+    val readiness = tracker.snapshot().single()
+
+    assertTrue(tracker.ready())
+    assertTrue(readiness.ready)
+    assertTrue(readiness.freshnessRequired)
+    assertFalse(readiness.symbolCoverageRequired)
+    assertEquals("continuous", readiness.readinessMode)
+    assertEquals("market_data_channel_fresh", readiness.reason)
+    assertEquals(2, readiness.subscribedSymbolCount)
+    assertEquals(1, readiness.observedSymbolCount)
+    assertEquals(listOf("NVDA260717C00160000"), readiness.freshSymbols)
+    assertEquals(emptyList(), readiness.missingSymbols)
+    assertEquals(emptyList(), readiness.staleSymbols)
+  }
+
+  @Test
+  fun `options trades are conditional but fail when observed provider events do not reach kafka`() {
+    var nowMs = Instant.parse("2026-07-07T14:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("trades"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.OPTIONS,
+      )
+
+    tracker.recordSubscriptionByChannel(mapOf("trades" to listOf("NVDA260717C00160000", "NVDA260717P00160000")))
+
+    val quietTrades = tracker.snapshot().single()
+    assertTrue(tracker.ready())
+    assertEquals("conditional", quietTrades.readinessMode)
+    assertFalse(quietTrades.freshnessRequired)
+    assertFalse(quietTrades.symbolCoverageRequired)
+    assertEquals("market_data_channel_conditional_no_events", quietTrades.reason)
+
+    tracker.recordProviderEvent("trades", "NVDA260717C00160000")
+    tracker.recordSerializedEvent("trades", "NVDA260717C00160000")
+
+    nowMs += 61_000
+
+    val missingKafka = tracker.snapshot().single()
+    assertFalse(tracker.ready())
+    assertEquals("market_data_channel_conditional_missing_kafka_success", missingKafka.reason)
+
+    tracker.recordKafkaSuccess("trades", "NVDA260717C00160000")
+
+    val deliveredTrade = tracker.snapshot().single()
+    assertTrue(tracker.ready())
+    assertEquals("market_data_channel_conditional_observed", deliveredTrade.reason)
+    assertEquals(listOf("NVDA260717C00160000"), deliveredTrade.observedSymbols)
+    assertEquals(emptyList(), deliveredTrade.missingSymbols)
+  }
 }


### PR DESCRIPTION
## Summary

- Keep option-contract symbol coverage visible in readiness payloads and metrics without requiring every subscribed contract to print within the freshness window.
- Treat options trades as conditional/event-driven readiness, while options quotes still require continuous fresh Kafka delivery.
- Add regression coverage for partial option quote coverage and conditional option trade delivery failures.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.MarketDataChannelFreshnessTrackerTest' --tests 'ai.proompteng.dorvud.ws.ForwarderSubscriptionTest' --tests 'ai.proompteng.dorvud.ws.ForwarderMetricsTest'`
- `cd services/dorvud && ./gradlew :websockets:ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
