### PR TITLE
chore(oirat): promote nix image sha-90cc200975cce30cfa233e63f3e23546a45d4653

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:ea89bc7c66cb89373661d09162bd046e0f70c8ada356bfb1773833dfd20a7214
+    digest: sha256:df5410d7c20aed97db5cc509db6d2d9e6526663874c8bc5ec1fd2e52271a9eb9


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:df5410d7c20aed97db5cc509db6d2d9e6526663874c8bc5ec1fd2e52271a9eb9`.
- Source commit: `90cc200975cce30cfa233e63f3e23546a45d4653`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:df5410d7c20aed97db5cc509db6d2d9e6526663874c8bc5ec1fd2e52271a9eb9" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.