### PR TITLE
feat(torghut): add market data chain smoke proof

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshness.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -14,6 +16,8 @@ data class MarketDataChannelReadiness(
   val channel: String,
   val ready: Boolean,
   @SerialName("required") val required: Boolean,
+  @SerialName("gate_active") val gateActive: Boolean,
+  @SerialName("market_session_state") val marketSessionState: String,
   @SerialName("readiness_mode") val readinessMode: String = "continuous",
   @SerialName("freshness_required") val freshnessRequired: Boolean = true,
   @SerialName("symbol_coverage_required") val symbolCoverageRequired: Boolean = true,
@@ -118,11 +122,12 @@ internal class MarketDataChannelFreshnessTracker(
     val subscribedAt = subscribedSinceMs.get()
     val symbolsByChannel = subscribedSymbolsByChannel.get()
     val hasAnySubscribedSymbols = symbolsByChannel.values.any { it.isNotEmpty() }
+    val sessionState = marketSessionState(Instant.ofEpochMilli(now), marketType, marketHolidays)
     val gateActive =
       hasAnySubscribedSymbols &&
         subscribedAt > 0 &&
         now - subscribedAt >= warmupMs &&
-        marketSessionActive(Instant.ofEpochMilli(now))
+        marketDataFreshnessGateActive(sessionState)
     return requiredChannels.map { channel ->
       val channelSymbols = symbolsByChannel[channel].orEmpty()
       val readinessMode = readinessModeFor(channel, marketType)
@@ -197,6 +202,8 @@ internal class MarketDataChannelFreshnessTracker(
         channel = channel,
         ready = ready,
         required = true,
+        gateActive = gateActive,
+        marketSessionState = sessionState,
         readinessMode = readinessMode.id,
         freshnessRequired = freshnessRequired,
         symbolCoverageRequired = symbolCoverageRequired,
@@ -241,12 +248,6 @@ internal class MarketDataChannelFreshnessTracker(
     return latestByChannel.computeIfAbsent(canonical) { ChannelFreshnessState() }
   }
 
-  private fun marketSessionActive(now: Instant): Boolean =
-    when (marketType) {
-      AlpacaMarketType.CRYPTO -> true
-      AlpacaMarketType.EQUITY, AlpacaMarketType.OPTIONS -> isRegularMarketSession(now, marketHolidays)
-    }
-
   private class ChannelFreshnessState {
     val latestProviderEventAtMs = AtomicLong(0)
     val latestSerializedAtMs = AtomicLong(0)
@@ -286,6 +287,31 @@ internal class MarketDataChannelFreshnessTracker(
       val normalized = normalizeSymbol(symbol) ?: return
       latestSymbol.set(normalized)
     }
+  }
+}
+
+private val marketDataFreshnessZoneId: ZoneId = ZoneId.of("America/New_York")
+private val regularSessionOpen: LocalTime = LocalTime.of(9, 30)
+private val regularSessionClose: LocalTime = LocalTime.of(16, 0)
+private val extendedSessionClose: LocalTime = LocalTime.of(20, 0)
+
+internal fun marketDataFreshnessGateActive(sessionState: String): Boolean = sessionState == "continuous" || sessionState == "regular"
+
+internal fun marketSessionState(
+  now: Instant,
+  marketType: AlpacaMarketType,
+  marketHolidays: Set<LocalDate> = emptySet(),
+): String {
+  if (marketType == AlpacaMarketType.CRYPTO) return "continuous"
+  val marketNow = now.atZone(marketDataFreshnessZoneId)
+  if (marketNow.toLocalDate() in marketHolidays) return "holiday"
+  if (marketNow.dayOfWeek.value >= 6) return "weekend"
+  val localTime = marketNow.toLocalTime()
+  return when {
+    localTime < regularSessionOpen -> "pre"
+    localTime < regularSessionClose -> "regular"
+    localTime < extendedSessionClose -> "post"
+    else -> "closed"
   }
 }
 

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderMetricsTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderMetricsTest.kt
@@ -133,6 +133,8 @@ class ForwarderMetricsTest {
           channel = "trades",
           ready = false,
           required = true,
+          gateActive = true,
+          marketSessionState = "regular",
           latestProviderEventAtMs = 100,
           latestSerializedAtMs = 110,
           latestKafkaSuccessAtMs = null,

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/MarketDataChannelFreshnessTrackerTest.kt
@@ -211,6 +211,8 @@ class MarketDataChannelFreshnessTrackerTest {
 
     val missingCoverage = tracker.snapshot().single()
     assertFalse(tracker.ready())
+    assertTrue(missingCoverage.gateActive)
+    assertEquals("regular", missingCoverage.marketSessionState)
     assertEquals("market_data_channel_missing_symbol_coverage", missingCoverage.reason)
     assertEquals(listOf("AMD"), missingCoverage.missingSymbols)
     assertEquals(listOf("NVDA"), missingCoverage.freshSymbols)
@@ -228,6 +230,30 @@ class MarketDataChannelFreshnessTrackerTest {
     assertEquals("market_data_channel_stale_symbol_coverage", staleCoverage.reason)
     assertEquals(listOf("NVDA"), staleCoverage.staleSymbols)
     assertEquals(listOf("AMD"), staleCoverage.freshSymbols)
+  }
+
+  @Test
+  fun `post-session readiness exposes inactive gate and stale channel diagnostics`() {
+    val nowMs = Instant.parse("2026-07-07T22:00:00Z").toEpochMilli()
+    val tracker =
+      MarketDataChannelFreshnessTracker(
+        requiredChannels = listOf("trades"),
+        maxLagMs = 60_000,
+        warmupMs = 0,
+        nowMs = { nowMs },
+        marketType = AlpacaMarketType.EQUITY,
+      )
+
+    tracker.recordSubscriptionByChannel(mapOf("trades" to listOf("NVDA", "AMD")))
+
+    val readiness = tracker.snapshot().single()
+
+    assertTrue(tracker.ready())
+    assertTrue(readiness.ready)
+    assertFalse(readiness.gateActive)
+    assertEquals("post", readiness.marketSessionState)
+    assertEquals("market_data_channel_gate_inactive", readiness.reason)
+    assertEquals(listOf("AMD", "NVDA"), readiness.subscribedSymbols)
   }
 
   @Test

--- a/services/torghut/app/api/proofs.py
+++ b/services/torghut/app/api/proofs.py
@@ -61,6 +61,7 @@ from .health_checks import (
     build_simple_lane_status_payload,
     build_tigerbeetle_ledger_status,
     empirical_jobs_status,
+    load_clickhouse_ta_status,
     load_tca_summary,
 )
 from .health_checks import (
@@ -83,6 +84,7 @@ _deferred_hypothesis_payload_for_live_submission_gate = (
     deferred_hypothesis_payload_for_live_submission_gate
 )
 _empirical_jobs_status = empirical_jobs_status
+_load_clickhouse_ta_status = load_clickhouse_ta_status
 _configured_paper_collection_target_plan = (
     _proofs_configured_collection.configured_paper_collection_target_plan
 )
@@ -166,6 +168,7 @@ def _build_trading_proofs_payload(
     quant_evidence = load_quant_evidence_status(
         account_label=settings.trading_account_label,
     )
+    clickhouse_ta_status = _load_clickhouse_ta_status(scheduler)
     gate_hypothesis_payload = _deferred_hypothesis_payload_for_live_submission_gate()
     with SessionLocal() as session:
         live_submission_gate = _build_live_submission_gate_payload(
@@ -178,6 +181,7 @@ def _build_trading_proofs_payload(
                 scheduler.llm_status().get("dspy_runtime", {}),
             ),
             quant_health_status=quant_evidence,
+            clickhouse_ta_status=clickhouse_ta_status,
         )
     if not bool(live_submission_gate.get("read_model_unavailable")):
         setattr(scheduler, "_last_live_submission_gate", dict(live_submission_gate))
@@ -206,6 +210,7 @@ def _build_trading_proofs_payload(
                 scheduler,
                 tca_summary=tca_summary,
                 market_context_status=market_context_status,
+                feature_readiness=clickhouse_ta_status,
             )
         )
         proof_floor = _build_profitability_proof_floor_payload(

--- a/services/torghut/scripts/verify_market_data_chain.py
+++ b/services/torghut/scripts/verify_market_data_chain.py
@@ -68,6 +68,31 @@ class ClickHouseFreshnessRow:
     latest_ingest_ts: str | None
 
 
+@dataclass(frozen=True)
+class MarketDataChainProbe:
+    generated_at: datetime
+    consumer_group_lag: Sequence[ConsumerGroupLag]
+    topic_offsets: Sequence[TopicOffset]
+    latest_messages: Sequence[LatestKafkaMessage]
+    clickhouse_rows: Sequence[ClickHouseFreshnessRow]
+
+
+@dataclass(frozen=True)
+class FreshnessThresholds:
+    kafka_age_seconds: int | None = None
+    clickhouse_age_seconds: int | None = None
+
+
+@dataclass(frozen=True)
+class KafkaProbeConfig:
+    namespace: str
+    pod: str
+    bootstrap: str
+    username: str
+    group: str
+    topics: Sequence[str]
+
+
 def parse_topic_offsets(output: str) -> list[TopicOffset]:
     rows: list[TopicOffset] = []
     for raw_line in output.splitlines():
@@ -170,46 +195,44 @@ def parse_clickhouse_freshness(output: str) -> list[ClickHouseFreshnessRow]:
 
 
 def build_summary(
+    probe: MarketDataChainProbe,
     *,
-    generated_at: datetime,
-    consumer_group_lag: Sequence[ConsumerGroupLag],
-    topic_offsets: Sequence[TopicOffset],
-    latest_messages: Sequence[LatestKafkaMessage],
-    clickhouse_rows: Sequence[ClickHouseFreshnessRow],
-    require_max_kafka_age_seconds: int | None = None,
-    require_max_clickhouse_age_seconds: int | None = None,
+    thresholds: FreshnessThresholds | None = None,
 ) -> dict[str, object]:
+    active_thresholds = thresholds or FreshnessThresholds()
     issues: list[str] = []
-    max_group_lag = max((row.lag for row in consumer_group_lag), default=0)
+    max_group_lag = max((row.lag for row in probe.consumer_group_lag), default=0)
     if max_group_lag > 0:
         issues.append("kafka_consumer_group_lag")
 
     latest_message_payloads = [
         {
             **asdict(row),
-            "age_seconds": _age_seconds_from_epoch_ms(generated_at, row.timestamp_ms),
+            "age_seconds": _age_seconds_from_epoch_ms(
+                probe.generated_at, row.timestamp_ms
+            ),
         }
-        for row in latest_messages
+        for row in probe.latest_messages
     ]
-    if require_max_kafka_age_seconds is not None:
+    if active_thresholds.kafka_age_seconds is not None:
         for row in latest_message_payloads:
             age = row["age_seconds"]
-            if isinstance(age, int) and age > require_max_kafka_age_seconds:
+            if isinstance(age, int) and age > active_thresholds.kafka_age_seconds:
                 issues.append(f"kafka_topic_stale:{row['topic']}:{row['partition']}")
 
     clickhouse_payloads = [
         {
             **asdict(row),
             "latest_event_age_seconds": _age_seconds_from_clickhouse_ts(
-                generated_at, row.latest_event_ts
+                probe.generated_at, row.latest_event_ts
             ),
             "latest_ingest_age_seconds": _age_seconds_from_clickhouse_ts(
-                generated_at, row.latest_ingest_ts
+                probe.generated_at, row.latest_ingest_ts
             ),
         }
-        for row in clickhouse_rows
+        for row in probe.clickhouse_rows
     ]
-    if require_max_clickhouse_age_seconds is not None:
+    if active_thresholds.clickhouse_age_seconds is not None:
         accepted_rows = [
             row
             for row in clickhouse_payloads
@@ -217,22 +240,22 @@ def build_summary(
         ]
         for row in accepted_rows:
             age = row["latest_event_age_seconds"]
-            if isinstance(age, int) and age > require_max_clickhouse_age_seconds:
+            if isinstance(age, int) and age > active_thresholds.clickhouse_age_seconds:
                 issues.append(f"clickhouse_accepted_source_stale:{row['table']}")
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "generated_at": generated_at.isoformat(),
+        "generated_at": probe.generated_at.isoformat(),
         "status": "ok" if not issues else "degraded",
         "issues": sorted(set(issues)),
         "summary": {
             "kafka_consumer_group_max_lag": max_group_lag,
-            "latest_kafka_message_count": len(latest_messages),
-            "clickhouse_row_count": len(clickhouse_rows),
+            "latest_kafka_message_count": len(probe.latest_messages),
+            "clickhouse_row_count": len(probe.clickhouse_rows),
         },
         "kafka": {
-            "consumer_group_lag": [asdict(row) for row in consumer_group_lag],
-            "topic_offsets": [asdict(row) for row in topic_offsets],
+            "consumer_group_lag": [asdict(row) for row in probe.consumer_group_lag],
+            "topic_offsets": [asdict(row) for row in probe.topic_offsets],
             "latest_messages": latest_message_payloads,
         },
         "clickhouse": {
@@ -252,13 +275,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         key=args.kafka_password_key,
     )
     kafka_output = run_kafka_probe(
-        namespace=args.kafka_namespace,
-        pod=args.kafka_pod,
-        bootstrap=args.kafka_bootstrap,
-        username=args.kafka_username,
+        KafkaProbeConfig(
+            namespace=args.kafka_namespace,
+            pod=args.kafka_pod,
+            bootstrap=args.kafka_bootstrap,
+            username=args.kafka_username,
+            group=args.ta_group,
+            topics=topics,
+        ),
         password=kafka_password,
-        group=args.ta_group,
-        topics=topics,
     )
     clickhouse_password = read_kubernetes_secret(
         namespace=args.clickhouse_namespace,
@@ -273,13 +298,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         query=args.clickhouse_query,
     )
     summary = build_summary(
-        generated_at=generated_at,
-        consumer_group_lag=parse_consumer_group_lag(kafka_output),
-        topic_offsets=parse_topic_offsets(kafka_output),
-        latest_messages=parse_latest_kafka_messages(kafka_output),
-        clickhouse_rows=parse_clickhouse_freshness(clickhouse_output),
-        require_max_kafka_age_seconds=args.require_max_kafka_age_seconds,
-        require_max_clickhouse_age_seconds=args.require_max_clickhouse_age_seconds,
+        MarketDataChainProbe(
+            generated_at=generated_at,
+            consumer_group_lag=parse_consumer_group_lag(kafka_output),
+            topic_offsets=parse_topic_offsets(kafka_output),
+            latest_messages=parse_latest_kafka_messages(kafka_output),
+            clickhouse_rows=parse_clickhouse_freshness(clickhouse_output),
+        ),
+        thresholds=FreshnessThresholds(
+            kafka_age_seconds=args.require_max_kafka_age_seconds,
+            clickhouse_age_seconds=args.require_max_clickhouse_age_seconds,
+        ),
     )
     print(format_summary(summary, args.format))
     return 0 if summary["status"] == "ok" else 2
@@ -331,35 +360,26 @@ def read_kubernetes_secret(*, namespace: str, name: str, key: str) -> str:
     return base64.b64decode(encoded).decode("utf-8")
 
 
-def run_kafka_probe(
-    *,
-    namespace: str,
-    pod: str,
-    bootstrap: str,
-    username: str,
-    password: str,
-    group: str,
-    topics: Sequence[str],
-) -> str:
-    topic_args = " ".join(shlex.quote(topic) for topic in topics)
+def run_kafka_probe(config: KafkaProbeConfig, *, password: str) -> str:
+    topic_args = " ".join(shlex.quote(topic) for topic in config.topics)
     script = f"""
 set -euo pipefail
 CONFIG=/tmp/torghut-market-data-smoke.properties
 trap 'rm -f "$CONFIG"' EXIT
 cat > "$CONFIG"
 echo "=== consumer_group ==="
-bin/kafka-consumer-groups.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --describe --group {shlex.quote(group)} || true
+bin/kafka-consumer-groups.sh --bootstrap-server {shlex.quote(config.bootstrap)} --command-config "$CONFIG" --describe --group {shlex.quote(config.group)} || true
 echo "=== topic_offsets ==="
 for topic in {topic_args}; do
-  bin/kafka-get-offsets.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --topic "$topic" --time latest
+  bin/kafka-get-offsets.sh --bootstrap-server {shlex.quote(config.bootstrap)} --command-config "$CONFIG" --topic "$topic" --time latest
 done
 echo "=== latest_messages ==="
 for topic in {topic_args}; do
   echo "=== $topic ==="
-  bin/kafka-get-offsets.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --topic "$topic" --time latest | while IFS=: read -r row_topic partition offset; do
+  bin/kafka-get-offsets.sh --bootstrap-server {shlex.quote(config.bootstrap)} --command-config "$CONFIG" --topic "$topic" --time latest | while IFS=: read -r row_topic partition offset; do
     if [ "$offset" -gt 0 ]; then
       start=$((offset - 1))
-      timeout 8 bin/kafka-console-consumer.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --topic "$row_topic" --partition "$partition" --offset "$start" --max-messages 1 --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter --formatter-property print.timestamp=true --formatter-property print.offset=true --formatter-property print.partition=true --formatter-property print.key=true --formatter-property print.value=false --timeout-ms 5000 || true
+      timeout 8 bin/kafka-console-consumer.sh --bootstrap-server {shlex.quote(config.bootstrap)} --command-config "$CONFIG" --topic "$row_topic" --partition "$partition" --offset "$start" --max-messages 1 --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter --formatter-property print.timestamp=true --formatter-property print.offset=true --formatter-property print.partition=true --formatter-property print.key=true --formatter-property print.value=false --timeout-ms 5000 || true
     fi
   done
 done
@@ -368,12 +388,23 @@ done
         (
             "security.protocol=SASL_PLAINTEXT",
             "sasl.mechanism=SCRAM-SHA-512",
-            f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{username}" password="{password}";',
+            f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{config.username}" password="{password}";',
             "",
         )
     )
     return _run(
-        ["kubectl", "exec", "-i", "-n", namespace, pod, "--", "bash", "-lc", script],
+        [
+            "kubectl",
+            "exec",
+            "-i",
+            "-n",
+            config.namespace,
+            config.pod,
+            "--",
+            "bash",
+            "-lc",
+            script,
+        ],
         input_text=properties,
     )
 

--- a/services/torghut/scripts/verify_market_data_chain.py
+++ b/services/torghut/scripts/verify_market_data_chain.py
@@ -80,7 +80,9 @@ def parse_topic_offsets(output: str) -> list[TopicOffset]:
         topic, partition, offset = parts
         if not partition.isdigit() or not offset.isdigit():
             continue
-        rows.append(TopicOffset(topic=topic, partition=int(partition), offset=int(offset)))
+        rows.append(
+            TopicOffset(topic=topic, partition=int(partition), offset=int(offset))
+        )
     return rows
 
 
@@ -198,8 +200,12 @@ def build_summary(
     clickhouse_payloads = [
         {
             **asdict(row),
-            "latest_event_age_seconds": _age_seconds_from_clickhouse_ts(generated_at, row.latest_event_ts),
-            "latest_ingest_age_seconds": _age_seconds_from_clickhouse_ts(generated_at, row.latest_ingest_ts),
+            "latest_event_age_seconds": _age_seconds_from_clickhouse_ts(
+                generated_at, row.latest_event_ts
+            ),
+            "latest_ingest_age_seconds": _age_seconds_from_clickhouse_ts(
+                generated_at, row.latest_ingest_ts
+            ),
         }
         for row in clickhouse_rows
     ]
@@ -296,7 +302,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Kafka topic to probe. Repeat to replace the default topic set.",
     )
     parser.add_argument("--clickhouse-namespace", default="torghut")
-    parser.add_argument("--clickhouse-pod", default="chi-torghut-clickhouse-default-0-0-0")
+    parser.add_argument(
+        "--clickhouse-pod", default="chi-torghut-clickhouse-default-0-0-0"
+    )
     parser.add_argument("--clickhouse-secret", default="torghut-clickhouse-auth")
     parser.add_argument("--clickhouse-password-key", default="torghut_password")
     parser.add_argument("--clickhouse-user", default="torghut")
@@ -364,7 +372,10 @@ done
             "",
         )
     )
-    return _run(["kubectl", "exec", "-i", "-n", namespace, pod, "--", "bash", "-lc", script], input_text=properties)
+    return _run(
+        ["kubectl", "exec", "-i", "-n", namespace, pod, "--", "bash", "-lc", script],
+        input_text=properties,
+    )
 
 
 def run_clickhouse_query(
@@ -385,7 +396,10 @@ cat >"$SQL_FILE" <<'SQL'
 SQL
 clickhouse-client --user {shlex.quote(user)} --password "$CLICKHOUSE_PASSWORD" < "$SQL_FILE"
 """.strip()
-    return _run(["kubectl", "exec", "-i", "-n", namespace, pod, "--", "bash", "-lc", script], input_text=f"{password}\n")
+    return _run(
+        ["kubectl", "exec", "-i", "-n", namespace, pod, "--", "bash", "-lc", script],
+        input_text=f"{password}\n",
+    )
 
 
 def format_summary(

--- a/services/torghut/scripts/verify_market_data_chain.py
+++ b/services/torghut/scripts/verify_market_data_chain.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import shlex
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Literal, Sequence
+
+
+SCHEMA_VERSION = "torghut.market-data-chain-smoke.v1"
+DEFAULT_TOPICS = (
+    "torghut.trades.v1",
+    "torghut.quotes.v1",
+    "torghut.bars.1m.v1",
+    "torghut.ta.bars.1s.v1",
+    "torghut.ta.signals.v1",
+    "torghut.ta.status.v1",
+)
+DEFAULT_CLICKHOUSE_QUERY = """
+SELECT 'ta_signals' AS table, source, count(), max(event_ts), max(ingest_ts)
+FROM torghut.ta_signals
+GROUP BY source
+UNION ALL
+SELECT 'ta_microbars' AS table, source, count(), max(event_ts), max(ingest_ts)
+FROM torghut.ta_microbars
+GROUP BY source
+ORDER BY table, source
+FORMAT TSVWithNames
+""".strip()
+
+
+@dataclass(frozen=True)
+class TopicOffset:
+    topic: str
+    partition: int
+    offset: int
+
+
+@dataclass(frozen=True)
+class ConsumerGroupLag:
+    group: str
+    topic: str
+    partition: int
+    current_offset: int
+    log_end_offset: int
+    lag: int
+
+
+@dataclass(frozen=True)
+class LatestKafkaMessage:
+    topic: str
+    partition: int
+    offset: int
+    timestamp_type: str
+    timestamp_ms: int
+    key: str | None
+
+
+@dataclass(frozen=True)
+class ClickHouseFreshnessRow:
+    table: str
+    source: str
+    row_count: int
+    latest_event_ts: str | None
+    latest_ingest_ts: str | None
+
+
+def parse_topic_offsets(output: str) -> list[TopicOffset]:
+    rows: list[TopicOffset] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("===", "---")):
+            continue
+        parts = line.split(":")
+        if len(parts) != 3:
+            continue
+        topic, partition, offset = parts
+        if not partition.isdigit() or not offset.isdigit():
+            continue
+        rows.append(TopicOffset(topic=topic, partition=int(partition), offset=int(offset)))
+    return rows
+
+
+def parse_consumer_group_lag(output: str) -> list[ConsumerGroupLag]:
+    rows: list[ConsumerGroupLag] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("Consumer group", "GROUP", "===", "---")):
+            continue
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        group, topic, partition, current_offset, log_end_offset, lag = parts[:6]
+        if not (
+            partition.isdigit()
+            and current_offset.lstrip("-").isdigit()
+            and log_end_offset.lstrip("-").isdigit()
+            and lag.lstrip("-").isdigit()
+        ):
+            continue
+        rows.append(
+            ConsumerGroupLag(
+                group=group,
+                topic=topic,
+                partition=int(partition),
+                current_offset=int(current_offset),
+                log_end_offset=int(log_end_offset),
+                lag=int(lag),
+            )
+        )
+    return rows
+
+
+def parse_latest_kafka_messages(output: str) -> list[LatestKafkaMessage]:
+    rows: list[LatestKafkaMessage] = []
+    current_topic: str | None = None
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if line.startswith("===") and line.endswith("==="):
+            current_topic = line.strip("= ")
+            continue
+        if not line.startswith(("CreateTime:", "LogAppendTime:", "NoTimestampType:")):
+            continue
+        fields = line.split("\t")
+        if len(fields) < 3 or current_topic is None:
+            continue
+        timestamp_type, timestamp = fields[0].split(":", 1)
+        partition = _field_int(fields[1], "Partition")
+        offset = _field_int(fields[2], "Offset")
+        if partition is None or offset is None or not timestamp.isdigit():
+            continue
+        key = fields[3] if len(fields) > 3 and fields[3] != "null" else None
+        rows.append(
+            LatestKafkaMessage(
+                topic=current_topic,
+                partition=partition,
+                offset=offset,
+                timestamp_type=timestamp_type,
+                timestamp_ms=int(timestamp),
+                key=key,
+            )
+        )
+    return rows
+
+
+def parse_clickhouse_freshness(output: str) -> list[ClickHouseFreshnessRow]:
+    rows: list[ClickHouseFreshnessRow] = []
+    for index, raw_line in enumerate(output.splitlines()):
+        line = raw_line.strip()
+        if not line or index == 0 and line.startswith("table\t"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 5 or not parts[2].isdigit():
+            continue
+        rows.append(
+            ClickHouseFreshnessRow(
+                table=parts[0],
+                source=parts[1],
+                row_count=int(parts[2]),
+                latest_event_ts=parts[3] or None,
+                latest_ingest_ts=parts[4] or None,
+            )
+        )
+    return rows
+
+
+def build_summary(
+    *,
+    generated_at: datetime,
+    consumer_group_lag: Sequence[ConsumerGroupLag],
+    topic_offsets: Sequence[TopicOffset],
+    latest_messages: Sequence[LatestKafkaMessage],
+    clickhouse_rows: Sequence[ClickHouseFreshnessRow],
+    require_max_kafka_age_seconds: int | None = None,
+    require_max_clickhouse_age_seconds: int | None = None,
+) -> dict[str, object]:
+    issues: list[str] = []
+    max_group_lag = max((row.lag for row in consumer_group_lag), default=0)
+    if max_group_lag > 0:
+        issues.append("kafka_consumer_group_lag")
+
+    latest_message_payloads = [
+        {
+            **asdict(row),
+            "age_seconds": _age_seconds_from_epoch_ms(generated_at, row.timestamp_ms),
+        }
+        for row in latest_messages
+    ]
+    if require_max_kafka_age_seconds is not None:
+        for row in latest_message_payloads:
+            age = row["age_seconds"]
+            if isinstance(age, int) and age > require_max_kafka_age_seconds:
+                issues.append(f"kafka_topic_stale:{row['topic']}:{row['partition']}")
+
+    clickhouse_payloads = [
+        {
+            **asdict(row),
+            "latest_event_age_seconds": _age_seconds_from_clickhouse_ts(generated_at, row.latest_event_ts),
+            "latest_ingest_age_seconds": _age_seconds_from_clickhouse_ts(generated_at, row.latest_ingest_ts),
+        }
+        for row in clickhouse_rows
+    ]
+    if require_max_clickhouse_age_seconds is not None:
+        accepted_rows = [
+            row
+            for row in clickhouse_payloads
+            if row["source"] == "ta" and row["table"] in {"ta_signals", "ta_microbars"}
+        ]
+        for row in accepted_rows:
+            age = row["latest_event_age_seconds"]
+            if isinstance(age, int) and age > require_max_clickhouse_age_seconds:
+                issues.append(f"clickhouse_accepted_source_stale:{row['table']}")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at.isoformat(),
+        "status": "ok" if not issues else "degraded",
+        "issues": sorted(set(issues)),
+        "summary": {
+            "kafka_consumer_group_max_lag": max_group_lag,
+            "latest_kafka_message_count": len(latest_messages),
+            "clickhouse_row_count": len(clickhouse_rows),
+        },
+        "kafka": {
+            "consumer_group_lag": [asdict(row) for row in consumer_group_lag],
+            "topic_offsets": [asdict(row) for row in topic_offsets],
+            "latest_messages": latest_message_payloads,
+        },
+        "clickhouse": {
+            "freshness": clickhouse_payloads,
+        },
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    topics = tuple(args.topic or DEFAULT_TOPICS)
+    generated_at = datetime.now(UTC)
+
+    kafka_password = read_kubernetes_secret(
+        namespace=args.kafka_namespace,
+        name=args.kafka_secret,
+        key=args.kafka_password_key,
+    )
+    kafka_output = run_kafka_probe(
+        namespace=args.kafka_namespace,
+        pod=args.kafka_pod,
+        bootstrap=args.kafka_bootstrap,
+        username=args.kafka_username,
+        password=kafka_password,
+        group=args.ta_group,
+        topics=topics,
+    )
+    clickhouse_password = read_kubernetes_secret(
+        namespace=args.clickhouse_namespace,
+        name=args.clickhouse_secret,
+        key=args.clickhouse_password_key,
+    )
+    clickhouse_output = run_clickhouse_query(
+        namespace=args.clickhouse_namespace,
+        pod=args.clickhouse_pod,
+        user=args.clickhouse_user,
+        password=clickhouse_password,
+        query=args.clickhouse_query,
+    )
+    summary = build_summary(
+        generated_at=generated_at,
+        consumer_group_lag=parse_consumer_group_lag(kafka_output),
+        topic_offsets=parse_topic_offsets(kafka_output),
+        latest_messages=parse_latest_kafka_messages(kafka_output),
+        clickhouse_rows=parse_clickhouse_freshness(clickhouse_output),
+        require_max_kafka_age_seconds=args.require_max_kafka_age_seconds,
+        require_max_clickhouse_age_seconds=args.require_max_clickhouse_age_seconds,
+    )
+    print(format_summary(summary, args.format))
+    return 0 if summary["status"] == "ok" else 2
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test Torghut WS -> Kafka -> Flink TA -> ClickHouse freshness without printing secrets.",
+    )
+    parser.add_argument("--kafka-namespace", default="kafka")
+    parser.add_argument("--kafka-pod", default="kafka-pool-a-0")
+    parser.add_argument("--kafka-secret", default="torghut-ws")
+    parser.add_argument("--kafka-password-key", default="password")
+    parser.add_argument("--kafka-username", default="torghut-ws")
+    parser.add_argument("--kafka-bootstrap", default="kafka-kafka-bootstrap.kafka:9092")
+    parser.add_argument("--ta-group", default="torghut-ta-live")
+    parser.add_argument(
+        "--topic",
+        action="append",
+        help="Kafka topic to probe. Repeat to replace the default topic set.",
+    )
+    parser.add_argument("--clickhouse-namespace", default="torghut")
+    parser.add_argument("--clickhouse-pod", default="chi-torghut-clickhouse-default-0-0-0")
+    parser.add_argument("--clickhouse-secret", default="torghut-clickhouse-auth")
+    parser.add_argument("--clickhouse-password-key", default="torghut_password")
+    parser.add_argument("--clickhouse-user", default="torghut")
+    parser.add_argument("--clickhouse-query", default=DEFAULT_CLICKHOUSE_QUERY)
+    parser.add_argument("--require-max-kafka-age-seconds", type=int)
+    parser.add_argument("--require-max-clickhouse-age-seconds", type=int)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    return parser.parse_args(argv)
+
+
+def read_kubernetes_secret(*, namespace: str, name: str, key: str) -> str:
+    encoded = _run(
+        [
+            "kubectl",
+            "get",
+            "secret",
+            "-n",
+            namespace,
+            name,
+            "-o",
+            f"jsonpath={{.data.{key}}}",
+        ]
+    ).strip()
+    return base64.b64decode(encoded).decode("utf-8")
+
+
+def run_kafka_probe(
+    *,
+    namespace: str,
+    pod: str,
+    bootstrap: str,
+    username: str,
+    password: str,
+    group: str,
+    topics: Sequence[str],
+) -> str:
+    topic_args = " ".join(shlex.quote(topic) for topic in topics)
+    script = f"""
+set -euo pipefail
+CONFIG=/tmp/torghut-market-data-smoke.properties
+trap 'rm -f "$CONFIG"' EXIT
+cat > "$CONFIG"
+echo "=== consumer_group ==="
+bin/kafka-consumer-groups.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --describe --group {shlex.quote(group)} || true
+echo "=== topic_offsets ==="
+for topic in {topic_args}; do
+  bin/kafka-get-offsets.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --topic "$topic" --time latest
+done
+echo "=== latest_messages ==="
+for topic in {topic_args}; do
+  echo "=== $topic ==="
+  bin/kafka-get-offsets.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --topic "$topic" --time latest | while IFS=: read -r row_topic partition offset; do
+    if [ "$offset" -gt 0 ]; then
+      start=$((offset - 1))
+      timeout 8 bin/kafka-console-consumer.sh --bootstrap-server {shlex.quote(bootstrap)} --command-config "$CONFIG" --topic "$row_topic" --partition "$partition" --offset "$start" --max-messages 1 --formatter org.apache.kafka.tools.consumer.DefaultMessageFormatter --formatter-property print.timestamp=true --formatter-property print.offset=true --formatter-property print.partition=true --formatter-property print.key=true --formatter-property print.value=false --timeout-ms 5000 || true
+    fi
+  done
+done
+""".strip()
+    properties = "\n".join(
+        (
+            "security.protocol=SASL_PLAINTEXT",
+            "sasl.mechanism=SCRAM-SHA-512",
+            f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{username}" password="{password}";',
+            "",
+        )
+    )
+    return _run(["kubectl", "exec", "-i", "-n", namespace, pod, "--", "bash", "-lc", script], input_text=properties)
+
+
+def run_clickhouse_query(
+    *,
+    namespace: str,
+    pod: str,
+    user: str,
+    password: str,
+    query: str,
+) -> str:
+    script = f"""
+set -euo pipefail
+read -r CLICKHOUSE_PASSWORD
+SQL_FILE=/tmp/torghut-market-data-smoke.sql
+trap 'rm -f "$SQL_FILE"' EXIT
+cat >"$SQL_FILE" <<'SQL'
+{query}
+SQL
+clickhouse-client --user {shlex.quote(user)} --password "$CLICKHOUSE_PASSWORD" < "$SQL_FILE"
+""".strip()
+    return _run(["kubectl", "exec", "-i", "-n", namespace, pod, "--", "bash", "-lc", script], input_text=f"{password}\n")
+
+
+def format_summary(
+    summary: dict[str, object],
+    output_format: Literal["json", "markdown"],
+) -> str:
+    if output_format == "json":
+        return json.dumps(summary, indent=2, sort_keys=True)
+    issues = summary.get("issues")
+    issue_text = (
+        ", ".join(str(issue) for issue in issues)
+        if isinstance(issues, list) and issues
+        else "none"
+    )
+    lines = [
+        "# Torghut Market Data Chain Smoke",
+        f"- Status: `{summary.get('status')}`",
+        f"- Issues: {issue_text}",
+    ]
+    nested_summary = summary.get("summary")
+    if isinstance(nested_summary, dict):
+        lines.extend(
+            [
+                f"- Kafka consumer group max lag: `{nested_summary.get('kafka_consumer_group_max_lag')}`",
+                f"- Latest Kafka messages checked: `{nested_summary.get('latest_kafka_message_count')}`",
+                f"- ClickHouse freshness rows checked: `{nested_summary.get('clickhouse_row_count')}`",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _run(cmd: Sequence[str], *, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        list(cmd),
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stdout.strip() or f"command failed: {cmd[0]}")
+    return result.stdout
+
+
+def _field_int(value: str, field: str) -> int | None:
+    prefix = f"{field}:"
+    if not value.startswith(prefix):
+        return None
+    raw = value.removeprefix(prefix)
+    return int(raw) if raw.isdigit() else None
+
+
+def _age_seconds_from_epoch_ms(now: datetime, timestamp_ms: int) -> int:
+    timestamp = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC)
+    return max(0, int((now - timestamp).total_seconds()))
+
+
+def _age_seconds_from_clickhouse_ts(now: datetime, value: str | None) -> int | None:
+    parsed = _parse_clickhouse_ts(value)
+    if parsed is None:
+        return None
+    return max(0, int((now - parsed).total_seconds()))
+
+
+def _parse_clickhouse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    raw = value.strip().replace(" ", "T", 1)
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/api/test_trading_api_live_gate_llm.py
+++ b/services/torghut/tests/api/test_trading_api_live_gate_llm.py
@@ -423,6 +423,17 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
             _mark_static_universe_loaded(scheduler)
             app.state.trading_scheduler = scheduler
             shared_gate = _shared_blocked_live_gate()
+            shared_clickhouse_ta_status = shared_gate["clickhouse_ta_freshness"]
+
+            def _proofs_live_submission_gate(
+                *_args: object,
+                **kwargs: object,
+            ) -> dict[str, object]:
+                self.assertEqual(
+                    kwargs["clickhouse_ta_status"],
+                    shared_clickhouse_ta_status,
+                )
+                return shared_gate
 
             with (
                 patch(
@@ -514,8 +525,12 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
                     },
                 ),
                 patch(
+                    "app.api.proofs._load_clickhouse_ta_status",
+                    return_value=shared_clickhouse_ta_status,
+                ) as load_proofs_clickhouse_ta_status,
+                patch(
                     "app.api.proofs._build_live_submission_gate_payload",
-                    return_value=shared_gate,
+                    side_effect=_proofs_live_submission_gate,
                 ),
                 patch(
                     "app.api.proofs._merge_external_paper_route_target_plan",
@@ -551,6 +566,7 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
             self.assertEqual(ready_response.status_code, 503)
             self.assertEqual(runtime_response.status_code, 200)
             self.assertEqual(proofs_response.status_code, 200)
+            load_proofs_clickhouse_ta_status.assert_called_once_with(scheduler)
             self.assertEqual(
                 status_response.json()["live_submission_gate"], shared_gate
             )

--- a/services/torghut/tests/scripts/test_verify_market_data_chain.py
+++ b/services/torghut/tests/scripts/test_verify_market_data_chain.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from scripts.verify_market_data_chain import (
+    ClickHouseFreshnessRow,
+    ConsumerGroupLag,
+    DEFAULT_TOPICS,
+    LatestKafkaMessage,
+    TopicOffset,
+    build_summary,
+    format_summary,
+    parse_clickhouse_freshness,
+    parse_args,
+    parse_consumer_group_lag,
+    parse_latest_kafka_messages,
+    parse_topic_offsets,
+)
+
+
+def test_parse_consumer_group_lag_skips_status_lines() -> None:
+    output = """
+Consumer group 'torghut-ta-live' has no active members.
+
+GROUP           TOPIC              PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG
+torghut-ta-live torghut.trades.v1  0          100             100             0
+torghut-ta-live torghut.quotes.v1  2          198             200             2
+"""
+
+    assert parse_consumer_group_lag(output) == [
+        ConsumerGroupLag(
+            group="torghut-ta-live",
+            topic="torghut.trades.v1",
+            partition=0,
+            current_offset=100,
+            log_end_offset=100,
+            lag=0,
+        ),
+        ConsumerGroupLag(
+            group="torghut-ta-live",
+            topic="torghut.quotes.v1",
+            partition=2,
+            current_offset=198,
+            log_end_offset=200,
+            lag=2,
+        ),
+    ]
+
+
+def test_parse_topic_offsets_reads_kafka_get_offsets_rows() -> None:
+    output = """
+=== topic_offsets ===
+torghut.trades.v1:0:4195924
+torghut.trades.v1:1:4519705
+ignored
+"""
+
+    assert parse_topic_offsets(output) == [
+        TopicOffset(topic="torghut.trades.v1", partition=0, offset=4195924),
+        TopicOffset(topic="torghut.trades.v1", partition=1, offset=4519705),
+    ]
+
+
+def test_parse_latest_kafka_messages_uses_topic_section_and_metadata() -> None:
+    output = """
+=== latest_messages ===
+=== torghut.trades.v1 ===
+CreateTime:1783544335234\tPartition:1\tOffset:4519704\tAMD
+Processed a total of 1 messages
+=== torghut.ta.status.v1 ===
+CreateTime:1783561193358\tPartition:0\tOffset:79160\tta
+"""
+
+    assert parse_latest_kafka_messages(output) == [
+        LatestKafkaMessage(
+            topic="torghut.trades.v1",
+            partition=1,
+            offset=4519704,
+            timestamp_type="CreateTime",
+            timestamp_ms=1783544335234,
+            key="AMD",
+        ),
+        LatestKafkaMessage(
+            topic="torghut.ta.status.v1",
+            partition=0,
+            offset=79160,
+            timestamp_type="CreateTime",
+            timestamp_ms=1783561193358,
+            key="ta",
+        ),
+    ]
+
+
+def test_parse_clickhouse_freshness_reads_tsv_with_names() -> None:
+    output = """table\tsource\tcount()\tmax(event_ts)\tmax(ingest_ts)
+ta_signals\tta\t1411008\t2026-07-08 20:57:00.000\t2026-07-08 20:58:55.269
+ta_microbars\tta\t1412773\t2026-07-08 20:56:30.000\t2026-07-08 20:58:55.269
+"""
+
+    assert parse_clickhouse_freshness(output) == [
+        ClickHouseFreshnessRow(
+            table="ta_signals",
+            source="ta",
+            row_count=1411008,
+            latest_event_ts="2026-07-08 20:57:00.000",
+            latest_ingest_ts="2026-07-08 20:58:55.269",
+        ),
+        ClickHouseFreshnessRow(
+            table="ta_microbars",
+            source="ta",
+            row_count=1412773,
+            latest_event_ts="2026-07-08 20:56:30.000",
+            latest_ingest_ts="2026-07-08 20:58:55.269",
+        ),
+    ]
+
+
+def test_parse_args_replaces_default_topics_when_topic_is_provided() -> None:
+    defaults = parse_args([])
+    custom = parse_args(["--topic", "custom.one", "--topic", "custom.two"])
+
+    assert defaults.topic is None
+    assert tuple(defaults.topic or DEFAULT_TOPICS) == DEFAULT_TOPICS
+    assert custom.topic == ["custom.one", "custom.two"]
+
+
+def test_build_summary_degrades_on_group_lag_and_accepted_clickhouse_staleness() -> None:
+    summary = build_summary(
+        generated_at=datetime(2026, 7, 8, 21, 10, tzinfo=UTC),
+        consumer_group_lag=[
+            ConsumerGroupLag(
+                group="torghut-ta-live",
+                topic="torghut.trades.v1",
+                partition=0,
+                current_offset=9,
+                log_end_offset=10,
+                lag=1,
+            )
+        ],
+        topic_offsets=[TopicOffset(topic="torghut.trades.v1", partition=0, offset=10)],
+        latest_messages=[
+            LatestKafkaMessage(
+                topic="torghut.trades.v1",
+                partition=0,
+                offset=9,
+                timestamp_type="CreateTime",
+                timestamp_ms=1783544335000,
+                key="AMD",
+            )
+        ],
+        clickhouse_rows=[
+            ClickHouseFreshnessRow(
+                table="ta_signals",
+                source="ta",
+                row_count=10,
+                latest_event_ts="2026-07-08 20:57:00.000",
+                latest_ingest_ts="2026-07-08 20:58:55.269",
+            )
+        ],
+        require_max_kafka_age_seconds=300,
+        require_max_clickhouse_age_seconds=300,
+    )
+
+    assert summary["status"] == "degraded"
+    assert summary["issues"] == [
+        "clickhouse_accepted_source_stale:ta_signals",
+        "kafka_consumer_group_lag",
+        "kafka_topic_stale:torghut.trades.v1:0",
+    ]
+    assert format_summary(summary, "markdown").startswith(
+        "# Torghut Market Data Chain Smoke"
+    )

--- a/services/torghut/tests/scripts/test_verify_market_data_chain.py
+++ b/services/torghut/tests/scripts/test_verify_market_data_chain.py
@@ -1,22 +1,32 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import json
+from datetime import UTC, datetime, tzinfo
+from typing import Sequence, cast
+
+import pytest
 
 from scripts.verify_market_data_chain import (
     ClickHouseFreshnessRow,
     ConsumerGroupLag,
     DEFAULT_TOPICS,
     FreshnessThresholds,
+    KafkaProbeConfig,
     LatestKafkaMessage,
     MarketDataChainProbe,
     TopicOffset,
+    _run,
     build_summary,
     format_summary,
+    main,
     parse_clickhouse_freshness,
     parse_args,
     parse_consumer_group_lag,
     parse_latest_kafka_messages,
     parse_topic_offsets,
+    read_kubernetes_secret,
+    run_clickhouse_query,
+    run_kafka_probe,
 )
 
 
@@ -117,6 +127,21 @@ ta_microbars\tta\t1412773\t2026-07-08 20:56:30.000\t2026-07-08 20:58:55.269
     ]
 
 
+def test_parsers_skip_malformed_rows() -> None:
+    assert parse_topic_offsets("topic:not-int:10\ntopic:0:not-int\n") == []
+    assert parse_consumer_group_lag("group topic\nbad topic x y z n\n") == []
+    assert (
+        parse_latest_kafka_messages(
+            "CreateTime:1783544335234\tPartition:1\tOffset:9\n"
+            "=== torghut.trades.v1 ===\n"
+            "CreateTime:bad\tPartition:1\tOffset:9\n"
+            "CreateTime:1783544335234\tPartition:x\tOffset:9\n"
+        )
+        == []
+    )
+    assert parse_clickhouse_freshness("ta_signals\tta\tbad\t\t\nshort\trow\n") == []
+
+
 def test_parse_args_replaces_default_topics_when_topic_is_provided() -> None:
     defaults = parse_args([])
     custom = parse_args(["--topic", "custom.one", "--topic", "custom.two"])
@@ -124,6 +149,92 @@ def test_parse_args_replaces_default_topics_when_topic_is_provided() -> None:
     assert defaults.topic is None
     assert tuple(defaults.topic or DEFAULT_TOPICS) == DEFAULT_TOPICS
     assert custom.topic == ["custom.one", "custom.two"]
+
+
+def test_read_kubernetes_secret_decodes_without_exposing_encoded_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[Sequence[str]] = []
+
+    def fake_run(cmd: Sequence[str], *, input_text: str | None = None) -> str:
+        calls.append(cmd)
+        assert input_text is None
+        return "c2VjcmV0Cg=="
+
+    monkeypatch.setattr("scripts.verify_market_data_chain._run", fake_run)
+
+    assert read_kubernetes_secret(
+        namespace="ns", name="secret-name", key="password"
+    ) == ("secret\n")
+    assert calls == [
+        [
+            "kubectl",
+            "get",
+            "secret",
+            "-n",
+            "ns",
+            "secret-name",
+            "-o",
+            "jsonpath={.data.password}",
+        ]
+    ]
+
+
+def test_run_kafka_probe_passes_secret_on_stdin_and_quotes_shell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[Sequence[str], str | None]] = []
+
+    def fake_run(cmd: Sequence[str], *, input_text: str | None = None) -> str:
+        calls.append((cmd, input_text))
+        return "kafka-output"
+
+    monkeypatch.setattr("scripts.verify_market_data_chain._run", fake_run)
+
+    output = run_kafka_probe(
+        KafkaProbeConfig(
+            namespace="kafka",
+            pod="kafka-0",
+            bootstrap="kafka:9092",
+            username="torghut-ws",
+            group="torghut-ta-live",
+            topics=("torghut.trades.v1", "topic with space"),
+        ),
+        password="kafka-password",
+    )
+
+    assert output == "kafka-output"
+    cmd, input_text = calls[0]
+    assert cmd[:6] == ["kubectl", "exec", "-i", "-n", "kafka", "kafka-0"]
+    assert "topic with space" in cmd[-1]
+    assert 'password="kafka-password"' in str(input_text)
+    assert "security.protocol=SASL_PLAINTEXT" in str(input_text)
+
+
+def test_run_clickhouse_query_passes_password_and_query_via_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[Sequence[str], str | None]] = []
+
+    def fake_run(cmd: Sequence[str], *, input_text: str | None = None) -> str:
+        calls.append((cmd, input_text))
+        return "table\tsource\tcount()\tmax(event_ts)\tmax(ingest_ts)\n"
+
+    monkeypatch.setattr("scripts.verify_market_data_chain._run", fake_run)
+
+    output = run_clickhouse_query(
+        namespace="torghut",
+        pod="clickhouse-0",
+        user="torghut",
+        password="clickhouse-password",
+        query="SELECT 1",
+    )
+
+    assert output.startswith("table\t")
+    cmd, input_text = calls[0]
+    assert cmd[:6] == ["kubectl", "exec", "-i", "-n", "torghut", "clickhouse-0"]
+    assert "SELECT 1" in cmd[-1]
+    assert input_text == "clickhouse-password\n"
 
 
 def test_build_summary_degrades_on_group_lag_and_accepted_clickhouse_staleness() -> (
@@ -180,3 +291,130 @@ def test_build_summary_degrades_on_group_lag_and_accepted_clickhouse_staleness()
     assert format_summary(summary, "markdown").startswith(
         "# Torghut Market Data Chain Smoke"
     )
+
+
+def test_build_summary_handles_missing_and_zulu_clickhouse_timestamps() -> None:
+    summary = build_summary(
+        MarketDataChainProbe(
+            generated_at=datetime(2026, 7, 8, 21, 10, tzinfo=UTC),
+            consumer_group_lag=[],
+            topic_offsets=[],
+            latest_messages=[],
+            clickhouse_rows=[
+                ClickHouseFreshnessRow(
+                    table="ta_signals",
+                    source="ta",
+                    row_count=1,
+                    latest_event_ts=None,
+                    latest_ingest_ts="2026-07-08T21:09:00Z",
+                )
+            ],
+        ),
+        thresholds=FreshnessThresholds(clickhouse_age_seconds=300),
+    )
+
+    clickhouse = cast(dict[str, object], summary["clickhouse"])
+    freshness_rows = cast(list[dict[str, object]], clickhouse["freshness"])
+    freshness = freshness_rows[0]
+    assert freshness["latest_event_age_seconds"] is None
+    assert freshness["latest_ingest_age_seconds"] == 60
+
+
+def test_format_summary_json_is_stable() -> None:
+    summary = build_summary(
+        MarketDataChainProbe(
+            generated_at=datetime(2026, 7, 8, 21, 10, tzinfo=UTC),
+            consumer_group_lag=[],
+            topic_offsets=[],
+            latest_messages=[],
+            clickhouse_rows=[],
+        )
+    )
+
+    encoded = format_summary(summary, "json")
+
+    assert json.loads(encoded)["schema_version"] == "torghut.market-data-chain-smoke.v1"
+
+
+def test_run_returns_stdout_and_raises_on_failure() -> None:
+    assert _run(["python", "-c", "print('ok')"]) == "ok\n"
+
+    with pytest.raises(RuntimeError, match="bad"):
+        _run(["python", "-c", "import sys; print('bad'); sys.exit(2)"])
+
+
+def test_main_orchestrates_kafka_clickhouse_and_returns_status(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret_calls: list[tuple[str, str, str]] = []
+    kafka_configs: list[KafkaProbeConfig] = []
+
+    def fake_secret(*, namespace: str, name: str, key: str) -> str:
+        secret_calls.append((namespace, name, key))
+        return f"{name}-password"
+
+    def fake_kafka_probe(config: KafkaProbeConfig, *, password: str) -> str:
+        kafka_configs.append(config)
+        assert password == "torghut-ws-password"
+        return """
+GROUP TOPIC PARTITION CURRENT-OFFSET LOG-END-OFFSET LAG
+torghut-ta-live torghut.trades.v1 0 10 10 0
+=== topic_offsets ===
+torghut.trades.v1:0:10
+=== latest_messages ===
+=== torghut.trades.v1 ===
+CreateTime:1783545000000\tPartition:0\tOffset:9\tAMD
+"""
+
+    def fake_clickhouse_query(
+        *,
+        namespace: str,
+        pod: str,
+        user: str,
+        password: str,
+        query: str,
+    ) -> str:
+        assert (namespace, pod, user, password) == (
+            "torghut",
+            "chi-torghut-clickhouse-default-0-0-0",
+            "torghut",
+            "torghut-clickhouse-auth-password",
+        )
+        assert "ta_signals" in query
+        return """table\tsource\tcount()\tmax(event_ts)\tmax(ingest_ts)
+ta_signals\tta\t1\t2026-07-08 21:09:00.000\t2026-07-08 21:09:30.000
+"""
+
+    monkeypatch.setattr(
+        "scripts.verify_market_data_chain.datetime",
+        _FixedDatetime,
+    )
+    monkeypatch.setattr(
+        "scripts.verify_market_data_chain.read_kubernetes_secret",
+        fake_secret,
+    )
+    monkeypatch.setattr(
+        "scripts.verify_market_data_chain.run_kafka_probe", fake_kafka_probe
+    )
+    monkeypatch.setattr(
+        "scripts.verify_market_data_chain.run_clickhouse_query",
+        fake_clickhouse_query,
+    )
+
+    exit_code = main(["--topic", "torghut.trades.v1", "--format", "json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["status"] == "ok"
+    assert secret_calls == [
+        ("kafka", "torghut-ws", "password"),
+        ("torghut", "torghut-clickhouse-auth", "torghut_password"),
+    ]
+    assert kafka_configs[0].topics == ("torghut.trades.v1",)
+
+
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz: tzinfo | None = None) -> datetime:
+        return datetime(2026, 7, 8, 21, 10, tzinfo=tz or UTC)

--- a/services/torghut/tests/scripts/test_verify_market_data_chain.py
+++ b/services/torghut/tests/scripts/test_verify_market_data_chain.py
@@ -124,7 +124,9 @@ def test_parse_args_replaces_default_topics_when_topic_is_provided() -> None:
     assert custom.topic == ["custom.one", "custom.two"]
 
 
-def test_build_summary_degrades_on_group_lag_and_accepted_clickhouse_staleness() -> None:
+def test_build_summary_degrades_on_group_lag_and_accepted_clickhouse_staleness() -> (
+    None
+):
     summary = build_summary(
         generated_at=datetime(2026, 7, 8, 21, 10, tzinfo=UTC),
         consumer_group_lag=[

--- a/services/torghut/tests/scripts/test_verify_market_data_chain.py
+++ b/services/torghut/tests/scripts/test_verify_market_data_chain.py
@@ -6,7 +6,9 @@ from scripts.verify_market_data_chain import (
     ClickHouseFreshnessRow,
     ConsumerGroupLag,
     DEFAULT_TOPICS,
+    FreshnessThresholds,
     LatestKafkaMessage,
+    MarketDataChainProbe,
     TopicOffset,
     build_summary,
     format_summary,
@@ -128,39 +130,45 @@ def test_build_summary_degrades_on_group_lag_and_accepted_clickhouse_staleness()
     None
 ):
     summary = build_summary(
-        generated_at=datetime(2026, 7, 8, 21, 10, tzinfo=UTC),
-        consumer_group_lag=[
-            ConsumerGroupLag(
-                group="torghut-ta-live",
-                topic="torghut.trades.v1",
-                partition=0,
-                current_offset=9,
-                log_end_offset=10,
-                lag=1,
-            )
-        ],
-        topic_offsets=[TopicOffset(topic="torghut.trades.v1", partition=0, offset=10)],
-        latest_messages=[
-            LatestKafkaMessage(
-                topic="torghut.trades.v1",
-                partition=0,
-                offset=9,
-                timestamp_type="CreateTime",
-                timestamp_ms=1783544335000,
-                key="AMD",
-            )
-        ],
-        clickhouse_rows=[
-            ClickHouseFreshnessRow(
-                table="ta_signals",
-                source="ta",
-                row_count=10,
-                latest_event_ts="2026-07-08 20:57:00.000",
-                latest_ingest_ts="2026-07-08 20:58:55.269",
-            )
-        ],
-        require_max_kafka_age_seconds=300,
-        require_max_clickhouse_age_seconds=300,
+        MarketDataChainProbe(
+            generated_at=datetime(2026, 7, 8, 21, 10, tzinfo=UTC),
+            consumer_group_lag=[
+                ConsumerGroupLag(
+                    group="torghut-ta-live",
+                    topic="torghut.trades.v1",
+                    partition=0,
+                    current_offset=9,
+                    log_end_offset=10,
+                    lag=1,
+                )
+            ],
+            topic_offsets=[
+                TopicOffset(topic="torghut.trades.v1", partition=0, offset=10)
+            ],
+            latest_messages=[
+                LatestKafkaMessage(
+                    topic="torghut.trades.v1",
+                    partition=0,
+                    offset=9,
+                    timestamp_type="CreateTime",
+                    timestamp_ms=1783544335000,
+                    key="AMD",
+                )
+            ],
+            clickhouse_rows=[
+                ClickHouseFreshnessRow(
+                    table="ta_signals",
+                    source="ta",
+                    row_count=10,
+                    latest_event_ts="2026-07-08 20:57:00.000",
+                    latest_ingest_ts="2026-07-08 20:58:55.269",
+                )
+            ],
+        ),
+        thresholds=FreshnessThresholds(
+            kafka_age_seconds=300,
+            clickhouse_age_seconds=300,
+        ),
     )
 
     assert summary["status"] == "degraded"


### PR DESCRIPTION
## Summary

- Adds WS readiness diagnostics for `gate_active` and `market_session_state` so regular-session freshness enforcement and post-session inactive gates are explicit.
- Adds `services/torghut/scripts/verify_market_data_chain.py`, a no-secret smoke verifier for WS -> Kafka -> Flink TA -> ClickHouse freshness using the existing Kubernetes secret refs.
- Makes `/trading/proofs` explicitly load and pass the accepted-source ClickHouse TA freshness contract into the shared live-submission gate and proof-floor hypothesis path.
- Adds parser/unit tests for the verifier, WS tests for regular-session blockers plus post-session diagnostics, and an API regression proving proofs uses the explicit accepted-source gate input.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen ruff format --check app tests scripts migrations`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base . scripts/verify_market_data_chain.py tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen ruff check scripts/verify_market_data_chain.py tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen pytest tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen python -m compileall scripts/verify_market_data_chain.py tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen ruff check app/api/proofs.py tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_live_gate_llm.py -k live_submission_gate_matches_status_health_and_readyz`
- `cd services/torghut && uv run --frozen python -m compileall app/api/proofs.py tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen python scripts/verify_market_data_chain.py --format json`
- `cd services/dorvud && ./gradlew :websockets:test`
- `cd services/dorvud && ./gradlew :websockets:ktlintCheck`

Live smoke result: verifier returned `status=ok`; `torghut-ta-live` max Kafka lag was `0`; `torghut.ta.status.v1` had a current heartbeat; accepted `ta_signals`/`ta_microbars` rows were current through the July 8, 2026 post-close window.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.