### PR TITLE
chore(torghut): promote ta image sha-0cbfd793dff3abc006eb2d511d5467cf35168a05

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:01b49b3e92e068b162967881d8b7e6393bc5a3eb0c2268a66d7a017a9c2f89ad
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 27
+  restartNonce: 28
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -88,9 +88,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-6652ce0838c223a5542b45631e210082d27ae8cc
+              value: sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
             - name: TORGHUT_TA_COMMIT
-              value: 6652ce0838c223a5542b45631e210082d27ae8cc
+              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:01b49b3e92e068b162967881d8b7e6393bc5a3eb0c2268a66d7a017a9c2f89ad
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 29
+  restartNonce: 30
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-6652ce0838c223a5542b45631e210082d27ae8cc
+              value: sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
             - name: TORGHUT_TA_COMMIT
-              value: 6652ce0838c223a5542b45631e210082d27ae8cc
+              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,9 +8,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:01b49b3e92e068b162967881d8b7e6393bc5a3eb0c2268a66d7a017a9c2f89ad
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 25
+  restartNonce: 26
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -159,9 +159,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-6652ce0838c223a5542b45631e210082d27ae8cc
+              value: sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
             - name: TORGHUT_TA_COMMIT
-              value: 6652ce0838c223a5542b45631e210082d27ae8cc
+              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `0cbfd793dff3abc006eb2d511d5467cf35168a05`
- Image tag: `sha-0cbfd793dff3abc006eb2d511d5467cf35168a05`
- Image digest: `sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12`
- Manifests: live TA, sim TA, options TA