### PR TITLE
chore(torghut): promote image sha-0701498479b1e9cac6355d4a5ec73d1e3648d688

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -52,7 +52,7 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 1d7229005121d50ffce49d8c4efb4f1e91b00d9d
+              value: 0701498479b1e9cac6355d4a5ec73d1e3648d688
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a3e774101bb2e56de81a789b27ed13a31ce7217bd44da3ea489ce4df54982df1
             - name: PYTHONPATH

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 1d7229005121d50ffce49d8c4efb4f1e91b00d9d
+              value: 0701498479b1e9cac6355d4a5ec73d1e3648d688
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a3e774101bb2e56de81a789b27ed13a31ce7217bd44da3ea489ce4df54982df1
             - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T22:41:14Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T23:21:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -539,9 +539,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1647-g1d7229005
+              value: v0.596.0-1650-g070149847
             - name: TORGHUT_COMMIT
-              value: 1d7229005121d50ffce49d8c4efb4f1e91b00d9d
+              value: 0701498479b1e9cac6355d4a5ec73d1e3648d688
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a3e774101bb2e56de81a789b27ed13a31ce7217bd44da3ea489ce4df54982df1
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-08T22:41:14Z"
+        client.knative.dev/updateTimestamp: "2026-07-08T23:21:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -418,9 +418,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1647-g1d7229005
+              value: v0.596.0-1650-g070149847
             - name: TORGHUT_COMMIT
-              value: 1d7229005121d50ffce49d8c4efb4f1e91b00d9d
+              value: 0701498479b1e9cac6355d4a5ec73d1e3648d688
             - name: TORGHUT_IMAGE_DIGEST
               value: sha256:a3e774101bb2e56de81a789b27ed13a31ce7217bd44da3ea489ce4df54982df1
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -48,7 +48,7 @@ spec:
                 - name: PYTHONUNBUFFERED
                   value: "1"
                 - name: TORGHUT_COMMIT
-                  value: 1d7229005121d50ffce49d8c4efb4f1e91b00d9d
+                  value: 0701498479b1e9cac6355d4a5ec73d1e3648d688
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:a3e774101bb2e56de81a789b27ed13a31ce7217bd44da3ea489ce4df54982df1
                 - name: DB_DSN


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `0701498479b1e9cac6355d4a5ec73d1e3648d688`
- Image tag: `sha-0701498479b1e9cac6355d4a5ec73d1e3648d688`
- Image digest: `sha256:a3e774101bb2e56de81a789b27ed13a31ce7217bd44da3ea489ce4df54982df1`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher