### PR TITLE
fix(torghut): mirror accepted freshness on live gate

### DIFF
--- a/services/torghut/app/trading/submission_council/gate_payloads.py
+++ b/services/torghut/app/trading/submission_council/gate_payloads.py
@@ -61,6 +61,7 @@ class _SubmissionPayloadContext(Protocol):
 
 def common_submission_payload(context: object) -> dict[str, object]:
     payload_context = cast(_SubmissionPayloadContext, context)
+    clickhouse_ta_freshness = _clickhouse_ta_freshness_ref(payload_context)
     return {
         "configured_live_promotion": payload_context.toggles.configured_live_promotion,
         "autonomy_promotion_eligible": (
@@ -86,12 +87,48 @@ def common_submission_payload(context: object) -> dict[str, object]:
         "quant_evidence": payload_context.quant.evidence,
         "quant_health_ref": _quant_health_ref(payload_context),
         "market_context_ref": payload_context.market_context_ref,
-        "clickhouse_ta_freshness": _clickhouse_ta_freshness_ref(payload_context),
+        **_accepted_source_gate_fields(clickhouse_ta_freshness),
+        "clickhouse_ta_freshness": clickhouse_ta_freshness,
         "live_submit_activation": live_submit_activation_status(
             now=payload_context.now
         ),
         **_runtime_ledger_payload(payload_context.runtime_inputs.runtime_ledger),
         "profit_lease_projection": payload_context.profit_lease_projection,
+    }
+
+
+def _accepted_source_gate_fields(
+    clickhouse_ta_freshness: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "accepted_sources": clickhouse_ta_freshness.get("accepted_sources"),
+        "latest_accepted_event_at": clickhouse_ta_freshness.get(
+            "latest_accepted_event_at"
+        ),
+        "accepted_lag_seconds": clickhouse_ta_freshness.get("accepted_lag_seconds"),
+        "accepted_max_lag_seconds": clickhouse_ta_freshness.get(
+            "accepted_max_lag_seconds"
+        ),
+        "accepted_source_state": clickhouse_ta_freshness.get("accepted_source_state"),
+        "blocking_reason": clickhouse_ta_freshness.get("blocking_reason"),
+        "fresh_until": clickhouse_ta_freshness.get("fresh_until"),
+        "freshness_reason_codes": clickhouse_ta_freshness.get("freshness_reason_codes")
+        or [],
+        "excluded_fresher_sources": clickhouse_ta_freshness.get(
+            "excluded_fresher_sources"
+        )
+        or [],
+        "per_symbol_coverage": clickhouse_ta_freshness.get("per_symbol_coverage") or [],
+        "stale_symbol_coverage": clickhouse_ta_freshness.get("stale_symbol_coverage")
+        or [],
+        "market_session_state": clickhouse_ta_freshness.get("market_session_state"),
+        "regular_session_open": clickhouse_ta_freshness.get("regular_session_open"),
+        "regular_session_open_at": clickhouse_ta_freshness.get(
+            "regular_session_open_at"
+        ),
+        "regular_session_close_at": clickhouse_ta_freshness.get(
+            "regular_session_close_at"
+        ),
     }
 
 

--- a/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate_clickhouse_freshness.py
@@ -12,7 +12,36 @@ from tests.submission_council.support import (
 )
 
 
+_ACCEPTED_SOURCE_GATE_FIELDS = (
+    "accepted_sources",
+    "latest_accepted_event_at",
+    "accepted_lag_seconds",
+    "accepted_max_lag_seconds",
+    "accepted_source_state",
+    "blocking_reason",
+    "fresh_until",
+    "freshness_reason_codes",
+    "excluded_fresher_sources",
+    "per_symbol_coverage",
+    "stale_symbol_coverage",
+    "market_session_state",
+    "regular_session_open",
+    "regular_session_open_at",
+    "regular_session_close_at",
+)
+
+
 class TestLiveSubmissionGateClickHouseFreshness(SubmissionCouncilTestCase):
+    def _assert_accepted_source_freshness_mirrored(
+        self,
+        result: dict[str, object],
+    ) -> None:
+        freshness = result["clickhouse_ta_freshness"]
+        self.assertIsInstance(freshness, dict)
+        for field in _ACCEPTED_SOURCE_GATE_FIELDS:
+            self.assertIn(field, result)
+            self.assertEqual(result[field], freshness[field])
+
     def test_build_live_submission_gate_payload_blocks_missing_accepted_clickhouse_ta_status(
         self,
     ) -> None:
@@ -73,6 +102,7 @@ class TestLiveSubmissionGateClickHouseFreshness(SubmissionCouncilTestCase):
             ["clickhouse_ta_latest_signal_missing"],
         )
         self.assertEqual(freshness["market_session_state"], "regular_open")
+        self._assert_accepted_source_freshness_mirrored(result)
 
     def test_build_live_submission_gate_payload_blocks_stale_accepted_clickhouse_ta_status(
         self,
@@ -130,6 +160,7 @@ class TestLiveSubmissionGateClickHouseFreshness(SubmissionCouncilTestCase):
             result["clickhouse_ta_freshness"]["accepted_source_state"],
             "stale",
         )
+        self._assert_accepted_source_freshness_mirrored(result)
 
     def test_clickhouse_stale_status_overrides_cached_runtime_ready_state(self) -> None:
         result = runtime_window_import_continuity_signal(


### PR DESCRIPTION
## Summary

- Mirror accepted-source freshness fields onto the shared `live_submission_gate` payload.
- Keep the existing nested `clickhouse_ta_freshness` payload for compatibility.
- Add regression coverage that top-level gate fields and nested freshness fields stay identical.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/submission_council/test_live_submission_gate_clickhouse_freshness.py tests/api/test_trading_api_live_gate_llm.py::TestTradingApiLiveGateLlm::test_live_submission_gate_matches_status_health_and_readyz tests/api/test_trading_api_health_contract.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council/gate_payloads.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council/gate_payloads.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app/trading/submission_council/gate_payloads.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines app/trading/submission_council/gate_payloads.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/submission_council/gate_payloads.py tests/submission_council/test_live_submission_gate_clickhouse_freshness.py`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
