### PR TITLE
chore(torghut): promote ws image sha-de62642ebe022f1ab81e6d63f0a999bb2fec3d7b

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:ddd3c26685bd9d78d88f00194e399d24ea006eaa5d375aa82457e934b26bd856
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7ac33279a0a16298b9a24f3ce32f465203ec840093d6346f43e1f2f0b951ea9f
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-57b68fe14eda42168aae573221afd9363c770751
+              value: main-sha-de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
             - name: TORGHUT_WS_COMMIT
-              value: 57b68fe14eda42168aae573221afd9363c770751
+              value: de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:ddd3c26685bd9d78d88f00194e399d24ea006eaa5d375aa82457e934b26bd856
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7ac33279a0a16298b9a24f3ce32f465203ec840093d6346f43e1f2f0b951ea9f
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-57b68fe14eda42168aae573221afd9363c770751
+              value: main-sha-de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
             - name: TORGHUT_WS_COMMIT
-              value: 57b68fe14eda42168aae573221afd9363c770751
+              value: de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `de62642ebe022f1ab81e6d63f0a999bb2fec3d7b`
- Image tag: `sha-de62642ebe022f1ab81e6d63f0a999bb2fec3d7b`
- Image digest: `sha256:7ac33279a0a16298b9a24f3ce32f465203ec840093d6346f43e1f2f0b951ea9f`