### PR TITLE
fix(torghut): accept live websocket ta signals

### DIFF
--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -93,6 +93,35 @@ const staleWsReadyz = {
   ],
 }
 
+const conditionalUpdatedBarsNoEventsReadyz = {
+  market_data_channels: freshWsReadyz.market_data_channels.map((channel) =>
+    channel.channel === 'updatedBars'
+      ? {
+          ...channel,
+          observed_symbol_count: 0,
+          fresh_symbol_count: 0,
+          latest_kafka_success_at_ms: null,
+          reason: 'market_data_channel_conditional_no_events',
+        }
+      : channel,
+  ),
+}
+
+const updatedBarsObservedWithoutKafkaReadyz = {
+  market_data_channels: freshWsReadyz.market_data_channels.map((channel) =>
+    channel.channel === 'updatedBars'
+      ? {
+          ...channel,
+          ready: false,
+          observed_symbol_count: 1,
+          fresh_symbol_count: 0,
+          latest_kafka_success_at_ms: null,
+          reason: 'market_data_channel_conditional_missing_kafka_success',
+        }
+      : channel,
+  ),
+}
+
 const partialCoverageWsReadyz = {
   market_data_channels: freshWsReadyz.market_data_channels.map((channel) =>
     channel.channel === 'trades'
@@ -517,6 +546,57 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.enforceFreshness).toBe(true)
     expect(result.ok).toBe(true)
     expect(result.failures).toEqual([])
+  })
+
+  it('passes during regular market hours when updatedBars has conditional no-events readiness', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: conditionalUpdatedBarsNoEventsReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: freshTaFlinkJob,
+      taStatusHeartbeat: freshTaStatusHeartbeat,
+    })
+
+    expect(result.enforceFreshness).toBe(true)
+    expect(result.ok).toBe(true)
+    expect(result.failures.join('\n')).not.toContain('ws_updatedBars_symbol_coverage_gap')
+    expect(result.failures.join('\n')).not.toContain('ws_updatedBars_missing_kafka_success')
+  })
+
+  it('fails during regular market hours when observed updatedBars corrections do not reach Kafka', () => {
+    const result = evaluateMarketDataSmoke({
+      now: new Date('2026-07-07T17:00:30Z'),
+      mode: 'auto',
+      holidays: new Set(),
+      maxKafkaLagSeconds: 300,
+      acceptedMaxLagSeconds: 300,
+      latestKafkaByRole: {
+        trades: { topic: 'torghut.trades.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        quotes: { topic: 'torghut.quotes.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+        bars: { topic: 'torghut.bars.1m.v1', eventTs: '2026-07-07T17:00:00Z', symbol: 'NVDA' },
+      },
+      wsReadyz: updatedBarsObservedWithoutKafkaReadyz,
+      tradingStatus: tradingStatusWithFreshAcceptedTa,
+      taRuntimeConfig: liveTaRuntimeConfig,
+      taFlinkJob: freshTaFlinkJob,
+      taStatusHeartbeat: freshTaStatusHeartbeat,
+    })
+
+    expect(result.enforceFreshness).toBe(true)
+    expect(result.ok).toBe(false)
+    expect(result.failures.join('\n')).toContain('ws_updatedBars_not_ready')
+    expect(result.failures.join('\n')).toContain('ws_updatedBars_symbol_coverage_gap')
+    expect(result.failures.join('\n')).toContain('ws_updatedBars_missing_kafka_success')
   })
 
   it('fails during regular market hours when WS symbol coverage is incomplete', () => {

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -85,6 +85,8 @@ const DEFAULT_TA_STATUS_TOPIC = 'torghut.ta.status.v1'
 const REQUIRED_WS_CHANNELS = ['trades', 'quotes', 'bars', 'updatedBars']
 const REQUIRED_KAFKA_ROLES: KafkaRole[] = ['trades', 'quotes', 'bars']
 const ACCEPTED_SOURCE_STALE_REASON = 'accepted_ta_signal_stale'
+const CONDITIONAL_NO_EVENT_WS_CHANNEL = 'updatedBars'
+const CONDITIONAL_NO_EVENT_REASON = 'market_data_channel_conditional_no_events'
 const DEFAULT_US_EQUITY_MARKET_HOLIDAYS = [
   '2026-01-01',
   '2026-01-19',
@@ -190,6 +192,9 @@ export const marketSessionState = (now: Date, holidays: Set<string> = new Set())
 
 const shouldEnforceFreshness = (mode: SmokeMode, sessionState: MarketSessionState): boolean =>
   mode === 'enforce' || (mode === 'auto' && sessionState === 'regular')
+
+const isConditionalNoEventWsChannel = (channel: string, ready: boolean, observed: number, reason: string): boolean =>
+  channel === CONDITIONAL_NO_EVENT_WS_CHANNEL && ready && observed === 0 && reason === CONDITIONAL_NO_EVENT_REASON
 
 const getWsChannels = (readyz: unknown): Map<string, JsonObject> => {
   const root = isObject(readyz) ? readyz : {}
@@ -465,6 +470,7 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
     const missingSymbols = asStringArray(status?.missing_symbols)
     const staleSymbols = asStringArray(status?.stale_symbols)
     const reason = asString(status?.reason) ?? 'missing'
+    const conditionalNoEventChannel = isConditionalNoEventWsChannel(channel, ready, observed, reason)
     summaryLines.push(
       `- WS ${channel}: ready=\`${ready}\`, subscribed=\`${subscribed}\`, observed=\`${observed}\`, ` +
         `fresh=\`${fresh ?? 'missing'}\`, ack_lag=\`${subscriptionAckLag ?? 'missing'}\`, ` +
@@ -483,7 +489,7 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
     if (
       missingSymbols.length > 0 ||
       staleSymbols.length > 0 ||
-      (fresh !== undefined && subscribed > 0 && fresh < subscribed)
+      (!conditionalNoEventChannel && fresh !== undefined && subscribed > 0 && fresh < subscribed)
     ) {
       pushFinding(
         enforceFreshness,
@@ -494,7 +500,7 @@ export const evaluateMarketDataSmoke = (input: MarketDataSmokeInput): MarketData
           `missing_symbols=${missingSymbols.join(',') || 'none'} stale_symbols=${staleSymbols.join(',') || 'none'}`,
       )
     }
-    if (enforceFreshness && status?.latest_kafka_success_at_ms === null) {
+    if (enforceFreshness && !conditionalNoEventChannel && status?.latest_kafka_success_at_ms === null) {
       failures.push(`ws_${channel}_missing_kafka_success: WS channel ${channel} has no Kafka success timestamp`)
     }
   }

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTechnicalAnalysisJob.kt
@@ -1576,7 +1576,9 @@ private class TaSignalsFunction(
               .toString(),
           end = envelope.payload.t.toString(),
         )
-    return envelope.withPayload(payload, window = window, seqOverride = envelope.seq)
+    return envelope
+      .withPayload(payload, window = window, seqOverride = envelope.seq)
+      .copy(source = taSignalOutputSource(envelope.source))
   }
 
   private fun rollingVwap(
@@ -1614,6 +1616,12 @@ private class TaSignalsFunction(
     return kotlin.math.sqrt(variance)
   }
 }
+
+internal fun taSignalOutputSource(inputSource: String): String =
+  when (inputSource.lowercase()) {
+    "ta", "ws" -> "ta"
+    else -> inputSource
+  }
 
 data class TimedQuoteState(
   val eventTs: Instant,

--- a/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/SerializationSchemasTest.kt
+++ b/services/dorvud/technical-analysis-flink/src/test/kotlin/ai/proompteng/dorvud/ta/flink/SerializationSchemasTest.kt
@@ -114,6 +114,17 @@ class SerializationSchemasTest {
   }
 
   @Test
+  fun `live websocket bar signals are emitted as accepted ta source`() {
+    assertEquals("ta", taSignalOutputSource("ws"))
+    assertEquals("ta", taSignalOutputSource("ta"))
+  }
+
+  @Test
+  fun `rest backfill bar signals remain excluded from accepted ta source`() {
+    assertEquals("rest", taSignalOutputSource("rest"))
+  }
+
+  @Test
   fun `flink ta config is serializable`() {
     assertSerializable(FlinkTaConfig.fromEnv())
   }


### PR DESCRIPTION
## Summary

- Treat `updatedBars` conditional no-event readiness as valid in the Torghut market-data smoke verifier while still failing real observed corrections that do not reach Kafka.
- Emit live websocket-derived Flink TA signals as `source=ta` so Torghut's accepted-source gate can use fresh TA output without widening `TRADING_SIGNAL_ALLOWED_SOURCES`.
- Keep REST backfill signals excluded from the accepted live TA path by preserving `source=rest`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/market-data-smoke.ts packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bun run --cwd packages/scripts lint:oxlint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `cd services/dorvud && ./gradlew :technical-analysis-flink:test`
- `cd services/dorvud && ./gradlew ktlintCheck`
- `cd services/dorvud && ./gradlew :websockets:test :technical-analysis:test :technical-analysis-flink:test`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
