### PR TITLE
chore(torghut): promote image sha-6652ce0838c223a5542b45631e210082d27ae8cc

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -52,7 +52,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: fc21addf1a380c201dec629cd2246e6ad35b9cc5
+              value: 6652ce0838c223a5542b45631e210082d27ae8cc
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:955648a316db2c17110f06a30dfd0ccc2bb235d3a7e5636ecdae7f71cab32972
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: fc21addf1a380c201dec629cd2246e6ad35b9cc5
+              value: 6652ce0838c223a5542b45631e210082d27ae8cc
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:955648a316db2c17110f06a30dfd0ccc2bb235d3a7e5636ecdae7f71cab32972
             - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T18:31:59Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T19:10:52Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -539,9 +539,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1634-gfc21addf1
+              value: v0.596.0-1636-g6652ce083
             - name: TORGHUT_COMMIT
-              value: fc21addf1a380c201dec629cd2246e6ad35b9cc5
+              value: 6652ce0838c223a5542b45631e210082d27ae8cc
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:955648a316db2c17110f06a30dfd0ccc2bb235d3a7e5636ecdae7f71cab32972
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T18:31:59Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T19:10:52Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -418,9 +418,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1634-gfc21addf1
+              value: v0.596.0-1636-g6652ce083
             - name: TORGHUT_COMMIT
-              value: fc21addf1a380c201dec629cd2246e6ad35b9cc5
+              value: 6652ce0838c223a5542b45631e210082d27ae8cc
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:955648a316db2c17110f06a30dfd0ccc2bb235d3a7e5636ecdae7f71cab32972
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -48,7 +48,7 @@ spec:
                 - name: PYTHONUNBUFFERED
                   value: "1"
                 - name: TORGHUT_COMMIT
-                  value: fc21addf1a380c201dec629cd2246e6ad35b9cc5
+                  value: 6652ce0838c223a5542b45631e210082d27ae8cc
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:955648a316db2c17110f06a30dfd0ccc2bb235d3a7e5636ecdae7f71cab32972
                 - name: DB_DSN


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `6652ce0838c223a5542b45631e210082d27ae8cc`
- Image tag: `sha-6652ce0838c223a5542b45631e210082d27ae8cc`
- Image digest: `sha256:955648a316db2c17110f06a30dfd0ccc2bb235d3a7e5636ecdae7f71cab32972`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher