### PR TITLE
chore(torghut): promote ws image sha-0cbfd793dff3abc006eb2d511d5467cf35168a05

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7ac33279a0a16298b9a24f3ce32f465203ec840093d6346f43e1f2f0b951ea9f
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:2789b8b87ba8547cb6f00e32838004c0c3d753e651f16070c741587b7e483567
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
+              value: main-sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
             - name: TORGHUT_WS_COMMIT
-              value: de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
+              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7ac33279a0a16298b9a24f3ce32f465203ec840093d6346f43e1f2f0b951ea9f
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:2789b8b87ba8547cb6f00e32838004c0c3d753e651f16070c741587b7e483567
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
+              value: main-sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
             - name: TORGHUT_WS_COMMIT
-              value: de62642ebe022f1ab81e6d63f0a999bb2fec3d7b
+              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `0cbfd793dff3abc006eb2d511d5467cf35168a05`
- Image tag: `sha-0cbfd793dff3abc006eb2d511d5467cf35168a05`
- Image digest: `sha256:2789b8b87ba8547cb6f00e32838004c0c3d753e651f16070c741587b7e483567`