### PR TITLE
fix(torghut): enforce accepted freshness rollout contract

### DIFF
--- a/packages/scripts/src/shared/__tests__/nix-oci-deploy.test.ts
+++ b/packages/scripts/src/shared/__tests__/nix-oci-deploy.test.ts
@@ -2,12 +2,22 @@ import { mkdtempSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 
-import { buildAndPushNixImage } from '../nix-oci-deploy'
+import { __private, buildAndPushNixImage } from '../nix-oci-deploy'
 
 describe('buildAndPushNixImage', () => {
+  afterEach(() => {
+    __private.setCollectToolVersions()
+  })
+
   it('writes an honest manual dry-run contract without claiming pushed platforms', async () => {
+    __private.setCollectToolVersions(() => ({
+      nix: 'nix (test)',
+      skopeo: 'skopeo (test)',
+      crane: 'crane (test)',
+    }))
+
     const dir = mkdtempSync(join(tmpdir(), 'nix-oci-deploy-contract-'))
     const contractPath = join(dir, 'manual-release-contract.json')
 
@@ -50,7 +60,11 @@ describe('buildAndPushNixImage', () => {
         'flake.lock': expect.stringMatching(/^[0-9a-f]{64}$/),
         'bun.lock': expect.stringMatching(/^[0-9a-f]{64}$/),
       },
-      toolVersions: expect.any(Object),
+      toolVersions: {
+        nix: 'nix (test)',
+        skopeo: 'skopeo (test)',
+        crane: 'crane (test)',
+      },
       cacheProvenance: {
         source: 'manual-script-not-collected',
       },

--- a/packages/scripts/src/shared/nix-oci-deploy.ts
+++ b/packages/scripts/src/shared/nix-oci-deploy.ts
@@ -90,6 +90,8 @@ const collectToolVersions = (): Record<string, string> =>
     }).filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].length > 0),
   )
 
+let collectToolVersionsImpl = collectToolVersions
+
 const manualScriptCacheProvenance: NixOciCacheProvenance = {
   source: 'manual-script-not-collected',
 }
@@ -148,7 +150,7 @@ export const buildAndPushNixImage = async (
     options.contractPath ?? `.artifacts/${options.service}/manual-release-contract.json`,
   )
   const lockfileHashes = collectLockfileHashes()
-  const toolVersions = collectToolVersions()
+  const toolVersions = collectToolVersionsImpl()
 
   if (options.dryRun) {
     const dryRunDigest = 'sha256:dry-run'
@@ -211,4 +213,10 @@ export const buildAndPushNixImage = async (
   }
   writeReleaseContract(result, 'manual-script')
   return result
+}
+
+export const __private = {
+  setCollectToolVersions: (impl: (() => Record<string, string>) | undefined = collectToolVersions) => {
+    collectToolVersionsImpl = impl ?? collectToolVersions
+  },
 }

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -179,8 +179,17 @@ const acceptedSourceStaleReadyz = {
     allowed: false,
     reason: 'accepted_ta_signal_stale',
     blocked_reasons: ['accepted_ta_signal_stale'],
+    accepted_sources: ['ta'],
+    latest_accepted_event_at: '2026-06-30T20:54:52Z',
+    accepted_lag_seconds: 615152,
+    accepted_max_lag_seconds: 120,
+    accepted_source_state: 'stale',
+    blocking_reason: 'accepted_ta_signal_stale',
     clickhouse_ta_freshness: {
       accepted_sources: ['ta'],
+      latest_accepted_event_at: '2026-06-30T20:54:52Z',
+      accepted_lag_seconds: 615152,
+      accepted_max_lag_seconds: 120,
       accepted_source_state: 'stale',
       blocking_reason: 'accepted_ta_signal_stale',
     },
@@ -216,6 +225,12 @@ const acceptedSourceStaleTradingStatus = {
     blocked_reasons: ['accepted_ta_signal_stale'],
     capital_stage: 'operational_blocked',
     capital_state: 'blocked',
+    accepted_sources: ['ta'],
+    latest_accepted_event_at: '2026-06-30T20:54:52Z',
+    accepted_lag_seconds: 615152,
+    accepted_max_lag_seconds: 120,
+    accepted_source_state: 'stale',
+    blocking_reason: 'accepted_ta_signal_stale',
     clickhouse_ta_freshness: {
       accepted_sources: ['ta'],
       latest_accepted_event_at: '2026-06-30T20:54:52Z',
@@ -369,6 +384,47 @@ describe('validatePostDeployEvidence', () => {
     expect(result.readyzAcceptedReason).toBe('repair_only_zero_notional')
     expect(result.liveSubmitContract).toBe('accepted_source_stale_zero_notional')
     expect(result.summaryLines.join('\n')).toContain('Live submit contract: `accepted_source_stale_zero_notional`')
+  })
+
+  it('rejects accepted TA stale status when top-level accepted freshness is missing', () => {
+    const {
+      accepted_sources: _acceptedSources,
+      latest_accepted_event_at: _latestAcceptedEventAt,
+      accepted_lag_seconds: _acceptedLagSeconds,
+      accepted_max_lag_seconds: _acceptedMaxLagSeconds,
+      accepted_source_state: _acceptedSourceState,
+      blocking_reason: _blockingReason,
+      ...gateWithoutTopLevelFreshness
+    } = acceptedSourceStaleTradingStatus.live_submission_gate
+
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: acceptedSourceStaleDigest,
+        tradingStatus: {
+          ...acceptedSourceStaleTradingStatus,
+          live_submission_gate: gateWithoutTopLevelFreshness,
+        },
+      }),
+    ).toThrow('torghut live_submission_gate.accepted_sources')
+  })
+
+  it('rejects accepted TA stale status when top-level freshness diverges from nested freshness', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: acceptedSourceStaleDigest,
+        tradingStatus: {
+          ...acceptedSourceStaleTradingStatus,
+          live_submission_gate: {
+            ...acceptedSourceStaleTradingStatus.live_submission_gate,
+            accepted_lag_seconds: 1,
+          },
+        },
+      }),
+    ).toThrow('accepted_lag_seconds must mirror')
   })
 
   it('rejects accepted TA stale contract with malformed submission authority schema', () => {
@@ -575,6 +631,23 @@ describe('validatePostDeployEvidence', () => {
     expect(result.liveSubmitContract).toBe('accepted_source_stale_zero_notional')
     expect(result.summaryLines.join('\n')).toContain('Readyz acceptance: `repair_only_zero_notional`')
     expect(result.summaryLines.join('\n')).toContain('Live submit contract: `accepted_source_stale_zero_notional`')
+  })
+
+  it('rejects accepted-source stale readyz 503 when top-level freshness is not mirrored', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '503',
+        readyz: {
+          ...acceptedSourceStaleReadyz,
+          live_submission_gate: {
+            ...acceptedSourceStaleReadyz.live_submission_gate,
+            accepted_lag_seconds: 1,
+          },
+        },
+        revenueRepairDigest: acceptedSourceStaleDigest,
+        tradingStatus: acceptedSourceStaleTradingStatus,
+      }),
+    ).toThrow('mirrored accepted-source freshness fields')
   })
 
   it('accepts core-dependencies-only readyz 503 when the deploy surface is healthy and the gate is closed', () => {

--- a/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
+++ b/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
@@ -59,8 +59,17 @@ const acceptedSourceStaleReadyz = {
     allowed: false,
     reason: 'accepted_ta_signal_stale',
     blocked_reasons: ['accepted_ta_signal_stale'],
+    accepted_sources: ['ta'],
+    latest_accepted_event_at: '2026-06-30T20:54:52Z',
+    accepted_lag_seconds: 615152,
+    accepted_max_lag_seconds: 300,
+    accepted_source_state: 'stale',
+    blocking_reason: 'accepted_ta_signal_stale',
     clickhouse_ta_freshness: {
       accepted_sources: ['ta'],
+      latest_accepted_event_at: '2026-06-30T20:54:52Z',
+      accepted_lag_seconds: 615152,
+      accepted_max_lag_seconds: 300,
       accepted_source_state: 'stale',
       blocking_reason: 'accepted_ta_signal_stale',
     },
@@ -113,6 +122,43 @@ describe('classifyReadyzForPostDeployRetry', () => {
           live_submission_gate: {
             ...acceptedSourceStaleReadyz.live_submission_gate,
             allowed: true,
+          },
+        },
+      }),
+    ).toBe('unacceptable')
+  })
+
+  it('rejects accepted-source stale 503 when accepted freshness is only nested', () => {
+    const {
+      accepted_sources: _acceptedSources,
+      latest_accepted_event_at: _latestAcceptedEventAt,
+      accepted_lag_seconds: _acceptedLagSeconds,
+      accepted_max_lag_seconds: _acceptedMaxLagSeconds,
+      accepted_source_state: _acceptedSourceState,
+      blocking_reason: _blockingReason,
+      ...gateWithoutTopLevelFreshness
+    } = acceptedSourceStaleReadyz.live_submission_gate
+
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: {
+          ...acceptedSourceStaleReadyz,
+          live_submission_gate: gateWithoutTopLevelFreshness,
+        },
+      }),
+    ).toBe('unacceptable')
+  })
+
+  it('rejects accepted-source stale 503 when top-level lag diverges from nested freshness', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: {
+          ...acceptedSourceStaleReadyz,
+          live_submission_gate: {
+            ...acceptedSourceStaleReadyz.live_submission_gate,
+            accepted_lag_seconds: 1,
           },
         },
       }),

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -57,6 +57,11 @@ const requireNonNegativeInteger = (value: unknown, label: string): number => {
   return normalized
 }
 
+const optionalNonNegativeInteger = (value: unknown): number | undefined => {
+  const normalized = typeof value === 'number' ? value : Number(value)
+  return Number.isInteger(normalized) && normalized >= 0 ? normalized : undefined
+}
+
 const formatScalar = (value: unknown, fallback = 'unknown'): string => {
   if (typeof value === 'string') return value
   if (typeof value === 'number' || typeof value === 'boolean') return String(value)
@@ -94,6 +99,103 @@ const requireArrayIncludes = (value: unknown, expected: string, label: string) =
 
 const arrayIncludesScalar = (value: unknown, expected: string): boolean =>
   Array.isArray(value) && value.map((item) => formatScalar(item, '')).includes(expected)
+
+const acceptedSourceFreshnessMirrorIsPresent = (liveSubmissionGate: JsonObject): boolean => {
+  const freshness =
+    liveSubmissionGate.clickhouse_ta_freshness &&
+    typeof liveSubmissionGate.clickhouse_ta_freshness === 'object' &&
+    !Array.isArray(liveSubmissionGate.clickhouse_ta_freshness)
+      ? (liveSubmissionGate.clickhouse_ta_freshness as JsonObject)
+      : {}
+  const liveLag = optionalNonNegativeInteger(liveSubmissionGate.accepted_lag_seconds)
+  const nestedLag = optionalNonNegativeInteger(freshness.accepted_lag_seconds)
+  const liveMaxLag = optionalNonNegativeInteger(liveSubmissionGate.accepted_max_lag_seconds)
+  const nestedMaxLag = optionalNonNegativeInteger(freshness.accepted_max_lag_seconds)
+
+  return (
+    arrayIncludesScalar(liveSubmissionGate.accepted_sources, 'ta') &&
+    arrayIncludesScalar(freshness.accepted_sources, 'ta') &&
+    liveSubmissionGate.accepted_source_state === 'stale' &&
+    freshness.accepted_source_state === 'stale' &&
+    liveSubmissionGate.blocking_reason === ACCEPTED_SOURCE_STALE_REASON &&
+    freshness.blocking_reason === ACCEPTED_SOURCE_STALE_REASON &&
+    formatScalar(liveSubmissionGate.latest_accepted_event_at, '') !== '' &&
+    formatScalar(liveSubmissionGate.latest_accepted_event_at, '') ===
+      formatScalar(freshness.latest_accepted_event_at, '') &&
+    liveLag !== undefined &&
+    liveLag === nestedLag &&
+    liveMaxLag !== undefined &&
+    liveMaxLag === nestedMaxLag
+  )
+}
+
+const requireAcceptedSourceFreshnessMirror = (liveSubmissionGate: JsonObject, freshness: JsonObject) => {
+  requireArrayIncludes(liveSubmissionGate.accepted_sources, 'ta', 'torghut live_submission_gate.accepted_sources')
+  requireArrayIncludes(
+    freshness.accepted_sources,
+    'ta',
+    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_sources',
+  )
+  requireScalarValue(
+    liveSubmissionGate.accepted_source_state,
+    'stale',
+    'torghut live_submission_gate.accepted_source_state',
+  )
+  requireScalarValue(
+    freshness.accepted_source_state,
+    'stale',
+    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_source_state',
+  )
+  requireScalarValue(
+    liveSubmissionGate.blocking_reason,
+    ACCEPTED_SOURCE_STALE_REASON,
+    'torghut live_submission_gate.blocking_reason',
+  )
+  requireScalarValue(
+    freshness.blocking_reason,
+    ACCEPTED_SOURCE_STALE_REASON,
+    'torghut live_submission_gate.clickhouse_ta_freshness.blocking_reason',
+  )
+  const latestAccepted = requireTimestamp(
+    liveSubmissionGate.latest_accepted_event_at,
+    'torghut live_submission_gate.latest_accepted_event_at',
+  )
+  const nestedLatestAccepted = requireTimestamp(
+    freshness.latest_accepted_event_at,
+    'torghut live_submission_gate.clickhouse_ta_freshness.latest_accepted_event_at',
+  )
+  if (Date.parse(latestAccepted) !== Date.parse(nestedLatestAccepted)) {
+    throw new Error(
+      'torghut live_submission_gate.latest_accepted_event_at must mirror clickhouse_ta_freshness.latest_accepted_event_at',
+    )
+  }
+  const acceptedLag = requireNonNegativeInteger(
+    liveSubmissionGate.accepted_lag_seconds,
+    'torghut live_submission_gate.accepted_lag_seconds',
+  )
+  const nestedAcceptedLag = requireNonNegativeInteger(
+    freshness.accepted_lag_seconds,
+    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_lag_seconds',
+  )
+  if (acceptedLag !== nestedAcceptedLag) {
+    throw new Error(
+      'torghut live_submission_gate.accepted_lag_seconds must mirror clickhouse_ta_freshness.accepted_lag_seconds',
+    )
+  }
+  const acceptedMaxLag = requireNonNegativeInteger(
+    liveSubmissionGate.accepted_max_lag_seconds,
+    'torghut live_submission_gate.accepted_max_lag_seconds',
+  )
+  const nestedAcceptedMaxLag = requireNonNegativeInteger(
+    freshness.accepted_max_lag_seconds,
+    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_max_lag_seconds',
+  )
+  if (acceptedMaxLag !== nestedAcceptedMaxLag) {
+    throw new Error(
+      'torghut live_submission_gate.accepted_max_lag_seconds must mirror clickhouse_ta_freshness.accepted_max_lag_seconds',
+    )
+  }
+}
 
 const parseHttpStatus = (value: string): number => {
   if (!/^[0-9]{3}$/.test(value)) {
@@ -229,7 +331,8 @@ const isAcceptedSourceStaleReadyz = (readyz: JsonObject): boolean => {
     readyz.status === 'degraded' &&
     dependencyGate.detail === ACCEPTED_SOURCE_STALE_REASON &&
     liveSubmissionGate.allowed === false &&
-    liveSubmissionGate.reason === ACCEPTED_SOURCE_STALE_REASON
+    liveSubmissionGate.reason === ACCEPTED_SOURCE_STALE_REASON &&
+    acceptedSourceFreshnessMirrorIsPresent(liveSubmissionGate)
   )
 }
 
@@ -637,21 +740,7 @@ const assertAcceptedSourceStaleZeroNotionalContract = (status: JsonObject, diges
   if (requireBoolean(submissionAuthority.can_submit_now, 'torghut submission_authority.can_submit_now') !== false) {
     throw new Error('accepted-source stale repair rollout requires submission_authority.can_submit_now=false')
   }
-  requireScalarValue(
-    freshness.accepted_source_state,
-    'stale',
-    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_source_state',
-  )
-  requireScalarValue(
-    freshness.blocking_reason,
-    ACCEPTED_SOURCE_STALE_REASON,
-    'torghut live_submission_gate.clickhouse_ta_freshness.blocking_reason',
-  )
-  requireArrayIncludes(
-    freshness.accepted_sources,
-    'ta',
-    'torghut live_submission_gate.clickhouse_ta_freshness.accepted_sources',
-  )
+  requireAcceptedSourceFreshnessMirror(liveSubmissionGate, freshness)
   assertLiveSubmitActivationContract(
     requireObject(
       liveSubmissionGate.live_submit_activation,
@@ -1026,9 +1115,19 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     }
     const dependencies = requireObject(readyz.dependencies, 'readyz dependencies')
     if (dependencies.live_submission_gate !== undefined || dependencies.profitability_proof_floor !== undefined) {
+      const dependencyLiveSubmissionGate =
+        dependencies.live_submission_gate &&
+        typeof dependencies.live_submission_gate === 'object' &&
+        !Array.isArray(dependencies.live_submission_gate)
+          ? (dependencies.live_submission_gate as JsonObject)
+          : {}
       if (isAcceptedSourceStaleReadyz(readyz)) {
         assertAcceptedSourceStaleZeroNotionalReadyz(readyz, status, digest)
         liveSubmitContract = 'accepted_source_stale_zero_notional'
+      } else if (dependencyLiveSubmissionGate.detail === ACCEPTED_SOURCE_STALE_REASON) {
+        throw new Error(
+          'accepted-source stale readyz requires mirrored accepted-source freshness fields on live_submission_gate',
+        )
       } else {
         assertRepairOnlyZeroNotionalReadyz(readyz, digest)
       }

--- a/packages/scripts/src/torghut/readyz-contract.ts
+++ b/packages/scripts/src/torghut/readyz-contract.ts
@@ -42,6 +42,13 @@ const arrayIncludes = (value: unknown, expected: string): boolean => {
   return value.some((item) => stringAt({ item }, 'item') === expected)
 }
 
+const numberAt = (value: unknown, key: string): number | undefined => {
+  if (!isObject(value)) return undefined
+  const nested = value[key]
+  const parsed = typeof nested === 'number' ? nested : Number(nested)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
 const parseHttpStatus = (value: string): number | undefined => {
   if (!/^[0-9]{3}$/.test(value)) return undefined
   return Number(value)
@@ -122,8 +129,26 @@ const hasAcceptedSourceStaleReadyzContract = (readyz: JsonObject): boolean => {
   if (!arrayIncludes(liveSubmissionGate.blocked_reasons, 'accepted_ta_signal_stale')) return false
   const freshness = objectAt(liveSubmissionGate, 'clickhouse_ta_freshness')
   if (!freshness) return false
+  if (stringAt(liveSubmissionGate, 'accepted_source_state') !== 'stale') return false
   if (stringAt(freshness, 'accepted_source_state') !== 'stale') return false
+  if (stringAt(liveSubmissionGate, 'blocking_reason') !== 'accepted_ta_signal_stale') return false
   if (stringAt(freshness, 'blocking_reason') !== 'accepted_ta_signal_stale') return false
+  if (!arrayIncludes(liveSubmissionGate.accepted_sources, 'ta')) return false
+  if (!arrayIncludes(freshness.accepted_sources, 'ta')) return false
+  if (!stringAt(liveSubmissionGate, 'latest_accepted_event_at')) return false
+  if (stringAt(liveSubmissionGate, 'latest_accepted_event_at') !== stringAt(freshness, 'latest_accepted_event_at')) {
+    return false
+  }
+  const topLevelLagSeconds = numberAt(liveSubmissionGate, 'accepted_lag_seconds')
+  const nestedLagSeconds = numberAt(freshness, 'accepted_lag_seconds')
+  if (topLevelLagSeconds === undefined || topLevelLagSeconds !== nestedLagSeconds) {
+    return false
+  }
+  const topLevelMaxLagSeconds = numberAt(liveSubmissionGate, 'accepted_max_lag_seconds')
+  const nestedMaxLagSeconds = numberAt(freshness, 'accepted_max_lag_seconds')
+  if (topLevelMaxLagSeconds === undefined || topLevelMaxLagSeconds !== nestedMaxLagSeconds) {
+    return false
+  }
 
   return true
 }


### PR DESCRIPTION
## Summary

- Requires accepted-source stale rollout evidence to expose freshness fields directly on `live_submission_gate`.
- Verifies top-level accepted-source freshness mirrors nested `clickhouse_ta_freshness` for source, state, blocker, timestamp, lag, and max lag.
- Adds negative coverage so readyz/post-deploy validators reject nested-only or divergent accepted TA freshness contracts.
- Stabilizes the package-scripts Nix OCI dry-run contract test by injecting deterministic tool-version metadata instead of probing runner binaries.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/torghut/readyz-contract.ts packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun test packages/scripts/src/shared/__tests__/nix-oci-deploy.test.ts packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun test packages/scripts/src -t "writes an honest manual dry-run contract"`
- `bun test packages/scripts/src`
- `bun run --cwd packages/scripts lint:oxlint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
