### PR TITLE
fix(dorvud): reconnect stalled hyperliquid market feed

### DIFF
--- a/.github/workflows/dorvud.yml
+++ b/.github/workflows/dorvud.yml
@@ -36,6 +36,6 @@ jobs:
         run: ./gradlew ktlintCheck
         working-directory: services/dorvud
 
-      - name: Run tests (platform, websockets, technical-analysis)
-        run: ./gradlew :platform:test :websockets:test :technical-analysis:test
+      - name: Run tests (platform, websockets, technical-analysis, hyperliquid-feed)
+        run: ./gradlew :platform:test :websockets:test :technical-analysis:test :hyperliquid-feed:test
         working-directory: services/dorvud

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/HyperliquidFeedApp.kt
@@ -216,6 +216,12 @@ class HyperliquidFeedApp(
           metrics.setWsConnected(true)
           subscribeAll(shard)
           updateReady()
+          val marketDataStallGuard =
+            MarketDataStallGuard(
+              connectedAtMs = nowMs(),
+              startupGraceMs = config.readyEventMaxAgeMs,
+              checkIntervalMs = config.heartbeatIntervalMs,
+            )
           val heartbeat = launch { heartbeatLoop() }
           try {
             while (scope.isActive) {
@@ -225,12 +231,26 @@ class HyperliquidFeedApp(
                 } ?: error(
                   "hyperliquid websocket shard=${shard.index} idle for ${config.wsReadIdleTimeoutMs}ms; reconnecting",
                 )
-              if (frame !is Frame.Text) continue
-              val raw = frame.readText()
-              val rawRecord = mapper.rawRecord(raw)
-              publishRecords(producer, clickHouseSink, listOf(rawRecord))
-              val normalized = mapper.websocketRecords(raw)
-              publishRecords(producer, clickHouseSink, normalized)
+              if (frame is Frame.Text) {
+                val raw = frame.readText()
+                val rawRecord = mapper.rawRecord(raw)
+                publishRecords(producer, clickHouseSink, listOf(rawRecord))
+                val normalized = mapper.websocketRecords(raw)
+                publishRecords(producer, clickHouseSink, normalized)
+              }
+
+              val staleMarketData =
+                marketDataStallGuard.staleSnapshotIfDue(
+                  observedAtMs = nowMs(),
+                  freshness = ::eventFreshnessSnapshot,
+                )
+              if (staleMarketData != null) {
+                error(
+                  "hyperliquid websocket shard=${shard.index} market data stale " +
+                    "last_seen_lag_ms=${staleMarketData.lastSeenLagMs} " +
+                    "ready_event_max_age_ms=${config.readyEventMaxAgeMs}; reconnecting",
+                )
+              }
             }
           } finally {
             heartbeat.cancel()

--- a/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/MarketDataStallGuard.kt
+++ b/services/dorvud/hyperliquid-feed/src/main/kotlin/ai/proompteng/dorvud/hyperliquid/MarketDataStallGuard.kt
@@ -1,0 +1,24 @@
+package ai.proompteng.dorvud.hyperliquid
+
+internal class MarketDataStallGuard(
+  connectedAtMs: Long,
+  startupGraceMs: Long,
+  private val checkIntervalMs: Long,
+) {
+  private var nextCheckAtMs = connectedAtMs + startupGraceMs
+
+  init {
+    require(startupGraceMs > 0) { "startupGraceMs must be positive" }
+    require(checkIntervalMs > 0) { "checkIntervalMs must be positive" }
+  }
+
+  fun staleSnapshotIfDue(
+    observedAtMs: Long,
+    freshness: () -> EventFreshnessSnapshot,
+  ): EventFreshnessSnapshot? {
+    if (observedAtMs < nextCheckAtMs) return null
+
+    nextCheckAtMs = observedAtMs + checkIntervalMs
+    return freshness().takeUnless { it.fresh }
+  }
+}

--- a/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/MarketDataStallGuardTest.kt
+++ b/services/dorvud/hyperliquid-feed/src/test/kotlin/ai/proompteng/dorvud/hyperliquid/MarketDataStallGuardTest.kt
@@ -1,0 +1,41 @@
+package ai.proompteng.dorvud.hyperliquid
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MarketDataStallGuardTest {
+  @Test
+  fun `ignores stale market data during startup grace then requests reconnect`() {
+    val guard = MarketDataStallGuard(connectedAtMs = 1_000, startupGraceMs = 180_000, checkIntervalMs = 30_000)
+    var freshnessChecks = 0
+    val staleSnapshot = EventFreshnessSnapshot(fresh = false, lastSeenLagMs = mapOf("bbo" to null, "candle" to null))
+
+    assertNull(
+      guard.staleSnapshotIfDue(observedAtMs = 180_999) {
+        freshnessChecks += 1
+        staleSnapshot
+      },
+    )
+    assertEquals(0, freshnessChecks)
+    assertEquals(
+      staleSnapshot,
+      guard.staleSnapshotIfDue(observedAtMs = 181_000) {
+        freshnessChecks += 1
+        staleSnapshot
+      },
+    )
+    assertEquals(1, freshnessChecks)
+  }
+
+  @Test
+  fun `rechecks healthy market data at the configured cadence`() {
+    val guard = MarketDataStallGuard(connectedAtMs = 0, startupGraceMs = 100, checkIntervalMs = 25)
+    val freshSnapshot = EventFreshnessSnapshot(fresh = true, lastSeenLagMs = mapOf("bbo" to 0))
+    val staleSnapshot = EventFreshnessSnapshot(fresh = false, lastSeenLagMs = mapOf("bbo" to 126))
+
+    assertNull(guard.staleSnapshotIfDue(observedAtMs = 100) { freshSnapshot })
+    assertNull(guard.staleSnapshotIfDue(observedAtMs = 124) { staleSnapshot })
+    assertEquals(staleSnapshot, guard.staleSnapshotIfDue(observedAtMs = 125) { staleSnapshot })
+  }
+}


### PR DESCRIPTION
## Summary

- reconnect the Hyperliquid websocket when required BBO/candle traffic remains stale after the configured startup grace period
- preserve the existing socket idle timeout while detecting connections kept alive only by heartbeat or unrelated frames
- add regression coverage for starvation detection timing and recheck cadence
- include the Hyperliquid feed tests in the required Dorvud CI test job

## Related Issues

None

## Testing

- `nix develop -c bash -c 'cd services/dorvud && ./gradlew :hyperliquid-feed:ktlintCheck :hyperliquid-feed:test'`
- `nix develop -c bash -c 'cd services/dorvud && ./gradlew ktlintCheck :platform:test :websockets:test :technical-analysis:test :hyperliquid-feed:test'`
- replaced the stuck live feed pod and verified `/readyz` returned `ready`, BBO/candle freshness recovered, Argo became `Healthy`, and both Alertmanager and Mimir ruler APIs returned no alerts

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation or release-note changes are required.
