### PR TITLE
test(torghut): align proof materialization fixture

### DIFF
--- a/services/torghut/tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py
+++ b/services/torghut/tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py
@@ -668,6 +668,10 @@ def test_url_payload_accepts_trading_proofs_materialization_plan(
                 },
                 "symbols": ["AAPL", "AMZN"],
                 "state": "waiting_for_session",
+                "account_state": {
+                    "blockers": [],
+                    "clean_baseline": True,
+                },
             }
         ],
         "summary": {"target_count": 1},


### PR DESCRIPTION
## Summary

- Adds the required minimal `account_state` to the legacy `/trading/proofs` materialization success fixture.
- Keeps the slim proof contract fail-closed when malformed proofs omit account-state baseline data.
- Fixes the red Torghut pytest shard from PR #12182 without changing runtime code.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py::test_url_payload_accepts_trading_proofs_materialization_plan tests/test_paper_route_target_plan_proofs_payload.py -q`
- `cd services/torghut && uv run --frozen ruff format --check tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py tests/test_paper_route_target_plan_proofs_payload.py`
- `cd services/torghut && uv run --frozen ruff check tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py tests/test_paper_route_target_plan_proofs_payload.py`
- `cd services/torghut && uv run --frozen python -m compileall tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py tests/test_paper_route_target_plan_proofs_payload.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main tests/materialize_bounded_paper_route_targets/test_dry_run_is_default_and_rolls_back_materialization.py`
- `cd services/torghut && uv run --frozen python scripts/measure_torghut_tech_debt.py --enforce-ratchet`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
