### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:c410d4f09aa4290dfb12da53982dd950a7c8d5a2630a06912d166fad2abbb9c3
+    digest: sha256:586a5a937f5812b059ff5f228fe8c6f7efb05c5a1ce3c67e4452fa6a8041c7ff
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:e9d7ebbff45c66bbf77c8b73a05ed8ec6801297a737ae2e7cdbda410ae1fe58d
+    digest: sha256:cf21ba6fbf2748f9db46f4b2d77731be54b11c97f80ef79a477b53f3c35beb75
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/olden/kustomization.yaml
+++ b/argocd/applications/olden/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - service.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/olden
-    digest: sha256:84b359d4418e036be781cc56ce2c910fbcc9c2a3c7c52732098d89c9bb22d3b5
+    digest: sha256:2de252806508e7223e4a69f069a2999eeca794904f84c4583356b41f50af550c
     newName: registry.ide-newton.ts.net/lab/olden

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:aeb92626912fb5c5f48a37b1ec67531fae4d5e1e4cb57c541bdacc9996074ee2
+  digest: sha256:68ec6a094936d44388504e9329cf8ae280823d81ca2458b3d5bcd4098d70e3ec
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:62486474c8875e2ed3341abeb5d06a45d385a25e8f53a8a8f7efb3dd6b3cee32
+    digest: sha256:a2b8df94bd38d5f281f2b29160ef626c8acbdd4d6a145405fcce57ee1f7a2311
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:586a5a937f5812b059ff5f228fe8c6f7efb05c5a1ce3c67e4452fa6a8041c7ff` from `90cc200975cce30cfa233e63f3e23546a45d4653`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:cf21ba6fbf2748f9db46f4b2d77731be54b11c97f80ef79a477b53f3c35beb75` from `90cc200975cce30cfa233e63f3e23546a45d4653`
- `olden`: `registry.ide-newton.ts.net/lab/olden@sha256:2de252806508e7223e4a69f069a2999eeca794904f84c4583356b41f50af550c` from `90cc200975cce30cfa233e63f3e23546a45d4653`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:68ec6a094936d44388504e9329cf8ae280823d81ca2458b3d5bcd4098d70e3ec` from `90cc200975cce30cfa233e63f3e23546a45d4653`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:a2b8df94bd38d5f281f2b29160ef626c8acbdd4d6a145405fcce57ee1f7a2311` from `90cc200975cce30cfa233e63f3e23546a45d4653`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.