### PR TITLE
fix(torghut): use durable inventory for fractional exits

### DIFF
--- a/services/torghut/app/trading/execution/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_core_methods.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Mapping
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional, cast
 
@@ -75,6 +76,16 @@ if TYPE_CHECKING:
     _OrderExecutorCoreBase = _OrderExecutorContract
 else:
     _OrderExecutorCoreBase = object
+
+
+@dataclass(frozen=True, slots=True)
+class _OrderPreparationInputs:
+    session: Session
+    execution_client: Any
+    decision: StrategyDecision
+    decision_row: TradeDecision
+    account_label: str
+    execution_policy_context: dict[str, Any]
 
 
 class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
@@ -211,12 +222,14 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             return None
 
         prepared = self._prepare_order_submission(
-            session=session,
-            execution_client=execution_client,
-            decision=decision,
-            decision_row=decision_row,
-            account_label=account_label,
-            execution_policy_context=execution_policy_context,
+            _OrderPreparationInputs(
+                session=session,
+                execution_client=execution_client,
+                decision=decision,
+                decision_row=decision_row,
+                account_label=account_label,
+                execution_policy_context=execution_policy_context,
+            )
         )
         if retry_delays is None:
             retry_delays = []
@@ -252,27 +265,21 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
 
     def _prepare_order_submission(
         self,
-        *,
-        session: Session,
-        execution_client: Any,
-        decision: StrategyDecision,
-        decision_row: TradeDecision,
-        account_label: str,
-        execution_policy_context: dict[str, Any],
+        inputs: _OrderPreparationInputs,
     ) -> _PreparedOrderSubmission:
-        request = _execution_request_from_decision(decision, decision_row)
+        request = _execution_request_from_decision(inputs.decision, inputs.decision_row)
         durable_position_qty = self._durable_position_qty_for_symbol(
-            session=session,
+            session=inputs.session,
             symbol=request.symbol,
-            account_label=account_label,
+            account_label=inputs.account_label,
         )
         quantity_resolution = self._quantity_resolution_for_request(
-            execution_client,
+            inputs.execution_client,
             request,
             durable_position_qty=durable_position_qty,
         )
         self._raise_order_submission_precheck_errors(
-            execution_client=execution_client,
+            execution_client=inputs.execution_client,
             request=request,
             quantity_resolution=quantity_resolution,
         )
@@ -280,10 +287,10 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             request=request,
             quantity_resolution=quantity_resolution,
             extra_params=_submission_extra_params(
-                execution_client=execution_client,
-                decision=decision,
-                decision_row=decision_row,
-                execution_policy_context=execution_policy_context,
+                execution_client=inputs.execution_client,
+                decision=inputs.decision,
+                decision_row=inputs.decision_row,
+                execution_policy_context=inputs.execution_policy_context,
                 request=request,
             ),
         )
@@ -393,7 +400,6 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
                     execution_client=execution_client,
                     request=request,
                     conflict=unresolved,
-                    position_qty=position_qty,
                     fractional_equities_enabled=fractional_equities_enabled,
                 )
             )

--- a/services/torghut/app/trading/execution/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_core_methods.py
@@ -211,9 +211,11 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             return None
 
         prepared = self._prepare_order_submission(
+            session=session,
             execution_client=execution_client,
             decision=decision,
             decision_row=decision_row,
+            account_label=account_label,
             execution_policy_context=execution_policy_context,
         )
         if retry_delays is None:
@@ -250,15 +252,23 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
     def _prepare_order_submission(
         self,
         *,
+        session: Session,
         execution_client: Any,
         decision: StrategyDecision,
         decision_row: TradeDecision,
+        account_label: str,
         execution_policy_context: dict[str, Any],
     ) -> _PreparedOrderSubmission:
         request = _execution_request_from_decision(decision, decision_row)
+        durable_position_qty = self._durable_position_qty_for_symbol(
+            session=session,
+            symbol=request.symbol,
+            account_label=account_label,
+        )
         quantity_resolution = self._quantity_resolution_for_request(
             execution_client,
             request,
+            durable_position_qty=durable_position_qty,
         )
         self._raise_order_submission_precheck_errors(
             execution_client=execution_client,
@@ -293,9 +303,40 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
         short_precheck_error = self._validate_short_sell_constraints(
             execution_client,
             request,
+            quantity_resolution=quantity_resolution,
         )
         if short_precheck_error is not None:
             raise RuntimeError(json.dumps(short_precheck_error))
+
+    @staticmethod
+    def _durable_position_qty_for_symbol(
+        *,
+        session: Session,
+        symbol: str,
+        account_label: str,
+    ) -> Decimal | None:
+        normalized_symbol = symbol.strip().upper()
+        if not normalized_symbol:
+            return None
+        stmt = select(Execution.side, Execution.filled_qty).where(
+            Execution.alpaca_account_label == account_label,
+            Execution.symbol == normalized_symbol,
+            Execution.filled_qty > 0,
+        )
+        total = Decimal("0")
+        observed = False
+        for side, filled_qty in session.execute(stmt):
+            qty = _optional_decimal(filled_qty)
+            if qty is None or qty <= 0:
+                continue
+            normalized_side = str(side or "").strip().lower()
+            if normalized_side == "buy":
+                total += qty
+                observed = True
+            elif normalized_side == "sell":
+                total -= qty
+                observed = True
+        return total if observed else None
 
     def _resolve_sell_inventory_before_submission(
         self,

--- a/services/torghut/app/trading/execution/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_core_methods.py
@@ -227,6 +227,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             decision=decision,
             decision_row=decision_row,
             request=prepared.request,
+            position_qty=prepared.quantity_resolution.position_qty,
             fractional_equities_enabled=bool(
                 prepared.quantity_resolution.fractional_allowed
             ),
@@ -346,12 +347,14 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
         decision: StrategyDecision,
         decision_row: TradeDecision,
         request: ExecutionRequest,
+        position_qty: Decimal | None,
         fractional_equities_enabled: bool,
     ) -> _ResolvedSellInventory:
         conflict = self._find_sell_inventory_conflict(
             execution_client,
             request,
             self._list_open_orders(execution_client),
+            position_qty=position_qty,
         )
         if conflict is None:
             return _ResolvedSellInventory(request=request, decision=decision)
@@ -362,6 +365,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             decision_row=decision_row,
             request=request,
             conflict=conflict,
+            position_qty=position_qty,
             fractional_equities_enabled=fractional_equities_enabled,
         )
 
@@ -374,6 +378,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
         decision_row: TradeDecision,
         request: ExecutionRequest,
         conflict: Mapping[str, Any],
+        position_qty: Decimal | None,
         fractional_equities_enabled: bool,
     ) -> _ResolvedSellInventory:
         request, adjustment, unresolved = self._resolve_sell_inventory_conflict(
@@ -388,6 +393,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
                     execution_client=execution_client,
                     request=request,
                     conflict=unresolved,
+                    position_qty=position_qty,
                     fractional_equities_enabled=fractional_equities_enabled,
                 )
             )
@@ -811,6 +817,8 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
         execution_client: Any,
         request: ExecutionRequest,
         open_orders: list[dict[str, Any]],
+        *,
+        position_qty: Decimal | None = None,
     ) -> dict[str, Any] | None:
         request_symbol = _sell_inventory_request_symbol(request)
         if request_symbol is None:
@@ -820,17 +828,21 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
         if reservations.held_qty <= 0:
             return None
 
-        position_qty = cls._position_qty_for_symbol(execution_client, request_symbol)
-        if position_qty is None:
+        resolved_position_qty = position_qty
+        if resolved_position_qty is None:
+            resolved_position_qty = cls._position_qty_for_symbol(
+                execution_client, request_symbol
+            )
+        if resolved_position_qty is None:
             return _unknown_position_sell_inventory_conflict(
                 request,
                 request_symbol=request_symbol,
                 reservations=reservations,
             )
-        if position_qty <= 0:
+        if resolved_position_qty <= 0:
             return None
 
-        available_qty = position_qty - reservations.held_qty
+        available_qty = resolved_position_qty - reservations.held_qty
         if available_qty < 0:
             available_qty = Decimal("0")
         if request.qty <= available_qty:
@@ -840,7 +852,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             request,
             request_symbol=request_symbol,
             reservations=reservations,
-            position_qty=position_qty,
+            position_qty=resolved_position_qty,
             available_qty=available_qty,
         )
 

--- a/services/torghut/app/trading/execution/order_executor_submission_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_submission_methods.py
@@ -143,10 +143,17 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
         self,
         execution_client: Any,
         request: ExecutionRequest,
+        *,
+        durable_position_qty: Decimal | None = None,
     ) -> QuantityResolution:
         position_qty = self._position_qty_for_symbol(
             execution_client,
             request.symbol.strip().upper(),
+        )
+        position_qty = self._submission_position_qty(
+            request=request,
+            broker_position_qty=position_qty,
+            durable_position_qty=durable_position_qty,
         )
         return resolve_quantity_resolution(
             request.symbol,
@@ -161,6 +168,8 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
         self,
         execution_client: Any,
         request: ExecutionRequest,
+        *,
+        quantity_resolution: QuantityResolution,
     ) -> dict[str, Any] | None:
         if request.side.strip().lower() != "sell":
             return None
@@ -168,8 +177,11 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
         if not symbol:
             return None
 
-        position_qty = self._position_qty_for_symbol(execution_client, symbol)
-        if not self._is_short_increasing_sell(position_qty, request.qty):
+        position_qty = quantity_resolution.position_qty
+        if not (
+            quantity_resolution.short_increasing
+            or self._is_short_increasing_sell(position_qty, request.qty)
+        ):
             return None
 
         if not settings.trading_allow_shorts:
@@ -296,6 +308,21 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
         if position_qty <= 0:
             return True
         return request_qty > position_qty
+
+    @staticmethod
+    def _submission_position_qty(
+        *,
+        request: ExecutionRequest,
+        broker_position_qty: Decimal | None,
+        durable_position_qty: Decimal | None,
+    ) -> Decimal | None:
+        if request.side.strip().lower() != "sell":
+            return broker_position_qty
+        if durable_position_qty is None or durable_position_qty <= 0:
+            return broker_position_qty
+        if broker_position_qty is None or broker_position_qty <= 0:
+            return durable_position_qty
+        return broker_position_qty
 
     @classmethod
     def _position_qty_for_symbol(

--- a/services/torghut/app/trading/execution/order_executor_submission_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_submission_methods.py
@@ -54,6 +54,7 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
         execution_client: Any,
         request: ExecutionRequest,
         conflict: Mapping[str, Any],
+        position_qty: Decimal | None,
         fractional_equities_enabled: bool,
     ) -> tuple[
         ExecutionRequest,
@@ -87,6 +88,7 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
             execution_client,
             request,
             self._list_open_orders(execution_client),
+            position_qty=position_qty,
         )
         recovery: dict[str, Any] = {
             "source": "broker_precheck",

--- a/services/torghut/app/trading/execution/order_executor_submission_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_submission_methods.py
@@ -54,7 +54,6 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
         execution_client: Any,
         request: ExecutionRequest,
         conflict: Mapping[str, Any],
-        position_qty: Decimal | None,
         fractional_equities_enabled: bool,
     ) -> tuple[
         ExecutionRequest,
@@ -88,7 +87,7 @@ class _OrderExecutorSubmissionMethods(_OrderExecutorSubmissionBase):
             execution_client,
             request,
             self._list_open_orders(execution_client),
-            position_qty=position_qty,
+            position_qty=_optional_decimal(conflict.get("position_qty")),
         )
         recovery: dict[str, Any] = {
             "source": "broker_precheck",

--- a/services/torghut/app/trading/execution/shared_context.py
+++ b/services/torghut/app/trading/execution/shared_context.py
@@ -222,7 +222,6 @@ class _OrderExecutorContract(Protocol):
         execution_client: Any,
         request: ExecutionRequest,
         conflict: Mapping[str, Any],
-        position_qty: Decimal | None,
         fractional_equities_enabled: bool,
     ) -> tuple[
         ExecutionRequest,

--- a/services/torghut/app/trading/execution/shared_context.py
+++ b/services/torghut/app/trading/execution/shared_context.py
@@ -222,6 +222,7 @@ class _OrderExecutorContract(Protocol):
         execution_client: Any,
         request: ExecutionRequest,
         conflict: Mapping[str, Any],
+        position_qty: Decimal | None,
         fractional_equities_enabled: bool,
     ) -> tuple[
         ExecutionRequest,
@@ -272,6 +273,8 @@ class _OrderExecutorContract(Protocol):
         execution_client: Any,
         request: ExecutionRequest,
         open_orders: list[dict[str, Any]],
+        *,
+        position_qty: Decimal | None = None,
     ) -> dict[str, Any] | None: ...
 
     @classmethod

--- a/services/torghut/app/trading/execution/shared_context.py
+++ b/services/torghut/app/trading/execution/shared_context.py
@@ -237,12 +237,16 @@ class _OrderExecutorContract(Protocol):
         self,
         execution_client: Any,
         request: ExecutionRequest,
+        *,
+        durable_position_qty: Decimal | None = None,
     ) -> QuantityResolution: ...
 
     def _validate_short_sell_constraints(
         self,
         execution_client: Any,
         request: ExecutionRequest,
+        *,
+        quantity_resolution: QuantityResolution,
     ) -> dict[str, Any] | None: ...
 
     @classmethod

--- a/services/torghut/app/trading/submission_authority.py
+++ b/services/torghut/app/trading/submission_authority.py
@@ -75,7 +75,9 @@ def operational_submission_gate_status(
     raw_blocked_reasons = _strings(gate.get("blocked_reasons"))
     raw_reason = _text(gate.get("reason"), "")
     raw_allowed = _bool(gate.get("allowed"))
-    execution_route = _mapping(gate.get("execution_route"))
+    execution_route = _mapping(gate.get("execution_route")) or _mapping(
+        live_submission_gate.get("execution_route")
+    )
     blocked_reasons = _active_submission_blockers(
         raw_blocked_reasons,
         raw_reason=raw_reason,

--- a/services/torghut/tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py
+++ b/services/torghut/tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py
@@ -669,6 +669,73 @@ class TestSimulationSubmitOrderWithoutPriceKeepsLegacyFallback(
             )
             self.assertIsNotNone(execution)
 
+    def test_submit_order_precheck_uses_durable_inventory_for_lagging_fractional_exit(
+        self,
+    ) -> None:
+        settings.trading_fractional_equities_enabled = True
+        settings.trading_allow_shorts = True
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            executor = OrderExecutor()
+            buy_decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, 14, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("0.5"),
+                params={"price": Decimal("100")},
+            )
+            buy_decision_row = executor.ensure_decision(
+                session, buy_decision, strategy, "paper"
+            )
+            buy_execution = executor.submit_order(
+                session,
+                FilledAlpacaClient(),
+                buy_decision,
+                buy_decision_row,
+                "paper",
+            )
+            self.assertIsNotNone(buy_execution)
+
+            sell_decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, 20, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("0.5"),
+                params={"price": Decimal("101")},
+            )
+            sell_decision_row = executor.ensure_decision(
+                session, sell_decision, strategy, "paper"
+            )
+            lagging_client = FakeAlpacaClient()
+
+            sell_execution = executor.submit_order(
+                session,
+                lagging_client,
+                sell_decision,
+                sell_decision_row,
+                "paper",
+            )
+
+            self.assertIsNotNone(sell_execution)
+            self.assertEqual(len(lagging_client.submitted), 1)
+            self.assertEqual(lagging_client.submitted[0]["side"], "sell")
+            self.assertEqual(lagging_client.submitted[0]["qty"], "0.5")
+
     def test_submit_order_precheck_blocks_fractional_short_increasing_sell_when_enabled(
         self,
     ) -> None:

--- a/services/torghut/tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py
+++ b/services/torghut/tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py
@@ -736,6 +736,99 @@ class TestSimulationSubmitOrderWithoutPriceKeepsLegacyFallback(
             self.assertEqual(lagging_client.submitted[0]["side"], "sell")
             self.assertEqual(lagging_client.submitted[0]["qty"], "0.5")
 
+    def test_submit_order_precheck_blocks_second_lagging_fractional_exit_when_reserved(
+        self,
+    ) -> None:
+        class LaggingReservedSellClient(FakeAlpacaClient):
+            def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+                if status != "open":
+                    return []
+                return [
+                    {
+                        "id": "reserved-sell-1",
+                        "client_order_id": "reserved-sell-client-id",
+                        "symbol": "AAPL",
+                        "side": "sell",
+                        "type": "limit",
+                        "time_in_force": "day",
+                        "qty": "0.5",
+                        "filled_qty": "0",
+                        "status": "accepted",
+                    }
+                ]
+
+        settings.trading_fractional_equities_enabled = True
+        settings.trading_allow_shorts = True
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            executor = OrderExecutor()
+            buy_decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, 14, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("0.5"),
+                params={"price": Decimal("100")},
+            )
+            buy_decision_row = executor.ensure_decision(
+                session, buy_decision, strategy, "paper"
+            )
+            self.assertIsNotNone(
+                executor.submit_order(
+                    session,
+                    FilledAlpacaClient(),
+                    buy_decision,
+                    buy_decision_row,
+                    "paper",
+                )
+            )
+
+            sell_decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, 20, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("0.5"),
+                params={"price": Decimal("101")},
+            )
+            sell_decision_row = executor.ensure_decision(
+                session, sell_decision, strategy, "paper"
+            )
+            lagging_client = LaggingReservedSellClient()
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    lagging_client,
+                    sell_decision,
+                    sell_decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "broker_precheck")
+            self.assertEqual(payload.get("code"), "precheck_sell_qty_exceeds_available")
+            self.assertEqual(Decimal(str(payload.get("position_qty"))), Decimal("0.5"))
+            self.assertEqual(
+                Decimal(str(payload.get("held_for_open_sells"))), Decimal("0.5")
+            )
+            self.assertEqual(Decimal(str(payload.get("available_qty"))), Decimal("0"))
+            self.assertEqual(payload.get("existing_order_id"), "reserved-sell-1")
+            self.assertEqual(len(lagging_client.submitted), 0)
+
     def test_submit_order_precheck_blocks_fractional_short_increasing_sell_when_enabled(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_authority.py
+++ b/services/torghut/tests/test_submission_authority.py
@@ -105,6 +105,38 @@ def test_submission_authority_blocks_testnet_route_even_if_raw_gate_allows() -> 
     ]
 
 
+def test_submission_authority_uses_top_level_route_when_nested_gate_omits_route() -> (
+    None
+):
+    status = build_submission_authority_status(
+        {
+            "allowed": True,
+            "reason": "operational_submission_ready",
+            "blocked_reasons": [],
+            "execution_route": {
+                "route": "testnet",
+                "alpaca_regular_session_open": False,
+            },
+            "operational_submission_gate": {
+                "allowed": True,
+                "reason": "operational_submission_ready",
+                "blocked_reasons": [],
+            },
+        },
+    )
+
+    assert status["effective_submit_mode"] == "blocked"
+    assert status["can_submit_now"] is False
+    assert status["reason"] == "mainnet_route_unavailable"
+    assert status["operational_submission_gate"]["execution_route"] == {
+        "route": "testnet",
+        "alpaca_regular_session_open": False,
+    }
+    assert status["operational_submission_gate"]["blocked_reasons"] == [
+        "mainnet_route_unavailable"
+    ]
+
+
 def test_submission_authority_keeps_unknown_false_gate_closed() -> None:
     status = build_submission_authority_status(
         {


### PR DESCRIPTION
## Summary

- Blocks mixed compatibility payloads where a nested operational gate omits `execution_route` but the top-level live gate still reports a non-Alpaca route.
- Uses durable filled execution inventory as a fallback when broker position readback is empty or lagging, so fractional sell exits are not misclassified as new short sells.
- Keeps short-sell controls intact by sharing the resolved quantity basis with the shortability pre-submit checks.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_authority.py tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py -q`
- `uv run --frozen pytest tests/order_idempotency -q`
- `uv run --frozen ruff format --check app tests/test_submission_authority.py tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py`
- `uv run --frozen ruff check app scripts tests migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/submission_authority.py app/trading/execution/order_executor_core_methods.py app/trading/execution/order_executor_submission_methods.py app/trading/execution/shared_context.py tests/test_submission_authority.py tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/submission_authority.py app/trading/execution/order_executor_core_methods.py app/trading/execution/order_executor_submission_methods.py app/trading/execution/shared_context.py tests/test_submission_authority.py tests/order_idempotency/test_simulation_submit_order_without_price_keeps_legacy_fallback.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
