### PR TITLE
chore(torghut): promote hyperliquid feed image sha-10bd17cdd5a053c431624bf743cdc30338a2ab21

### DIFF
--- a/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-feed/deployment.yaml
@@ -32,18 +32,18 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-feed
-          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:87e837baf513737c788b946b0e11b9dffea0180bf705c32500c14387f38dc9fd
+          image: registry.ide-newton.ts.net/lab/torghut-hyperliquid-feed@sha256:dd853157f98d3e9ddecfc2bc62edd608b71036c4cf7a86e539f6b9bf53e06264
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: torghut-hyperliquid-feed-config
           env:
             - name: TORGHUT_HYPERLIQUID_FEED_VERSION
-              value: main-sha-b2bde9f21285e3733e8a25a664f9f7e10d1485b4
+              value: main-sha-10bd17cdd5a053c431624bf743cdc30338a2ab21
             - name: TORGHUT_HYPERLIQUID_FEED_COMMIT
-              value: b2bde9f21285e3733e8a25a664f9f7e10d1485b4
+              value: 10bd17cdd5a053c431624bf743cdc30338a2ab21
             - name: TORGHUT_HYPERLIQUID_FEED_IMAGE_DIGEST
-              value: sha256:87e837baf513737c788b946b0e11b9dffea0180bf705c32500c14387f38dc9fd
+              value: sha256:dd853157f98d3e9ddecfc2bc62edd608b71036c4cf7a86e539f6b9bf53e06264
             - name: KAFKA_SASL_USER
               value: torghut-hyperliquid-feed
             - name: KAFKA_SASL_PASSWORD


### PR DESCRIPTION
## Summary
Promote the Torghut Hyperliquid feed image into GitOps manifests.

- Source commit: `10bd17cdd5a053c431624bf743cdc30338a2ab21`
- Image tag: `sha-10bd17cdd5a053c431624bf743cdc30338a2ab21`
- Image digest: `sha256:dd853157f98d3e9ddecfc2bc62edd608b71036c4cf7a86e539f6b9bf53e06264`
- Manifest: Hyperliquid feed Deployment