### PR TITLE
fix(torghut): accept fail-closed ta readiness rollouts

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -165,6 +165,28 @@ const baseReadyz = {
   },
 }
 
+const acceptedSourceStaleReadyz = {
+  status: 'degraded',
+  scheduler: { ok: true, running: true },
+  dependencies: {
+    postgres: { ok: true },
+    clickhouse: { ok: true },
+    database: { ok: true },
+    live_submission_gate: { ok: false, detail: 'accepted_ta_signal_stale' },
+    profitability_proof_floor: { ok: false, detail: 'repair_only', capital_state: 'zero_notional' },
+  },
+  live_submission_gate: {
+    allowed: false,
+    reason: 'accepted_ta_signal_stale',
+    blocked_reasons: ['accepted_ta_signal_stale'],
+    clickhouse_ta_freshness: {
+      accepted_sources: ['ta'],
+      accepted_source_state: 'stale',
+      blocking_reason: 'accepted_ta_signal_stale',
+    },
+  },
+}
+
 const acceptedSourceStaleDigest = {
   ...baseDigest,
   blockers: [{ reason: 'accepted_ta_signal_stale' }, { reason: 'hypothesis_not_promotion_eligible' }],
@@ -539,6 +561,20 @@ describe('validatePostDeployEvidence', () => {
 
     expect(result.readyzAcceptedReason).toBe('repair_only_zero_notional')
     expect(result.summaryLines.join('\n')).toContain('Readyz acceptance: `repair_only_zero_notional`')
+  })
+
+  it('accepts accepted-source stale readyz 503 when submission is fail-closed at zero notional', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '503',
+      readyz: acceptedSourceStaleReadyz,
+      revenueRepairDigest: acceptedSourceStaleDigest,
+      tradingStatus: acceptedSourceStaleTradingStatus,
+    })
+
+    expect(result.readyzAcceptedReason).toBe('repair_only_zero_notional')
+    expect(result.liveSubmitContract).toBe('accepted_source_stale_zero_notional')
+    expect(result.summaryLines.join('\n')).toContain('Readyz acceptance: `repair_only_zero_notional`')
+    expect(result.summaryLines.join('\n')).toContain('Live submit contract: `accepted_source_stale_zero_notional`')
   })
 
   it('accepts core-dependencies-only readyz 503 when the deploy surface is healthy and the gate is closed', () => {

--- a/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
+++ b/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
@@ -45,6 +45,28 @@ const coreDependenciesOnlyReadyz = {
   },
 }
 
+const acceptedSourceStaleReadyz = {
+  status: 'degraded',
+  scheduler: { ok: true, running: true },
+  dependencies: {
+    postgres: { ok: true, detail: 'ok' },
+    clickhouse: { ok: true, detail: 'ok' },
+    database: { ok: true, detail: 'ok' },
+    live_submission_gate: { ok: false, detail: 'accepted_ta_signal_stale' },
+    profitability_proof_floor: { ok: false, detail: 'repair_only', capital_state: 'zero_notional' },
+  },
+  live_submission_gate: {
+    allowed: false,
+    reason: 'accepted_ta_signal_stale',
+    blocked_reasons: ['accepted_ta_signal_stale'],
+    clickhouse_ta_freshness: {
+      accepted_sources: ['ta'],
+      accepted_source_state: 'stale',
+      blocking_reason: 'accepted_ta_signal_stale',
+    },
+  },
+}
+
 describe('classifyReadyzForPostDeployRetry', () => {
   it('accepts healthy 2xx readyz payloads immediately', () => {
     expect(
@@ -71,6 +93,30 @@ describe('classifyReadyzForPostDeployRetry', () => {
         readyz: coreDependenciesOnlyReadyz,
       }),
     ).toBe('acceptable')
+  })
+
+  it('accepts accepted-source stale 503 when runtime dependencies are healthy and TA is fail-closed', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: acceptedSourceStaleReadyz,
+      }),
+    ).toBe('acceptable')
+  })
+
+  it('rejects accepted-source stale 503 when the top-level gate still allows submission', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: {
+          ...acceptedSourceStaleReadyz,
+          live_submission_gate: {
+            ...acceptedSourceStaleReadyz.live_submission_gate,
+            allowed: true,
+          },
+        },
+      }),
+    ).toBe('unacceptable')
   })
 
   it('rejects core-dependencies-only 503 when the readiness gate carries authority', () => {

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -208,6 +208,69 @@ const assertRepairOnlyZeroNotionalReadyz = (readyz: JsonObject, digest: JsonObje
   }
 }
 
+const isAcceptedSourceStaleReadyz = (readyz: JsonObject): boolean => {
+  const dependencies =
+    readyz.dependencies && typeof readyz.dependencies === 'object' && !Array.isArray(readyz.dependencies)
+      ? (readyz.dependencies as JsonObject)
+      : {}
+  const dependencyGate =
+    dependencies.live_submission_gate &&
+    typeof dependencies.live_submission_gate === 'object' &&
+    !Array.isArray(dependencies.live_submission_gate)
+      ? (dependencies.live_submission_gate as JsonObject)
+      : {}
+  const liveSubmissionGate =
+    readyz.live_submission_gate &&
+    typeof readyz.live_submission_gate === 'object' &&
+    !Array.isArray(readyz.live_submission_gate)
+      ? (readyz.live_submission_gate as JsonObject)
+      : {}
+  return (
+    readyz.status === 'degraded' &&
+    dependencyGate.detail === ACCEPTED_SOURCE_STALE_REASON &&
+    liveSubmissionGate.allowed === false &&
+    liveSubmissionGate.reason === ACCEPTED_SOURCE_STALE_REASON
+  )
+}
+
+const assertAcceptedSourceStaleZeroNotionalReadyz = (readyz: JsonObject, status: JsonObject, digest: JsonObject) => {
+  if (readyz.status !== 'degraded') {
+    throw new Error('accepted-source stale /readyz is only accepted when payload.status is degraded')
+  }
+
+  const dependencies = requireObject(readyz.dependencies, 'readyz dependencies')
+  requireDependencyOk(dependencies, 'postgres')
+  requireDependencyOk(dependencies, 'clickhouse')
+  requireDependencyOk(dependencies, 'database')
+
+  const scheduler = requireObject(readyz.scheduler, 'readyz scheduler')
+  if (scheduler.ok !== true || scheduler.running !== true) {
+    throw new Error('readyz scheduler must be ok and running for accepted-source stale rollout acceptance')
+  }
+
+  const liveSubmissionGate = requireObject(
+    dependencies.live_submission_gate,
+    'readyz dependencies.live_submission_gate',
+  )
+  if (liveSubmissionGate.detail !== ACCEPTED_SOURCE_STALE_REASON) {
+    throw new Error(
+      'accepted-source stale rollout acceptance requires live_submission_gate.detail=accepted_ta_signal_stale',
+    )
+  }
+
+  const proofFloor = requireObject(
+    dependencies.profitability_proof_floor,
+    'readyz dependencies.profitability_proof_floor',
+  )
+  if (proofFloor.detail !== 'repair_only' || proofFloor.capital_state !== 'zero_notional') {
+    throw new Error(
+      'accepted-source stale rollout acceptance requires profitability_proof_floor repair_only zero_notional',
+    )
+  }
+
+  assertAcceptedSourceStaleZeroNotionalContract(status, digest)
+}
+
 const assertLiveSubmitActivationContract = (activation: JsonObject): LiveSubmitContract => {
   if (requireBoolean(activation.configured, 'torghut live_submit_activation.configured') !== true) {
     throw new Error('torghut live_submit_activation.configured must be true')
@@ -963,7 +1026,12 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     }
     const dependencies = requireObject(readyz.dependencies, 'readyz dependencies')
     if (dependencies.live_submission_gate !== undefined || dependencies.profitability_proof_floor !== undefined) {
-      assertRepairOnlyZeroNotionalReadyz(readyz, digest)
+      if (isAcceptedSourceStaleReadyz(readyz)) {
+        assertAcceptedSourceStaleZeroNotionalReadyz(readyz, status, digest)
+        liveSubmitContract = 'accepted_source_stale_zero_notional'
+      } else {
+        assertRepairOnlyZeroNotionalReadyz(readyz, digest)
+      }
       readyzAcceptedReason = 'repair_only_zero_notional'
     } else {
       assertCoreDependenciesOnlyReadyz(readyz)

--- a/packages/scripts/src/torghut/readyz-contract.ts
+++ b/packages/scripts/src/torghut/readyz-contract.ts
@@ -91,6 +91,43 @@ const hasRepairOnlyReadyzContract = (readyz: JsonObject): boolean => {
   return true
 }
 
+const hasAcceptedSourceStaleReadyzContract = (readyz: JsonObject): boolean => {
+  if (readyz.status !== 'degraded') return false
+
+  const dependencies = objectAt(readyz, 'dependencies')
+  if (!dependencies) return false
+  if (!dependencyOk(dependencies, 'postgres')) return false
+  if (!dependencyOk(dependencies, 'clickhouse')) return false
+  if (!dependencyOk(dependencies, 'database')) return false
+
+  const scheduler = objectAt(readyz, 'scheduler')
+  if (!scheduler || scheduler.ok !== true || scheduler.running !== true) return false
+
+  const dependencyGate = objectAt(dependencies, 'live_submission_gate')
+  if (!dependencyGate || stringAt(dependencyGate, 'detail') !== 'accepted_ta_signal_stale') return false
+
+  const proofFloor = objectAt(dependencies, 'profitability_proof_floor')
+  if (
+    !proofFloor ||
+    stringAt(proofFloor, 'detail') !== 'repair_only' ||
+    stringAt(proofFloor, 'capital_state') !== 'zero_notional'
+  ) {
+    return false
+  }
+
+  const liveSubmissionGate = objectAt(readyz, 'live_submission_gate')
+  if (!liveSubmissionGate) return false
+  if (booleanAt(liveSubmissionGate, 'allowed') !== false) return false
+  if (stringAt(liveSubmissionGate, 'reason') !== 'accepted_ta_signal_stale') return false
+  if (!arrayIncludes(liveSubmissionGate.blocked_reasons, 'accepted_ta_signal_stale')) return false
+  const freshness = objectAt(liveSubmissionGate, 'clickhouse_ta_freshness')
+  if (!freshness) return false
+  if (stringAt(freshness, 'accepted_source_state') !== 'stale') return false
+  if (stringAt(freshness, 'blocking_reason') !== 'accepted_ta_signal_stale') return false
+
+  return true
+}
+
 const hasCoreDependenciesOnlyReadyzContract = (readyz: JsonObject): boolean => {
   if (readyz.status !== 'degraded') return false
   if (stringAt(readyz, 'readiness_surface') !== 'core_dependencies_only') return false
@@ -140,6 +177,7 @@ export const classifyReadyzForPostDeployRetry = ({
   if (statusCode >= 200 && statusCode < 300) return 'acceptable'
   if (statusCode !== 503 || readyz.status !== 'degraded') return 'unacceptable'
   if (hasRepairOnlyReadyzContract(readyz)) return 'acceptable'
+  if (hasAcceptedSourceStaleReadyzContract(readyz)) return 'acceptable'
   if (hasCoreDependenciesOnlyReadyzContract(readyz)) return 'acceptable'
 
   const database = objectAt(objectAt(readyz, 'dependencies'), 'database')

--- a/services/torghut/app/trading/submission_council/__init__.py
+++ b/services/torghut/app/trading/submission_council/__init__.py
@@ -257,6 +257,7 @@ def _build_submission_gate_context(
         empirical_ready=dependencies.empirical_ready,
         dspy_mode=dependencies.dspy_mode,
         dspy_live_ready=dependencies.dspy_live_ready,
+        clickhouse_ta_status=inputs.clickhouse_ta_status,
     )
     return _SubmissionGateContext(
         state=inputs.state,

--- a/services/torghut/app/trading/submission_council/certificate_eval.py
+++ b/services/torghut/app/trading/submission_council/certificate_eval.py
@@ -34,6 +34,9 @@ from .common import (
 from .repair_candidates import (
     build_submission_gate_market_context_status,
 )
+from .quant_health import (
+    fresh_clickhouse_signal_continuity as _fresh_clickhouse_signal_continuity,
+)
 from .runtime_certificates import (
     certificate_runtime_ledger_reason_codes as _certificate_runtime_ledger_reason_codes,
 )
@@ -52,6 +55,7 @@ def segment_summary(
     empirical_ready: bool | None,
     dspy_mode: str,
     dspy_live_ready: bool | None,
+    clickhouse_ta_status: Mapping[str, Any] | None = None,
 ) -> dict[str, dict[str, object]]:
     market_context_ref = build_submission_gate_market_context_status(state)
     domain_states = {
@@ -85,11 +89,21 @@ def segment_summary(
     )
 
     ta_core_reasons: list[str] = []
-    if bool(getattr(state, "signal_continuity_alert_active", False)):
+    clickhouse_signal = _fresh_clickhouse_signal_continuity(clickhouse_ta_status)
+    clickhouse_signal_current = (
+        clickhouse_signal is not None
+        and clickhouse_signal[0] == "true"
+        and clickhouse_signal[1] == "clickhouse_ta_status"
+    )
+    if (
+        bool(getattr(state, "signal_continuity_alert_active", False))
+        and not clickhouse_signal_current
+    ):
         ta_core_reasons.append("signal_continuity_alert_active")
     if (
         _safe_int(getattr(getattr(state, "metrics", None), "signal_lag_seconds", None))
         > 0
+        and not clickhouse_signal_current
     ):
         signal_lag = _safe_int(
             getattr(getattr(state, "metrics", None), "signal_lag_seconds", None)

--- a/services/torghut/tests/pipeline/test_trading_pipeline_live_regime_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_live_regime_a.py
@@ -793,6 +793,7 @@ class TestTradingPipelineLiveRegimeA(TradingPipelineTestCaseBase):
                 account_label="live",
                 session_factory=self.session_local,
             )
+            pipeline._is_market_session_open = lambda _now=None: False
 
             with (
                 patch(

--- a/services/torghut/tests/submission_council/test_live_submission_gate.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate.py
@@ -387,6 +387,7 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
     def test_build_live_submission_gate_payload_clears_signal_lag_with_fresh_clickhouse_status(
         self,
     ) -> None:
+        latest_signal_at = datetime.now(timezone.utc).isoformat()
         result = build_live_submission_gate_payload(
             SimpleNamespace(
                 last_autonomy_promotion_eligible=False,
@@ -419,7 +420,10 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
             quant_health_status=self._healthy_quant_status(),
             clickhouse_ta_status={
                 "state": "current",
-                "latest_signal_at": datetime.now(timezone.utc).isoformat(),
+                "latest_signal_at": latest_signal_at,
+                "latest_accepted_event_at": latest_signal_at,
+                "accepted_source_state": "current",
+                "accepted_sources": ["ta"],
                 "equity_ta_rows": 12,
                 "equity_ta_symbols": 2,
                 "source_ref": "clickhouse:ta_signals",
@@ -430,6 +434,62 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
         self.assertEqual(result["continuity_source"], "clickhouse_ta_status")
         self.assertEqual(result["continuity_reason"], "signals_present")
         self.assertEqual(result["runtime_window_import_health_gate"]["blockers"], [])
+        ta_core = result["segment_summary"]["segments"]["ta-core"]
+        self.assertEqual(ta_core["state"], "ok")
+        self.assertNotIn("signal_continuity_alert_active", ta_core["reason_codes"])
+        self.assertNotIn("signal_lag_exceeded", ta_core["reason_codes"])
+
+    def test_build_live_submission_gate_payload_keeps_ta_core_blocked_when_clickhouse_accepted_source_stale(
+        self,
+    ) -> None:
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                market_session_open=True,
+                last_autonomy_promotion_eligible=False,
+                last_autonomy_promotion_action=None,
+                drift_live_promotion_eligible=True,
+                last_signal_continuity_state="signal_lag_exceeded",
+                last_signal_continuity_reason="signal_lag_exceeded",
+                last_signal_continuity_actionable=True,
+                signal_continuity_alert_active=True,
+                signal_continuity_alert_reason="signal_lag_exceeded",
+                last_market_context_freshness_seconds=45,
+                metrics=SimpleNamespace(
+                    signal_lag_seconds=900,
+                    feature_batch_rows_total=9,
+                    feature_null_rate={"price": 0.0},
+                    feature_staleness_ms_p95=250,
+                    feature_duplicate_ratio=0.0,
+                    decision_state_total={},
+                ),
+            ),
+            hypothesis_summary={
+                "promotion_eligible_total": 0,
+                "capital_stage_totals": {"shadow": 1},
+                "dependency_quorum": {
+                    "decision": "allow",
+                    "reasons": [],
+                    "message": "ready",
+                },
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+            clickhouse_ta_status={
+                "state": "current",
+                "latest_signal_at": "2026-06-30T20:54:52+00:00",
+                "latest_accepted_event_at": "2026-06-30T20:54:52+00:00",
+                "accepted_sources": ["ta"],
+                "accepted_source_state": "stale",
+                "blocking_reason": "accepted_ta_signal_stale",
+            },
+        )
+
+        ta_core = result["segment_summary"]["segments"]["ta-core"]
+        self.assertFalse(result["allowed"])
+        self.assertIn("accepted_ta_signal_stale", result["blocked_reasons"])
+        self.assertEqual(ta_core["state"], "blocked")
+        self.assertIn("signal_continuity_alert_active", ta_core["reason_codes"])
+        self.assertIn("signal_lag_exceeded", ta_core["reason_codes"])
 
     def test_build_live_submission_gate_payload_keeps_empty_quant_evidence_diagnostic_only(
         self,


### PR DESCRIPTION
## Summary

- Accept the existing accepted-TA-stale fail-closed zero-notional contract when `/readyz` returns HTTP 503 during post-deploy verification.
- Keep the post-deploy verifier strict: runtime database dependencies, scheduler health, closed live-submission gate, accepted-source stale reason, and zero-notional proof floor must all line up.
- Use ClickHouse accepted-source freshness to clear stale in-memory TA-core signal lag diagnostics once persisted TA is current.
- Add regressions for accepted-source-stale 503 handling and TA-core segment cleanup when ClickHouse TA is fresh.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/submission_council/test_live_submission_gate.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_readyz_contract.py::TestTradingApiReadyzLiveGateContract::test_readyz_fails_closed_when_accepted_ta_is_stale tests/api/test_trading_api_live_gate_llm.py::TestTradingApiLiveGateLlm::test_live_submission_gate_matches_status_health_and_readyz`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/readyz-contract.ts packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- Live readback: port-forwarded current Torghut service, captured `/readyz`, `/trading/status`, and `/trading/revenue-repair`, then ran this branch's `packages/scripts/src/torghut/post-deploy-evidence.ts`; verifier accepted current live payloads.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
