### PR TITLE
fix(torghut): preserve tigerbeetle reconciliation freshness

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -45,6 +45,7 @@ SIM_SOURCE_BATCH_SIZE = 100
 SIM_RUNTIME_LEDGER_BATCH_SIZE = 100
 SIM_ORDER_EVENT_SCAN_LIMIT = 5000
 RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS = 120.0
+RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS = 1800
 
 
 @dataclass(frozen=True)
@@ -58,6 +59,7 @@ class JournalCronCommand:
     event_scan_limit: int | None = None
     skip_reconcile: bool = False
     reconcile_empty_selection: bool = False
+    reconcile_empty_selection_freshness_headroom_seconds: int = 0
     allow_data_quality_degraded: bool = False
     commit_each_row: bool = False
     progress_interval: int | None = None
@@ -196,6 +198,9 @@ def _live_commands(
             max_batches=1,
             reconcile_limit=LIVE_RECONCILE_LIMIT,
             reconcile_empty_selection=True,
+            reconcile_empty_selection_freshness_headroom_seconds=(
+                RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS
+            ),
             allow_data_quality_degraded=True,
             journal_batch_chunk_size=journal_batch_chunk_size,
             supervise_timeout_seconds=max(
@@ -276,6 +281,9 @@ def _sim_commands(
             reconcile_limit=reconcile_limit,
             account_label=account_label,
             reconcile_empty_selection=True,
+            reconcile_empty_selection_freshness_headroom_seconds=(
+                RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS
+            ),
             allow_data_quality_degraded=True,
             journal_batch_chunk_size=journal_batch_chunk_size,
             supervise_timeout_seconds=max(
@@ -364,6 +372,13 @@ def _argv_for_command(
         argv.append("--skip-reconcile")
     if command.reconcile_empty_selection:
         argv.append("--reconcile-empty-selection")
+    if command.reconcile_empty_selection_freshness_headroom_seconds > 0:
+        argv.extend(
+            [
+                "--reconcile-empty-selection-freshness-headroom-seconds",
+                str(command.reconcile_empty_selection_freshness_headroom_seconds),
+            ]
+        )
     argv.append("--fail-on-degraded")
     if command.allow_data_quality_degraded:
         argv.append("--allow-data-quality-degraded")

--- a/services/torghut/scripts/tigerbeetle_order_journal/cli.py
+++ b/services/torghut/scripts/tigerbeetle_order_journal/cli.py
@@ -248,6 +248,11 @@ def main() -> int:
                     session,
                     settings_obj=settings_obj,
                     account_label=args.account_label,
+                    freshness_headroom_seconds=getattr(
+                        args,
+                        "reconcile_empty_selection_freshness_headroom_seconds",
+                        0,
+                    ),
                 )
             if reconciliation is None:
                 reconciliation = reconcile_tigerbeetle_transfers(

--- a/services/torghut/scripts/tigerbeetle_order_journal/journal_core.py
+++ b/services/torghut/scripts/tigerbeetle_order_journal/journal_core.py
@@ -121,6 +121,7 @@ def _parse_args() -> argparse.Namespace:
             "default empty source slices remain a no-op."
         ),
     )
+    _add_reconcile_empty_selection_headroom_arg(parser)
     parser.add_argument(
         "--fail-on-degraded",
         action="store_true",
@@ -178,6 +179,20 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
+
+
+def _add_reconcile_empty_selection_headroom_arg(
+    parser: argparse.ArgumentParser,
+) -> None:
+    parser.add_argument(
+        "--reconcile-empty-selection-freshness-headroom-seconds",
+        type=int,
+        default=0,
+        help=(
+            "When reusing a previous clean reconciliation for an empty source "
+            "selection, require this many seconds of freshness budget to remain."
+        ),
+    )
 
 
 def _sqlalchemy_dsn(dsn: str) -> str:

--- a/services/torghut/scripts/tigerbeetle_order_journal/journal_payloads.py
+++ b/services/torghut/scripts/tigerbeetle_order_journal/journal_payloads.py
@@ -39,6 +39,7 @@ def _fresh_reconciliation_for_empty_selection(
     *,
     settings_obj: Settings,
     account_label: str | None,
+    freshness_headroom_seconds: int = 0,
 ) -> dict[str, object] | None:
     latest = latest_tigerbeetle_reconciliation_payload(
         session,
@@ -59,6 +60,11 @@ def _fresh_reconciliation_for_empty_selection(
     )
     if blocked:
         return None
+    age_seconds = int(latest.get("age_seconds") or 0)
+    remaining_freshness_seconds = max_age_seconds - age_seconds
+    required_headroom_seconds = max(0, int(freshness_headroom_seconds))
+    if remaining_freshness_seconds < required_headroom_seconds:
+        return None
     return {
         "ok": True,
         "status": "skipped",
@@ -68,9 +74,11 @@ def _fresh_reconciliation_for_empty_selection(
         "latest_status": str(latest.get("status") or ""),
         "latest_started_at": latest.get("started_at"),
         "latest_finished_at": latest.get("finished_at"),
-        "age_seconds": int(latest.get("age_seconds") or 0),
+        "age_seconds": age_seconds,
         "reconciliation_stale": False,
         "reconciliation_max_age_seconds": max_age_seconds,
+        "remaining_freshness_seconds": remaining_freshness_seconds,
+        "required_freshness_headroom_seconds": required_headroom_seconds,
         "checked_transfer_count": int(latest.get("checked_transfer_count") or 0),
         "runtime_ledger_checked_transfer_count": int(
             latest.get("runtime_ledger_checked_transfer_count") or 0

--- a/services/torghut/tests/journal_tigerbeetle_order_events/test_empty_selection_reconciliation_headroom.py
+++ b/services/torghut/tests/journal_tigerbeetle_order_events/test_empty_selection_reconciliation_headroom.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from tests.journal_tigerbeetle_order_events.support import (
+    Base,
+    FakeJournal,
+    Session,
+    Settings,
+    SimpleNamespace,
+    TigerBeetleReconciliationRun,
+    _TestJournalTigerBeetleOrderEventsScriptBase,
+    cast,
+    create_engine,
+    datetime,
+    io,
+    json,
+    os,
+    patch,
+    redirect_stdout,
+    script,
+    script_cli,
+    script_payloads,
+    sys,
+    tempfile,
+    timedelta,
+    timezone,
+)
+
+
+class TestEmptySelectionReconciliationHeadroom(
+    _TestJournalTigerBeetleOrderEventsScriptBase
+):
+    def test_reuses_reconciliation_when_freshness_headroom_is_sufficient(
+        self,
+    ) -> None:
+        session = object()
+        with patch.object(
+            script_payloads,
+            "latest_tigerbeetle_reconciliation_payload",
+            return_value={
+                "ok": True,
+                "status": "ok",
+                "reconciliation_stale": False,
+                "reconciliation_max_age_seconds": 3600,
+                "age_seconds": 600,
+                "blockers": [],
+                "client_lookup_ok": True,
+                "checked_transfer_count": 12,
+            },
+        ):
+            result = script._fresh_reconciliation_for_empty_selection(
+                session,
+                settings_obj=cast(
+                    Settings,
+                    SimpleNamespace(tigerbeetle_cluster_id=2001),
+                ),
+                account_label=None,
+                freshness_headroom_seconds=1800,
+            )
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["remaining_freshness_seconds"], 3000)
+        self.assertEqual(result["required_freshness_headroom_seconds"], 1800)
+
+    def test_rejects_reconciliation_when_freshness_headroom_is_low(
+        self,
+    ) -> None:
+        session = object()
+        with patch.object(
+            script_payloads,
+            "latest_tigerbeetle_reconciliation_payload",
+            return_value={
+                "ok": True,
+                "status": "ok",
+                "reconciliation_stale": False,
+                "reconciliation_max_age_seconds": 3600,
+                "age_seconds": 3512,
+                "blockers": [],
+                "client_lookup_ok": True,
+            },
+        ) as latest:
+            result = script._fresh_reconciliation_for_empty_selection(
+                session,
+                settings_obj=cast(
+                    Settings,
+                    SimpleNamespace(tigerbeetle_cluster_id=2001),
+                ),
+                account_label=None,
+                freshness_headroom_seconds=1800,
+            )
+
+        self.assertIsNone(result)
+        latest.assert_called_once_with(session, cluster_id=2001)
+
+    def test_main_refreshes_empty_selection_when_freshness_headroom_is_low(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                observed_at = datetime.now(timezone.utc) - timedelta(seconds=3512)
+                session.add(
+                    TigerBeetleReconciliationRun(
+                        cluster_id=2001,
+                        started_at=observed_at,
+                        finished_at=observed_at,
+                        status="ok",
+                        checked_transfer_count=26,
+                        missing_transfer_count=0,
+                        mismatched_transfer_count=0,
+                        source_missing_count=0,
+                        payload_json={
+                            "ok": True,
+                            "status": "ok",
+                            "blockers": [],
+                            "reconciliation_max_age_seconds": 3600,
+                            "runtime_ledger_checked_transfer_count": 26,
+                            "runtime_ledger_signed_transfer_count": 26,
+                            "runtime_ledger_missing_signed_ref_count": 0,
+                        },
+                    )
+                )
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--sources",
+                        "strategy_runtime_ledger_bucket",
+                        "--batch-size",
+                        "5",
+                        "--reconcile-limit",
+                        "12",
+                        "--reconcile-empty-selection",
+                        "--reconcile-empty-selection-freshness-headroom-seconds",
+                        "1800",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script_cli, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script_cli,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={
+                        "ok": True,
+                        "status": "ok",
+                        "account_label": None,
+                    },
+                ) as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["selected"], 0)
+        self.assertEqual(payload["reconciliation"]["status"], "ok")
+        reconcile.assert_called_once()

--- a/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
@@ -543,3 +543,35 @@ class TestTigerbeetleJournalOrderEventsCronjobCoversLiveAndSim(
         )
         _require_flag_enabled_false("torghut_llm_fail_open_live_approved")
         _require_flag_enabled_false("torghut_llm_shadow_mode")
+
+
+class TestTigerBeetleJournalRuntimeReconcileFreshnessHeadroom(
+    _TestLiveConfigManifestContractBase
+):
+    def test_live_runtime_command_preserves_reconciliation_headroom(self) -> None:
+        [command] = [
+            item
+            for item in tigerbeetle_journal_runner._live_commands(
+                execution_batch_size=5
+            )
+            if item.source
+            == tigerbeetle_journal_runner.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET
+        ]
+
+        self.assertEqual(
+            command.reconcile_empty_selection_freshness_headroom_seconds,
+            tigerbeetle_journal_runner.RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS,
+        )
+
+    def test_sim_runtime_command_preserves_reconciliation_headroom(self) -> None:
+        [command] = [
+            item
+            for item in tigerbeetle_journal_runner._sim_commands()
+            if item.source
+            == tigerbeetle_journal_runner.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET
+        ]
+
+        self.assertEqual(
+            command.reconcile_empty_selection_freshness_headroom_seconds,
+            tigerbeetle_journal_runner.RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS,
+        )

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -234,6 +234,10 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(commands[3].batch_size, 40)
         self.assertFalse(commands[3].skip_reconcile)
         self.assertTrue(commands[3].reconcile_empty_selection)
+        self.assertEqual(
+            commands[3].reconcile_empty_selection_freshness_headroom_seconds,
+            runner.RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS,
+        )
         self.assertEqual(commands[3].reconcile_limit, runner.LIVE_RECONCILE_LIMIT)
 
     def test_live_runtime_ledger_command_refreshes_empty_selection_reconciliation(
@@ -248,6 +252,16 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
 
         self.assertIn("--reconcile-empty-selection", argv)
+        self.assertIn(
+            "--reconcile-empty-selection-freshness-headroom-seconds",
+            argv,
+        )
+        self.assertEqual(
+            argv[
+                argv.index("--reconcile-empty-selection-freshness-headroom-seconds") + 1
+            ],
+            str(runner.RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS),
+        )
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],
@@ -278,6 +292,16 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
 
         self.assertIn("--reconcile-empty-selection", argv)
+        self.assertIn(
+            "--reconcile-empty-selection-freshness-headroom-seconds",
+            argv,
+        )
+        self.assertEqual(
+            argv[
+                argv.index("--reconcile-empty-selection-freshness-headroom-seconds") + 1
+            ],
+            str(runner.RUNTIME_LEDGER_RECONCILE_FRESHNESS_HEADROOM_SECONDS),
+        )
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],


### PR DESCRIPTION
## Summary

- Prevent the TigerBeetle journal cron from reusing an empty-selection reconciliation when too little freshness budget remains.
- Add a dedicated CLI headroom option and wire live/sim runtime-ledger cron slices to require 1800 seconds of remaining freshness.
- Cover the exact stale-edge case where a clean reconciliation at age 3512s must be refreshed before it can break post-deploy proof validation.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check scripts/tigerbeetle_order_journal/journal_core.py scripts/tigerbeetle_order_journal/journal_payloads.py scripts/tigerbeetle_order_journal/cli.py scripts/run_tigerbeetle_journal_cron.py tests/journal_tigerbeetle_order_events/test_empty_selection_reconciliation_headroom.py tests/journal_tigerbeetle_order_events/test_main_exit_policy.py tests/journal_tigerbeetle_order_events/test_source_selection_and_reconciliation.py tests/test_run_tigerbeetle_journal_cron.py tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `cd services/torghut && uv run --frozen ruff check scripts/tigerbeetle_order_journal/journal_core.py scripts/tigerbeetle_order_journal/journal_payloads.py scripts/tigerbeetle_order_journal/cli.py scripts/run_tigerbeetle_journal_cron.py tests/journal_tigerbeetle_order_events/test_empty_selection_reconciliation_headroom.py tests/journal_tigerbeetle_order_events/test_main_exit_policy.py tests/journal_tigerbeetle_order_events/test_source_selection_and_reconciliation.py tests/test_run_tigerbeetle_journal_cron.py tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `cd services/torghut && uv run --frozen pytest tests/journal_tigerbeetle_order_events/test_empty_selection_reconciliation_headroom.py tests/journal_tigerbeetle_order_events/test_main_exit_policy.py tests/journal_tigerbeetle_order_events/test_source_selection_and_reconciliation.py tests/test_run_tigerbeetle_journal_cron.py tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base "$(git merge-base origin/main HEAD)" --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks scripts/tigerbeetle_order_journal/journal_core.py scripts/tigerbeetle_order_journal/journal_payloads.py scripts/tigerbeetle_order_journal/cli.py scripts/run_tigerbeetle_journal_cron.py`
- `cd services/torghut && uv run --frozen python -m compileall scripts/tigerbeetle_order_journal scripts/run_tigerbeetle_journal_cron.py tests/journal_tigerbeetle_order_events tests/test_run_tigerbeetle_journal_cron.py tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.