### PR TITLE
chore(torghut): promote image sha-a7afa88811facffa5b5ae1082d432a2821a32f5b

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -52,7 +52,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: c0e8390a98b600daea0907f3e924cfbfbdaf4ac6
+              value: a7afa88811facffa5b5ae1082d432a2821a32f5b
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:adc762e15c661821c0fe81f6473e2d701556dcd916eeaa7f70c74f91c8652912
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: c0e8390a98b600daea0907f3e924cfbfbdaf4ac6
+              value: a7afa88811facffa5b5ae1082d432a2821a32f5b
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:adc762e15c661821c0fe81f6473e2d701556dcd916eeaa7f70c74f91c8652912
             - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T20:39:12Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T21:23:56Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -539,9 +539,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1641-gc0e8390a9
+              value: v0.596.0-1643-ga7afa8881
             - name: TORGHUT_COMMIT
-              value: c0e8390a98b600daea0907f3e924cfbfbdaf4ac6
+              value: a7afa88811facffa5b5ae1082d432a2821a32f5b
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:adc762e15c661821c0fe81f6473e2d701556dcd916eeaa7f70c74f91c8652912
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T20:39:12Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T21:23:56Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -418,9 +418,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1641-gc0e8390a9
+              value: v0.596.0-1643-ga7afa8881
             - name: TORGHUT_COMMIT
-              value: c0e8390a98b600daea0907f3e924cfbfbdaf4ac6
+              value: a7afa88811facffa5b5ae1082d432a2821a32f5b
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:adc762e15c661821c0fe81f6473e2d701556dcd916eeaa7f70c74f91c8652912
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -48,7 +48,7 @@ spec:
                 - name: PYTHONUNBUFFERED
                   value: "1"
                 - name: TORGHUT_COMMIT
-                  value: c0e8390a98b600daea0907f3e924cfbfbdaf4ac6
+                  value: a7afa88811facffa5b5ae1082d432a2821a32f5b
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:adc762e15c661821c0fe81f6473e2d701556dcd916eeaa7f70c74f91c8652912
                 - name: DB_DSN


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a7afa88811facffa5b5ae1082d432a2821a32f5b`
- Image tag: `sha-a7afa88811facffa5b5ae1082d432a2821a32f5b`
- Image digest: `sha256:adc762e15c661821c0fe81f6473e2d701556dcd916eeaa7f70c74f91c8652912`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher