### PR TITLE
fix(arc): lower runner cpu requests and add metrics

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -78,7 +78,7 @@ spec:
                       docker version
                   resources:
                     requests:
-                      cpu: "4"
+                      cpu: "2"
                       memory: "8Gi"
                       ephemeral-storage: "4Gi"
                     limits:
@@ -110,7 +110,7 @@ spec:
                     - --max-concurrent-uploads=8
                   resources:
                     requests:
-                      cpu: "4"
+                      cpu: "2"
                       memory: "8Gi"
                       ephemeral-storage: "6Gi"
                     limits:
@@ -199,7 +199,7 @@ spec:
                       docker version
                   resources:
                     requests:
-                      cpu: "4"
+                      cpu: "2"
                       memory: "8Gi"
                       ephemeral-storage: "4Gi"
                     limits:
@@ -231,7 +231,7 @@ spec:
                     - --max-concurrent-uploads=8
                   resources:
                     requests:
-                      cpu: "4"
+                      cpu: "2"
                       memory: "8Gi"
                       ephemeral-storage: "6Gi"
                     limits:

--- a/argocd/applications/observability/README.md
+++ b/argocd/applications/observability/README.md
@@ -77,3 +77,23 @@ kubectl -n observability get secret rook-ceph-rgw-loki
 kubectl -n observability get pods
 kubectl -n argocd get app observability
 ```
+
+## Cluster metrics
+
+The observability app owns the cluster metrics pipeline used for ARC runner sizing:
+
+- `observability-kube-state-metrics`: Kubernetes object state and request/limit/allocatable metrics.
+- `observability-cluster-metrics-alloy`: scrapes kube-state-metrics plus kubelet `/metrics` and `/metrics/cadvisor`, filters to runner-sizing metrics, and remote-writes to Mimir.
+- `arc-runner-capacity-dashboard`: Grafana dashboard for ARC CPU, memory, pending pods, and requested CPU saturation.
+
+Validate the Mimir tenant after sync:
+
+```bash
+kubectl -n observability port-forward svc/observability-mimir-gateway 19090:80
+curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
+  --data-urlencode 'query=count(container_cpu_usage_seconds_total{namespace="arc"})' \
+  http://127.0.0.1:19090/prometheus/api/v1/query
+curl -fsS -G -H 'X-Scope-OrgID: anonymous' \
+  --data-urlencode 'query=count(kube_pod_container_resource_requests{namespace="arc"})' \
+  http://127.0.0.1:19090/prometheus/api/v1/query
+```

--- a/argocd/applications/observability/arc-runner-capacity-dashboard-configmap.yaml
+++ b/argocd/applications/observability/arc-runner-capacity-dashboard-configmap.yaml
@@ -1,0 +1,243 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: arc-runner-capacity-dashboard
+  namespace: observability
+data:
+  arc-runner-capacity-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cores"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"arc\",pod=~\"arc-(amd64|arm64).*runner.*\",container=~\"runner|dind\"}[5m]))",
+              "legendFormat": "used {{container}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"arc\",resource=\"cpu\",pod=~\"arc-(amd64|arm64).*runner.*\",container=~\"runner|dind\"})",
+              "legendFormat": "requested {{container}}",
+              "refId": "B"
+            }
+          ],
+          "title": "ARC CPU Used vs Requested",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"arc\",pod=~\"arc-(amd64|arm64).*runner.*\",container=~\"runner|dind\"})",
+              "legendFormat": "working set {{container}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"arc\",resource=\"memory\",pod=~\"arc-(amd64|arm64).*runner.*\",container=~\"runner|dind\"})",
+              "legendFormat": "requested {{container}}",
+              "refId": "B"
+            }
+          ],
+          "title": "ARC Memory Used vs Requested",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "expr": "sum by (phase) (kube_pod_status_phase{namespace=\"arc\",pod=~\"arc-(amd64|arm64).*runner.*\",phase=~\"Pending|Running\"})",
+              "legendFormat": "{{phase}}",
+              "refId": "A"
+            }
+          ],
+          "title": "ARC Runner Pod Phase",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "expr": "sum by (node) (kube_pod_container_resource_requests{resource=\"cpu\",node!=\"\"}) / sum by (node) (kube_node_status_allocatable{resource=\"cpu\"})",
+              "legendFormat": "{{node}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node Requested CPU Fraction",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 42,
+      "tags": [
+        "arc",
+        "capacity",
+        "kubernetes"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "ARC Runner Capacity",
+      "uid": "arc-runner-capacity",
+      "version": 1,
+      "weekStart": ""
+    }
+

--- a/argocd/applications/observability/cluster-metrics-alloy-configmap.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-configmap.yaml
@@ -1,0 +1,114 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observability-cluster-metrics-alloy
+  namespace: observability
+data:
+  config.river: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+
+    prometheus.remote_write "mimir" {
+      endpoint {
+        url = "http://observability-mimir-gateway.observability.svc.cluster.local/api/v1/push"
+      }
+    }
+
+    prometheus.relabel "arc_resource_metrics" {
+      forward_to     = [prometheus.remote_write.mimir.receiver]
+      max_cache_size = 0
+      cache_ttl      = "10m"
+
+      rule {
+        action        = "keep"
+        source_labels = ["__name__"]
+        regex         = "up|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|kube_deployment_status_replicas_available|kube_node_status_allocatable|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_info|kube_pod_labels|kube_pod_status_phase|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes"
+      }
+    }
+
+    discovery.kubernetes "nodes" {
+      role = "node"
+    }
+
+    discovery.relabel "kubelet_cadvisor" {
+      targets = discovery.kubernetes.nodes.targets
+
+      rule {
+        target_label = "__address__"
+        replacement  = "kubernetes.default.svc:443"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_node_name"]
+        target_label  = "__metrics_path__"
+        replacement   = "/api/v1/nodes/$1/proxy/metrics/cadvisor"
+      }
+
+      rule {
+        target_label = "job"
+        replacement  = "kubelet-cadvisor"
+      }
+    }
+
+    discovery.relabel "kubelet_metrics" {
+      targets = discovery.kubernetes.nodes.targets
+
+      rule {
+        target_label = "__address__"
+        replacement  = "kubernetes.default.svc:443"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_node_name"]
+        target_label  = "__metrics_path__"
+        replacement   = "/api/v1/nodes/$1/proxy/metrics"
+      }
+
+      rule {
+        target_label = "job"
+        replacement  = "kubelet"
+      }
+    }
+
+    prometheus.scrape "kubelet_cadvisor" {
+      targets           = discovery.relabel.kubelet_cadvisor.output
+      scheme            = "https"
+      scrape_interval   = "30s"
+      scrape_timeout    = "10s"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      forward_to        = [prometheus.relabel.arc_resource_metrics.receiver]
+
+      tls_config {
+        ca_file     = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        server_name = "kubernetes.default.svc"
+      }
+    }
+
+    prometheus.scrape "kubelet" {
+      targets           = discovery.relabel.kubelet_metrics.output
+      scheme            = "https"
+      scrape_interval   = "30s"
+      scrape_timeout    = "10s"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      forward_to        = [prometheus.relabel.arc_resource_metrics.receiver]
+
+      tls_config {
+        ca_file     = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        server_name = "kubernetes.default.svc"
+      }
+    }
+
+    prometheus.scrape "kube_state_metrics" {
+      targets = [
+        {
+          "__address__" = "observability-kube-state-metrics.observability.svc.cluster.local:8080",
+          "job"         = "kube-state-metrics",
+        },
+      ]
+      scrape_interval = "30s"
+      scrape_timeout  = "10s"
+      forward_to      = [prometheus.relabel.arc_resource_metrics.receiver]
+    }
+

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: observability-cluster-metrics-alloy
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: observability-cluster-metrics-alloy
+    app.kubernetes.io/component: cluster-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: observability-cluster-metrics-alloy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: observability-cluster-metrics-alloy
+        app.kubernetes.io/component: cluster-metrics
+    spec:
+      serviceAccountName: observability-cluster-metrics-alloy
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 473
+        runAsGroup: 473
+        fsGroup: 473
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.11.2
+          args:
+            - run
+            - /etc/alloy/config.river
+          workingDir: /var/lib/alloy
+          ports:
+            - name: http
+              containerPort: 12345
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: observability-cluster-metrics-alloy
+        - name: data
+          emptyDir: {}

--- a/argocd/applications/observability/cluster-metrics-alloy-rbac.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: observability-cluster-metrics-alloy
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: observability-cluster-metrics-alloy
+rules:
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - namespaces
+      - nodes
+      - nodes/metrics
+      - nodes/proxy
+      - pods
+      - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs:
+      - /metrics
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: observability-cluster-metrics-alloy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: observability-cluster-metrics-alloy
+subjects:
+  - kind: ServiceAccount
+    name: observability-cluster-metrics-alloy
+    namespace: observability
+

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -133,6 +133,57 @@ data:
                 AgentRun step pods are active while agents-alloy has no available replicas.
                 Logs can be lost once Job pods terminate.
               runbook_url: docs/runbooks/agents-log-observability.md
+      - name: arc-runner-capacity.rules
+        rules:
+          - alert: ArcRunnerResourceMetricsMissing
+            expr: |
+              absent(container_cpu_usage_seconds_total{namespace="arc"}) or
+              absent(kube_pod_container_resource_requests{namespace="arc"})
+            for: 10m
+            labels:
+              severity: warning
+              team: platform
+              service: arc
+            annotations:
+              summary: ARC runner resource metrics are missing
+              description: |
+                Mimir is not receiving ARC container CPU metrics or Kubernetes resource request metrics.
+                Check observability-cluster-metrics-alloy and observability-kube-state-metrics in the observability app.
+          - alert: ArcRunnerPodsPending
+            expr: |
+              sum(
+                kube_pod_status_phase{
+                  namespace="arc",
+                  pod=~"arc-(amd64|arm64).*runner.*",
+                  phase="Pending"
+                }
+              ) > 0
+            for: 10m
+            labels:
+              severity: warning
+              team: platform
+              service: arc
+            annotations:
+              summary: ARC runner pods are pending
+              description: |
+                One or more lab ARC runner pods have been Pending for 10 minutes.
+                Compare requested CPU and memory against node allocatable capacity in the ARC Runner Capacity dashboard.
+          - alert: ArcArm64RequestedCpuSaturated
+            expr: |
+              max by (node) (
+                sum by (node) (kube_pod_container_resource_requests{resource="cpu",node!="",node="talos-192-168-1-85"}) /
+                sum by (node) (kube_node_status_allocatable{resource="cpu",node="talos-192-168-1-85"})
+              ) > 0.9
+            for: 15m
+            labels:
+              severity: warning
+              team: platform
+              service: arc
+            annotations:
+              summary: Altra requested CPU is saturated
+              description: |
+                Requested CPU on the arm64 runner node is above 90% of allocatable CPU for 15 minutes.
+                ARC arm64 runner scale-out may be blocked even if live CPU usage is low.
       - name: torghut-clickhouse.guardrails.rules
         rules:
           - alert: TorghutClickHouseDiskFreeLowWarning

--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -51,6 +51,7 @@ dashboardsConfigMaps:
   graf-bumba-dashboard: graf-bumba-dashboard
   codex-pipeline-dashboard: codex-pipeline-dashboard
   torghut-execution-recovery-dashboard: torghut-execution-recovery-dashboard
+  arc-runner-capacity-dashboard: arc-runner-capacity-dashboard
 
 dashboardProviders:
   dashboardproviders.yaml:
@@ -88,3 +89,11 @@ dashboardProviders:
         editable: true
         options:
           path: /var/lib/grafana/dashboards/torghut-execution-recovery-dashboard
+      - name: arc-runner-capacity-dashboard
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/arc-runner-capacity-dashboard

--- a/argocd/applications/observability/kube-state-metrics-values.yaml
+++ b/argocd/applications/observability/kube-state-metrics-values.yaml
@@ -1,0 +1,11 @@
+fullnameOverride: observability-kube-state-metrics
+prometheusScrape: false
+replicas: 1
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -13,8 +13,19 @@ resources:
   - symphony-fleet-dashboard-configmap.yaml
   - codex-pipeline-dashboard-configmap.yaml
   - torghut-execution-recovery-dashboard-configmap.yaml
+  - arc-runner-capacity-dashboard-configmap.yaml
+  - cluster-metrics-alloy-rbac.yaml
+  - cluster-metrics-alloy-configmap.yaml
+  - cluster-metrics-alloy-deployment.yaml
 
 helmCharts:
+  - name: kube-state-metrics
+    repo: https://prometheus-community.github.io/helm-charts
+    version: 7.3.0
+    releaseName: observability-kube-state-metrics
+    namespace: observability
+    includeCRDs: true
+    valuesFile: kube-state-metrics-values.yaml
   - name: mimir-distributed
     repo: https://grafana.github.io/helm-charts
     version: 6.1.0

--- a/docs/superpowers/plans/2026-07-09-arc-runner-observability-metrics.md
+++ b/docs/superpowers/plans/2026-07-09-arc-runner-observability-metrics.md
@@ -1,0 +1,114 @@
+# ARC Runner Observability Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce normal lab ARC runner CPU requests where benchmarks support it, and make Kubernetes/container runner metrics available in the `observability` Argo CD application for ongoing CI sizing.
+
+**Architecture:** Keep runtime CPU limits unchanged so jobs are not throttled by this request change. Install kube-state-metrics plus an observability-owned Alloy collector that scrapes kube-state-metrics and kubelet/cAdvisor, filters to runner sizing metrics, and remote-writes to the existing Mimir gateway. Provision a Grafana dashboard and Mimir alert rules from the same observability app so the signal is owned by GitOps.
+
+**Tech Stack:** Argo CD, Kustomize Helm integration, kube-state-metrics chart `7.3.0`, Grafana Alloy `v1.11.2`, Grafana Mimir, Grafana dashboards, GitHub Actions ARC.
+
+---
+
+## Benchmark Summary
+
+The ARC request change lowers only scheduler requests for the normal `arc-amd64` and `arc-arm64` scale sets:
+
+- `runner.requests.cpu`: `4` to `2`
+- `dind.requests.cpu`: `4` to `2`
+- CPU limits remain `runner=8`, `dind=12`
+- Memory, storage, labels, and `maxRunners=25` remain unchanged
+
+Kubernetes CPU requests do not cap runtime CPU. They decide whether a pod can schedule. Runtime speed is affected by CPU limits and by actual node contention.
+
+Recent GitHub Actions baseline, last five successful runs where available:
+
+| Workflow job                         | Runner      | Average |
+| ------------------------------------ | ----------- | ------: |
+| `agents-build-push` controller image | `arc-amd64` |  219.8s |
+| `agents-build-push` controller image | `arc-arm64` |  472.8s |
+| `agents-build-push` runner image     | `arc-amd64` |  210.6s |
+| `agents-build-push` runner image     | `arc-arm64` |  380.8s |
+| `jangar-build-push` Nix image        | `arc-amd64` |  465.8s |
+| `jangar-build-push` Nix image        | `arc-arm64` |  862.4s |
+| `torghut-build-push` Nix image       | `arc-amd64` |  169.2s |
+| `torghut-build-push` Nix image       | `arc-arm64` |  202.4s |
+| `Temporal Bun SDK CI` test           | `arc-arm64` |  551.6s |
+
+Live Kubernetes benchmark, same runner image and dind sidecar:
+
+| Profile                 | Scheduled |  CPU avg | Docker avg | Total avg |
+| ----------------------- | --------: | -------: | ---------: | --------: |
+| `amd64` current `4+4`   |       8/8 | 1226.4ms |   3302.1ms |  4536.0ms |
+| `amd64` candidate `2+2` |       8/8 | 1226.0ms |   4017.4ms |  5251.1ms |
+| `arm64` current `4+4`   |     11/12 | 1444.5ms |  10842.0ms | 12300.5ms |
+| `arm64` candidate `2+2` |     18/25 | 1453.6ms |  19836.4ms | 21304.8ms |
+
+Decision:
+
+- CPU-bound work was flat: `amd64` changed by ~0.0%, `arm64` by ~0.6%.
+- Docker-heavy synthetic work slowed on arm64 at higher density, but current `4+4` already fails to schedule even 12 pods; candidate `2+2` scheduled 18 pods before Altra reached 98% requested CPU.
+- Proceed with `2+2` requests because the change improves scheduling without lowering CPU limits.
+- Do not lower CPU limits from the current `runner=8`, `dind=12` without real Mimir P95/P99 data.
+- Next performance optimization should split normal Nix/non-Docker runners from Docker/dind runners, because most Nix OCI workflows do not need dind but currently reserve it.
+
+## Files
+
+- Modify: `argocd/applications/arc/application.yaml`
+  - Lower normal lab `arc-amd64` and `arc-arm64` runner/dind CPU requests.
+- Modify: `argocd/applications/observability/kustomization.yaml`
+  - Add kube-state-metrics Helm chart and cluster metrics resources.
+- Create: `argocd/applications/observability/kube-state-metrics-values.yaml`
+  - Configure kube-state-metrics resources and naming.
+- Create: `argocd/applications/observability/cluster-metrics-alloy-rbac.yaml`
+  - Grant Alloy read access for node, pod, service, endpoint, endpoint slice, and kubelet proxy scrapes.
+- Create: `argocd/applications/observability/cluster-metrics-alloy-configmap.yaml`
+  - Scrape kube-state-metrics, kubelet `/metrics`, and kubelet `/metrics/cadvisor`.
+  - Keep only ARC sizing and existing kube alert metrics before remote_write.
+- Create: `argocd/applications/observability/cluster-metrics-alloy-deployment.yaml`
+  - Run the cluster metrics Alloy collector in the `observability` namespace.
+- Create: `argocd/applications/observability/arc-runner-capacity-dashboard-configmap.yaml`
+  - Provision Grafana dashboard `ARC Runner Capacity`.
+- Modify: `argocd/applications/observability/grafana-values.yaml`
+  - Mount the ARC dashboard.
+- Modify: `argocd/applications/observability/graf-mimir-rules.yaml`
+  - Alert when ARC metrics disappear, runner pods stay pending, or Altra requested CPU is saturated.
+
+## Execution Tasks
+
+### Task 1: ARC Request Reduction
+
+- [x] Change normal `arc-arm64` runner CPU request from `4` to `2`.
+- [x] Change normal `arc-arm64` dind CPU request from `4` to `2`.
+- [x] Change normal `arc-amd64` runner CPU request from `4` to `2`.
+- [x] Change normal `arc-amd64` dind CPU request from `4` to `2`.
+- [x] Leave analysis runner requests unchanged at `1+1`.
+- [x] Leave CPU limits unchanged.
+
+### Task 2: Observability Metrics Pipeline
+
+- [x] Install kube-state-metrics from the `observability` app.
+- [x] Add an Alloy collector in the `observability` namespace.
+- [x] Scrape kube-state-metrics for `kube_pod_container_resource_requests`, `kube_pod_container_resource_limits`, `kube_node_status_allocatable`, `kube_pod_status_phase`, `kube_pod_labels`, and deployment/restart metrics.
+- [x] Scrape kubelet cAdvisor for `container_cpu_usage_seconds_total` and `container_memory_working_set_bytes`.
+- [x] Remote-write the filtered metrics to the existing Mimir gateway.
+
+### Task 3: Dashboards And Alerts
+
+- [x] Add Grafana dashboard `ARC Runner Capacity`.
+- [x] Add Mimir rule `ArcRunnerResourceMetricsMissing`.
+- [x] Add Mimir rule `ArcRunnerPodsPending`.
+- [x] Add Mimir rule `ArcArm64RequestedCpuSaturated`.
+
+### Task 4: Validation
+
+- [x] Run `kustomize build --enable-helm argocd/applications/observability`.
+- [x] Run `kubectl apply --dry-run=server -f argocd/applications/arc/application.yaml`.
+- [x] Run server dry-run validation for the new observability Alloy and dashboard manifests.
+- [x] Parse the ARC dashboard JSON from `argocd/applications/observability/arc-runner-capacity-dashboard-configmap.yaml`.
+- [x] Run `bunx oxfmt --check argocd/applications/arc/application.yaml argocd/applications/observability docs/superpowers/plans/2026-07-09-arc-runner-observability-metrics.md`.
+- [ ] Open PR using `.github/PULL_REQUEST_TEMPLATE.md`.
+- [ ] Merge with squash after checks pass.
+- [ ] Refresh/sync `arc` and `observability` Argo CD apps.
+- [ ] Verify `arc-amd64` and `arc-arm64` live runner templates have `runner=2`, `dind=2` CPU requests.
+- [ ] Verify Mimir has these series in tenant `anonymous`: `container_cpu_usage_seconds_total`, `container_memory_working_set_bytes`, `kube_pod_container_resource_requests`, `kube_node_status_allocatable`.


### PR DESCRIPTION
## Summary

- Lowers normal lab ARC `arc-amd64` and `arc-arm64` runner/dind CPU requests from `4+4` to `2+2` while keeping existing CPU limits unchanged.
- Adds observability-owned kube-state-metrics plus a Grafana Alloy collector that scrapes kube-state and kubelet/cAdvisor metrics into Mimir.
- Adds an ARC Runner Capacity Grafana dashboard, Mimir alert rules for missing/pending/saturated runner metrics, and a documented benchmark/rollout plan.

## Related Issues

None

## Testing

- Live GitHub Actions baseline timing aggregation for recent `agents-build-push`, `jangar-build-push`, `torghut-build-push`, `temporal-bun-sdk`, and `torghut-ci` runs.
- Live Kubernetes benchmark in `arc` using the runner image and `docker:dind` sidecar for current `4+4` and candidate `2+2` request profiles.
- `kustomize build --enable-helm argocd/applications/observability`
- `kubectl apply --dry-run=server -f argocd/applications/arc/application.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/observability/cluster-metrics-alloy-rbac.yaml -f argocd/applications/observability/cluster-metrics-alloy-configmap.yaml -f argocd/applications/observability/cluster-metrics-alloy-deployment.yaml -f argocd/applications/observability/arc-runner-capacity-dashboard-configmap.yaml`
- Dashboard JSON parse check for `argocd/applications/observability/arc-runner-capacity-dashboard-configmap.yaml`
- `bunx oxfmt --check argocd/applications/arc/application.yaml argocd/applications/observability docs/superpowers/plans/2026-07-09-arc-runner-observability-metrics.md`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
