### PR TITLE
fix(torghut): keep live health gate consistent

### DIFF
--- a/services/torghut/app/api/readiness_helpers/readiness_surface.py
+++ b/services/torghut/app/api/readiness_helpers/readiness_surface.py
@@ -835,55 +835,84 @@ def _health_surface_timeout_dependencies(
     )
 
 
+def _health_surface_timeout_core_dependencies(
+    *,
+    scheduler: TradingScheduler,
+    scheduler_ok: bool,
+    include_database_contract: bool,
+    reason_code: str,
+) -> tuple[dict[str, object], list[str]]:
+    try:
+        return _core_readiness_dependencies(
+            scheduler=scheduler,
+            scheduler_ok=scheduler_ok,
+            include_database_contract=include_database_contract,
+            allow_stale_dependency_cache=True,
+        )
+    except _READINESS_LIVE_GATE_EXCEPTIONS as exc:
+        logger.warning("Health timeout core readiness fallback failed: %s", exc)
+        dependencies = _health_surface_timeout_dependencies(
+            include_database_contract=include_database_contract,
+            reason_code=reason_code,
+        )
+        return dependencies, readiness_dependency_degradation_reason_codes(
+            dependencies,
+            scheduler_ok=scheduler_ok,
+        )
+
+
 def _minimal_health_surface_timeout_payload(
     *,
     include_database_contract: bool,
     reason_code: str,
     detail: str,
 ) -> dict[str, object]:
-    dependencies = _health_surface_timeout_dependencies(
-        include_database_contract=include_database_contract,
-        reason_code=reason_code,
-    )
-
-    dependencies["health_evaluation"] = {
-        "ok": False,
-        "detail": detail,
-        "reason_codes": [reason_code],
-    }
     scheduler = get_trading_scheduler()
     _scheduler_ok, scheduler_payload = _evaluate_scheduler_status(scheduler)
-    live_submission_gate = minimal_health_surface_timeout_live_submission_gate(
-        reason_code=reason_code,
-        detail=detail,
+    dependencies, readiness_dependency_reasons = (
+        _health_surface_timeout_core_dependencies(
+            scheduler=scheduler,
+            scheduler_ok=_scheduler_ok,
+            include_database_contract=include_database_contract,
+            reason_code=reason_code,
+        )
+    )
+    live_submission_gate = readiness_live_submission_gate(
+        scheduler,
+        readiness_dependency_reasons=readiness_dependency_reasons,
     )
     proof_floor = minimal_health_surface_timeout_proof_floor()
     live_mode = settings.trading_mode == "live"
-    dependencies["live_submission_gate"] = {
-        "ok": bool(live_submission_gate.get("allowed", False)),
-        "detail": str(live_submission_gate.get("reason") or reason_code),
-        "capital_stage": live_submission_gate.get("capital_stage"),
-    }
+    dependencies["live_submission_gate"] = readiness_live_submission_gate_dependency(
+        live_submission_gate
+    )
+    readiness_cache = dependencies.get("readiness_cache")
+    if isinstance(readiness_cache, Mapping):
+        readiness_cache_payload = deepcopy(
+            dict(cast(Mapping[str, object], readiness_cache))
+        )
+        readiness_cache_payload["health_surface_timeout_fallback"] = True
+        dependencies["readiness_cache"] = readiness_cache_payload
     dependencies["profitability_proof_floor"] = {
         "ok": False if live_mode else True,
         "detail": str(proof_floor.get("route_state") or "repair_only"),
         "capital_state": proof_floor.get("capital_state"),
         "required": live_mode,
     }
-    return cast(
-        dict[str, object],
-        strip_promotion_authority_claims_for_readiness(
-            {
-                "status": "degraded",
-                "reason": reason_code,
-                "reason_codes": [reason_code],
-                "scheduler": scheduler_payload,
-                "dependencies": dependencies,
-                "live_submission_gate": live_submission_gate,
-                "proof_floor": proof_floor,
-            }
-        ),
-    )
+    dependencies["health_evaluation"] = {
+        "ok": False,
+        "detail": detail,
+        "reason_codes": [reason_code],
+    }
+    return {
+        "status": "degraded",
+        "reason": reason_code,
+        "reason_codes": [reason_code],
+        "scheduler": scheduler_payload,
+        "dependencies": dependencies,
+        "live_submission_gate": live_submission_gate,
+        "proof_floor": proof_floor,
+    }
 
 
 def health_surface_timeout_fallback_payload(
@@ -926,19 +955,15 @@ def health_surface_timeout_fallback_payload(
     payload["dependencies"] = dependencies_payload
     live_submission_gate = payload.get("live_submission_gate")
     if isinstance(live_submission_gate, Mapping):
-        payload["live_submission_gate"] = guard_live_submission_gate_for_readiness(
-            cast(Mapping[str, object], live_submission_gate),
-            readiness_dependency_reasons=[reason_code],
+        payload["live_submission_gate"] = dict(
+            cast(Mapping[str, object], live_submission_gate)
         )
     else:
         payload["live_submission_gate"] = fail_closed_health_evaluation_gate(
             reason_code=reason_code,
             detail=detail,
         )
-    return cast(
-        dict[str, object],
-        strip_promotion_authority_claims_for_readiness(payload),
-    )
+    return payload
 
 
 evaluate_core_readiness_payload = _evaluate_core_readiness_payload

--- a/services/torghut/app/trading/submission_council/certificate_eval.py
+++ b/services/torghut/app/trading/submission_council/certificate_eval.py
@@ -112,13 +112,12 @@ def segment_summary(
             getattr(state, "signal_continuity_alert_active", False)
         ):
             ta_core_reasons.append("signal_lag_exceeded")
-    for item in runtime_items:
-        item_reasons = [
-            str(reason).strip()
-            for reason in cast(Sequence[object], item.get("reasons") or [])
-            if str(reason).strip() in _TA_CORE_REASON_CODES
-        ]
-        ta_core_reasons.extend(item_reasons)
+    ta_core_reasons.extend(
+        _runtime_ta_core_reasons(
+            runtime_items=runtime_items,
+            clickhouse_signal_current=clickhouse_signal_current,
+        )
+    )
 
     execution_reasons = (
         ["critical_toggle_parity_diverged"] if list(blocking_toggle_mismatches) else []
@@ -144,6 +143,28 @@ def segment_summary(
         }
         for segment, reasons in sorted(raw_segments.items())
     }
+
+
+def _runtime_ta_core_reasons(
+    *,
+    runtime_items: Sequence[Mapping[str, Any]],
+    clickhouse_signal_current: bool,
+) -> list[str]:
+    clickhouse_superseded_runtime_reasons: frozenset[str] = (
+        frozenset({"signal_continuity_alert_active", "signal_lag_exceeded"})
+        if clickhouse_signal_current
+        else frozenset()
+    )
+    ta_core_reasons: list[str] = []
+    for item in runtime_items:
+        item_reasons = [
+            str(reason).strip()
+            for reason in cast(Sequence[object], item.get("reasons") or [])
+            if str(reason).strip() in _TA_CORE_REASON_CODES
+            and str(reason).strip() not in clickhouse_superseded_runtime_reasons
+        ]
+        ta_core_reasons.extend(item_reasons)
+    return ta_core_reasons
 
 
 def evaluate_certificate_candidates(

--- a/services/torghut/tests/api/test_trading_api_health_cache.py
+++ b/services/torghut/tests/api/test_trading_api_health_cache.py
@@ -75,10 +75,46 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
             time.sleep(0.2)
             return ({"status": "ok", "live_submission_gate": {"allowed": True}}, 200)
 
+        shared_gate = {
+            "allowed": True,
+            "reason": "operational_submission_ready",
+            "blocked_reasons": [],
+            "reason_codes": [],
+            "promotion_authority": True,
+            "promotion_authority_ok": True,
+            "final_authority_ok": True,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "capital_stage": "live",
+            "clickhouse_ta_freshness": {
+                "accepted_source_state": "current",
+                "accepted_lag_seconds": 120,
+                "accepted_max_lag_seconds": 300,
+                "blocking_reason": None,
+            },
+        }
+        healthy_dependencies = {
+            "postgres": {"ok": True, "detail": "ok"},
+            "clickhouse": {"ok": True, "detail": "ok"},
+            "alpaca": {"ok": True, "detail": "ok"},
+            "tigerbeetle": {"ok": True, "detail": "ok"},
+            "readiness_cache": {"cache_used": False},
+        }
+
         try:
-            with patch(
-                "app.api.readiness_helpers.evaluate_trading_health_payload.evaluate_trading_health_payload",
-                side_effect=_slow_health_payload,
+            with (
+                patch(
+                    "app.api.readiness_helpers.evaluate_trading_health_payload.evaluate_trading_health_payload",
+                    side_effect=_slow_health_payload,
+                ),
+                patch(
+                    "app.api.readiness_helpers.readiness_surface._core_readiness_dependencies",
+                    return_value=(healthy_dependencies, []),
+                ),
+                patch(
+                    "app.api.readiness_helpers.readiness_surface.readiness_live_submission_gate",
+                    return_value=shared_gate,
+                ),
             ):
                 started_at = time.monotonic()
                 response = self.client.get("/trading/health")
@@ -100,11 +136,13 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
             payload["dependencies"]["health_evaluation"]["reason_codes"],
         )
         self.assertIsInstance(payload["dependencies"]["postgres"], dict)
-        self.assertFalse(payload["dependencies"]["postgres"]["ok"])
+        self.assertTrue(payload["dependencies"]["postgres"]["ok"])
         self.assertIsInstance(payload["scheduler"], dict)
-        self.assertFalse(payload["live_submission_gate"]["allowed"])
-        self.assertFalse(payload["live_submission_gate"]["promotion_authority"])
-        self.assertFalse(payload["live_submission_gate"]["final_authority_ok"])
+        self.assertEqual(payload["live_submission_gate"], shared_gate)
+        self.assertNotIn(
+            "trading_health_evaluation_timeout",
+            payload["live_submission_gate"]["reason_codes"],
+        )
 
     def test_trading_health_timeout_uses_cached_dependency_shape(self) -> None:
         original_timeout = health_cache_state.TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
@@ -166,9 +204,10 @@ class TestTradingApiHealthCache(TradingApiTestCaseBase):
             dependencies["readiness_cache"]["health_surface_timeout_fallback"]
         )
         self.assertIsInstance(payload["scheduler"], dict)
-        self.assertFalse(payload["live_submission_gate"]["promotion_authority"])
-        self.assertFalse(payload["live_submission_gate"]["final_authority_ok"])
-        self.assertFalse(payload["live_submission_gate"]["final_promotion_allowed"])
+        self.assertNotEqual(
+            payload["live_submission_gate"].get("reason"),
+            "trading_health_evaluation_timeout",
+        )
 
     def test_trading_health_serves_completed_health_cache_while_refreshing(
         self,

--- a/services/torghut/tests/api/test_trading_api_health_timeout_fallback.py
+++ b/services/torghut/tests/api/test_trading_api_health_timeout_fallback.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from app.api import health_cache_state
+from app.api.readiness_helpers import readiness_surface as readiness_surface_helpers
+
+from tests.api.trading_api_support import (
+    TradingApiTestCaseBase,
+    TradingScheduler,
+    datetime,
+    patch,
+    timezone,
+)
+
+
+class TestTradingApiHealthTimeoutFallback(TradingApiTestCaseBase):
+    def test_health_timeout_core_readiness_falls_back_to_dependency_placeholders(
+        self,
+    ) -> None:
+        scheduler = TradingScheduler()
+
+        with patch(
+            "app.api.readiness_helpers.readiness_surface._core_readiness_dependencies",
+            side_effect=RuntimeError("core readiness unavailable"),
+        ):
+            dependencies, reasons = (
+                readiness_surface_helpers._health_surface_timeout_core_dependencies(
+                    scheduler=scheduler,
+                    scheduler_ok=True,
+                    include_database_contract=False,
+                    reason_code="trading_health_evaluation_timeout",
+                )
+            )
+
+        self.assertFalse(dependencies["postgres"]["ok"])
+        self.assertIn("postgres_degraded", reasons)
+        self.assertIn("clickhouse_degraded", reasons)
+
+    def test_health_timeout_cached_payload_preserves_existing_live_gate(self) -> None:
+        cache_key = "test-health-timeout-preserves-live-gate"
+        checked_at = datetime.now(timezone.utc)
+        live_submission_gate = {
+            "allowed": True,
+            "reason": "operational_submission_ready",
+            "reason_codes": [],
+            "blocked_reasons": [],
+        }
+        with health_cache_state.TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            health_cache_state.TRADING_HEALTH_SURFACE_PAYLOAD_CACHE[cache_key] = {
+                "payload": {
+                    "status": "ok",
+                    "dependencies": {},
+                    "live_submission_gate": live_submission_gate,
+                },
+                "status_code": 200,
+                "checked_at": checked_at,
+            }
+        try:
+            payload = readiness_surface_helpers.health_surface_timeout_fallback_payload(
+                cache_key=cache_key,
+                include_database_contract=False,
+                reason_code="trading_health_evaluation_timeout",
+                detail="trading health evaluation exceeded timeout",
+            )
+        finally:
+            with health_cache_state.TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                health_cache_state.TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.pop(
+                    cache_key,
+                    None,
+                )
+
+        self.assertEqual(payload["live_submission_gate"], live_submission_gate)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(
+            payload["dependencies"]["health_evaluation"]["reason_codes"],
+            ["trading_health_evaluation_timeout"],
+        )

--- a/services/torghut/tests/submission_council/test_live_submission_gate.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate.py
@@ -415,6 +415,17 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
                     "reasons": [],
                     "message": "ready",
                 },
+                "items": [
+                    {
+                        "hypothesis_id": "H-CONT-01",
+                        "promotion_eligible": False,
+                        "capital_stage": "shadow",
+                        "reasons": [
+                            "signal_continuity_alert_active",
+                            "signal_lag_exceeded",
+                        ],
+                    }
+                ],
             },
             empirical_jobs_status={"ready": True, "status": "healthy"},
             quant_health_status=self._healthy_quant_status(),


### PR DESCRIPTION
## Summary

- Keep `/trading/health` timeout fallback degraded without rewriting the embedded live-submission gate to `trading_health_evaluation_timeout`.
- Rebuild timeout fallback live-gate data through the same lightweight readiness gate path used by `/readyz`.
- Suppress stale runtime `signal_lag_exceeded`/`signal_continuity_alert_active` segment reasons when accepted ClickHouse TA freshness is current.
- Add regressions for the timeout fallback contract and stale runtime TA segment reasons.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/submission_council/test_live_submission_gate.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py tests/api/test_trading_api_health_cache.py tests/api/test_trading_api_health_timeout_fallback.py tests/api/test_trading_api_health_contract.py tests/api/test_trading_api_live_gate_llm.py::TestTradingApiLiveGateLlm::test_live_submission_gate_matches_status_health_and_readyz`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
