### PR TITLE
chore(torghut): promote ws image sha-57b68fe14eda42168aae573221afd9363c770751

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:709761db25d418cb1ccb9ea8dc37a6080b9dfbde97c341af04ffa0060fdae977
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:ddd3c26685bd9d78d88f00194e399d24ea006eaa5d375aa82457e934b26bd856
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-6f31af28144d0f531786f3f12a83b5272657a2f7
+              value: main-sha-57b68fe14eda42168aae573221afd9363c770751
             - name: TORGHUT_WS_COMMIT
-              value: 6f31af28144d0f531786f3f12a83b5272657a2f7
+              value: 57b68fe14eda42168aae573221afd9363c770751
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:709761db25d418cb1ccb9ea8dc37a6080b9dfbde97c341af04ffa0060fdae977
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:ddd3c26685bd9d78d88f00194e399d24ea006eaa5d375aa82457e934b26bd856
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-6f31af28144d0f531786f3f12a83b5272657a2f7
+              value: main-sha-57b68fe14eda42168aae573221afd9363c770751
             - name: TORGHUT_WS_COMMIT
-              value: 6f31af28144d0f531786f3f12a83b5272657a2f7
+              value: 57b68fe14eda42168aae573221afd9363c770751
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `57b68fe14eda42168aae573221afd9363c770751`
- Image tag: `sha-57b68fe14eda42168aae573221afd9363c770751`
- Image digest: `sha256:ddd3c26685bd9d78d88f00194e399d24ea006eaa5d375aa82457e934b26bd856`