### PR TITLE
fix(torghut): fail closed on missing accepted TA

### DIFF
--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_market_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_market_methods.py
@@ -41,12 +41,6 @@ from .clickhouse_signal_ingestor_market_support import (
     signal_scope_key as _signal_scope_key,
     split_table as _split_table,
 )
-from .clickhouse_signal_source_freshness import (
-    ClickHouseSignalFreshnessContext as _ClickHouseSignalFreshnessContext,
-    accepted_signal_sources as _accepted_signal_sources,
-    build_accepted_source_freshness_contract as _build_accepted_source_freshness_contract,
-    latest_signal_readiness_counts as _latest_signal_readiness_counts,
-)
 
 logger = logging.getLogger("app.trading.ingest")
 
@@ -178,84 +172,6 @@ class _ClickHouseSignalIngestorMarketMethods(_ClickHouseSignalIngestorMarketBase
             self._latest_signal_ts_cache = latest
             return
         self._latest_signal_ts_scoped_cache[scope_key] = latest
-
-    def latest_signal_status(self) -> dict[str, Any]:
-        if not self.url:
-            return {
-                "state": "missing",
-                "reason_codes": ["clickhouse_url_missing"],
-                "source_ref": self.table,
-            }
-        try:
-            time_column = self._resolve_time_column()
-            latest_signal_at = self._latest_signal_timestamp(time_column)
-        except Exception as exc:
-            logger.warning("Failed to load ClickHouse TA freshness status: %s", exc)
-            return {
-                "state": "missing",
-                "reason_codes": ["clickhouse_ta_status_query_failed"],
-                "source_ref": self.table,
-                "detail": str(exc)[:200],
-            }
-        if latest_signal_at is None:
-            return {
-                "state": "missing",
-                "reason_codes": ["clickhouse_ta_latest_signal_missing"],
-                "source_ref": self.table,
-                "time_column": time_column,
-            }
-        status: dict[str, Any] = {
-            "state": "current",
-            "latest_signal_at": latest_signal_at,
-            "source_ref": self.table,
-            "time_column": time_column,
-        }
-        status.update(
-            self._accepted_source_freshness_contract(
-                time_column=time_column,
-                latest_signal_at=latest_signal_at,
-            )
-        )
-        try:
-            status.update(
-                _latest_signal_readiness_counts(
-                    context=self._signal_freshness_context(),
-                    time_column=time_column,
-                    latest_signal_at=latest_signal_at,
-                )
-            )
-        except (RuntimeError, OSError, ValueError, TypeError) as exc:
-            logger.warning("Failed to load ClickHouse TA readiness counts: %s", exc)
-            status["readiness_reason_codes"] = ["clickhouse_ta_readiness_query_failed"]
-            status["readiness_detail"] = str(exc)[:200]
-        return status
-
-    def _accepted_source_freshness_contract(
-        self,
-        *,
-        time_column: str,
-        latest_signal_at: datetime,
-    ) -> dict[str, Any]:
-        return _build_accepted_source_freshness_contract(
-            context=self._signal_freshness_context(),
-            time_column=time_column,
-            latest_signal_at=latest_signal_at,
-        )
-
-    def _signal_freshness_context(self) -> _ClickHouseSignalFreshnessContext:
-        return _ClickHouseSignalFreshnessContext(
-            table=self.table,
-            simulation_mode=self.simulation_mode,
-            initial_lookback_minutes=self.initial_lookback_minutes,
-            max_staleness_ms=settings.trading_feature_max_staleness_ms,
-            allowed_sources_raw=",".join(self._accepted_signal_sources()),
-            query_clickhouse=self._query_clickhouse,
-            resolve_columns=self._resolve_columns,
-            source_where_clause=self._source_where_clause,
-        )
-
-    def _accepted_signal_sources(self) -> tuple[str, ...]:
-        return _accepted_signal_sources(settings.trading_signal_allowed_sources_raw)
 
     def _latest_signal_timestamp_queries(
         self,

--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py
@@ -31,6 +31,9 @@ from .clickhouse_signal_ingestor_core_methods import (
 from .clickhouse_signal_ingestor_market_methods import (
     ClickHouseSignalIngestorMarketMethods as _ClickHouseSignalIngestorMarketMethods,
 )
+from .clickhouse_signal_ingestor_status_methods import (
+    ClickHouseSignalIngestorStatusMethods as _ClickHouseSignalIngestorStatusMethods,
+)
 
 
 if TYPE_CHECKING:
@@ -146,6 +149,7 @@ class ClickHouseSignalIngestor(
     _ClickHouseSignalIngestorFields,
     _ClickHouseSignalIngestorCoreMethods,
     _ClickHouseSignalIngestorMarketMethods,
+    _ClickHouseSignalIngestorStatusMethods,
     _ClickHouseSignalIngestorPersistenceMethods,
 ):
     pass

--- a/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_status_methods.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_ingestor_status_methods.py
@@ -1,0 +1,143 @@
+"""ClickHouse signal status and accepted-source freshness contracts."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Mapping
+
+from ...config import settings
+
+from .clickhouse_signal_source_freshness import (
+    ClickHouseSignalFreshnessContext as _ClickHouseSignalFreshnessContext,
+    accepted_signal_sources as _accepted_signal_sources,
+    build_accepted_source_freshness_contract as _build_accepted_source_freshness_contract,
+    build_unavailable_accepted_source_freshness_contract as _build_unavailable_accepted_source_freshness_contract,
+    latest_signal_readiness_counts as _latest_signal_readiness_counts,
+)
+from .shared_context import (
+    ClickHouseSignalIngestorContract as _ClickHouseSignalIngestorContract,
+)
+
+logger = logging.getLogger("app.trading.ingest")
+
+_CLICKHOUSE_STATUS_EXCEPTIONS = (RuntimeError, OSError, ValueError, TypeError)
+
+
+if TYPE_CHECKING:
+    _ClickHouseSignalIngestorStatusBase = _ClickHouseSignalIngestorContract
+else:
+    _ClickHouseSignalIngestorStatusBase = object
+
+
+class _ClickHouseSignalIngestorStatusMethods(_ClickHouseSignalIngestorStatusBase):
+    def latest_signal_status(self) -> dict[str, object]:
+        if not self.url:
+            return self._unavailable_signal_status(
+                state="unavailable",
+                reason_code="clickhouse_url_missing",
+                blocking_reason="accepted_ta_signal_unavailable",
+            )
+        try:
+            time_column = self._resolve_time_column()
+            latest_signal_at = self._latest_signal_timestamp(time_column)
+        except _CLICKHOUSE_STATUS_EXCEPTIONS as exc:
+            logger.warning("Failed to load ClickHouse TA freshness status: %s", exc)
+            return self._unavailable_signal_status(
+                state="unavailable",
+                reason_code="clickhouse_ta_status_query_failed",
+                blocking_reason="accepted_ta_signal_unavailable",
+                extra_status={"detail": str(exc)[:200]},
+            )
+        if latest_signal_at is None:
+            return self._unavailable_signal_status(
+                state="missing",
+                reason_code="clickhouse_ta_latest_signal_missing",
+                blocking_reason="accepted_ta_signal_missing",
+                extra_status={"time_column": time_column},
+            )
+        status: dict[str, object] = {
+            "state": "current",
+            "latest_signal_at": latest_signal_at,
+            "source_ref": self.table,
+            "time_column": time_column,
+        }
+        status.update(
+            self._accepted_source_freshness_contract(
+                time_column=time_column,
+                latest_signal_at=latest_signal_at,
+            )
+        )
+        try:
+            status.update(
+                _latest_signal_readiness_counts(
+                    context=self._signal_freshness_context(),
+                    time_column=time_column,
+                    latest_signal_at=latest_signal_at,
+                )
+            )
+        except _CLICKHOUSE_STATUS_EXCEPTIONS as exc:
+            logger.warning("Failed to load ClickHouse TA readiness counts: %s", exc)
+            status["readiness_reason_codes"] = ["clickhouse_ta_readiness_query_failed"]
+            status["readiness_detail"] = str(exc)[:200]
+        return status
+
+    def _unavailable_signal_status(
+        self,
+        *,
+        state: str,
+        reason_code: str,
+        blocking_reason: str,
+        extra_status: Mapping[str, object] | None = None,
+    ) -> dict[str, object]:
+        status: dict[str, object] = {
+            "state": "missing",
+            "reason_codes": [reason_code],
+            "source_ref": self.table,
+        }
+        if extra_status is not None:
+            status.update(extra_status)
+        status.update(
+            _build_unavailable_accepted_source_freshness_contract(
+                context=self._signal_freshness_context(),
+                state=state,
+                reason_code=reason_code,
+                blocking_reason=blocking_reason,
+            )
+        )
+        return status
+
+    def _accepted_source_freshness_contract(
+        self,
+        *,
+        time_column: str,
+        latest_signal_at: datetime,
+    ) -> dict[str, object]:
+        return _build_accepted_source_freshness_contract(
+            context=self._signal_freshness_context(),
+            time_column=time_column,
+            latest_signal_at=latest_signal_at,
+        )
+
+    def _signal_freshness_context(self) -> _ClickHouseSignalFreshnessContext:
+        return _ClickHouseSignalFreshnessContext(
+            table=self.table,
+            simulation_mode=self.simulation_mode,
+            initial_lookback_minutes=self.initial_lookback_minutes,
+            max_staleness_ms=settings.trading_feature_max_staleness_ms,
+            allowed_sources_raw=",".join(self._accepted_signal_sources()),
+            query_clickhouse=self._query_clickhouse,
+            resolve_columns=self._resolve_columns,
+            source_where_clause=self._source_where_clause,
+        )
+
+    def _accepted_signal_sources(self) -> tuple[str, ...]:
+        return _accepted_signal_sources(settings.trading_signal_allowed_sources_raw)
+
+
+ClickHouseSignalIngestorStatusMethods = _ClickHouseSignalIngestorStatusMethods
+
+
+__all__ = [
+    "ClickHouseSignalIngestorStatusMethods",
+]

--- a/services/torghut/app/trading/ingest/clickhouse_signal_source_freshness.py
+++ b/services/torghut/app/trading/ingest/clickhouse_signal_source_freshness.py
@@ -122,6 +122,34 @@ def build_accepted_source_freshness_contract(
     }
 
 
+def build_unavailable_accepted_source_freshness_contract(
+    *,
+    context: ClickHouseSignalFreshnessContext,
+    state: str,
+    reason_code: str,
+    blocking_reason: str,
+) -> dict[str, object]:
+    now = context.now().astimezone(timezone.utc)
+    max_age_seconds = max(1, int(context.max_staleness_ms) // 1000)
+    market_session = regular_market_session_state(now)
+    accepted_sources = accepted_signal_sources(context.allowed_sources_raw)
+    resolved_blocking_reason = None if context.simulation_mode else blocking_reason
+    return {
+        "accepted_sources": list(accepted_sources) if accepted_sources else ["*"],
+        "latest_accepted_event_at": None,
+        "accepted_lag_seconds": None,
+        "accepted_max_lag_seconds": max_age_seconds,
+        "accepted_source_state": state,
+        "blocking_reason": resolved_blocking_reason,
+        "fresh_until": None,
+        "excluded_fresher_sources": [],
+        "per_symbol_coverage": [],
+        "stale_symbol_coverage": [],
+        **market_session,
+        "freshness_reason_codes": [reason_code],
+    }
+
+
 def _accepted_source_freshness_gate(
     *,
     lag_seconds: int,
@@ -369,6 +397,7 @@ __all__ = [
     "accepted_per_symbol_coverage",
     "accepted_signal_sources",
     "build_accepted_source_freshness_contract",
+    "build_unavailable_accepted_source_freshness_contract",
     "ClickHouseSignalFreshnessContext",
     "excluded_fresher_sources_after_accepted_latest",
     "latest_signal_readiness_counts",

--- a/services/torghut/app/trading/submission_council/__init__.py
+++ b/services/torghut/app/trading/submission_council/__init__.py
@@ -621,6 +621,12 @@ def _accepted_ta_submission_blocker(
     )
     if accepted_source_state == "stale":
         return "accepted_ta_signal_stale"
+    if accepted_source_state == "missing":
+        return "accepted_ta_signal_missing"
+    if accepted_source_state == "unavailable":
+        return "accepted_ta_signal_unavailable"
+    if _safe_text(clickhouse_ta_status.get("state")) == "missing":
+        return "accepted_ta_signal_unavailable"
     return None
 
 

--- a/services/torghut/app/trading/submission_council/gate_payloads.py
+++ b/services/torghut/app/trading/submission_council/gate_payloads.py
@@ -118,9 +118,15 @@ def _clickhouse_ta_freshness_ref(
         "accepted_max_lag_seconds": status.get("accepted_max_lag_seconds"),
         "accepted_source_state": status.get("accepted_source_state"),
         "blocking_reason": status.get("blocking_reason"),
+        "fresh_until": status.get("fresh_until"),
+        "freshness_reason_codes": status.get("freshness_reason_codes") or [],
         "excluded_fresher_sources": status.get("excluded_fresher_sources") or [],
         "per_symbol_coverage": status.get("per_symbol_coverage") or [],
+        "stale_symbol_coverage": status.get("stale_symbol_coverage") or [],
         "market_session_state": status.get("market_session_state"),
+        "regular_session_open": status.get("regular_session_open"),
+        "regular_session_open_at": status.get("regular_session_open_at"),
+        "regular_session_close_at": status.get("regular_session_close_at"),
     }
 
 

--- a/services/torghut/tests/api/test_trading_api_live_gate_llm.py
+++ b/services/torghut/tests/api/test_trading_api_live_gate_llm.py
@@ -333,6 +333,21 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
                     return_value={"ready": True, "status": "healthy"},
                 ),
                 patch(
+                    "app.api.trading_status._load_clickhouse_ta_status",
+                    return_value={
+                        "state": "current",
+                        "accepted_sources": ["ta"],
+                        "latest_accepted_event_at": "2026-03-20T09:59:00Z",
+                        "accepted_lag_seconds": 30,
+                        "accepted_max_lag_seconds": 300,
+                        "accepted_source_state": "current",
+                        "blocking_reason": None,
+                        "excluded_fresher_sources": [],
+                        "per_symbol_coverage": [],
+                        "market_session_state": "regular_open",
+                    },
+                ),
+                patch(
                     "app.api.trading_status.load_quant_evidence_status",
                     return_value={
                         "required": True,

--- a/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
+++ b/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
@@ -99,7 +99,22 @@ class TestTradingApiSimpleLaneProfitFloor(TradingApiTestCaseBase):
             }
             app.state.trading_scheduler = scheduler
 
-            response = self.client.get("/trading/status")
+            with patch(
+                "app.api.trading_status._load_clickhouse_ta_status",
+                return_value={
+                    "state": "current",
+                    "accepted_sources": ["ta"],
+                    "latest_accepted_event_at": "2026-03-20T09:59:00Z",
+                    "accepted_lag_seconds": 30,
+                    "accepted_max_lag_seconds": 300,
+                    "accepted_source_state": "current",
+                    "blocking_reason": None,
+                    "excluded_fresher_sources": [],
+                    "per_symbol_coverage": [],
+                    "market_session_state": "regular_open",
+                },
+            ):
+                response = self.client.get("/trading/status")
             self.assertEqual(response.status_code, 200)
             payload = response.json()
 

--- a/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
@@ -13,6 +13,67 @@ from tests.submission_council.support import (
 
 
 class TestLiveSubmissionGateClickHouseFreshness(SubmissionCouncilTestCase):
+    def test_build_live_submission_gate_payload_blocks_missing_accepted_clickhouse_ta_status(
+        self,
+    ) -> None:
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                market_session_open=True,
+                last_autonomy_promotion_eligible=False,
+                last_autonomy_promotion_action=None,
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=45,
+                metrics=SimpleNamespace(
+                    feature_batch_rows_total=0,
+                    feature_null_rate={},
+                    feature_staleness_ms_p95=0,
+                    feature_duplicate_ratio=0.0,
+                    decision_state_total={},
+                ),
+            ),
+            hypothesis_summary={
+                "promotion_eligible_total": 0,
+                "capital_stage_totals": {"shadow": 1},
+                "dependency_quorum": {
+                    "decision": "allow",
+                    "reasons": [],
+                    "message": "ready",
+                },
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+            clickhouse_ta_status={
+                "state": "missing",
+                "reason_codes": ["clickhouse_ta_latest_signal_missing"],
+                "accepted_sources": ["ta"],
+                "latest_accepted_event_at": None,
+                "accepted_lag_seconds": None,
+                "accepted_max_lag_seconds": 300,
+                "accepted_source_state": "missing",
+                "blocking_reason": "accepted_ta_signal_missing",
+                "fresh_until": None,
+                "freshness_reason_codes": ["clickhouse_ta_latest_signal_missing"],
+                "excluded_fresher_sources": [],
+                "per_symbol_coverage": [],
+                "stale_symbol_coverage": [],
+                "market_session_state": "regular_open",
+                "regular_session_open": True,
+            },
+        )
+
+        self.assertFalse(result["allowed"])
+        self.assertIn("accepted_ta_signal_missing", result["blocked_reasons"])
+        self.assertEqual(result["continuity_source"], "clickhouse_ta_status")
+        self.assertEqual(result["continuity_reason"], "accepted_ta_signal_missing")
+        freshness = result["clickhouse_ta_freshness"]
+        self.assertEqual(freshness["accepted_source_state"], "missing")
+        self.assertEqual(freshness["blocking_reason"], "accepted_ta_signal_missing")
+        self.assertEqual(
+            freshness["freshness_reason_codes"],
+            ["clickhouse_ta_latest_signal_missing"],
+        )
+        self.assertEqual(freshness["market_session_state"], "regular_open")
+
     def test_build_live_submission_gate_payload_blocks_stale_accepted_clickhouse_ta_status(
         self,
     ) -> None:

--- a/services/torghut/tests/test_signal_readiness_status.py
+++ b/services/torghut/tests/test_signal_readiness_status.py
@@ -84,6 +84,28 @@ class SourceFreshnessIngestor(SourceFilteredReadinessIngestor):
         return super()._query_clickhouse(query)
 
 
+class MissingLatestSignalIngestor(SourceFreshnessIngestor):
+    def _latest_signal_timestamp(
+        self,
+        time_column: str,
+        *,
+        symbols: tuple[str, ...] = (),
+        timeframes: tuple[str, ...] = (),
+    ) -> datetime | None:
+        return None
+
+
+class FailingLatestSignalIngestor(SourceFreshnessIngestor):
+    def _latest_signal_timestamp(
+        self,
+        time_column: str,
+        *,
+        symbols: tuple[str, ...] = (),
+        timeframes: tuple[str, ...] = (),
+    ) -> datetime | None:
+        raise RuntimeError("latest accepted source query failed")
+
+
 def test_coerce_count_handles_clickhouse_json_values() -> None:
     assert coerce_count(True) == 1
     assert coerce_count(12) == 12
@@ -150,6 +172,80 @@ def test_latest_signal_readiness_counts_include_source_filter() -> None:
     ]
     assert readiness_queries
     assert "lower(source) IN ('ta')" in readiness_queries[0]
+
+
+def test_latest_signal_status_blocks_when_clickhouse_url_is_missing() -> None:
+    now = datetime(2026, 5, 13, 15, 30, tzinfo=timezone.utc)
+    ingestor = SourceFreshnessIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="",
+        latest_signal_ts=now,
+        signal_rows=0,
+        symbol_count=0,
+        source_rows=[],
+        coverage_rows=[],
+        now=now,
+    )
+
+    status = ingestor.latest_signal_status()
+
+    assert status["state"] == "missing"
+    assert status["reason_codes"] == ["clickhouse_url_missing"]
+    assert status["accepted_sources"] == ["ta"]
+    assert status["latest_accepted_event_at"] is None
+    assert status["accepted_lag_seconds"] is None
+    assert status["accepted_source_state"] == "unavailable"
+    assert status["blocking_reason"] == "accepted_ta_signal_unavailable"
+    assert status["market_session_state"] == "regular_open"
+    assert status["freshness_reason_codes"] == ["clickhouse_url_missing"]
+
+
+def test_latest_signal_status_blocks_when_freshness_query_fails() -> None:
+    now = datetime(2026, 5, 13, 15, 30, tzinfo=timezone.utc)
+    ingestor = FailingLatestSignalIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="http://example",
+        latest_signal_ts=now,
+        signal_rows=0,
+        symbol_count=0,
+        source_rows=[],
+        coverage_rows=[],
+        now=now,
+    )
+
+    status = ingestor.latest_signal_status()
+
+    assert status["state"] == "missing"
+    assert status["reason_codes"] == ["clickhouse_ta_status_query_failed"]
+    assert status["accepted_source_state"] == "unavailable"
+    assert status["blocking_reason"] == "accepted_ta_signal_unavailable"
+    assert status["freshness_reason_codes"] == ["clickhouse_ta_status_query_failed"]
+    assert "latest accepted source query failed" in status["detail"]
+
+
+def test_latest_signal_status_blocks_when_no_accepted_source_row_exists() -> None:
+    now = datetime(2026, 5, 13, 15, 30, tzinfo=timezone.utc)
+    ingestor = MissingLatestSignalIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="http://example",
+        latest_signal_ts=now,
+        signal_rows=0,
+        symbol_count=0,
+        source_rows=[],
+        coverage_rows=[],
+        now=now,
+    )
+
+    status = ingestor.latest_signal_status()
+
+    assert status["state"] == "missing"
+    assert status["reason_codes"] == ["clickhouse_ta_latest_signal_missing"]
+    assert status["accepted_source_state"] == "missing"
+    assert status["blocking_reason"] == "accepted_ta_signal_missing"
+    assert status["freshness_reason_codes"] == ["clickhouse_ta_latest_signal_missing"]
 
 
 def test_latest_signal_status_blocks_stale_accepted_source_and_reports_excluded_fresher_source() -> (


### PR DESCRIPTION
## Summary

- Fail closed when accepted-source TA freshness is unavailable, missing, or query-failed by emitting a typed accepted-source contract with `blocking_reason`.
- Extract ClickHouse ingestor status/freshness logic into a semantic status mixin, dropping the market-methods module from 999/1038-line pressure to 914 lines under the 1000-line gate.
- Carry freshness reason codes, stale symbol coverage, `fresh_until`, and regular-session metadata through the shared live-submission gate.
- Add regressions for missing ClickHouse URL, query failure, no accepted-source row, and live-gate propagation of `accepted_ta_signal_missing`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_signal_readiness_status.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_readyz_contract.py tests/api/test_trading_api_live_gate_llm.py tests/test_trading_proofs_api.py tests/test_proofs_service.py`
- `cd services/torghut && uv run --frozen pytest tests/test_signal_readiness_status.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py tests/api/test_trading_api_readyz_contract.py tests/api/test_trading_api_live_gate_llm.py tests/test_trading_proofs_api.py tests/test_proofs_service.py`
- `cd services/torghut && uv run --frozen ruff check app tests migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app/trading/ingest/clickhouse_signal_ingestor_market_methods.py app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py app/trading/ingest/clickhouse_signal_ingestor_status_methods.py app/trading/ingest/clickhouse_signal_source_freshness.py app/trading/submission_council/__init__.py app/trading/submission_council/gate_payloads.py tests/api/test_trading_api_live_gate_llm.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py tests/test_signal_readiness_status.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/ingest/clickhouse_signal_ingestor_market_methods.py app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py app/trading/ingest/clickhouse_signal_ingestor_status_methods.py app/trading/ingest/clickhouse_signal_source_freshness.py app/trading/submission_council/__init__.py app/trading/submission_council/gate_payloads.py tests/api/test_trading_api_live_gate_llm.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py tests/test_signal_readiness_status.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/ingest/clickhouse_signal_ingestor_market_methods.py app/trading/ingest/clickhouse_signal_ingestor_persistence_methods.py app/trading/ingest/clickhouse_signal_ingestor_status_methods.py app/trading/ingest/clickhouse_signal_source_freshness.py app/trading/submission_council/__init__.py app/trading/submission_council/gate_payloads.py tests/api/test_trading_api_live_gate_llm.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py tests/test_signal_readiness_status.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Live submission gates now fail closed when accepted-source TA status is missing or unavailable instead of treating that state as diagnostic-only.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
