### PR TITLE
fix(torghut): isolate rejected pair allocations

### DIFF
--- a/services/torghut/app/trading/portfolio/allocation_helpers.py
+++ b/services/torghut/app/trading/portfolio/allocation_helpers.py
@@ -65,6 +65,68 @@ def position_summary(
     return total_qty, total_value
 
 
+def position_qty(symbol: str, positions: Iterable[dict[str, Any]]) -> Decimal:
+    return position_summary(symbol, positions)[0]
+
+
+def position_market_value(
+    symbol: str,
+    positions: Iterable[dict[str, Any]],
+) -> Decimal | None:
+    total_market_value = Decimal("0")
+    has_market_value = False
+    for position in positions:
+        if position.get("symbol") != symbol:
+            continue
+        market_value = optional_decimal(position.get("market_value"))
+        if market_value is None:
+            continue
+        total_market_value += market_value
+        has_market_value = True
+    return total_market_value if has_market_value else None
+
+
+def projected_position_market_value(
+    current_market_value: Decimal | None,
+    delta: Decimal,
+    decision_price: Decimal | None,
+) -> Decimal | None:
+    if decision_price is None:
+        return current_market_value
+    return (current_market_value or Decimal("0")) + (delta * decision_price)
+
+
+def apply_projected_position_decision(
+    positions: list[dict[str, Any]],
+    decision: StrategyDecision,
+) -> None:
+    qty = optional_decimal(decision.qty)
+    if qty is None or qty <= 0 or decision.action not in {"buy", "sell"}:
+        return
+    current_qty = position_qty(decision.symbol, positions)
+    current_market_value = position_market_value(decision.symbol, positions)
+    delta = qty if decision.action == "buy" else -qty
+    projected_qty = current_qty + delta
+    projected_market_value = projected_position_market_value(
+        current_market_value,
+        delta,
+        extract_decision_price(decision),
+    )
+    positions[:] = [
+        position for position in positions if position.get("symbol") != decision.symbol
+    ]
+    if projected_qty == 0:
+        return
+    projected_position = {
+        "symbol": decision.symbol,
+        "qty": str(abs(projected_qty)),
+        "side": "short" if projected_qty < 0 else "long",
+    }
+    if projected_market_value is not None:
+        projected_position["market_value"] = str(projected_market_value)
+    positions.append(projected_position)
+
+
 def gross_cap_for_symbol(
     max_gross: Optional[Decimal],
     current_gross: Decimal,

--- a/services/torghut/app/trading/scheduler/capital_controls.py
+++ b/services/torghut/app/trading/scheduler/capital_controls.py
@@ -24,6 +24,7 @@ from ..prices import PriceFetcher
 from ..session_context import regular_session_open_utc_for
 from ..tigerbeetle_reconcile.latest_tigerbeetle_reconciliation_status_p import (
     latest_tigerbeetle_reconciliation_status_payload,
+    reconcile_tigerbeetle_transfers,
 )
 from ..time_source import trading_now
 from .state import TradingState
@@ -236,6 +237,20 @@ class CapitalSafetyController:
             return reason
 
         reason = self._tigerbeetle_reconciliation_reason(payload)
+        if reason is not None:
+            try:
+                payload = reconcile_tigerbeetle_transfers(session)
+            except (
+                OSError,
+                SQLAlchemyError,
+                RuntimeError,
+                TypeError,
+                ValueError,
+            ) as exc:
+                logger.exception("TigerBeetle reconciliation safety refresh failed")
+                reason = f"tigerbeetle_reconciliation_unavailable:{type(exc).__name__}"
+            else:
+                reason = self._tigerbeetle_reconciliation_reason(payload)
         self._record_ledger_state(reason=reason, now=now)
         return reason
 

--- a/services/torghut/app/trading/scheduler/pair_execution.py
+++ b/services/torghut/app/trading/scheduler/pair_execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Iterable, Mapping
 from dataclasses import replace
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import cast
 
@@ -37,16 +38,13 @@ def reserve_pair_allocations(
     account: dict[str, str],
     positions: list[dict[str, object]],
 ) -> list[list[AllocationResult]]:
-    grouped: dict[tuple[str, str, str], list[AllocationResult]] = {}
-    for allocation in allocations:
-        decision = allocation.decision
-        grouped.setdefault(_pair_signal_epoch(decision), []).append(allocation)
+    grouped = _pair_allocation_cohorts(allocations)
     projected_positions: list[dict[str, object]] = [
         dict(position) for position in positions
     ]
     remaining_buying_power = _spendable_buying_power(account)
     reserved_groups: list[list[AllocationResult]] = []
-    for _, group in sorted(grouped.items()):
+    for group in grouped:
         reserved_group = _reserve_group(
             group,
             account=account,
@@ -66,6 +64,130 @@ def reserve_pair_allocations(
         for item in reserved_group:
             apply_projected_position_decision(projected_positions, item.decision)
     return reserved_groups
+
+
+def _pair_allocation_cohorts(
+    allocations: Iterable[AllocationResult],
+) -> list[list[AllocationResult]]:
+    scopes: dict[tuple[str, str, int], list[AllocationResult]] = {}
+    for allocation in allocations:
+        decision = allocation.decision
+        scope = (
+            decision.strategy_id,
+            decision.timeframe,
+            _pair_side_count(decision),
+        )
+        scopes.setdefault(scope, []).append(allocation)
+
+    max_skew = timedelta(milliseconds=max(1, settings.trading_poll_ms))
+    cohorts: list[list[AllocationResult]] = []
+    for (_, _, side_count), scoped_allocations in sorted(scopes.items()):
+        matches, unmatched = _nearest_opposite_side_matches(
+            scoped_allocations, max_skew=max_skew
+        )
+        cohorts.extend(
+            _cohort_pair_matches(
+                matches,
+                side_count=side_count,
+                max_skew=max_skew,
+            )
+        )
+        cohorts.extend([[allocation] for allocation in unmatched])
+    return sorted(cohorts, key=_pair_group_order)
+
+
+def _nearest_opposite_side_matches(
+    allocations: list[AllocationResult],
+    *,
+    max_skew: timedelta,
+) -> tuple[list[tuple[AllocationResult, AllocationResult]], list[AllocationResult]]:
+    high = [item for item in allocations if _pair_side(item.decision) == "high_rank"]
+    low = [item for item in allocations if _pair_side(item.decision) == "low_rank"]
+    candidates: list[tuple[timedelta, datetime, datetime, str, str, int, int]] = []
+    for high_index, high_item in enumerate(high):
+        for low_index, low_item in enumerate(low):
+            high_ts = high_item.decision.event_ts
+            low_ts = low_item.decision.event_ts
+            skew = abs(high_ts - low_ts)
+            if skew <= max_skew:
+                candidates.append(
+                    (
+                        skew,
+                        min(high_ts, low_ts),
+                        max(high_ts, low_ts),
+                        high_item.decision.symbol,
+                        low_item.decision.symbol,
+                        high_index,
+                        low_index,
+                    )
+                )
+
+    used_high: set[int] = set()
+    used_low: set[int] = set()
+    matches: list[tuple[AllocationResult, AllocationResult]] = []
+    for *_, high_index, low_index in sorted(candidates):
+        if high_index in used_high or low_index in used_low:
+            continue
+        used_high.add(high_index)
+        used_low.add(low_index)
+        matches.append((high[high_index], low[low_index]))
+
+    matched_ids = {id(item) for match in matches for item in match}
+    unmatched = [item for item in allocations if id(item) not in matched_ids]
+    return matches, unmatched
+
+
+def _cohort_pair_matches(
+    matches: list[tuple[AllocationResult, AllocationResult]],
+    *,
+    side_count: int,
+    max_skew: timedelta,
+) -> list[list[AllocationResult]]:
+    cohorts: list[list[AllocationResult]] = []
+    current: list[tuple[AllocationResult, AllocationResult]] = []
+    for match in sorted(matches, key=_pair_match_order):
+        candidate = [*current, match]
+        if current and (
+            len(candidate) > side_count or _pair_match_span(candidate) > max_skew
+        ):
+            cohorts.append([item for pair in current for item in pair])
+            current = []
+        current.append(match)
+        if len(current) == side_count:
+            cohorts.append([item for pair in current for item in pair])
+            current = []
+    if current:
+        cohorts.append([item for pair in current for item in pair])
+    return cohorts
+
+
+def _pair_match_order(
+    match: tuple[AllocationResult, AllocationResult],
+) -> tuple[datetime, datetime, str, str]:
+    high, low = match
+    return (
+        min(high.decision.event_ts, low.decision.event_ts),
+        max(high.decision.event_ts, low.decision.event_ts),
+        high.decision.symbol,
+        low.decision.symbol,
+    )
+
+
+def _pair_match_span(
+    matches: list[tuple[AllocationResult, AllocationResult]],
+) -> timedelta:
+    timestamps = [item.decision.event_ts for match in matches for item in match]
+    return max(timestamps) - min(timestamps)
+
+
+def _pair_group_order(group: list[AllocationResult]) -> tuple[datetime, str, str]:
+    first = min(group, key=lambda item: _allocation_order(item))
+    return _allocation_order(first)
+
+
+def _allocation_order(allocation: AllocationResult) -> tuple[datetime, str, str]:
+    decision = allocation.decision
+    return decision.event_ts, decision.strategy_id, decision.symbol
 
 
 def _reserve_group(
@@ -140,6 +262,11 @@ def _pair_group_rejection(group: list[AllocationResult]) -> str | None:
         return "pair_opposite_leg_missing"
     if high_count != low_count:
         return "pair_leg_count_unbalanced"
+    expected_side_counts = {_pair_side_count(item.decision) for item in group}
+    if len(expected_side_counts) != 1:
+        return "pair_leg_contract_inconsistent"
+    if high_count != expected_side_counts.pop():
+        return "pair_leg_count_incomplete"
     if len({item.decision.symbol for item in group}) != len(group):
         return "pair_symbol_duplicated"
     return None
@@ -151,6 +278,17 @@ def _pair_side(decision: StrategyDecision) -> str | None:
         if separator and key == "pair_side" and value in {"high_rank", "low_rank"}:
             return value
     return None
+
+
+def _pair_side_count(decision: StrategyDecision) -> int:
+    for token in str(decision.rationale or "").split(","):
+        key, separator, value = token.strip().partition(":")
+        if separator and key == "pair_side_count":
+            try:
+                return max(1, int(value))
+            except ValueError:
+                return 1
+    return 1
 
 
 def _reserved_leg_notional(
@@ -215,19 +353,18 @@ def _spendable_buying_power(account: Mapping[str, object]) -> Decimal | None:
 
 def _pair_group_id(group: list[AllocationResult]) -> str:
     parts = [
-        ":".join((*_pair_signal_epoch(item.decision), item.decision.symbol))
+        ":".join(
+            (
+                item.decision.strategy_id,
+                item.decision.timeframe,
+                item.decision.event_ts.isoformat(),
+                item.decision.symbol,
+            )
+        )
         for item in sorted(group, key=lambda item: item.decision.symbol)
     ]
     digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:20]
     return f"pair-{digest}"
-
-
-def _pair_signal_epoch(decision: StrategyDecision) -> tuple[str, str, str]:
-    return (
-        decision.strategy_id,
-        decision.timeframe,
-        decision.event_ts.isoformat(),
-    )
 
 
 def _reject_pair_allocation(

--- a/services/torghut/app/trading/scheduler/pair_execution.py
+++ b/services/torghut/app/trading/scheduler/pair_execution.py
@@ -31,7 +31,7 @@ def reserve_pair_allocations(
     account: dict[str, str],
     positions: list[dict[str, object]],
 ) -> list[list[AllocationResult]]:
-    grouped: dict[tuple[str, str, str, str], list[AllocationResult]] = {}
+    grouped: dict[tuple[str, str, str], list[AllocationResult]] = {}
     for allocation in allocations:
         decision = allocation.decision
         grouped.setdefault(_pair_signal_epoch(decision), []).append(allocation)
@@ -171,17 +171,11 @@ def _pair_group_id(group: list[AllocationResult]) -> str:
     return f"pair-{digest}"
 
 
-def _pair_signal_epoch(decision: StrategyDecision) -> tuple[str, str, str, str]:
-    raw_signal_seq = decision.params.get("signal_seq")
-    try:
-        signal_seq = str(int(str(raw_signal_seq)))
-    except (TypeError, ValueError):
-        signal_seq = ""
+def _pair_signal_epoch(decision: StrategyDecision) -> tuple[str, str, str]:
     return (
         decision.strategy_id,
         decision.timeframe,
         decision.event_ts.isoformat(),
-        signal_seq,
     )
 
 

--- a/services/torghut/app/trading/scheduler/pair_execution.py
+++ b/services/torghut/app/trading/scheduler/pair_execution.py
@@ -6,13 +6,19 @@ import hashlib
 from collections.abc import Iterable, Mapping
 from dataclasses import replace
 from decimal import Decimal
-from typing import cast
+from typing import Any, cast
 
 from ...config import settings
 from ..models import StrategyDecision
 from ..pair_intent import is_pair_entry
 from ..portfolio import AllocationResult
-from ..portfolio.allocation_helpers import extract_decision_price, portfolio_exposure
+from ..portfolio.allocation_helpers import (
+    apply_projected_position_decision,
+    extract_decision_price,
+    portfolio_exposure,
+    position_market_value,
+    remaining_symbol_capacity,
+)
 
 
 def partition_pair_allocations(
@@ -35,23 +41,50 @@ def reserve_pair_allocations(
     for allocation in allocations:
         decision = allocation.decision
         grouped.setdefault(_pair_signal_epoch(decision), []).append(allocation)
-    return [
-        _reserve_group(group, account=account, positions=positions)
-        for _, group in sorted(grouped.items())
+    projected_positions: list[dict[str, Any]] = [
+        dict(position) for position in positions
     ]
+    remaining_buying_power = _spendable_buying_power(account)
+    reserved_groups: list[list[AllocationResult]] = []
+    for _, group in sorted(grouped.items()):
+        reserved_group = _reserve_group(
+            group,
+            account=account,
+            positions=projected_positions,
+            buying_power_available=remaining_buying_power,
+        )
+        reserved_groups.append(reserved_group)
+        if not reserved_group or any(not item.approved for item in reserved_group):
+            continue
+        reserved_notional = sum(
+            (item.approved_notional or Decimal("0")) for item in reserved_group
+        )
+        if remaining_buying_power is not None:
+            remaining_buying_power = max(
+                Decimal("0"), remaining_buying_power - reserved_notional
+            )
+        for item in reserved_group:
+            apply_projected_position_decision(projected_positions, item.decision)
+    return reserved_groups
 
 
 def _reserve_group(
     group: list[AllocationResult],
     *,
     account: dict[str, str],
-    positions: list[dict[str, object]],
+    positions: list[dict[str, Any]],
+    buying_power_available: Decimal | None,
 ) -> list[AllocationResult]:
     reason = _pair_group_rejection(group)
     if reason is not None:
         return [_reject_pair_allocation(item, reason) for item in group]
 
-    leg_notional = _reserved_leg_notional(group, account=account, positions=positions)
+    leg_notional = _reserved_leg_notional(
+        group,
+        account=account,
+        positions=positions,
+        buying_power_available=buying_power_available,
+    )
     if leg_notional <= 0:
         return [
             _reject_pair_allocation(item, "pair_capital_reservation_unavailable")
@@ -124,16 +157,20 @@ def _reserved_leg_notional(
     group: list[AllocationResult],
     *,
     account: dict[str, str],
-    positions: list[dict[str, object]],
+    positions: list[dict[str, Any]],
+    buying_power_available: Decimal | None,
 ) -> Decimal:
     equity = _positive_decimal(account.get("equity"))
-    buying_power = _nonnegative_decimal(account.get("buying_power"))
     approved_notionals = [
         item.approved_notional
         for item in group
         if item.approved_notional is not None and item.approved_notional > 0
     ]
-    if equity is None or buying_power is None or len(approved_notionals) != len(group):
+    if (
+        equity is None
+        or buying_power_available is None
+        or len(approved_notionals) != len(group)
+    ):
         return Decimal("0")
 
     gross, net = portfolio_exposure(positions)
@@ -146,20 +183,34 @@ def _reserved_leg_notional(
     if net_fraction is not None and abs(net) > equity * net_fraction:
         return Decimal("0")
     gross_room_per_leg = max(Decimal("0"), gross_limit - gross) / len(group)
-    buying_power_fraction = (
-        Decimal("10000")
-        - Decimal(str(settings.trading_simple_buying_power_reserve_bps))
-    ) / Decimal("10000")
-    buying_power_per_leg = max(
-        Decimal("0"), buying_power * buying_power_fraction
-    ) / len(group)
+    buying_power_per_leg = max(Decimal("0"), buying_power_available) / len(group)
     symbol_limit = equity * Decimal(str(settings.trading_simple_max_symbol_pct_equity))
+    symbol_rooms = [
+        remaining_symbol_capacity(
+            symbol_limit,
+            current_value=position_market_value(item.decision.symbol, positions)
+            or Decimal("0"),
+            action=item.decision.action,
+            allow_shorts=True,
+        )
+        or Decimal("0")
+        for item in group
+    ]
     return min(
         min(approved_notionals),
         gross_room_per_leg,
         buying_power_per_leg,
-        symbol_limit,
+        min(symbol_rooms),
     )
+
+
+def _spendable_buying_power(account: Mapping[str, object]) -> Decimal | None:
+    buying_power = _nonnegative_decimal(account.get("buying_power"))
+    reserve_bps = _nonnegative_decimal(settings.trading_simple_buying_power_reserve_bps)
+    if buying_power is None or reserve_bps is None:
+        return None
+    reserve_bps = min(Decimal("10000"), reserve_bps)
+    return buying_power * (Decimal("10000") - reserve_bps) / Decimal("10000")
 
 
 def _pair_group_id(group: list[AllocationResult]) -> str:

--- a/services/torghut/app/trading/scheduler/pair_execution.py
+++ b/services/torghut/app/trading/scheduler/pair_execution.py
@@ -6,7 +6,7 @@ import hashlib
 from collections.abc import Iterable, Mapping
 from dataclasses import replace
 from decimal import Decimal
-from typing import Any, cast
+from typing import cast
 
 from ...config import settings
 from ..models import StrategyDecision
@@ -41,7 +41,7 @@ def reserve_pair_allocations(
     for allocation in allocations:
         decision = allocation.decision
         grouped.setdefault(_pair_signal_epoch(decision), []).append(allocation)
-    projected_positions: list[dict[str, Any]] = [
+    projected_positions: list[dict[str, object]] = [
         dict(position) for position in positions
     ]
     remaining_buying_power = _spendable_buying_power(account)
@@ -72,7 +72,7 @@ def _reserve_group(
     group: list[AllocationResult],
     *,
     account: dict[str, str],
-    positions: list[dict[str, Any]],
+    positions: list[dict[str, object]],
     buying_power_available: Decimal | None,
 ) -> list[AllocationResult]:
     reason = _pair_group_rejection(group)
@@ -157,7 +157,7 @@ def _reserved_leg_notional(
     group: list[AllocationResult],
     *,
     account: dict[str, str],
-    positions: list[dict[str, Any]],
+    positions: list[dict[str, object]],
     buying_power_available: Decimal | None,
 ) -> Decimal:
     equity = _positive_decimal(account.get("equity"))

--- a/services/torghut/app/trading/scheduler/pair_execution.py
+++ b/services/torghut/app/trading/scheduler/pair_execution.py
@@ -31,12 +31,10 @@ def reserve_pair_allocations(
     account: dict[str, str],
     positions: list[dict[str, object]],
 ) -> list[list[AllocationResult]]:
-    grouped: dict[tuple[str, str], list[AllocationResult]] = {}
+    grouped: dict[tuple[str, str, str, str], list[AllocationResult]] = {}
     for allocation in allocations:
         decision = allocation.decision
-        grouped.setdefault((decision.strategy_id, decision.timeframe), []).append(
-            allocation
-        )
+        grouped.setdefault(_pair_signal_epoch(decision), []).append(allocation)
     return [
         _reserve_group(group, account=account, positions=positions)
         for _, group in sorted(grouped.items())
@@ -166,11 +164,25 @@ def _reserved_leg_notional(
 
 def _pair_group_id(group: list[AllocationResult]) -> str:
     parts = [
-        f"{item.decision.strategy_id}:{item.decision.symbol}:{item.decision.event_ts.isoformat()}"
+        ":".join((*_pair_signal_epoch(item.decision), item.decision.symbol))
         for item in sorted(group, key=lambda item: item.decision.symbol)
     ]
     digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:20]
     return f"pair-{digest}"
+
+
+def _pair_signal_epoch(decision: StrategyDecision) -> tuple[str, str, str, str]:
+    raw_signal_seq = decision.params.get("signal_seq")
+    try:
+        signal_seq = str(int(str(raw_signal_seq)))
+    except (TypeError, ValueError):
+        signal_seq = ""
+    return (
+        decision.strategy_id,
+        decision.timeframe,
+        decision.event_ts.isoformat(),
+        signal_seq,
+    )
 
 
 def _reject_pair_allocation(
@@ -196,7 +208,9 @@ def _reject_pair_allocation(
     )
     if reason not in reason_codes:
         reason_codes.append(reason)
-    allocator_payload.update({"approved": False, "reason_codes": reason_codes})
+    allocator_payload.update(
+        {"status": "rejected", "approved": False, "reason_codes": reason_codes}
+    )
     params["allocator"] = allocator_payload
     return replace(
         allocation,

--- a/services/torghut/app/trading/scheduler/pipeline/run_cycle.py
+++ b/services/torghut/app/trading/scheduler/pipeline/run_cycle.py
@@ -169,6 +169,7 @@ class TradingPipelineRunCycleMixin(TradingPipelinePositionExposureMixin):
             self._prepare_run_once(session)
             account_snapshot = self._get_account_snapshot(session)
             self.capital_safety.evaluate(session, account_snapshot)
+            session.commit()
             if self.state.emergency_stop_active:
                 return
             strategies = self._load_strategies(session)

--- a/services/torghut/app/trading/scheduler/pipeline/support.py
+++ b/services/torghut/app/trading/scheduler/pipeline/support.py
@@ -18,6 +18,10 @@ from ....config import settings
 from ....models import TradeDecision
 from ...llm.schema import PortfolioSnapshot, RecentDecisionSummary
 from ...models import StrategyDecision
+from ...portfolio.allocation_helpers import (
+    apply_projected_position_decision,
+    position_qty,
+)
 from ...prices import MarketSnapshot
 from ...regime_hmm import (
     resolve_hmm_context,
@@ -255,37 +259,6 @@ def allocator_rejection_reasons(decision: StrategyDecision) -> list[str]:
         if reason_codes:
             return reason_codes
     return ["allocator_rejected"]
-
-
-def apply_projected_position_decision(
-    positions: list[dict[str, Any]],
-    decision: StrategyDecision,
-) -> None:
-    qty = optional_decimal(decision.qty)
-    if qty is None or qty <= 0 or decision.action not in {"buy", "sell"}:
-        return
-    current_qty = position_qty(decision.symbol, positions)
-    current_market_value = position_market_value(decision.symbol, positions)
-    delta = qty if decision.action == "buy" else -qty
-    projected_qty = current_qty + delta
-    projected_market_value = projected_position_market_value(
-        current_market_value,
-        delta,
-        extract_decision_price(decision),
-    )
-    positions[:] = [
-        position for position in positions if position.get("symbol") != decision.symbol
-    ]
-    if projected_qty == 0:
-        return
-    projected_position = {
-        "symbol": decision.symbol,
-        "qty": str(abs(projected_qty)),
-        "side": "short" if projected_qty < 0 else "long",
-    }
-    if projected_market_value is not None:
-        projected_position["market_value"] = str(projected_market_value)
-    positions.append(projected_position)
 
 
 def project_open_orders_onto_positions(
@@ -536,62 +509,6 @@ def llm_guardrail_controls_snapshot() -> dict[str, Any]:
         "uncertainty_fail_mode": settings.llm_quality_fail_mode,
         "effective_fail_mode": settings.llm_effective_fail_mode_for_current_rollout(),
     }
-
-
-def position_qty(symbol: str, positions: list[dict[str, Any]]) -> Decimal:
-    total_qty = Decimal("0")
-    for position in positions:
-        if position.get("symbol") != symbol:
-            continue
-        qty = optional_decimal(position.get("qty"))
-        if qty is None:
-            qty = optional_decimal(position.get("quantity"))
-        if qty is None:
-            continue
-        side = str(position.get("side") or "").strip().lower()
-        if side == "short":
-            qty = -abs(qty)
-        total_qty += qty
-    return total_qty
-
-
-def position_market_value(
-    symbol: str,
-    positions: list[dict[str, Any]],
-) -> Decimal | None:
-    total_market_value = Decimal("0")
-    has_market_value = False
-    for position in positions:
-        if position.get("symbol") != symbol:
-            continue
-        market_value = optional_decimal(position.get("market_value"))
-        if market_value is None:
-            continue
-        total_market_value += market_value
-        has_market_value = True
-    if not has_market_value:
-        return None
-    return total_market_value
-
-
-def projected_position_market_value(
-    current_market_value: Decimal | None,
-    delta: Decimal,
-    decision_price: Decimal | None,
-) -> Decimal | None:
-    if decision_price is None:
-        return current_market_value
-    return (current_market_value or Decimal("0")) + (delta * decision_price)
-
-
-def extract_decision_price(decision: StrategyDecision) -> Decimal | None:
-    for key in ("price", "limit_price", "stop_price"):
-        value = decision.params.get(key)
-        if value is None:
-            value = getattr(decision, key, None)
-        if value is not None:
-            return optional_decimal(value)
-    return None
 
 
 def open_order_projection(

--- a/services/torghut/tests/pipeline/test_trading_pipeline_capital_safety_ordering.py
+++ b/services/torghut/tests/pipeline/test_trading_pipeline_capital_safety_ordering.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock, Mock
 from app.trading.scheduler.pipeline import TradingPipeline
 
 
-def _pipeline() -> tuple[TradingPipeline, object]:
+def _pipeline() -> tuple[TradingPipeline, MagicMock]:
     pipeline = TradingPipeline.__new__(TradingPipeline)
-    session = object()
+    session = MagicMock()
     session_scope = MagicMock()
     session_scope.__enter__.return_value = session
     pipeline.session_factory = Mock(return_value=session_scope)
@@ -32,14 +32,16 @@ def test_capital_safety_runs_when_no_strategy_is_enabled() -> None:
     pipeline.capital_safety.evaluate.assert_called_once_with(
         session, pipeline._get_account_snapshot.return_value
     )
+    session.commit.assert_called_once_with()
 
 
 def test_capital_safety_runs_before_empty_signal_exit() -> None:
-    pipeline, _ = _pipeline()
+    pipeline, session = _pipeline()
     events: list[str] = []
     pipeline.capital_safety.evaluate.side_effect = lambda *_args: events.append(
         "capital_safety"
     )
+    session.commit.side_effect = lambda: events.append("capital_safety_commit")
     pipeline._load_strategies = Mock(return_value=[object()])
     pipeline._warm_session_context_from_open = Mock()
     pipeline.ingestor = Mock()
@@ -51,4 +53,4 @@ def test_capital_safety_runs_before_empty_signal_exit() -> None:
 
     pipeline.run_once()
 
-    assert events == ["capital_safety", "fetch_signals"]
+    assert events == ["capital_safety", "capital_safety_commit", "fetch_signals"]

--- a/services/torghut/tests/test_capital_controls.py
+++ b/services/torghut/tests/test_capital_controls.py
@@ -133,6 +133,10 @@ class TestCapitalSafetyController(TestCase):
                     "blockers": [],
                 },
             ),
+            patch(
+                "app.trading.scheduler.capital_controls.reconcile_tigerbeetle_transfers",
+                side_effect=RuntimeError("reconciliation unavailable"),
+            ),
         ):
             controller.evaluate(
                 SimpleNamespace(),
@@ -140,12 +144,84 @@ class TestCapitalSafetyController(TestCase):
             )
 
         self.assertTrue(controller.state.emergency_stop_active)
-        self.assertIn(
-            "tigerbeetle_reconciliation_stale",
-            controller.state.emergency_stop_reason,
-        )
+        self.assertIn("RuntimeError", controller.state.emergency_stop_reason)
         self.assertEqual(controller.state.capital_ledger_state, "blocked")
         self.assertEqual(adapter.cancel_calls, 1)
+
+    def test_required_stale_ledger_refreshes_before_allowing_exposure(self) -> None:
+        adapter = _ExecutionAdapter([])
+        controller = self._controller(adapter)
+        now = datetime(2026, 7, 10, 14, 0, tzinfo=ZoneInfo("America/New_York"))
+        risk = CapitalRiskSnapshot(
+            current_equity=Decimal("10000"),
+            daily_start_equity=Decimal("10000"),
+            high_water_equity=Decimal("10000"),
+            daily_loss_ratio=Decimal("0"),
+            drawdown_ratio=Decimal("0"),
+        )
+
+        with (
+            patch.object(settings, "trading_mode", "live"),
+            patch.object(settings, "tigerbeetle_required", True),
+            patch.object(settings, "tigerbeetle_reconcile_required", True),
+            patch.object(controller, "_load_risk_snapshot", return_value=risk),
+            patch(
+                "app.trading.scheduler.capital_controls.latest_tigerbeetle_reconciliation_status_payload",
+                return_value={
+                    "ok": True,
+                    "reconciliation_stale": True,
+                    "blockers": [],
+                },
+            ),
+            patch(
+                "app.trading.scheduler.capital_controls.reconcile_tigerbeetle_transfers",
+                return_value={
+                    "ok": True,
+                    "reconciliation_stale": False,
+                    "blockers": [],
+                },
+            ) as refresh,
+        ):
+            controller.evaluate(SimpleNamespace(), SimpleNamespace(as_of=now))
+
+        refresh.assert_called_once()
+        self.assertFalse(controller.state.emergency_stop_active)
+        self.assertEqual(controller.state.capital_ledger_state, "current")
+        self.assertEqual(adapter.cancel_calls, 0)
+
+    def test_required_current_ledger_does_not_refresh(self) -> None:
+        controller = self._controller()
+        now = datetime(2026, 7, 10, 14, 0, tzinfo=ZoneInfo("America/New_York"))
+        risk = CapitalRiskSnapshot(
+            current_equity=Decimal("10000"),
+            daily_start_equity=Decimal("10000"),
+            high_water_equity=Decimal("10000"),
+            daily_loss_ratio=Decimal("0"),
+            drawdown_ratio=Decimal("0"),
+        )
+
+        with (
+            patch.object(settings, "trading_mode", "live"),
+            patch.object(settings, "tigerbeetle_required", True),
+            patch.object(settings, "tigerbeetle_reconcile_required", True),
+            patch.object(controller, "_load_risk_snapshot", return_value=risk),
+            patch(
+                "app.trading.scheduler.capital_controls.latest_tigerbeetle_reconciliation_status_payload",
+                return_value={
+                    "ok": True,
+                    "reconciliation_stale": False,
+                    "blockers": [],
+                },
+            ),
+            patch(
+                "app.trading.scheduler.capital_controls.reconcile_tigerbeetle_transfers"
+            ) as refresh,
+        ):
+            controller.evaluate(SimpleNamespace(), SimpleNamespace(as_of=now))
+
+        refresh.assert_not_called()
+        self.assertFalse(controller.state.emergency_stop_active)
+        self.assertEqual(controller.state.capital_ledger_state, "current")
 
     def test_new_exposure_is_blocked_at_1530_et(self) -> None:
         controller = self._controller()

--- a/services/torghut/tests/test_pair_execution.py
+++ b/services/torghut/tests/test_pair_execution.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -23,6 +23,7 @@ def _allocation(
     pair_side: str,
     notional: Decimal,
     event_ts: datetime | None = None,
+    pair_side_count: int = 1,
 ) -> AllocationResult:
     price = Decimal("100")
     decision = StrategyDecision(
@@ -36,7 +37,8 @@ def _allocation(
         limit_price=price,
         rationale=(
             "microbar_cross_sectional_pair_entry,"
-            f"pair_side:{pair_side},selection_mode:continuation"
+            f"pair_side:{pair_side},pair_side_count:{pair_side_count},"
+            f"max_pair_legs:{pair_side_count * 2},selection_mode:continuation"
         ),
         params={
             "price": str(price),
@@ -176,6 +178,155 @@ def test_pair_reservation_scopes_groups_by_signal_timestamp() -> None:
         for item in group
     }
     assert len(group_ids) == 2
+
+
+def test_pair_reservation_matches_staggered_legs_within_poll_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "trading_poll_ms", 5000)
+    first_event = datetime(2026, 7, 10, 14, 30, tzinfo=timezone.utc)
+
+    groups = reserve_pair_allocations(
+        [
+            _allocation(
+                symbol="AAPL",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event,
+            ),
+            _allocation(
+                symbol="AMZN",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event + timedelta(seconds=1),
+            ),
+        ],
+        account={"equity": "40000", "buying_power": "100000"},
+        positions=[],
+    )
+
+    assert len(groups) == 1
+    assert all(item.approved for item in groups[0])
+    assert {item.decision.symbol for item in groups[0]} == {"AAPL", "AMZN"}
+
+
+def test_pair_reservation_matches_nearest_legs_across_staggered_epochs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "trading_poll_ms", 5000)
+    first_event = datetime(2026, 7, 10, 14, 30, tzinfo=timezone.utc)
+
+    groups = reserve_pair_allocations(
+        [
+            _allocation(
+                symbol="AAPL",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event,
+            ),
+            _allocation(
+                symbol="NVDA",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event + timedelta(seconds=1),
+            ),
+            _allocation(
+                symbol="AMD",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event + timedelta(seconds=1),
+            ),
+            _allocation(
+                symbol="AMZN",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event + timedelta(seconds=2),
+            ),
+        ],
+        account={"equity": "40000", "buying_power": "100000"},
+        positions=[],
+    )
+
+    assert len(groups) == 2
+    assert all(len(group) == 2 for group in groups)
+    assert all(item.approved for group in groups for item in group)
+    assert [{item.decision.symbol for item in group} for group in groups] == [
+        {"AAPL", "AMZN"},
+        {"NVDA", "AMD"},
+    ]
+
+
+def test_pair_reservation_rejects_legs_beyond_poll_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "trading_poll_ms", 5000)
+    first_event = datetime(2026, 7, 10, 14, 30, tzinfo=timezone.utc)
+
+    groups = reserve_pair_allocations(
+        [
+            _allocation(
+                symbol="AAPL",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event,
+            ),
+            _allocation(
+                symbol="AMZN",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event + timedelta(seconds=6),
+            ),
+        ],
+        account={"equity": "40000", "buying_power": "100000"},
+        positions=[],
+    )
+
+    assert len(groups) == 2
+    assert not any(item.approved for group in groups for item in group)
+    assert all(
+        "pair_opposite_leg_missing" in item.reason_codes
+        for group in groups
+        for item in group
+    )
+
+
+def test_pair_reservation_rejects_incomplete_multi_pair_cohort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "trading_poll_ms", 5000)
+
+    groups = reserve_pair_allocations(
+        [
+            _allocation(
+                symbol="AAPL",
+                action="buy",
+                pair_side="high_rank",
+                pair_side_count=2,
+                notional=Decimal("10000"),
+            ),
+            _allocation(
+                symbol="AMZN",
+                action="sell",
+                pair_side="low_rank",
+                pair_side_count=2,
+                notional=Decimal("10000"),
+            ),
+        ],
+        account={"equity": "40000", "buying_power": "100000"},
+        positions=[],
+    )
+
+    assert len(groups) == 1
+    assert not any(item.approved for item in groups[0])
+    assert all("pair_leg_count_incomplete" in item.reason_codes for item in groups[0])
 
 
 @pytest.mark.parametrize(

--- a/services/torghut/tests/test_pair_execution.py
+++ b/services/torghut/tests/test_pair_execution.py
@@ -21,7 +21,6 @@ def _allocation(
     pair_side: str,
     notional: Decimal,
     event_ts: datetime | None = None,
-    signal_seq: int = 1,
 ) -> AllocationResult:
     price = Decimal("100")
     decision = StrategyDecision(
@@ -39,7 +38,6 @@ def _allocation(
         ),
         params={
             "price": str(price),
-            "signal_seq": signal_seq,
             "allocator": {"approved": True},
         },
     )
@@ -161,59 +159,6 @@ def test_pair_reservation_scopes_groups_by_signal_timestamp() -> None:
                 pair_side="low_rank",
                 notional=Decimal("10000"),
                 event_ts=second_event,
-            ),
-        ],
-        account={"equity": "40000", "buying_power": "100000"},
-        positions=[],
-    )
-
-    assert len(groups) == 2
-    assert all(len(group) == 2 for group in groups)
-    assert all(item.approved for group in groups for item in group)
-    group_ids = {
-        item.decision.params["pair_execution"]["group_id"]
-        for group in groups
-        for item in group
-    }
-    assert len(group_ids) == 2
-
-
-def test_pair_reservation_scopes_same_timestamp_by_signal_sequence() -> None:
-    event_ts = datetime(2026, 7, 10, 14, 0, tzinfo=timezone.utc)
-
-    groups = reserve_pair_allocations(
-        [
-            _allocation(
-                symbol="NVDA",
-                action="buy",
-                pair_side="high_rank",
-                notional=Decimal("10000"),
-                event_ts=event_ts,
-                signal_seq=1,
-            ),
-            _allocation(
-                symbol="AMD",
-                action="sell",
-                pair_side="low_rank",
-                notional=Decimal("10000"),
-                event_ts=event_ts,
-                signal_seq=1,
-            ),
-            _allocation(
-                symbol="NVDA",
-                action="buy",
-                pair_side="high_rank",
-                notional=Decimal("10000"),
-                event_ts=event_ts,
-                signal_seq=2,
-            ),
-            _allocation(
-                symbol="AMD",
-                action="sell",
-                pair_side="low_rank",
-                notional=Decimal("10000"),
-                event_ts=event_ts,
-                signal_seq=2,
             ),
         ],
         account={"equity": "40000", "buying_power": "100000"},

--- a/services/torghut/tests/test_pair_execution.py
+++ b/services/torghut/tests/test_pair_execution.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 
+import pytest
+
 from app.config import settings
 from app.trading.models import StrategyDecision
 from app.trading.portfolio import (
@@ -174,6 +176,85 @@ def test_pair_reservation_scopes_groups_by_signal_timestamp() -> None:
         for item in group
     }
     assert len(group_ids) == 2
+
+
+@pytest.mark.parametrize(
+    (
+        "gross_limit",
+        "symbol_limit",
+        "reserve_bps",
+        "buying_power",
+        "symbols",
+        "expected_first_notional",
+    ),
+    [
+        (4.0, 0.5, 0.0, "200000", ("NVDA", "AMD"), Decimal("20000")),
+        (1.0, 1.0, 0.0, "200000", ("MU", "AVGO"), Decimal("20000")),
+        (4.0, 1.0, 1000.0, "40000", ("MU", "AVGO"), Decimal("18000")),
+    ],
+    ids=("symbol", "gross", "buying-power"),
+)
+def test_pair_reservations_carry_capacity_across_epochs(
+    monkeypatch: pytest.MonkeyPatch,
+    gross_limit: float,
+    symbol_limit: float,
+    reserve_bps: float,
+    buying_power: str,
+    symbols: tuple[str, str],
+    expected_first_notional: Decimal,
+) -> None:
+    monkeypatch.setattr(
+        settings, "trading_simple_max_gross_exposure_pct_equity", gross_limit
+    )
+    monkeypatch.setattr(settings, "trading_simple_max_symbol_pct_equity", symbol_limit)
+    monkeypatch.setattr(
+        settings, "trading_simple_buying_power_reserve_bps", reserve_bps
+    )
+    first_event = datetime(2026, 7, 10, 14, 0, tzinfo=timezone.utc)
+    second_event = datetime(2026, 7, 10, 14, 1, tzinfo=timezone.utc)
+
+    groups = reserve_pair_allocations(
+        [
+            _allocation(
+                symbol="NVDA",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("20000"),
+                event_ts=first_event,
+            ),
+            _allocation(
+                symbol="AMD",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("20000"),
+                event_ts=first_event,
+            ),
+            _allocation(
+                symbol=symbols[0],
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("20000"),
+                event_ts=second_event,
+            ),
+            _allocation(
+                symbol=symbols[1],
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("20000"),
+                event_ts=second_event,
+            ),
+        ],
+        account={"equity": "40000", "buying_power": buying_power},
+        positions=[],
+    )
+
+    assert all(item.approved for item in groups[0])
+    assert {item.approved_notional for item in groups[0]} == {expected_first_notional}
+    assert not any(item.approved for item in groups[1])
+    assert all(
+        "pair_capital_reservation_unavailable" in item.reason_codes
+        for item in groups[1]
+    )
 
 
 def test_pair_reservation_submits_the_net_reducing_leg_first() -> None:

--- a/services/torghut/tests/test_pair_execution.py
+++ b/services/torghut/tests/test_pair_execution.py
@@ -11,6 +11,7 @@ from app.trading.portfolio import (
     PortfolioSizingConfig,
 )
 from app.trading.scheduler.pair_execution import reserve_pair_allocations
+from app.trading.scheduler.pipeline.support import allocator_rejection_reasons
 
 
 def _allocation(
@@ -19,12 +20,14 @@ def _allocation(
     action: str,
     pair_side: str,
     notional: Decimal,
+    event_ts: datetime | None = None,
+    signal_seq: int = 1,
 ) -> AllocationResult:
     price = Decimal("100")
     decision = StrategyDecision(
         strategy_id="pairs-v1",
         symbol=symbol,
-        event_ts=datetime(2026, 7, 10, 14, 0, tzinfo=timezone.utc),
+        event_ts=event_ts or datetime(2026, 7, 10, 14, 0, tzinfo=timezone.utc),
         timeframe="1Min",
         action=action,
         qty=notional / price,
@@ -34,7 +37,11 @@ def _allocation(
             "microbar_cross_sectional_pair_entry,"
             f"pair_side:{pair_side},selection_mode:continuation"
         ),
-        params={"price": str(price), "allocator": {"approved": True}},
+        params={
+            "price": str(price),
+            "signal_seq": signal_seq,
+            "allocator": {"approved": True},
+        },
     )
     return AllocationResult(
         decision=decision,
@@ -115,6 +122,113 @@ def test_pair_reservation_rejects_a_single_unhedged_leg() -> None:
     assert not allocation.approved
     assert "pair_opposite_leg_missing" in allocation.reason_codes
     assert allocation.decision.params["allocator"]["approved"] is False
+    assert allocation.decision.params["allocator"]["status"] == "rejected"
+    assert allocator_rejection_reasons(allocation.decision) == [
+        "pair_opposite_leg_missing"
+    ]
+
+
+def test_pair_reservation_scopes_groups_by_signal_timestamp() -> None:
+    first_event = datetime(2026, 7, 10, 14, 0, tzinfo=timezone.utc)
+    second_event = datetime(2026, 7, 10, 14, 1, tzinfo=timezone.utc)
+
+    groups = reserve_pair_allocations(
+        [
+            _allocation(
+                symbol="NVDA",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event,
+            ),
+            _allocation(
+                symbol="AMD",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=first_event,
+            ),
+            _allocation(
+                symbol="NVDA",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=second_event,
+            ),
+            _allocation(
+                symbol="AMD",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=second_event,
+            ),
+        ],
+        account={"equity": "40000", "buying_power": "100000"},
+        positions=[],
+    )
+
+    assert len(groups) == 2
+    assert all(len(group) == 2 for group in groups)
+    assert all(item.approved for group in groups for item in group)
+    group_ids = {
+        item.decision.params["pair_execution"]["group_id"]
+        for group in groups
+        for item in group
+    }
+    assert len(group_ids) == 2
+
+
+def test_pair_reservation_scopes_same_timestamp_by_signal_sequence() -> None:
+    event_ts = datetime(2026, 7, 10, 14, 0, tzinfo=timezone.utc)
+
+    groups = reserve_pair_allocations(
+        [
+            _allocation(
+                symbol="NVDA",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=event_ts,
+                signal_seq=1,
+            ),
+            _allocation(
+                symbol="AMD",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=event_ts,
+                signal_seq=1,
+            ),
+            _allocation(
+                symbol="NVDA",
+                action="buy",
+                pair_side="high_rank",
+                notional=Decimal("10000"),
+                event_ts=event_ts,
+                signal_seq=2,
+            ),
+            _allocation(
+                symbol="AMD",
+                action="sell",
+                pair_side="low_rank",
+                notional=Decimal("10000"),
+                event_ts=event_ts,
+                signal_seq=2,
+            ),
+        ],
+        account={"equity": "40000", "buying_power": "100000"},
+        positions=[],
+    )
+
+    assert len(groups) == 2
+    assert all(len(group) == 2 for group in groups)
+    assert all(item.approved for group in groups for item in group)
+    group_ids = {
+        item.decision.params["pair_execution"]["group_id"]
+        for group in groups
+        for item in group
+    }
+    assert len(group_ids) == 2
 
 
 def test_pair_reservation_submits_the_net_reducing_leg_first() -> None:


### PR DESCRIPTION
## Summary

- Mark rejected pair reservations with the explicit allocator rejection status consumed by submission policy, preventing a failed pair from falling through to live unhedged submission.
- Match pair cohorts by strategy, timeframe, expected leg count, and nearest opposite-side event within one scheduler poll interval; leave distant or incomplete cohorts rejected instead of borrowing a hedge from another epoch.
- Reserve successive cohorts against one projected portfolio and spendable-buying-power balance, with deterministic identities derived from every constituent symbol and event timestamp.
- Add regressions for staggered legs, interleaved epochs, distant and incomplete cohorts, rejected single-leg pairs, and cumulative symbol, gross, and buying-power exhaustion; live TA validation confirms sequence numbers are symbol-local.
- Refresh required TigerBeetle reconciliation evidence from the capital-safety path when the persisted result is stale, and remain fail-closed when refresh fails.
- Commit capital-safety evidence before no-strategy and no-signal exits so reconciliation cannot be rolled back by an otherwise idle cycle.

## Related Issues

Follow-up to #12213. Addresses Codex review threads `PRRT_kwDOLkRLus6PyFxx`, `PRRT_kwDOLkRLus6PyFxz`, `PRRT_kwDOLkRLus6Pyj5C`, and `PRRT_kwDOLkRLus6Pyy95`.

## Testing

- `uv run --frozen pytest -q tests/test_pair_execution.py tests/test_capital_controls.py tests/pipeline/test_trading_pipeline_capital_safety_ordering.py` (25 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.strict.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.strict.json`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen ruff format --check app tests scripts migrations`
- `uv run --frozen python -m compileall -q app scripts tests`
- Torghut structural, changed-line quality, changed-file design, and file-length Pylint gates

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
