### PR TITLE
fix(observability): remove unsupported alloy relabel option

### DIFF
--- a/argocd/applications/observability/cluster-metrics-alloy-configmap.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-configmap.yaml
@@ -19,7 +19,6 @@ data:
     prometheus.relabel "arc_resource_metrics" {
       forward_to     = [prometheus.remote_write.mimir.receiver]
       max_cache_size = 0
-      cache_ttl      = "10m"
 
       rule {
         action        = "keep"
@@ -111,4 +110,3 @@ data:
       scrape_timeout  = "10s"
       forward_to      = [prometheus.relabel.arc_resource_metrics.receiver]
     }
-


### PR DESCRIPTION
## Summary

- Remove the unsupported `cache_ttl` attribute from the ARC cluster metrics Alloy relabel component.
- Keep the relabel cache disabled with the supported `max_cache_size = 0` setting.
- Restore the observability collector rollout introduced by the ARC runner metrics change.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/observability >/tmp/observability-hotfix-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/observability-hotfix-render.yaml`
- `kubectl -n observability` temporary validation pod running `grafana/alloy:v1.11.2 validate /etc/alloy/config.river`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
