### PR TITLE
fix(observability): use default alloy relabel cache

### DIFF
--- a/argocd/applications/observability/cluster-metrics-alloy-configmap.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-configmap.yaml
@@ -17,8 +17,7 @@ data:
     }
 
     prometheus.relabel "arc_resource_metrics" {
-      forward_to     = [prometheus.remote_write.mimir.receiver]
-      max_cache_size = 0
+      forward_to = [prometheus.remote_write.mimir.receiver]
 
       rule {
         action        = "keep"


### PR DESCRIPTION
## Summary

- Remove the unsupported `max_cache_size = 0` override from the ARC cluster metrics Alloy relabel component.
- Let Alloy use its default relabel cache settings so the collector can complete startup.
- Validate the corrected River config with an actual short-lived `alloy run` pod using the production service account.

## Related Issues

None

## Testing

- `kustomize build --enable-helm argocd/applications/observability >/tmp/observability-cache-hotfix-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/observability-cache-hotfix-render.yaml`
- Temporary `kubectl -n observability` pod running `grafana/alloy:v1.11.2 run /etc/alloy/config.river` with `serviceAccountName: observability-cluster-metrics-alloy`; verified it reached `Running` and logs contained `finished complete graph evaluation` with no initial-load errors.
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
