### PR TITLE
fix(torghut): accept restored bounded Flink source

### DIFF
--- a/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts
@@ -734,7 +734,7 @@ describe('market data smoke freshness evaluation', () => {
     expect(result.summaryLines.join('\n')).toContain('source_write_records=`15`')
   })
 
-  it('allows the bounded startup heartbeat source to finish after emitting', () => {
+  it('allows the bounded startup heartbeat source to stay finished after savepoint restore', () => {
     const result = evaluateMarketDataSmoke({
       now: new Date('2026-07-07T17:00:30Z'),
       mode: 'auto',
@@ -756,7 +756,7 @@ describe('market data smoke freshness evaluation', () => {
           {
             name: 'Source: Collection Source',
             status: 'FINISHED',
-            metrics: { 'read-records': 0, 'write-records': 1 },
+            metrics: { 'read-records': 0, 'write-records': 0 },
           },
         ],
       },

--- a/packages/scripts/src/torghut/market-data-smoke.ts
+++ b/packages/scripts/src/torghut/market-data-smoke.ts
@@ -321,7 +321,7 @@ const sumOptionalRecords = (
 }
 
 const isExpectedFinishedTaFlinkVertex = (vertex: TaFlinkVertexSnapshot): boolean =>
-  vertex.name === 'Source: Collection Source' && vertex.status === 'FINISHED' && vertex.writeRecords > 0
+  vertex.name === 'Source: Collection Source' && vertex.status === 'FINISHED'
 
 const summarizeKafkaRole = (
   now: Date,


### PR DESCRIPTION
## Summary

- Treat Flink's bounded `Collection Source` vertex as expected when it is `FINISHED`, including after savepoint restore resets its current-run record counters to zero.
- Preserve strict failure behavior for every other unexpected non-running Flink vertex.
- Add a regression matching the live restored vertex state that blocked Torghut post-deploy verification.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/torghut/market-data-smoke.ts packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/market-data-smoke.test.ts` (20 passed)
- Live cluster: ran `bun run smoke:torghut-market-data` in auto mode against the restored Flink job; completed successfully with weekend freshness warnings only.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no additional documentation is required for this verifier-only correction.
