### PR TITLE
fix(torghut): pin file length gate threshold

### DIFF
--- a/services/torghut/scripts/run_pylint_torghut_file_length_gate.py
+++ b/services/torghut/scripts/run_pylint_torghut_file_length_gate.py
@@ -13,6 +13,7 @@ _PYLINT_MESSAGE_RE = re.compile(
     r"^(?P<path>[^:]+):(?P<line>\d+):(?P<column>\d+): "
     r"(?P<code>[A-Z]\d+): "
 )
+_MAX_MODULE_LINES = 1000
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -33,6 +34,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             *args.files,
             "--disable=all",
             "--enable=too-many-lines",
+            f"--max-module-lines={_MAX_MODULE_LINES}",
             "--score=n",
         ],
         check=False,

--- a/services/torghut/tests/test_pylint_torghut_gate_helpers.py
+++ b/services/torghut/tests/test_pylint_torghut_gate_helpers.py
@@ -94,6 +94,7 @@ def test_file_length_main_blocks_legacy_extracted_source_debt(
     def fake_run(command, *, check: bool, cwd=None):
         assert check is False
         assert cwd is None
+        assert "--max-module-lines=1000" in command
         return subprocess.CompletedProcess(
             command,
             0,


### PR DESCRIPTION
## Summary

- Pins Torghut's custom Pylint file-length wrapper to `--max-module-lines=1000` explicitly.
- Keeps the existing strict C0302 blocking behavior and removes ambiguity from local/default Pylint config resolution.
- Adds a regression assertion that the wrapper invokes Pylint with the 1000-line threshold.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_pylint_torghut_gate_helpers.py tests/scripts/test_measure_torghut_tech_debt.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app scripts tests`
- `cd services/torghut && uv run --frozen ruff check scripts/run_pylint_torghut_file_length_gate.py tests/test_pylint_torghut_gate_helpers.py tests/scripts/test_measure_torghut_tech_debt.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
