### PR TITLE
fix(bumba): reduce temporal activity backlog failures

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,13 +71,13 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@50c26221def75ebe05c4788dc2b5e1601e15988e
+              value: bumba@extended-db-activity-timeout-v1
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
-              value: "64"
+              value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY
-              value: "32"
+              value: "4"
             - name: TEMPORAL_STICKY_CACHE_SIZE
-              value: "1024"
+              value: "128"
             - name: TEMPORAL_DETERMINISM_MARKER_MODE
               value: delta
             - name: TEMPORAL_DETERMINISM_MARKER_INTERVAL_TASKS
@@ -126,6 +126,12 @@ spec:
               value: /workspace/.bun-install-cache
             - name: BUMBA_HEALTH_PORT
               value: "3001"
+            - name: BUMBA_GITHUB_EVENT_BATCH_SIZE
+              value: "20"
+            - name: BUMBA_GITHUB_EVENT_MAX_DISPATCH_EVENTS_PER_TICK
+              value: "2"
+            - name: BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS
+              value: "30000"
             - name: REPOSITORY
               value: proompteng/lab
             - name: GITHUB_TOKEN
@@ -197,10 +203,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 256Mi
+              memory: 512Mi
             limits:
               cpu: "1"
-              memory: 1Gi
+              memory: 2Gi
           volumeMounts:
             - name: workspace
               mountPath: /workspace

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-xNgeqqGdtrwynJWfVAmzQiqGBqH+VvLHznZQQ7dapB8=";
-    aarch64-linux = "sha256-xNgeqqGdtrwynJWfVAmzQiqGBqH+VvLHznZQQ7dapB8=";
+    x86_64-linux = "sha256-sOKfHdBKUXIGP5GjiGncU8HquF3TC5KcC0ulqNePOPs=";
+    aarch64-linux = "sha256-sOKfHdBKUXIGP5GjiGncU8HquF3TC5KcC0ulqNePOPs=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/services/bumba/src/event-consumer.test.ts
+++ b/services/bumba/src/event-consumer.test.ts
@@ -7,6 +7,7 @@ const ENV_KEYS = [
   'BUMBA_GITHUB_EVENT_CONSUMER_ENABLED',
   'BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS',
   'BUMBA_GITHUB_EVENT_BATCH_SIZE',
+  'BUMBA_GITHUB_EVENT_MAX_DISPATCH_EVENTS_PER_TICK',
   'BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS',
   'BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES',
   'BUMBA_GITHUB_EVENT_NONTERMINAL_STALE_MS',
@@ -102,6 +103,7 @@ test('resolveConsumerConfig reads environment overrides', () => {
   process.env.BUMBA_GITHUB_EVENT_CONSUMER_ENABLED = 'false'
   process.env.BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS = '2500'
   process.env.BUMBA_GITHUB_EVENT_BATCH_SIZE = '11'
+  process.env.BUMBA_GITHUB_EVENT_MAX_DISPATCH_EVENTS_PER_TICK = '2'
   process.env.BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS = '55'
   process.env.BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES = '3'
   process.env.BUMBA_GITHUB_EVENT_NONTERMINAL_STALE_MS = '600000'
@@ -114,12 +116,186 @@ test('resolveConsumerConfig reads environment overrides', () => {
   expect(config.enabled).toBe(false)
   expect(config.pollIntervalMs).toBe(2500)
   expect(config.batchSize).toBe(11)
+  expect(config.maxDispatchEventsPerTick).toBe(2)
   expect(config.maxEventFileTargets).toBe(55)
   expect(config.maxDispatchFailures).toBe(3)
   expect(config.nonterminalIngestionStaleMs).toBe(600000)
   expect(config.routingAlignmentEnabled).toBe(false)
   expect(config.taskQueue).toBe('jangar')
   expect(config.repoRoot).toBe('/workspace/lab')
+})
+
+test('resolveConsumerConfig defaults dispatch limit to scan batch size', () => {
+  process.env.BUMBA_GITHUB_EVENT_BATCH_SIZE = '17'
+  delete process.env.BUMBA_GITHUB_EVENT_MAX_DISPATCH_EVENTS_PER_TICK
+
+  const config = __test__.resolveConsumerConfig()
+
+  expect(config.batchSize).toBe(17)
+  expect(config.maxDispatchEventsPerTick).toBe(17)
+})
+
+test('runEventConsumerTick scans past waiting rows before applying dispatch limit', async () => {
+  const events = [
+    {
+      id: 'event-waiting-1',
+      delivery_id: 'waiting-1',
+      event_type: 'push',
+      repository: 'proompteng/lab',
+      payload: {},
+    },
+    {
+      id: 'event-waiting-2',
+      delivery_id: 'waiting-2',
+      event_type: 'push',
+      repository: 'proompteng/lab',
+      payload: {},
+    },
+    {
+      id: 'event-dispatch-1',
+      delivery_id: 'dispatch-1',
+      event_type: 'push',
+      repository: 'proompteng/lab',
+      payload: {},
+    },
+    {
+      id: 'event-dispatch-2',
+      delivery_id: 'dispatch-2',
+      event_type: 'push',
+      repository: 'proompteng/lab',
+      payload: {},
+    },
+  ]
+  const processedDeliveries: string[] = []
+  const dispatchedDeliveries: string[] = []
+  const markedProcessed: string[] = []
+
+  await __test__.runEventConsumerTick({
+    db: {} as never,
+    client: {} as never,
+    config: {
+      enabled: true,
+      pollIntervalMs: 10_000,
+      batchSize: events.length,
+      maxDispatchEventsPerTick: 1,
+      maxEventFileTargets: 200,
+      maxDispatchFailures: 6,
+      nonterminalIngestionStaleMs: 12 * 60 * 60 * 1000,
+      routingAlignmentEnabled: false,
+      taskQueue: 'bumba',
+      repoRoot: '/workspace/lab',
+    },
+    inFlightDeliveries: new Set(),
+    dispatchFailureCounts: new Map(),
+    ensureRoutingAlignment: async () => true,
+    listPendingEvents: async (_db, batchSize) => {
+      expect(batchSize).toBe(events.length)
+      return events
+    },
+    processPendingEvent: async (_db, _client, _config, event) => {
+      processedDeliveries.push(event.delivery_id)
+      if (event.delivery_id.startsWith('waiting-')) {
+        return {
+          processed: false,
+          waitingOnIngestion: true,
+          dispatchStarted: 0,
+          dispatchAlreadyStarted: 0,
+          dispatchFailed: 0,
+        }
+      }
+
+      dispatchedDeliveries.push(event.delivery_id)
+      return {
+        processed: false,
+        waitingOnIngestion: false,
+        dispatchStarted: 1,
+        dispatchAlreadyStarted: 0,
+        dispatchFailed: 0,
+      }
+    },
+    markProcessed: async (_db, deliveryId) => {
+      markedProcessed.push(deliveryId)
+    },
+  })
+
+  expect(processedDeliveries).toEqual(['waiting-1', 'waiting-2', 'dispatch-1'])
+  expect(dispatchedDeliveries).toEqual(['dispatch-1'])
+  expect(markedProcessed).toEqual([])
+})
+
+test('runEventConsumerTick does not count already-started rows against dispatch limit', async () => {
+  const events = [
+    {
+      id: 'event-duplicate',
+      delivery_id: 'duplicate-1',
+      event_type: 'push',
+      repository: 'proompteng/lab',
+      payload: {},
+    },
+    {
+      id: 'event-dispatch',
+      delivery_id: 'dispatch-1',
+      event_type: 'push',
+      repository: 'proompteng/lab',
+      payload: {},
+    },
+    {
+      id: 'event-dispatch-2',
+      delivery_id: 'dispatch-2',
+      event_type: 'push',
+      repository: 'proompteng/lab',
+      payload: {},
+    },
+  ]
+  const processedDeliveries: string[] = []
+  const dispatchedDeliveries: string[] = []
+  const failureCounts = new Map<string, number>([['duplicate-1', 1]])
+
+  await __test__.runEventConsumerTick({
+    db: {} as never,
+    client: {} as never,
+    config: {
+      enabled: true,
+      pollIntervalMs: 10_000,
+      batchSize: events.length,
+      maxDispatchEventsPerTick: 1,
+      maxEventFileTargets: 200,
+      maxDispatchFailures: 6,
+      nonterminalIngestionStaleMs: 12 * 60 * 60 * 1000,
+      routingAlignmentEnabled: false,
+      taskQueue: 'bumba',
+      repoRoot: '/workspace/lab',
+    },
+    inFlightDeliveries: new Set(),
+    dispatchFailureCounts: failureCounts,
+    ensureRoutingAlignment: async () => true,
+    listPendingEvents: async () => events,
+    processPendingEvent: async (_db, _client, _config, event) => {
+      processedDeliveries.push(event.delivery_id)
+      if (event.delivery_id === 'duplicate-1') {
+        return {
+          processed: false,
+          waitingOnIngestion: false,
+          dispatchStarted: 0,
+          dispatchAlreadyStarted: 1,
+          dispatchFailed: 0,
+        }
+      }
+
+      dispatchedDeliveries.push(event.delivery_id)
+      return {
+        processed: false,
+        waitingOnIngestion: false,
+        dispatchStarted: 1,
+        dispatchAlreadyStarted: 0,
+        dispatchFailed: 0,
+      }
+    },
+  })
+
+  expect(processedDeliveries).toEqual(['duplicate-1', 'dispatch-1'])
+  expect(dispatchedDeliveries).toEqual(['dispatch-1'])
+  expect(failureCounts.has('duplicate-1')).toBe(false)
 })
 
 test('isWorkflowAlreadyStartedError recognizes Temporal already-started errors', () => {

--- a/services/bumba/src/event-consumer.ts
+++ b/services/bumba/src/event-consumer.ts
@@ -104,6 +104,7 @@ type GithubEventConsumerConfig = {
   enabled: boolean
   pollIntervalMs: number
   batchSize: number
+  maxDispatchEventsPerTick: number
   maxEventFileTargets: number
   maxDispatchFailures: number
   nonterminalIngestionStaleMs: number
@@ -123,7 +124,20 @@ type ProcessEventResult = {
   processed: boolean
   waitingOnIngestion: boolean
   dispatchStarted: number
+  dispatchAlreadyStarted: number
   dispatchFailed: number
+}
+
+type EventConsumerTickDependencies = {
+  db: SqlClient
+  client: TemporalClient
+  config: GithubEventConsumerConfig
+  inFlightDeliveries: Set<string>
+  dispatchFailureCounts: Map<string, number>
+  ensureRoutingAlignment: () => Promise<boolean>
+  listPendingEvents?: typeof listPendingGithubEvents
+  processPendingEvent?: typeof processEvent
+  markProcessed?: typeof markEventProcessed
 }
 
 export type GithubEventConsumer = {
@@ -155,33 +169,37 @@ const parseBoolean = (value: string | undefined, fallback: boolean) => {
   return fallback
 }
 
-const resolveConsumerConfig = (): GithubEventConsumerConfig => ({
-  enabled: parseBoolean(process.env.BUMBA_GITHUB_EVENT_CONSUMER_ENABLED, true),
-  pollIntervalMs: parsePositiveInt(process.env.BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS),
-  batchSize: parsePositiveInt(process.env.BUMBA_GITHUB_EVENT_BATCH_SIZE, DEFAULT_BATCH_SIZE),
-  maxEventFileTargets: parsePositiveInt(
-    process.env.BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS,
-    DEFAULT_MAX_EVENT_FILE_TARGETS,
-  ),
-  maxDispatchFailures: parsePositiveInt(
-    process.env.BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES,
-    DEFAULT_MAX_DISPATCH_FAILURES,
-  ),
-  nonterminalIngestionStaleMs: parsePositiveInt(
-    process.env.BUMBA_GITHUB_EVENT_NONTERMINAL_STALE_MS,
-    DEFAULT_NONTERMINAL_INGESTION_STALE_MS,
-  ),
-  routingAlignmentEnabled: parseBoolean(
-    process.env.BUMBA_GITHUB_EVENT_ROUTING_ALIGNMENT_ENABLED,
-    DEFAULT_ROUTING_ALIGNMENT_ENABLED,
-  ),
-  taskQueue: normalizeOptionalText(process.env.TEMPORAL_TASK_QUEUE) ?? DEFAULT_TASK_QUEUE,
-  repoRoot: resolve(
-    normalizeOptionalText(process.env.BUMBA_WORKSPACE_ROOT) ??
-      normalizeOptionalText(process.env.CODEX_CWD) ??
-      process.cwd(),
-  ),
-})
+const resolveConsumerConfig = (): GithubEventConsumerConfig => {
+  const batchSize = parsePositiveInt(process.env.BUMBA_GITHUB_EVENT_BATCH_SIZE, DEFAULT_BATCH_SIZE)
+  return {
+    enabled: parseBoolean(process.env.BUMBA_GITHUB_EVENT_CONSUMER_ENABLED, true),
+    pollIntervalMs: parsePositiveInt(process.env.BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS),
+    batchSize,
+    maxDispatchEventsPerTick: parsePositiveInt(process.env.BUMBA_GITHUB_EVENT_MAX_DISPATCH_EVENTS_PER_TICK, batchSize),
+    maxEventFileTargets: parsePositiveInt(
+      process.env.BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS,
+      DEFAULT_MAX_EVENT_FILE_TARGETS,
+    ),
+    maxDispatchFailures: parsePositiveInt(
+      process.env.BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES,
+      DEFAULT_MAX_DISPATCH_FAILURES,
+    ),
+    nonterminalIngestionStaleMs: parsePositiveInt(
+      process.env.BUMBA_GITHUB_EVENT_NONTERMINAL_STALE_MS,
+      DEFAULT_NONTERMINAL_INGESTION_STALE_MS,
+    ),
+    routingAlignmentEnabled: parseBoolean(
+      process.env.BUMBA_GITHUB_EVENT_ROUTING_ALIGNMENT_ENABLED,
+      DEFAULT_ROUTING_ALIGNMENT_ENABLED,
+    ),
+    taskQueue: normalizeOptionalText(process.env.TEMPORAL_TASK_QUEUE) ?? DEFAULT_TASK_QUEUE,
+    repoRoot: resolve(
+      normalizeOptionalText(process.env.BUMBA_WORKSPACE_ROOT) ??
+        normalizeOptionalText(process.env.CODEX_CWD) ??
+        process.cwd(),
+    ),
+  }
+}
 
 const withDefaultSslMode = (rawUrl: string) => {
   let url: URL
@@ -483,6 +501,7 @@ const processEvent = async (
       processed: true,
       waitingOnIngestion: false,
       dispatchStarted: 0,
+      dispatchAlreadyStarted: 0,
       dispatchFailed: 0,
     }
   }
@@ -499,6 +518,7 @@ const processEvent = async (
       processed: true,
       waitingOnIngestion: false,
       dispatchStarted: 0,
+      dispatchAlreadyStarted: 0,
       dispatchFailed: 0,
     }
   }
@@ -514,6 +534,7 @@ const processEvent = async (
       processed: true,
       waitingOnIngestion: false,
       dispatchStarted: 0,
+      dispatchAlreadyStarted: 0,
       dispatchFailed: 0,
     }
   }
@@ -526,6 +547,7 @@ const processEvent = async (
         processed: true,
         waitingOnIngestion: false,
         dispatchStarted: 0,
+        dispatchAlreadyStarted: 0,
         dispatchFailed: 0,
       }
     }
@@ -552,6 +574,7 @@ const processEvent = async (
             processed: true,
             waitingOnIngestion: false,
             dispatchStarted: 0,
+            dispatchAlreadyStarted: 0,
             dispatchFailed: 0,
           }
         }
@@ -562,6 +585,7 @@ const processEvent = async (
       processed: false,
       waitingOnIngestion: true,
       dispatchStarted: 0,
+      dispatchAlreadyStarted: 0,
       dispatchFailed: 0,
     }
   }
@@ -569,6 +593,7 @@ const processEvent = async (
   const ref = resolveEventRef(payload)
 
   let started = 0
+  let alreadyStarted = 0
   let failed = 0
 
   for (const filePath of files) {
@@ -577,7 +602,7 @@ const processEvent = async (
       started += 1
     } catch (error) {
       if (isWorkflowAlreadyStartedError(error)) {
-        started += 1
+        alreadyStarted += 1
         continue
       }
 
@@ -591,11 +616,12 @@ const processEvent = async (
     }
   }
 
-  if (started > 0) {
+  if (started > 0 || alreadyStarted > 0) {
     console.info('[bumba][event-consumer] dispatched event workflows', {
       deliveryId: event.delivery_id,
       repository: event.repository,
       started,
+      alreadyStarted,
       failed,
       files: files.length,
     })
@@ -603,6 +629,7 @@ const processEvent = async (
       processed: false,
       waitingOnIngestion: false,
       dispatchStarted: started,
+      dispatchAlreadyStarted: alreadyStarted,
       dispatchFailed: failed,
     }
   }
@@ -617,7 +644,74 @@ const processEvent = async (
     processed: false,
     waitingOnIngestion: false,
     dispatchStarted: 0,
+    dispatchAlreadyStarted: 0,
     dispatchFailed: failed,
+  }
+}
+
+const runEventConsumerTick = async ({
+  db,
+  client,
+  config,
+  inFlightDeliveries,
+  dispatchFailureCounts,
+  ensureRoutingAlignment,
+  listPendingEvents = listPendingGithubEvents,
+  processPendingEvent = processEvent,
+  markProcessed = markEventProcessed,
+}: EventConsumerTickDependencies) => {
+  if (!(await ensureRoutingAlignment())) return
+
+  const events = await listPendingEvents(db, config.batchSize)
+  if (events.length === 0) return
+
+  let dispatchedEvents = 0
+  for (const event of events) {
+    if (dispatchedEvents >= config.maxDispatchEventsPerTick) break
+    if (inFlightDeliveries.has(event.delivery_id)) continue
+
+    inFlightDeliveries.add(event.delivery_id)
+    try {
+      const result = await processPendingEvent(db, client, config, event)
+      if (result.dispatchStarted > 0) {
+        dispatchedEvents += 1
+      }
+
+      if (
+        result.processed ||
+        result.waitingOnIngestion ||
+        result.dispatchStarted > 0 ||
+        result.dispatchAlreadyStarted > 0
+      ) {
+        dispatchFailureCounts.delete(event.delivery_id)
+        continue
+      }
+
+      if (result.dispatchFailed > 0) {
+        const failures = (dispatchFailureCounts.get(event.delivery_id) ?? 0) + 1
+        if (failures >= config.maxDispatchFailures) {
+          console.error('[bumba][event-consumer] giving up on event after repeated dispatch failures', {
+            deliveryId: event.delivery_id,
+            repository: event.repository,
+            dispatchFailed: result.dispatchFailed,
+            attempts: failures,
+          })
+          await markProcessed(db, event.delivery_id)
+          dispatchFailureCounts.delete(event.delivery_id)
+        } else {
+          dispatchFailureCounts.set(event.delivery_id, failures)
+          console.warn('[bumba][event-consumer] retaining event for retry after dispatch failures', {
+            deliveryId: event.delivery_id,
+            repository: event.repository,
+            dispatchFailed: result.dispatchFailed,
+            attempts: failures,
+            maxAttempts: config.maxDispatchFailures,
+          })
+        }
+      }
+    } finally {
+      inFlightDeliveries.delete(event.delivery_id)
+    }
   }
 }
 
@@ -716,49 +810,14 @@ export const createGithubEventConsumer = (
 
   const runTick = async () => {
     if (!started || !db || !client) return
-    if (!(await ensureRoutingAlignment())) return
-
-    const events = await listPendingGithubEvents(db, config.batchSize)
-    if (events.length === 0) return
-
-    for (const event of events) {
-      if (inFlightDeliveries.has(event.delivery_id)) continue
-
-      inFlightDeliveries.add(event.delivery_id)
-      try {
-        const result = await processEvent(db, client, config, event)
-
-        if (result.processed || result.waitingOnIngestion || result.dispatchStarted > 0) {
-          dispatchFailureCounts.delete(event.delivery_id)
-          continue
-        }
-
-        if (result.dispatchFailed > 0) {
-          const failures = (dispatchFailureCounts.get(event.delivery_id) ?? 0) + 1
-          if (failures >= config.maxDispatchFailures) {
-            console.error('[bumba][event-consumer] giving up on event after repeated dispatch failures', {
-              deliveryId: event.delivery_id,
-              repository: event.repository,
-              dispatchFailed: result.dispatchFailed,
-              attempts: failures,
-            })
-            await markEventProcessed(db, event.delivery_id)
-            dispatchFailureCounts.delete(event.delivery_id)
-          } else {
-            dispatchFailureCounts.set(event.delivery_id, failures)
-            console.warn('[bumba][event-consumer] retaining event for retry after dispatch failures', {
-              deliveryId: event.delivery_id,
-              repository: event.repository,
-              dispatchFailed: result.dispatchFailed,
-              attempts: failures,
-              maxAttempts: config.maxDispatchFailures,
-            })
-          }
-        }
-      } finally {
-        inFlightDeliveries.delete(event.delivery_id)
-      }
-    }
+    await runEventConsumerTick({
+      db,
+      client,
+      config,
+      inFlightDeliveries,
+      dispatchFailureCounts,
+      ensureRoutingAlignment,
+    })
   }
 
   const queueTick = () => {
@@ -794,6 +853,7 @@ export const createGithubEventConsumer = (
         pollIntervalMs: config.pollIntervalMs,
         batchSize: config.batchSize,
         maxDispatchFailures: config.maxDispatchFailures,
+        maxDispatchEventsPerTick: config.maxDispatchEventsPerTick,
         nonterminalIngestionStaleMs: config.nonterminalIngestionStaleMs,
         routingAlignmentEnabled: config.routingAlignmentEnabled,
         workerDeploymentName,
@@ -851,5 +911,6 @@ export const __test__ = {
   extractCurrentDeploymentBuildId,
   isTransientRoutingAlignmentError,
   isDeploymentApiUnavailableError,
+  runEventConsumerTick,
   TERMINAL_INGESTION_STATUSES,
 }

--- a/services/bumba/src/workflows/index.test.ts
+++ b/services/bumba/src/workflows/index.test.ts
@@ -47,6 +47,54 @@ const execute = async (executor: WorkflowExecutor, overrides: ExecuteOverrides):
     mode: overrides.mode,
   })
 
+const shiftActivityResults = (entries: Array<[string, ActivityResolution]>, offset: number) =>
+  new Map<string, ActivityResolution>(
+    entries.map(([activityId, resolution]) => {
+      const sequence = Number.parseInt(activityId.slice('activity-'.length), 10)
+      return [`activity-${sequence + offset}`, resolution]
+    }),
+  )
+
+const legacyRepositoryIngestionState = (
+  deliveryId: string,
+  workflowId = 'test-workflow-id',
+): WorkflowDeterminismState => ({
+  commandHistory: [
+    {
+      intent: {
+        id: 'schedule-activity-0',
+        kind: 'schedule-activity',
+        sequence: 0,
+        activityType: 'upsertIngestion',
+        activityId: 'activity-0',
+        taskQueue: 'bumba',
+        input: [
+          {
+            deliveryId,
+            workflowId,
+            status: 'running',
+          },
+        ],
+        timeouts: {
+          scheduleToCloseTimeoutMs: 120_000,
+          startToCloseTimeoutMs: 30_000,
+        },
+        retry: {
+          initialIntervalMs: 2_000,
+          backoffCoefficient: 2,
+          maximumIntervalMs: 30_000,
+          maximumAttempts: 4,
+        },
+        requestEagerExecution: undefined,
+      },
+    },
+  ],
+  randomValues: [],
+  timeValues: [],
+  signals: [],
+  queries: [],
+})
+
 test('enrichFile schedules the first activity and blocks', async () => {
   const { executor, dataConverter } = makeExecutor()
   const input = {
@@ -89,14 +137,16 @@ test('enrichFile schedules ingestion when event delivery is provided', async () 
   const output = await execute(executor, { workflowType: 'enrichFile', arguments: input })
 
   expect(output.completion).toBe('pending')
-  expect(output.commands).toHaveLength(1)
-  const schedule = output.commands[0]
+  expect(output.commands).toHaveLength(2)
+  expect(output.commands[0].commandType).toBe(CommandType.RECORD_MARKER)
+  const schedule = output.commands[1]
   expect(schedule.commandType).toBe(CommandType.SCHEDULE_ACTIVITY_TASK)
   if (schedule.attributes?.case !== 'scheduleActivityTaskCommandAttributes') {
-    throw new Error('Expected schedule activity attributes on first command.')
+    throw new Error('Expected schedule activity attributes on ingestion command.')
   }
   const attrs = schedule.attributes.value
   expect(attrs?.activityType?.name).toBe('upsertIngestion')
+  expect(Number(attrs?.scheduleToCloseTimeout?.seconds ?? 0n)).toBe(900)
 
   const decoded = await decodePayloadsToValues(dataConverter, attrs?.input?.payloads ?? [])
   expect(decoded).toEqual([
@@ -192,25 +242,28 @@ test('enrichFile marks ingestion failed when initial upsertIngestion fails', asy
     eventDeliveryId: 'delivery-1',
   }
 
-  const activityResults = new Map<string, ActivityResolution>([
+  const activityResults = shiftActivityResults(
     [
-      'activity-0',
-      {
-        status: 'failed',
-        error: new Error('upsert timeout'),
-      },
-    ],
-    [
-      'activity-1',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
+      [
+        'activity-0',
+        {
+          status: 'failed',
+          error: new Error('upsert timeout'),
         },
-      },
+      ],
+      [
+        'activity-1',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
+        },
+      ],
     ],
-  ])
+    1,
+  )
 
   const output = await execute(executor, {
     workflowType: 'enrichFile',
@@ -244,134 +297,137 @@ test('enrichFile completes when all activities are resolved', async () => {
     eventDeliveryId: 'delivery-1',
   }
 
-  const activityResults = new Map<string, ActivityResolution>([
+  const activityResults = shiftActivityResults(
     [
-      'activity-0',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
+      [
+        'activity-0',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-1',
-      {
-        status: 'completed',
-        value: {
-          content: 'console.log("hi")',
-          metadata: {
-            repoName: 'lab',
-            repoRef: 'main',
-            repoCommit: 'deadbeef',
-            path: input.filePath,
-            contentHash: 'hash',
-            language: 'ts',
-            byteSize: 17,
-            lineCount: 1,
-            sourceTimestamp: null,
+      ],
+      [
+        'activity-1',
+        {
+          status: 'completed',
+          value: {
+            content: 'console.log("hi")',
+            metadata: {
+              repoName: 'lab',
+              repoRef: 'main',
+              repoCommit: 'deadbeef',
+              path: input.filePath,
+              contentHash: 'hash',
+              language: 'ts',
+              byteSize: 17,
+              lineCount: 1,
+              sourceTimestamp: null,
+              metadata: {},
+            },
+          },
+        },
+      ],
+      [
+        'activity-2',
+        {
+          status: 'completed',
+          value: {
+            astSummary: 'summary',
+            facts: [],
             metadata: {},
           },
         },
-      },
-    ],
-    [
-      'activity-2',
-      {
-        status: 'completed',
-        value: {
-          astSummary: 'summary',
-          facts: [],
-          metadata: {},
+      ],
+      [
+        'activity-4',
+        {
+          status: 'completed',
+          value: {
+            repositoryId: 'repo-id',
+            fileKeyId: 'file-key-id',
+            fileVersionId: 'file-version-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-4',
-      {
-        status: 'completed',
-        value: {
-          repositoryId: 'repo-id',
-          fileKeyId: 'file-key-id',
-          fileVersionId: 'file-version-id',
+      ],
+      [
+        'activity-5',
+        {
+          status: 'completed',
+          value: {
+            eventFileId: 'event-file-id',
+            eventId: 'event-id',
+            fileKeyId: 'file-key-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-5',
-      {
-        status: 'completed',
-        value: {
-          eventFileId: 'event-file-id',
-          eventId: 'event-id',
-          fileKeyId: 'file-key-id',
+      ],
+      [
+        'activity-6',
+        {
+          status: 'completed',
+          value: {},
         },
-      },
-    ],
-    [
-      'activity-6',
-      {
-        status: 'completed',
-        value: {},
-      },
-    ],
-    [
-      'activity-7',
-      {
-        status: 'completed',
-        value: {
-          skipped: true,
-          reason: 'disabled',
-          chunks: 0,
-          embedded: 0,
+      ],
+      [
+        'activity-7',
+        {
+          status: 'completed',
+          value: {
+            skipped: true,
+            reason: 'disabled',
+            chunks: 0,
+            embedded: 0,
+          },
         },
-      },
-    ],
-    [
-      'activity-8',
-      {
-        status: 'completed',
-        value: {
-          summary: 'short summary',
-          enriched: '- bullet',
-          metadata: {},
+      ],
+      [
+        'activity-8',
+        {
+          status: 'completed',
+          value: {
+            summary: 'short summary',
+            enriched: '- bullet',
+            metadata: {},
+          },
         },
-      },
-    ],
-    [
-      'activity-9',
-      {
-        status: 'completed',
-        value: {
-          embedding: [0.1, 0.2, 0.3],
+      ],
+      [
+        'activity-9',
+        {
+          status: 'completed',
+          value: {
+            embedding: [0.1, 0.2, 0.3],
+          },
         },
-      },
-    ],
-    [
-      'activity-10',
-      {
-        status: 'completed',
-        value: {
-          enrichmentId: 'enrichment-id',
+      ],
+      [
+        'activity-10',
+        {
+          status: 'completed',
+          value: {
+            enrichmentId: 'enrichment-id',
+          },
         },
-      },
+      ],
+      [
+        'activity-11',
+        {
+          status: 'completed',
+          value: {},
+        },
+      ],
+      [
+        'activity-12',
+        {
+          status: 'completed',
+          value: {},
+        },
+      ],
     ],
-    [
-      'activity-11',
-      {
-        status: 'completed',
-        value: {},
-      },
-    ],
-    [
-      'activity-12',
-      {
-        status: 'completed',
-        value: {},
-      },
-    ],
-  ])
+    1,
+  )
 
   const output = await execute(executor, {
     workflowType: 'enrichFile',
@@ -413,103 +469,106 @@ test('enrichFile fails when enrichWithModel times out', async () => {
     eventDeliveryId: 'delivery-1',
   }
 
-  const activityResults = new Map<string, ActivityResolution>([
+  const activityResults = shiftActivityResults(
     [
-      'activity-0',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
+      [
+        'activity-0',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-1',
-      {
-        status: 'completed',
-        value: {
-          content: 'console.log("hi")',
-          metadata: {
-            repoName: 'lab',
-            repoRef: 'main',
-            repoCommit: 'deadbeef',
-            path: input.filePath,
-            contentHash: 'hash',
-            language: 'ts',
-            byteSize: 17,
-            lineCount: 1,
-            sourceTimestamp: null,
+      ],
+      [
+        'activity-1',
+        {
+          status: 'completed',
+          value: {
+            content: 'console.log("hi")',
+            metadata: {
+              repoName: 'lab',
+              repoRef: 'main',
+              repoCommit: 'deadbeef',
+              path: input.filePath,
+              contentHash: 'hash',
+              language: 'ts',
+              byteSize: 17,
+              lineCount: 1,
+              sourceTimestamp: null,
+              metadata: {},
+            },
+          },
+        },
+      ],
+      [
+        'activity-2',
+        {
+          status: 'completed',
+          value: {
+            astSummary: 'summary',
+            facts: [],
             metadata: {},
           },
         },
-      },
-    ],
-    [
-      'activity-2',
-      {
-        status: 'completed',
-        value: {
-          astSummary: 'summary',
-          facts: [],
-          metadata: {},
+      ],
+      [
+        'activity-3',
+        {
+          status: 'completed',
+          value: {
+            repositoryId: 'repo-id',
+            fileKeyId: 'file-key-id',
+            fileVersionId: 'file-version-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-3',
-      {
-        status: 'completed',
-        value: {
-          repositoryId: 'repo-id',
-          fileKeyId: 'file-key-id',
-          fileVersionId: 'file-version-id',
+      ],
+      [
+        'activity-4',
+        {
+          status: 'completed',
+          value: {
+            eventFileId: 'event-file-id',
+            eventId: 'event-id',
+            fileKeyId: 'file-key-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-4',
-      {
-        status: 'completed',
-        value: {
-          eventFileId: 'event-file-id',
-          eventId: 'event-id',
-          fileKeyId: 'file-key-id',
+      ],
+      [
+        'activity-5',
+        {
+          status: 'completed',
+          value: {},
         },
-      },
-    ],
-    [
-      'activity-5',
-      {
-        status: 'completed',
-        value: {},
-      },
-    ],
-    [
-      'activity-6',
-      {
-        status: 'completed',
-        value: { skipped: true, reason: 'disabled', chunks: 0, embedded: 0 },
-      },
-    ],
-    [
-      'activity-7',
-      {
-        status: 'failed',
-        error: new Error('completion request timed out after 60000ms'),
-      },
-    ],
-    [
-      'activity-8',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
+      ],
+      [
+        'activity-6',
+        {
+          status: 'completed',
+          value: { skipped: true, reason: 'disabled', chunks: 0, embedded: 0 },
         },
-      },
+      ],
+      [
+        'activity-7',
+        {
+          status: 'failed',
+          error: new Error('completion request timed out after 60000ms'),
+        },
+      ],
+      [
+        'activity-8',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
+        },
+      ],
     ],
-  ])
+    1,
+  )
 
   const output = await execute(executor, {
     workflowType: 'enrichFile',
@@ -532,146 +591,149 @@ test('enrichFile schedules cleanup when force is enabled', async () => {
     force: true,
   }
 
-  const activityResults = new Map<string, ActivityResolution>([
+  const activityResults = shiftActivityResults(
     [
-      'activity-0',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
+      [
+        'activity-0',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-1',
-      {
-        status: 'completed',
-        value: {
-          content: 'console.log("hi")',
-          metadata: {
-            repoName: 'lab',
-            repoRef: 'main',
-            repoCommit: 'deadbeef',
-            path: input.filePath,
-            contentHash: 'hash',
-            language: 'ts',
-            byteSize: 17,
-            lineCount: 1,
-            sourceTimestamp: null,
+      ],
+      [
+        'activity-1',
+        {
+          status: 'completed',
+          value: {
+            content: 'console.log("hi")',
+            metadata: {
+              repoName: 'lab',
+              repoRef: 'main',
+              repoCommit: 'deadbeef',
+              path: input.filePath,
+              contentHash: 'hash',
+              language: 'ts',
+              byteSize: 17,
+              lineCount: 1,
+              sourceTimestamp: null,
+              metadata: {},
+            },
+          },
+        },
+      ],
+      [
+        'activity-2',
+        {
+          status: 'completed',
+          value: {
+            fileVersions: 1,
+            enrichments: 1,
+            embeddings: 1,
+            facts: 0,
+          },
+        },
+      ],
+      [
+        'activity-3',
+        {
+          status: 'completed',
+          value: {
+            astSummary: 'summary',
+            facts: [],
             metadata: {},
           },
         },
-      },
-    ],
-    [
-      'activity-2',
-      {
-        status: 'completed',
-        value: {
-          fileVersions: 1,
-          enrichments: 1,
-          embeddings: 1,
-          facts: 0,
+      ],
+      [
+        'activity-5',
+        {
+          status: 'completed',
+          value: {
+            repositoryId: 'repo-id',
+            fileKeyId: 'file-key-id',
+            fileVersionId: 'file-version-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-3',
-      {
-        status: 'completed',
-        value: {
-          astSummary: 'summary',
-          facts: [],
-          metadata: {},
+      ],
+      [
+        'activity-6',
+        {
+          status: 'completed',
+          value: {
+            eventFileId: 'event-file-id',
+            eventId: 'event-id',
+            fileKeyId: 'file-key-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-5',
-      {
-        status: 'completed',
-        value: {
-          repositoryId: 'repo-id',
-          fileKeyId: 'file-key-id',
-          fileVersionId: 'file-version-id',
+      ],
+      [
+        'activity-7',
+        {
+          status: 'completed',
+          value: {},
         },
-      },
-    ],
-    [
-      'activity-6',
-      {
-        status: 'completed',
-        value: {
-          eventFileId: 'event-file-id',
-          eventId: 'event-id',
-          fileKeyId: 'file-key-id',
+      ],
+      [
+        'activity-8',
+        {
+          status: 'completed',
+          value: {
+            skipped: true,
+            reason: 'disabled',
+            chunks: 0,
+            embedded: 0,
+          },
         },
-      },
-    ],
-    [
-      'activity-7',
-      {
-        status: 'completed',
-        value: {},
-      },
-    ],
-    [
-      'activity-8',
-      {
-        status: 'completed',
-        value: {
-          skipped: true,
-          reason: 'disabled',
-          chunks: 0,
-          embedded: 0,
+      ],
+      [
+        'activity-9',
+        {
+          status: 'completed',
+          value: {
+            summary: 'short summary',
+            enriched: '- bullet',
+            metadata: {},
+          },
         },
-      },
-    ],
-    [
-      'activity-9',
-      {
-        status: 'completed',
-        value: {
-          summary: 'short summary',
-          enriched: '- bullet',
-          metadata: {},
+      ],
+      [
+        'activity-10',
+        {
+          status: 'completed',
+          value: {
+            embedding: [0.1, 0.2, 0.3],
+          },
         },
-      },
-    ],
-    [
-      'activity-10',
-      {
-        status: 'completed',
-        value: {
-          embedding: [0.1, 0.2, 0.3],
+      ],
+      [
+        'activity-11',
+        {
+          status: 'completed',
+          value: {
+            enrichmentId: 'enrichment-id',
+          },
         },
-      },
-    ],
-    [
-      'activity-11',
-      {
-        status: 'completed',
-        value: {
-          enrichmentId: 'enrichment-id',
+      ],
+      [
+        'activity-12',
+        {
+          status: 'completed',
+          value: {},
         },
-      },
+      ],
+      [
+        'activity-13',
+        {
+          status: 'completed',
+          value: {},
+        },
+      ],
     ],
-    [
-      'activity-12',
-      {
-        status: 'completed',
-        value: {},
-      },
-    ],
-    [
-      'activity-13',
-      {
-        status: 'completed',
-        value: {},
-      },
-    ],
-  ])
+    1,
+  )
 
   const output = await execute(executor, {
     workflowType: 'enrichFile',
@@ -949,6 +1011,95 @@ test('enrichRepository completes when child workflows signal completion', async 
   })
 })
 
+test('enrichRepository keeps legacy upsert timeout when completing old event histories', async () => {
+  const { executor, dataConverter } = makeExecutor()
+  const files = ['path/to/file-0.ts', 'path/to/file-1.ts']
+  const input = {
+    repoRoot: '/workspace/lab/.worktrees/bumba',
+    repository: 'proompteng/lab',
+    eventDeliveryId: 'delivery-legacy-complete',
+    files,
+  }
+  const workflowId = 'repo-workflow-legacy-complete'
+  const runId = 'run-legacy-complete'
+
+  const initial = await execute(executor, {
+    workflowType: 'enrichRepository',
+    arguments: input,
+    workflowId,
+    runId,
+    determinismState: legacyRepositoryIngestionState(input.eventDeliveryId, workflowId),
+    activityResults: new Map<string, ActivityResolution>([
+      [
+        'activity-0',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
+        },
+      ],
+    ]),
+  })
+
+  expect(initial.completion).toBe('pending')
+
+  const signalDeliveries = files.map((_filePath, index) => ({
+    name: '__childWorkflowCompleted',
+    args: [
+      {
+        workflowId: `${workflowId}-child-${runId}-${index}`,
+        status: 'completed',
+      },
+    ],
+  }))
+
+  const completion = await execute(executor, {
+    workflowType: 'enrichRepository',
+    arguments: input,
+    workflowId,
+    runId,
+    determinismState: initial.determinismState,
+    activityResults: new Map<string, ActivityResolution>([
+      [
+        'activity-0',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
+        },
+      ],
+    ]),
+    signalDeliveries,
+    pendingChildWorkflows: new Set(),
+  })
+
+  expect(completion.completion).toBe('pending')
+
+  const upsertSchedule = completion.commands.find((command) => {
+    const attrs =
+      command.attributes?.case === 'scheduleActivityTaskCommandAttributes' ? command.attributes.value : undefined
+    return attrs?.activityType?.name === 'upsertIngestion'
+  })
+  if (upsertSchedule?.attributes?.case !== 'scheduleActivityTaskCommandAttributes') {
+    throw new Error('Expected final upsertIngestion schedule command.')
+  }
+  const attrs = upsertSchedule.attributes.value
+  expect(Number(attrs.scheduleToCloseTimeout?.seconds ?? 0n)).toBe(120)
+
+  const decoded = await decodePayloadsToValues(dataConverter, attrs.input?.payloads ?? [])
+  expect(decoded).toEqual([
+    {
+      deliveryId: input.eventDeliveryId,
+      workflowId,
+      status: 'completed',
+    },
+  ])
+})
+
 test('enrichRepository fails when child workflows report failures', async () => {
   const { executor } = makeExecutor()
   const files = ['path/to/file-0.ts', 'path/to/file-1.ts']
@@ -1005,6 +1156,67 @@ test('enrichRepository fails when child workflows report failures', async () => 
   expect((completion.failure as Error).message).toContain('1 child workflows failed')
 })
 
+test('enrichRepository keeps legacy upsert timeout on old event catch-path failures', async () => {
+  const { executor, dataConverter } = makeExecutor()
+  const input = {
+    repoRoot: '/workspace/lab/.worktrees/bumba',
+    repository: 'proompteng/lab',
+    commit: 'deadbeef',
+    pathPrefix: 'services',
+    eventDeliveryId: 'delivery-legacy-failure',
+  }
+  const workflowId = 'repo-workflow-legacy-failure'
+
+  const output = await execute(executor, {
+    workflowType: 'enrichRepository',
+    arguments: input,
+    workflowId,
+    determinismState: legacyRepositoryIngestionState(input.eventDeliveryId, workflowId),
+    activityResults: new Map<string, ActivityResolution>([
+      [
+        'activity-0',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
+        },
+      ],
+      [
+        'activity-1',
+        {
+          status: 'failed',
+          error: new Error('list timeout'),
+        },
+      ],
+    ]),
+  })
+
+  expect(output.completion).toBe('pending')
+
+  const upsertSchedule = output.commands.find((command) => {
+    const attrs =
+      command.attributes?.case === 'scheduleActivityTaskCommandAttributes' ? command.attributes.value : undefined
+    return attrs?.activityType?.name === 'upsertIngestion'
+  })
+  if (upsertSchedule?.attributes?.case !== 'scheduleActivityTaskCommandAttributes') {
+    throw new Error('Expected catch-path upsertIngestion schedule command.')
+  }
+  const attrs = upsertSchedule.attributes.value
+  expect(Number(attrs.scheduleToCloseTimeout?.seconds ?? 0n)).toBe(120)
+
+  const decoded = await decodePayloadsToValues(dataConverter, attrs.input?.payloads ?? [])
+  expect(decoded).toEqual([
+    {
+      deliveryId: input.eventDeliveryId,
+      workflowId,
+      status: 'failed',
+      error: 'list timeout',
+    },
+  ])
+})
+
 test('enrichRepository marks ingestion failed when initial upsertIngestion fails', async () => {
   const { executor } = makeExecutor()
   const input = {
@@ -1014,25 +1226,28 @@ test('enrichRepository marks ingestion failed when initial upsertIngestion fails
     files: ['path/to/file.ts'],
   }
 
-  const activityResults = new Map<string, ActivityResolution>([
+  const activityResults = shiftActivityResults(
     [
-      'activity-0',
-      {
-        status: 'failed',
-        error: new Error('upsert timeout'),
-      },
-    ],
-    [
-      'activity-1',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
+      [
+        'activity-0',
+        {
+          status: 'failed',
+          error: new Error('upsert timeout'),
         },
-      },
+      ],
+      [
+        'activity-1',
+        {
+          status: 'completed',
+          value: {
+            ingestionId: 'ingestion-id',
+            eventId: 'event-id',
+          },
+        },
+      ],
     ],
-  ])
+    1,
+  )
 
   const output = await execute(executor, {
     workflowType: 'enrichRepository',

--- a/services/bumba/src/workflows/index.ts
+++ b/services/bumba/src/workflows/index.ts
@@ -56,19 +56,24 @@ const createEmbeddingTimeouts = {
   scheduleToCloseTimeoutMs: 900_000,
 }
 
+const LEGACY_PERSIST_SCHEDULE_TO_CLOSE_MS = 300_000
+const LEGACY_UPSERT_SCHEDULE_TO_CLOSE_MS = 120_000
+const EXTENDED_DB_SCHEDULE_TO_CLOSE_MS = 900_000
+const EXTENDED_DB_ACTIVITY_TIMEOUT_PATCH = 'bumba.extendedDbActivityScheduleToClose.v1'
+
 const persistFileVersionTimeouts = {
   startToCloseTimeoutMs: 60_000,
-  scheduleToCloseTimeoutMs: 300_000,
+  scheduleToCloseTimeoutMs: EXTENDED_DB_SCHEDULE_TO_CLOSE_MS,
 }
 
 const persistEnrichmentRecordTimeouts = {
   startToCloseTimeoutMs: 60_000,
-  scheduleToCloseTimeoutMs: 300_000,
+  scheduleToCloseTimeoutMs: EXTENDED_DB_SCHEDULE_TO_CLOSE_MS,
 }
 
 const persistEmbeddingTimeouts = {
   startToCloseTimeoutMs: 60_000,
-  scheduleToCloseTimeoutMs: 300_000,
+  scheduleToCloseTimeoutMs: EXTENDED_DB_SCHEDULE_TO_CLOSE_MS,
 }
 
 const persistFactsTimeouts = {
@@ -83,23 +88,62 @@ const indexFileChunksTimeouts = {
 
 const upsertIngestionTimeouts = {
   startToCloseTimeoutMs: 30_000,
-  scheduleToCloseTimeoutMs: 120_000,
+  scheduleToCloseTimeoutMs: EXTENDED_DB_SCHEDULE_TO_CLOSE_MS,
 }
 
 const upsertEventFileTimeouts = {
   startToCloseTimeoutMs: 30_000,
-  scheduleToCloseTimeoutMs: 120_000,
+  scheduleToCloseTimeoutMs: EXTENDED_DB_SCHEDULE_TO_CLOSE_MS,
 }
 
 const upsertIngestionTargetTimeouts = {
   startToCloseTimeoutMs: 30_000,
-  scheduleToCloseTimeoutMs: 120_000,
+  scheduleToCloseTimeoutMs: EXTENDED_DB_SCHEDULE_TO_CLOSE_MS,
 }
 
 const cleanupEnrichmentTimeouts = {
   startToCloseTimeoutMs: 120_000,
   scheduleToCloseTimeoutMs: 600_000,
 }
+
+const legacyDbActivityTimeouts = {
+  persistFileVersion: {
+    ...persistFileVersionTimeouts,
+    scheduleToCloseTimeoutMs: LEGACY_PERSIST_SCHEDULE_TO_CLOSE_MS,
+  },
+  persistEnrichmentRecord: {
+    ...persistEnrichmentRecordTimeouts,
+    scheduleToCloseTimeoutMs: LEGACY_PERSIST_SCHEDULE_TO_CLOSE_MS,
+  },
+  persistEmbedding: {
+    ...persistEmbeddingTimeouts,
+    scheduleToCloseTimeoutMs: LEGACY_PERSIST_SCHEDULE_TO_CLOSE_MS,
+  },
+  upsertIngestion: {
+    ...upsertIngestionTimeouts,
+    scheduleToCloseTimeoutMs: LEGACY_UPSERT_SCHEDULE_TO_CLOSE_MS,
+  },
+  upsertEventFile: {
+    ...upsertEventFileTimeouts,
+    scheduleToCloseTimeoutMs: LEGACY_UPSERT_SCHEDULE_TO_CLOSE_MS,
+  },
+  upsertIngestionTarget: {
+    ...upsertIngestionTargetTimeouts,
+    scheduleToCloseTimeoutMs: LEGACY_UPSERT_SCHEDULE_TO_CLOSE_MS,
+  },
+}
+
+const extendedDbActivityTimeouts = {
+  persistFileVersion: persistFileVersionTimeouts,
+  persistEnrichmentRecord: persistEnrichmentRecordTimeouts,
+  persistEmbedding: persistEmbeddingTimeouts,
+  upsertIngestion: upsertIngestionTimeouts,
+  upsertEventFile: upsertEventFileTimeouts,
+  upsertIngestionTarget: upsertIngestionTargetTimeouts,
+}
+
+const resolveDbActivityTimeouts = (useExtendedTimeouts: boolean) =>
+  useExtendedTimeouts ? extendedDbActivityTimeouts : legacyDbActivityTimeouts
 
 const PARENT_CLOSE_POLICY_ABANDON = 2
 const DEFAULT_CHILD_WORKFLOW_BATCH_SIZE = 24
@@ -224,6 +268,14 @@ export const workflows = [
     const { repoRoot, filePath, repository, ref, commit, context, eventDeliveryId, force } = input
 
     return Effect.gen(function* () {
+      let dbActivityTimeouts: ReturnType<typeof resolveDbActivityTimeouts> | null = null
+      const getDbActivityTimeouts = () => {
+        if (!dbActivityTimeouts) {
+          dbActivityTimeouts = resolveDbActivityTimeouts(determinism.patched(EXTENDED_DB_ACTIVITY_TIMEOUT_PATCH))
+        }
+        return dbActivityTimeouts
+      }
+
       logWorkflow('enrichFile.started', {
         workflowId: info.workflowId,
         runId: info.runId,
@@ -257,7 +309,7 @@ export const workflows = [
             },
           ],
           {
-            ...upsertIngestionTimeouts,
+            ...getDbActivityTimeouts().upsertIngestion,
             retry: activityRetry,
           },
         )
@@ -275,7 +327,7 @@ export const workflows = [
               },
             ],
             {
-              ...upsertIngestionTimeouts,
+              ...getDbActivityTimeouts().upsertIngestion,
               retry: activityRetry,
             },
           )) as UpsertIngestionOutput
@@ -423,7 +475,7 @@ export const workflows = [
               },
             ],
             {
-              ...persistFileVersionTimeouts,
+              ...getDbActivityTimeouts().persistFileVersion,
               retry: activityRetry,
             },
           ) as Effect.Effect<PersistFileVersionOutput, unknown, never>
@@ -441,7 +493,7 @@ export const workflows = [
                   },
                 ],
                 {
-                  ...upsertEventFileTimeouts,
+                  ...getDbActivityTimeouts().upsertEventFile,
                   retry: activityRetry,
                 },
               )
@@ -458,7 +510,7 @@ export const workflows = [
                   },
                 ],
                 {
-                  ...upsertIngestionTargetTimeouts,
+                  ...getDbActivityTimeouts().upsertIngestionTarget,
                   retry: activityRetry,
                 },
               )
@@ -533,7 +585,7 @@ export const workflows = [
             },
           ],
           {
-            ...persistEnrichmentRecordTimeouts,
+            ...getDbActivityTimeouts().persistEnrichmentRecord,
             retry: activityRetry,
           },
         )) as PersistEnrichmentRecordOutput
@@ -547,7 +599,7 @@ export const workflows = [
             },
           ],
           {
-            ...persistEmbeddingTimeouts,
+            ...getDbActivityTimeouts().persistEmbedding,
             retry: activityRetry,
           },
         )
@@ -618,8 +670,16 @@ export const workflows = [
     name: 'enrichRepository',
     schema: EnrichRepositoryInput,
     signals: enrichRepositorySignals,
-    handler: ({ input, activities, childWorkflows, signals, info }) =>
+    handler: ({ input, activities, childWorkflows, signals, info, determinism }) =>
       Effect.gen(function* () {
+        let dbActivityTimeouts: ReturnType<typeof resolveDbActivityTimeouts> | null = null
+        const getDbActivityTimeouts = () => {
+          if (!dbActivityTimeouts) {
+            dbActivityTimeouts = resolveDbActivityTimeouts(determinism.patched(EXTENDED_DB_ACTIVITY_TIMEOUT_PATCH))
+          }
+          return dbActivityTimeouts
+        }
+
         const { repoRoot, repository, ref, commit, context, pathPrefix, maxFiles, eventDeliveryId } = input
 
         const childWorkflowBatchSize = resolveChildWorkflowConcurrency(input)
@@ -651,7 +711,7 @@ export const workflows = [
                   },
                 ],
                 {
-                  ...upsertIngestionTimeouts,
+                  ...getDbActivityTimeouts().upsertIngestion,
                   retry: activityRetry,
                 },
               )) as UpsertIngestionOutput)
@@ -787,7 +847,7 @@ export const workflows = [
                 },
               ],
               {
-                ...upsertIngestionTimeouts,
+                ...getDbActivityTimeouts().upsertIngestion,
                 retry: activityRetry,
               },
             )
@@ -834,7 +894,7 @@ export const workflows = [
                   },
                 ],
                 {
-                  ...upsertIngestionTimeouts,
+                  ...getDbActivityTimeouts().upsertIngestion,
                   retry: activityRetry,
                 },
               )


### PR DESCRIPTION
## Summary

- Reduce Bumba Temporal worker concurrency and sticky cache size to avoid activity-slot hoarding during backlog drains.
- Increase Bumba memory requests/limits and throttle GitHub event ingestion starts while keeping the scan window large enough to skip past waiting ingestions.
- Gate extended Bumba DB activity schedule windows behind a Temporal determinism patch so old histories replay with legacy 120s/300s timeouts.
- Bump the pinned Bumba Temporal worker build ID for the workflow patch so new marker histories are separated from old pollers.
- Refresh the Bumba Nix dependency hash from the CI-observed fixed-output derivation.

## Related Issues

None

## Testing

- `bun test services/bumba/src/workflows/index.test.ts services/bumba/src/event-consumer.test.ts`
- `bunx oxfmt --check argocd/applications/bumba/deployment.yaml services/bumba/src/workflows/index.ts services/bumba/src/workflows/index.test.ts services/bumba/src/event-consumer.ts services/bumba/src/event-consumer.test.ts`
- `git diff --check`
- Regression coverage now includes old-history `enrichRepository` final-status and catch-path failed-ingestion upserts retaining legacy 120s schedule-to-close.
- Regression coverage now includes `runEventConsumerTick` scanning past waiting rows before enforcing `maxDispatchEventsPerTick` on actual dispatches.
- Regression coverage now includes already-started workflow rows not counting against `maxDispatchEventsPerTick` while still clearing retry state.
- CI log check: bumba amd64 image job reported `bumba-bun-deps` got `sha256-sOKfHdBKUXIGP5GjiGncU8HquF3TC5KcC0ulqNePOPs=` after review fixes.
- Review threads replied and resolved: replay-safe timeout gating, repository completion/catch-path timeout gating, worker build-id bump, event-consumer scan/dispatch throttle, dispatch-scanning regression coverage, and already-started dispatch cap accounting.
- Live Temporal check before review fixes: `bumba-live-final-canary-20260709-045751` completed on task queue `bumba` in 9.13s with result id `071a612a-daa1-494d-90d2-3e8d793ae439`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.