### PR TITLE
fix(torghut): preserve proof baseline state

### DIFF
--- a/services/torghut/app/trading/paper_route_target_plan/target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan/target_plan.py
@@ -39,6 +39,7 @@ PAPER_ROUTE_TARGET_NOTIONAL_SOURCE_DECISION_SEED_QTY = Decimal("1")
 CONFIGURED_SIMPLE_LANE_PAPER_COLLECTION_SOURCE_KIND = (
     "configured_simple_lane_paper_data_collection"
 )
+PROOF_ACCOUNT_STATE_MISSING_BLOCKER = "proof_account_state_missing"
 
 
 @dataclass(frozen=True)
@@ -103,10 +104,13 @@ def _target_from_proof_identity(proof: Mapping[str, Any]) -> dict[str, Any]:
     window = _to_str_map(proof.get("window"))
     if not identity:
         return {}
+    account_state_missing = not isinstance(proof.get("account_state"), Mapping)
     account_state = _to_str_map(proof.get("account_state"))
     account_blockers = _text_items(account_state.get("blockers"))
+    if account_state_missing:
+        account_blockers = [PROOF_ACCOUNT_STATE_MISSING_BLOCKER, *account_blockers]
     clean_baseline = account_state.get("clean_baseline")
-    baseline_clean = clean_baseline is not False and not account_blockers
+    baseline_clean = clean_baseline is True and not account_blockers
     raw_symbols = proof.get("symbols")
     if isinstance(raw_symbols, str):
         symbol_values: Sequence[object] = raw_symbols.split(",")

--- a/services/torghut/app/trading/proofs/schemas.py
+++ b/services/torghut/app/trading/proofs/schemas.py
@@ -123,6 +123,7 @@ class ProofPayload(TypedDict):
     identity: ProofIdentityPayload
     window: ProofWindowPayload
     symbols: list[str]
+    account_state: AccountStatePayload
     state: ProofState
     blockers: list[str]
     next_action: str
@@ -131,7 +132,6 @@ class ProofPayload(TypedDict):
 class FullAuditProofPayload(ProofPayload):
     source_counts: SourceCountsPayload
     runtime_ledger: RuntimeLedgerPayload
-    account_state: AccountStatePayload
     health: HealthPayload
     post_cost_pnl_basis: str | None
     post_cost_pnl_value: str | None

--- a/services/torghut/app/trading/proofs/service.py
+++ b/services/torghut/app/trading/proofs/service.py
@@ -566,6 +566,7 @@ def _proof_response_payload(
         "identity": proof["identity"],
         "window": proof["window"],
         "symbols": proof["symbols"],
+        "account_state": proof["account_state"],
         "state": proof["state"],
         "blockers": proof["blockers"],
         "next_action": proof["next_action"],

--- a/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
+++ b/services/torghut/tests/test_paper_route_target_plan_proofs_payload.py
@@ -89,6 +89,10 @@ def test_slim_proofs_payload_still_materializes_target_plan() -> None:
                         "start": "2026-06-18T13:30:00+00:00",
                         "end": "2026-06-18T20:00:00+00:00",
                     },
+                    "account_state": {
+                        "blockers": [],
+                        "clean_baseline": True,
+                    },
                     "state": "waiting_for_session",
                     "blockers": [],
                     "next_action": "wait_for_session_open",
@@ -104,3 +108,46 @@ def test_slim_proofs_payload_still_materializes_target_plan() -> None:
     assert target["window_start"] == "2026-06-18T13:30:00+00:00"
     assert target["window_end"] == "2026-06-18T20:00:00+00:00"
     assert target["paper_route_probe_symbols"] == ["AAPL", "AMZN"]
+
+
+def test_proofs_payload_missing_account_state_fails_closed() -> None:
+    plan = paper_route_target_plan_from_payload(
+        {
+            "schema_version": "torghut.proofs.v1",
+            "proofs": [
+                {
+                    "proof_id": "H-PAIRS-01|candidate-1|pairs-v1",
+                    "identity": {
+                        "account_label": "TORGHUT_SIM",
+                        "candidate_id": "candidate-1",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "runtime_strategy_name": "pairs-v1",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_kind": "runtime_window",
+                        "source_plan_ref": "proof-plan:candidate-1",
+                        "strategy_family": "pairs",
+                        "strategy_name": "pairs-v1",
+                        "target_notional": "1000000",
+                    },
+                    "symbols": ["AAPL"],
+                    "window": {
+                        "start": "2026-06-18T13:30:00+00:00",
+                        "end": "2026-06-18T20:00:00+00:00",
+                    },
+                    "state": "waiting_for_session",
+                    "blockers": [],
+                    "next_action": "wait_for_session_open",
+                }
+            ],
+        }
+    )
+
+    target = plan["targets"][0]
+    assert target["paper_route_clean_window_state"] == "blocked"
+    assert target["paper_route_clean_window_baseline_state"] == {
+        "state": "blocked",
+        "blockers": ["proof_account_state_missing"],
+    }
+    assert target["paper_route_clean_window_baseline_blockers"] == [
+        "proof_account_state_missing"
+    ]

--- a/services/torghut/tests/test_proofs_service.py
+++ b/services/torghut/tests/test_proofs_service.py
@@ -239,15 +239,17 @@ def test_build_proofs_payload_defaults_to_slim_machine_contract() -> None:
         "identity",
         "window",
         "symbols",
+        "account_state",
         "state",
         "blockers",
         "next_action",
     }
     assert proof["state"] == "waiting_for_session"
     assert "runtime_ledger" not in proof
-    assert "account_state" not in proof
     assert "source_counts" not in proof
     assert "health" not in proof
+    assert proof["account_state"]["clean_baseline"] is None
+    assert proof["account_state"]["blockers"] == ["clean_baseline_snapshot_missing"]
 
 
 def test_build_proofs_payload_full_audit_keeps_diagnostics() -> None:


### PR DESCRIPTION
## Summary

- Preserves `account_state` in slim `/trading/proofs` payloads so default proof consumers keep baseline readiness evidence.
- Makes proof-to-target-plan conversion fail closed with `proof_account_state_missing` when a malformed proof omits account state.
- Adds regression coverage for slim proof materialization with account state and missing-account-state blockers.

## Related Issues

Follow-up for Codex review on #12181: https://github.com/proompteng/lab/pull/12181#discussion_r3548751455

## Testing

- `cd services/torghut && uv run --frozen ruff format --check app/trading/proofs/service.py app/trading/proofs/schemas.py app/trading/paper_route_target_plan/target_plan.py tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/proofs/service.py app/trading/proofs/schemas.py app/trading/paper_route_target_plan/target_plan.py tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen pytest tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base "$(git merge-base origin/main HEAD)" --ignore-base-lines --enable=torghut-wildcard-import,torghut-source-string-exec,torghut-generated-source-segment,torghut-dynamic-globals-reexport,torghut-module-replacement,torghut-compat-module-wrapper,torghut-custom-module-class,torghut-file-ruff-noqa,torghut-file-pyright-suppression,torghut-type-ignore,torghut-dynamic-all,torghut-vague-split-name app/trading/proofs/service.py app/trading/proofs/schemas.py app/trading/paper_route_target_plan/target_plan.py tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `cd services/torghut && uv run --frozen python -m compileall app/trading/proofs app/trading/paper_route_target_plan tests/test_proofs_service.py tests/test_paper_route_target_plan_proofs_payload.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
