### PR TITLE
fix(torghut): select kafka broker pods for smoke tails

### DIFF
--- a/packages/scripts/src/kafka/__tests__/tail-topic.test.ts
+++ b/packages/scripts/src/kafka/__tests__/tail-topic.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+
+import { selectKafkaPodName } from '../tail-topic'
+
+describe('Kafka tail topic helper', () => {
+  it('prefers ready Strimzi broker pods over controller pods', () => {
+    expect(
+      selectKafkaPodName([
+        {
+          metadata: {
+            name: 'kafka-pool-a-0',
+            labels: {
+              'strimzi.io/broker-role': 'false',
+              'strimzi.io/controller-role': 'true',
+            },
+          },
+          status: {
+            phase: 'Running',
+            conditions: [{ type: 'Ready', status: 'True' }],
+          },
+        },
+        {
+          metadata: {
+            name: 'kafka-pool-b-3',
+            labels: {
+              'strimzi.io/broker-role': 'true',
+              'strimzi.io/controller-role': 'false',
+            },
+          },
+          status: {
+            phase: 'Running',
+            conditions: [{ type: 'Ready', status: 'True' }],
+          },
+        },
+      ]),
+    ).toBe('kafka-pool-b-3')
+  })
+
+  it('falls back to the first ready pool pod when role labels are absent', () => {
+    expect(
+      selectKafkaPodName([
+        {
+          metadata: { name: 'kafka-pool-a-0' },
+          status: {
+            phase: 'Pending',
+            conditions: [{ type: 'Ready', status: 'False' }],
+          },
+        },
+        {
+          metadata: { name: 'kafka-pool-a-1' },
+          status: {
+            phase: 'Running',
+            conditions: [{ type: 'Ready', status: 'True' }],
+          },
+        },
+      ]),
+    ).toBe('kafka-pool-a-1')
+  })
+})

--- a/packages/scripts/src/kafka/tail-topic.ts
+++ b/packages/scripts/src/kafka/tail-topic.ts
@@ -20,6 +20,20 @@ type Args = {
   format: 'raw' | 'summary' | 'json' | 'base64' | 'partitions'
 }
 
+type KafkaPodListItem = {
+  metadata: {
+    name: string
+    labels?: Record<string, string>
+  }
+  status?: {
+    phase?: string
+    conditions?: Array<{
+      type?: string
+      status?: string
+    }>
+  }
+}
+
 const usage = () =>
   `
 Usage:
@@ -151,15 +165,31 @@ const kubectlJson = async <T>(args: string[]): Promise<T> => {
   return JSON.parse(stdout) as T
 }
 
-const pickKafkaPod = async (namespace: string) => {
-  const data = await kubectlJson<{ items: Array<{ metadata: { name: string } }> }>(['-n', namespace, 'get', 'pods'])
-  const candidates = data.items
-    .map((item) => item.metadata.name)
-    .filter((name) => name.startsWith('kafka-pool-'))
-    .sort()
+const podIsReady = (pod: KafkaPodListItem) =>
+  pod.status?.phase === 'Running' &&
+  pod.status.conditions?.some((condition) => condition.type === 'Ready' && condition.status === 'True')
+
+export const selectKafkaPodName = (items: KafkaPodListItem[]) => {
+  const candidates = items
+    .filter((item) => item.metadata.name.startsWith('kafka-pool-'))
+    .sort((left, right) => left.metadata.name.localeCompare(right.metadata.name))
+
+  const brokerCandidates = candidates.filter((item) => item.metadata.labels?.['strimzi.io/broker-role'] === 'true')
+  const brokerReadyCandidates = brokerCandidates.filter(podIsReady)
+  const readyCandidates = candidates.filter(podIsReady)
+
   return (
-    candidates[0] ?? fatal(`No Kafka broker pod found in namespace '${namespace}' (expected name like kafka-pool-*)`)
+    brokerReadyCandidates[0]?.metadata.name ??
+    brokerCandidates[0]?.metadata.name ??
+    readyCandidates[0]?.metadata.name ??
+    candidates[0]?.metadata.name
   )
+}
+
+const pickKafkaPod = async (namespace: string) => {
+  const data = await kubectlJson<{ items: KafkaPodListItem[] }>(['-n', namespace, 'get', 'pods'])
+  const selected = selectKafkaPodName(data.items)
+  return selected ?? fatal(`No Kafka broker pod found in namespace '${namespace}' (expected name like kafka-pool-*)`)
 }
 
 const toSummary = (line: string) => {


### PR DESCRIPTION
## Summary

- Fixes Kafka topic tail auto-detection to prefer ready Strimzi broker pods instead of controller pods.
- Keeps compatibility for older Kafka pools without broker-role labels by falling back to ready pool pods.
- Adds regression coverage for controller/broker split pools so Torghut market-data smoke can read live Kafka evidence.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/kafka/tail-topic.ts packages/scripts/src/kafka/__tests__/tail-topic.test.ts`
- `bun test packages/scripts/src/kafka/__tests__/tail-topic.test.ts packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bun run --cwd packages/scripts lint:oxlint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `bun run packages/scripts/src/kafka/tail-topic.ts --topic torghut.trades.v1 --partition 2 --tail 1 --timeout-ms 20000 --username torghut-ws --password-secret-namespace torghut --password-secret-name torghut-ws --password-secret-key password --format json`
- `MARKET_DATA_PRINT_SUMMARIES=false MARKET_DATA_FRESHNESS_MODE=auto TIMEOUT_MS=20000 bun run smoke:torghut-market-data`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
