### PR TITLE
fix(torghut): slim default proof payload

### DIFF
--- a/services/torghut/app/trading/proofs/schemas.py
+++ b/services/torghut/app/trading/proofs/schemas.py
@@ -123,15 +123,18 @@ class ProofPayload(TypedDict):
     identity: ProofIdentityPayload
     window: ProofWindowPayload
     symbols: list[str]
+    state: ProofState
+    blockers: list[str]
+    next_action: str
+
+
+class FullAuditProofPayload(ProofPayload):
     source_counts: SourceCountsPayload
     runtime_ledger: RuntimeLedgerPayload
     account_state: AccountStatePayload
     health: HealthPayload
     post_cost_pnl_basis: str | None
     post_cost_pnl_value: str | None
-    state: ProofState
-    blockers: list[str]
-    next_action: str
 
 
 class ProofSummaryPayload(TypedDict):
@@ -159,6 +162,6 @@ class ProofsPayload(TypedDict):
     window: dict[str, object]
     live_submission_gate: dict[str, object]
     tigerbeetle_reconciliation: TigerBeetleReconciliationPayload
-    proofs: list[ProofPayload]
+    proofs: list[ProofPayload | FullAuditProofPayload]
     summary: ProofSummaryPayload
     promotion_authority: PromotionAuthorityPayload

--- a/services/torghut/app/trading/proofs/service.py
+++ b/services/torghut/app/trading/proofs/service.py
@@ -17,11 +17,13 @@ from .health import build_health_payload
 from .ledger import load_runtime_ledger
 from .schemas import (
     DEFAULT_PROOFS_LIMIT,
+    FullAuditProofPayload,
     MAX_PROOFS_LIMIT,
     PROOFS_SCHEMA_VERSION,
     ProofKind,
     ProofPayload,
     ProofState,
+    ProofSummaryPayload,
     ProofWindowSelector,
     ProofsPayload,
     TigerBeetleReconciliationPayload,
@@ -46,6 +48,53 @@ TIGERBEETLE_RECONCILIATION_SCHEMA_VERSION = (
 _TIGERBEETLE_LEDGER_STATUS_MISSING = "tigerbeetle_ledger_status_missing"
 _TIGERBEETLE_LEDGER_STATUS_UNAVAILABLE = "tigerbeetle_ledger_status_unavailable"
 _TIGERBEETLE_LEDGER_NOT_OK = "tigerbeetle_ledger_not_ok"
+_LIVE_SUBMISSION_GATE_CONTRACT_KEYS = (
+    "schema_version",
+    "allowed",
+    "reason",
+    "blocked_reasons",
+    "reason_codes",
+    "blocking_reason",
+    "accepted_sources",
+    "latest_accepted_event_at",
+    "accepted_lag_seconds",
+    "accepted_max_lag_seconds",
+    "accepted_source_state",
+    "excluded_fresher_sources",
+    "per_symbol_coverage",
+    "stale_symbol_coverage",
+    "market_session_state",
+    "regular_session_open",
+    "regular_session_open_at",
+    "regular_session_close_at",
+    "fresh_until",
+    "expires_at",
+    "issued_at",
+    "execution_route",
+    "pipeline_mode",
+    "authority_scope",
+    "configured_live_submit",
+    "configured_live_promotion",
+    "capital_state",
+    "capital_stage",
+    "active_capital_stage",
+    "simple_submit_enabled",
+    "testnet_after_hours_enabled",
+    "read_model_unavailable",
+)
+_CLICKHOUSE_TA_FRESHNESS_CONTRACT_KEYS = (
+    "accepted_sources",
+    "latest_accepted_event_at",
+    "accepted_lag_seconds",
+    "accepted_max_lag_seconds",
+    "accepted_source_state",
+    "excluded_fresher_sources",
+    "per_symbol_coverage",
+    "stale_symbol_coverage",
+    "market_session_state",
+    "blocking_reason",
+    "freshness_reason_codes",
+)
 
 
 def build_proofs_payload(
@@ -76,7 +125,7 @@ def build_proofs_payload(
         generated_at=resolved_generated_at,
         strategy_universe_by_name=strategy_universe_by_name,
     )
-    proofs = [
+    full_audit_proofs = [
         _build_proof(
             session,
             target,
@@ -87,12 +136,12 @@ def build_proofs_payload(
         )
         for target in targets
     ]
-    state_counts = Counter(proof["state"] for proof in proofs)
-    blocker_counts: Counter[str] = Counter()
-    for proof in proofs:
-        blocker_counts.update(proof["blockers"])
-    gate_payload = _live_submission_gate_payload(live_submission_gate)
-    gate_freshness = _live_submission_gate_freshness(gate_payload)
+    full_gate_payload = _live_submission_gate_payload(live_submission_gate)
+    gate_payload = _proofs_live_submission_gate_payload(
+        full_gate_payload,
+        full_audit=full_audit,
+    )
+    gate_freshness = _live_submission_gate_freshness(full_gate_payload)
     tigerbeetle_reconciliation = _tigerbeetle_reconciliation_payload(
         tigerbeetle_ledger_status
     )
@@ -104,46 +153,70 @@ def build_proofs_payload(
         "window": _window_summary(
             window=window,
             generated_at=resolved_generated_at,
-            proofs=proofs,
+            proofs=full_audit_proofs,
         ),
         "live_submission_gate": gate_payload,
         "tigerbeetle_reconciliation": tigerbeetle_reconciliation,
-        "proofs": proofs,
-        "summary": {
-            "target_count": len(targets),
-            "proof_count": len(proofs),
-            "state_counts": dict(sorted(state_counts.items())),
-            "blocker_counts": dict(sorted(blocker_counts.items())),
-            "ready_count": state_counts.get("proof_ready", 0),
-            "import_due_count": state_counts.get("import_due", 0),
-            "blocked_count": state_counts.get("blocked", 0),
-            "live_submission_allowed": bool(gate_payload.get("allowed")),
-            "live_submission_reason": _text_or_none(gate_payload.get("reason")),
-            "accepted_source_state": _text_or_none(
-                gate_freshness.get("accepted_source_state")
-            ),
-            "accepted_lag_seconds": _float_or_none(
-                gate_freshness.get("accepted_lag_seconds")
-            ),
-            "tigerbeetle_reconciliation_ok": bool(
-                tigerbeetle_reconciliation.get("reconciliation_ok")
-            ),
-            "tigerbeetle_reconciliation_stale": bool(
-                tigerbeetle_reconciliation.get("reconciliation_stale")
-            ),
-            "tigerbeetle_reconciliation_age_seconds": _int_or_none(
-                tigerbeetle_reconciliation.get("reconciliation_age_seconds")
-            ),
-            "tigerbeetle_reconciliation_required": bool(
-                tigerbeetle_reconciliation.get("reconciliation_required")
-            ),
-        },
+        "proofs": [
+            _proof_response_payload(proof, full_audit=full_audit)
+            for proof in full_audit_proofs
+        ],
+        "summary": _proofs_summary_payload(
+            target_count=len(targets),
+            full_audit_proofs=full_audit_proofs,
+            gate_payload=gate_payload,
+            gate_freshness=gate_freshness,
+            tigerbeetle_reconciliation=tigerbeetle_reconciliation,
+        ),
         "promotion_authority": {
             "allowed": False,
             "final_promotion_allowed": False,
             "reason": "proof_collection_only",
             "blockers": promotion_blockers,
         },
+    }
+
+
+def _proofs_summary_payload(
+    *,
+    target_count: int,
+    full_audit_proofs: Sequence[FullAuditProofPayload],
+    gate_payload: Mapping[str, object],
+    gate_freshness: Mapping[str, object],
+    tigerbeetle_reconciliation: Mapping[str, object],
+) -> ProofSummaryPayload:
+    state_counts = Counter(proof["state"] for proof in full_audit_proofs)
+    blocker_counts: Counter[str] = Counter()
+    for proof in full_audit_proofs:
+        blocker_counts.update(proof["blockers"])
+    return {
+        "target_count": target_count,
+        "proof_count": len(full_audit_proofs),
+        "state_counts": dict(sorted(state_counts.items())),
+        "blocker_counts": dict(sorted(blocker_counts.items())),
+        "ready_count": state_counts.get("proof_ready", 0),
+        "import_due_count": state_counts.get("import_due", 0),
+        "blocked_count": state_counts.get("blocked", 0),
+        "live_submission_allowed": bool(gate_payload.get("allowed")),
+        "live_submission_reason": _text_or_none(gate_payload.get("reason")),
+        "accepted_source_state": _text_or_none(
+            gate_freshness.get("accepted_source_state")
+        ),
+        "accepted_lag_seconds": _float_or_none(
+            gate_freshness.get("accepted_lag_seconds")
+        ),
+        "tigerbeetle_reconciliation_ok": bool(
+            tigerbeetle_reconciliation.get("reconciliation_ok")
+        ),
+        "tigerbeetle_reconciliation_stale": bool(
+            tigerbeetle_reconciliation.get("reconciliation_stale")
+        ),
+        "tigerbeetle_reconciliation_age_seconds": _int_or_none(
+            tigerbeetle_reconciliation.get("reconciliation_age_seconds")
+        ),
+        "tigerbeetle_reconciliation_required": bool(
+            tigerbeetle_reconciliation.get("reconciliation_required")
+        ),
     }
 
 
@@ -266,6 +339,30 @@ def _live_submission_gate_payload(
     }
 
 
+def _proofs_live_submission_gate_payload(
+    live_submission_gate: Mapping[str, object],
+    *,
+    full_audit: bool,
+) -> dict[str, object]:
+    if full_audit:
+        return dict(live_submission_gate)
+
+    payload = {
+        key: live_submission_gate[key]
+        for key in _LIVE_SUBMISSION_GATE_CONTRACT_KEYS
+        if key in live_submission_gate
+    }
+    freshness = live_submission_gate.get("clickhouse_ta_freshness")
+    if isinstance(freshness, Mapping):
+        typed_freshness = cast(Mapping[str, object], freshness)
+        payload["clickhouse_ta_freshness"] = {
+            key: typed_freshness[key]
+            for key in _CLICKHOUSE_TA_FRESHNESS_CONTRACT_KEYS
+            if key in typed_freshness
+        }
+    return payload
+
+
 def _live_submission_gate_freshness(
     live_submission_gate: Mapping[str, object],
 ) -> Mapping[str, object]:
@@ -364,7 +461,7 @@ def _build_proof(
     full_audit: bool,
     target_account_audit_available: bool,
     live_submission_gate: Mapping[str, object],
-) -> ProofPayload:
+) -> FullAuditProofPayload:
     window_closed = generated_at >= target.window_end
     source_counts = load_source_activity_counts(session, target)
     ledger = load_runtime_ledger(session, target)
@@ -457,6 +554,24 @@ def _proof_state(
     return "proof_ready"
 
 
+def _proof_response_payload(
+    proof: FullAuditProofPayload,
+    *,
+    full_audit: bool,
+) -> ProofPayload | FullAuditProofPayload:
+    if full_audit:
+        return proof
+    return {
+        "proof_id": proof["proof_id"],
+        "identity": proof["identity"],
+        "window": proof["window"],
+        "symbols": proof["symbols"],
+        "state": proof["state"],
+        "blockers": proof["blockers"],
+        "next_action": proof["next_action"],
+    }
+
+
 def _next_action(state: ProofState, blockers: list[str]) -> str:
     if state == "waiting_for_session":
         return "wait_for_session_open"
@@ -492,7 +607,7 @@ def _window_summary(
     *,
     window: ProofWindowSelector,
     generated_at: datetime,
-    proofs: list[ProofPayload],
+    proofs: list[FullAuditProofPayload],
 ) -> dict[str, object]:
     if proofs:
         starts = sorted(str(proof["window"]["start"]) for proof in proofs)

--- a/services/torghut/tests/api/test_trading_api_live_gate_llm.py
+++ b/services/torghut/tests/api/test_trading_api_live_gate_llm.py
@@ -578,7 +578,22 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
                 shared_gate,
             )
             proofs_payload = proofs_response.json()
-            self.assertEqual(proofs_payload["live_submission_gate"], shared_gate)
+            self.assertEqual(
+                proofs_payload["live_submission_gate"],
+                {
+                    "allowed": shared_gate["allowed"],
+                    "reason": shared_gate["reason"],
+                    "blocked_reasons": shared_gate["blocked_reasons"],
+                    "reason_codes": shared_gate["reason_codes"],
+                    "capital_state": shared_gate["capital_state"],
+                    "capital_stage": shared_gate["capital_stage"],
+                    "issued_at": shared_gate["issued_at"],
+                    "expires_at": shared_gate["expires_at"],
+                    "clickhouse_ta_freshness": shared_gate["clickhouse_ta_freshness"],
+                },
+            )
+            self.assertNotIn("segment_summary", proofs_payload["live_submission_gate"])
+            self.assertNotIn("quant_health_ref", proofs_payload["live_submission_gate"])
             self.assertEqual(
                 proofs_payload["summary"]["live_submission_reason"],
                 "promotion_certificate_missing",

--- a/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
+++ b/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
@@ -63,3 +63,44 @@ def test_proofs_payload_configured_collection_targets_keep_paper_stage() -> None
         "AMZN": "buy",
     }
     assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}
+
+
+def test_slim_proofs_payload_still_materializes_target_plan() -> None:
+    plan = paper_route_target_plan_from_payload(
+        {
+            "schema_version": "torghut.proofs.v1",
+            "proofs": [
+                {
+                    "proof_id": "H-PAIRS-01|candidate-1|pairs-v1",
+                    "identity": {
+                        "account_label": "TORGHUT_SIM",
+                        "candidate_id": "candidate-1",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "runtime_strategy_name": "pairs-v1",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_kind": "runtime_window",
+                        "source_plan_ref": "proof-plan:candidate-1",
+                        "strategy_family": "pairs",
+                        "strategy_name": "pairs-v1",
+                        "target_notional": "1000000",
+                    },
+                    "symbols": ["AAPL", "AMZN"],
+                    "window": {
+                        "start": "2026-06-18T13:30:00+00:00",
+                        "end": "2026-06-18T20:00:00+00:00",
+                    },
+                    "state": "waiting_for_session",
+                    "blockers": [],
+                    "next_action": "wait_for_session_open",
+                }
+            ],
+        }
+    )
+
+    assert plan["source"] == "trading_proofs_endpoint"
+    assert plan["target_count"] == 1
+    target = plan["targets"][0]
+    assert target["candidate_id"] == "candidate-1"
+    assert target["window_start"] == "2026-06-18T13:30:00+00:00"
+    assert target["window_end"] == "2026-06-18T20:00:00+00:00"
+    assert target["paper_route_probe_symbols"] == ["AAPL", "AMZN"]

--- a/services/torghut/tests/test_proofs_service.py
+++ b/services/torghut/tests/test_proofs_service.py
@@ -70,6 +70,8 @@ def _gate(
             "target_count": 1,
             "targets": [target],
         },
+        "runtime_ledger_repair_candidates": [{"candidate_id": "audit-only"}],
+        "segment_summary": {"proof_diagnostics": "audit-only"},
     }
 
 
@@ -124,6 +126,7 @@ def _build(
     blockers: list[str] | None = None,
     accepted_lag_seconds: object = 420.5,
     tigerbeetle_ledger_status: dict[str, object] | None = None,
+    full_audit: bool = True,
 ) -> dict[str, object]:
     return build_proofs_payload(
         session,
@@ -134,7 +137,7 @@ def _build(
         tigerbeetle_ledger_status=tigerbeetle_ledger_status,
         generated_at=generated_at,
         window="auto",
-        full_audit=True,
+        full_audit=full_audit,
     )
 
 
@@ -201,6 +204,71 @@ def test_build_proofs_payload_exposes_live_submission_gate_and_freshness_summary
         "reason": "proof_collection_only",
         "blockers": ["live_runtime_ledger_authority_required"],
     }
+
+
+def test_build_proofs_payload_defaults_to_slim_machine_contract() -> None:
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    window_end = datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc)
+    target = _target(window_start, window_end)
+    with _session() as session:
+        payload = _build(
+            session,
+            target=target,
+            generated_at=window_start - timedelta(minutes=1),
+            full_audit=False,
+        )
+
+    assert set(payload["live_submission_gate"]) == {
+        "allowed",
+        "reason",
+        "blocked_reasons",
+        "clickhouse_ta_freshness",
+    }
+    assert "runtime_ledger_repair_candidates" not in payload["live_submission_gate"]
+    assert "segment_summary" not in payload["live_submission_gate"]
+    assert payload["live_submission_gate"]["clickhouse_ta_freshness"] == {
+        "accepted_sources": ["ta"],
+        "latest_accepted_event_at": "2026-06-08T13:29:00+00:00",
+        "accepted_lag_seconds": 420.5,
+        "accepted_source_state": "stale",
+        "blocking_reason": "accepted_ta_signal_stale",
+    }
+    proof = payload["proofs"][0]
+    assert set(proof) == {
+        "proof_id",
+        "identity",
+        "window",
+        "symbols",
+        "state",
+        "blockers",
+        "next_action",
+    }
+    assert proof["state"] == "waiting_for_session"
+    assert "runtime_ledger" not in proof
+    assert "account_state" not in proof
+    assert "source_counts" not in proof
+    assert "health" not in proof
+
+
+def test_build_proofs_payload_full_audit_keeps_diagnostics() -> None:
+    window_start = datetime(2026, 6, 8, 13, 30, tzinfo=timezone.utc)
+    window_end = datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc)
+    target = _target(window_start, window_end)
+    with _session() as session:
+        payload = _build(
+            session,
+            target=target,
+            generated_at=window_start - timedelta(minutes=1),
+            full_audit=True,
+        )
+
+    assert "runtime_ledger_repair_candidates" in payload["live_submission_gate"]
+    assert "segment_summary" in payload["live_submission_gate"]
+    proof = payload["proofs"][0]
+    assert "runtime_ledger" in proof
+    assert "account_state" in proof
+    assert "source_counts" in proof
+    assert "health" in proof
 
 
 def test_build_proofs_payload_blocks_promotion_authority_on_stale_reconciliation() -> (


### PR DESCRIPTION
## Summary

- Splits `/trading/proofs` proof items into a slim default contract and a full-audit contract.
- Keeps target-plan compatibility by preserving proof identity, window, symbols, state, blockers, and next action in the default response.
- Trims default `live_submission_gate` to canonical freshness/gate fields while preserving the full gate when `full_audit=true`.
- Adds regressions for default slim payloads, full-audit diagnostics, and slim proof target-plan materialization.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check app/trading/proofs/service.py app/trading/proofs/schemas.py tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen pytest tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py tests/test_trading_proofs_api.py tests/api/test_trading_api_live_gate_llm.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base "$(git merge-base origin/main HEAD)" --ignore-base-lines --enable=torghut-wildcard-import,torghut-source-string-exec,torghut-generated-source-segment,torghut-dynamic-globals-reexport,torghut-module-replacement,torghut-compat-module-wrapper,torghut-custom-module-class,torghut-file-ruff-noqa,torghut-file-pyright-suppression,torghut-type-ignore,torghut-dynamic-all,torghut-vague-split-name app/trading/proofs/service.py app/trading/proofs/schemas.py tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `cd services/torghut && uv run --frozen python -m compileall app/trading/proofs tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py tests/api/test_trading_api_live_gate_llm.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

Default `/trading/proofs` no longer returns heavy proof audit fields or the full live-submission gate. Consumers that need `runtime_ledger`, `account_state`, `source_counts`, `health`, or full gate diagnostics must request `full_audit=true`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
