### PR TITLE
fix(torghut): block non-mainnet live submission gate

### DIFF
--- a/services/torghut/app/trading/submission_authority.py
+++ b/services/torghut/app/trading/submission_authority.py
@@ -14,6 +14,7 @@ _OPERATIONAL_SUBMISSION_REASONS = frozenset(
         "invalid_order",
         "kill_switch_enabled",
         "live_submit_disabled",
+        "mainnet_route_unavailable",
         "risk_breach",
         "submit_disabled",
         "testnet_after_hours_disabled",
@@ -74,10 +75,19 @@ def operational_submission_gate_status(
     raw_blocked_reasons = _strings(gate.get("blocked_reasons"))
     raw_reason = _text(gate.get("reason"), "")
     raw_allowed = _bool(gate.get("allowed"))
+    execution_route = _mapping(gate.get("execution_route"))
     blocked_reasons = _active_submission_blockers(
         raw_blocked_reasons,
         raw_reason=raw_reason,
         raw_allowed=raw_allowed,
+    )
+    blocked_reasons = list(
+        dict.fromkeys(
+            [
+                *blocked_reasons,
+                *_execution_route_submission_blockers(execution_route),
+            ]
+        )
     )
     reason = _active_submission_reason(
         raw_reason,
@@ -97,7 +107,7 @@ def operational_submission_gate_status(
         "allowed": allowed,
         "reason": reason,
         "blocked_reasons": blocked_reasons,
-        "execution_route": _mapping(gate.get("execution_route")),
+        "execution_route": execution_route,
     }
 
 
@@ -159,6 +169,15 @@ def _is_operational_submission_reason(reason: str) -> bool:
         or reason.endswith(_OPERATIONAL_SUBMISSION_SUFFIXES)
         or reason.startswith(_OPERATIONAL_SUBMISSION_PREFIXES)
     )
+
+
+def _execution_route_submission_blockers(
+    execution_route: Mapping[str, Any],
+) -> list[str]:
+    route = _text(execution_route.get("route"), "")
+    if route and route != "alpaca":
+        return ["mainnet_route_unavailable"]
+    return []
 
 
 def _has_only_diagnostic_submission_reasons(

--- a/services/torghut/app/trading/submission_council/__init__.py
+++ b/services/torghut/app/trading/submission_council/__init__.py
@@ -598,6 +598,8 @@ def _operational_submission_blocked_reasons(
     execution_route = _execution_route_payload(context)
     if execution_route["route"] == "alpaca" and not _alpaca_broker_available():
         blocked_reasons.append("broker_unavailable")
+    if execution_route["route"] != "alpaca":
+        blocked_reasons.append("mainnet_route_unavailable")
     if (
         execution_route["route"] == "testnet"
         and not settings.trading_testnet_after_hours_enabled

--- a/services/torghut/tests/api/test_trading_api_live_gate_llm.py
+++ b/services/torghut/tests/api/test_trading_api_live_gate_llm.py
@@ -194,6 +194,7 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
             settings.trading_kill_switch_enabled = True
 
             scheduler = TradingScheduler()
+            scheduler.state.market_session_open = True
             app.state.trading_scheduler = scheduler
 
             hypothesis_summary = {
@@ -290,6 +291,7 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
             settings.trading_testnet_after_hours_enabled = True
 
             scheduler = TradingScheduler()
+            scheduler.state.market_session_open = True
             app.state.trading_scheduler = scheduler
 
             hypothesis_summary = {
@@ -311,6 +313,10 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
             )
 
             with (
+                patch(
+                    "app.trading.submission_council._alpaca_broker_available",
+                    return_value=True,
+                ),
                 patch(
                     "app.api.status_helpers._build_hypothesis_runtime_payload",
                     return_value=(
@@ -381,7 +387,7 @@ class TestTradingApiLiveGateLlm(TradingApiTestCaseBase):
             self.assertEqual(gate["reason"], "operational_submission_ready")
             self.assertEqual(gate["capital_state"], "live")
             self.assertNotIn("quant_latest_store_alarm", gate["blocked_reasons"])
-            self.assertEqual(payload["execution_route"], "testnet")
+            self.assertEqual(payload["execution_route"], "alpaca")
             self.assertTrue(payload["operational_submission_gate"]["allowed"])
             self.assertEqual(payload["quant_evidence"]["window"], "15m")
             self.assertFalse(payload["quant_evidence"]["ok"])

--- a/services/torghut/tests/api/test_trading_api_readyz_contract.py
+++ b/services/torghut/tests/api/test_trading_api_readyz_contract.py
@@ -312,6 +312,7 @@ class TestTradingApiReadyzLiveGateContract(TradingApiTestCaseBase):
     ) -> None:
         original = _live_submission_settings_snapshot()
         scheduler = TradingScheduler()
+        scheduler.state.market_session_open = True
         try:
             _enable_live_submission_settings()
             with (
@@ -343,9 +344,14 @@ class TestTradingApiReadyzLiveGateContract(TradingApiTestCaseBase):
     ) -> None:
         original = _live_submission_settings_snapshot()
         scheduler = TradingScheduler()
+        scheduler.state.market_session_open = True
         try:
             _enable_live_submission_settings()
             with (
+                patch(
+                    "app.trading.submission_council._alpaca_broker_available",
+                    return_value=True,
+                ),
                 patch(
                     "app.api.readiness_helpers.status_dependencies.load_clickhouse_ta_status",
                     return_value=_fresh_clickhouse_ta_status(),

--- a/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
+++ b/services/torghut/tests/api/test_trading_api_simple_lane_profit_floor.py
@@ -76,6 +76,7 @@ class TestTradingApiSimpleLaneProfitFloor(TradingApiTestCaseBase):
         settings.trading_kill_switch_enabled = False
         try:
             scheduler = TradingScheduler()
+            scheduler.state.market_session_open = True
             scheduler.state.metrics.orders_submitted_total = 7
             scheduler.state.metrics.decision_reject_reason_total = {
                 "broker_submit_failed": 2,
@@ -99,20 +100,26 @@ class TestTradingApiSimpleLaneProfitFloor(TradingApiTestCaseBase):
             }
             app.state.trading_scheduler = scheduler
 
-            with patch(
-                "app.api.trading_status._load_clickhouse_ta_status",
-                return_value={
-                    "state": "current",
-                    "accepted_sources": ["ta"],
-                    "latest_accepted_event_at": "2026-03-20T09:59:00Z",
-                    "accepted_lag_seconds": 30,
-                    "accepted_max_lag_seconds": 300,
-                    "accepted_source_state": "current",
-                    "blocking_reason": None,
-                    "excluded_fresher_sources": [],
-                    "per_symbol_coverage": [],
-                    "market_session_state": "regular_open",
-                },
+            with (
+                patch(
+                    "app.trading.submission_council._alpaca_broker_available",
+                    return_value=True,
+                ),
+                patch(
+                    "app.api.trading_status._load_clickhouse_ta_status",
+                    return_value={
+                        "state": "current",
+                        "accepted_sources": ["ta"],
+                        "latest_accepted_event_at": "2026-03-20T09:59:00Z",
+                        "accepted_lag_seconds": 30,
+                        "accepted_max_lag_seconds": 300,
+                        "accepted_source_state": "current",
+                        "blocking_reason": None,
+                        "excluded_fresher_sources": [],
+                        "per_symbol_coverage": [],
+                        "market_session_state": "regular_open",
+                    },
+                ),
             ):
                 response = self.client.get("/trading/status")
             self.assertEqual(response.status_code, 200)

--- a/services/torghut/tests/pipeline/test_trading_pipeline_dspy_gate_c.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_dspy_gate_c.py
@@ -31,6 +31,18 @@ from tests.pipeline.trading_pipeline_base import (
 
 
 class TestTradingPipelineDspyGateC(TradingPipelineTestCaseBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._broker_available_patcher = patch(
+            "app.trading.submission_council._alpaca_broker_available",
+            return_value=True,
+        )
+        self._broker_available_patcher.start()
+
+    def tearDown(self) -> None:
+        self._broker_available_patcher.stop()
+        super().tearDown()
+
     def test_pipeline_llm_dspy_live_runtime_gate_can_pass_through_with_degraded_qty(
         self,
     ) -> None:
@@ -133,7 +145,7 @@ class TestTradingPipelineDspyGateC(TradingPipelineTestCaseBase):
                 session_factory=self.session_local,
                 llm_review_engine=CountingLLMReviewEngine(),
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             eligible_summary = {
                 "promotion_eligible_total": 1,
@@ -329,7 +341,7 @@ class TestTradingPipelineDspyGateC(TradingPipelineTestCaseBase):
                 account_label="live",
                 session_factory=self.session_local,
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             eligible_summary = {
                 "promotion_eligible_total": 1,
@@ -536,7 +548,7 @@ class TestTradingPipelineDspyGateC(TradingPipelineTestCaseBase):
                 session_factory=self.session_local,
                 llm_review_engine=CountingLLMReviewEngine(),
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             eligible_summary = {
                 "promotion_eligible_total": 1,
@@ -884,7 +896,7 @@ class TestTradingPipelineDspyGateC(TradingPipelineTestCaseBase):
                 account_label="live",
                 session_factory=self.session_local,
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             eligible_summary = {
                 "promotion_eligible_total": 1,

--- a/services/torghut/tests/pipeline/test_trading_pipeline_execution_llm_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_execution_llm_b.py
@@ -32,6 +32,18 @@ from tests.pipeline.trading_pipeline_base import (
 
 
 class TestTradingPipelineExecutionLlmB(TradingPipelineTestCaseBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._broker_available_patcher = patch(
+            "app.trading.submission_council._alpaca_broker_available",
+            return_value=True,
+        )
+        self._broker_available_patcher.start()
+
+    def tearDown(self) -> None:
+        self._broker_available_patcher.stop()
+        super().tearDown()
+
     def test_pipeline_llm_adjust(self) -> None:
         from app import config
 
@@ -327,7 +339,7 @@ class TestTradingPipelineExecutionLlmB(TradingPipelineTestCaseBase):
                 session_factory=self.session_local,
                 llm_review_engine=FakeLLMReviewEngine(error=RuntimeError("boom")),
             )
-            pipeline_live._is_market_session_open = lambda _now=None: False
+            pipeline_live._is_market_session_open = lambda _now=None: True
             eligible_summary = {
                 "promotion_eligible_total": 1,
                 "capital_stage_totals": {"shadow": 1},

--- a/services/torghut/tests/pipeline/test_trading_pipeline_live_regime_a.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_live_regime_a.py
@@ -424,9 +424,13 @@ class TestTradingPipelineLiveRegimeA(TradingPipelineTestCaseBase):
                 account_label="paper",
                 session_factory=self.session_local,
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             with (
+                patch(
+                    "app.trading.submission_council._alpaca_broker_available",
+                    return_value=True,
+                ),
                 patch(
                     "app.trading.scheduler.pipeline.decision_lifecycle.build_hypothesis_runtime_summary",
                     return_value=eligible_summary,
@@ -642,9 +646,13 @@ class TestTradingPipelineLiveRegimeA(TradingPipelineTestCaseBase):
                 account_label="live",
                 session_factory=self.session_local,
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             with (
+                patch(
+                    "app.trading.submission_council._alpaca_broker_available",
+                    return_value=True,
+                ),
                 patch(
                     "app.trading.scheduler.pipeline.decision_lifecycle.build_hypothesis_runtime_summary",
                     return_value=eligible_summary,
@@ -793,9 +801,13 @@ class TestTradingPipelineLiveRegimeA(TradingPipelineTestCaseBase):
                 account_label="live",
                 session_factory=self.session_local,
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             with (
+                patch(
+                    "app.trading.submission_council._alpaca_broker_available",
+                    return_value=True,
+                ),
                 patch(
                     "app.trading.scheduler.pipeline.decision_lifecycle.build_hypothesis_runtime_summary",
                     return_value=blocked_summary,

--- a/services/torghut/tests/pipeline/test_trading_pipeline_live_regime_b.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_live_regime_b.py
@@ -111,9 +111,13 @@ class TestTradingPipelineLiveRegimeB(TradingPipelineTestCaseBase):
                 account_label="paper",
                 session_factory=self.session_local,
             )
-            pipeline._is_market_session_open = lambda _now=None: False
+            pipeline._is_market_session_open = lambda _now=None: True
 
             with (
+                patch(
+                    "app.trading.submission_council._alpaca_broker_available",
+                    return_value=True,
+                ),
                 patch(
                     "app.trading.scheduler.pipeline.decision_lifecycle.build_hypothesis_runtime_summary",
                     return_value=allowed_summary,

--- a/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
+++ b/services/torghut/tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py
@@ -64,13 +64,13 @@ def test_simple_live_submission_gate_drops_retired_source_collection_blockers(
 
         gate = pipeline._live_submission_gate()
 
-        assert gate["allowed"] is True
-        assert gate["reason"] == "operational_submission_ready"
-        assert gate["blocked_reasons"] == []
+        assert gate["allowed"] is False
+        assert gate["reason"] == "mainnet_route_unavailable"
+        assert gate["blocked_reasons"] == ["mainnet_route_unavailable"]
         assert gate["operational_submission_gate"] == {
-            "allowed": True,
-            "reason": "operational_submission_ready",
-            "blocked_reasons": [],
+            "allowed": False,
+            "reason": "mainnet_route_unavailable",
+            "blocked_reasons": ["mainnet_route_unavailable"],
             "execution_route": {
                 "route": "testnet",
                 "alpaca_regular_session_open": False,

--- a/services/torghut/tests/submission_council/support.py
+++ b/services/torghut/tests/submission_council/support.py
@@ -172,6 +172,11 @@ class SubmissionCouncilTestCase(TestCase):
             "trading_drift_live_promotion_max_evidence_age_seconds": settings.trading_drift_live_promotion_max_evidence_age_seconds,
         }
         _QUANT_HEALTH_CACHE.clear()
+        self._alpaca_broker_available_patcher = patch(
+            "app.trading.submission_council._alpaca_broker_available",
+            return_value=True,
+        )
+        self._alpaca_broker_available_patcher.start()
         settings.trading_enabled = True
         settings.trading_mode = "live"
         settings.trading_autonomy_enabled = False
@@ -183,6 +188,7 @@ class SubmissionCouncilTestCase(TestCase):
         settings.trading_simple_submit_enabled = True
 
     def tearDown(self) -> None:
+        self._alpaca_broker_available_patcher.stop()
         settings.trading_enabled = self._settings_snapshot["trading_enabled"]
         settings.trading_mode = self._settings_snapshot["trading_mode"]
         settings.trading_autonomy_enabled = self._settings_snapshot[

--- a/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_a.py
+++ b/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_a.py
@@ -610,7 +610,7 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryA(SubmissionCouncilTestCase):
             ):
                 gate = build_live_submission_gate_payload(
                     SimpleNamespace(
-                        market_session_open=False,
+                        market_session_open=True,
                         last_autonomy_promotion_eligible=True,
                         last_autonomy_promotion_action="promote",
                         drift_live_promotion_eligible=False,

--- a/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_b.py
+++ b/services/torghut/tests/submission_council/test_hypothesis_runtime_summary_b.py
@@ -123,6 +123,7 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
 
             gate = build_live_submission_gate_payload(
                 SimpleNamespace(
+                    market_session_open=True,
                     last_autonomy_promotion_eligible=True,
                     last_autonomy_promotion_action="promote",
                     drift_live_promotion_eligible=False,
@@ -190,6 +191,7 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
         )
         stale_gate = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,
@@ -221,6 +223,7 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
 
         non_shadow_paper_gate = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,
@@ -372,7 +375,7 @@ class TestSubmissionCouncilHypothesisRuntimeSummaryB(SubmissionCouncilTestCase):
             forced_summary["promotion_eligible_total"] = 1
             forced_summary["items"] = [forced_item]
             gate = build_live_submission_gate_payload(
-                SimpleNamespace(market_session_open=False),
+                SimpleNamespace(market_session_open=True),
                 hypothesis_summary=forced_summary,
                 empirical_jobs_status={"ready": True},
                 dspy_runtime_status={"mode": "inactive"},

--- a/services/torghut/tests/submission_council/test_live_submission_gate.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate.py
@@ -42,6 +42,7 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
         settings.trading_live_submit_activation_expires_at = "2000-01-01T00:00:00Z"
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,
@@ -91,6 +92,7 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
     def test_stale_empirical_status_no_longer_blocks_live_gate(self) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=False,
                 last_autonomy_promotion_action=None,
                 drift_live_promotion_eligible=False,
@@ -149,6 +151,41 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
         self.assertIn("submit_disabled", result["blocked_reasons"])
         self.assertIn("submit_disabled", operational_gate["blocked_reasons"])
 
+    def test_live_gate_blocks_testnet_route_as_not_mainnet(self) -> None:
+        from app.config import settings
+
+        settings.trading_simple_submit_enabled = True
+        settings.trading_live_submit_enabled = True
+        settings.trading_testnet_after_hours_enabled = True
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                market_session_open=False,
+                last_autonomy_promotion_eligible=False,
+                last_autonomy_promotion_action=None,
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=45,
+            ),
+            hypothesis_summary={
+                "promotion_eligible_total": 0,
+                "capital_stage_totals": {"shadow": 1},
+                "dependency_quorum": {
+                    "decision": "allow",
+                    "reasons": [],
+                    "message": "ready",
+                },
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+        )
+
+        operational_gate = result["operational_submission_gate"]
+        self.assertFalse(result["allowed"])
+        self.assertEqual(result["reason"], "mainnet_route_unavailable")
+        self.assertIn("mainnet_route_unavailable", result["blocked_reasons"])
+        self.assertFalse(operational_gate["allowed"])
+        self.assertEqual(operational_gate["reason"], "mainnet_route_unavailable")
+        self.assertEqual(operational_gate["execution_route"]["route"], "testnet")
+
     def test_live_submit_activation_is_diagnostic_for_operational_gate(
         self,
     ) -> None:
@@ -182,7 +219,8 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
         )
 
         self.assertNotIn("bounded_live_paper_collection_gate", result)
-        self.assertTrue(result["operational_submission_gate"]["allowed"])
+        self.assertFalse(result["operational_submission_gate"]["allowed"])
+        self.assertIn("mainnet_route_unavailable", result["blocked_reasons"])
         self.assertNotIn(
             "live_submit_activation_expiry_invalid",
             result["blocked_reasons"],
@@ -263,7 +301,8 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
             settings.trading_account_label = account_label_before
             settings.trading_static_symbols_raw = static_symbols_before
 
-        self.assertTrue(result["allowed"])
+        self.assertFalse(result["allowed"])
+        self.assertEqual(result["reason"], "mainnet_route_unavailable")
         self.assertNotIn(
             "runtime_window_import_required",
             result["blocked_reasons"],
@@ -281,7 +320,8 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
             )
         )
         self.assertNotIn("bounded_live_paper_collection_gate", result)
-        self.assertTrue(result["operational_submission_gate"]["allowed"])
+        self.assertFalse(result["operational_submission_gate"]["allowed"])
+        self.assertIn("mainnet_route_unavailable", result["blocked_reasons"])
 
     def test_build_live_submission_gate_payload_exports_runtime_window_health_inputs(
         self,
@@ -507,6 +547,7 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
     ) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,
@@ -563,6 +604,7 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
     ) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,
@@ -612,6 +654,7 @@ class TestSubmissionCouncilLiveSubmissionGate(SubmissionCouncilTestCase):
     ) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,

--- a/services/torghut/tests/submission_council/test_live_submission_gate_probation_diagnostics.py
+++ b/services/torghut/tests/submission_council/test_live_submission_gate_probation_diagnostics.py
@@ -13,6 +13,7 @@ class TestLiveSubmissionGateProbationDiagnostics(SubmissionCouncilTestCase):
     ) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=False,
                 last_autonomy_promotion_action=None,
                 drift_live_promotion_eligible=False,
@@ -117,6 +118,7 @@ class TestLiveSubmissionGateProbationDiagnostics(SubmissionCouncilTestCase):
     ) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,
@@ -153,6 +155,7 @@ class TestLiveSubmissionGateProbationDiagnostics(SubmissionCouncilTestCase):
     ) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,
@@ -203,6 +206,7 @@ class TestLiveSubmissionGateProbationDiagnostics(SubmissionCouncilTestCase):
     ) -> None:
         result = build_live_submission_gate_payload(
             SimpleNamespace(
+                market_session_open=True,
                 last_autonomy_promotion_eligible=True,
                 last_autonomy_promotion_action="promote",
                 drift_live_promotion_eligible=False,

--- a/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
+++ b/services/torghut/tests/submission_council/test_runtime_certificate_merge.py
@@ -59,7 +59,7 @@ class TestSubmissionCouncilRuntimeCertificateMerge(SubmissionCouncilTestCase):
             ):
                 gate = build_live_submission_gate_payload(
                     SimpleNamespace(
-                        market_session_open=False,
+                        market_session_open=True,
                         last_autonomy_promotion_eligible=False,
                         last_autonomy_promotion_action=None,
                         drift_live_promotion_eligible=False,

--- a/services/torghut/tests/submission_council/test_runtime_ledger_repair_candidates.py
+++ b/services/torghut/tests/submission_council/test_runtime_ledger_repair_candidates.py
@@ -262,7 +262,7 @@ class TestSubmissionCouncilRuntimeLedgerRepairCandidates(SubmissionCouncilTestCa
             ):
                 gate = build_live_submission_gate_payload(
                     SimpleNamespace(
-                        market_session_open=False,
+                        market_session_open=True,
                         last_autonomy_promotion_eligible=False,
                         last_autonomy_promotion_action=None,
                         drift_live_promotion_eligible=False,

--- a/services/torghut/tests/submission_council/test_source_collection_candidates.py
+++ b/services/torghut/tests/submission_council/test_source_collection_candidates.py
@@ -849,7 +849,7 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
             ):
                 gate = build_live_submission_gate_payload(
                     SimpleNamespace(
-                        market_session_open=False,
+                        market_session_open=True,
                         last_autonomy_promotion_eligible=False,
                         last_autonomy_promotion_action=None,
                         drift_live_promotion_eligible=False,
@@ -882,7 +882,7 @@ class TestSubmissionCouncilSourceCollectionCandidates(SubmissionCouncilTestCase)
                 )
                 waiting_gate = build_live_submission_gate_payload(
                     SimpleNamespace(
-                        market_session_open=False,
+                        market_session_open=True,
                         last_autonomy_promotion_eligible=False,
                         last_autonomy_promotion_action=None,
                         drift_live_promotion_eligible=False,

--- a/services/torghut/tests/test_execution_runtime.py
+++ b/services/torghut/tests/test_execution_runtime.py
@@ -90,9 +90,9 @@ def test_execution_status_filters_diagnostic_reject_reasons() -> None:
                 "research_evidence_missing",
             ],
             "execution_route": {
-                "route": "testnet",
-                "reason": "alpaca_regular_session_closed",
-                "alpaca_regular_session_open": False,
+                "route": "alpaca",
+                "reason": "alpaca_regular_session_open",
+                "alpaca_regular_session_open": True,
             },
         },
     )
@@ -101,6 +101,33 @@ def test_execution_status_filters_diagnostic_reject_reasons() -> None:
     assert payload["gate"]["reason"] == "operational_submission_ready"
     assert payload["gate"]["blocked_reasons"] == []
     assert payload["reject_reason_totals"] == {"broker_submit_failed": 2}
+
+
+def test_execution_status_blocks_testnet_route_as_not_mainnet() -> None:
+    metrics = SimpleNamespace(
+        orders_submitted_total=0,
+        orders_rejected_total=0,
+        decision_reject_reason_total={},
+    )
+    state = SimpleNamespace(metrics=metrics, last_execution_order=None)
+
+    payload = build_execution_status_payload(
+        state=state,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "operational_submission_ready",
+            "blocked_reasons": [],
+            "execution_route": {
+                "route": "testnet",
+                "reason": "alpaca_regular_session_closed",
+                "alpaca_regular_session_open": False,
+            },
+        },
+    )
+
+    assert payload["gate"]["allowed"] is False
+    assert payload["gate"]["reason"] == "mainnet_route_unavailable"
+    assert payload["gate"]["blocked_reasons"] == ["mainnet_route_unavailable"]
 
 
 def test_execution_gate_payload_preserves_operational_blockers() -> None:

--- a/services/torghut/tests/test_submission_authority.py
+++ b/services/torghut/tests/test_submission_authority.py
@@ -11,8 +11,8 @@ def test_submission_authority_allows_operational_submission() -> None:
                 "reason": "operational_submission_ready",
                 "blocked_reasons": [],
                 "execution_route": {
-                    "route": "testnet",
-                    "alpaca_regular_session_open": False,
+                    "route": "alpaca",
+                    "alpaca_regular_session_open": True,
                 },
             },
         },
@@ -27,8 +27,8 @@ def test_submission_authority_allows_operational_submission() -> None:
         "reason": "operational_submission_ready",
         "blocked_reasons": [],
         "execution_route": {
-            "route": "testnet",
-            "alpaca_regular_session_open": False,
+            "route": "alpaca",
+            "alpaca_regular_session_open": True,
         },
     }
     assert "simple_lane_contract" not in status
@@ -77,7 +77,31 @@ def test_submission_authority_blocks_disabled_testnet_after_hours_gate() -> None
     assert status["can_submit_now"] is False
     assert status["reason"] == "testnet_after_hours_disabled"
     assert status["operational_submission_gate"]["blocked_reasons"] == [
-        "testnet_after_hours_disabled"
+        "testnet_after_hours_disabled",
+        "mainnet_route_unavailable",
+    ]
+
+
+def test_submission_authority_blocks_testnet_route_even_if_raw_gate_allows() -> None:
+    status = build_submission_authority_status(
+        {
+            "operational_submission_gate": {
+                "allowed": True,
+                "reason": "operational_submission_ready",
+                "blocked_reasons": [],
+                "execution_route": {
+                    "route": "testnet",
+                    "alpaca_regular_session_open": False,
+                },
+            },
+        },
+    )
+
+    assert status["effective_submit_mode"] == "blocked"
+    assert status["can_submit_now"] is False
+    assert status["reason"] == "mainnet_route_unavailable"
+    assert status["operational_submission_gate"]["blocked_reasons"] == [
+        "mainnet_route_unavailable"
     ]
 
 
@@ -131,8 +155,8 @@ def test_submission_authority_diagnostic_reasons_do_not_block() -> None:
                 "research_evidence_missing",
             ],
             "execution_route": {
-                "route": "testnet",
-                "alpaca_regular_session_open": False,
+                "route": "alpaca",
+                "alpaca_regular_session_open": True,
             },
         },
     )


### PR DESCRIPTION
## Summary

- Make Torghut live submission authority fail closed when the selected execution route is not Alpaca/mainnet.
- Add defensive route blocking in the shared submission authority projection so stale or legacy `testnet` gate payloads cannot be reclassified as operationally ready.
- Update status, readiness, simple-pipeline, submission-council, execution-runtime, and pipeline tests to separate regular-session mainnet assertions from after-hours/testnet diagnostics.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/submission_council -q`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_authority.py tests/test_execution_runtime.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/submission_council -q`
- `cd services/torghut && uv run --frozen pytest tests/api/test_trading_api_readyz_contract.py tests/api/test_trading_api_health_cache.py tests/api/test_trading_api_live_gate_llm.py tests/api/test_trading_api_status_consumer_evidence.py tests/api/test_trading_api_status_contract.py tests/api/test_trading_api_simple_lane_profit_floor.py tests/pipeline/test_trading_pipeline_live_regime_a.py tests/pipeline/test_trading_pipeline_live_regime_b.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py -q`
- `cd services/torghut && uv run --frozen pytest tests/api tests/pipeline tests/simple_pipeline tests/submission_council tests/test_execution_runtime.py tests/test_submission_authority.py -q`
- `cd services/torghut && uv run --frozen pytest tests/pipeline/test_trading_pipeline_dspy_gate_c.py tests/pipeline/test_trading_pipeline_execution_llm_b.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_authority.py tests/test_execution_runtime.py tests/submission_council/test_live_submission_gate.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app scripts tests migrations`
- `cd services/torghut && uv run --frozen ruff check app scripts tests migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/submission_authority.py app/trading/submission_council/__init__.py tests/api/test_trading_api_live_gate_llm.py tests/api/test_trading_api_readyz_contract.py tests/api/test_trading_api_simple_lane_profit_floor.py tests/pipeline/test_trading_pipeline_dspy_gate_c.py tests/pipeline/test_trading_pipeline_execution_llm_b.py tests/pipeline/test_trading_pipeline_live_regime_a.py tests/pipeline/test_trading_pipeline_live_regime_b.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/submission_council/support.py tests/submission_council/test_hypothesis_runtime_summary_a.py tests/submission_council/test_hypothesis_runtime_summary_b.py tests/submission_council/test_live_submission_gate.py tests/submission_council/test_live_submission_gate_probation_diagnostics.py tests/submission_council/test_runtime_certificate_merge.py tests/submission_council/test_runtime_ledger_repair_candidates.py tests/submission_council/test_source_collection_candidates.py tests/test_execution_runtime.py tests/test_submission_authority.py`
- `cd services/torghut && uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/submission_authority.py app/trading/submission_council/__init__.py tests/api/test_trading_api_live_gate_llm.py tests/api/test_trading_api_readyz_contract.py tests/api/test_trading_api_simple_lane_profit_floor.py tests/pipeline/test_trading_pipeline_dspy_gate_c.py tests/pipeline/test_trading_pipeline_execution_llm_b.py tests/pipeline/test_trading_pipeline_live_regime_a.py tests/pipeline/test_trading_pipeline_live_regime_b.py tests/simple_pipeline/test_live_bounded_paper_route_probe_contract.py tests/submission_council/support.py tests/submission_council/test_hypothesis_runtime_summary_a.py tests/submission_council/test_hypothesis_runtime_summary_b.py tests/submission_council/test_live_submission_gate.py tests/submission_council/test_live_submission_gate_probation_diagnostics.py tests/submission_council/test_runtime_certificate_merge.py tests/submission_council/test_runtime_ledger_repair_candidates.py tests/submission_council/test_source_collection_candidates.py tests/test_execution_runtime.py tests/test_submission_authority.py`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`

## Breaking Changes

None. Live status and authority payloads now correctly report non-Alpaca routes as blocked for live submission authority.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
