### PR TITLE
fix(torghut): make market data smoke session aware

### DIFF
--- a/services/torghut/scripts/verify_market_data_chain.py
+++ b/services/torghut/scripts/verify_market_data_chain.py
@@ -8,9 +8,17 @@ import subprocess
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Literal, Sequence
+from zoneinfo import ZoneInfo
+
+from app.trading.ingest.clickhouse_signal_source_freshness import (
+    configured_market_holidays,
+)
 
 
 SCHEMA_VERSION = "torghut.market-data-chain-smoke.v1"
+MARKET_TIMEZONE = ZoneInfo("America/New_York")
+REGULAR_SESSION_OPEN_MINUTE = 9 * 60 + 30
+REGULAR_SESSION_CLOSE_MINUTE = 16 * 60
 DEFAULT_TOPICS = (
     "torghut.trades.v1",
     "torghut.quotes.v1",
@@ -19,6 +27,10 @@ DEFAULT_TOPICS = (
     "torghut.ta.signals.v1",
     "torghut.ta.status.v1",
 )
+FreshnessMarketSessionSelection = Literal[
+    "auto", "regular_open", "outside_regular_session"
+]
+FreshnessMarketSessionState = Literal["regular_open", "outside_regular_session"]
 DEFAULT_CLICKHOUSE_QUERY = """
 SELECT 'ta_signals' AS table, source, count(), max(event_ts), max(ingest_ts)
 FROM torghut.ta_signals
@@ -81,6 +93,8 @@ class MarketDataChainProbe:
 class FreshnessThresholds:
     kafka_age_seconds: int | None = None
     clickhouse_age_seconds: int | None = None
+    market_session_state: FreshnessMarketSessionState = "regular_open"
+    market_session_source: FreshnessMarketSessionSelection = "regular_open"
 
 
 @dataclass(frozen=True)
@@ -213,6 +227,11 @@ def build_summary(
 
     clickhouse_payloads = _clickhouse_payloads(probe)
     issues.extend(_clickhouse_issues(clickhouse_payloads, active_thresholds))
+    suppressed_age_issues = _suppressed_age_issues(
+        latest_message_payloads,
+        clickhouse_payloads,
+        active_thresholds,
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -223,6 +242,10 @@ def build_summary(
             "kafka_consumer_group_max_lag": max_group_lag,
             "latest_kafka_message_count": len(probe.latest_messages),
             "clickhouse_row_count": len(probe.clickhouse_rows),
+            "freshness_market_session_state": active_thresholds.market_session_state,
+            "freshness_market_session_source": active_thresholds.market_session_source,
+            "freshness_age_enforced": _freshness_age_enforced(active_thresholds),
+            "suppressed_freshness_age_issues": suppressed_age_issues,
         },
         "kafka": {
             "consumer_group_lag": [asdict(row) for row in probe.consumer_group_lag],
@@ -278,6 +301,19 @@ def _kafka_message_issues(
             issues.append(
                 f"kafka_topic_evidence_missing:{offset.topic}:{offset.partition}"
             )
+    if not _freshness_age_enforced(thresholds):
+        return issues
+    issues.extend(_kafka_age_issues(latest_message_payloads, thresholds))
+    return issues
+
+
+def _kafka_age_issues(
+    latest_message_payloads: Sequence[dict[str, object]],
+    thresholds: FreshnessThresholds,
+) -> list[str]:
+    if thresholds.kafka_age_seconds is None:
+        return []
+    issues: list[str] = []
     for row in latest_message_payloads:
         age = row["age_seconds"]
         if isinstance(age, int) and age > thresholds.kafka_age_seconds:
@@ -317,6 +353,19 @@ def _clickhouse_issues(
         row = accepted_by_table.get(table)
         if _clickhouse_accepted_row_missing(row):
             issues.append(f"clickhouse_accepted_source_missing:{table}")
+    if not _freshness_age_enforced(thresholds):
+        return issues
+    issues.extend(_clickhouse_age_issues(accepted_rows, thresholds))
+    return issues
+
+
+def _clickhouse_age_issues(
+    accepted_rows: Sequence[dict[str, object]],
+    thresholds: FreshnessThresholds,
+) -> list[str]:
+    if thresholds.clickhouse_age_seconds is None:
+        return []
+    issues: list[str] = []
     for row in accepted_rows:
         age = row["latest_event_age_seconds"]
         if isinstance(age, int) and age > thresholds.clickhouse_age_seconds:
@@ -330,6 +379,47 @@ def _clickhouse_accepted_row_missing(row: dict[str, object] | None) -> bool:
     return int(row.get("row_count", 0)) <= 0 or not isinstance(
         row.get("latest_event_age_seconds"), int
     )
+
+
+def _suppressed_age_issues(
+    latest_message_payloads: Sequence[dict[str, object]],
+    clickhouse_payloads: Sequence[dict[str, object]],
+    thresholds: FreshnessThresholds,
+) -> list[str]:
+    if _freshness_age_enforced(thresholds):
+        return []
+    accepted_rows = [
+        row
+        for row in clickhouse_payloads
+        if row["source"] == "ta" and row["table"] in {"ta_signals", "ta_microbars"}
+    ]
+    issues = [
+        *_kafka_age_issues(latest_message_payloads, thresholds),
+        *_clickhouse_age_issues(accepted_rows, thresholds),
+    ]
+    return sorted(set(issues))
+
+
+def _freshness_age_enforced(thresholds: FreshnessThresholds) -> bool:
+    return thresholds.market_session_state == "regular_open"
+
+
+def resolve_freshness_market_session_state(
+    now: datetime,
+    selection: FreshnessMarketSessionSelection,
+) -> FreshnessMarketSessionState:
+    if selection != "auto":
+        return selection
+    local_now = now.astimezone(MARKET_TIMEZONE)
+    minute_of_day = local_now.hour * 60 + local_now.minute
+    if local_now.date() in configured_market_holidays():
+        return "outside_regular_session"
+    if (
+        local_now.weekday() < 5
+        and REGULAR_SESSION_OPEN_MINUTE <= minute_of_day < REGULAR_SESSION_CLOSE_MINUTE
+    ):
+        return "regular_open"
+    return "outside_regular_session"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -376,6 +466,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         thresholds=FreshnessThresholds(
             kafka_age_seconds=args.require_max_kafka_age_seconds,
             clickhouse_age_seconds=args.require_max_clickhouse_age_seconds,
+            market_session_state=resolve_freshness_market_session_state(
+                generated_at,
+                args.freshness_market_session,
+            ),
+            market_session_source=args.freshness_market_session,
         ),
     )
     print(format_summary(summary, args.format))
@@ -408,6 +503,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--clickhouse-query", default=DEFAULT_CLICKHOUSE_QUERY)
     parser.add_argument("--require-max-kafka-age-seconds", type=int)
     parser.add_argument("--require-max-clickhouse-age-seconds", type=int)
+    parser.add_argument(
+        "--freshness-market-session",
+        choices=("auto", "regular_open", "outside_regular_session"),
+        default="auto",
+        help=(
+            "Session used for age freshness enforcement. Auto enforces during "
+            "regular NYSE hours and suppresses age-only staleness outside them."
+        ),
+    )
     parser.add_argument("--format", choices=("json", "markdown"), default="json")
     return parser.parse_args(argv)
 
@@ -525,6 +629,8 @@ def format_summary(
                 f"- Kafka consumer group max lag: `{nested_summary.get('kafka_consumer_group_max_lag')}`",
                 f"- Latest Kafka messages checked: `{nested_summary.get('latest_kafka_message_count')}`",
                 f"- ClickHouse freshness rows checked: `{nested_summary.get('clickhouse_row_count')}`",
+                f"- Freshness market session: `{nested_summary.get('freshness_market_session_state')}`",
+                f"- Freshness age enforced: `{nested_summary.get('freshness_age_enforced')}`",
             ]
         )
     return "\n".join(lines)

--- a/services/torghut/tests/scripts/test_verify_market_data_chain.py
+++ b/services/torghut/tests/scripts/test_verify_market_data_chain.py
@@ -25,6 +25,7 @@ from scripts.verify_market_data_chain import (
     parse_latest_kafka_messages,
     parse_topic_offsets,
     read_kubernetes_secret,
+    resolve_freshness_market_session_state,
     run_clickhouse_query,
     run_kafka_probe,
 )
@@ -148,7 +149,42 @@ def test_parse_args_replaces_default_topics_when_topic_is_provided() -> None:
 
     assert defaults.topic is None
     assert tuple(defaults.topic or DEFAULT_TOPICS) == DEFAULT_TOPICS
+    assert defaults.freshness_market_session == "auto"
     assert custom.topic == ["custom.one", "custom.two"]
+
+
+def test_resolve_freshness_market_session_state_uses_regular_nyse_hours() -> None:
+    assert (
+        resolve_freshness_market_session_state(
+            datetime(2026, 7, 8, 15, 0, tzinfo=UTC),
+            "auto",
+        )
+        == "regular_open"
+    )
+    assert (
+        resolve_freshness_market_session_state(
+            datetime(2026, 7, 9, 6, 0, tzinfo=UTC),
+            "auto",
+        )
+        == "outside_regular_session"
+    )
+    assert (
+        resolve_freshness_market_session_state(
+            datetime(2026, 7, 8, 15, 0, tzinfo=UTC),
+            "outside_regular_session",
+        )
+        == "outside_regular_session"
+    )
+
+
+def test_resolve_freshness_market_session_state_uses_market_holidays() -> None:
+    assert (
+        resolve_freshness_market_session_state(
+            datetime(2026, 7, 3, 15, 0, tzinfo=UTC),
+            "auto",
+        )
+        == "outside_regular_session"
+    )
 
 
 def test_read_kubernetes_secret_decodes_without_exposing_encoded_value(
@@ -337,6 +373,69 @@ def test_build_summary_degrades_when_required_clickhouse_rows_are_missing() -> N
 
     assert summary["status"] == "degraded"
     assert summary["issues"] == ["clickhouse_accepted_source_missing:ta_microbars"]
+
+
+def test_build_summary_suppresses_age_only_staleness_outside_regular_session() -> None:
+    summary = build_summary(
+        MarketDataChainProbe(
+            generated_at=datetime(2026, 7, 9, 6, 10, tzinfo=UTC),
+            consumer_group_lag=[
+                ConsumerGroupLag(
+                    group="torghut-ta-live",
+                    topic="torghut.trades.v1",
+                    partition=0,
+                    current_offset=10,
+                    log_end_offset=10,
+                    lag=0,
+                )
+            ],
+            topic_offsets=[
+                TopicOffset(topic="torghut.trades.v1", partition=0, offset=10)
+            ],
+            latest_messages=[
+                LatestKafkaMessage(
+                    topic="torghut.trades.v1",
+                    partition=0,
+                    offset=9,
+                    timestamp_type="CreateTime",
+                    timestamp_ms=1783544335000,
+                    key="AMD",
+                )
+            ],
+            clickhouse_rows=[
+                ClickHouseFreshnessRow(
+                    table="ta_signals",
+                    source="ta",
+                    row_count=10,
+                    latest_event_ts="2026-07-08 20:57:00.000",
+                    latest_ingest_ts="2026-07-09 05:54:57.345",
+                ),
+                ClickHouseFreshnessRow(
+                    table="ta_microbars",
+                    source="ta",
+                    row_count=10,
+                    latest_event_ts="2026-07-08 20:57:00.000",
+                    latest_ingest_ts="2026-07-09 05:54:57.345",
+                ),
+            ],
+        ),
+        thresholds=FreshnessThresholds(
+            kafka_age_seconds=300,
+            clickhouse_age_seconds=300,
+            market_session_state="outside_regular_session",
+            market_session_source="auto",
+        ),
+    )
+
+    nested_summary = cast(dict[str, object], summary["summary"])
+    assert summary["status"] == "ok"
+    assert summary["issues"] == []
+    assert nested_summary["freshness_age_enforced"] is False
+    assert nested_summary["suppressed_freshness_age_issues"] == [
+        "clickhouse_accepted_source_stale:ta_microbars",
+        "clickhouse_accepted_source_stale:ta_signals",
+        "kafka_topic_stale:torghut.trades.v1:0",
+    ]
 
 
 def test_build_summary_handles_missing_and_zulu_clickhouse_timestamps() -> None:


### PR DESCRIPTION
## Summary

- Makes the Torghut market-data-chain smoke session-aware for age freshness enforcement.
- Keeps the smoke fail-closed during regular NYSE hours while avoiding false degraded results for age-only staleness outside regular session.
- Preserves hard failures for missing Kafka evidence, consumer lag, and missing accepted ClickHouse `ta` rows.
- Adds focused tests for auto session resolution and outside-session suppressed age diagnostics.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/scripts/test_verify_market_data_chain.py -q`
- `cd services/torghut && uv run --frozen ruff format --check scripts/verify_market_data_chain.py tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen ruff check scripts/verify_market_data_chain.py tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main scripts/verify_market_data_chain.py tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main scripts/verify_market_data_chain.py tests/scripts/test_verify_market_data_chain.py`
- `cd services/torghut && uv run --frozen python scripts/verify_market_data_chain.py --format json --require-max-kafka-age-seconds 300 --require-max-clickhouse-age-seconds 300`
- `cd services/torghut && uv run --frozen python scripts/verify_market_data_chain.py --format json --require-max-kafka-age-seconds 300 --require-max-clickhouse-age-seconds 300 --freshness-market-session regular_open`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
