### PR TITLE
fix(torghut): restart failed TA simulation job

### DIFF
--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 30
+  restartNonce: 31
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:


### PR DESCRIPTION
## Summary

- Bump the Torghut TA simulation FlinkDeployment restart nonce from 30 to 31.
- Redeploy the failed simulation job after Kafka and Karapace recovered from the cluster outage.
- Preserve the existing image, job configuration, and stateless upgrade mode.

## Related Issues

None

## Testing

- `git diff --check`
- `nix develop --command kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-render.yaml`
- `nix develop --command kubectl apply --dry-run=client -f /tmp/torghut-render.yaml >/tmp/torghut-dry-run.txt`
- Verified `http://karapace.kafka.svc.cluster.local:8081/subjects` returns the registered Torghut schemas.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
