### PR TITLE
fix(arc): raise lab runner caps to 25

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -28,7 +28,7 @@ spec:
           scaleSetLabels:
             - arc-arm64
           minRunners: 1
-          maxRunners: 10
+          maxRunners: 25
           listenerTemplate:
             spec:
               dnsConfig:
@@ -153,7 +153,7 @@ spec:
           scaleSetLabels:
             - arc-amd64
           minRunners: 1
-          maxRunners: 10
+          maxRunners: 25
           listenerTemplate:
             spec:
               dnsConfig:

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -70,10 +70,10 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerReleaseWorkflow).not.toContain('PersistentVolumeClaim')
   })
 
-  it('allows ten concurrent lab ARC runners per architecture and keeps runners warm', () => {
-    expect(runnerScaleSetBlock('arc-arm64')).toContain('maxRunners: 10')
+  it('allows twenty-five concurrent lab ARC runners per architecture and keeps runners warm', () => {
+    expect(runnerScaleSetBlock('arc-arm64')).toContain('maxRunners: 25')
     expect(runnerScaleSetBlock('arc-arm64')).toContain('minRunners: 1')
-    expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 10')
+    expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 25')
     expect(runnerScaleSetBlock('arc-amd64')).toContain('minRunners: 1')
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('maxRunners: 5')
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('minRunners: 1')


### PR DESCRIPTION
## Summary

- raises `arc-arm64` maximum runners from 10 to 25
- raises `arc-amd64` maximum runners from 10 to 25
- updates the ARC runner config test to assert the new 25-runner cap

## Related Issues

None

## Testing

- `git diff --check`
- `bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `bunx oxfmt --check argocd/applications/arc/application.yaml packages/scripts/src/shared/__tests__/arc-runner.test.ts`

## Breaking Changes

None. This increases ARC concurrency capacity only; `analysis-arm64` remains unchanged at 5.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
