### PR TITLE
fix(torghut): prove tigerbeetle reconciliation in proofs

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -26,6 +26,46 @@ const baseLiveSubmitActivation = {
   reason: null,
 }
 
+const baseTigerBeetleLedger = {
+  schema_version: 'torghut.tigerbeetle-ledger-status.v1',
+  ok: true,
+  reconciliation_ok: true,
+  reconciliation_stale: false,
+  reconciliation_age_seconds: 30,
+  reconciliation_max_age_seconds: 300,
+  latest_reconciliation: {
+    status: 'ok',
+    ok: true,
+    finished_at: '2026-06-17T14:00:00+00:00',
+  },
+  blockers: [],
+}
+
+const baseProofTigerBeetleReconciliation = {
+  schema_version: 'torghut.proofs.tigerbeetle-reconciliation.v1',
+  status_available: true,
+  ok: true,
+  protocol_ok: true,
+  protocol_probe_skipped: false,
+  reconciliation_required: true,
+  reconciliation_ok: true,
+  reconciliation_stale: false,
+  reconciliation_age_seconds: 30,
+  reconciliation_max_age_seconds: 300,
+  cluster_id: 100,
+  claimed_by_runtime_evidence: true,
+  runtime_ledger_ref_count: 2,
+  runtime_ledger_signed_ref_count: 2,
+  runtime_ledger_missing_signed_ref_count: 0,
+  runtime_ledger_missing_account_ref_count: 0,
+  latest_reconciliation: {
+    status: 'ok',
+    ok: true,
+    finished_at: '2026-06-17T14:00:00+00:00',
+  },
+  blockers: [],
+}
+
 const baseTradingStatus = {
   autonomy_enabled: false,
   empirical_jobs: {
@@ -58,6 +98,7 @@ const baseTradingStatus = {
     },
   },
   route_reacquisition_board: baseRouteBoard,
+  tigerbeetle_ledger: baseTigerBeetleLedger,
 }
 
 const paperRouteTarget = {
@@ -106,9 +147,11 @@ const buildPaperRouteEvidence = (targets: Array<Record<string, unknown>>) => ({
 
 const buildProofs = (targets: Array<Record<string, unknown>>) => ({
   schema_version: 'torghut.proofs.v1',
+  tigerbeetle_reconciliation: baseProofTigerBeetleReconciliation,
   promotion_authority: {
     allowed: false,
     final_promotion_allowed: false,
+    blockers: ['live_runtime_ledger_authority_required'],
   },
   proofs: targets.map((target) => ({
     identity: {
@@ -744,6 +787,66 @@ describe('validatePostDeployEvidence', () => {
     expect(result.summaryLines.join('\n')).toContain('Torghut Paper Route Target Mirror')
     expect(result.summaryLines.join('\n')).toContain('Live target count: `1`')
     expect(result.summaryLines.join('\n')).toContain('Sim target count: `1`')
+  })
+
+  it('rejects canonical proofs that omit TigerBeetle reconciliation proof', () => {
+    const proofPayload = buildProofs([paperRouteTarget])
+    delete (proofPayload as Record<string, unknown>).tigerbeetle_reconciliation
+
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: proofPayload,
+        simPaperRouteEvidence: buildProofs([{ ...paperRouteTarget, source_account_label: 'TORGHUT_SIM' }]),
+      }),
+    ).toThrow('tigerbeetle_reconciliation must be an object')
+  })
+
+  it('rejects canonical proofs with stale TigerBeetle reconciliation proof', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: {
+          ...buildProofs([paperRouteTarget]),
+          tigerbeetle_reconciliation: {
+            ...baseProofTigerBeetleReconciliation,
+            ok: false,
+            reconciliation_ok: false,
+            reconciliation_stale: true,
+            blockers: ['tigerbeetle_reconciliation_stale'],
+          },
+        },
+        simPaperRouteEvidence: buildProofs([{ ...paperRouteTarget, source_account_label: 'TORGHUT_SIM' }]),
+      }),
+    ).toThrow('tigerbeetle_reconciliation.ok must be true')
+  })
+
+  it('rejects canonical proofs whose TigerBeetle reconciliation readback diverges from status', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: {
+          ...buildProofs([paperRouteTarget]),
+          tigerbeetle_reconciliation: {
+            ...baseProofTigerBeetleReconciliation,
+            latest_reconciliation: {
+              ...baseProofTigerBeetleReconciliation.latest_reconciliation,
+              finished_at: '2026-06-17T14:01:00+00:00',
+            },
+          },
+        },
+        simPaperRouteEvidence: buildProofs([{ ...paperRouteTarget, source_account_label: 'TORGHUT_SIM' }]),
+      }),
+    ).toThrow('latest finished_at must mirror torghut status')
   })
 
   it('uses raw paper-route targets when source collection is the selected next plan', () => {

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -5,6 +5,7 @@ import process from 'node:process'
 
 const ROUTE_BOARD_SCHEMA_VERSION = 'torghut.route-reacquisition-board.v1'
 const PROOFS_SCHEMA_VERSION = 'torghut.proofs.v1'
+const PROOFS_TIGERBEETLE_RECONCILIATION_SCHEMA_VERSION = 'torghut.proofs.tigerbeetle-reconciliation.v1'
 const PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = 'torghut.paper-route-evidence.v1'
 const PAPER_ROUTE_TARGETS_SCHEMA_VERSION = 'torghut.next-paper-route-runtime-window-targets.v1'
 const RUNTIME_WINDOW_IMPORT_HEALTH_GATE_SCHEMA_VERSION = 'torghut.runtime-window-import-health-gate.v1'
@@ -1019,6 +1020,106 @@ const parseProofTargets = (
   }
 }
 
+const assertProofsTigerBeetleReconciliation = (evidence: unknown, status: JsonObject | undefined, label: string) => {
+  const payload = requireObject(evidence, `${label} payload`)
+  if (formatScalar(payload.schema_version, 'missing') !== PROOFS_SCHEMA_VERSION) {
+    return
+  }
+
+  const reconciliation = requireObject(payload.tigerbeetle_reconciliation, `${label} tigerbeetle_reconciliation`)
+  requireScalarValue(
+    reconciliation.schema_version,
+    PROOFS_TIGERBEETLE_RECONCILIATION_SCHEMA_VERSION,
+    `${label} tigerbeetle_reconciliation.schema_version`,
+  )
+  if (
+    requireBoolean(reconciliation.status_available, `${label} tigerbeetle_reconciliation.status_available`) !== true
+  ) {
+    throw new Error(`${label} tigerbeetle_reconciliation.status_available must be true`)
+  }
+  if (requireBoolean(reconciliation.ok, `${label} tigerbeetle_reconciliation.ok`) !== true) {
+    throw new Error(`${label} tigerbeetle_reconciliation.ok must be true`)
+  }
+  if (
+    requireBoolean(reconciliation.reconciliation_ok, `${label} tigerbeetle_reconciliation.reconciliation_ok`) !== true
+  ) {
+    throw new Error(`${label} tigerbeetle_reconciliation.reconciliation_ok must be true`)
+  }
+  if (
+    requireBoolean(reconciliation.reconciliation_stale, `${label} tigerbeetle_reconciliation.reconciliation_stale`) !==
+    false
+  ) {
+    throw new Error(`${label} tigerbeetle_reconciliation.reconciliation_stale must be false`)
+  }
+
+  const ageSeconds = requireNonNegativeInteger(
+    reconciliation.reconciliation_age_seconds,
+    `${label} tigerbeetle_reconciliation.reconciliation_age_seconds`,
+  )
+  const maxAgeSeconds = requireNonNegativeInteger(
+    reconciliation.reconciliation_max_age_seconds,
+    `${label} tigerbeetle_reconciliation.reconciliation_max_age_seconds`,
+  )
+  if (ageSeconds > maxAgeSeconds) {
+    throw new Error(`${label} tigerbeetle_reconciliation age exceeds max age`)
+  }
+  if (requireArray(reconciliation.blockers, `${label} tigerbeetle_reconciliation.blockers`).length > 0) {
+    throw new Error(`${label} tigerbeetle_reconciliation.blockers must be empty for rollout acceptance`)
+  }
+
+  const latestReconciliation = requireObject(
+    reconciliation.latest_reconciliation,
+    `${label} tigerbeetle_reconciliation.latest_reconciliation`,
+  )
+  const latestFinishedAt = requireTimestamp(
+    latestReconciliation.finished_at,
+    `${label} tigerbeetle_reconciliation.latest_reconciliation.finished_at`,
+  )
+
+  const promotionAuthority = requireObject(payload.promotion_authority, `${label} promotion_authority`)
+  requireArrayIncludes(
+    promotionAuthority.blockers,
+    'live_runtime_ledger_authority_required',
+    `${label} promotion_authority.blockers`,
+  )
+
+  if (!status) {
+    return
+  }
+
+  const statusTigerBeetle = requireObject(status.tigerbeetle_ledger, 'torghut status tigerbeetle_ledger')
+  if (
+    requireBoolean(statusTigerBeetle.reconciliation_ok, 'torghut status tigerbeetle_ledger.reconciliation_ok') !== true
+  ) {
+    throw new Error('torghut status tigerbeetle_ledger.reconciliation_ok must be true')
+  }
+  if (
+    requireBoolean(statusTigerBeetle.reconciliation_stale, 'torghut status tigerbeetle_ledger.reconciliation_stale') !==
+    false
+  ) {
+    throw new Error('torghut status tigerbeetle_ledger.reconciliation_stale must be false')
+  }
+  const statusMaxAgeSeconds = requireNonNegativeInteger(
+    statusTigerBeetle.reconciliation_max_age_seconds,
+    'torghut status tigerbeetle_ledger.reconciliation_max_age_seconds',
+  )
+  if (statusMaxAgeSeconds !== maxAgeSeconds) {
+    throw new Error(`${label} tigerbeetle_reconciliation max age must mirror torghut status`)
+  }
+
+  const statusLatestReconciliation = requireObject(
+    statusTigerBeetle.latest_reconciliation,
+    'torghut status tigerbeetle_ledger.latest_reconciliation',
+  )
+  const statusFinishedAt = requireTimestamp(
+    statusLatestReconciliation.finished_at,
+    'torghut status tigerbeetle_ledger.latest_reconciliation.finished_at',
+  )
+  if (Date.parse(statusFinishedAt) !== Date.parse(latestFinishedAt)) {
+    throw new Error(`${label} tigerbeetle_reconciliation latest finished_at must mirror torghut status`)
+  }
+}
+
 const requireSameList = (left: string[], right: string[], label: string) => {
   if (left.length !== right.length || left.some((value, index) => value !== right[index])) {
     throw new Error(`${label}: expected ${left.join(',') || 'none'}, got ${right.join(',') || 'none'}`)
@@ -1255,6 +1356,8 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     if (input.paperRouteEvidence === undefined || input.simPaperRouteEvidence === undefined) {
       throw new Error('both torghut and torghut-sim paper-route evidence payloads are required for mirror validation')
     }
+    assertProofsTigerBeetleReconciliation(input.paperRouteEvidence, status, 'torghut proof evidence')
+    assertProofsTigerBeetleReconciliation(input.simPaperRouteEvidence, undefined, 'torghut-sim proof evidence')
     const mirror = validatePaperRouteMirror(input.paperRouteEvidence, input.simPaperRouteEvidence)
     lines.push(
       '',

--- a/services/torghut/app/api/proofs.py
+++ b/services/torghut/app/api/proofs.py
@@ -59,6 +59,7 @@ from .health_checks import (
     build_api_live_submission_gate_payload,
     build_hypothesis_runtime_payload,
     build_simple_lane_status_payload,
+    build_tigerbeetle_ledger_status,
     empirical_jobs_status,
     load_tca_summary,
 )
@@ -77,6 +78,7 @@ from .vnext_helpers import to_str_map as _to_str_map
 _build_hypothesis_runtime_payload = build_hypothesis_runtime_payload
 _build_live_submission_gate_payload = build_api_live_submission_gate_payload
 _build_simple_lane_status_payload = build_simple_lane_status_payload
+_build_tigerbeetle_ledger_status = build_tigerbeetle_ledger_status
 _deferred_hypothesis_payload_for_live_submission_gate = (
     deferred_hypothesis_payload_for_live_submission_gate
 )
@@ -222,11 +224,14 @@ def _build_trading_proofs_payload(
             proof_floor.get("route_reacquisition_book") or {},
         )
     with SessionLocal() as session:
+        tigerbeetle_ledger_status = _build_tigerbeetle_ledger_status(session)
+    with SessionLocal() as session:
         return dict(
             build_proofs_payload(
                 session,
                 live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
                 route_reacquisition_book=route_reacquisition_book,
+                tigerbeetle_ledger_status=tigerbeetle_ledger_status,
                 kind=kind,
                 limit=limit,
                 window=window,

--- a/services/torghut/app/trading/proofs/schemas.py
+++ b/services/torghut/app/trading/proofs/schemas.py
@@ -40,6 +40,27 @@ class PromotionAuthorityPayload(TypedDict):
     blockers: list[str]
 
 
+class TigerBeetleReconciliationPayload(TypedDict, total=False):
+    schema_version: str
+    status_available: bool
+    ok: bool
+    protocol_ok: bool
+    protocol_probe_skipped: bool
+    reconciliation_required: bool
+    reconciliation_ok: bool
+    reconciliation_stale: bool
+    reconciliation_age_seconds: int | None
+    reconciliation_max_age_seconds: int | None
+    cluster_id: int | None
+    claimed_by_runtime_evidence: bool
+    runtime_ledger_ref_count: int
+    runtime_ledger_signed_ref_count: int
+    runtime_ledger_missing_signed_ref_count: int
+    runtime_ledger_missing_account_ref_count: int
+    latest_reconciliation: dict[str, object] | None
+    blockers: list[str]
+
+
 class ProofIdentityPayload(TypedDict, total=False):
     hypothesis_id: str | None
     candidate_id: str | None
@@ -125,6 +146,10 @@ class ProofSummaryPayload(TypedDict):
     live_submission_reason: str | None
     accepted_source_state: str | None
     accepted_lag_seconds: float | None
+    tigerbeetle_reconciliation_ok: bool
+    tigerbeetle_reconciliation_stale: bool
+    tigerbeetle_reconciliation_age_seconds: int | None
+    tigerbeetle_reconciliation_required: bool
 
 
 class ProofsPayload(TypedDict):
@@ -133,6 +158,7 @@ class ProofsPayload(TypedDict):
     kind: ProofKind
     window: dict[str, object]
     live_submission_gate: dict[str, object]
+    tigerbeetle_reconciliation: TigerBeetleReconciliationPayload
     proofs: list[ProofPayload]
     summary: ProofSummaryPayload
     promotion_authority: PromotionAuthorityPayload

--- a/services/torghut/app/trading/proofs/service.py
+++ b/services/torghut/app/trading/proofs/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import cast
@@ -24,6 +24,7 @@ from .schemas import (
     ProofState,
     ProofWindowSelector,
     ProofsPayload,
+    TigerBeetleReconciliationPayload,
 )
 from .source_activity import (
     load_source_activity_counts,
@@ -39,12 +40,20 @@ from .targets import (
     select_proof_targets,
 )
 
+TIGERBEETLE_RECONCILIATION_SCHEMA_VERSION = (
+    "torghut.proofs.tigerbeetle-reconciliation.v1"
+)
+_TIGERBEETLE_LEDGER_STATUS_MISSING = "tigerbeetle_ledger_status_missing"
+_TIGERBEETLE_LEDGER_STATUS_UNAVAILABLE = "tigerbeetle_ledger_status_unavailable"
+_TIGERBEETLE_LEDGER_NOT_OK = "tigerbeetle_ledger_not_ok"
+
 
 def build_proofs_payload(
     session: Session,
     *,
     live_submission_gate: Mapping[str, object],
     route_reacquisition_book: Mapping[str, object],
+    tigerbeetle_ledger_status: Mapping[str, object] | None = None,
     generated_at: datetime | None = None,
     kind: ProofKind = "runtime_window",
     limit: int = DEFAULT_PROOFS_LIMIT,
@@ -84,6 +93,10 @@ def build_proofs_payload(
         blocker_counts.update(proof["blockers"])
     gate_payload = _live_submission_gate_payload(live_submission_gate)
     gate_freshness = _live_submission_gate_freshness(gate_payload)
+    tigerbeetle_reconciliation = _tigerbeetle_reconciliation_payload(
+        tigerbeetle_ledger_status
+    )
+    promotion_blockers = _promotion_authority_blockers(tigerbeetle_reconciliation)
     return {
         "schema_version": PROOFS_SCHEMA_VERSION,
         "generated_at": isoformat(resolved_generated_at),
@@ -94,6 +107,7 @@ def build_proofs_payload(
             proofs=proofs,
         ),
         "live_submission_gate": gate_payload,
+        "tigerbeetle_reconciliation": tigerbeetle_reconciliation,
         "proofs": proofs,
         "summary": {
             "target_count": len(targets),
@@ -111,14 +125,135 @@ def build_proofs_payload(
             "accepted_lag_seconds": _float_or_none(
                 gate_freshness.get("accepted_lag_seconds")
             ),
+            "tigerbeetle_reconciliation_ok": bool(
+                tigerbeetle_reconciliation.get("reconciliation_ok")
+            ),
+            "tigerbeetle_reconciliation_stale": bool(
+                tigerbeetle_reconciliation.get("reconciliation_stale")
+            ),
+            "tigerbeetle_reconciliation_age_seconds": _int_or_none(
+                tigerbeetle_reconciliation.get("reconciliation_age_seconds")
+            ),
+            "tigerbeetle_reconciliation_required": bool(
+                tigerbeetle_reconciliation.get("reconciliation_required")
+            ),
         },
         "promotion_authority": {
             "allowed": False,
             "final_promotion_allowed": False,
             "reason": "proof_collection_only",
-            "blockers": ["live_runtime_ledger_authority_required"],
+            "blockers": promotion_blockers,
         },
     }
+
+
+def _tigerbeetle_reconciliation_payload(
+    tigerbeetle_ledger_status: Mapping[str, object] | None,
+) -> TigerBeetleReconciliationPayload:
+    if tigerbeetle_ledger_status is None:
+        return {
+            "schema_version": TIGERBEETLE_RECONCILIATION_SCHEMA_VERSION,
+            "status_available": False,
+            "ok": False,
+            "protocol_ok": False,
+            "protocol_probe_skipped": False,
+            "reconciliation_required": False,
+            "reconciliation_ok": False,
+            "reconciliation_stale": False,
+            "reconciliation_age_seconds": None,
+            "reconciliation_max_age_seconds": None,
+            "cluster_id": None,
+            "claimed_by_runtime_evidence": False,
+            "runtime_ledger_ref_count": 0,
+            "runtime_ledger_signed_ref_count": 0,
+            "runtime_ledger_missing_signed_ref_count": 0,
+            "runtime_ledger_missing_account_ref_count": 0,
+            "latest_reconciliation": None,
+            "blockers": [_TIGERBEETLE_LEDGER_STATUS_MISSING],
+        }
+
+    status = tigerbeetle_ledger_status
+    status_available = not bool(status.get("read_model_unavailable"))
+    blockers = _text_items(status.get("blockers"))
+    if not status_available:
+        blockers.append(_TIGERBEETLE_LEDGER_STATUS_UNAVAILABLE)
+    if status_available and not bool(status.get("ok")) and not blockers:
+        blockers.append(_TIGERBEETLE_LEDGER_NOT_OK)
+
+    return {
+        "schema_version": TIGERBEETLE_RECONCILIATION_SCHEMA_VERSION,
+        "status_available": status_available,
+        "ok": bool(status.get("ok")),
+        "protocol_ok": bool(status.get("protocol_ok")),
+        "protocol_probe_skipped": bool(status.get("protocol_probe_skipped")),
+        "reconciliation_required": bool(status.get("reconciliation_required")),
+        "reconciliation_ok": bool(status.get("reconciliation_ok")),
+        "reconciliation_stale": bool(status.get("reconciliation_stale")),
+        "reconciliation_age_seconds": _int_or_none(
+            status.get("reconciliation_age_seconds")
+        ),
+        "reconciliation_max_age_seconds": _int_or_none(
+            status.get("reconciliation_max_age_seconds")
+        ),
+        "cluster_id": _int_or_none(status.get("cluster_id")),
+        "claimed_by_runtime_evidence": bool(status.get("claimed_by_runtime_evidence")),
+        "runtime_ledger_ref_count": _int_or_zero(
+            status.get("runtime_ledger_ref_count")
+        ),
+        "runtime_ledger_signed_ref_count": _int_or_zero(
+            status.get("runtime_ledger_signed_ref_count")
+        ),
+        "runtime_ledger_missing_signed_ref_count": _int_or_zero(
+            status.get("runtime_ledger_missing_signed_ref_count")
+        ),
+        "runtime_ledger_missing_account_ref_count": _int_or_zero(
+            status.get("runtime_ledger_missing_account_ref_count")
+        ),
+        "latest_reconciliation": _latest_reconciliation_summary(
+            status.get("latest_reconciliation")
+        ),
+        "blockers": list(dict.fromkeys(blockers)),
+    }
+
+
+def _latest_reconciliation_summary(value: object) -> dict[str, object] | None:
+    if not isinstance(value, Mapping):
+        return None
+    payload = cast(Mapping[str, object], value)
+    keys = (
+        "id",
+        "cluster_id",
+        "status",
+        "ok",
+        "started_at",
+        "finished_at",
+        "age_seconds",
+        "reconciliation_stale",
+        "checked_transfer_count",
+        "missing_transfer_count",
+        "mismatched_transfer_count",
+        "source_missing_count",
+        "runtime_ledger_ref_count",
+        "runtime_ledger_signed_ref_count",
+        "runtime_ledger_missing_signed_ref_count",
+        "runtime_ledger_missing_account_ref_count",
+        "blockers",
+    )
+    return {key: payload.get(key) for key in keys if key in payload}
+
+
+def _promotion_authority_blockers(
+    tigerbeetle_reconciliation: Mapping[str, object],
+) -> list[str]:
+    blockers = ["live_runtime_ledger_authority_required"]
+    if not bool(tigerbeetle_reconciliation.get("status_available")) or not bool(
+        tigerbeetle_reconciliation.get("ok")
+    ):
+        reconciliation_blockers = _text_items(
+            tigerbeetle_reconciliation.get("blockers")
+        )
+        blockers.extend(reconciliation_blockers or [_TIGERBEETLE_LEDGER_NOT_OK])
+    return list(dict.fromkeys(blockers))
 
 
 def _live_submission_gate_payload(
@@ -160,6 +295,43 @@ def _float_or_none(value: object) -> float | None:
         return float(value)
     except ValueError:
         return None
+
+
+def _int_or_zero(value: object) -> int:
+    return _int_or_none(value) or 0
+
+
+def _int_or_none(value: object) -> int | None:
+    normalized: int | None = None
+    if value is None or isinstance(value, bool):
+        return normalized
+    if isinstance(value, int):
+        normalized = value
+    elif isinstance(value, Decimal):
+        if value == value.to_integral_value():
+            normalized = int(value)
+    elif isinstance(value, float):
+        if value.is_integer():
+            normalized = int(value)
+    elif isinstance(value, str):
+        try:
+            normalized = int(value)
+        except ValueError:
+            normalized = None
+    return normalized
+
+
+def _text_items(value: object) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return [
+            text
+            for item in cast(Sequence[object], value)
+            if (text := str(item).strip())
+        ]
+    return []
 
 
 def _load_strategy_universe_by_name(

--- a/services/torghut/tests/test_proofs_service.py
+++ b/services/torghut/tests/test_proofs_service.py
@@ -73,6 +73,49 @@ def _gate(
     }
 
 
+def _tigerbeetle_status(
+    *,
+    ok: bool = True,
+    reconciliation_ok: bool = True,
+    reconciliation_stale: bool = False,
+    blockers: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.tigerbeetle-ledger-status.v1",
+        "ok": ok,
+        "protocol_ok": True,
+        "protocol_probe_skipped": False,
+        "reconciliation_required": True,
+        "reconciliation_ok": reconciliation_ok,
+        "reconciliation_stale": reconciliation_stale,
+        "reconciliation_age_seconds": 30,
+        "reconciliation_max_age_seconds": 300,
+        "cluster_id": 100,
+        "claimed_by_runtime_evidence": True,
+        "runtime_ledger_ref_count": 2,
+        "runtime_ledger_signed_ref_count": 2,
+        "runtime_ledger_missing_signed_ref_count": 0,
+        "runtime_ledger_missing_account_ref_count": 0,
+        "latest_reconciliation": {
+            "id": "recon-1",
+            "cluster_id": 100,
+            "status": "ok" if reconciliation_ok else "blocked",
+            "ok": reconciliation_ok,
+            "started_at": "2026-06-08T20:05:00+00:00",
+            "finished_at": "2026-06-08T20:05:02+00:00",
+            "age_seconds": 30,
+            "reconciliation_stale": reconciliation_stale,
+            "checked_transfer_count": 12,
+            "runtime_ledger_ref_count": 2,
+            "runtime_ledger_signed_ref_count": 2,
+            "runtime_ledger_missing_signed_ref_count": 0,
+            "runtime_ledger_missing_account_ref_count": 0,
+            "blockers": blockers or [],
+        },
+        "blockers": blockers or [],
+    }
+
+
 def _build(
     session: Session,
     *,
@@ -80,6 +123,7 @@ def _build(
     target: dict[str, object] | None = None,
     blockers: list[str] | None = None,
     accepted_lag_seconds: object = 420.5,
+    tigerbeetle_ledger_status: dict[str, object] | None = None,
 ) -> dict[str, object]:
     return build_proofs_payload(
         session,
@@ -87,6 +131,7 @@ def _build(
             _gate(target, blockers, accepted_lag_seconds) if target else {}
         ),
         route_reacquisition_book={},
+        tigerbeetle_ledger_status=tigerbeetle_ledger_status,
         generated_at=generated_at,
         window="auto",
         full_audit=True,
@@ -103,6 +148,11 @@ def test_build_proofs_payload_reports_no_target() -> None:
     assert payload["proofs"] == []
     assert payload["summary"]["target_count"] == 0
     assert payload["promotion_authority"]["allowed"] is False
+    assert payload["tigerbeetle_reconciliation"]["status_available"] is False
+    assert (
+        "tigerbeetle_ledger_status_missing"
+        in payload["promotion_authority"]["blockers"]
+    )
 
 
 def test_build_proofs_payload_exposes_live_submission_gate_and_freshness_summary() -> (
@@ -116,6 +166,7 @@ def test_build_proofs_payload_exposes_live_submission_gate_and_freshness_summary
             session,
             target=target,
             generated_at=window_start - timedelta(minutes=1),
+            tigerbeetle_ledger_status=_tigerbeetle_status(),
         )
 
     assert payload["live_submission_gate"]["allowed"] is False
@@ -124,12 +175,145 @@ def test_build_proofs_payload_exposes_live_submission_gate_and_freshness_summary
     assert payload["summary"]["live_submission_reason"] == "accepted_ta_signal_stale"
     assert payload["summary"]["accepted_source_state"] == "stale"
     assert payload["summary"]["accepted_lag_seconds"] == 420.5
+    assert payload["summary"]["tigerbeetle_reconciliation_ok"] is True
+    assert payload["summary"]["tigerbeetle_reconciliation_stale"] is False
+    assert payload["summary"]["tigerbeetle_reconciliation_age_seconds"] == 30
+    assert payload["summary"]["tigerbeetle_reconciliation_required"] is True
+    assert payload["tigerbeetle_reconciliation"]["latest_reconciliation"] == {
+        "id": "recon-1",
+        "cluster_id": 100,
+        "status": "ok",
+        "ok": True,
+        "started_at": "2026-06-08T20:05:00+00:00",
+        "finished_at": "2026-06-08T20:05:02+00:00",
+        "age_seconds": 30,
+        "reconciliation_stale": False,
+        "checked_transfer_count": 12,
+        "runtime_ledger_ref_count": 2,
+        "runtime_ledger_signed_ref_count": 2,
+        "runtime_ledger_missing_signed_ref_count": 0,
+        "runtime_ledger_missing_account_ref_count": 0,
+        "blockers": [],
+    }
     assert payload["promotion_authority"] == {
         "allowed": False,
         "final_promotion_allowed": False,
         "reason": "proof_collection_only",
         "blockers": ["live_runtime_ledger_authority_required"],
     }
+
+
+def test_build_proofs_payload_blocks_promotion_authority_on_stale_reconciliation() -> (
+    None
+):
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    window_end = datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc)
+    target = _target(window_start, window_end)
+    with _session() as session:
+        payload = _build(
+            session,
+            target=target,
+            generated_at=window_start - timedelta(minutes=1),
+            tigerbeetle_ledger_status=_tigerbeetle_status(
+                ok=False,
+                reconciliation_ok=False,
+                reconciliation_stale=True,
+                blockers=["tigerbeetle_reconciliation_stale"],
+            ),
+        )
+
+    assert payload["summary"]["tigerbeetle_reconciliation_ok"] is False
+    assert payload["summary"]["tigerbeetle_reconciliation_stale"] is True
+    assert (
+        "tigerbeetle_reconciliation_stale" in payload["promotion_authority"]["blockers"]
+    )
+
+
+def test_build_proofs_payload_blocks_promotion_authority_on_unavailable_reconciliation() -> (
+    None
+):
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    status = _tigerbeetle_status()
+    status["read_model_unavailable"] = True
+    status["blockers"] = "tigerbeetle_read_model_unavailable"
+
+    with _session() as session:
+        payload = _build(
+            session,
+            generated_at=window_start - timedelta(minutes=1),
+            tigerbeetle_ledger_status=status,
+        )
+
+    assert payload["tigerbeetle_reconciliation"]["status_available"] is False
+    assert payload["tigerbeetle_reconciliation"]["blockers"] == [
+        "tigerbeetle_read_model_unavailable",
+        "tigerbeetle_ledger_status_unavailable",
+    ]
+    assert (
+        "tigerbeetle_read_model_unavailable"
+        in payload["promotion_authority"]["blockers"]
+    )
+    assert (
+        "tigerbeetle_ledger_status_unavailable"
+        in payload["promotion_authority"]["blockers"]
+    )
+
+
+def test_build_proofs_payload_adds_default_tigerbeetle_blocker_when_status_not_ok() -> (
+    None
+):
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    status = _tigerbeetle_status(ok=False)
+    status["blockers"] = 123
+
+    with _session() as session:
+        payload = _build(
+            session,
+            generated_at=window_start - timedelta(minutes=1),
+            tigerbeetle_ledger_status=status,
+        )
+
+    assert payload["tigerbeetle_reconciliation"]["blockers"] == [
+        "tigerbeetle_ledger_not_ok"
+    ]
+    assert "tigerbeetle_ledger_not_ok" in payload["promotion_authority"]["blockers"]
+
+
+def test_build_proofs_payload_normalizes_tigerbeetle_numeric_fields() -> None:
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    status = _tigerbeetle_status()
+    status["reconciliation_age_seconds"] = Decimal("42")
+    status["reconciliation_max_age_seconds"] = 300.0
+    status["cluster_id"] = "100"
+    status["runtime_ledger_ref_count"] = "2"
+    status["runtime_ledger_signed_ref_count"] = 3.0
+    status["runtime_ledger_missing_signed_ref_count"] = "not-an-int"
+    status["runtime_ledger_missing_account_ref_count"] = Decimal("1")
+
+    with _session() as session:
+        payload = _build(
+            session,
+            generated_at=window_start - timedelta(minutes=1),
+            tigerbeetle_ledger_status=status,
+        )
+
+    assert payload["tigerbeetle_reconciliation"]["reconciliation_age_seconds"] == 42
+    assert (
+        payload["tigerbeetle_reconciliation"]["reconciliation_max_age_seconds"] == 300
+    )
+    assert payload["tigerbeetle_reconciliation"]["cluster_id"] == 100
+    assert payload["tigerbeetle_reconciliation"]["runtime_ledger_ref_count"] == 2
+    assert payload["tigerbeetle_reconciliation"]["runtime_ledger_signed_ref_count"] == 3
+    assert (
+        payload["tigerbeetle_reconciliation"]["runtime_ledger_missing_signed_ref_count"]
+        == 0
+    )
+    assert (
+        payload["tigerbeetle_reconciliation"][
+            "runtime_ledger_missing_account_ref_count"
+        ]
+        == 1
+    )
 
 
 def test_build_proofs_payload_normalizes_invalid_accepted_lag_summary() -> None:


### PR DESCRIPTION
## Summary

- Exposes TigerBeetle reconciliation status on the canonical `/trading/proofs` payload using the same ledger health helper as `/trading/status`.
- Adds proof summary fields and promotion-authority blockers when reconciliation status is missing, unavailable, stale, or not ok.
- Hardens the Torghut post-deploy evidence validator so canonical proof payloads must carry fresh TigerBeetle reconciliation and mirror the `/trading/status` latest reconciliation readback.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_proofs_service.py tests/test_trading_proofs_api.py`
- `cd services/torghut && uv run --frozen coverage run -m pytest tests/test_proofs_service.py tests/test_trading_proofs_api.py`
- `cd services/torghut && uv run --frozen coverage xml -o coverage.xml || true`
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app scripts tests`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
