### PR TITLE
ci(kubeconform): validate changed manifests in PRs

### DIFF
--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -38,4 +38,27 @@ jobs:
             experimental-features = nix-command flakes
 
       - name: Validate manifests
-        run: nix develop -c scripts/kubeconform.sh argocd
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+            mapfile -d '' changed_manifests < <(
+              git diff \
+                --name-only \
+                -z \
+                --diff-filter=ACMR \
+                "${{ github.event.pull_request.base.sha }}" \
+                -- 'argocd/**/*.yaml'
+            )
+            if [ "${#changed_manifests[@]}" -eq 0 ]; then
+              echo "No changed Argo CD manifests to validate."
+              exit 0
+            fi
+
+            printf 'Validating changed manifest: %s\n' "${changed_manifests[@]}"
+            nix develop -c scripts/kubeconform.sh "${changed_manifests[@]}"
+          else
+            nix develop -c scripts/kubeconform.sh argocd
+          fi

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="${1:-argocd}"
+PATHS=("$@")
+if [[ ${#PATHS[@]} -eq 0 ]]; then
+  PATHS=("argocd")
+fi
 SCHEMA_DIR="${PWD}/schemas/custom"
+KUBECONFORM_CACHE_DIR="${KUBECONFORM_CACHE_DIR:-${PWD}/.cache/kubeconform}"
 
 if ! command -v kubeconform >/dev/null 2>&1; then
   echo "kubeconform is required but not installed" >&2
@@ -10,17 +14,35 @@ if ! command -v kubeconform >/dev/null 2>&1; then
 fi
 
 filtered=()
-while IFS= read -r -d '' file; do
+add_manifest_file() {
+  local file="$1"
   if [[ "$file" == *"/charts/"* ]] || [[ "$file" == *".patch.yaml" ]]; then
-    continue
+    return
   fi
   if grep -Eq '^[[:space:]]*kind:' "$file"; then
     filtered+=("$file")
   fi
-done < <(find "$ROOT_DIR" -type f -name '*.yaml' -print0)
+}
+
+for path in "${PATHS[@]}"; do
+  if [[ -d "$path" ]]; then
+    while IFS= read -r -d '' file; do
+      add_manifest_file "$file"
+    done < <(find "$path" -type f -name '*.yaml' -print0)
+  elif [[ -f "$path" ]]; then
+    case "$path" in
+      *.yaml | *.yml)
+        add_manifest_file "$path"
+        ;;
+    esac
+  else
+    echo "kubeconform input path does not exist: $path" >&2
+    exit 1
+  fi
+done
 
 if [[ ${#filtered[@]} -eq 0 ]]; then
-  echo "No Kubernetes manifests with a kind key found under $ROOT_DIR" >&2
+  echo "No Kubernetes manifests with a kind key found in kubeconform inputs" >&2
   exit 0
 fi
 
@@ -41,12 +63,16 @@ KUBECONFORM_ARGS=(
   --strict
   --summary
   --ignore-missing-schemas
+  --cache "${KUBECONFORM_CACHE_DIR}"
+  -n "${KUBECONFORM_CONCURRENCY:-2}"
   --ignore-filename-pattern 'overlays/'
   --ignore-filename-pattern 'charts/'
   --ignore-filename-pattern 'Chart.yaml'
   --ignore-filename-pattern 'values.yaml'
   "${SCHEMA_ARGS[@]}"
 )
+
+mkdir -p "$KUBECONFORM_CACHE_DIR"
 
 status=0
 batch=()


### PR DESCRIPTION
## Summary

- Makes the shared kubeconform script accept explicit manifest files as well as directories.
- Narrows pull-request kubeconform validation to changed `argocd/**/*.yaml` manifests while preserving full-tree validation on main pushes.
- Adds a local kubeconform schema cache and lower default concurrency to reduce repeated external schema fetch failures.

## Related Issues

None

## Testing

- `bash -n scripts/kubeconform.sh`
- `rm -rf .cache/kubeconform && nix develop -c scripts/kubeconform.sh argocd/applications/torghut/db-migrations-job.yaml`
- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
