### PR TITLE
fix(torghut): harden market data freshness smoke

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -603,7 +603,7 @@ jobs:
           MARKET_DATA_MAX_LAG_SECONDS: '300'
           MARKET_DATA_ACCEPTED_MAX_LAG_SECONDS: '300'
           MARKET_DATA_HOLIDAYS: '2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25'
-          KAFKA_TOPIC_PARTITIONS: '0,1,2'
+          MARKET_DATA_PRINT_SUMMARIES: 'false'
         run: |
           set -euo pipefail
           bun run smoke:torghut-market-data

--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -129,6 +129,18 @@ kubectl get analysisrun -n torghut
 Kafka topics (v1):
 - Inputs: `torghut.trades.v1`, `torghut.quotes.v1`, `torghut.bars.1m.v1`
 - Outputs (derived): `torghut.ta.bars.1s.v1`, `torghut.ta.signals.v1`
+- Status: `torghut.ta.status.v1`
+
+Market-data freshness smoke:
+
+```bash
+MARKET_DATA_PRINT_SUMMARIES=false bun run smoke:torghut-market-data
+```
+
+The smoke tails Kafka through the Strimzi broker using Kubernetes Secret refs, fetches in-cluster WS/Torghut/Flink
+surfaces through the TA pod by default, and fails during regular market hours when WS channels, Kafka source topics, TA
+heartbeat, or accepted-source freshness are stale. Use `MARKET_DATA_FRESHNESS_MODE=observe` for after-hours diagnostics
+without claiming regular-session proof.
 
 ### Replay window constraints (what can be replayed)
 Replay is constrained by **both** Kafka retention (inputs) and ClickHouse TTL (outputs):

--- a/packages/scripts/src/kafka/tail-topic.ts
+++ b/packages/scripts/src/kafka/tail-topic.ts
@@ -17,7 +17,7 @@ type Args = {
   passwordSecretKey: string
   kafkaNamespace: string
   kafkaPod?: string
-  format: 'raw' | 'summary' | 'json' | 'base64'
+  format: 'raw' | 'summary' | 'json' | 'base64' | 'partitions'
 }
 
 const usage = () =>
@@ -44,7 +44,8 @@ Options:
   --kafka-namespace <ns>              Namespace that contains the Kafka broker pod (default: kafka)
   --kafka-pod <pod>                   Kafka broker pod to exec into (default: auto-detect)
 
-  --format raw|summary|json|base64    Output format (default: summary)
+  --format raw|summary|json|base64|partitions
+                                      Output format (default: summary)
 
 Examples:
   KAFKA_USERNAME=torghut-ws KAFKA_PASSWORD=$(kubectl -n torghut get secret torghut-ws -o jsonpath='{.data.password}' | base64 -d) \\
@@ -130,8 +131,10 @@ const execCapture = async (
   })
 
   if (options.stdin !== undefined) {
-    void subprocess.stdin.write(options.stdin)
-    void subprocess.stdin.end()
+    const stdin = subprocess.stdin
+    if (stdin === undefined) return fatal('Subprocess stdin pipe was not created')
+    void stdin.write(options.stdin)
+    void stdin.end()
   }
 
   const stdout = await new Response(subprocess.stdout).text()
@@ -246,7 +249,7 @@ const main = async () => {
   }
 
   args.format = args.format ?? 'summary'
-  if (!['raw', 'summary', 'json', 'base64'].includes(args.format)) {
+  if (!['raw', 'summary', 'json', 'base64', 'partitions'].includes(args.format)) {
     fatal(`Invalid --format: ${String(args.format)}`)
   }
 
@@ -254,15 +257,16 @@ const main = async () => {
   if (!args.username) fatal('Missing --username (or env KAFKA_USERNAME)')
 
   if (!args.password) {
-    if (!args.passwordSecretName) {
-      fatal('Missing --password (or env KAFKA_PASSWORD), or provide --password-secret-name/namespace/key')
+    const passwordSecretName = args.passwordSecretName
+    if (!passwordSecretName) {
+      return fatal('Missing --password (or env KAFKA_PASSWORD), or provide --password-secret-name/namespace/key')
     }
     const encoded = await execCapture('kubectl', [
       '-n',
       args.passwordSecretNamespace,
       'get',
       'secret',
-      args.passwordSecretName,
+      passwordSecretName,
       '-o',
       `jsonpath={.data.${args.passwordSecretKey}}`,
     ])
@@ -280,7 +284,12 @@ const main = async () => {
     'sasl.mechanism=$SASL_MECHANISM',
     'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$KAFKA_USERNAME" password="$PASS";',
     'PROPS',
-    'end_offset=$(/opt/kafka/bin/kafka-get-offsets.sh --bootstrap-server "$BOOTSTRAP" --command-config "$CLIENT" --topic "$TOPIC" --time latest | awk -F: -v p="$PARTITION" \'$2==p{print $3}\' | tail -n 1)',
+    'offsets=$(/opt/kafka/bin/kafka-get-offsets.sh --bootstrap-server "$BOOTSTRAP" --command-config "$CLIENT" --topic "$TOPIC" --time latest)',
+    'if [ "$FORMAT" = "partitions" ]; then',
+    '  printf "%s\n" "$offsets" | awk -F: \'NF>=3 {printf "{\\\"topic\\\":\\\"%s\\\",\\\"partition\\\":%s,\\\"endOffset\\\":%s}\\n", $1, $2, $3}\'',
+    '  exit 0',
+    'fi',
+    'end_offset=$(printf "%s\n" "$offsets" | awk -F: -v p="$PARTITION" \'$2==p{print $3}\' | tail -n 1)',
     'if [ -z "$end_offset" ]; then end_offset=0; fi',
     'start_offset=$(( end_offset - TAIL ))',
     'if [ "$start_offset" -lt 0 ]; then start_offset=0; fi',
@@ -329,6 +338,12 @@ const main = async () => {
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
+
+  if (args.format === 'partitions') {
+    const partitions = lines.map((line) => JSON.parse(line))
+    process.stdout.write(`${JSON.stringify(partitions, null, 2)}\n`)
+    return
+  }
 
   if (args.format === 'raw') {
     process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''))

--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -860,11 +860,18 @@ describe('market data smoke freshness evaluation', () => {
     })
   })
 
-  it('does not depend on execing into the distroless websocket container', () => {
+  it('uses a non-WS pod proxy for in-cluster HTTP probes by default', () => {
     expect(marketDataSmokeSource).not.toContain('TORGHUT_WS_EXEC_TARGET')
     expect(marketDataSmokeSource).not.toContain('fetchJsonViaWsPod')
-    expect(marketDataSmokeSource).toContain('const wsReadyz = await fetchJson(settings.wsReadyzUrl)')
+    expect(marketDataSmokeSource).toContain('TORGHUT_MARKET_DATA_HTTP_MODE')
+    expect(marketDataSmokeSource).toContain('parseHttpProbeMode(process.env.TORGHUT_MARKET_DATA_HTTP_MODE)')
+    expect(marketDataSmokeSource).toContain(
+      "httpExecTarget: process.env.TORGHUT_MARKET_DATA_HTTP_EXEC_TARGET ?? 'deploy/torghut-ta'",
+    )
+    expect(marketDataSmokeSource).toContain('const wsReadyz = await fetchRuntimeJson(settings.wsReadyzUrl, settings)')
     expect(marketDataSmokeSource).toContain('http://torghut-ws.torghut.svc.cluster.local/readyz')
     expect(marketDataSmokeSource).toContain('KAFKA_TOPIC_PARTITIONS')
+    expect(marketDataSmokeSource).toContain("raw.trim().toLowerCase() === 'auto'")
+    expect(marketDataSmokeSource).toContain("tailArgs(topic, 'partitions', settings, 0, '1')")
   })
 })

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -80,7 +80,8 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain(
       "MARKET_DATA_HOLIDAYS: '2026-01-01,2026-01-19,2026-02-16,2026-04-03,2026-05-25,2026-06-19,2026-07-03,2026-09-07,2026-11-26,2026-12-25'",
     )
-    expect(workflow).toContain("KAFKA_TOPIC_PARTITIONS: '0,1,2'")
+    expect(workflow).toContain("MARKET_DATA_PRINT_SUMMARIES: 'false'")
+    expect(workflow).not.toContain("KAFKA_TOPIC_PARTITIONS: '0,1,2'")
     expect(workflow).toContain('bun run smoke:torghut-market-data')
   })
 

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -13,6 +13,8 @@ type KafkaRole = 'trades' | 'quotes' | 'bars'
 
 type SmokeMode = 'auto' | 'enforce' | 'observe'
 
+type HttpProbeMode = 'direct' | 'pod'
+
 type MarketSessionState = 'pre' | 'regular' | 'post' | 'closed' | 'weekend' | 'holiday'
 
 type KafkaTopicRecord = {
@@ -115,10 +117,11 @@ const parsePositiveNumber = (raw: string | undefined, fallback: number, label: s
   return parsed
 }
 
-const parsePartitions = (raw: string | undefined): number[] => {
-  const values = parseList(raw, ['0', '1', '2']).map((item) => Number(item))
+const parsePartitions = (raw: string | undefined): number[] | undefined => {
+  if (raw === undefined || raw.trim() === '' || raw.trim().toLowerCase() === 'auto') return undefined
+  const values = parseList(raw, []).map((item) => Number(item))
   if (values.length === 0 || values.some((value) => !Number.isInteger(value) || value < 0)) {
-    fatal('KAFKA_TOPIC_PARTITIONS must be a comma-separated list of non-negative integers')
+    fatal('KAFKA_TOPIC_PARTITIONS must be auto or a comma-separated list of non-negative integers')
   }
   return [...new Set(values)].sort((left, right) => left - right)
 }
@@ -126,7 +129,13 @@ const parsePartitions = (raw: string | undefined): number[] => {
 const parseMode = (raw: string | undefined): SmokeMode => {
   const mode = (raw ?? 'auto').trim().toLowerCase()
   if (mode === 'auto' || mode === 'enforce' || mode === 'observe') return mode
-  fatal('MARKET_DATA_FRESHNESS_MODE must be auto, enforce, or observe')
+  return fatal('MARKET_DATA_FRESHNESS_MODE must be auto, enforce, or observe')
+}
+
+const parseHttpProbeMode = (raw: string | undefined): HttpProbeMode => {
+  const mode = (raw ?? 'pod').trim().toLowerCase()
+  if (mode === 'direct' || mode === 'pod') return mode
+  return fatal('TORGHUT_MARKET_DATA_HTTP_MODE must be direct or pod')
 }
 
 const isObject = (value: unknown): value is JsonObject =>
@@ -199,12 +208,12 @@ const isConditionalNoEventWsChannel = (channel: string, ready: boolean, observed
 const getWsChannels = (readyz: unknown): Map<string, JsonObject> => {
   const root = isObject(readyz) ? readyz : {}
   const channels = Array.isArray(root.market_data_channels) ? root.market_data_channels : []
-  return new Map(
-    channels
-      .filter(isObject)
-      .map((channel) => [asString(channel.channel) ?? '', channel])
-      .filter(([channel]) => channel.length > 0),
-  )
+  const entries: Array<[string, JsonObject]> = []
+  for (const channel of channels.filter(isObject)) {
+    const channelName = asString(channel.channel)
+    if (channelName) entries.push([channelName, channel])
+  }
+  return new Map(entries)
 }
 
 const getAcceptedFreshness = (status: unknown): JsonObject | undefined => {
@@ -598,8 +607,10 @@ const execCapture = async (
   })
 
   if (options.stdin !== undefined) {
-    void subprocess.stdin.write(options.stdin)
-    void subprocess.stdin.end()
+    const stdin = subprocess.stdin
+    if (stdin === undefined) return fatal('Subprocess stdin pipe was not created')
+    void stdin.write(options.stdin)
+    void stdin.end()
   }
 
   const stdout = await new Response(subprocess.stdout).text()
@@ -613,7 +624,7 @@ const execCapture = async (
 
 const tailArgs = (
   topic: string,
-  format: 'summary' | 'json' | 'base64',
+  format: 'summary' | 'json' | 'base64' | 'partitions',
   settings: RuntimeSettings,
   partition: number,
   tail = settings.tail,
@@ -640,19 +651,43 @@ const tailArgs = (
   format,
 ]
 
+const kafkaPartitionsForTopic = async (topic: string, settings: RuntimeSettings): Promise<number[]> => {
+  if (settings.kafkaPartitions) return settings.kafkaPartitions
+  const cached = settings.kafkaPartitionCache.get(topic)
+  if (cached) return cached
+
+  const stdout = await execCapture('bun', tailArgs(topic, 'partitions', settings, 0, '1'), { cwd: repoRoot })
+  const parsed = JSON.parse(stdout) as unknown
+  if (!Array.isArray(parsed)) {
+    return fatal(`Kafka partition discovery for ${topic} did not return a JSON array`)
+  }
+  const partitionRows: unknown[] = parsed
+  const partitionNumbers = partitionRows
+    .filter(isObject)
+    .map((record) => asNumber(record.partition))
+    .filter((partition): partition is number => partition !== undefined)
+  const partitions = [...new Set(partitionNumbers)].sort((left, right) => left - right)
+  if (partitions.length === 0) {
+    fatal(`Kafka partition discovery for ${topic} returned no partitions`)
+  }
+  settings.kafkaPartitionCache.set(topic, partitions)
+  return partitions
+}
+
 const captureLatestKafkaRecord = async (
   role: KafkaRole,
   topic: string,
   settings: RuntimeSettings,
 ): Promise<KafkaTopicRecord | undefined> => {
   const records: KafkaTopicRecord[] = []
-  for (const partition of settings.kafkaPartitions) {
+  for (const partition of await kafkaPartitionsForTopic(topic, settings)) {
     const stdout = await execCapture('bun', tailArgs(topic, 'json', settings, partition), { cwd: repoRoot })
     const parsed = JSON.parse(stdout) as unknown
     if (!Array.isArray(parsed)) {
-      fatal(`Kafka tail for ${topic} partition ${partition} did not return a JSON array`)
+      return fatal(`Kafka tail for ${topic} partition ${partition} did not return a JSON array`)
     }
-    for (const record of parsed.filter(isObject)) {
+    const rows: unknown[] = parsed
+    for (const record of rows.filter(isObject)) {
       const eventTs = asString(record.eventTs)
       if (!eventTs) continue
       records.push({
@@ -684,7 +719,7 @@ const captureLatestTaStatusHeartbeat = async (
   settings: RuntimeSettings,
 ): Promise<TaStatusHeartbeatRecord | undefined> => {
   const heartbeats: TaStatusHeartbeatRecord[] = []
-  for (const partition of settings.kafkaPartitions) {
+  for (const partition of await kafkaPartitionsForTopic(topic, settings)) {
     const stdout = await execCapture('bun', tailArgs(topic, 'base64', settings, partition, '1'), { cwd: repoRoot })
     const encoded = stdout.trim()
     if (!encoded) continue
@@ -704,9 +739,21 @@ const fetchJsonViaPod = async (target: string, url: string, settings: RuntimeSet
     settings.torghutNamespace,
     target,
     '--',
-    'wget',
-    '-qO-',
-    url,
+    'env',
+    `URL=${url}`,
+    'sh',
+    '-lc',
+    [
+      'set -eu',
+      'if command -v wget >/dev/null 2>&1; then',
+      '  exec wget -qO- "$URL"',
+      'fi',
+      'if command -v curl >/dev/null 2>&1; then',
+      '  exec curl -fsSL "$URL"',
+      'fi',
+      'echo "no wget or curl available in probe target" >&2',
+      'exit 127',
+    ].join('\n'),
   ])
   return JSON.parse(stdout) as unknown
 }
@@ -719,6 +766,11 @@ const fetchJson = async (url: string): Promise<unknown> => {
   return (await response.json()) as unknown
 }
 
+const fetchRuntimeJson = async (url: string, settings: RuntimeSettings): Promise<unknown> => {
+  if (settings.httpProbeMode === 'direct') return fetchJson(url)
+  return fetchJsonViaPod(settings.httpExecTarget, url, settings)
+}
+
 type RuntimeSettings = {
   topics: string[]
   topicByRole: Record<KafkaRole, string>
@@ -728,7 +780,8 @@ type RuntimeSettings = {
   passwordSecretName: string
   passwordSecretKey: string
   tail: string
-  kafkaPartitions: number[]
+  kafkaPartitions?: number[]
+  kafkaPartitionCache: Map<string, number[]>
   timeoutMs: string
   mode: SmokeMode
   maxKafkaLagSeconds: number
@@ -737,6 +790,8 @@ type RuntimeSettings = {
   now: Date
   printSummaries: boolean
   torghutNamespace: string
+  httpProbeMode: HttpProbeMode
+  httpExecTarget: string
   wsReadyzUrl: string
   tradingStatusUrl: string
   taConfigMapName: string
@@ -758,6 +813,7 @@ const runtimeSettings = (): RuntimeSettings => ({
   passwordSecretKey: process.env.KAFKA_PASSWORD_SECRET_KEY ?? 'password',
   tail: process.env.TAIL ?? '1',
   kafkaPartitions: parsePartitions(process.env.KAFKA_TOPIC_PARTITIONS),
+  kafkaPartitionCache: new Map(),
   timeoutMs: process.env.TIMEOUT_MS ?? '8000',
   mode: parseMode(process.env.MARKET_DATA_FRESHNESS_MODE),
   maxKafkaLagSeconds: parsePositiveNumber(process.env.MARKET_DATA_MAX_LAG_SECONDS, 300, 'MARKET_DATA_MAX_LAG_SECONDS'),
@@ -770,6 +826,8 @@ const runtimeSettings = (): RuntimeSettings => ({
   now: process.env.MARKET_DATA_NOW ? new Date(process.env.MARKET_DATA_NOW) : new Date(),
   printSummaries: process.env.MARKET_DATA_PRINT_SUMMARIES !== 'false',
   torghutNamespace: process.env.TORGHUT_NAMESPACE ?? 'torghut',
+  httpProbeMode: parseHttpProbeMode(process.env.TORGHUT_MARKET_DATA_HTTP_MODE),
+  httpExecTarget: process.env.TORGHUT_MARKET_DATA_HTTP_EXEC_TARGET ?? 'deploy/torghut-ta',
   wsReadyzUrl: process.env.TORGHUT_WS_READYZ_URL ?? 'http://torghut-ws.torghut.svc.cluster.local/readyz',
   tradingStatusUrl: process.env.TORGHUT_STATUS_URL ?? 'http://torghut.torghut.svc.cluster.local/trading/status',
   taConfigMapName: process.env.TORGHUT_TA_CONFIGMAP ?? 'torghut-ta-config',
@@ -821,7 +879,10 @@ const fetchFlinkVertexRates = async (
     ? metricCatalog
         .filter(isObject)
         .map((metric) => asString(metric.id))
-        .filter((id) => id?.endsWith('numRecordsInPerSecond') || id?.endsWith('numRecordsOutPerSecond'))
+        .filter(
+          (id): id is string =>
+            typeof id === 'string' && (id.endsWith('numRecordsInPerSecond') || id.endsWith('numRecordsOutPerSecond')),
+        )
     : []
   if (metricIds.length === 0) return {}
 
@@ -885,7 +946,9 @@ const main = async () => {
 
   if (settings.printSummaries) {
     for (const topic of settings.topics) {
-      await run('bun', tailArgs(topic, 'summary', settings, 0), { cwd: repoRoot })
+      for (const partition of await kafkaPartitionsForTopic(topic, settings)) {
+        await run('bun', tailArgs(topic, 'summary', settings, partition), { cwd: repoRoot })
+      }
     }
   }
 
@@ -895,8 +958,8 @@ const main = async () => {
   }
   const taStatusHeartbeat = await captureLatestTaStatusHeartbeat(settings.taStatusTopic, settings)
 
-  const wsReadyz = await fetchJson(settings.wsReadyzUrl)
-  const tradingStatus = await fetchJson(settings.tradingStatusUrl)
+  const wsReadyz = await fetchRuntimeJson(settings.wsReadyzUrl, settings)
+  const tradingStatus = await fetchRuntimeJson(settings.tradingStatusUrl, settings)
   const taRuntimeConfig = await fetchConfigMapData(settings.torghutNamespace, settings.taConfigMapName)
   const taFlinkJob = await fetchTaFlinkJob(settings)
   const result = evaluateMarketDataSmoke({


### PR DESCRIPTION
## Summary

- Makes `bun run smoke:torghut-market-data` usable from CI/operator workstations by fetching in-cluster Torghut/WS/Flink HTTP surfaces through a non-WS pod by default.
- Adds Kafka topic partition discovery to `packages/scripts/src/kafka/tail-topic.ts` and removes the hard-coded `0,1,2` partition override from Torghut post-deploy verification.
- Keeps the post-deploy market-data smoke bounded with `MARKET_DATA_PRINT_SUMMARIES=false` while still checking Kafka source topics, WS channel coverage, TA heartbeat, Flink job state, and Torghut accepted-source freshness.
- Documents the canonical no-secret market-data smoke command in the Torghut GitOps README.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check .github/workflows/torghut-post-deploy-verify.yml packages/scripts/src/kafka/tail-topic.ts packages/scripts/src/torghut/market-data-smoke.ts packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run --cwd packages/scripts lint:oxlint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `git diff --check`
- `bun run packages/scripts/src/kafka/tail-topic.ts --topic torghut.trades.v1 --format partitions --username torghut-ws --password-secret-namespace torghut --password-secret-name torghut-ws --password-secret-key password`
- `MARKET_DATA_PRINT_SUMMARIES=false MARKET_DATA_FRESHNESS_MODE=auto TIMEOUT_MS=8000 bun run smoke:torghut-market-data`
- `bunx tsc --noEmit -p packages/scripts/tsconfig.json` remains red on existing package-wide baseline errors; filtered output has no errors in touched files.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
