### PR TITLE
chore(torghut): promote image sha-bbae620397cf466e099b700d53186526abd937d8

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: eedc5aebd0d7dd1ae0c9c62c46c34b6440b1da6c
+              value: bbae620397cf466e099b700d53186526abd937d8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+              value: sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: eedc5aebd0d7dd1ae0c9c62c46c34b6440b1da6c
+              value: bbae620397cf466e099b700d53186526abd937d8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+              value: sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-10T05:54:57Z"
+        client.knative.dev/updateTimestamp: "2026-07-11T05:37:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
           ports:
             - name: http1
               containerPort: 8181
@@ -533,11 +533,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1690-geedc5aebd
+              value: v0.596.0-1701-gbbae62039
             - name: TORGHUT_COMMIT
-              value: eedc5aebd0d7dd1ae0c9c62c46c34b6440b1da6c
+              value: bbae620397cf466e099b700d53186526abd937d8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+              value: sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-10T05:54:57Z"
+        client.knative.dev/updateTimestamp: "2026-07-11T05:37:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
           ports:
             - name: http1
               containerPort: 8181
@@ -434,11 +434,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1690-geedc5aebd
+              value: v0.596.0-1701-gbbae62039
             - name: TORGHUT_COMMIT
-              value: eedc5aebd0d7dd1ae0c9c62c46c34b6440b1da6c
+              value: bbae620397cf466e099b700d53186526abd937d8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+              value: sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:dd448af877a1f48c202d2cfa90146b1250675ba5f6fd372909cac87bff5c4495
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `bbae620397cf466e099b700d53186526abd937d8`
- Image tag: `sha-bbae620397cf466e099b700d53186526abd937d8`
- Image digest: `sha256:22619863222589c61a7d0b5a3730dd74fe35a7636477ba10dd1b2370b9bb84ed`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher