### PR TITLE
chore(bumba): promote nix image sha-90cc200975cce30cfa233e63f3e23546a45d4653

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@2088dafb789815f3a9403f8ce6609d6f3c515f4a
+              value: bumba@90cc200975cce30cfa233e63f3e23546a45d4653
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:3d5552cc7553f9ac5c73eebcc3ae99a6026996d54279b1c4102217ea884f6e15
+    digest: sha256:e2841fc00fc42a53e8e4bffe84f63480c749112e6a5fbed0d8496ad0e0a48cc2
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:e2841fc00fc42a53e8e4bffe84f63480c749112e6a5fbed0d8496ad0e0a48cc2`.
- Source commit: `90cc200975cce30cfa233e63f3e23546a45d4653`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:e2841fc00fc42a53e8e4bffe84f63480c749112e6a5fbed0d8496ad0e0a48cc2" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.