### PR TITLE
test(torghut): align live proof gate contract

### DIFF
--- a/services/torghut/tests/api/test_trading_api_live_gate_llm.py
+++ b/services/torghut/tests/api/test_trading_api_live_gate_llm.py
@@ -584,14 +584,14 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
                     "allowed": shared_gate["allowed"],
                     "reason": shared_gate["reason"],
                     "blocked_reasons": shared_gate["blocked_reasons"],
-                    "reason_codes": shared_gate["reason_codes"],
-                    "capital_state": shared_gate["capital_state"],
-                    "capital_stage": shared_gate["capital_stage"],
-                    "issued_at": shared_gate["issued_at"],
-                    "expires_at": shared_gate["expires_at"],
                     "clickhouse_ta_freshness": shared_gate["clickhouse_ta_freshness"],
                 },
             )
+            self.assertNotIn("capital_state", proofs_payload["live_submission_gate"])
+            self.assertNotIn("capital_stage", proofs_payload["live_submission_gate"])
+            self.assertNotIn("expires_at", proofs_payload["live_submission_gate"])
+            self.assertNotIn("issued_at", proofs_payload["live_submission_gate"])
+            self.assertNotIn("reason_codes", proofs_payload["live_submission_gate"])
             self.assertNotIn("segment_summary", proofs_payload["live_submission_gate"])
             self.assertNotIn("quant_health_ref", proofs_payload["live_submission_gate"])
             self.assertEqual(


### PR DESCRIPTION
## Summary

- Update the live-gate API consistency test to expect the slim default `/trading/proofs` gate contract.
- Add explicit negative assertions for the removed noisy default gate keys: `reason_codes`, `capital_state`, `capital_stage`, `issued_at`, and `expires_at`.
- Fix the `Pytest shard 1` failure from main after #12187 merged.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_live_gate_llm.py::TestTradingApiLiveGateLlm::test_live_submission_gate_matches_status_health_and_readyz tests/test_proofs_service.py::test_build_proofs_payload_defaults_to_slim_machine_contract -q`
- `cd services/torghut && uv run --frozen ruff format --check tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen ruff check tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen python -m compileall tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main tests/api/test_trading_api_live_gate_llm.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
