### PR TITLE
chore(symphony): promote image sha-90cc200975cce30cfa233e63f3e23546a45d4653

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T11:12:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-10T06:34:25Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-5e046147da58bd014bca17565cbd731626ec875b"
-    digest: sha256:8602e26cc30db8af3e1af8eabe3051c8661f36263086ae2db3b18a384e7fc391
+    newTag: "sha-90cc200975cce30cfa233e63f3e23546a45d4653"
+    digest: sha256:54193ab6a6f418df3aff6442f0b75575b82e00e93a6ab6bbdf4e2e23bafc11d9

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T11:12:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-10T06:34:25Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-5e046147da58bd014bca17565cbd731626ec875b"
-    digest: sha256:8602e26cc30db8af3e1af8eabe3051c8661f36263086ae2db3b18a384e7fc391
+    newTag: "sha-90cc200975cce30cfa233e63f3e23546a45d4653"
+    digest: sha256:54193ab6a6f418df3aff6442f0b75575b82e00e93a6ab6bbdf4e2e23bafc11d9

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-04T11:12:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-10T06:34:25Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-5e046147da58bd014bca17565cbd731626ec875b"
-    digest: sha256:8602e26cc30db8af3e1af8eabe3051c8661f36263086ae2db3b18a384e7fc391
+    newTag: "sha-90cc200975cce30cfa233e63f3e23546a45d4653"
+    digest: sha256:54193ab6a6f418df3aff6442f0b75575b82e00e93a6ab6bbdf4e2e23bafc11d9


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `90cc200975cce30cfa233e63f3e23546a45d4653`
- Image tag: `sha-90cc200975cce30cfa233e63f3e23546a45d4653`
- Image digest: `sha256:54193ab6a6f418df3aff6442f0b75575b82e00e93a6ab6bbdf4e2e23bafc11d9`