### PR TITLE
fix(torghut): isolate singleton trading scheduler

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -263,6 +263,29 @@ jobs:
             echo "${label} release manifest pins a multi-arch image digest for ${source_sha}: ${image_ref}"
           }
 
+          assert_image_contract_parity() {
+            local env_name="$1"
+            local image_name="$2"
+            local reference_manifest="$3"
+            shift 3
+            local reference_source_sha reference_image_ref manifest_path source_sha image_ref
+
+            reference_source_sha="$(resolve_source_sha "${reference_manifest}" "${env_name}")"
+            reference_image_ref="$(resolve_image_ref "${reference_manifest}" "${image_name}")"
+            for manifest_path in "$@"; do
+              source_sha="$(resolve_source_sha "${manifest_path}" "${env_name}")"
+              image_ref="$(resolve_image_ref "${manifest_path}" "${image_name}")"
+              if [ "${source_sha}" != "${reference_source_sha}" ]; then
+                echo "Runtime manifest ${manifest_path} ${env_name}=${source_sha:-unset} differs from ${reference_manifest}=${reference_source_sha:-unset}"
+                exit 1
+              fi
+              if [ "${image_ref}" != "${reference_image_ref}" ]; then
+                echo "Runtime manifest ${manifest_path} image=${image_ref:-unset} differs from ${reference_manifest}=${reference_image_ref:-unset}"
+                exit 1
+              fi
+            done
+          }
+
           verified_any=false
           if matches_changed '^argocd/applications/(torghut/(knative-service(-sim)?|scheduler-deployment|db-migrations-job|historical-simulation-workflowtemplate|analysis-template-(runtime-ready|activity|teardown-clean|artifact-bundle)|empirical-jobs-backfill-job|zero-notional-drift-repair-cronjob|generated-resource-retention-cronjob|whitepaper-semantic-backfill-job|tigerbeetle-smoke-job)\.yaml|torghut-options/(catalog|enricher)/deployment\.yaml|torghut-hyperliquid-runtime/(deployment|db-migrations-job)\.yaml)$'; then
             verify_image_contract \
@@ -270,6 +293,22 @@ jobs:
               argocd/applications/torghut/knative-service.yaml \
               TORGHUT_COMMIT \
               registry.ide-newton.ts.net/lab/torghut
+            verify_image_contract \
+              "Torghut simulation" \
+              argocd/applications/torghut/knative-service-sim.yaml \
+              TORGHUT_COMMIT \
+              registry.ide-newton.ts.net/lab/torghut
+            verify_image_contract \
+              "Torghut scheduler" \
+              argocd/applications/torghut/scheduler-deployment.yaml \
+              TORGHUT_COMMIT \
+              registry.ide-newton.ts.net/lab/torghut
+            assert_image_contract_parity \
+              TORGHUT_COMMIT \
+              registry.ide-newton.ts.net/lab/torghut \
+              argocd/applications/torghut/knative-service.yaml \
+              argocd/applications/torghut/knative-service-sim.yaml \
+              argocd/applications/torghut/scheduler-deployment.yaml
             verified_any=true
           fi
           if matches_changed '^argocd/applications/(torghut/(ta|ta-sim)/flinkdeployment\.yaml|torghut-options/ta/flinkdeployment\.yaml)$'; then

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -264,7 +264,7 @@ jobs:
           }
 
           verified_any=false
-          if matches_changed '^argocd/applications/(torghut/(knative-service(-sim)?|db-migrations-job|historical-simulation-workflowtemplate|analysis-template-(runtime-ready|activity|teardown-clean|artifact-bundle)|empirical-jobs-backfill-job|zero-notional-drift-repair-cronjob|generated-resource-retention-cronjob|whitepaper-semantic-backfill-job|tigerbeetle-smoke-job)\.yaml|torghut-options/(catalog|enricher)/deployment\.yaml|torghut-hyperliquid-runtime/(deployment|db-migrations-job)\.yaml)$'; then
+          if matches_changed '^argocd/applications/(torghut/(knative-service(-sim)?|scheduler-deployment|db-migrations-job|historical-simulation-workflowtemplate|analysis-template-(runtime-ready|activity|teardown-clean|artifact-bundle)|empirical-jobs-backfill-job|zero-notional-drift-repair-cronjob|generated-resource-retention-cronjob|whitepaper-semantic-backfill-job|tigerbeetle-smoke-job)\.yaml|torghut-options/(catalog|enricher)/deployment\.yaml|torghut-hyperliquid-runtime/(deployment|db-migrations-job)\.yaml)$'; then
             verify_image_contract \
               "Torghut" \
               argocd/applications/torghut/knative-service.yaml \

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -11,6 +11,7 @@ on:
       - unlabeled
     paths:
       - 'argocd/applications/torghut/knative-service.yaml'
+      - 'argocd/applications/torghut/scheduler-deployment.yaml'
       - 'argocd/applications/torghut/knative-service-sim.yaml'
       - 'argocd/applications/torghut/db-migrations-job.yaml'
       - 'argocd/applications/torghut/historical-simulation-workflowtemplate.yaml'
@@ -85,6 +86,7 @@ jobs:
 
           allowed_paths=(
             'argocd/applications/torghut/knative-service.yaml'
+            'argocd/applications/torghut/scheduler-deployment.yaml'
             'argocd/applications/torghut/knative-service-sim.yaml'
             'argocd/applications/torghut/db-migrations-job.yaml'
             'argocd/applications/torghut/historical-simulation-workflowtemplate.yaml'

--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -233,6 +233,22 @@ jobs:
             done
           done
 
+          TORGHUT_SCHEDULER_REPLICAS="$(
+            kubectl get deployment torghut-scheduler -n torghut -o jsonpath='{.spec.replicas}'
+          )"
+          case "${TORGHUT_SCHEDULER_REPLICAS}" in
+            0 | 1)
+              ;;
+            *)
+              echo "Torghut scheduler replicas must be exactly 0 or 1; got ${TORGHUT_SCHEDULER_REPLICAS:-unset}"
+              exit 1
+              ;;
+          esac
+          echo "Torghut scheduler desired replicas: ${TORGHUT_SCHEDULER_REPLICAS}"
+          if [ "${TORGHUT_SCHEDULER_REPLICAS}" = '1' ]; then
+            kubectl rollout status deployment/torghut-scheduler -n torghut --timeout=10m
+          fi
+
           KNSVC_READY_ATTEMPTS=60
           KNSVC_READY_INTERVAL_SECONDS=2
 
@@ -419,69 +435,63 @@ jobs:
             done
           }
 
-          fetch_json_2xx() {
-            local url="$1"
-            local output_path="$2"
-            local label="$3"
-            local status
-
-            for attempt in $(seq 1 "${JSON_EVIDENCE_ATTEMPTS}"); do
-              status="$(
-                curl -sS --connect-timeout "${HTTP_CONNECT_TIMEOUT_SECONDS}" --max-time "${HTTP_MAX_TIME_SECONDS}" \
-                  -o "${output_path}" -w '%{http_code}' "${url}" || true
-              )"
-              if [[ "${status}" =~ ^2[0-9][0-9]$ ]] &&
-                python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
-                return 0
-              fi
-
-              if [ "${attempt}" -eq "${JSON_EVIDENCE_ATTEMPTS}" ]; then
-                if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
-                  [ "${status}" != '000' ] &&
-                  python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
-                  echo "${label} returned HTTP ${status}; expected 2xx" >&2
-                else
-                  echo "${label} did not return a parseable JSON HTTP 2xx response; status=${status:-empty}" >&2
-                fi
-                head -c 1000 "${output_path}" >&2 || true
-                echo >&2
-                return 1
-              fi
-
-              if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
-                [ "${status}" != '000' ] &&
-                python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
-                echo "Attempt ${attempt}: ${label} returned HTTP ${status}; expected 2xx; retrying" >&2
-              else
-                echo "Attempt ${attempt}: ${label} status=${status:-empty} not usable JSON 2xx yet; retrying" >&2
-              fi
-              sleep "${EVIDENCE_RETRY_INTERVAL_SECONDS}"
-            done
-          }
-
-          TORGHUT_READYZ_HTTP_STATUS="$(
-            fetch_readyz_json \
+          TORGHUT_API_READYZ_HTTP_STATUS="$(
+            fetch_json \
               http://torghut.torghut.svc.cluster.local/readyz \
-              "${EVIDENCE_DIR}/torghut-readyz.json" \
-              "Torghut /readyz"
+              "${EVIDENCE_DIR}/torghut-api-readyz.json" \
+              "Torghut stable API /readyz"
           )"
-          if [ -z "${TORGHUT_READYZ_HTTP_STATUS}" ] || [ "${TORGHUT_READYZ_HTTP_STATUS}" = '000' ]; then
-            echo "Torghut /readyz did not return an HTTP response"
+          if [ -z "${TORGHUT_API_READYZ_HTTP_STATUS}" ] || [ "${TORGHUT_API_READYZ_HTTP_STATUS}" = '000' ]; then
+            echo "Torghut stable API /readyz did not return an HTTP response"
             exit 1
           fi
-          if ! [[ "${TORGHUT_READYZ_HTTP_STATUS}" =~ ^[0-9]{3}$ ]]; then
-            echo "Torghut /readyz returned invalid HTTP status ${TORGHUT_READYZ_HTTP_STATUS}"
+          if ! [[ "${TORGHUT_API_READYZ_HTTP_STATUS}" =~ ^[0-9]{3}$ ]]; then
+            echo "Torghut stable API /readyz returned invalid HTTP status ${TORGHUT_API_READYZ_HTTP_STATUS}"
             exit 1
           fi
-          echo "Torghut /readyz HTTP ${TORGHUT_READYZ_HTTP_STATUS}"
+          echo "Torghut stable API /readyz HTTP ${TORGHUT_API_READYZ_HTTP_STATUS}"
 
-          fetch_json_2xx \
-            http://torghut.torghut.svc.cluster.local/trading/status \
-            "${EVIDENCE_DIR}/torghut-status.json" \
-            "Torghut /trading/status"
+          if [ "${TORGHUT_SCHEDULER_REPLICAS}" = '1' ]; then
+            TORGHUT_SCHEDULER_READYZ_HTTP_STATUS="$(
+              fetch_readyz_json \
+                http://torghut-scheduler.torghut.svc.cluster.local:8183/readyz \
+                "${EVIDENCE_DIR}/torghut-scheduler-readyz.json" \
+                "Torghut scheduler /readyz"
+            )"
+            if [ -z "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" ] || [ "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" = '000' ]; then
+              echo "Torghut scheduler /readyz did not return an HTTP response"
+              exit 1
+            fi
+            if ! [[ "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" =~ ^[0-9]{3}$ ]]; then
+              echo "Torghut scheduler /readyz returned invalid HTTP status ${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}"
+              exit 1
+            fi
+            echo "Torghut scheduler /readyz HTTP ${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}"
+            export TORGHUT_SCHEDULER_READYZ_HTTP_STATUS
+            export TORGHUT_SCHEDULER_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-scheduler-readyz.json"
+          fi
+
+          TORGHUT_STATUS_HTTP_STATUS="$(
+            fetch_json \
+              http://torghut.torghut.svc.cluster.local/trading/status \
+              "${EVIDENCE_DIR}/torghut-status.json" \
+              "Torghut /trading/status"
+          )"
+          if [ -z "${TORGHUT_STATUS_HTTP_STATUS}" ] || [ "${TORGHUT_STATUS_HTTP_STATUS}" = '000' ]; then
+            echo "Torghut /trading/status did not return an HTTP response"
+            exit 1
+          fi
+          if ! [[ "${TORGHUT_STATUS_HTTP_STATUS}" =~ ^[0-9]{3}$ ]]; then
+            echo "Torghut /trading/status returned invalid HTTP status ${TORGHUT_STATUS_HTTP_STATUS}"
+            exit 1
+          fi
+          echo "Torghut /trading/status HTTP ${TORGHUT_STATUS_HTTP_STATUS}"
+
+          export TORGHUT_SCHEDULER_REPLICAS
+          export TORGHUT_STATUS_HTTP_STATUS
           export TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"
-          export TORGHUT_READYZ_HTTP_STATUS
-          export TORGHUT_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-readyz.json"
+          export TORGHUT_API_READYZ_HTTP_STATUS
+          export TORGHUT_API_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-api-readyz.json"
           bun run packages/scripts/src/torghut/post-deploy-evidence.ts
 
       - name: Verify market-data freshness

--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -249,6 +249,31 @@ jobs:
             kubectl rollout status deployment/torghut-scheduler -n torghut --timeout=10m
           fi
 
+          if ! TORGHUT_SIM_TRADING_ENABLED="$(
+            kubectl get ksvc torghut-sim -n torghut -o json |
+              jq -r '
+                [.spec.template.spec.containers[]
+                  | select(.name == "user-container")
+                  | (.env // [])[]
+                  | select(.name == "TRADING_ENABLED")
+                  | (.value // "")]
+                | if length == 1 then .[0] else "" end
+              '
+          )"; then
+            echo "Failed to read torghut-sim desired TRADING_ENABLED from the live Knative Service"
+            exit 1
+          fi
+          case "${TORGHUT_SIM_TRADING_ENABLED}" in
+            true | false)
+              ;;
+            *)
+              echo "torghut-sim desired TRADING_ENABLED must be exactly true or false; got ${TORGHUT_SIM_TRADING_ENABLED:-unset}"
+              exit 1
+              ;;
+          esac
+          export TORGHUT_SIM_TRADING_ENABLED
+          echo "torghut-sim desired TRADING_ENABLED=${TORGHUT_SIM_TRADING_ENABLED}"
+
           KNSVC_READY_ATTEMPTS=60
           KNSVC_READY_INTERVAL_SECONDS=2
 
@@ -450,6 +475,7 @@ jobs:
             rm -f \
               "${EVIDENCE_DIR}/torghut-api-readyz.json" \
               "${EVIDENCE_DIR}/torghut-scheduler-readyz.json" \
+              "${EVIDENCE_DIR}/torghut-sim-status.json" \
               "${EVIDENCE_DIR}/torghut-status.json"
             unset TORGHUT_SCHEDULER_READYZ_HTTP_STATUS TORGHUT_SCHEDULER_READYZ_PAYLOAD
             CONTRACT_CAPTURE_OK='true'
@@ -505,12 +531,29 @@ jobs:
               append_contract_diagnostic "trading status returned invalid HTTP status ${TORGHUT_STATUS_HTTP_STATUS:-unset}"
             fi
 
+            if ! TORGHUT_SIM_STATUS_HTTP_STATUS="$(
+              fetch_json \
+                http://torghut-sim.torghut.svc.cluster.local/trading/status \
+                "${EVIDENCE_DIR}/torghut-sim-status.json" \
+                "Torghut simulation /trading/status" \
+                2> "${EVIDENCE_DIR}/torghut-sim-status-fetch.err"
+            )"; then
+              CONTRACT_CAPTURE_OK='false'
+              append_contract_diagnostic 'simulation trading status capture failed'
+            elif ! [[ "${TORGHUT_SIM_STATUS_HTTP_STATUS}" =~ ^[0-9]{3}$ ]] ||
+              [ "${TORGHUT_SIM_STATUS_HTTP_STATUS}" = '000' ]; then
+              CONTRACT_CAPTURE_OK='false'
+              append_contract_diagnostic "simulation trading status returned invalid HTTP status ${TORGHUT_SIM_STATUS_HTTP_STATUS:-unset}"
+            fi
+
             if [ "${CONTRACT_CAPTURE_OK}" = 'true' ]; then
               export TORGHUT_SCHEDULER_REPLICAS
               export TORGHUT_STATUS_HTTP_STATUS
               export TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"
               export TORGHUT_API_READYZ_HTTP_STATUS
               export TORGHUT_API_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-api-readyz.json"
+              export TORGHUT_SIM_STATUS_HTTP_STATUS
+              export TORGHUT_SIM_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-sim-status.json"
               if CONTRACT_DIAGNOSTICS="$(
                 bun run packages/scripts/src/torghut/post-deploy-evidence.ts 2>&1
               )"; then

--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -338,6 +338,8 @@ jobs:
           JSON_EVIDENCE_ATTEMPTS=3
           READYZ_EVIDENCE_ATTEMPTS=12
           EVIDENCE_RETRY_INTERVAL_SECONDS=2
+          FULL_CONTRACT_ATTEMPTS=120
+          FULL_CONTRACT_INTERVAL_SECONDS=10
 
           fetch_json() {
             local url="$1"
@@ -435,64 +437,99 @@ jobs:
             done
           }
 
-          TORGHUT_API_READYZ_HTTP_STATUS="$(
-            fetch_json \
-              http://torghut.torghut.svc.cluster.local/readyz \
+          append_contract_diagnostic() {
+            local message="$1"
+            if [ -n "${CONTRACT_DIAGNOSTICS}" ]; then
+              CONTRACT_DIAGNOSTICS="${CONTRACT_DIAGNOSTICS}; ${message}"
+            else
+              CONTRACT_DIAGNOSTICS="${message}"
+            fi
+          }
+
+          for contract_attempt in $(seq 1 "${FULL_CONTRACT_ATTEMPTS}"); do
+            rm -f \
               "${EVIDENCE_DIR}/torghut-api-readyz.json" \
-              "Torghut stable API /readyz"
-          )"
-          if [ -z "${TORGHUT_API_READYZ_HTTP_STATUS}" ] || [ "${TORGHUT_API_READYZ_HTTP_STATUS}" = '000' ]; then
-            echo "Torghut stable API /readyz did not return an HTTP response"
-            exit 1
-          fi
-          if ! [[ "${TORGHUT_API_READYZ_HTTP_STATUS}" =~ ^[0-9]{3}$ ]]; then
-            echo "Torghut stable API /readyz returned invalid HTTP status ${TORGHUT_API_READYZ_HTTP_STATUS}"
-            exit 1
-          fi
-          echo "Torghut stable API /readyz HTTP ${TORGHUT_API_READYZ_HTTP_STATUS}"
+              "${EVIDENCE_DIR}/torghut-scheduler-readyz.json" \
+              "${EVIDENCE_DIR}/torghut-status.json"
+            unset TORGHUT_SCHEDULER_READYZ_HTTP_STATUS TORGHUT_SCHEDULER_READYZ_PAYLOAD
+            CONTRACT_CAPTURE_OK='true'
+            CONTRACT_DIAGNOSTICS=''
 
-          if [ "${TORGHUT_SCHEDULER_REPLICAS}" = '1' ]; then
-            TORGHUT_SCHEDULER_READYZ_HTTP_STATUS="$(
-              fetch_readyz_json \
-                http://torghut-scheduler.torghut.svc.cluster.local:8183/readyz \
-                "${EVIDENCE_DIR}/torghut-scheduler-readyz.json" \
-                "Torghut scheduler /readyz"
+            if ! TORGHUT_API_READYZ_HTTP_STATUS="$(
+              fetch_json \
+                http://torghut.torghut.svc.cluster.local/readyz \
+                "${EVIDENCE_DIR}/torghut-api-readyz.json" \
+                "Torghut stable API /readyz" \
+                2> "${EVIDENCE_DIR}/torghut-api-readyz-fetch.err"
+            )"; then
+              CONTRACT_CAPTURE_OK='false'
+              append_contract_diagnostic 'stable API readiness capture failed'
+            elif ! [[ "${TORGHUT_API_READYZ_HTTP_STATUS}" =~ ^[0-9]{3}$ ]] ||
+              [ "${TORGHUT_API_READYZ_HTTP_STATUS}" = '000' ]; then
+              CONTRACT_CAPTURE_OK='false'
+              append_contract_diagnostic "stable API readiness returned invalid HTTP status ${TORGHUT_API_READYZ_HTTP_STATUS:-unset}"
+            fi
+
+            if [ "${TORGHUT_SCHEDULER_REPLICAS}" = '1' ]; then
+              if ! TORGHUT_SCHEDULER_READYZ_HTTP_STATUS="$(
+                fetch_readyz_json \
+                  http://torghut-scheduler.torghut.svc.cluster.local:8183/readyz \
+                  "${EVIDENCE_DIR}/torghut-scheduler-readyz.json" \
+                  "Torghut scheduler /readyz" \
+                  2> "${EVIDENCE_DIR}/torghut-scheduler-readyz-fetch.err"
+              )"; then
+                CONTRACT_CAPTURE_OK='false'
+                append_contract_diagnostic 'scheduler readiness capture failed'
+              elif ! [[ "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" =~ ^[0-9]{3}$ ]] ||
+                [ "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" = '000' ]; then
+                CONTRACT_CAPTURE_OK='false'
+                append_contract_diagnostic "scheduler readiness returned invalid HTTP status ${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS:-unset}"
+              else
+                export TORGHUT_SCHEDULER_READYZ_HTTP_STATUS
+                export TORGHUT_SCHEDULER_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-scheduler-readyz.json"
+              fi
+            fi
+
+            if ! TORGHUT_STATUS_HTTP_STATUS="$(
+              fetch_json \
+                http://torghut.torghut.svc.cluster.local/trading/status \
+                "${EVIDENCE_DIR}/torghut-status.json" \
+                "Torghut /trading/status" \
+                2> "${EVIDENCE_DIR}/torghut-status-fetch.err"
+            )"; then
+              CONTRACT_CAPTURE_OK='false'
+              append_contract_diagnostic 'trading status capture failed'
+            elif ! [[ "${TORGHUT_STATUS_HTTP_STATUS}" =~ ^[0-9]{3}$ ]] ||
+              [ "${TORGHUT_STATUS_HTTP_STATUS}" = '000' ]; then
+              CONTRACT_CAPTURE_OK='false'
+              append_contract_diagnostic "trading status returned invalid HTTP status ${TORGHUT_STATUS_HTTP_STATUS:-unset}"
+            fi
+
+            if [ "${CONTRACT_CAPTURE_OK}" = 'true' ]; then
+              export TORGHUT_SCHEDULER_REPLICAS
+              export TORGHUT_STATUS_HTTP_STATUS
+              export TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"
+              export TORGHUT_API_READYZ_HTTP_STATUS
+              export TORGHUT_API_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-api-readyz.json"
+              if CONTRACT_DIAGNOSTICS="$(
+                bun run packages/scripts/src/torghut/post-deploy-evidence.ts 2>&1
+              )"; then
+                printf '%s\n' "${CONTRACT_DIAGNOSTICS}"
+                echo "Torghut full post-deploy contract converged on attempt ${contract_attempt}"
+                break
+              fi
+            fi
+
+            CONTRACT_DIAGNOSTIC_LINE="$(
+              printf '%s\n' "${CONTRACT_DIAGNOSTICS}" | tail -n 1 | cut -c 1-500
             )"
-            if [ -z "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" ] || [ "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" = '000' ]; then
-              echo "Torghut scheduler /readyz did not return an HTTP response"
+            echo "Attempt ${contract_attempt}/${FULL_CONTRACT_ATTEMPTS}: Torghut full contract not converged: ${CONTRACT_DIAGNOSTIC_LINE:-unknown error}"
+            if [ "${contract_attempt}" -eq "${FULL_CONTRACT_ATTEMPTS}" ]; then
+              echo "Torghut full post-deploy contract did not converge after ${FULL_CONTRACT_ATTEMPTS} attempts"
               exit 1
             fi
-            if ! [[ "${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}" =~ ^[0-9]{3}$ ]]; then
-              echo "Torghut scheduler /readyz returned invalid HTTP status ${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}"
-              exit 1
-            fi
-            echo "Torghut scheduler /readyz HTTP ${TORGHUT_SCHEDULER_READYZ_HTTP_STATUS}"
-            export TORGHUT_SCHEDULER_READYZ_HTTP_STATUS
-            export TORGHUT_SCHEDULER_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-scheduler-readyz.json"
-          fi
-
-          TORGHUT_STATUS_HTTP_STATUS="$(
-            fetch_json \
-              http://torghut.torghut.svc.cluster.local/trading/status \
-              "${EVIDENCE_DIR}/torghut-status.json" \
-              "Torghut /trading/status"
-          )"
-          if [ -z "${TORGHUT_STATUS_HTTP_STATUS}" ] || [ "${TORGHUT_STATUS_HTTP_STATUS}" = '000' ]; then
-            echo "Torghut /trading/status did not return an HTTP response"
-            exit 1
-          fi
-          if ! [[ "${TORGHUT_STATUS_HTTP_STATUS}" =~ ^[0-9]{3}$ ]]; then
-            echo "Torghut /trading/status returned invalid HTTP status ${TORGHUT_STATUS_HTTP_STATUS}"
-            exit 1
-          fi
-          echo "Torghut /trading/status HTTP ${TORGHUT_STATUS_HTTP_STATUS}"
-
-          export TORGHUT_SCHEDULER_REPLICAS
-          export TORGHUT_STATUS_HTTP_STATUS
-          export TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"
-          export TORGHUT_API_READYZ_HTTP_STATUS
-          export TORGHUT_API_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-api-readyz.json"
-          bun run packages/scripts/src/torghut/post-deploy-evidence.ts
+            sleep "${FULL_CONTRACT_INTERVAL_SECONDS}"
+          done
 
       - name: Verify market-data freshness
         shell: bash

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -269,6 +269,7 @@ jobs:
           set -euo pipefail
           if git diff --quiet -- \
             argocd/applications/torghut/knative-service.yaml \
+            argocd/applications/torghut/scheduler-deployment.yaml \
             argocd/applications/torghut/knative-service-sim.yaml \
             argocd/applications/torghut/db-migrations-job.yaml \
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml \
@@ -307,6 +308,7 @@ jobs:
           draft: true
           add-paths: |
             argocd/applications/torghut/knative-service.yaml
+            argocd/applications/torghut/scheduler-deployment.yaml
             argocd/applications/torghut/knative-service-sim.yaml
             argocd/applications/torghut/db-migrations-job.yaml
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -349,6 +351,7 @@ jobs:
           delete-branch: true
           add-paths: |
             argocd/applications/torghut/knative-service.yaml
+            argocd/applications/torghut/scheduler-deployment.yaml
             argocd/applications/torghut/knative-service-sim.yaml
             argocd/applications/torghut/db-migrations-job.yaml
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -531,25 +531,24 @@ data:
               runbook_url: docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
       - name: torghut-trading.rules
         rules:
-          - alert: TorghutTradingRevisionMetricsMissing
+          - alert: TorghutApiServiceMissing
             expr: |
               absent(
-                up{
-                  job="torghut",
+                kube_service_info{
                   namespace="torghut",
-                  service=~"torghut-[0-9]{5}-private"
+                  service="torghut"
                 }
               ) == 1
             for: 10m
             labels:
               severity: warning
             annotations:
-              summary: Torghut trading revision metrics missing
+              summary: Torghut API service is missing
               description: |
-                No active Knative private revision service metrics are being scraped for torghut.
-                If torghut should be running, this may indicate revision readiness failures or scrape config drift.
+                The stable Knative API Service is absent from Kubernetes inventory.
+                Private revision metrics may be absent normally while the stateless API is scaled to zero.
               runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
-          - alert: TorghutTradingRevisionMetricsDown
+          - alert: TorghutActiveApiRevisionMetricsDown
             expr: |
               max(
                 up{
@@ -562,9 +561,122 @@ data:
             labels:
               severity: critical
             annotations:
-              summary: Torghut trading revision metrics endpoint is down
+              summary: Active Torghut API revision metrics endpoint is down
               description: |
-                The active Knative private revision for torghut is being scraped but up=0 for 5 minutes.
+                A currently active stateless Knative API revision is being scraped but up=0 for 5 minutes.
+                No alert is expected while Knative has intentionally scaled the API to zero.
+              runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
+          - alert: TorghutSchedulerMetricsMissing
+            expr: |
+              (
+                kube_deployment_spec_replicas{
+                  namespace="torghut",
+                  deployment="torghut-scheduler"
+                } > 0
+              )
+              unless on (namespace)
+              max by (namespace) (
+                up{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-scheduler"
+                }
+              )
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut scheduler metrics are missing
+              description: |
+                The scheduler Deployment expects a writer, but no torghut-scheduler metrics target exists.
+                Keep trading contained and inspect the Deployment, Service endpoints, and Alloy discovery.
+              runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
+          - alert: TorghutSchedulerMetricsDown
+            expr: |
+              max by (namespace) (
+                up{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-scheduler"
+                }
+              ) == 0
+              and on (namespace)
+              kube_deployment_spec_replicas{
+                namespace="torghut",
+                deployment="torghut-scheduler"
+              } > 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut scheduler metrics endpoint is down
+              description: |
+                The scheduler writer should be active, but its metrics endpoint has been down for 5 minutes.
+                Keep trading contained until the writer and leadership state are healthy.
+              runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
+          - alert: TorghutSchedulerWriterCountInvalid
+            expr: |
+              (
+                (
+                  sum by (namespace) (
+                    torghut_scheduler_leadership_acquired{
+                      job="torghut",
+                      namespace="torghut",
+                      service="torghut-scheduler"
+                    }
+                  )
+                  or on (namespace)
+                  0 * kube_deployment_spec_replicas{
+                    namespace="torghut",
+                    deployment="torghut-scheduler"
+                  }
+                ) != 1
+              )
+              and on (namespace)
+              kube_deployment_spec_replicas{
+                namespace="torghut",
+                deployment="torghut-scheduler"
+              } > 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut scheduler does not have exactly one writer
+              description: |
+                Exactly one scheduler must hold the durable leadership lock whenever the Deployment is enabled.
+                Keep trading contained until the acquired-leadership gauge sums to one.
+              runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
+          - alert: TorghutSchedulerLeadershipUnhealthy
+            expr: |
+              (
+                (
+                  sum by (namespace) (
+                    torghut_scheduler_leadership_healthy{
+                      job="torghut",
+                      namespace="torghut",
+                      service="torghut-scheduler"
+                    }
+                  )
+                  or on (namespace)
+                  0 * kube_deployment_spec_replicas{
+                    namespace="torghut",
+                    deployment="torghut-scheduler"
+                  }
+                ) != 1
+              )
+              and on (namespace)
+              kube_deployment_spec_replicas{
+                namespace="torghut",
+                deployment="torghut-scheduler"
+              } > 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut scheduler leadership is unhealthy
+              description: |
+                The enabled scheduler does not report exactly one healthy durable-leadership holder.
+                Cancel broker-affecting work and restore the database leadership session before resuming.
               runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
       - name: torghut-llm.rules
         rules:
@@ -1061,7 +1173,7 @@ data:
                     torghut_trading_decisions_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut"
+                      service="torghut-scheduler"
                     }[5m]
                   )
                 ) == 0
@@ -1089,7 +1201,7 @@ data:
                   torghut_trading_no_signal_windows_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[10m]
                 ) >= 2
               )
@@ -1116,7 +1228,7 @@ data:
                   torghut_trading_no_signal_reason_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut",
+                    service="torghut-scheduler",
                     reason="cursor_ahead_of_stream"
                   }[10m]
                 ) >= 2
@@ -1144,7 +1256,7 @@ data:
                   torghut_trading_signal_continuity_actionable{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[10m]
                 ) >= 1
               )
@@ -1171,7 +1283,7 @@ data:
                   torghut_trading_universe_fail_safe_reason_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[10m]
                 ) > 0
               )
@@ -1198,7 +1310,7 @@ data:
                   torghut_trading_signal_staleness_alert_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[15m]
                 ) >= 3
               )
@@ -1225,7 +1337,7 @@ data:
                   torghut_trading_execution_fallback_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut",
+                    service="torghut-scheduler",
                     from="lean",
                     to="alpaca"
                   }[15m]
@@ -1236,7 +1348,7 @@ data:
                     torghut_trading_execution_requests_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut",
+                      service="torghut-scheduler",
                       adapter="lean"
                     }[15m]
                   ),
@@ -1248,7 +1360,7 @@ data:
                 torghut_trading_execution_requests_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut",
+                  service="torghut-scheduler",
                   adapter="lean"
                 }[15m]
               ) > 0.01
@@ -1266,13 +1378,13 @@ data:
               torghut_trading_route_provenance_coverage_ratio{
                 job="torghut",
                 namespace="torghut",
-                service="torghut"
+                service="torghut-scheduler"
               } < 0.98
               and
               torghut_trading_route_provenance_total{
                 job="torghut",
                 namespace="torghut",
-                service="torghut"
+                service="torghut-scheduler"
               } >= 20
             for: 15m
             labels:
@@ -1289,7 +1401,7 @@ data:
                 torghut_trading_evidence_continuity_failures_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[2h]
               ) > 0
             for: 5m
@@ -1309,7 +1421,7 @@ data:
                   torghut_trading_orders_rejected_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[15m]
                 )
                 /
@@ -1318,7 +1430,7 @@ data:
                     torghut_trading_orders_submitted_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut"
+                      service="torghut-scheduler"
                     }[15m]
                   ),
                   1
@@ -1329,7 +1441,7 @@ data:
                 torghut_trading_orders_submitted_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[15m]
               ) > 0
             for: 10m
@@ -1347,7 +1459,7 @@ data:
                 torghut_trading_execution_clean_ratio{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[15m]
               ) < 0.75
               and
@@ -1355,7 +1467,7 @@ data:
                 torghut_trading_decisions_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[15m]
               ) > 20
             for: 10m
@@ -1373,7 +1485,7 @@ data:
                 torghut_trading_signal_batch_order_violation_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[5m]
               ) > 0
             for: 0m
@@ -1391,7 +1503,7 @@ data:
                 torghut_trading_execution_validation_mismatch_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[5m]
               ) > 0
             for: 0m
@@ -1410,7 +1522,7 @@ data:
                   torghut_trading_execution_submit_attempt_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[15m]
                 )
               ) > 0
@@ -1420,7 +1532,7 @@ data:
                   torghut_trading_execution_submit_result_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut",
+                    service="torghut-scheduler",
                     status="accepted"
                   }[15m]
                 )
@@ -1442,7 +1554,7 @@ data:
                     torghut_trading_execution_local_reject_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut"
+                      service="torghut-scheduler"
                     }[5m]
                   )
                 )
@@ -1453,7 +1565,7 @@ data:
                       torghut_trading_execution_submit_attempt_total{
                         job="torghut",
                         namespace="torghut",
-                        service="torghut"
+                        service="torghut-scheduler"
                       }[5m]
                     )
                   ),
@@ -1466,7 +1578,7 @@ data:
                   torghut_trading_execution_submit_attempt_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[5m]
                 )
               ) >= 5
@@ -1485,7 +1597,7 @@ data:
                 torghut_trading_decisions_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[15m]
               ) > 10
               and
@@ -1494,7 +1606,7 @@ data:
                   torghut_trading_execution_submit_attempt_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[15m]
                 )
               ) == 0
@@ -1514,7 +1626,7 @@ data:
                   torghut_trading_decision_reject_reason_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut",
+                    service="torghut-scheduler",
                     reason="qty_below_min"
                   }[30m]
                 )
@@ -1524,7 +1636,7 @@ data:
                     torghut_trading_decisions_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut"
+                      service="torghut-scheduler"
                     }[30m]
                   ),
                   1
@@ -1535,7 +1647,7 @@ data:
                 torghut_trading_decisions_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[30m]
               ) > 25
             for: 10m
@@ -1555,7 +1667,7 @@ data:
                     torghut_trading_decision_reject_reason_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut",
+                      service="torghut-scheduler",
                       reason=~"llm_unavailable_.*"
                     }[30m]
                   )
@@ -1566,7 +1678,7 @@ data:
                     torghut_trading_decisions_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut"
+                      service="torghut-scheduler"
                     }[30m]
                   ),
                   1
@@ -1577,7 +1689,7 @@ data:
                 torghut_trading_decisions_total{
                   job="torghut",
                   namespace="torghut",
-                  service="torghut"
+                  service="torghut-scheduler"
                 }[30m]
               ) > 25
             for: 10m
@@ -1596,7 +1708,7 @@ data:
                   torghut_trading_llm_error_total{
                     job="torghut",
                     namespace="torghut",
-                    service="torghut"
+                    service="torghut-scheduler"
                   }[15m]
                 )
                 /
@@ -1605,7 +1717,7 @@ data:
                     torghut_trading_llm_requests_total{
                       job="torghut",
                       namespace="torghut",
-                      service="torghut"
+                      service="torghut-scheduler"
                     }[15m]
                   ),
                   1

--- a/argocd/applications/observability/torghut-execution-recovery-dashboard-configmap.yaml
+++ b/argocd/applications/observability/torghut-execution-recovery-dashboard-configmap.yaml
@@ -32,12 +32,12 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "torghut_trading_execution_clean_ratio{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}",
+              "expr": "torghut_trading_execution_clean_ratio{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}",
               "legendFormat": "clean ratio",
               "refId": "A"
             },
             {
-              "expr": "torghut_trading_execution_reject_ratio{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}",
+              "expr": "torghut_trading_execution_reject_ratio{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}",
               "legendFormat": "reject ratio",
               "refId": "B"
             }
@@ -53,12 +53,12 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "increase(torghut_trading_decision_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\", reason=\"qty_below_min\"}[30m]) / clamp_min(increase(torghut_trading_decisions_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[30m]), 1)",
+              "expr": "increase(torghut_trading_decision_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\", reason=\"qty_below_min\"}[30m]) / clamp_min(increase(torghut_trading_decisions_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[30m]), 1)",
               "legendFormat": "qty_below_min ratio (30m)",
               "refId": "A"
             },
             {
-              "expr": "sum(increase(torghut_trading_decision_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\", reason=~\"llm_unavailable_.*\"}[30m])) / clamp_min(increase(torghut_trading_decisions_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[30m]), 1)",
+              "expr": "sum(increase(torghut_trading_decision_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\", reason=~\"llm_unavailable_.*\"}[30m])) / clamp_min(increase(torghut_trading_decisions_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[30m]), 1)",
               "legendFormat": "llm_unavailable ratio (30m)",
               "refId": "B"
             }
@@ -74,7 +74,7 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "topk(10, increase(torghut_trading_decision_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[2h]))",
+              "expr": "topk(10, increase(torghut_trading_decision_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[2h]))",
               "legendFormat": "{{reason}}",
               "refId": "A"
             }
@@ -90,7 +90,7 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "increase(torghut_trading_llm_unavailable_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[2h])",
+              "expr": "increase(torghut_trading_llm_unavailable_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[2h])",
               "legendFormat": "{{reason}}",
               "refId": "A"
             }
@@ -106,7 +106,7 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "increase(torghut_trading_llm_unavailable_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[2h])",
+              "expr": "increase(torghut_trading_llm_unavailable_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[2h])",
               "legendFormat": "{{reason}}",
               "refId": "A"
             }
@@ -122,12 +122,12 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "rate(torghut_trading_orders_submitted_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[15m])",
+              "expr": "rate(torghut_trading_orders_submitted_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[15m])",
               "legendFormat": "submitted/s",
               "refId": "A"
             },
             {
-              "expr": "rate(torghut_trading_orders_rejected_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[15m])",
+              "expr": "rate(torghut_trading_orders_rejected_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[15m])",
               "legendFormat": "rejected/s",
               "refId": "B"
             }
@@ -175,27 +175,27 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "sum(increase(torghut_trading_feature_quality_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[15m]))",
+              "expr": "sum(increase(torghut_trading_feature_quality_reject_reason_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[15m]))",
               "legendFormat": "quality rejected",
               "refId": "A"
             },
             {
-              "expr": "increase(torghut_trading_decisions_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[15m])",
+              "expr": "increase(torghut_trading_decisions_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[15m])",
               "legendFormat": "decisions",
               "refId": "B"
             },
             {
-              "expr": "sum(increase(torghut_trading_execution_submit_attempt_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[15m]))",
+              "expr": "sum(increase(torghut_trading_execution_submit_attempt_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[15m]))",
               "legendFormat": "submit attempts",
               "refId": "C"
             },
             {
-              "expr": "sum(increase(torghut_trading_execution_submit_result_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\", status=\"accepted\"}[15m]))",
+              "expr": "sum(increase(torghut_trading_execution_submit_result_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\", status=\"accepted\"}[15m]))",
               "legendFormat": "submit accepted",
               "refId": "D"
             },
             {
-              "expr": "increase(torghut_trading_orders_submitted_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[15m])",
+              "expr": "increase(torghut_trading_orders_submitted_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[15m])",
               "legendFormat": "orders submitted",
               "refId": "E"
             }
@@ -211,7 +211,7 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "sum by (stage, outcome) (increase(torghut_trading_qty_resolution_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[30m]))",
+              "expr": "sum by (stage, outcome) (increase(torghut_trading_qty_resolution_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[30m]))",
               "legendFormat": "{{stage}} {{outcome}}",
               "refId": "A"
             }
@@ -227,7 +227,7 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "sum by (stage, context) (increase(torghut_trading_sell_inventory_context_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[30m]))",
+              "expr": "sum by (stage, context) (increase(torghut_trading_sell_inventory_context_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[30m]))",
               "legendFormat": "{{stage}} {{context}}",
               "refId": "A"
             }
@@ -243,17 +243,17 @@ data:
           "options": {"tooltip": {"mode": "single"}},
           "targets": [
             {
-              "expr": "increase(torghut_trading_signal_batch_order_violation_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[30m])",
+              "expr": "increase(torghut_trading_signal_batch_order_violation_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[30m])",
               "legendFormat": "order violations",
               "refId": "A"
             },
             {
-              "expr": "increase(torghut_trading_execution_validation_mismatch_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[30m])",
+              "expr": "increase(torghut_trading_execution_validation_mismatch_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[30m])",
               "legendFormat": "validation mismatches",
               "refId": "B"
             },
             {
-              "expr": "sum by (code, reason) (increase(torghut_trading_execution_local_reject_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut\"}[30m]))",
+              "expr": "sum by (code, reason) (increase(torghut_trading_execution_local_reject_total{job=\"torghut\", namespace=\"torghut\", service=\"torghut-scheduler\"}[30m]))",
               "legendFormat": "{{code}} {{reason}}",
               "refId": "C"
             }

--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -2,6 +2,25 @@
 
 This directory contains the Argo CD application resources for the `torghut` namespace.
 
+## Live API and scheduler ownership
+
+The Knative `Service/torghut` is a stateless API reader (`TORGHUT_PROCESS_ROLE=api`). It must never start trading or
+reconciliation loops. `Deployment/torghut-scheduler` is the only workload configured with
+`TORGHUT_PROCESS_ROLE=scheduler`; it uses `Recreate` rollout semantics and starts at zero replicas for P0a containment.
+
+Rollout is deliberately two-stage. First promote and prove the scheduler-free API image while the scheduler
+Deployment remains at zero. Then perform the documented one-time emergency removal of legacy Knative revisions and
+prove that no scheduler loop remains. Only after those checks pass may a follow-up GitOps change scale the advisory-
+locked scheduler Deployment to one replica. Do not add a persistent revision-cleanup Job or combine those stages.
+Do not restore `autoscaling.knative.dev/minScale` on the API template: the annotation is copied onto immutable
+revisions and was the reason stale revisions remained hot. Activate the current API revision with an explicit request
+when rollout proof needs a running pod.
+
+The API and scheduler currently keep explicit environment entries so the live direct-env safety contract remains
+auditable. `test_single_writer_scheduler_manifest.py` enforces exact parity except for the process role and the two
+scheduler-only leadership settings; migrate both manifests to one typed generated source in a follow-up without
+weakening that contract.
+
 ## TA replay workflow (canonical)
 
 This is the single, canonical TA replay/backfill workflow that oncall should follow (and that an AgentRun can later
@@ -178,7 +197,7 @@ This script intentionally keeps defaults conservative and does not automate dest
 ### Safety gates (read first)
 - **Trading safety (prerequisite):** if there is any uncertainty about signal correctness (stale/corrupt/partial), pause
   trading first and keep it paused until verification passes.
-  - set `TRADING_ENABLED=false` in `argocd/applications/torghut/knative-service.yaml`
+  - set `spec.replicas: 0` in `argocd/applications/torghut/scheduler-deployment.yaml`
   - keep `TRADING_MODE=paper` unless the recovery explicitly requires live mode
 - **Unique consumer group required (hard requirement):** every replay/backfill must use a **new** `TA_GROUP_ID`
   (consumer-group isolation). Never reuse an old replay group id.
@@ -206,7 +225,7 @@ Before touching the TA job or Kafka topics, record the following in your ticket/
 Goal: recompute TA outputs from retained Kafka inputs without deleting topics or Flink state.
 
 1) Pause trading (recommended; required if signal correctness is uncertain)
-   - `argocd/applications/torghut/knative-service.yaml`: set `TRADING_ENABLED=false`, then Argo sync.
+   - `argocd/applications/torghut/scheduler-deployment.yaml`: set `spec.replicas: 0`, then Argo sync.
 2) Suspend TA to stop writes while you switch group id
    - GitOps-first: set `spec.job.state: suspended` in `argocd/applications/torghut/ta/flinkdeployment.yaml`, then Argo sync.
    - Emergency-only:
@@ -251,7 +270,7 @@ Before starting, get explicit human confirmation that the following are acceptab
 - Deleting Flink checkpoint/savepoint directories under `s3a://flink-checkpoints/torghut/technical-analysis/...`
 
 0) Pause trading (required)
-- Set `TRADING_ENABLED=false` in `argocd/applications/torghut/knative-service.yaml` and Argo sync.
+- Set `spec.replicas: 0` in `argocd/applications/torghut/scheduler-deployment.yaml` and Argo sync.
 
 1) Suspend the job (same as Mode 1)
 

--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -7,6 +7,8 @@ This directory contains the Argo CD application resources for the `torghut` name
 The Knative `Service/torghut` is a stateless API reader (`TORGHUT_PROCESS_ROLE=api`). It must never start trading or
 reconciliation loops. `Deployment/torghut-scheduler` is the only workload configured with
 `TORGHUT_PROCESS_ROLE=scheduler`; it uses `Recreate` rollout semantics and starts at zero replicas for P0a containment.
+The API proxies `/trading/status` and `/metrics` to that scheduler and returns `503` when it is unavailable; it never
+manufactures runtime state from its dormant local scheduler object.
 
 Rollout is deliberately two-stage. First promote and prove the scheduler-free API image while the scheduler
 Deployment remains at zero. Then perform the documented one-time emergency removal of legacy Knative revisions and

--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -7,8 +7,9 @@ This directory contains the Argo CD application resources for the `torghut` name
 The Knative `Service/torghut` is a stateless API reader (`TORGHUT_PROCESS_ROLE=api`). It must never start trading or
 reconciliation loops. `Deployment/torghut-scheduler` is the only workload configured with
 `TORGHUT_PROCESS_ROLE=scheduler`; it uses `Recreate` rollout semantics and starts at zero replicas for P0a containment.
-The API proxies `/trading/status` and `/metrics` to that scheduler and returns `503` when it is unavailable; it never
-manufactures runtime state from its dormant local scheduler object.
+The API proxies only the scheduler-owned `/trading/status` surface and returns `503` while the scheduler is unavailable.
+API `/metrics` is process-local API health telemetry, not scheduler or writer proof. Scheduler metrics are exposed
+directly by `Service/torghut-scheduler` and are intentionally unavailable while its Deployment has zero replicas.
 
 Rollout is deliberately two-stage. First promote and prove the scheduler-free API image while the scheduler
 Deployment remains at zero. Then perform the documented one-time emergency removal of legacy Knative revisions and
@@ -17,6 +18,398 @@ locked scheduler Deployment to one replica. Do not add a persistent revision-cle
 Do not restore `autoscaling.knative.dev/minScale` on the API template: the annotation is copied onto immutable
 revisions and was the reason stale revisions remained hot. Activate the current API revision with an explicit request
 when rollout proof needs a running pod.
+
+### P0a one-time legacy Knative revision cleanup
+
+This is a one-time, operator-run cleanup after the scheduler-free API image is synced. It is not a recurring retention
+mechanism. Do not implement it as a `Job`, `CronJob`, Argo hook, init container, or controller. Never delete revisions
+by label: the deletion list must be pinned and each legacy revision must be named explicitly.
+
+Run the procedure from one Bash shell with `kubectl`, `jq`, `curl`, and the `kubectl cnpg` plugin available. Any failed
+command or assertion is a stop gate: leave `Deployment/torghut-scheduler` at zero, delete nothing else, and investigate.
+Save the command output and the exact deleted revision list in the incident or rollout record.
+
+#### 1. Prove GitOps convergence and scheduler containment
+
+```bash
+set -euo pipefail
+
+NS=torghut
+KSVC=torghut
+SCHEDULER=torghut-scheduler
+
+fail() {
+  echo "P0a cleanup blocked: $*" >&2
+  exit 1
+}
+
+ARGO_SYNC="$(kubectl -n argocd get application torghut -o jsonpath='{.status.sync.status}')"
+ARGO_HEALTH="$(kubectl -n argocd get application torghut -o jsonpath='{.status.health.status}')"
+[[ "$ARGO_SYNC" == "Synced" && "$ARGO_HEALTH" == "Healthy" ]] \
+  || fail "Argo application is sync=$ARGO_SYNC health=$ARGO_HEALTH"
+
+SCHEDULER_JSON="$(kubectl -n "$NS" get deployment "$SCHEDULER" -o json)"
+SCHEDULER_DESIRED="$(jq -r '.spec.replicas // 0' <<<"$SCHEDULER_JSON")"
+SCHEDULER_CURRENT="$(jq -r '.status.replicas // 0' <<<"$SCHEDULER_JSON")"
+SCHEDULER_READY="$(jq -r '.status.readyReplicas // 0' <<<"$SCHEDULER_JSON")"
+SCHEDULER_AVAILABLE="$(jq -r '.status.availableReplicas // 0' <<<"$SCHEDULER_JSON")"
+[[ "$SCHEDULER_DESIRED" == "0" && "$SCHEDULER_CURRENT" == "0" \
+  && "$SCHEDULER_READY" == "0" && "$SCHEDULER_AVAILABLE" == "0" ]] \
+  || fail "scheduler is not fully at zero"
+
+SCHEDULER_PODS="$(
+  kubectl -n "$NS" get pods -l app.kubernetes.io/component=trading-scheduler -o json \
+    | jq '[.items[] | select(.status.phase != "Succeeded" and .status.phase != "Failed")] | length'
+)"
+[[ "$SCHEDULER_PODS" == "0" ]] || fail "scheduler pods still exist"
+
+SCHEDULER_ENDPOINTS="$(
+  kubectl -n "$NS" get endpointslices \
+    -l kubernetes.io/service-name="$SCHEDULER" -o json \
+    | jq '[.items[].endpoints[]?.addresses[]?] | length'
+)"
+[[ "$SCHEDULER_ENDPOINTS" == "0" ]] \
+  || fail "scheduler Service still has endpoints"
+```
+
+The empty scheduler endpoint is expected at this stage. Do not probe API `/metrics` for scheduler leadership; it is the
+wrong process. Do not continue if the Deployment spec is nonzero even when its pods happen to be absent.
+
+#### 2. Pin the new ready revision and its only traffic target
+
+```bash
+read_ksvc_state() {
+  KSVC_JSON="$(kubectl -n "$NS" get ksvc "$KSVC" -o json)"
+  KSVC_UID="$(jq -r '.metadata.uid // ""' <<<"$KSVC_JSON")"
+  KSVC_GENERATION="$(jq -r '.metadata.generation // 0' <<<"$KSVC_JSON")"
+  KSVC_OBSERVED_GENERATION="$(jq -r '.status.observedGeneration // 0' <<<"$KSVC_JSON")"
+  KSVC_URL="$(jq -r '.status.url // ""' <<<"$KSVC_JSON")"
+  API_HOST="${KSVC_URL#*://}"
+  API_HOST="${API_HOST%%/*}"
+  LATEST_CREATED="$(jq -r '.status.latestCreatedRevisionName // ""' <<<"$KSVC_JSON")"
+  LATEST_READY="$(jq -r '.status.latestReadyRevisionName // ""' <<<"$KSVC_JSON")"
+  KSVC_READY="$(
+    jq -r '[.status.conditions[]? | select(.type == "Ready")][0].status // ""' \
+      <<<"$KSVC_JSON"
+  )"
+  TRAFFIC_OK="$(
+    jq -r --arg revision "$LATEST_READY" '
+      (.spec.traffic | length) == 1
+      and .spec.traffic[0].latestRevision == true
+      and (.spec.traffic[0].percent // 0) == 100
+      and (.spec.traffic[0].tag // "") == ""
+      and (.spec.traffic[0].revisionName // "") == ""
+      and (.status.traffic | length) == 1
+      and .status.traffic[0].latestRevision == true
+      and (.status.traffic[0].percent // 0) == 100
+      and .status.traffic[0].revisionName == $revision
+      and (.status.traffic[0].tag // "") == ""
+      and (.status.traffic[0].url // "") == ""
+      and
+      all(.status.traffic[]?; (.tag // "") == "" and (.url // "") == "")
+    ' <<<"$KSVC_JSON"
+  )"
+
+  [[ -n "$KSVC_UID" ]] || fail "Knative Service UID is empty"
+  [[ "$KSVC_GENERATION" == "$KSVC_OBSERVED_GENERATION" ]] \
+    || fail "KService generation=$KSVC_GENERATION observed=$KSVC_OBSERVED_GENERATION"
+  [[ -n "$LATEST_READY" ]] || fail "latestReadyRevisionName is empty"
+  [[ -n "$API_HOST" ]] || fail "Knative Service URL/host is empty"
+  [[ "$KSVC_READY" == "True" ]] || fail "Knative Service Ready=$KSVC_READY"
+  [[ "$LATEST_CREATED" == "$LATEST_READY" ]] \
+    || fail "latestCreated=$LATEST_CREATED differs from latestReady=$LATEST_READY"
+  [[ "$TRAFFIC_OK" == "true" ]] \
+    || fail "traffic is not one untagged 100% latestReady target=$LATEST_READY"
+  if [[ -n "${PINNED_KSVC_UID:-}" ]]; then
+    [[ "$KSVC_UID" == "$PINNED_KSVC_UID" ]] \
+      || fail "KService UID changed during cleanup"
+    [[ "$KSVC_GENERATION" == "$PINNED_KSVC_GENERATION" ]] \
+      || fail "KService generation changed during cleanup"
+  fi
+}
+
+read_ksvc_state
+PINNED_KSVC_UID="$KSVC_UID"
+PINNED_KSVC_GENERATION="$KSVC_GENERATION"
+PINNED_LATEST_READY="$LATEST_READY"
+
+jq '{
+  uid: .metadata.uid,
+  generation: .metadata.generation,
+  observedGeneration: .status.observedGeneration,
+  latestCreatedRevisionName: .status.latestCreatedRevisionName,
+  latestReadyRevisionName: .status.latestReadyRevisionName,
+  specTraffic: [.spec.traffic[]? | {revisionName, latestRevision, percent, tag}],
+  statusTraffic: [.status.traffic[]? | {revisionName, latestRevision, percent, tag, url}],
+  ready: [.status.conditions[]? | select(.type == "Ready")][0].status
+}' <<<"$KSVC_JSON"
+```
+
+Do not proceed when a newer revision is unready, traffic is split, traffic points to an older revision, or
+`latestCreatedRevisionName` changes during the procedure.
+
+#### 3. Activate and inspect the scheduler-free API
+
+The Knative API has no `minScale`; send real traffic through the local Knative gateway to activate the pinned
+revision. The stable `Service/torghut` is an `ExternalName` Service and cannot itself be used with `kubectl
+port-forward`. The gateway port-forward plus the KService `Host` header creates no Kubernetes workload.
+
+```bash
+LOCAL_PORT="${LOCAL_PORT:-18181}"
+PF_LOG="$(mktemp)"
+METRICS_BODY="$(mktemp)"
+STATUS_BODY="$(mktemp)"
+
+kubectl -n istio-system port-forward service/knative-local-gateway \
+  "$LOCAL_PORT":80 >"$PF_LOG" 2>&1 &
+PF_PID=$!
+cleanup_probe() {
+  kill "$PF_PID" 2>/dev/null || true
+  wait "$PF_PID" 2>/dev/null || true
+  rm -f "$PF_LOG" "$METRICS_BODY" "$STATUS_BODY"
+}
+trap cleanup_probe EXIT
+
+for _ in $(seq 1 30); do
+  if curl -fsS -H "Host: $API_HOST" \
+    "http://127.0.0.1:$LOCAL_PORT/healthz" >/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+curl -fsS -H "Host: $API_HOST" \
+  "http://127.0.0.1:$LOCAL_PORT/healthz" | jq -e '.status == "ok"'
+curl -fsS -H "Host: $API_HOST" \
+  "http://127.0.0.1:$LOCAL_PORT/readyz" | jq -e '.status == "ok"'
+curl -fsS -H "Host: $API_HOST" \
+  "http://127.0.0.1:$LOCAL_PORT/metrics" >"$METRICS_BODY"
+[[ -s "$METRICS_BODY" ]] || fail "API-local metrics response is empty"
+grep -qx 'torghut_api_process_ready 1' "$METRICS_BODY" \
+  || fail "API-local readiness metric is missing"
+grep -qx 'torghut_process_role_info{role="api"} 1' "$METRICS_BODY" \
+  || fail "API-local role metric is missing"
+if grep -q '^torghut_scheduler_leadership_' "$METRICS_BODY"; then
+  fail "API metrics incorrectly expose scheduler leadership"
+fi
+
+STATUS_CODE="$(
+  curl -sS -H "Host: $API_HOST" -o "$STATUS_BODY" -w '%{http_code}' \
+    "http://127.0.0.1:$LOCAL_PORT/trading/status"
+)"
+[[ "$STATUS_CODE" == "503" ]] \
+  || fail "expected /trading/status=503 with scheduler at zero; got $STATUS_CODE"
+jq -e '
+  .detail == "scheduler_runtime_unavailable"
+  and .owner == "torghut-scheduler"
+' "$STATUS_BODY"
+
+cleanup_probe
+trap - EXIT
+
+kubectl -n "$NS" wait --for=condition=Ready pod \
+  -l serving.knative.dev/revision="$PINNED_LATEST_READY" --timeout=180s
+
+API_PODS_JSON="$(
+  kubectl -n "$NS" get pods \
+    -l serving.knative.dev/revision="$PINNED_LATEST_READY" -o json
+)"
+API_POD_COUNT="$(
+  jq '[.items[]
+    | select(.status.phase == "Running")
+    | select(any(.status.containerStatuses[]?;
+        .name == "user-container" and .ready == true))] | length' \
+    <<<"$API_PODS_JSON"
+)"
+[[ "$API_POD_COUNT" == "1" ]] \
+  || fail "expected one ready pinned API pod; found $API_POD_COUNT"
+API_POD="$(
+  jq -r '.items[]
+    | select(.status.phase == "Running")
+    | select(any(.status.containerStatuses[]?;
+        .name == "user-container" and .ready == true))
+    | .metadata.name' <<<"$API_PODS_JSON"
+)"
+
+REVISION_JSON="$(kubectl -n "$NS" get revision "$PINNED_LATEST_READY" -o json)"
+DESIRED_IMAGE="$(jq -r '.spec.template.spec.containers[] | select(.name == "user-container") | .image' <<<"$KSVC_JSON")"
+REVISION_IMAGE="$(jq -r '.spec.containers[] | select(.name == "user-container") | .image' <<<"$REVISION_JSON")"
+REVISION_ROLE="$(
+  jq -r '.spec.containers[] | select(.name == "user-container")
+    | .env[] | select(.name == "TORGHUT_PROCESS_ROLE") | .value' \
+    <<<"$REVISION_JSON"
+)"
+[[ "$REVISION_IMAGE" == "$DESIRED_IMAGE" ]] \
+  || fail "pinned revision image differs from the Knative Service template"
+[[ "$REVISION_ROLE" == "api" ]] \
+  || fail "pinned revision TORGHUT_PROCESS_ROLE=$REVISION_ROLE"
+
+jq '{
+  revision: .metadata.name,
+  image: [.spec.containers[] | select(.name == "user-container") | .image][0],
+  env: [.spec.containers[] | select(.name == "user-container") | .env[]
+    | select(.name | test("^(TORGHUT_PROCESS_ROLE|TRADING_ENABLED|TRADING_MODE|TRADING_SCHEDULER_RUNTIME_BASE_URL|APCA_API_BASE_URL)$"))]
+}' <<<"$REVISION_JSON"
+
+POD_ROLE="$(
+  kubectl -n "$NS" exec "$API_POD" -c user-container -- \
+    printenv TORGHUT_PROCESS_ROLE
+)"
+[[ "$POD_ROLE" == "api" ]] || fail "running pod role=$POD_ROLE"
+
+API_LOGS="$(mktemp)"
+kubectl -n "$NS" logs "$API_POD" -c user-container --since=30m >"$API_LOGS"
+grep -q 'background_worker_owner=external' "$API_LOGS" \
+  || fail "API did not report external background-worker ownership"
+if grep -Eq 'Trading scheduler (starting|loop running)' "$API_LOGS"; then
+  fail "scheduler loop startup found in pinned API logs"
+fi
+rm -f "$API_LOGS"
+```
+
+`/healthz`, `/readyz`, and API-local `/metrics` must succeed. `/trading/status` must fail closed with `503` because the
+scheduler is deliberately absent. A `200` status response at this point is evidence of another scheduler and blocks
+cleanup.
+
+#### 4. Freeze and delete only the legacy revisions
+
+Re-read the Service immediately before inventory and deletion. The pinned revision and traffic assertions must still
+hold. Preflight delete permission, print the exact inventory, and record it before continuing.
+
+```bash
+read_ksvc_state
+[[ "$LATEST_READY" == "$PINNED_LATEST_READY" ]] \
+  || fail "latestReady changed after API proof"
+[[ "$(kubectl auth can-i delete revisions.serving.knative.dev -n "$NS")" == "yes" ]] \
+  || fail "current identity cannot delete Knative revisions"
+
+kubectl -n "$NS" get revisions \
+  -l serving.knative.dev/service="$KSVC" \
+  -o custom-columns='NAME:.metadata.name,CREATED:.metadata.creationTimestamp,READY:.status.conditions[?(@.type=="Ready")].status'
+
+REVISIONS_JSON="$(
+  kubectl -n "$NS" get revisions \
+    -l serving.knative.dev/service="$KSVC" -o json
+)"
+LEGACY_REVISIONS="$(
+  jq -r --arg keep "$PINNED_LATEST_READY" '
+    [.items[] | select(.metadata.name != $keep)]
+    | sort_by(.metadata.creationTimestamp)
+    | .[].metadata.name
+  ' <<<"$REVISIONS_JSON"
+)"
+
+echo "Pinned revision: $PINNED_LATEST_READY"
+printf 'Legacy revisions approved for one-time deletion:\n%s\n' \
+  "${LEGACY_REVISIONS:-<none>}"
+```
+
+If the printed list is wrong, empty unexpectedly, or contains the pinned revision, stop. Run the following deletion
+block once. It intentionally has no label-based delete and rechecks latest-ready and traffic state before every
+revision.
+
+```bash
+while IFS= read -r revision; do
+  [[ -n "$revision" ]] || continue
+  [[ "$revision" != "$PINNED_LATEST_READY" ]] \
+    || fail "refusing to delete pinned revision"
+
+  read_ksvc_state
+  [[ "$LATEST_READY" == "$PINNED_LATEST_READY" ]] \
+    || fail "latestReady changed before deleting $revision"
+  jq -e --arg revision "$revision" '
+    all(.status.traffic[]?;
+      .revisionName != $revision and (.tag // "") == "" and (.url // "") == "")
+  ' <<<"$KSVC_JSON" >/dev/null \
+    || fail "legacy revision $revision remains directly routable"
+
+  kubectl -n "$NS" delete revision "$revision" --wait=true
+  LEGACY_PODS="$(
+    kubectl -n "$NS" get pods \
+      -l serving.knative.dev/revision="$revision" -o name
+  )"
+  if [[ -n "$LEGACY_PODS" ]]; then
+    kubectl -n "$NS" wait --for=delete $LEGACY_PODS --timeout=180s
+  fi
+done <<<"$LEGACY_REVISIONS"
+```
+
+Do not take a fresh list and rerun the deletion block. If the Knative Service changes, stop and begin a new reviewed
+rollout procedure; do not expand this cleanup transaction.
+
+#### 5. Prove one API revision and zero scheduler writers
+
+```bash
+read_ksvc_state
+[[ "$LATEST_READY" == "$PINNED_LATEST_READY" ]] \
+  || fail "latestReady changed during cleanup"
+
+FINAL_REVISIONS_JSON="$(
+  kubectl -n "$NS" get revisions \
+    -l serving.knative.dev/service="$KSVC" -o json
+)"
+FINAL_REVISION_COUNT="$(jq '.items | length' <<<"$FINAL_REVISIONS_JSON")"
+FINAL_REVISION_NAME="$(jq -r '.items[0].metadata.name // ""' <<<"$FINAL_REVISIONS_JSON")"
+[[ "$FINAL_REVISION_COUNT" == "1" \
+  && "$FINAL_REVISION_NAME" == "$PINNED_LATEST_READY" ]] \
+  || fail "revision inventory is not exactly the pinned latestReady revision"
+
+NONLATEST_API_PODS="$(
+  kubectl -n "$NS" get pods \
+    -l serving.knative.dev/service="$KSVC" -o json \
+    | jq --arg keep "$PINNED_LATEST_READY" '
+        [.items[]
+          | select(.metadata.labels["serving.knative.dev/revision"] != $keep)
+          | select(.status.phase != "Succeeded" and .status.phase != "Failed")]
+        | length'
+)"
+[[ "$NONLATEST_API_PODS" == "0" ]] || fail "non-latest API pods remain"
+
+SCHEDULER_JSON="$(kubectl -n "$NS" get deployment "$SCHEDULER" -o json)"
+[[ "$(jq -r '.spec.replicas // 0' <<<"$SCHEDULER_JSON")" == "0" \
+  && "$(jq -r '.status.replicas // 0' <<<"$SCHEDULER_JSON")" == "0" \
+  && "$(jq -r '.status.readyReplicas // 0' <<<"$SCHEDULER_JSON")" == "0" \
+  && "$(jq -r '.status.availableReplicas // 0' <<<"$SCHEDULER_JSON")" == "0" ]] \
+  || fail "scheduler Deployment is no longer fully at zero"
+
+SCHEDULER_PODS="$(
+  kubectl -n "$NS" get pods -l app.kubernetes.io/component=trading-scheduler -o json \
+    | jq '[.items[] | select(.status.phase != "Succeeded" and .status.phase != "Failed")] | length'
+)"
+[[ "$SCHEDULER_PODS" == "0" ]] || fail "scheduler pods exist after cleanup"
+
+SCHEDULER_ENDPOINTS="$(
+  kubectl -n "$NS" get endpointslices \
+    -l kubernetes.io/service-name="$SCHEDULER" -o json \
+    | jq '[.items[].endpoints[]?.addresses[]?] | length'
+)"
+[[ "$SCHEDULER_ENDPOINTS" == "0" ]] || fail "scheduler endpoints exist after cleanup"
+
+# DEFAULT_SCHEDULER_ADVISORY_LOCK_ID=-5582680098985332512 is represented
+# by classid=2995148295, objid=1029058784, objsubid=1 in pg_locks.
+WRITER_LOCK_COUNT="$(
+  kubectl cnpg psql -n "$NS" torghut-db -- \
+    -d torghut -At -v ON_ERROR_STOP=1 \
+    -c "SELECT count(*) FROM pg_locks
+        WHERE locktype = 'advisory'
+          AND classid = '2995148295'::oid
+          AND objid = '1029058784'::oid
+          AND objsubid = 1
+          AND granted;"
+)"
+[[ "$WRITER_LOCK_COUNT" == "0" ]] \
+  || fail "scheduler advisory writer lock count=$WRITER_LOCK_COUNT"
+
+kubectl -n "$NS" get ksvc "$KSVC" -o wide
+kubectl -n "$NS" get revisions \
+  -l serving.knative.dev/service="$KSVC" -o wide
+kubectl -n "$NS" get deployment "$SCHEDULER" -o wide
+echo "P0a cleanup proof passed: latest=$PINNED_LATEST_READY scheduler=0 writers=0"
+```
+
+If CNPG access is denied or any proof query is unavailable, the gate is not satisfied. Do not infer zero writers from
+an absent metrics series. Keep the scheduler at zero until all checks can be rerun successfully. Scaling the dedicated
+scheduler to one is a separate GitOps change after this cleanup proof is recorded.
 
 The API and scheduler currently keep explicit environment entries so the live direct-env safety contract remains
 auditable. `test_single_writer_scheduler_manifest.py` enforces exact parity except for the process role and the two

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -127,6 +127,10 @@ spec:
               value: "10"
             - name: TRADING_ENABLED
               value: "false"
+            - name: TRADING_ORDER_MAX_ATTEMPTS
+              value: "1"
+            - name: TRADING_EXECUTION_MAX_RETRIES
+              value: "0"
             - name: TRADING_PIPELINE_MODE
               value: simple
             - name: TRADING_SIMPLE_SUBMIT_ENABLED

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -36,6 +36,12 @@ spec:
             - name: http1
               containerPort: 8181
           env:
+            - name: TORGHUT_PROCESS_ROLE
+              value: simulation
+            - name: TRADING_SCHEDULER_LEADERSHIP_REQUIRED
+              value: "true"
+            - name: TRADING_SCHEDULER_LEADERSHIP_LOCK_NAME
+              value: torghut:simulation-scheduler
             - name: APP_ENV
               value: prod
             - name: LOG_LEVEL
@@ -120,7 +126,7 @@ spec:
             - name: CLICKHOUSE_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_ENABLED
-              value: "true"
+              value: "false"
             - name: TRADING_PIPELINE_MODE
               value: simple
             - name: TRADING_SIMPLE_SUBMIT_ENABLED

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -133,7 +133,9 @@ spec:
             - name: CLICKHOUSE_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_ENABLED
-              value: "true"
+              # The GitOps manifest can land before the matching image promotion.
+              # Keep even the previous image scheduler-free during that window.
+              value: "false"
             - name: TRADING_PIPELINE_MODE
               value: simple
             - name: TRADING_SIMPLE_SUBMIT_ENABLED

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -42,6 +42,10 @@ spec:
               value: http://torghut-scheduler.torghut.svc.cluster.local:8183
             - name: TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS
               value: "2"
+            - name: TRADING_SCHEDULER_SHUTDOWN_DRAIN_SECONDS
+              value: "45"
+            - name: TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS
+              value: "30"
             - name: APP_ENV
               value: prod
             - name: LOG_LEVEL

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -38,6 +38,10 @@ spec:
           env:
             - name: TORGHUT_PROCESS_ROLE
               value: api
+            - name: TRADING_SCHEDULER_RUNTIME_BASE_URL
+              value: http://torghut-scheduler.torghut.svc.cluster.local:8183
+            - name: TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS
+              value: "2"
             - name: APP_ENV
               value: prod
             - name: LOG_LEVEL

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -415,7 +415,9 @@ spec:
             - name: TRADING_ORDER_REPRICE_SECONDS
               value: "2"
             - name: TRADING_ORDER_MAX_ATTEMPTS
-              value: "3"
+              value: "1"
+            - name: TRADING_EXECUTION_MAX_RETRIES
+              value: "0"
             - name: TRADING_ORDER_SLIPPAGE_BPS
               value: "8"
             - name: TRADING_CLOSEOUT_REPRICE_SECONDS

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -17,6 +17,8 @@ resources:
   - tigerbeetle-cluster.yaml
   - tigerbeetle-smoke-job.yaml
   - knative-service.yaml
+  - scheduler-deployment.yaml
+  - scheduler-service.yaml
   - knative-service-sim.yaml
   - tailscale-service.yaml
   - ingressroute-flink-k8s-private.yaml

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -431,7 +431,9 @@ spec:
             - name: TRADING_ORDER_REPRICE_SECONDS
               value: "2"
             - name: TRADING_ORDER_MAX_ATTEMPTS
-              value: "3"
+              value: "1"
+            - name: TRADING_EXECUTION_MAX_RETRIES
+              value: "0"
             - name: TRADING_ORDER_SLIPPAGE_BPS
               value: "8"
             - name: TRADING_CLOSEOUT_REPRICE_SECONDS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -56,6 +56,10 @@ spec:
               value: http://torghut-scheduler.torghut.svc.cluster.local:8183
             - name: TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS
               value: "2"
+            - name: TRADING_SCHEDULER_SHUTDOWN_DRAIN_SECONDS
+              value: "45"
+            - name: TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS
+              value: "30"
             - name: TRADING_SCHEDULER_LEADERSHIP_REQUIRED
               value: "true"
             - name: TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -1,43 +1,61 @@
-apiVersion: serving.knative.dev/v1
-kind: Service
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: torghut
+  name: torghut-scheduler
   namespace: torghut
   labels:
     app.kubernetes.io/name: torghut
-    app.kubernetes.io/component: backend
+    app.kubernetes.io/component: trading-scheduler
     app.kubernetes.io/part-of: lab
-    networking.knative.dev/visibility: cluster-local
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
-    serving.knative.dev/rollout-duration: 10s
-    argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut
+    argocd.argoproj.io/sync-wave: "2"
 spec:
+  # P0a containment: keep the dedicated writer disabled until the scheduler-free
+  # API revision is live and every legacy Knative revision has been removed.
+  replicas: 0
+  revisionHistoryLimit: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: torghut
+      app.kubernetes.io/component: trading-scheduler
   template:
     metadata:
-      annotations:
-        client.knative.dev/updateTimestamp: "2026-07-11T06:40:51Z"
-        autoscaling.knative.dev/maxScale: "1"
-        autoscaling.knative.dev/target: "80"
+      labels:
+        app.kubernetes.io/name: torghut
+        app.kubernetes.io/component: trading-scheduler
+        app.kubernetes.io/part-of: lab
     spec:
+      serviceAccountName: torghut-runtime
       nodeSelector:
         kubernetes.io/arch: arm64
-      containerConcurrency: 0
-      timeoutSeconds: 60
+      terminationGracePeriodSeconds: 60
       containers:
-        - name: user-container
+        - name: torghut-scheduler
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:
               type: Unconfined
           image: registry.ide-newton.ts.net/lab/torghut@sha256:1eeedfdf05a52af671a315110af7a8247496c8b67f7433d58e4751a64458ad20
+          command:
+            - uvicorn
+          args:
+            - app.scheduler_main:app
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8183"
           ports:
-            - name: http1
-              containerPort: 8181
+            - name: metrics
+              containerPort: 8183
           env:
             - name: TORGHUT_PROCESS_ROLE
-              value: api
+              value: scheduler
+            - name: TRADING_SCHEDULER_LEADERSHIP_REQUIRED
+              value: "true"
+            - name: TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS
+              value: "5"
             - name: APP_ENV
               value: prod
             - name: LOG_LEVEL
@@ -445,24 +463,24 @@ spec:
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8181
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 10
           startupProbe:
             httpGet:
               path: /healthz
-              port: 8181
+              port: 8183
             failureThreshold: 60
             periodSeconds: 5
             timeoutSeconds: 10
-          readinessProbe:
+          livenessProbe:
             httpGet:
               path: /healthz
-              port: 8181
+              port: 8183
+            failureThreshold: 6
+            periodSeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /scheduler/readyz
+              port: 8183
             failureThreshold: 3
             periodSeconds: 5
             timeoutSeconds: 10
@@ -477,19 +495,7 @@ spec:
             - name: strategy-config
               mountPath: /etc/torghut
               readOnly: true
-            - name: whitepapers-config
-              mountPath: /etc/torghut/whitepapers-config
-              readOnly: true
-            - name: whitepapers-secret
-              mountPath: /etc/torghut/whitepapers-secret
-              readOnly: true
       volumes:
         - name: strategy-config
           configMap:
             name: torghut-strategy-config
-        - name: whitepapers-config
-          configMap:
-            name: torghut-whitepapers
-        - name: whitepapers-secret
-          secret:
-            secretName: torghut-whitepapers

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -52,6 +52,10 @@ spec:
           env:
             - name: TORGHUT_PROCESS_ROLE
               value: scheduler
+            - name: TRADING_SCHEDULER_RUNTIME_BASE_URL
+              value: http://torghut-scheduler.torghut.svc.cluster.local:8183
+            - name: TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS
+              value: "2"
             - name: TRADING_SCHEDULER_LEADERSHIP_REQUIRED
               value: "true"
             - name: TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS

--- a/argocd/applications/torghut/scheduler-service.yaml
+++ b/argocd/applications/torghut/scheduler-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: torghut-scheduler
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: trading-scheduler
+    app.kubernetes.io/part-of: lab
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  selector:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: trading-scheduler
+  ports:
+    - name: metrics
+      port: 8183
+      targetPort: metrics

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -314,6 +314,65 @@ describe('torghut build-push workflow', () => {
     expect(ciWorkflow).not.toContain('--workflow torghut-ci.yml')
   })
 
+  it('verifies every core Torghut runtime manifest directly when the runtime manifest group changes', () => {
+    const releaseManifestJob = ciWorkflow.indexOf('release-manifests:')
+    const releaseManifestJobBody = ciWorkflow.slice(
+      releaseManifestJob,
+      ciWorkflow.indexOf('\n  pyright:', releaseManifestJob),
+    )
+    const runtimeGroupStart = releaseManifestJobBody.indexOf(
+      "if matches_changed '^argocd/applications/(torghut/(knative-service(-sim)?|scheduler-deployment",
+    )
+    const runtimeGroupEnd = releaseManifestJobBody.indexOf('verified_any=true', runtimeGroupStart)
+    const runtimeGroupBody = releaseManifestJobBody.slice(runtimeGroupStart, runtimeGroupEnd)
+    const runtimeGroupLines = runtimeGroupBody.split('\n').map((line) => line.trim())
+    const runtimeCalls = runtimeGroupLines.reduce<string[][]>((calls, line) => {
+      if (line === 'verify_image_contract \\') {
+        calls.push([line])
+      } else if (calls.length > 0 && calls.at(-1)!.length < 5) {
+        calls.at(-1)!.push(line)
+      }
+      return calls
+    }, [])
+
+    expect(runtimeGroupStart).toBeGreaterThan(-1)
+    expect(runtimeGroupEnd).toBeGreaterThan(runtimeGroupStart)
+    expect(runtimeCalls).toEqual([
+      [
+        'verify_image_contract \\',
+        '"Torghut" \\',
+        'argocd/applications/torghut/knative-service.yaml \\',
+        'TORGHUT_COMMIT \\',
+        'registry.ide-newton.ts.net/lab/torghut',
+      ],
+      [
+        'verify_image_contract \\',
+        '"Torghut simulation" \\',
+        'argocd/applications/torghut/knative-service-sim.yaml \\',
+        'TORGHUT_COMMIT \\',
+        'registry.ide-newton.ts.net/lab/torghut',
+      ],
+      [
+        'verify_image_contract \\',
+        '"Torghut scheduler" \\',
+        'argocd/applications/torghut/scheduler-deployment.yaml \\',
+        'TORGHUT_COMMIT \\',
+        'registry.ide-newton.ts.net/lab/torghut',
+      ],
+    ])
+    const parityCall = runtimeGroupLines.indexOf('assert_image_contract_parity \\')
+    expect(runtimeGroupLines.slice(parityCall, parityCall + 6)).toEqual([
+      'assert_image_contract_parity \\',
+      'TORGHUT_COMMIT \\',
+      'registry.ide-newton.ts.net/lab/torghut \\',
+      'argocd/applications/torghut/knative-service.yaml \\',
+      'argocd/applications/torghut/knative-service-sim.yaml \\',
+      'argocd/applications/torghut/scheduler-deployment.yaml',
+    ])
+    expect(releaseManifestJobBody).toContain('if [ "${source_sha}" != "${reference_source_sha}" ]; then')
+    expect(releaseManifestJobBody).toContain('if [ "${image_ref}" != "${reference_image_ref}" ]; then')
+  })
+
   it('shards the expensive autoresearch runner tests in Torghut CI', () => {
     const autoresearchJob = ciWorkflow.indexOf('pytest-autoresearch-runner:')
     const nextJob = ciWorkflow.indexOf('\n  lint-and-tests:', autoresearchJob)

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -298,6 +298,7 @@ describe('torghut build-push workflow', () => {
     expect(releaseManifestJobBody).not.toContain('runs-on: arc-arm64')
     expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net, which is only')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/knative-service.yaml')
+    expect(releaseManifestJobBody).toContain('torghut/(knative-service(-sim)?|scheduler-deployment|db-migrations-job')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ta/flinkdeployment.yaml')
     expect(releaseManifestJobBody).toContain('argocd/applications/torghut/ws/deployment.yaml')
     expect(releaseManifestJobBody).toContain('registry.ide-newton.ts.net/lab/torghut')

--- a/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts
@@ -63,6 +63,13 @@ describe('torghut-deploy-automerge workflow', () => {
     }
   })
 
+  test('carries the scheduler image through release and automatic deploy merge allowlists', () => {
+    const schedulerManifest = 'argocd/applications/torghut/scheduler-deployment.yaml'
+
+    expect(countOccurrences(releaseWorkflow, schedulerManifest)).toBe(3)
+    expect(countOccurrences(deployAutomergeWorkflow, `'${schedulerManifest}'`)).toBe(2)
+  })
+
   test('allowlists TA and WS promotion manifests for automatic release PR merges', () => {
     const promotedTaManifests = [
       'argocd/applications/torghut/ta/flinkdeployment.yaml',

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -83,12 +83,30 @@ const tradingStatus = (gate: typeof activeGate | typeof marketClosedGate = activ
   },
 })
 
+const simulationStatus = {
+  enabled: true,
+  mode: 'paper',
+  process_role: 'simulation',
+  running: true,
+  runtime_owner: 'torghut-sim',
+  service: 'torghut',
+}
+
+const simulationContainedStatus = {
+  ...simulationStatus,
+  enabled: false,
+  running: false,
+}
+
 const activeEvidence = (overrides: Partial<EvidenceInput> = {}): EvidenceInput => ({
   apiReadyz: containmentReadyz,
   apiReadyzHttpStatus: '200',
   schedulerReplicas: '1',
   schedulerReadyz: readyz(),
   schedulerReadyzHttpStatus: '200',
+  simTradingEnabled: 'true',
+  simStatus: simulationStatus,
+  simStatusHttpStatus: '200',
   tradingStatus: tradingStatus(),
   tradingStatusHttpStatus: '200',
   ...overrides,
@@ -117,6 +135,9 @@ const containmentEvidence = (overrides: Partial<EvidenceInput> = {}): EvidenceIn
   apiReadyz: containmentReadyz,
   apiReadyzHttpStatus: '200',
   schedulerReplicas: '0',
+  simTradingEnabled: 'false',
+  simStatus: simulationContainedStatus,
+  simStatusHttpStatus: '200',
   tradingStatus: containmentStatus,
   tradingStatusHttpStatus: '503',
   ...overrides,
@@ -127,9 +148,11 @@ describe('Torghut post-deploy evidence', () => {
     const result = validatePostDeployEvidence(activeEvidence())
 
     expect(result.readinessContract).toBe('active_session_ready')
+    expect(result.simulationContract).toBe('simulation_active')
     expect(result.apiReadyzStatusCode).toBe(200)
     expect(result.schedulerReadyzStatusCode).toBe(200)
     expect(result.summaryLines.join('\n')).toContain('4x gross')
+    expect(result.summaryLines.join('\n')).toContain('Simulation runtime: `simulation_active`')
   })
 
   it('accepts a healthy runtime whose only blocker is a closed regular session', () => {
@@ -236,7 +259,71 @@ describe('Torghut post-deploy evidence', () => {
     const result = validatePostDeployEvidence(containmentEvidence())
 
     expect(result.readinessContract).toBe('api_containment')
+    expect(result.simulationContract).toBe('simulation_containment')
     expect(result.summaryLines.join('\n')).toContain('Scheduler replicas: `0`')
+    expect(result.summaryLines.join('\n')).toContain('Simulation runtime: `simulation_containment`')
+  })
+
+  it('rejects non-2xx torghut-sim trading status', () => {
+    expect(() => validatePostDeployEvidence(containmentEvidence({ simStatusHttpStatus: '503' }))).toThrow(
+      'torghut-sim /trading/status must return HTTP 2xx, got 503',
+    )
+  })
+
+  for (const [field, invalidValue] of [
+    ['service', 'torghut-sim'],
+    ['mode', 'live'],
+    ['process_role', 'api'],
+    ['runtime_owner', 'torghut-scheduler'],
+  ] as const) {
+    it(`rejects torghut-sim status with invalid ${field}`, () => {
+      expect(() =>
+        validatePostDeployEvidence(
+          containmentEvidence({
+            simStatus: { ...simulationContainedStatus, [field]: invalidValue },
+          }),
+        ),
+      ).toThrow('must describe the local paper simulation runtime')
+    })
+  }
+
+  it('rejects state mismatches when torghut-sim is desired active', () => {
+    expect(() =>
+      validatePostDeployEvidence(activeEvidence({ simStatus: { ...simulationStatus, enabled: false } })),
+    ).toThrow('desired enabled state requires enabled=true and running=true')
+    expect(() =>
+      validatePostDeployEvidence(activeEvidence({ simStatus: { ...simulationStatus, running: false } })),
+    ).toThrow('desired enabled state requires enabled=true and running=true')
+  })
+
+  it('rejects state mismatches when torghut-sim is desired contained', () => {
+    expect(() =>
+      validatePostDeployEvidence(containmentEvidence({ simStatus: { ...simulationContainedStatus, enabled: true } })),
+    ).toThrow('desired disabled state requires enabled=false and running=false')
+    expect(() =>
+      validatePostDeployEvidence(containmentEvidence({ simStatus: { ...simulationContainedStatus, running: true } })),
+    ).toThrow('desired disabled state requires enabled=false and running=false')
+  })
+
+  it('rejects an invalid torghut-sim desired TRADING_ENABLED value', () => {
+    expect(() => validatePostDeployEvidence(activeEvidence({ simTradingEnabled: 'enabled' }))).toThrow(
+      'TORGHUT_SIM_TRADING_ENABLED must be exactly true or false, got enabled',
+    )
+  })
+
+  it('rejects legacy torghut-sim status without local-role ownership fields', () => {
+    expect(() =>
+      validatePostDeployEvidence(
+        containmentEvidence({
+          simStatus: {
+            enabled: true,
+            mode: 'paper',
+            running: false,
+            service: 'torghut',
+          },
+        }),
+      ),
+    ).toThrow('must describe the local paper simulation runtime')
   })
 
   it('rejects a scheduler-zero trading status that is not HTTP 503', () => {

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'bun:test'
 
 import { validatePostDeployEvidence } from '../post-deploy-evidence'
 
+type EvidenceInput = Parameters<typeof validatePostDeployEvidence>[0]
+
 const build = {
   active_revision: 'torghut-00123',
   commit: '1234567890abcdef1234567890abcdef12345678',
@@ -81,24 +83,63 @@ const tradingStatus = (gate: typeof activeGate | typeof marketClosedGate = activ
   },
 })
 
+const activeEvidence = (overrides: Partial<EvidenceInput> = {}): EvidenceInput => ({
+  apiReadyz: containmentReadyz,
+  apiReadyzHttpStatus: '200',
+  schedulerReplicas: '1',
+  schedulerReadyz: readyz(),
+  schedulerReadyzHttpStatus: '200',
+  tradingStatus: tradingStatus(),
+  tradingStatusHttpStatus: '200',
+  ...overrides,
+})
+
+const containmentReadyz = {
+  process_role: 'api',
+  reason_codes: [],
+  runtime_owner: 'torghut-scheduler',
+  scheduler: {
+    availability: 'not_evaluated',
+    owner: 'torghut-scheduler',
+    ownership: 'external',
+  },
+  status: 'ok',
+}
+
+const containmentStatus = {
+  detail: 'scheduler_runtime_unavailable',
+  error_class: 'URLError',
+  ok: false,
+  owner: 'torghut-scheduler',
+}
+
+const containmentEvidence = (overrides: Partial<EvidenceInput> = {}): EvidenceInput => ({
+  apiReadyz: containmentReadyz,
+  apiReadyzHttpStatus: '200',
+  schedulerReplicas: '0',
+  tradingStatus: containmentStatus,
+  tradingStatusHttpStatus: '503',
+  ...overrides,
+})
+
 describe('Torghut post-deploy evidence', () => {
   it('accepts a healthy active-session runtime', () => {
-    const result = validatePostDeployEvidence({
-      readyz: readyz(),
-      readyzHttpStatus: '200',
-      tradingStatus: tradingStatus(),
-    })
+    const result = validatePostDeployEvidence(activeEvidence())
 
     expect(result.readinessContract).toBe('active_session_ready')
+    expect(result.apiReadyzStatusCode).toBe(200)
+    expect(result.schedulerReadyzStatusCode).toBe(200)
     expect(result.summaryLines.join('\n')).toContain('4x gross')
   })
 
   it('accepts a healthy runtime whose only blocker is a closed regular session', () => {
-    const result = validatePostDeployEvidence({
-      readyz: readyz(marketClosedGate),
-      readyzHttpStatus: '503',
-      tradingStatus: tradingStatus(marketClosedGate),
-    })
+    const result = validatePostDeployEvidence(
+      activeEvidence({
+        schedulerReadyz: readyz(marketClosedGate),
+        schedulerReadyzHttpStatus: '503',
+        tradingStatus: tradingStatus(marketClosedGate),
+      }),
+    )
 
     expect(result.readinessContract).toBe('market_closed')
   })
@@ -110,21 +151,23 @@ describe('Torghut post-deploy evidence', () => {
     }
 
     expect(() =>
-      validatePostDeployEvidence({
-        readyz: readyz(gate),
-        readyzHttpStatus: '503',
-        tradingStatus: tradingStatus(gate),
-      }),
+      validatePostDeployEvidence(
+        activeEvidence({
+          schedulerReadyz: readyz(gate),
+          schedulerReadyzHttpStatus: '503',
+          tradingStatus: tradingStatus(gate),
+        }),
+      ),
     ).toThrow('acceptable only when the regular market session is closed')
   })
 
   it('rejects disagreement between readiness and status submission authority', () => {
     expect(() =>
-      validatePostDeployEvidence({
-        readyz: readyz(),
-        readyzHttpStatus: '200',
-        tradingStatus: tradingStatus(marketClosedGate),
-      }),
+      validatePostDeployEvidence(
+        activeEvidence({
+          tradingStatus: tradingStatus(marketClosedGate),
+        }),
+      ),
     ).toThrow('contracts differ')
   })
 
@@ -132,9 +175,9 @@ describe('Torghut post-deploy evidence', () => {
     const status = tradingStatus()
     status.tigerbeetle_ledger.reconciliation_stale = true
 
-    expect(() =>
-      validatePostDeployEvidence({ readyz: readyz(), readyzHttpStatus: '200', tradingStatus: status }),
-    ).toThrow('ledger reconciliation is not current and healthy')
+    expect(() => validatePostDeployEvidence(activeEvidence({ tradingStatus: status }))).toThrow(
+      'ledger reconciliation is not current and healthy',
+    )
   })
 
   it('accepts stale reconciliation diagnostics when periodic reconciliation is optional', () => {
@@ -144,11 +187,7 @@ describe('Torghut post-deploy evidence', () => {
     status.tigerbeetle_ledger.reconciliation_required = false
     status.tigerbeetle_ledger.reconciliation_stale = true
 
-    const result = validatePostDeployEvidence({
-      readyz: readyz(),
-      readyzHttpStatus: '200',
-      tradingStatus: status,
-    })
+    const result = validatePostDeployEvidence(activeEvidence({ tradingStatus: status }))
 
     expect(result.readinessContract).toBe('active_session_ready')
   })
@@ -159,9 +198,9 @@ describe('Torghut post-deploy evidence', () => {
     status.tigerbeetle_ledger.reconciliation_ok = false
     status.tigerbeetle_ledger.reconciliation_required = false
 
-    expect(() =>
-      validatePostDeployEvidence({ readyz: readyz(), readyzHttpStatus: '200', tradingStatus: status }),
-    ).toThrow('ledger has blockers: tigerbeetle_runtime_ledger_signed_refs_missing')
+    expect(() => validatePostDeployEvidence(activeEvidence({ tradingStatus: status }))).toThrow(
+      'ledger has blockers: tigerbeetle_runtime_ledger_signed_refs_missing',
+    )
   })
 
   it('rejects an unhealthy TigerBeetle protocol when reconciliation is optional', () => {
@@ -170,26 +209,145 @@ describe('Torghut post-deploy evidence', () => {
     status.tigerbeetle_ledger.protocol_ok = false
     status.tigerbeetle_ledger.reconciliation_required = false
 
-    expect(() =>
-      validatePostDeployEvidence({ readyz: readyz(), readyzHttpStatus: '200', tradingStatus: status }),
-    ).toThrow('ledger protocol is not healthy')
+    expect(() => validatePostDeployEvidence(activeEvidence({ tradingStatus: status }))).toThrow(
+      'ledger protocol is not healthy',
+    )
   })
 
   it('rejects a drifted capital limit', () => {
     const status = tradingStatus()
     status.capital_controls.gross_limit = 1
 
-    expect(() =>
-      validatePostDeployEvidence({ readyz: readyz(), readyzHttpStatus: '200', tradingStatus: status }),
-    ).toThrow('capital_controls.gross_limit must be 4')
+    expect(() => validatePostDeployEvidence(activeEvidence({ tradingStatus: status }))).toThrow(
+      'capital_controls.gross_limit must be 4',
+    )
   })
 
   it('rejects an unhealthy core dependency', () => {
     const payload = readyz()
     payload.dependencies.clickhouse.ok = false
 
+    expect(() => validatePostDeployEvidence(activeEvidence({ schedulerReadyz: payload }))).toThrow(
+      'clickhouse is not healthy',
+    )
+  })
+
+  it('accepts the exact scheduler-zero API containment contract', () => {
+    const result = validatePostDeployEvidence(containmentEvidence())
+
+    expect(result.readinessContract).toBe('api_containment')
+    expect(result.summaryLines.join('\n')).toContain('Scheduler replicas: `0`')
+  })
+
+  it('rejects a scheduler-zero trading status that is not HTTP 503', () => {
+    expect(() => validatePostDeployEvidence(containmentEvidence({ tradingStatusHttpStatus: '200' }))).toThrow(
+      'scheduler replicas=0 requires /trading/status HTTP 503, got 200',
+    )
+  })
+
+  it('rejects a scheduler-zero trading status with the wrong detail', () => {
     expect(() =>
-      validatePostDeployEvidence({ readyz: payload, readyzHttpStatus: '200', tradingStatus: tradingStatus() }),
-    ).toThrow('clickhouse is not healthy')
+      validatePostDeployEvidence(
+        containmentEvidence({
+          tradingStatus: { ...containmentStatus, detail: 'scheduler_starting' },
+        }),
+      ),
+    ).toThrow('must report the unavailable torghut-scheduler runtime')
+  })
+
+  it('rejects a scheduler-zero trading status with the wrong owner', () => {
+    expect(() =>
+      validatePostDeployEvidence(
+        containmentEvidence({
+          tradingStatus: { ...containmentStatus, owner: 'torghut-api' },
+        }),
+      ),
+    ).toThrow('must report the unavailable torghut-scheduler runtime')
+  })
+
+  it('rejects a scheduler-zero trading status without the fail-closed marker', () => {
+    expect(() =>
+      validatePostDeployEvidence(
+        containmentEvidence({
+          tradingStatus: { ...containmentStatus, ok: true },
+        }),
+      ),
+    ).toThrow('must report the unavailable torghut-scheduler runtime')
+  })
+
+  it('rejects non-2xx API readiness in scheduler-zero containment', () => {
+    expect(() => validatePostDeployEvidence(containmentEvidence({ apiReadyzHttpStatus: '503' }))).toThrow(
+      'stable API /readyz must return HTTP 2xx, got 503',
+    )
+  })
+
+  it('rejects drift in the scheduler-zero external ownership contract', () => {
+    expect(() =>
+      validatePostDeployEvidence(
+        containmentEvidence({
+          apiReadyz: {
+            ...containmentReadyz,
+            scheduler: { ...containmentReadyz.scheduler, ownership: 'local' },
+          },
+        }),
+      ),
+    ).toThrow('scheduler ownership contract is invalid')
+  })
+
+  it('requires the exact stable API ownership contract when the scheduler is active', () => {
+    expect(() =>
+      validatePostDeployEvidence(
+        activeEvidence({
+          apiReadyz: {
+            ...containmentReadyz,
+            runtime_owner: 'torghut-api',
+          },
+        }),
+      ),
+    ).toThrow('must report the process-local API role and external scheduler owner')
+  })
+
+  it('rejects non-2xx stable API readiness when the scheduler is active', () => {
+    expect(() => validatePostDeployEvidence(activeEvidence({ apiReadyzHttpStatus: '503' }))).toThrow(
+      'stable API /readyz must return HTTP 2xx, got 503',
+    )
+  })
+
+  it('requires scheduler-owned readiness evidence when the scheduler is active', () => {
+    expect(() => validatePostDeployEvidence(activeEvidence({ schedulerReadyz: undefined }))).toThrow(
+      'Torghut scheduler readyz payload must be an object',
+    )
+    expect(() => validatePostDeployEvidence(activeEvidence({ schedulerReadyzHttpStatus: undefined }))).toThrow(
+      'TORGHUT_SCHEDULER_READYZ_HTTP_STATUS must be a three-digit status',
+    )
+  })
+
+  it('rejects the API-local readiness payload as scheduler-owned evidence', () => {
+    expect(() => validatePostDeployEvidence(activeEvidence({ schedulerReadyz: containmentReadyz }))).toThrow(
+      'scheduler readyz.live_submission_gate must be an object',
+    )
+  })
+
+  it('rejects an unsupported scheduler readiness HTTP status', () => {
+    expect(() => validatePostDeployEvidence(activeEvidence({ schedulerReadyzHttpStatus: '500' }))).toThrow(
+      'Torghut /readyz returned unsupported HTTP 500',
+    )
+  })
+
+  it('rejects scheduler replica counts above the single-writer ceiling', () => {
+    expect(() => validatePostDeployEvidence(activeEvidence({ schedulerReplicas: '2' }))).toThrow(
+      'scheduler replicas must be exactly 0 or 1, got 2',
+    )
+  })
+
+  it('rejects HTTP 503 trading status when the scheduler is active', () => {
+    expect(() =>
+      validatePostDeployEvidence(
+        activeEvidence({
+          tradingStatus: containmentStatus,
+          tradingStatusHttpStatus: '503',
+        }),
+      ),
+    ).toThrow('scheduler replicas=1 requires /trading/status HTTP 2xx, got 503')
   })
 })

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -122,14 +122,45 @@ describe('torghut post-deploy verifier workflow', () => {
     const apiCapture = workflow.indexOf('TORGHUT_API_READYZ_HTTP_STATUS="$(')
     const schedulerCondition = workflow.indexOf('if [ "${TORGHUT_SCHEDULER_REPLICAS}" = \'1\' ]; then', apiCapture)
     const schedulerCapture = workflow.indexOf('TORGHUT_SCHEDULER_READYZ_HTTP_STATUS="$(')
-    const schedulerConditionEnd = workflow.indexOf('\n          fi', schedulerCapture)
+    const schedulerPayloadExport = workflow.indexOf('export TORGHUT_SCHEDULER_READYZ_PAYLOAD', schedulerCapture)
 
     expect(apiCapture).toBeGreaterThan(-1)
     expect(workflow).toContain('http://torghut.torghut.svc.cluster.local/readyz')
     expect(schedulerCondition).toBeGreaterThan(apiCapture)
     expect(schedulerCapture).toBeGreaterThan(schedulerCondition)
-    expect(schedulerConditionEnd).toBeGreaterThan(schedulerCapture)
+    expect(schedulerPayloadExport).toBeGreaterThan(schedulerCapture)
     expect(workflow).not.toContain('touch "${EVIDENCE_DIR}/torghut-scheduler-readyz.json"')
+  })
+
+  it('bounds full-contract convergence and fails after the final attempt', () => {
+    const finalFailure = workflow.indexOf(
+      'Torghut full post-deploy contract did not converge after ${FULL_CONTRACT_ATTEMPTS} attempts',
+    )
+    const finalExit = workflow.indexOf('exit 1', finalFailure)
+
+    expect(workflow).toContain('FULL_CONTRACT_ATTEMPTS=120')
+    expect(workflow).toContain('FULL_CONTRACT_INTERVAL_SECONDS=10')
+    expect(workflow).toContain('for contract_attempt in $(seq 1 "${FULL_CONTRACT_ATTEMPTS}"); do')
+    expect(workflow).toContain('sleep "${FULL_CONTRACT_INTERVAL_SECONDS}"')
+    expect(workflow).toContain('[ "${contract_attempt}" -eq "${FULL_CONTRACT_ATTEMPTS}" ]')
+    expect(finalFailure).toBeGreaterThan(-1)
+    expect(finalExit).toBeGreaterThan(finalFailure)
+  })
+
+  it('refetches every evidence surface and invokes the strict validator inside each convergence attempt', () => {
+    const loopStart = workflow.indexOf('for contract_attempt in $(seq 1 "${FULL_CONTRACT_ATTEMPTS}"); do')
+    const loopEnd = workflow.indexOf('\n          done', loopStart)
+    const loopBody = workflow.slice(loopStart, loopEnd)
+
+    expect(loopStart).toBeGreaterThan(-1)
+    expect(loopEnd).toBeGreaterThan(loopStart)
+    expect(loopBody).toContain('rm -f \\')
+    expect(loopBody).toContain('TORGHUT_API_READYZ_HTTP_STATUS="$(')
+    expect(loopBody).toContain('TORGHUT_SCHEDULER_READYZ_HTTP_STATUS="$(')
+    expect(loopBody).toContain('TORGHUT_STATUS_HTTP_STATUS="$(')
+    expect(loopBody).toContain('bun run packages/scripts/src/torghut/post-deploy-evidence.ts 2>&1')
+    expect(loopBody).toContain('[ "${TORGHUT_SCHEDULER_REPLICAS}" = \'1\' ]')
+    expect(loopBody).not.toContain('contract_mismatch_accepted')
   })
 
   it('retries parseable JSON evidence capture before invoking the validator', () => {
@@ -144,7 +175,7 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('TORGHUT_STATUS_HTTP_STATUS="$(')
     expect(workflow).toContain('http://torghut.torghut.svc.cluster.local/trading/status')
     expect(workflow).toContain('export TORGHUT_STATUS_HTTP_STATUS')
-    expect(workflow).toContain('Torghut /trading/status HTTP ${TORGHUT_STATUS_HTTP_STATUS}')
+    expect(workflow).toContain('trading status returned invalid HTTP status ${TORGHUT_STATUS_HTTP_STATUS:-unset}')
     expect(workflow).toContain('HTTP_MAX_TIME_SECONDS=15')
     expect(workflow).toContain('JSON_EVIDENCE_ATTEMPTS=3')
     expect(workflow).toContain('--max-time "${HTTP_MAX_TIME_SECONDS}"')

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -69,9 +69,12 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('TORGHUT_SCHEDULER_REPLICAS')
     expect(workflow).toContain('TORGHUT_API_READYZ_HTTP_STATUS')
     expect(workflow).toContain('TORGHUT_SCHEDULER_READYZ_HTTP_STATUS')
+    expect(workflow).toContain('TORGHUT_SIM_TRADING_ENABLED')
+    expect(workflow).toContain('TORGHUT_SIM_STATUS_HTTP_STATUS')
     expect(workflow).toContain('TORGHUT_STATUS_HTTP_STATUS')
     expect(workflow).toContain('TORGHUT_API_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-api-readyz.json"')
     expect(workflow).toContain('TORGHUT_SCHEDULER_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-scheduler-readyz.json"')
+    expect(workflow).toContain('TORGHUT_SIM_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-sim-status.json"')
     expect(workflow).toContain('TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"')
     expect(workflow).toContain('bun run packages/scripts/src/torghut/post-deploy-evidence.ts')
     expect(workflow).not.toContain('/trading/revenue-repair')
@@ -92,6 +95,20 @@ describe('torghut post-deploy verifier workflow', () => {
     )
     expect(workflow).toContain('if [ "${TORGHUT_SCHEDULER_REPLICAS}" = \'1\' ]; then')
     expect(workflow).toContain('kubectl rollout status deployment/torghut-scheduler -n torghut --timeout=10m')
+  })
+
+  it('reads and exports the desired torghut-sim trading state from the live Knative Service', () => {
+    const desiredStateRead = workflow.indexOf('kubectl get ksvc torghut-sim -n torghut -o json')
+    const argoWait = workflow.indexOf('for app in torghut torghut-options; do')
+
+    expect(desiredStateRead).toBeGreaterThan(argoWait)
+    expect(workflow).toContain('select(.name == "TRADING_ENABLED")')
+    expect(workflow).toContain('case "${TORGHUT_SIM_TRADING_ENABLED}" in')
+    expect(workflow).toContain('true | false)')
+    expect(workflow).toContain(
+      'torghut-sim desired TRADING_ENABLED must be exactly true or false; got ${TORGHUT_SIM_TRADING_ENABLED:-unset}',
+    )
+    expect(workflow).toContain('export TORGHUT_SIM_TRADING_ENABLED')
   })
 
   it('runs market-data freshness verification after deploy evidence is accepted', () => {
@@ -157,7 +174,10 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(loopBody).toContain('rm -f \\')
     expect(loopBody).toContain('TORGHUT_API_READYZ_HTTP_STATUS="$(')
     expect(loopBody).toContain('TORGHUT_SCHEDULER_READYZ_HTTP_STATUS="$(')
+    expect(loopBody).toContain('TORGHUT_SIM_STATUS_HTTP_STATUS="$(')
     expect(loopBody).toContain('TORGHUT_STATUS_HTTP_STATUS="$(')
+    expect(loopBody).toContain('http://torghut-sim.torghut.svc.cluster.local/trading/status')
+    expect(loopBody).toContain('"${EVIDENCE_DIR}/torghut-sim-status.json"')
     expect(loopBody).toContain('bun run packages/scripts/src/torghut/post-deploy-evidence.ts 2>&1')
     expect(loopBody).toContain('[ "${TORGHUT_SCHEDULER_REPLICAS}" = \'1\' ]')
     expect(loopBody).not.toContain('contract_mismatch_accepted')
@@ -184,8 +204,12 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).not.toContain('--max-time 90')
   })
 
-  it('keeps simulation rollout readiness without obsolete paper-route evidence', () => {
+  it('keeps simulation rollout readiness and adds strict local-runtime evidence', () => {
     expect(workflow).toContain('wait_knative_service_ready torghut-sim')
+    expect(workflow).toContain('TORGHUT_SIM_STATUS_HTTP_STATUS="$(')
+    expect(workflow).toContain('export TORGHUT_SIM_STATUS_HTTP_STATUS')
+    expect(workflow).toContain('export TORGHUT_SIM_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-sim-status.json"')
+    expect(workflow).toContain('simulation trading status capture failed')
     expect(workflow).not.toContain('PAPER_ROUTE_EVIDENCE')
     expect(workflow).not.toContain('SIM_MIRROR')
   })

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -65,13 +65,33 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('torghut-ws-options')
   })
 
-  it('delegates readyz and status agreement to the runtime contract validator', () => {
-    expect(workflow).toContain('TORGHUT_READYZ_HTTP_STATUS')
-    expect(workflow).toContain('TORGHUT_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-readyz.json"')
+  it('delegates distinct API, scheduler, and status evidence to the runtime contract validator', () => {
+    expect(workflow).toContain('TORGHUT_SCHEDULER_REPLICAS')
+    expect(workflow).toContain('TORGHUT_API_READYZ_HTTP_STATUS')
+    expect(workflow).toContain('TORGHUT_SCHEDULER_READYZ_HTTP_STATUS')
+    expect(workflow).toContain('TORGHUT_STATUS_HTTP_STATUS')
+    expect(workflow).toContain('TORGHUT_API_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-api-readyz.json"')
+    expect(workflow).toContain('TORGHUT_SCHEDULER_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-scheduler-readyz.json"')
     expect(workflow).toContain('TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"')
     expect(workflow).toContain('bun run packages/scripts/src/torghut/post-deploy-evidence.ts')
     expect(workflow).not.toContain('/trading/revenue-repair')
     expect(workflow).not.toContain('/trading/proofs')
+  })
+
+  it('reads and bounds the live scheduler replica count after Argo convergence', () => {
+    const replicaRead = workflow.indexOf(
+      "kubectl get deployment torghut-scheduler -n torghut -o jsonpath='{.spec.replicas}'",
+    )
+    const argoWait = workflow.indexOf('for app in torghut torghut-options; do')
+
+    expect(replicaRead).toBeGreaterThan(argoWait)
+    expect(workflow).toContain('case "${TORGHUT_SCHEDULER_REPLICAS}" in')
+    expect(workflow).toContain('0 | 1)')
+    expect(workflow).toContain(
+      'Torghut scheduler replicas must be exactly 0 or 1; got ${TORGHUT_SCHEDULER_REPLICAS:-unset}',
+    )
+    expect(workflow).toContain('if [ "${TORGHUT_SCHEDULER_REPLICAS}" = \'1\' ]; then')
+    expect(workflow).toContain('kubectl rollout status deployment/torghut-scheduler -n torghut --timeout=10m')
   })
 
   it('runs market-data freshness verification after deploy evidence is accepted', () => {
@@ -95,24 +115,41 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('without an acceptable readyz contract')
     expect(workflow).toContain('READYZ_EVIDENCE_ATTEMPTS=12')
     expect(workflow).toContain('fetch_readyz_json \\')
+    expect(workflow).toContain('http://torghut-scheduler.torghut.svc.cluster.local:8183/readyz')
   })
 
-  it('retries Knative service JSON evidence capture before invoking the validator', () => {
+  it('always captures stable API readiness and conditionally captures scheduler readiness', () => {
+    const apiCapture = workflow.indexOf('TORGHUT_API_READYZ_HTTP_STATUS="$(')
+    const schedulerCondition = workflow.indexOf('if [ "${TORGHUT_SCHEDULER_REPLICAS}" = \'1\' ]; then', apiCapture)
+    const schedulerCapture = workflow.indexOf('TORGHUT_SCHEDULER_READYZ_HTTP_STATUS="$(')
+    const schedulerConditionEnd = workflow.indexOf('\n          fi', schedulerCapture)
+
+    expect(apiCapture).toBeGreaterThan(-1)
+    expect(workflow).toContain('http://torghut.torghut.svc.cluster.local/readyz')
+    expect(schedulerCondition).toBeGreaterThan(apiCapture)
+    expect(schedulerCapture).toBeGreaterThan(schedulerCondition)
+    expect(schedulerConditionEnd).toBeGreaterThan(schedulerCapture)
+    expect(workflow).not.toContain('touch "${EVIDENCE_DIR}/torghut-scheduler-readyz.json"')
+  })
+
+  it('retries parseable JSON evidence capture before invoking the validator', () => {
     expect(workflow).toContain('fetch_json()')
     expect(workflow).toContain('python3 -m json.tool "${output_path}"')
     expect(workflow).toContain('not usable JSON yet; retrying')
-    expect(workflow).toContain('fetch_json_2xx')
-    expect(workflow).not.toContain('fetch_json_2xx_optional')
+    expect(workflow).not.toContain('fetch_json_2xx')
     expect(workflow).not.toContain('curl -fsS http://torghut.torghut.svc.cluster.local/trading/status')
   })
 
-  it('retries parseable non-2xx deploy evidence before failing', () => {
-    expect(workflow).toContain('Attempt ${attempt}: ${label} returned HTTP ${status}; expected 2xx; retrying')
-    expect(workflow).toContain('did not return a parseable JSON HTTP 2xx response')
+  it('captures the trading status HTTP code for mode-aware validation without requiring 2xx', () => {
+    expect(workflow).toContain('TORGHUT_STATUS_HTTP_STATUS="$(')
+    expect(workflow).toContain('http://torghut.torghut.svc.cluster.local/trading/status')
+    expect(workflow).toContain('export TORGHUT_STATUS_HTTP_STATUS')
+    expect(workflow).toContain('Torghut /trading/status HTTP ${TORGHUT_STATUS_HTTP_STATUS}')
     expect(workflow).toContain('HTTP_MAX_TIME_SECONDS=15')
     expect(workflow).toContain('JSON_EVIDENCE_ATTEMPTS=3')
     expect(workflow).toContain('--max-time "${HTTP_MAX_TIME_SECONDS}"')
-    expect(workflow).not.toContain('status="$(fetch_json "${url}" "${output_path}" "${label}")"')
+    expect(workflow).not.toContain('fetch_json_2xx')
+    expect(workflow).not.toContain('expected 2xx')
     expect(workflow).not.toContain('--max-time 90')
   })
 

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -9,6 +9,7 @@ import { __private } from '../update-manifests'
 const createFixture = () => {
   const dir = mkdtempSync(join(tmpdir(), 'torghut-manifests-test-'))
   const serviceManifestPath = join(dir, 'knative-service.yaml')
+  const schedulerManifestPath = join(dir, 'scheduler-deployment.yaml')
   const simulationServiceManifestPath = join(dir, 'knative-service-sim.yaml')
   const migrationManifestPath = join(dir, 'db-migrations-job.yaml')
   const historicalWorkflowManifestPath = join(dir, 'historical-simulation-workflowtemplate.yaml')
@@ -45,6 +46,30 @@ spec:
               value: old-version
             - name: TORGHUT_COMMIT
               value: old-commit
+`,
+    'utf8',
+  )
+  writeFileSync(
+    schedulerManifestPath,
+    `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: torghut-scheduler
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
+          env:
+            - name: TORGHUT_VERSION
+              value: old-version
+            - name: TORGHUT_COMMIT
+              value: old-commit
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:1111111111111111111111111111111111111111111111111111111111111111
+            - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
+              value: linux/amd64
+            - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS
+              value: linux/amd64
 `,
     'utf8',
   )
@@ -171,6 +196,7 @@ spec:
   return {
     dir,
     serviceManifestPath,
+    schedulerManifestPath,
     simulationServiceManifestPath,
     migrationManifestPath,
     historicalWorkflowManifestPath,
@@ -200,6 +226,7 @@ const updateOptionsForFixture = (
   commit: '1234567890abcdef1234567890abcdef12345678',
   rolloutTimestamp: '2026-02-21T04:00:00Z',
   manifestPath: relative(repoRoot, fixture.serviceManifestPath),
+  schedulerManifestPath: relative(repoRoot, fixture.schedulerManifestPath),
   simulationManifestPath: relative(repoRoot, fixture.simulationServiceManifestPath),
   migrationManifestPath: relative(repoRoot, fixture.migrationManifestPath),
   historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
@@ -261,6 +288,7 @@ describe('update-manifests', () => {
     const result = __private.updateTorghutManifests(updateOptionsForFixture(fixture))
 
     const serviceManifest = readFileSync(fixture.serviceManifestPath, 'utf8')
+    const schedulerManifest = readFileSync(fixture.schedulerManifestPath, 'utf8')
     const simulationServiceManifest = readFileSync(fixture.simulationServiceManifestPath, 'utf8')
     const migrationManifest = readFileSync(fixture.migrationManifestPath, 'utf8')
     const historicalWorkflowManifest = readFileSync(fixture.historicalWorkflowManifestPath, 'utf8')
@@ -287,6 +315,15 @@ describe('update-manifests', () => {
     expect(serviceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(serviceManifest).toContain('value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
     expect(serviceManifest).toContain('value: linux/amd64,linux/arm64')
+    expect(schedulerManifest).toContain(
+      'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+    )
+    expect(schedulerManifest).toContain('value: v0.600.0')
+    expect(schedulerManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(schedulerManifest).toContain(
+      'value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+    )
+    expect(schedulerManifest.match(/value: linux\/amd64,linux\/arm64/g)?.length).toBe(2)
     expect(simulationServiceManifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
     expect(simulationServiceManifest).toContain('value: v0.600.0')
     expect(simulationServiceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
@@ -327,7 +364,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(15)
+    expect(result.changedPaths.length).toBe(16)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -349,7 +386,7 @@ describe('update-manifests', () => {
       expect(manifest).toContain('value: old-version')
       expect(manifest).toContain('value: old-commit')
     }
-    expect(result.changedPaths.length).toBe(13)
+    expect(result.changedPaths.length).toBe(14)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -11,12 +11,16 @@ export type PostDeployEvidenceInput = {
   schedulerReplicas: string
   schedulerReadyzHttpStatus?: string
   schedulerReadyz?: unknown
+  simTradingEnabled: string
+  simStatusHttpStatus: string
+  simStatus: unknown
   tradingStatusHttpStatus: string
   tradingStatus: unknown
 }
 
 export type PostDeployEvidenceResult = {
   readinessContract: 'active_session_ready' | 'api_containment' | 'market_closed'
+  simulationContract: 'simulation_active' | 'simulation_containment'
   apiReadyzStatusCode: number
   schedulerReadyzStatusCode?: number
   summaryLines: string[]
@@ -246,10 +250,47 @@ const requireApiReadiness = (apiReadyzStatusCode: number, apiReadyz: JsonObject)
   }
 }
 
+const requireSimulationRuntime = (
+  desiredTradingEnabled: string,
+  simStatusCode: number,
+  simStatus: JsonObject,
+): PostDeployEvidenceResult['simulationContract'] => {
+  if (simStatusCode < 200 || simStatusCode >= 300) {
+    throw new Error(`torghut-sim /trading/status must return HTTP 2xx, got ${simStatusCode}`)
+  }
+  if (
+    simStatus.service !== 'torghut' ||
+    simStatus.mode !== 'paper' ||
+    simStatus.process_role !== 'simulation' ||
+    simStatus.runtime_owner !== 'torghut-sim'
+  ) {
+    throw new Error('torghut-sim status must describe the local paper simulation runtime')
+  }
+  if (desiredTradingEnabled === 'false') {
+    if (simStatus.enabled !== false || simStatus.running !== false) {
+      throw new Error('torghut-sim desired disabled state requires enabled=false and running=false')
+    }
+    return 'simulation_containment'
+  }
+  if (desiredTradingEnabled === 'true') {
+    if (simStatus.enabled !== true || simStatus.running !== true) {
+      throw new Error('torghut-sim desired enabled state requires enabled=true and running=true')
+    }
+    return 'simulation_active'
+  }
+  throw new Error(`TORGHUT_SIM_TRADING_ENABLED must be exactly true or false, got ${desiredTradingEnabled || 'unset'}`)
+}
+
+const simulationSummaryLine = (contract: PostDeployEvidenceResult['simulationContract']): string =>
+  contract === 'simulation_active'
+    ? '- Simulation runtime: `simulation_active` (local paper, running)'
+    : '- Simulation runtime: `simulation_containment` (local paper, disabled)'
+
 const validateApiContainment = (
   apiReadyzStatusCode: number,
   tradingStatusCode: number,
   status: JsonObject,
+  simulationContract: PostDeployEvidenceResult['simulationContract'],
 ): PostDeployEvidenceResult => {
   if (tradingStatusCode !== 503) {
     throw new Error(`scheduler replicas=0 requires /trading/status HTTP 503, got ${tradingStatusCode}`)
@@ -265,6 +306,7 @@ const validateApiContainment = (
 
   return {
     readinessContract: 'api_containment',
+    simulationContract,
     apiReadyzStatusCode,
     summaryLines: [
       '## Torghut Runtime Contract',
@@ -273,6 +315,7 @@ const validateApiContainment = (
       '- Scheduler replicas: `0`',
       '- Runtime owner: `torghut-scheduler` (external)',
       '- Trading status: `scheduler_runtime_unavailable` (HTTP 503)',
+      simulationSummaryLine(simulationContract),
     ],
   }
 }
@@ -280,13 +323,16 @@ const validateApiContainment = (
 export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): PostDeployEvidenceResult => {
   const schedulerReplicas = requireSchedulerReplicas(input.schedulerReplicas)
   const apiReadyzStatusCode = requireHttpStatus(input.apiReadyzHttpStatus, 'TORGHUT_API_READYZ_HTTP_STATUS')
+  const simStatusCode = requireHttpStatus(input.simStatusHttpStatus, 'TORGHUT_SIM_STATUS_HTTP_STATUS')
   const tradingStatusCode = requireHttpStatus(input.tradingStatusHttpStatus, 'TORGHUT_STATUS_HTTP_STATUS')
   const apiReadyz = requireObject(input.apiReadyz, 'Torghut stable API readyz payload')
+  const simStatus = requireObject(input.simStatus, 'torghut-sim trading status payload')
   const status = requireObject(input.tradingStatus, 'torghut trading status payload')
   requireApiReadiness(apiReadyzStatusCode, apiReadyz)
+  const simulationContract = requireSimulationRuntime(input.simTradingEnabled, simStatusCode, simStatus)
 
   if (schedulerReplicas === 0) {
-    return validateApiContainment(apiReadyzStatusCode, tradingStatusCode, status)
+    return validateApiContainment(apiReadyzStatusCode, tradingStatusCode, status, simulationContract)
   }
 
   if (tradingStatusCode < 200 || tradingStatusCode >= 300) {
@@ -313,6 +359,7 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
 
   return {
     readinessContract,
+    simulationContract,
     apiReadyzStatusCode,
     schedulerReadyzStatusCode,
     summaryLines: [
@@ -324,6 +371,7 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
       `- Execution route: \`${statusGate.route}\``,
       '- Capital limits: `4x gross`, `0.5x net`, `0.5x symbol`, `10% buying-power reserve`',
       '- TigerBeetle reconciliation: `current`',
+      simulationSummaryLine(simulationContract),
     ],
   }
 }
@@ -342,6 +390,9 @@ export const runPostDeployEvidenceCli = (env: NodeJS.ProcessEnv = process.env): 
     schedulerReadyz: env.TORGHUT_SCHEDULER_READYZ_PAYLOAD?.trim()
       ? loadJsonFile(env.TORGHUT_SCHEDULER_READYZ_PAYLOAD, 'TORGHUT_SCHEDULER_READYZ_PAYLOAD')
       : undefined,
+    simTradingEnabled: env.TORGHUT_SIM_TRADING_ENABLED ?? '',
+    simStatusHttpStatus: env.TORGHUT_SIM_STATUS_HTTP_STATUS ?? '',
+    simStatus: loadJsonFile(env.TORGHUT_SIM_STATUS_PAYLOAD ?? '', 'TORGHUT_SIM_STATUS_PAYLOAD'),
     tradingStatusHttpStatus: env.TORGHUT_STATUS_HTTP_STATUS ?? '',
     tradingStatus: loadJsonFile(env.TORGHUT_STATUS_PAYLOAD ?? '', 'TORGHUT_STATUS_PAYLOAD'),
   })

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -6,14 +6,19 @@ import process from 'node:process'
 type JsonObject = Record<string, unknown>
 
 export type PostDeployEvidenceInput = {
-  readyzHttpStatus: string
-  readyz: unknown
+  apiReadyzHttpStatus: string
+  apiReadyz: unknown
+  schedulerReplicas: string
+  schedulerReadyzHttpStatus?: string
+  schedulerReadyz?: unknown
+  tradingStatusHttpStatus: string
   tradingStatus: unknown
 }
 
 export type PostDeployEvidenceResult = {
-  readinessContract: 'active_session_ready' | 'market_closed'
-  readyzStatusCode: number
+  readinessContract: 'active_session_ready' | 'api_containment' | 'market_closed'
+  apiReadyzStatusCode: number
+  schedulerReadyzStatusCode?: number
   summaryLines: string[]
 }
 
@@ -67,11 +72,25 @@ const requireStringList = (value: unknown, label: string): string[] => {
   return [...value]
 }
 
-const requireHttpStatus = (value: string): number => {
+const requireHttpStatus = (value: string, label: string): number => {
   if (!/^\d{3}$/.test(value)) {
-    throw new Error(`TORGHUT_READYZ_HTTP_STATUS must be a three-digit status, got ${value || 'unset'}`)
+    throw new Error(`${label} must be a three-digit status, got ${value || 'unset'}`)
   }
   return Number(value)
+}
+
+const requireSchedulerReplicas = (value: string): 0 | 1 => {
+  if (value === '0') return 0
+  if (value === '1') return 1
+  throw new Error(`Torghut scheduler replicas must be exactly 0 or 1, got ${value || 'unset'}`)
+}
+
+const requireExactKeys = (value: JsonObject, label: string, expectedKeys: string[]) => {
+  const actual = Object.keys(value).sort()
+  const expected = [...expectedKeys].sort()
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label} must contain exactly: ${expected.join(', ')}`)
+  }
 }
 
 const gateSnapshot = (value: unknown, label: string): GateSnapshot => {
@@ -194,31 +213,113 @@ const validateReadinessContract = (
   return 'market_closed'
 }
 
+const requireApiReadiness = (apiReadyzStatusCode: number, apiReadyz: JsonObject) => {
+  if (apiReadyzStatusCode < 200 || apiReadyzStatusCode >= 300) {
+    throw new Error(`stable API /readyz must return HTTP 2xx, got ${apiReadyzStatusCode}`)
+  }
+
+  requireExactKeys(apiReadyz, 'stable API readyz payload', [
+    'process_role',
+    'reason_codes',
+    'runtime_owner',
+    'scheduler',
+    'status',
+  ])
+  if (
+    apiReadyz.status !== 'ok' ||
+    apiReadyz.process_role !== 'api' ||
+    apiReadyz.runtime_owner !== 'torghut-scheduler' ||
+    !Array.isArray(apiReadyz.reason_codes) ||
+    apiReadyz.reason_codes.length !== 0
+  ) {
+    throw new Error('stable API readyz must report the process-local API role and external scheduler owner')
+  }
+
+  const scheduler = requireObject(apiReadyz.scheduler, 'stable API readyz scheduler')
+  requireExactKeys(scheduler, 'stable API readyz scheduler', ['availability', 'owner', 'ownership'])
+  if (
+    scheduler.ownership !== 'external' ||
+    scheduler.owner !== 'torghut-scheduler' ||
+    scheduler.availability !== 'not_evaluated'
+  ) {
+    throw new Error('stable API readyz scheduler ownership contract is invalid')
+  }
+}
+
+const validateApiContainment = (
+  apiReadyzStatusCode: number,
+  tradingStatusCode: number,
+  status: JsonObject,
+): PostDeployEvidenceResult => {
+  if (tradingStatusCode !== 503) {
+    throw new Error(`scheduler replicas=0 requires /trading/status HTTP 503, got ${tradingStatusCode}`)
+  }
+  if (
+    status.ok !== false ||
+    status.detail !== 'scheduler_runtime_unavailable' ||
+    status.owner !== 'torghut-scheduler' ||
+    !requireString(status.error_class, 'API containment trading status error_class')
+  ) {
+    throw new Error('API containment trading status must report the unavailable torghut-scheduler runtime')
+  }
+
+  return {
+    readinessContract: 'api_containment',
+    apiReadyzStatusCode,
+    summaryLines: [
+      '## Torghut Runtime Contract',
+      '',
+      '- Readiness: `api_containment`',
+      '- Scheduler replicas: `0`',
+      '- Runtime owner: `torghut-scheduler` (external)',
+      '- Trading status: `scheduler_runtime_unavailable` (HTTP 503)',
+    ],
+  }
+}
+
 export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): PostDeployEvidenceResult => {
-  const readyzStatusCode = requireHttpStatus(input.readyzHttpStatus)
-  const readyz = requireObject(input.readyz, 'torghut readyz payload')
+  const schedulerReplicas = requireSchedulerReplicas(input.schedulerReplicas)
+  const apiReadyzStatusCode = requireHttpStatus(input.apiReadyzHttpStatus, 'TORGHUT_API_READYZ_HTTP_STATUS')
+  const tradingStatusCode = requireHttpStatus(input.tradingStatusHttpStatus, 'TORGHUT_STATUS_HTTP_STATUS')
+  const apiReadyz = requireObject(input.apiReadyz, 'Torghut stable API readyz payload')
   const status = requireObject(input.tradingStatus, 'torghut trading status payload')
+  requireApiReadiness(apiReadyzStatusCode, apiReadyz)
+
+  if (schedulerReplicas === 0) {
+    return validateApiContainment(apiReadyzStatusCode, tradingStatusCode, status)
+  }
+
+  if (tradingStatusCode < 200 || tradingStatusCode >= 300) {
+    throw new Error(`scheduler replicas=1 requires /trading/status HTTP 2xx, got ${tradingStatusCode}`)
+  }
+  const schedulerReadyzStatusCode = requireHttpStatus(
+    input.schedulerReadyzHttpStatus ?? '',
+    'TORGHUT_SCHEDULER_READYZ_HTTP_STATUS',
+  )
+  const schedulerReadyz = requireObject(input.schedulerReadyz, 'Torghut scheduler readyz payload')
   if (status.service !== 'torghut' || status.mode !== 'live' || status.enabled !== true) {
     throw new Error('trading status must describe the enabled live Torghut runtime')
   }
 
-  const readyzGate = gateSnapshot(readyz.live_submission_gate, 'readyz.live_submission_gate')
+  const readyzGate = gateSnapshot(schedulerReadyz.live_submission_gate, 'scheduler readyz.live_submission_gate')
   const statusGate = gateSnapshot(status.live_submission_gate, 'trading status live_submission_gate')
   requireSameGate(readyzGate, statusGate)
-  requireSameBuild(readyz, status)
-  requireHealthyDependencies(readyz)
+  requireSameBuild(schedulerReadyz, status)
+  requireHealthyDependencies(schedulerReadyz)
   requireCapitalLimits(status)
   requireExecutionProjection(status, statusGate)
   requireLedgerHealth(status)
-  const readinessContract = validateReadinessContract(readyzStatusCode, readyz, readyzGate)
+  const readinessContract = validateReadinessContract(schedulerReadyzStatusCode, schedulerReadyz, readyzGate)
 
   return {
     readinessContract,
-    readyzStatusCode,
+    apiReadyzStatusCode,
+    schedulerReadyzStatusCode,
     summaryLines: [
       '## Torghut Runtime Contract',
       '',
       `- Readiness: \`${readinessContract}\``,
+      '- API readiness: `process-local` (external scheduler owner)',
       `- Live gate: \`${statusGate.reason}\``,
       `- Execution route: \`${statusGate.route}\``,
       '- Capital limits: `4x gross`, `0.5x net`, `0.5x symbol`, `10% buying-power reserve`',
@@ -234,14 +335,24 @@ const loadJsonFile = (path: string, label: string): unknown => {
 
 export const runPostDeployEvidenceCli = (env: NodeJS.ProcessEnv = process.env): PostDeployEvidenceResult => {
   const result = validatePostDeployEvidence({
-    readyzHttpStatus: env.TORGHUT_READYZ_HTTP_STATUS ?? '',
-    readyz: loadJsonFile(env.TORGHUT_READYZ_PAYLOAD ?? '', 'TORGHUT_READYZ_PAYLOAD'),
+    apiReadyzHttpStatus: env.TORGHUT_API_READYZ_HTTP_STATUS ?? '',
+    apiReadyz: loadJsonFile(env.TORGHUT_API_READYZ_PAYLOAD ?? '', 'TORGHUT_API_READYZ_PAYLOAD'),
+    schedulerReplicas: env.TORGHUT_SCHEDULER_REPLICAS ?? '',
+    schedulerReadyzHttpStatus: env.TORGHUT_SCHEDULER_READYZ_HTTP_STATUS,
+    schedulerReadyz: env.TORGHUT_SCHEDULER_READYZ_PAYLOAD?.trim()
+      ? loadJsonFile(env.TORGHUT_SCHEDULER_READYZ_PAYLOAD, 'TORGHUT_SCHEDULER_READYZ_PAYLOAD')
+      : undefined,
+    tradingStatusHttpStatus: env.TORGHUT_STATUS_HTTP_STATUS ?? '',
     tradingStatus: loadJsonFile(env.TORGHUT_STATUS_PAYLOAD ?? '', 'TORGHUT_STATUS_PAYLOAD'),
   })
   if (env.GITHUB_STEP_SUMMARY?.trim()) {
     appendFileSync(env.GITHUB_STEP_SUMMARY, `${result.summaryLines.join('\n')}\n`, 'utf8')
   }
-  console.log(`Torghut post-deploy contract: ${result.readinessContract} (HTTP ${result.readyzStatusCode})`)
+  const schedulerReadyzSummary =
+    result.schedulerReadyzStatusCode === undefined ? '' : `, scheduler readyz HTTP ${result.schedulerReadyzStatusCode}`
+  console.log(
+    `Torghut post-deploy contract: ${result.readinessContract} (API readyz HTTP ${result.apiReadyzStatusCode}${schedulerReadyzSummary})`,
+  )
   return result
 }
 

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -11,6 +11,7 @@ import { inspectOciImageDigest } from '../shared/oci-digest'
 const defaultRegistry = 'registry.ide-newton.ts.net'
 const defaultRepository = 'lab/torghut'
 const defaultManifestPath = 'argocd/applications/torghut/knative-service.yaml'
+const defaultSchedulerManifestPath = 'argocd/applications/torghut/scheduler-deployment.yaml'
 const defaultSimulationManifestPath = 'argocd/applications/torghut/knative-service-sim.yaml'
 const defaultMigrationManifestPath = 'argocd/applications/torghut/db-migrations-job.yaml'
 const defaultHistoricalSimulationWorkflowManifestPath =
@@ -39,6 +40,7 @@ type UpdateManifestsOptions = {
   commit: string
   rolloutTimestamp: string
   manifestPath?: string
+  schedulerManifestPath?: string
   simulationManifestPath?: string
   migrationManifestPath?: string
   historicalSimulationWorkflowManifestPath?: string
@@ -65,6 +67,7 @@ type CliOptions = {
   commit?: string
   rolloutTimestamp?: string
   manifestPath?: string
+  schedulerManifestPath?: string
   simulationManifestPath?: string
   migrationManifestPath?: string
   historicalSimulationWorkflowManifestPath?: string
@@ -213,10 +216,25 @@ const updateImageOnlyManifest = (options: UpdateManifestsOptions, manifestPathVa
   let updated = replaceSingle(source, imagePattern, `$1${imageRef}`, label)
   updated = replaceAllIfPresent(
     updated,
+    /(- name:\s*TORGHUT_VERSION\s*\n\s*value:\s*)([^\n]+)/g,
+    `$1${options.version}`,
+  )
+  updated = replaceAllIfPresent(
+    updated,
     /(- name:\s*TORGHUT_IMAGE_DIGEST\s*\n\s*value:\s*)([^\n]+)/g,
     `$1${options.digest}`,
   )
   updated = replaceAllIfPresent(updated, /(- name:\s*TORGHUT_COMMIT\s*\n\s*value:\s*)([^\n]+)/g, `$1${options.commit}`)
+  updated = replaceAllIfPresent(
+    updated,
+    /(- name:\s*TORGHUT_REQUIRED_IMAGE_PLATFORMS\s*\n\s*value:\s*)([^\n]+)/g,
+    `$1${defaultRequiredImagePlatforms}`,
+  )
+  updated = replaceAllIfPresent(
+    updated,
+    /(- name:\s*TORGHUT_OBSERVED_IMAGE_PLATFORMS\s*\n\s*value:\s*)([^\n]+)/g,
+    `$1${defaultRequiredImagePlatforms}`,
+  )
 
   if (updated !== source) {
     writeFileSync(manifestPath, updated, 'utf8')
@@ -273,6 +291,11 @@ const updateVersionedDeploymentManifest = (
 
 const updateTorghutManifests = (options: UpdateManifestsOptions) => {
   const service = updateTorghutManifest(options)
+  const scheduler = updateImageOnlyManifest(
+    options,
+    options.schedulerManifestPath ?? defaultSchedulerManifestPath,
+    'torghut-scheduler image reference',
+  )
   const simulationService = updateTorghutManifest({
     ...options,
     manifestPath: options.simulationManifestPath ?? defaultSimulationManifestPath,
@@ -351,6 +374,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     : []
   const changedPaths = [
     service,
+    scheduler,
     simulationService,
     migration,
     historicalSimulationWorkflow,
@@ -391,6 +415,7 @@ Options:
   --commit <sha40>
   --rollout-timestamp <ISO8601>
   --manifest-path <path>
+  --scheduler-manifest-path <path>
   --simulation-manifest-path <path>
   --migration-manifest-path <path>
   --historical-simulation-workflow-manifest-path <path>
@@ -451,6 +476,9 @@ Options:
         break
       case '--manifest-path':
         options.manifestPath = value
+        break
+      case '--scheduler-manifest-path':
+        options.schedulerManifestPath = value
         break
       case '--simulation-manifest-path':
         options.simulationManifestPath = value
@@ -535,6 +563,7 @@ const main = (cliOptions?: CliOptions) => {
     commit,
     rolloutTimestamp,
     manifestPath: parsed.manifestPath ?? process.env.TORGHUT_MANIFEST_PATH,
+    schedulerManifestPath: parsed.schedulerManifestPath ?? process.env.TORGHUT_SCHEDULER_MANIFEST_PATH,
     simulationManifestPath: parsed.simulationManifestPath ?? process.env.TORGHUT_SIMULATION_MANIFEST_PATH,
     migrationManifestPath: parsed.migrationManifestPath ?? process.env.TORGHUT_MIGRATION_MANIFEST_PATH,
     historicalSimulationWorkflowManifestPath:

--- a/services/torghut/Dockerfile
+++ b/services/torghut/Dockerfile
@@ -30,6 +30,7 @@ ARG TORGHUT_COMMIT
 COPY app ./app
 COPY migrations ./migrations
 RUN test -f /app/app/main.py \
+ && test -f /app/app/scheduler_main.py \
  && test -f /app/app/trading/forecast_runtime.py \
  && test -f /app/app/trading/lean_runtime.py
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -72,6 +73,7 @@ COPY migrations ./migrations
 COPY scripts ./scripts
 COPY README.md .
 RUN test -f /app/app/main.py \
+ && test -f /app/app/scheduler_main.py \
  && test -f /app/app/trading/forecast_runtime.py \
  && test -f /app/app/trading/lean_runtime.py
 

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -144,9 +144,13 @@ TRADING_NEW_EXPOSURE_CUTOFF_TIME_ET=15:30:00
 TRADING_FLATTEN_START_TIME_ET=15:45:00
 TRADING_FLAT_CONFIRMATION_TIME_ET=15:50:00
 TRADING_ORDER_REPRICE_SECONDS=2
-TRADING_ORDER_MAX_ATTEMPTS=3
+TRADING_ORDER_MAX_ATTEMPTS=1
+TRADING_EXECUTION_MAX_RETRIES=0
 TRADING_ORDER_SLIPPAGE_BPS=8
 ```
+
+Keep decision submissions at one lifecycle attempt and zero transport retries until every broker submit/cancel step has
+a durable mutation receipt. Emergency reduce-only closeout attempts remain a separate risk-control contract.
 
 Do not add fixed live notional, paper probe, target-plan, proof-floor, or configured-collection settings. Historical
 simulation may retain deterministic fixed sizing for replay compatibility, but those values must not enter live order

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -150,7 +150,8 @@ TRADING_ORDER_SLIPPAGE_BPS=8
 ```
 
 Keep decision submissions at one lifecycle attempt and zero transport retries until every broker submit/cancel step has
-a durable mutation receipt. Emergency reduce-only closeout attempts remain a separate risk-control contract.
+a durable mutation receipt. Read-only recovery still scans the historical `-r2` and `-r3` broker idempotency keys
+without authorizing new attempts. Emergency reduce-only closeout attempts remain a separate risk-control contract.
 
 Do not add fixed live notional, paper probe, target-plan, proof-floor, or configured-collection settings. Historical
 simulation may retain deterministic fixed sizing for replay compatibility, but those values must not enter live order

--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -63,6 +63,38 @@ class _StockDataClientLike(Protocol):
     def get_stock_bars(self, _request_params: StockBarsRequest, /) -> Any: ...
 
 
+class _SingleAttemptTradingClient(TradingClient):
+    """Alpaca trading client with SDK-level HTTP retries disabled.
+
+    A broker mutation can succeed even when its HTTP response is lost. Retrying that
+    request inside the SDK would hide a second broker attempt from Torghut's durable
+    execution state machine, so every service-created client performs one HTTP
+    attempt and lets the caller reconcile an ambiguous result.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        secret_key: str | None = None,
+        *,
+        paper: bool = True,
+        url_override: str | None = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            secret_key=secret_key,
+            paper=paper,
+            url_override=url_override,
+        )
+
+        retry_configuration = vars(self)
+        retry_attempts = retry_configuration.get("_retry")
+        if type(retry_attempts) is not int:
+            raise RuntimeError("alpaca_sdk_retry_control_unavailable")
+
+        self._retry = 0
+
+
 class _ReadOnlyTradingClient:
     """Named Alpaca trading reads exposed outside the firewall boundary."""
 
@@ -108,16 +140,29 @@ class TorghutAlpacaClient:
         use_paper = paper if paper is not None else settings.trading_mode != "live"
         self.endpoint_class = "paper" if use_paper else "live"
 
-        # Default to paper trading; override URL if provided.
-        raw_trading_client: _TradingClientLike = trading_client or TradingClient(
-            api_key=key,
-            secret_key=secret,
-            paper=use_paper,
-            url_override=base,
-        )
-        self._trading = raw_trading_client
+        # Broker mutations use a dedicated single-attempt client so an ambiguous
+        # response cannot cause a hidden resubmission. Reads keep the SDK's retry
+        # policy because repeating a read does not create broker-side state.
+        if trading_client is None:
+            read_trading_client: _ReadOnlyTradingClientLike = TradingClient(
+                api_key=key,
+                secret_key=secret,
+                paper=use_paper,
+                url_override=base,
+            )
+            mutation_trading_client: _TradingClientLike = _SingleAttemptTradingClient(
+                api_key=key,
+                secret_key=secret,
+                paper=use_paper,
+                url_override=base,
+            )
+        else:
+            read_trading_client = trading_client
+            mutation_trading_client = trading_client
+
+        self._trading = mutation_trading_client
         self.trading: _ReadOnlyTradingClient = _ReadOnlyTradingClient(
-            raw_trading_client
+            read_trading_client
         )
 
         # Market Data v2 (stocks).

--- a/services/torghut/app/api/application.py
+++ b/services/torghut/app/api/application.py
@@ -2,17 +2,20 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, FastAPI
 
-_current_app: FastAPI | None = None
+from app.config import settings
+
+RuntimeRole = Literal["api", "scheduler"]
+_apps_by_runtime_role: dict[RuntimeRole, FastAPI] = {}
 
 
-def register_app(app: FastAPI) -> FastAPI:
+def register_app(app: FastAPI, *, runtime_role: RuntimeRole = "api") -> FastAPI:
     """Register the process-local FastAPI app used by route helpers."""
 
-    global _current_app
-
-    _current_app = app
+    _apps_by_runtime_role[runtime_role] = app
     return app
 
 
@@ -40,20 +43,26 @@ def mount_api_routes(app: FastAPI) -> FastAPI:
 
 def build_registered_app(
     app: FastAPI,
+    *,
+    runtime_role: RuntimeRole = "api",
 ) -> FastAPI:
     """Register the process app and mount its operational routes."""
 
-    register_app(app)
+    register_app(app, runtime_role=runtime_role)
     mount_api_routes(app)
     return app
 
 
-def get_app() -> FastAPI:
+def get_app(runtime_role: RuntimeRole | None = None) -> FastAPI:
     """Return the registered FastAPI app."""
 
-    if _current_app is None:
-        raise RuntimeError("torghut FastAPI app is not registered")
-    return _current_app
+    resolved_role: RuntimeRole = runtime_role or settings.process_role
+    app = _apps_by_runtime_role.get(resolved_role)
+    if app is None:
+        raise RuntimeError(
+            f"torghut FastAPI app is not registered for role={resolved_role}"
+        )
+    return app
 
 
 __all__ = (
@@ -62,4 +71,5 @@ __all__ = (
     "get_app",
     "mount_api_routes",
     "register_app",
+    "RuntimeRole",
 )

--- a/services/torghut/app/api/application.py
+++ b/services/torghut/app/api/application.py
@@ -8,8 +8,18 @@ from fastapi import APIRouter, FastAPI
 
 from app.config import settings
 
-RuntimeRole = Literal["api", "scheduler"]
+RuntimeRole = Literal["api", "scheduler", "simulation"]
 _apps_by_runtime_role: dict[RuntimeRole, FastAPI] = {}
+
+
+def runtime_owner_for_role(runtime_role: RuntimeRole) -> str:
+    """Return the service that owns trading state for a process role."""
+
+    if runtime_role == "simulation":
+        return "torghut-sim"
+    if runtime_role in {"api", "scheduler"}:
+        return "torghut-scheduler"
+    raise RuntimeError(f"unsupported Torghut runtime role: {runtime_role}")
 
 
 def register_app(app: FastAPI, *, runtime_role: RuntimeRole = "api") -> FastAPI:
@@ -71,5 +81,6 @@ __all__ = (
     "get_app",
     "mount_api_routes",
     "register_app",
+    "runtime_owner_for_role",
     "RuntimeRole",
 )

--- a/services/torghut/app/api/metrics.py
+++ b/services/torghut/app/api/metrics.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from fastapi import APIRouter
 from fastapi.responses import Response
 
+from app.config import settings
 from app.metrics import render_trading_metrics
 
+from .scheduler_proxy import proxy_scheduler_response
 from .trading_scheduler_state import get_trading_scheduler
 
 router = APIRouter()
@@ -14,6 +16,12 @@ router = APIRouter()
 
 @router.get("/metrics")
 def prometheus_metrics() -> Response:
+    if settings.process_role == "api":
+        return proxy_scheduler_response(
+            path="/metrics",
+            accept="text/plain; version=0.0.4",
+        )
+
     scheduler = get_trading_scheduler()
     state = scheduler.state
     leadership = scheduler.leadership_status

--- a/services/torghut/app/api/metrics.py
+++ b/services/torghut/app/api/metrics.py
@@ -16,8 +16,11 @@ router = APIRouter()
 def prometheus_metrics() -> Response:
     scheduler = get_trading_scheduler()
     state = scheduler.state
+    leadership = scheduler.leadership_status
     payload = {
         **state.metrics.to_payload(),
+        "scheduler_leadership_acquired": int(leadership.acquired),
+        "scheduler_leadership_healthy": int(leadership.healthy),
         "capital_new_exposure_allowed": int(state.capital_new_exposure_allowed),
         "capital_daily_loss_ratio": state.capital_daily_loss_ratio,
         "capital_drawdown_ratio": state.capital_drawdown_ratio,

--- a/services/torghut/app/api/metrics.py
+++ b/services/torghut/app/api/metrics.py
@@ -8,12 +8,13 @@ from fastapi.responses import Response
 from app.config import settings
 from app.metrics import render_trading_metrics
 
+from .application import runtime_owner_for_role
 from .trading_scheduler_state import get_trading_scheduler
 
 router = APIRouter()
 
 
-def _process_owner_metrics(*, role: str) -> str:
+def _process_owner_metrics(*, role: str, owner: str) -> str:
     return "\n".join(
         (
             "# HELP torghut_process_role_info Process-local Torghut runtime role.",
@@ -21,7 +22,7 @@ def _process_owner_metrics(*, role: str) -> str:
             f'torghut_process_role_info{{role="{role}"}} 1',
             "# HELP torghut_trading_runtime_owner_info Declared owner of the trading runtime.",
             "# TYPE torghut_trading_runtime_owner_info gauge",
-            'torghut_trading_runtime_owner_info{owner="torghut-scheduler"} 1',
+            f'torghut_trading_runtime_owner_info{{owner="{owner}"}} 1',
             "",
         )
     )
@@ -36,7 +37,10 @@ def prometheus_metrics() -> Response:
                     "# HELP torghut_api_process_ready Whether the stateless API process is serving.",
                     "# TYPE torghut_api_process_ready gauge",
                     "torghut_api_process_ready 1",
-                    _process_owner_metrics(role="api"),
+                    _process_owner_metrics(
+                        role="api",
+                        owner=runtime_owner_for_role("api"),
+                    ),
                 )
             ),
             media_type="text/plain; version=0.0.4",
@@ -57,7 +61,10 @@ def prometheus_metrics() -> Response:
     }
     return Response(
         content=render_trading_metrics(payload)
-        + _process_owner_metrics(role="scheduler"),
+        + _process_owner_metrics(
+            role=settings.process_role,
+            owner=runtime_owner_for_role(settings.process_role),
+        ),
         media_type="text/plain; version=0.0.4",
     )
 

--- a/services/torghut/app/api/metrics.py
+++ b/services/torghut/app/api/metrics.py
@@ -8,18 +8,38 @@ from fastapi.responses import Response
 from app.config import settings
 from app.metrics import render_trading_metrics
 
-from .scheduler_proxy import proxy_scheduler_response
 from .trading_scheduler_state import get_trading_scheduler
 
 router = APIRouter()
 
 
+def _process_owner_metrics(*, role: str) -> str:
+    return "\n".join(
+        (
+            "# HELP torghut_process_role_info Process-local Torghut runtime role.",
+            "# TYPE torghut_process_role_info gauge",
+            f'torghut_process_role_info{{role="{role}"}} 1',
+            "# HELP torghut_trading_runtime_owner_info Declared owner of the trading runtime.",
+            "# TYPE torghut_trading_runtime_owner_info gauge",
+            'torghut_trading_runtime_owner_info{owner="torghut-scheduler"} 1',
+            "",
+        )
+    )
+
+
 @router.get("/metrics")
 def prometheus_metrics() -> Response:
     if settings.process_role == "api":
-        return proxy_scheduler_response(
-            path="/metrics",
-            accept="text/plain; version=0.0.4",
+        return Response(
+            content="\n".join(
+                (
+                    "# HELP torghut_api_process_ready Whether the stateless API process is serving.",
+                    "# TYPE torghut_api_process_ready gauge",
+                    "torghut_api_process_ready 1",
+                    _process_owner_metrics(role="api"),
+                )
+            ),
+            media_type="text/plain; version=0.0.4",
         )
 
     scheduler = get_trading_scheduler()
@@ -36,7 +56,8 @@ def prometheus_metrics() -> Response:
         "capital_flat_confirmed": int(state.capital_flat_confirmed_at is not None),
     }
     return Response(
-        content=render_trading_metrics(payload),
+        content=render_trading_metrics(payload)
+        + _process_owner_metrics(role="scheduler"),
         media_type="text/plain; version=0.0.4",
     )
 

--- a/services/torghut/app/api/readiness.py
+++ b/services/torghut/app/api/readiness.py
@@ -6,6 +6,8 @@ from fastapi import APIRouter
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
+from app.config import settings
+
 from . import readiness_helpers
 
 router = APIRouter()
@@ -13,7 +15,23 @@ router = APIRouter()
 
 @router.get("/readyz")
 def readyz() -> JSONResponse:
-    """Readiness endpoint with dependency-aware status for rollout safety."""
+    """Return process-local readiness, with dependency checks on the scheduler."""
+
+    if settings.process_role == "api":
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "ok",
+                "reason_codes": [],
+                "process_role": "api",
+                "runtime_owner": "torghut-scheduler",
+                "scheduler": {
+                    "ownership": "external",
+                    "owner": "torghut-scheduler",
+                    "availability": "not_evaluated",
+                },
+            },
+        )
 
     payload, status_code = readiness_helpers.evaluate_core_readiness_payload(
         include_database_contract=True,

--- a/services/torghut/app/api/readiness.py
+++ b/services/torghut/app/api/readiness.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from app.config import settings
 
 from . import readiness_helpers
+from .application import runtime_owner_for_role
 
 router = APIRouter()
 
@@ -37,6 +38,11 @@ def readyz() -> JSONResponse:
         include_database_contract=True,
         allow_stale_dependency_cache=True,
     )
+    payload = {
+        **payload,
+        "process_role": settings.process_role,
+        "runtime_owner": runtime_owner_for_role(settings.process_role),
+    }
     return JSONResponse(
         status_code=status_code,
         content=jsonable_encoder(payload),

--- a/services/torghut/app/api/scheduler_proxy.py
+++ b/services/torghut/app/api/scheduler_proxy.py
@@ -1,0 +1,51 @@
+"""Fail-closed proxy from the stateless API to scheduler-owned runtime surfaces."""
+
+from __future__ import annotations
+
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from fastapi.responses import JSONResponse, Response
+
+from app.config import settings
+
+
+def proxy_scheduler_response(*, path: str, accept: str) -> Response:
+    """Return an exact scheduler response or an explicit unavailable payload."""
+
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    base_url = settings.trading_scheduler_runtime_base_url.rstrip("/")
+    request = Request(
+        f"{base_url}{normalized_path}",
+        headers={"Accept": accept},
+        method="GET",
+    )
+    try:
+        with urlopen(
+            request,
+            timeout=settings.trading_scheduler_runtime_timeout_seconds,
+        ) as upstream:
+            return Response(
+                content=upstream.read(),
+                status_code=upstream.status,
+                media_type=upstream.headers.get_content_type(),
+            )
+    except HTTPError as exc:
+        return Response(
+            content=exc.read(),
+            status_code=exc.code,
+            media_type=exc.headers.get_content_type(),
+        )
+    except (OSError, TimeoutError, URLError, ValueError) as exc:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "ok": False,
+                "detail": "scheduler_runtime_unavailable",
+                "owner": "torghut-scheduler",
+                "error_class": type(exc).__name__,
+            },
+        )
+
+
+__all__ = ["proxy_scheduler_response"]

--- a/services/torghut/app/api/trading_status.py
+++ b/services/torghut/app/api/trading_status.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import TypeVar
 
 from fastapi import APIRouter
+from fastapi.responses import Response
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -26,6 +27,7 @@ from .health_checks import (
     load_tca_summary,
 )
 from .runtime_ledger_status import daily_runtime_ledger_portfolio_summary
+from .scheduler_proxy import proxy_scheduler_response
 
 router = APIRouter()
 T = TypeVar("T")
@@ -112,8 +114,14 @@ def _runtime_ledger(session: Session) -> dict[str, object]:
     )
 
 
-@router.get("/trading/status")
-def trading_status() -> dict[str, object]:
+@router.get("/trading/status", response_model=None)
+def trading_status() -> dict[str, object] | Response:
+    if settings.process_role == "api":
+        return proxy_scheduler_response(
+            path="/trading/status",
+            accept="application/json",
+        )
+
     scheduler = get_trading_scheduler()
     state = scheduler.state
     accepted_source = load_clickhouse_ta_status(scheduler)

--- a/services/torghut/app/api/trading_status.py
+++ b/services/torghut/app/api/trading_status.py
@@ -18,7 +18,7 @@ from app.db import SessionLocal
 from app.trading.execution_runtime import build_execution_status_payload
 from app.trading.scheduler import TradingScheduler
 
-from .application import get_app
+from .application import get_app, runtime_owner_for_role
 from .health_checks import (
     build_api_live_submission_gate_payload,
     build_tigerbeetle_ledger_status,
@@ -150,6 +150,8 @@ def trading_status() -> dict[str, object] | Response:
     )
     return {
         "service": "torghut",
+        "process_role": settings.process_role,
+        "runtime_owner": runtime_owner_for_role(settings.process_role),
         "build": {
             "version": BUILD_VERSION,
             "commit": BUILD_COMMIT,

--- a/services/torghut/app/bootstrap.py
+++ b/services/torghut/app/bootstrap.py
@@ -13,14 +13,9 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from .api.build_metadata import BUILD_COMMIT, BUILD_VERSION
 from .config import settings
-from .db import SessionLocal, ensure_schema
+from .db import ensure_schema
 from .observability import capture_posthog_event, shutdown_posthog_telemetry
-from .trading.autonomy import assert_runtime_gate_policy_contract
 from .trading.scheduler import TradingScheduler
-from .whitepapers import (
-    WhitepaperKafkaWorker,
-    whitepaper_workflow_enabled,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +23,14 @@ logger = logging.getLogger(__name__)
 def _evaluate_scheduler_status(
     scheduler: TradingScheduler,
 ) -> tuple[bool, dict[str, object]]:
+    if settings.process_role == "api":
+        return True, {
+            "ok": True,
+            "detail": "external_scheduler",
+            "running": False,
+            "owner": "torghut-scheduler",
+        }
+
     scheduler_ok = True
     scheduler_detail = "ok"
 
@@ -80,19 +83,23 @@ def _assert_dspy_cutover_migration_guard() -> None:
 async def lifespan(app: FastAPI):
     """Run startup/shutdown tasks using FastAPI lifespan hooks."""
 
+    if settings.process_role != "api":
+        raise RuntimeError(
+            "torghut_api_process_role_mismatch:expected=api:"
+            f"actual={settings.process_role}"
+        )
+
     scheduler = TradingScheduler()
-    whitepaper_worker = WhitepaperKafkaWorker(session_factory=SessionLocal)
     app.state.trading_scheduler = scheduler
-    app.state.whitepaper_worker = whitepaper_worker
     logger.info(
-        "Torghut startup initiated build_version=%s build_commit=%s app_env=%s log_level=%s log_format=%s trading_enabled=%s whitepaper_workflow_enabled=%s",
+        "Torghut startup initiated build_version=%s build_commit=%s app_env=%s process_role=%s log_level=%s log_format=%s trading_enabled=%s",
         BUILD_VERSION,
         BUILD_COMMIT,
         settings.app_env,
+        settings.process_role,
         settings.log_level,
         settings.log_format,
         settings.trading_enabled,
-        whitepaper_workflow_enabled(),
     )
 
     try:
@@ -100,28 +107,15 @@ async def lifespan(app: FastAPI):
     except SQLAlchemyError as exc:  # pragma: no cover - defensive for startup only
         logger.warning("Database not reachable during startup: %s", exc)
 
-    if settings.trading_autonomy_enabled:
-        assert_runtime_gate_policy_contract(settings.trading_autonomy_gate_policy_path)
+    logger.info("Torghut startup complete background_worker_owner=external")
 
-    if settings.trading_enabled:
-        _assert_dspy_cutover_migration_guard()
-        await scheduler.start()
-    if whitepaper_workflow_enabled():
-        await whitepaper_worker.start()
-
-    logger.info(
-        "Torghut startup complete trading_scheduler_started=%s whitepaper_worker_started=%s",
-        bool(getattr(scheduler, "_task", None)),
-        bool(getattr(whitepaper_worker, "_task", None)),
-    )
-
-    yield
-
-    logger.info("Torghut shutdown initiated")
-    await whitepaper_worker.stop()
-    await scheduler.stop()
-    shutdown_posthog_telemetry()
-    logger.info("Torghut shutdown complete")
+    try:
+        yield
+    finally:
+        logger.info("Torghut shutdown initiated")
+        await scheduler.stop()
+        shutdown_posthog_telemetry()
+        logger.info("Torghut shutdown complete")
 
 
 def sqlalchemy_exception_handler(

--- a/services/torghut/app/bootstrap.py
+++ b/services/torghut/app/bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -13,11 +14,86 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from .api.build_metadata import BUILD_COMMIT, BUILD_VERSION
 from .config import settings
-from .db import ensure_schema
+from .db import SessionLocal, ensure_schema
 from .observability import capture_posthog_event, shutdown_posthog_telemetry
+from .trading.autonomy import assert_runtime_gate_policy_contract
 from .trading.scheduler import TradingScheduler
+from .trading.scheduler.leadership import (
+    DEFAULT_SCHEDULER_ADVISORY_LOCK_NAME,
+    SchedulerLeadershipError,
+)
+from .whitepapers import WhitepaperKafkaWorker, whitepaper_workflow_enabled
 
 logger = logging.getLogger(__name__)
+
+_MAIN_PROCESS_ROLES = frozenset({"api", "simulation"})
+
+
+def _assert_main_process_role_contract() -> bool:
+    """Return whether this main process owns an isolated embedded scheduler."""
+
+    process_role = settings.process_role
+    if process_role not in _MAIN_PROCESS_ROLES:
+        raise RuntimeError(
+            "torghut_api_process_role_mismatch:expected=api|simulation:"
+            f"actual={process_role}"
+        )
+    if process_role != "simulation":
+        return False
+    if settings.trading_mode != "paper":
+        raise RuntimeError(
+            "torghut_simulation_process_mode_mismatch:expected=paper:"
+            f"actual={settings.trading_mode}"
+        )
+    if settings.trading_enabled and not settings.trading_scheduler_leadership_required:
+        raise RuntimeError("torghut_simulation_scheduler_leadership_required")
+    if (
+        settings.trading_enabled
+        and settings.trading_scheduler_leadership_lock_name
+        == DEFAULT_SCHEDULER_ADVISORY_LOCK_NAME
+    ):
+        raise RuntimeError("torghut_simulation_scheduler_lock_must_be_isolated")
+    return True
+
+
+async def _supervise_embedded_scheduler(scheduler: TradingScheduler) -> None:
+    """Retry only expected leadership contention during a Knative handoff."""
+
+    retry_seconds = settings.trading_scheduler_leadership_check_seconds
+    while True:
+        try:
+            await scheduler.start()
+            return
+        except SchedulerLeadershipError as exc:
+            logger.info(
+                "Simulation scheduler standing by for writer leadership retry_seconds=%s error=%s",
+                retry_seconds,
+                exc,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive supervisor boundary
+            scheduler.state.last_error = (
+                f"scheduler_startup_supervisor_failed:{type(exc).__name__}"
+            )
+            logger.exception(
+                "Simulation scheduler supervisor stopped after non-retryable startup failure"
+            )
+            return
+        await asyncio.sleep(retry_seconds)
+
+
+async def _stop_embedded_scheduler_supervisor(
+    supervisor: asyncio.Task[None] | None,
+) -> None:
+    if supervisor is None:
+        return
+    if not supervisor.done():
+        supervisor.cancel()
+    try:
+        await supervisor
+    except asyncio.CancelledError:
+        pass
 
 
 def _evaluate_scheduler_status(
@@ -83,16 +159,20 @@ def _assert_dspy_cutover_migration_guard() -> None:
 async def lifespan(app: FastAPI):
     """Run startup/shutdown tasks using FastAPI lifespan hooks."""
 
-    if settings.process_role != "api":
-        raise RuntimeError(
-            "torghut_api_process_role_mismatch:expected=api:"
-            f"actual={settings.process_role}"
-        )
+    owns_embedded_scheduler = _assert_main_process_role_contract()
 
     scheduler = TradingScheduler()
+    whitepaper_worker = (
+        WhitepaperKafkaWorker(session_factory=SessionLocal)
+        if owns_embedded_scheduler
+        else None
+    )
     app.state.trading_scheduler = scheduler
+    if whitepaper_worker is not None:
+        app.state.whitepaper_worker = whitepaper_worker
+    scheduler_supervisor: asyncio.Task[None] | None = None
     logger.info(
-        "Torghut startup initiated build_version=%s build_commit=%s app_env=%s process_role=%s log_level=%s log_format=%s trading_enabled=%s",
+        "Torghut startup initiated build_version=%s build_commit=%s app_env=%s process_role=%s log_level=%s log_format=%s trading_enabled=%s background_worker_owner=%s",
         BUILD_VERSION,
         BUILD_COMMIT,
         settings.app_env,
@@ -100,19 +180,46 @@ async def lifespan(app: FastAPI):
         settings.log_level,
         settings.log_format,
         settings.trading_enabled,
+        "local" if owns_embedded_scheduler else "external",
     )
 
     try:
-        ensure_schema()
-    except SQLAlchemyError as exc:  # pragma: no cover - defensive for startup only
-        logger.warning("Database not reachable during startup: %s", exc)
+        if owns_embedded_scheduler:
+            ensure_schema()
+            if settings.trading_autonomy_enabled:
+                assert_runtime_gate_policy_contract(
+                    settings.trading_autonomy_gate_policy_path
+                )
+            if settings.trading_enabled:
+                _assert_dspy_cutover_migration_guard()
+                scheduler_supervisor = asyncio.create_task(
+                    _supervise_embedded_scheduler(scheduler),
+                    name="torghut-simulation-scheduler-supervisor",
+                )
+                app.state.trading_scheduler_supervisor = scheduler_supervisor
+            if whitepaper_worker is not None and whitepaper_workflow_enabled():
+                await whitepaper_worker.start()
+        else:
+            try:
+                ensure_schema()
+            except SQLAlchemyError as exc:  # pragma: no cover - startup defense only
+                logger.warning("Database not reachable during startup: %s", exc)
 
-    logger.info("Torghut startup complete background_worker_owner=external")
-
-    try:
+        logger.info(
+            "Torghut startup complete trading_scheduler_started=%s whitepaper_worker_started=%s background_worker_owner=%s",
+            bool(getattr(scheduler, "_task", None)),
+            bool(
+                whitepaper_worker is not None
+                and getattr(whitepaper_worker, "_task", None)
+            ),
+            "local" if owns_embedded_scheduler else "external",
+        )
         yield
     finally:
         logger.info("Torghut shutdown initiated")
+        await _stop_embedded_scheduler_supervisor(scheduler_supervisor)
+        if whitepaper_worker is not None:
+            await whitepaper_worker.stop()
         await scheduler.stop()
         shutdown_posthog_telemetry()
         logger.info("Torghut shutdown complete")
@@ -164,6 +271,9 @@ evaluate_scheduler_status = _evaluate_scheduler_status
 
 __all__ = [
     "_assert_dspy_cutover_migration_guard",
+    "_assert_main_process_role_contract",
+    "_stop_embedded_scheduler_supervisor",
+    "_supervise_embedded_scheduler",
     "_evaluate_scheduler_status",
     "assert_dspy_cutover_migration_guard",
     "create_app",

--- a/services/torghut/app/bootstrap.py
+++ b/services/torghut/app/bootstrap.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from typing import Any, cast
 
 from fastapi import FastAPI, Request
@@ -70,26 +71,35 @@ async def _supervise_embedded_scheduler(scheduler: TradingScheduler) -> None:
                 retry_seconds,
                 exc,
             )
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:  # pragma: no cover - defensive supervisor boundary
-            scheduler.state.last_error = (
-                f"scheduler_startup_supervisor_failed:{type(exc).__name__}"
-            )
-            logger.exception(
-                "Simulation scheduler supervisor stopped after non-retryable startup failure"
-            )
-            return
         await asyncio.sleep(retry_seconds)
+
+
+def _embedded_scheduler_supervisor_completed(
+    scheduler: TradingScheduler,
+    supervisor: asyncio.Task[None],
+) -> None:
+    """Latch an unexpected supervisor failure without retrying unsafe errors."""
+
+    if supervisor.cancelled():
+        return
+    error = supervisor.exception()
+    if error is None:
+        return
+    scheduler.state.last_error = (
+        f"scheduler_startup_supervisor_failed:{type(error).__name__}"
+    )
+    logger.error(
+        "Simulation scheduler supervisor stopped after non-retryable startup failure",
+        exc_info=(type(error), error, error.__traceback__),
+    )
 
 
 async def _stop_embedded_scheduler_supervisor(
     supervisor: asyncio.Task[None] | None,
 ) -> None:
-    if supervisor is None:
+    if supervisor is None or supervisor.done():
         return
-    if not supervisor.done():
-        supervisor.cancel()
+    supervisor.cancel()
     try:
         await supervisor
     except asyncio.CancelledError:
@@ -196,6 +206,9 @@ async def lifespan(app: FastAPI):
                     _supervise_embedded_scheduler(scheduler),
                     name="torghut-simulation-scheduler-supervisor",
                 )
+                scheduler_supervisor.add_done_callback(
+                    partial(_embedded_scheduler_supervisor_completed, scheduler)
+                )
                 app.state.trading_scheduler_supervisor = scheduler_supervisor
             if whitepaper_worker is not None and whitepaper_workflow_enabled():
                 await whitepaper_worker.start()
@@ -272,6 +285,7 @@ evaluate_scheduler_status = _evaluate_scheduler_status
 __all__ = [
     "_assert_dspy_cutover_migration_guard",
     "_assert_main_process_role_contract",
+    "_embedded_scheduler_supervisor_completed",
     "_stop_embedded_scheduler_supervisor",
     "_supervise_embedded_scheduler",
     "_evaluate_scheduler_status",

--- a/services/torghut/app/bootstrap.py
+++ b/services/torghut/app/bootstrap.py
@@ -57,11 +57,14 @@ def _assert_main_process_role_contract() -> bool:
     return True
 
 
-async def _supervise_embedded_scheduler(scheduler: TradingScheduler) -> None:
+async def _supervise_embedded_scheduler(
+    scheduler: TradingScheduler,
+    stop_event: asyncio.Event,
+) -> None:
     """Retry only expected leadership contention during a Knative handoff."""
 
     retry_seconds = settings.trading_scheduler_leadership_check_seconds
-    while True:
+    while not stop_event.is_set():
         try:
             await scheduler.start()
             return
@@ -71,7 +74,10 @@ async def _supervise_embedded_scheduler(scheduler: TradingScheduler) -> None:
                 retry_seconds,
                 exc,
             )
-        await asyncio.sleep(retry_seconds)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=retry_seconds)
+        except TimeoutError:
+            pass
 
 
 def _embedded_scheduler_supervisor_completed(
@@ -96,14 +102,12 @@ def _embedded_scheduler_supervisor_completed(
 
 async def _stop_embedded_scheduler_supervisor(
     supervisor: asyncio.Task[None] | None,
+    stop_event: asyncio.Event,
 ) -> None:
     if supervisor is None or supervisor.done():
         return
-    supervisor.cancel()
-    try:
-        await supervisor
-    except asyncio.CancelledError:
-        pass
+    stop_event.set()
+    await supervisor
 
 
 def _evaluate_scheduler_status(
@@ -181,6 +185,7 @@ async def lifespan(app: FastAPI):
     if whitepaper_worker is not None:
         app.state.whitepaper_worker = whitepaper_worker
     scheduler_supervisor: asyncio.Task[None] | None = None
+    scheduler_supervisor_stop = asyncio.Event()
     logger.info(
         "Torghut startup initiated build_version=%s build_commit=%s app_env=%s process_role=%s log_level=%s log_format=%s trading_enabled=%s background_worker_owner=%s",
         BUILD_VERSION,
@@ -203,7 +208,10 @@ async def lifespan(app: FastAPI):
             if settings.trading_enabled:
                 _assert_dspy_cutover_migration_guard()
                 scheduler_supervisor = asyncio.create_task(
-                    _supervise_embedded_scheduler(scheduler),
+                    _supervise_embedded_scheduler(
+                        scheduler,
+                        scheduler_supervisor_stop,
+                    ),
                     name="torghut-simulation-scheduler-supervisor",
                 )
                 scheduler_supervisor.add_done_callback(
@@ -230,7 +238,10 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         logger.info("Torghut shutdown initiated")
-        await _stop_embedded_scheduler_supervisor(scheduler_supervisor)
+        await _stop_embedded_scheduler_supervisor(
+            scheduler_supervisor,
+            scheduler_supervisor_stop,
+        )
         if whitepaper_worker is not None:
             await whitepaper_worker.stop()
         await scheduler.stop()

--- a/services/torghut/app/config/runtime_risk_fields.py
+++ b/services/torghut/app/config/runtime_risk_fields.py
@@ -280,9 +280,12 @@ class RuntimeRiskSettingsFields(BaseSettings):
     )
 
     trading_order_max_attempts: int = Field(
-        default=3,
+        default=1,
         alias="TRADING_ORDER_MAX_ATTEMPTS",
-        description="Maximum live marketable-limit submissions for one decision.",
+        description=(
+            "Maximum live marketable-limit submissions for one decision. "
+            "Keep at one until every submit/cancel mutation has a durable receipt."
+        ),
     )
 
     trading_order_slippage_bps: float = Field(

--- a/services/torghut/app/config/service_fields.py
+++ b/services/torghut/app/config/service_fields.py
@@ -11,6 +11,28 @@ from pydantic_settings import BaseSettings
 class CoreSettingsFields(BaseSettings):
     """Environment-backed settings."""
 
+    process_role: Literal["api", "scheduler"] = Field(
+        default="api",
+        alias="TORGHUT_PROCESS_ROLE",
+        description=(
+            "Exclusive runtime role for this process. API processes remain stateless; "
+            "only scheduler processes may own trading background loops."
+        ),
+    )
+
+    trading_scheduler_leadership_required: bool = Field(
+        default=False,
+        alias="TRADING_SCHEDULER_LEADERSHIP_REQUIRED",
+        description="Require durable PostgreSQL leadership before scheduler work starts.",
+    )
+
+    trading_scheduler_leadership_check_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        alias="TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS",
+        description="Interval between scheduler leadership-session health checks.",
+    )
+
     app_env: Literal["dev", "stage", "prod"] = Field(
         default="dev", alias="APP_ENV", description="Deployment environment."
     )

--- a/services/torghut/app/config/service_fields.py
+++ b/services/torghut/app/config/service_fields.py
@@ -33,6 +33,19 @@ class CoreSettingsFields(BaseSettings):
         description="Interval between scheduler leadership-session health checks.",
     )
 
+    trading_scheduler_runtime_base_url: str = Field(
+        default="http://torghut-scheduler.torghut.svc.cluster.local:8183",
+        alias="TRADING_SCHEDULER_RUNTIME_BASE_URL",
+        description="Internal base URL for scheduler-owned status and metrics surfaces.",
+    )
+
+    trading_scheduler_runtime_timeout_seconds: float = Field(
+        default=2.0,
+        gt=0,
+        alias="TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS",
+        description="Timeout for stateless API reads of scheduler-owned runtime surfaces.",
+    )
+
     app_env: Literal["dev", "stage", "prod"] = Field(
         default="dev", alias="APP_ENV", description="Deployment environment."
     )

--- a/services/torghut/app/config/service_fields.py
+++ b/services/torghut/app/config/service_fields.py
@@ -33,6 +33,26 @@ class CoreSettingsFields(BaseSettings):
         description="Interval between scheduler leadership-session health checks.",
     )
 
+    trading_scheduler_shutdown_drain_seconds: float = Field(
+        default=45.0,
+        gt=0,
+        alias="TRADING_SCHEDULER_SHUTDOWN_DRAIN_SECONDS",
+        description=(
+            "Maximum graceful-shutdown time for in-flight broker work. A timeout "
+            "terminates the process without releasing scheduler leadership."
+        ),
+    )
+
+    trading_scheduler_success_max_age_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        alias="TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS",
+        description=(
+            "Maximum age of the scheduler's last fully successful trading cycle "
+            "before readiness fails closed."
+        ),
+    )
+
     trading_scheduler_runtime_base_url: str = Field(
         default="http://torghut-scheduler.torghut.svc.cluster.local:8183",
         alias="TRADING_SCHEDULER_RUNTIME_BASE_URL",

--- a/services/torghut/app/config/service_fields.py
+++ b/services/torghut/app/config/service_fields.py
@@ -11,12 +11,13 @@ from pydantic_settings import BaseSettings
 class CoreSettingsFields(BaseSettings):
     """Environment-backed settings."""
 
-    process_role: Literal["api", "scheduler"] = Field(
+    process_role: Literal["api", "scheduler", "simulation"] = Field(
         default="api",
         alias="TORGHUT_PROCESS_ROLE",
         description=(
             "Exclusive runtime role for this process. API processes remain stateless; "
-            "only scheduler processes may own trading background loops."
+            "dedicated scheduler processes own live trading background loops, while "
+            "the isolated simulation service may own its paper scheduler locally."
         ),
     )
 
@@ -24,6 +25,17 @@ class CoreSettingsFields(BaseSettings):
         default=False,
         alias="TRADING_SCHEDULER_LEADERSHIP_REQUIRED",
         description="Require durable PostgreSQL leadership before scheduler work starts.",
+    )
+
+    trading_scheduler_leadership_lock_name: str = Field(
+        default="torghut:trading-scheduler",
+        min_length=1,
+        max_length=128,
+        alias="TRADING_SCHEDULER_LEADERSHIP_LOCK_NAME",
+        description=(
+            "Stable namespace hashed into the PostgreSQL scheduler advisory-lock ID. "
+            "Independent trading runtimes must use distinct names."
+        ),
     )
 
     trading_scheduler_leadership_check_seconds: float = Field(
@@ -416,7 +428,15 @@ class CoreSettingsFields(BaseSettings):
 
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
 
-    trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")
+    trading_reconcile_ms: int = Field(
+        default=15000,
+        gt=0,
+        alias="TRADING_RECONCILE_MS",
+        description=(
+            "Interval between reconciliation cycles. Must remain below the scheduler "
+            "success freshness window so a healthy scheduler can stay ready."
+        ),
+    )
 
     trading_order_feed_enabled: bool = Field(
         default=False, alias="TRADING_ORDER_FEED_ENABLED"

--- a/services/torghut/app/config/settings.py
+++ b/services/torghut/app/config/settings.py
@@ -20,6 +20,14 @@ from .normalization import SettingsNormalizationMixin
 
 
 class SettingsAccessorsMixin(SettingsNormalizationMixin):
+    def _validate_scheduler_timing_settings(self) -> None:
+        success_max_age_ms = self.trading_scheduler_success_max_age_seconds * 1000.0
+        if self.trading_reconcile_ms >= success_max_age_ms:
+            raise ValueError(
+                "TRADING_RECONCILE_MS must be strictly less than "
+                "TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS * 1000"
+            )
+
     def _validate_tigerbeetle_settings(self) -> None:
         if self.tigerbeetle_cluster_id <= 0:
             raise ValueError("TORGHUT_TIGERBEETLE_CLUSTER_ID must be > 0")
@@ -48,6 +56,7 @@ class SettingsAccessorsMixin(SettingsNormalizationMixin):
         self._normalize_optional_nullable_settings()
         self._normalize_trading_csv_settings()
         self._normalize_tigerbeetle_settings()
+        self._validate_scheduler_timing_settings()
         self._validate_trading_source_settings()
         self._normalize_llm_settings()
         self._validate_allocator_scalar_settings()

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from . import bootstrap as app_bootstrap
 from .api.application import build_registered_app
+from .config import settings
 
 create_app = app_bootstrap.create_app
 
-app = build_registered_app(create_app())
+app = build_registered_app(create_app(), runtime_role=settings.process_role)
 
 __all__ = ("app", "create_app")

--- a/services/torghut/app/metrics/core.py
+++ b/services/torghut/app/metrics/core.py
@@ -426,6 +426,14 @@ SERVICE_LABEL_GAUGES: dict[str, tuple[str, str]] = {
 }
 
 DIRECT_GAUGES: dict[str, tuple[str, str]] = {
+    "scheduler_leadership_acquired": (
+        "torghut_scheduler_leadership_acquired",
+        "Whether this process currently owns the PostgreSQL scheduler writer fence.",
+    ),
+    "scheduler_leadership_healthy": (
+        "torghut_scheduler_leadership_healthy",
+        "Whether the scheduler writer fence is currently healthy.",
+    ),
     "feature_staleness_ms_p95": (
         "torghut_trading_feature_staleness_ms_p95",
         "Feature staleness p95 for the latest ingest batch.",

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -37,7 +37,9 @@ def _scheduler_readiness_detail(
     *,
     running: bool,
     last_run_at: object,
-    success_is_fresh: bool,
+    trading_success_is_fresh: bool,
+    last_reconcile_at: object,
+    reconcile_success_is_fresh: bool,
     cycle_failed: bool,
     leadership_ok: bool,
 ) -> str:
@@ -47,19 +49,24 @@ def _scheduler_readiness_detail(
         return "scheduler_cycle_failed"
     if last_run_at is None:
         return "scheduler_success_missing"
-    if not success_is_fresh:
+    if not trading_success_is_fresh:
         return "scheduler_success_stale"
+    if last_reconcile_at is None:
+        return "scheduler_reconcile_success_missing"
+    if not reconcile_success_is_fresh:
+        return "scheduler_reconcile_success_stale"
     if not leadership_ok:
         return "scheduler_leadership_unhealthy"
     return "ok"
 
 
 def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object]:
-    """Require a fresh, fully successful cycle and healthy writer leadership."""
+    """Require fresh trading and reconciliation success plus healthy leadership."""
 
     state = scheduler.state
     running = bool(getattr(state, "running", False))
     last_run_at = getattr(state, "last_run_at", None)
+    last_reconcile_at = getattr(state, "last_reconcile_at", None)
     loop_errors = {
         "last_error": getattr(state, "last_error", None),
         "last_trading_error": getattr(state, "last_trading_error", None),
@@ -67,17 +74,30 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
         "last_autonomy_error": getattr(state, "last_autonomy_error", None),
         "last_evidence_error": getattr(state, "last_evidence_error", None),
     }
-    success_age_seconds = _scheduler_success_age_seconds(last_run_at)
-    success_is_fresh = (
-        success_age_seconds is not None
+    trading_success_age_seconds = _scheduler_success_age_seconds(last_run_at)
+    trading_success_is_fresh = (
+        trading_success_age_seconds is not None
         and 0
-        <= success_age_seconds
+        <= trading_success_age_seconds
+        <= settings.trading_scheduler_success_max_age_seconds
+    )
+    reconcile_success_age_seconds = _scheduler_success_age_seconds(last_reconcile_at)
+    reconcile_success_is_fresh = (
+        reconcile_success_age_seconds is not None
+        and 0
+        <= reconcile_success_age_seconds
         <= settings.trading_scheduler_success_max_age_seconds
     )
     leadership = scheduler_liveness_payload(scheduler)
     leadership_ok = bool(leadership["ok"])
     cycle_failed = any(error is not None for error in loop_errors.values())
-    ready = running and success_is_fresh and not cycle_failed and leadership_ok
+    ready = (
+        running
+        and trading_success_is_fresh
+        and reconcile_success_is_fresh
+        and not cycle_failed
+        and leadership_ok
+    )
     payload: dict[str, object] = {
         "ok": ready,
         "process_role": settings.process_role,
@@ -85,17 +105,26 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
         "detail": _scheduler_readiness_detail(
             running=running,
             last_run_at=last_run_at,
-            success_is_fresh=success_is_fresh,
+            trading_success_is_fresh=trading_success_is_fresh,
+            last_reconcile_at=last_reconcile_at,
+            reconcile_success_is_fresh=reconcile_success_is_fresh,
             cycle_failed=cycle_failed,
             leadership_ok=leadership_ok,
         ),
         "success_max_age_seconds": settings.trading_scheduler_success_max_age_seconds,
+        "trading_success_is_fresh": trading_success_is_fresh,
+        "reconcile_success_is_fresh": reconcile_success_is_fresh,
         "leadership": leadership.get("leadership"),
     }
-    if last_run_at is not None:
+    if isinstance(last_run_at, datetime):
         payload["last_run_at"] = last_run_at.isoformat()
-    if success_age_seconds is not None:
-        payload["success_age_seconds"] = success_age_seconds
+    if trading_success_age_seconds is not None:
+        payload["success_age_seconds"] = trading_success_age_seconds
+        payload["trading_success_age_seconds"] = trading_success_age_seconds
+    if isinstance(last_reconcile_at, datetime):
+        payload["last_reconcile_at"] = last_reconcile_at.isoformat()
+    if reconcile_success_age_seconds is not None:
+        payload["reconcile_success_age_seconds"] = reconcile_success_age_seconds
     for key, error in loop_errors.items():
         if error is not None:
             payload[key] = str(error)
@@ -141,7 +170,7 @@ async def scheduler_healthz(request: Request) -> JSONResponse:
 
 
 async def scheduler_readyz(request: Request) -> JSONResponse:
-    """Fail closed until the scheduler is running and has completed one cycle."""
+    """Fail closed until fresh trading and reconciliation cycles have succeeded."""
 
     scheduler = cast(TradingScheduler, request.app.state.trading_scheduler)
     payload = scheduler_readiness_payload(scheduler)

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import cast
 
@@ -24,6 +25,14 @@ from .whitepapers import WhitepaperKafkaWorker, whitepaper_workflow_enabled
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class _SchedulerSuccessFreshness:
+    observed: bool
+    observed_at: datetime | None
+    age_seconds: float | None
+    is_fresh: bool
+
+
 def _scheduler_success_age_seconds(last_run_at: object) -> float | None:
     if not isinstance(last_run_at, datetime):
         return None
@@ -33,31 +42,42 @@ def _scheduler_success_age_seconds(last_run_at: object) -> float | None:
     return (datetime.now(timezone.utc) - normalized).total_seconds()
 
 
+def _scheduler_success_freshness(
+    last_success_at: object,
+) -> _SchedulerSuccessFreshness:
+    age_seconds = _scheduler_success_age_seconds(last_success_at)
+    return _SchedulerSuccessFreshness(
+        observed=last_success_at is not None,
+        observed_at=last_success_at if isinstance(last_success_at, datetime) else None,
+        age_seconds=age_seconds,
+        is_fresh=(
+            age_seconds is not None
+            and 0 <= age_seconds <= settings.trading_scheduler_success_max_age_seconds
+        ),
+    )
+
+
 def _scheduler_readiness_detail(
     *,
     running: bool,
-    last_run_at: object,
-    trading_success_is_fresh: bool,
-    last_reconcile_at: object,
-    reconcile_success_is_fresh: bool,
+    trading_success: _SchedulerSuccessFreshness,
+    reconcile_success: _SchedulerSuccessFreshness,
     cycle_failed: bool,
     leadership_ok: bool,
 ) -> str:
-    if not running:
-        return "scheduler_not_running"
-    if cycle_failed:
-        return "scheduler_cycle_failed"
-    if last_run_at is None:
-        return "scheduler_success_missing"
-    if not trading_success_is_fresh:
-        return "scheduler_success_stale"
-    if last_reconcile_at is None:
-        return "scheduler_reconcile_success_missing"
-    if not reconcile_success_is_fresh:
-        return "scheduler_reconcile_success_stale"
-    if not leadership_ok:
-        return "scheduler_leadership_unhealthy"
-    return "ok"
+    failed_conditions = (
+        (not running, "scheduler_not_running"),
+        (cycle_failed, "scheduler_cycle_failed"),
+        (not trading_success.observed, "scheduler_success_missing"),
+        (not trading_success.is_fresh, "scheduler_success_stale"),
+        (not reconcile_success.observed, "scheduler_reconcile_success_missing"),
+        (not reconcile_success.is_fresh, "scheduler_reconcile_success_stale"),
+        (not leadership_ok, "scheduler_leadership_unhealthy"),
+    )
+    return next(
+        (detail for failed, detail in failed_conditions if failed),
+        "ok",
+    )
 
 
 def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object]:
@@ -65,8 +85,6 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
 
     state = scheduler.state
     running = bool(getattr(state, "running", False))
-    last_run_at = getattr(state, "last_run_at", None)
-    last_reconcile_at = getattr(state, "last_reconcile_at", None)
     loop_errors = {
         "last_error": getattr(state, "last_error", None),
         "last_trading_error": getattr(state, "last_trading_error", None),
@@ -74,27 +92,17 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
         "last_autonomy_error": getattr(state, "last_autonomy_error", None),
         "last_evidence_error": getattr(state, "last_evidence_error", None),
     }
-    trading_success_age_seconds = _scheduler_success_age_seconds(last_run_at)
-    trading_success_is_fresh = (
-        trading_success_age_seconds is not None
-        and 0
-        <= trading_success_age_seconds
-        <= settings.trading_scheduler_success_max_age_seconds
-    )
-    reconcile_success_age_seconds = _scheduler_success_age_seconds(last_reconcile_at)
-    reconcile_success_is_fresh = (
-        reconcile_success_age_seconds is not None
-        and 0
-        <= reconcile_success_age_seconds
-        <= settings.trading_scheduler_success_max_age_seconds
+    trading_success = _scheduler_success_freshness(getattr(state, "last_run_at", None))
+    reconcile_success = _scheduler_success_freshness(
+        getattr(state, "last_reconcile_at", None)
     )
     leadership = scheduler_liveness_payload(scheduler)
     leadership_ok = bool(leadership["ok"])
     cycle_failed = any(error is not None for error in loop_errors.values())
     ready = (
         running
-        and trading_success_is_fresh
-        and reconcile_success_is_fresh
+        and trading_success.is_fresh
+        and reconcile_success.is_fresh
         and not cycle_failed
         and leadership_ok
     )
@@ -104,27 +112,25 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
         "running": running,
         "detail": _scheduler_readiness_detail(
             running=running,
-            last_run_at=last_run_at,
-            trading_success_is_fresh=trading_success_is_fresh,
-            last_reconcile_at=last_reconcile_at,
-            reconcile_success_is_fresh=reconcile_success_is_fresh,
+            trading_success=trading_success,
+            reconcile_success=reconcile_success,
             cycle_failed=cycle_failed,
             leadership_ok=leadership_ok,
         ),
         "success_max_age_seconds": settings.trading_scheduler_success_max_age_seconds,
-        "trading_success_is_fresh": trading_success_is_fresh,
-        "reconcile_success_is_fresh": reconcile_success_is_fresh,
+        "trading_success_is_fresh": trading_success.is_fresh,
+        "reconcile_success_is_fresh": reconcile_success.is_fresh,
         "leadership": leadership.get("leadership"),
     }
-    if isinstance(last_run_at, datetime):
-        payload["last_run_at"] = last_run_at.isoformat()
-    if trading_success_age_seconds is not None:
-        payload["success_age_seconds"] = trading_success_age_seconds
-        payload["trading_success_age_seconds"] = trading_success_age_seconds
-    if isinstance(last_reconcile_at, datetime):
-        payload["last_reconcile_at"] = last_reconcile_at.isoformat()
-    if reconcile_success_age_seconds is not None:
-        payload["reconcile_success_age_seconds"] = reconcile_success_age_seconds
+    if trading_success.observed_at is not None:
+        payload["last_run_at"] = trading_success.observed_at.isoformat()
+    if trading_success.age_seconds is not None:
+        payload["success_age_seconds"] = trading_success.age_seconds
+        payload["trading_success_age_seconds"] = trading_success.age_seconds
+    if reconcile_success.observed_at is not None:
+        payload["last_reconcile_at"] = reconcile_success.observed_at.isoformat()
+    if reconcile_success.age_seconds is not None:
+        payload["reconcile_success_age_seconds"] = reconcile_success.age_seconds
     for key, error in loop_errors.items():
         if error is not None:
             payload[key] = str(error)

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -60,9 +60,13 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
     state = scheduler.state
     running = bool(getattr(state, "running", False))
     last_run_at = getattr(state, "last_run_at", None)
-    last_error = getattr(state, "last_error", None)
-    last_trading_error = getattr(state, "last_trading_error", None)
-    last_reconcile_error = getattr(state, "last_reconcile_error", None)
+    loop_errors = {
+        "last_error": getattr(state, "last_error", None),
+        "last_trading_error": getattr(state, "last_trading_error", None),
+        "last_reconcile_error": getattr(state, "last_reconcile_error", None),
+        "last_autonomy_error": getattr(state, "last_autonomy_error", None),
+        "last_evidence_error": getattr(state, "last_evidence_error", None),
+    }
     success_age_seconds = _scheduler_success_age_seconds(last_run_at)
     success_is_fresh = (
         success_age_seconds is not None
@@ -72,10 +76,7 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
     )
     leadership = scheduler_liveness_payload(scheduler)
     leadership_ok = bool(leadership["ok"])
-    cycle_failed = any(
-        error is not None
-        for error in (last_error, last_trading_error, last_reconcile_error)
-    )
+    cycle_failed = any(error is not None for error in loop_errors.values())
     ready = running and success_is_fresh and not cycle_failed and leadership_ok
     payload: dict[str, object] = {
         "ok": ready,
@@ -95,12 +96,9 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
         payload["last_run_at"] = last_run_at.isoformat()
     if success_age_seconds is not None:
         payload["success_age_seconds"] = success_age_seconds
-    if last_error is not None:
-        payload["last_error"] = str(last_error)
-    if last_trading_error is not None:
-        payload["last_trading_error"] = str(last_trading_error)
-    if last_reconcile_error is not None:
-        payload["last_reconcile_error"] = str(last_reconcile_error)
+    for key, error in loop_errors.items():
+        if error is not None:
+            payload[key] = str(error)
     return payload
 
 

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -149,7 +149,7 @@ def create_scheduler_app() -> FastAPI:
     return app
 
 
-app = build_registered_app(create_scheduler_app())
+app = build_registered_app(create_scheduler_app(), runtime_role="scheduler")
 
 __all__ = (
     "app",

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from typing import cast
 
 from fastapi import FastAPI, Request
@@ -23,24 +24,83 @@ from .whitepapers import WhitepaperKafkaWorker, whitepaper_workflow_enabled
 logger = logging.getLogger(__name__)
 
 
+def _scheduler_success_age_seconds(last_run_at: object) -> float | None:
+    if not isinstance(last_run_at, datetime):
+        return None
+    normalized = last_run_at
+    if normalized.tzinfo is None:
+        normalized = normalized.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - normalized).total_seconds()
+
+
+def _scheduler_readiness_detail(
+    *,
+    running: bool,
+    last_run_at: object,
+    success_is_fresh: bool,
+    cycle_failed: bool,
+    leadership_ok: bool,
+) -> str:
+    if not running:
+        return "scheduler_not_running"
+    if cycle_failed:
+        return "scheduler_cycle_failed"
+    if last_run_at is None:
+        return "scheduler_success_missing"
+    if not success_is_fresh:
+        return "scheduler_success_stale"
+    if not leadership_ok:
+        return "scheduler_leadership_unhealthy"
+    return "ok"
+
+
 def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object]:
-    """Return a process-local scheduler readiness snapshot."""
+    """Require a fresh, fully successful cycle and healthy writer leadership."""
 
     state = scheduler.state
     running = bool(getattr(state, "running", False))
     last_run_at = getattr(state, "last_run_at", None)
     last_error = getattr(state, "last_error", None)
-    ready = running and last_run_at is not None and last_error is None
+    last_trading_error = getattr(state, "last_trading_error", None)
+    last_reconcile_error = getattr(state, "last_reconcile_error", None)
+    success_age_seconds = _scheduler_success_age_seconds(last_run_at)
+    success_is_fresh = (
+        success_age_seconds is not None
+        and 0
+        <= success_age_seconds
+        <= settings.trading_scheduler_success_max_age_seconds
+    )
+    leadership = scheduler_liveness_payload(scheduler)
+    leadership_ok = bool(leadership["ok"])
+    cycle_failed = any(
+        error is not None
+        for error in (last_error, last_trading_error, last_reconcile_error)
+    )
+    ready = running and success_is_fresh and not cycle_failed and leadership_ok
     payload: dict[str, object] = {
         "ok": ready,
         "process_role": settings.process_role,
         "running": running,
-        "detail": "ok" if ready else "scheduler_not_ready",
+        "detail": _scheduler_readiness_detail(
+            running=running,
+            last_run_at=last_run_at,
+            success_is_fresh=success_is_fresh,
+            cycle_failed=cycle_failed,
+            leadership_ok=leadership_ok,
+        ),
+        "success_max_age_seconds": settings.trading_scheduler_success_max_age_seconds,
+        "leadership": leadership.get("leadership"),
     }
     if last_run_at is not None:
         payload["last_run_at"] = last_run_at.isoformat()
+    if success_age_seconds is not None:
+        payload["success_age_seconds"] = success_age_seconds
     if last_error is not None:
         payload["last_error"] = str(last_error)
+    if last_trading_error is not None:
+        payload["last_trading_error"] = str(last_trading_error)
+    if last_reconcile_error is not None:
+        payload["last_reconcile_error"] = str(last_reconcile_error)
     return payload
 
 

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -1,0 +1,158 @@
+"""Dedicated Torghut trading scheduler process entrypoint."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any, cast
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
+
+from .api.application import build_registered_app
+from .bootstrap import assert_dspy_cutover_migration_guard, sqlalchemy_exception_handler
+from .config import settings
+from .db import SessionLocal, ensure_schema
+from .observability import shutdown_posthog_telemetry
+from .trading.autonomy import assert_runtime_gate_policy_contract
+from .trading.scheduler import TradingScheduler
+from .whitepapers import WhitepaperKafkaWorker, whitepaper_workflow_enabled
+
+logger = logging.getLogger(__name__)
+
+
+def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object]:
+    """Return a process-local scheduler readiness snapshot."""
+
+    state = scheduler.state
+    running = bool(getattr(state, "running", False))
+    last_run_at = getattr(state, "last_run_at", None)
+    last_error = getattr(state, "last_error", None)
+    ready = running and last_run_at is not None and last_error is None
+    payload: dict[str, object] = {
+        "ok": ready,
+        "process_role": settings.process_role,
+        "running": running,
+        "detail": "ok" if ready else "scheduler_not_ready",
+    }
+    if last_run_at is not None:
+        payload["last_run_at"] = last_run_at.isoformat()
+    if last_error is not None:
+        payload["last_error"] = str(last_error)
+    return payload
+
+
+def scheduler_liveness_payload(scheduler: TradingScheduler) -> dict[str, object]:
+    """Fail closed when durable scheduler leadership is missing or unhealthy."""
+
+    leadership_status = getattr(scheduler, "leadership_status", None)
+    if callable(leadership_status):
+        leadership_status = leadership_status()
+    if leadership_status is None:
+        return {
+            "ok": False,
+            "process_role": settings.process_role,
+            "detail": "leadership_status_unavailable",
+        }
+
+    required = bool(getattr(leadership_status, "required", True))
+    acquired = bool(getattr(leadership_status, "acquired", False))
+    healthy = bool(getattr(leadership_status, "healthy", False))
+    ok = healthy and (acquired or not required)
+    return {
+        "ok": ok,
+        "process_role": settings.process_role,
+        "detail": "ok" if ok else "scheduler_leadership_unhealthy",
+        "leadership": {
+            "required": required,
+            "acquired": acquired,
+            "healthy": healthy,
+            "failure_reason": getattr(leadership_status, "failure_reason", None),
+        },
+    }
+
+
+async def scheduler_healthz(request: Request) -> JSONResponse:
+    """Return scheduler liveness, including durable-leadership health."""
+
+    scheduler = cast(TradingScheduler, request.app.state.trading_scheduler)
+    payload = scheduler_liveness_payload(scheduler)
+    return JSONResponse(status_code=200 if payload["ok"] else 503, content=payload)
+
+
+async def scheduler_readyz(request: Request) -> JSONResponse:
+    """Fail closed until the scheduler is running and has completed one cycle."""
+
+    scheduler = cast(TradingScheduler, request.app.state.trading_scheduler)
+    payload = scheduler_readiness_payload(scheduler)
+    return JSONResponse(status_code=200 if payload["ok"] else 503, content=payload)
+
+
+@asynccontextmanager
+async def scheduler_lifespan(app: FastAPI):
+    """Own exactly one scheduler lifecycle in the dedicated process."""
+
+    if settings.process_role != "scheduler":
+        raise RuntimeError(
+            "torghut_scheduler_process_role_mismatch:expected=scheduler:"
+            f"actual={settings.process_role}"
+        )
+
+    scheduler = TradingScheduler()
+    whitepaper_worker = WhitepaperKafkaWorker(session_factory=SessionLocal)
+    app.state.trading_scheduler = scheduler
+    app.state.whitepaper_worker = whitepaper_worker
+    logger.info(
+        "Torghut scheduler startup initiated app_env=%s process_role=%s trading_enabled=%s",
+        settings.app_env,
+        settings.process_role,
+        settings.trading_enabled,
+    )
+
+    try:
+        ensure_schema()
+        if settings.trading_autonomy_enabled:
+            assert_runtime_gate_policy_contract(
+                settings.trading_autonomy_gate_policy_path
+            )
+        if settings.trading_enabled:
+            assert_dspy_cutover_migration_guard()
+            await scheduler.start()
+        if whitepaper_workflow_enabled():
+            await whitepaper_worker.start()
+
+        logger.info(
+            "Torghut scheduler startup complete trading_scheduler_started=%s whitepaper_worker_started=%s",
+            bool(getattr(scheduler, "_task", None)),
+            bool(getattr(whitepaper_worker, "_task", None)),
+        )
+        yield
+    finally:
+        logger.info("Torghut scheduler shutdown initiated")
+        await whitepaper_worker.stop()
+        await scheduler.stop()
+        shutdown_posthog_telemetry()
+        logger.info("Torghut scheduler shutdown complete")
+
+
+def create_scheduler_app() -> FastAPI:
+    app = FastAPI(title="torghut-scheduler", lifespan=scheduler_lifespan)
+    app.state.settings = settings
+    app.add_exception_handler(SQLAlchemyError, cast(Any, sqlalchemy_exception_handler))
+    app.add_api_route("/healthz", scheduler_healthz, methods=["GET"])
+    app.add_api_route("/scheduler/readyz", scheduler_readyz, methods=["GET"])
+    return app
+
+
+app = build_registered_app(create_scheduler_app())
+
+__all__ = (
+    "app",
+    "create_scheduler_app",
+    "scheduler_lifespan",
+    "scheduler_healthz",
+    "scheduler_liveness_payload",
+    "scheduler_readiness_payload",
+    "scheduler_readyz",
+)

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -138,32 +138,61 @@ def scheduler_readiness_payload(scheduler: TradingScheduler) -> dict[str, object
 
 
 def scheduler_liveness_payload(scheduler: TradingScheduler) -> dict[str, object]:
-    """Fail closed when durable scheduler leadership is missing or unhealthy."""
+    """Require a healthy trading loop and leadership when trading is enabled."""
 
+    trading_enabled = bool(settings.trading_enabled)
+    running = bool(getattr(scheduler.state, "running", False))
     leadership_status = getattr(scheduler, "leadership_status", None)
     if callable(leadership_status):
         leadership_status = leadership_status()
+    trading_payload = {
+        "enabled": trading_enabled,
+        "loop_required": trading_enabled,
+        "running": running,
+    }
     if leadership_status is None:
+        if not trading_enabled:
+            return {
+                "ok": True,
+                "process_role": settings.process_role,
+                "detail": "trading_disabled",
+                "trading": trading_payload,
+            }
         return {
             "ok": False,
             "process_role": settings.process_role,
             "detail": "leadership_status_unavailable",
+            "trading": trading_payload,
         }
 
     required = bool(getattr(leadership_status, "required", True))
     acquired = bool(getattr(leadership_status, "acquired", False))
     healthy = bool(getattr(leadership_status, "healthy", False))
-    ok = healthy and (acquired or not required)
+    leadership_ok = healthy and (acquired or not required)
+    leadership_payload = {
+        "required": required,
+        "acquired": acquired,
+        "healthy": healthy,
+        "failure_reason": getattr(leadership_status, "failure_reason", None),
+    }
+    if not trading_enabled:
+        ok = True
+        detail = "trading_disabled"
+    elif not leadership_ok:
+        ok = False
+        detail = "scheduler_leadership_unhealthy"
+    elif not running:
+        ok = False
+        detail = "scheduler_loop_not_running"
+    else:
+        ok = True
+        detail = "ok"
     return {
         "ok": ok,
         "process_role": settings.process_role,
-        "detail": "ok" if ok else "scheduler_leadership_unhealthy",
-        "leadership": {
-            "required": required,
-            "acquired": acquired,
-            "healthy": healthy,
-            "failure_reason": getattr(leadership_status, "failure_reason", None),
-        },
+        "detail": detail,
+        "trading": trading_payload,
+        "leadership": leadership_payload,
     }
 
 

--- a/services/torghut/app/scheduler_main.py
+++ b/services/torghut/app/scheduler_main.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, cast
+from typing import cast
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import SQLAlchemyError
+from starlette.types import ExceptionHandler
 
 from .api.application import build_registered_app
 from .bootstrap import assert_dspy_cutover_migration_guard, sqlalchemy_exception_handler
@@ -139,7 +140,10 @@ async def scheduler_lifespan(app: FastAPI):
 def create_scheduler_app() -> FastAPI:
     app = FastAPI(title="torghut-scheduler", lifespan=scheduler_lifespan)
     app.state.settings = settings
-    app.add_exception_handler(SQLAlchemyError, cast(Any, sqlalchemy_exception_handler))
+    app.add_exception_handler(
+        SQLAlchemyError,
+        cast(ExceptionHandler, sqlalchemy_exception_handler),
+    )
     app.add_api_route("/healthz", scheduler_healthz, methods=["GET"])
     app.add_api_route("/scheduler/readyz", scheduler_readyz, methods=["GET"])
     return app

--- a/services/torghut/app/trading/execution/order_executor_core_methods.py
+++ b/services/torghut/app/trading/execution/order_executor_core_methods.py
@@ -32,6 +32,7 @@ from .order_lifecycle import (
     OrderLifecyclePolicy,
     OrderLifecycleResult,
     fetch_existing_orders,
+    live_order_recovery_scan_limit,
     submit_with_bounded_repricing,
 )
 from ..quantity_rules import (
@@ -560,7 +561,7 @@ class _OrderExecutorCoreMethods(_OrderExecutorCoreBase):
             execution_client,
             decision_row.decision_hash,
             max_attempts=(
-                settings.trading_order_max_attempts
+                live_order_recovery_scan_limit(settings.trading_order_max_attempts)
                 if settings.trading_mode == "live"
                 else 1
             ),

--- a/services/torghut/app/trading/execution/order_lifecycle.py
+++ b/services/torghut/app/trading/execution/order_lifecycle.py
@@ -19,6 +19,16 @@ class OrderLifecycleSafetyError(RuntimeError):
 _TERMINAL_ORDER_STATUSES = {"canceled", "expired", "filled", "rejected"}
 _RETRYABLE_TERMINAL_ORDER_STATUSES = {"canceled", "expired"}
 
+# Previous live manifests permitted these broker idempotency-key attempts. Keep
+# the read-only recovery boundary stable when new submission attempts are reduced.
+HISTORICAL_LIVE_ORDER_ATTEMPT_SCAN_LIMIT = 3
+
+
+def live_order_recovery_scan_limit(configured_attempts: int) -> int:
+    """Include historical broker ids without authorizing new attempts."""
+
+    return max(configured_attempts, HISTORICAL_LIVE_ORDER_ATTEMPT_SCAN_LIMIT)
+
 
 class OrderLifecycleClient(Protocol):
     """Broker mutations and reads needed by bounded repricing."""
@@ -437,5 +447,6 @@ __all__ = [
     "OrderLifecycleSafetyError",
     "attempt_client_order_ids",
     "fetch_existing_orders",
+    "live_order_recovery_scan_limit",
     "submit_with_bounded_repricing",
 ]

--- a/services/torghut/app/trading/scheduler/leadership.py
+++ b/services/torghut/app/trading/scheduler/leadership.py
@@ -1,0 +1,209 @@
+"""PostgreSQL-backed leadership for the singleton trading scheduler."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Callable
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def scheduler_advisory_lock_id(name: str = "torghut:trading-scheduler") -> int:
+    """Return a stable signed 64-bit advisory-lock identifier."""
+
+    digest = hashlib.sha256(name.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+DEFAULT_SCHEDULER_ADVISORY_LOCK_ID = scheduler_advisory_lock_id()
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerLeadershipStatus:
+    """Current scheduler-leadership state for readiness and telemetry."""
+
+    required: bool
+    lock_id: int
+    acquired: bool = False
+    healthy: bool = False
+    acquired_at: datetime | None = None
+    last_checked_at: datetime | None = None
+    failure_reason: str | None = None
+
+
+class SchedulerLeadershipError(RuntimeError):
+    """Raised when required scheduler leadership cannot be established."""
+
+
+class PostgresSchedulerLeadership:
+    """Hold a PostgreSQL session advisory lock for scheduler lifetime.
+
+    PostgreSQL releases the lock if the owning connection disappears. Callers must
+    stop broker-affecting work immediately when :meth:`check` returns ``False``.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: Engine,
+        required: bool,
+        lock_id: int = DEFAULT_SCHEDULER_ADVISORY_LOCK_ID,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._engine = engine
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self._connection: Connection | None = None
+        self._mutex = threading.Lock()
+        self._status = SchedulerLeadershipStatus(
+            required=required,
+            lock_id=lock_id,
+            healthy=not required,
+        )
+
+    @property
+    def status(self) -> SchedulerLeadershipStatus:
+        with self._mutex:
+            return self._status
+
+    def acquire(self) -> None:
+        """Acquire required leadership or raise without starting the scheduler."""
+
+        with self._mutex:
+            if not self._status.required:
+                self._status = replace(
+                    self._status,
+                    healthy=True,
+                    last_checked_at=self._now(),
+                    failure_reason=None,
+                )
+                return
+            if self._connection is not None and self._status.acquired:
+                return
+
+            connection: Connection | None = None
+            try:
+                connection = self._engine.connect()
+                acquired = bool(
+                    connection.execute(
+                        text("SELECT pg_try_advisory_lock(:lock_id)"),
+                        {"lock_id": self._status.lock_id},
+                    ).scalar_one()
+                )
+                connection.commit()
+            except SQLAlchemyError as exc:
+                if connection is not None:
+                    connection.close()
+                self._mark_failed_locked(
+                    f"leadership_probe_failed:{type(exc).__name__}"
+                )
+                raise SchedulerLeadershipError(
+                    "required scheduler leadership probe failed"
+                ) from exc
+
+            if not acquired:
+                connection.close()
+                self._mark_failed_locked("leadership_contended")
+                raise SchedulerLeadershipError(
+                    "required scheduler leadership is held by another process"
+                )
+
+            acquired_at = self._now()
+            self._connection = connection
+            self._status = replace(
+                self._status,
+                acquired=True,
+                healthy=True,
+                acquired_at=acquired_at,
+                last_checked_at=acquired_at,
+                failure_reason=None,
+            )
+
+    def check(self) -> bool:
+        """Verify that the lock-owning database session is still usable."""
+
+        with self._mutex:
+            if not self._status.required:
+                self._status = replace(
+                    self._status,
+                    healthy=True,
+                    last_checked_at=self._now(),
+                    failure_reason=None,
+                )
+                return True
+            connection = self._connection
+            if connection is None or not self._status.acquired:
+                self._mark_failed_locked("leadership_not_acquired")
+                return False
+
+            try:
+                connection.execute(text("SELECT 1")).scalar_one()
+                connection.commit()
+            except SQLAlchemyError as exc:
+                connection.close()
+                self._connection = None
+                self._mark_failed_locked(
+                    f"leadership_connection_lost:{type(exc).__name__}"
+                )
+                return False
+
+            self._status = replace(
+                self._status,
+                healthy=True,
+                last_checked_at=self._now(),
+                failure_reason=None,
+            )
+            return True
+
+    def release(self) -> None:
+        """Release leadership and close the dedicated database session."""
+
+        with self._mutex:
+            connection = self._connection
+            self._connection = None
+            if connection is not None:
+                try:
+                    if self._status.acquired:
+                        connection.execute(
+                            text("SELECT pg_advisory_unlock(:lock_id)"),
+                            {"lock_id": self._status.lock_id},
+                        ).scalar_one()
+                        connection.commit()
+                except SQLAlchemyError:
+                    # Closing the session is the authoritative release fallback.
+                    pass
+                finally:
+                    connection.close()
+            self._status = replace(
+                self._status,
+                acquired=False,
+                healthy=not self._status.required,
+                acquired_at=None,
+                last_checked_at=self._now(),
+                failure_reason=(
+                    None if not self._status.required else "leadership_released"
+                ),
+            )
+
+    def _mark_failed_locked(self, reason: str) -> None:
+        self._status = replace(
+            self._status,
+            acquired=False,
+            healthy=False,
+            acquired_at=None,
+            last_checked_at=self._now(),
+            failure_reason=reason,
+        )
+
+
+__all__ = [
+    "DEFAULT_SCHEDULER_ADVISORY_LOCK_ID",
+    "PostgresSchedulerLeadership",
+    "SchedulerLeadershipError",
+    "SchedulerLeadershipStatus",
+    "scheduler_advisory_lock_id",
+]

--- a/services/torghut/app/trading/scheduler/leadership.py
+++ b/services/torghut/app/trading/scheduler/leadership.py
@@ -13,7 +13,12 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 
-def scheduler_advisory_lock_id(name: str = "torghut:trading-scheduler") -> int:
+DEFAULT_SCHEDULER_ADVISORY_LOCK_NAME = "torghut:trading-scheduler"
+
+
+def scheduler_advisory_lock_id(
+    name: str = DEFAULT_SCHEDULER_ADVISORY_LOCK_NAME,
+) -> int:
     """Return a stable signed 64-bit advisory-lock identifier."""
 
     digest = hashlib.sha256(name.encode("utf-8")).digest()
@@ -215,6 +220,7 @@ class PostgresSchedulerLeadership:
 
 __all__ = [
     "DEFAULT_SCHEDULER_ADVISORY_LOCK_ID",
+    "DEFAULT_SCHEDULER_ADVISORY_LOCK_NAME",
     "PostgresSchedulerLeadership",
     "SchedulerLeadership",
     "SchedulerLeadershipError",

--- a/services/torghut/app/trading/scheduler/leadership.py
+++ b/services/torghut/app/trading/scheduler/leadership.py
@@ -6,7 +6,7 @@ import hashlib
 import threading
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import Callable
+from typing import Callable, Protocol
 
 from sqlalchemy import text
 from sqlalchemy.engine import Connection, Engine
@@ -38,6 +38,19 @@ class SchedulerLeadershipStatus:
 
 class SchedulerLeadershipError(RuntimeError):
     """Raised when required scheduler leadership cannot be established."""
+
+
+class SchedulerLeadership(Protocol):
+    """Structural writer-fence contract used by the scheduler runtime."""
+
+    @property
+    def status(self) -> SchedulerLeadershipStatus: ...
+
+    def acquire(self) -> None: ...
+
+    def check(self) -> bool: ...
+
+    def release(self) -> None: ...
 
 
 class PostgresSchedulerLeadership:
@@ -203,6 +216,7 @@ class PostgresSchedulerLeadership:
 __all__ = [
     "DEFAULT_SCHEDULER_ADVISORY_LOCK_ID",
     "PostgresSchedulerLeadership",
+    "SchedulerLeadership",
     "SchedulerLeadershipError",
     "SchedulerLeadershipStatus",
     "scheduler_advisory_lock_id",

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -513,6 +513,7 @@ class TradingScheduler(
             self.state.signal_bootstrap_completed_at = None
             self.state.running = False
             self._task = asyncio.create_task(self._run_loop())
+            self._task.add_done_callback(self._scheduler_loop_completed)
             self._leadership_task = asyncio.create_task(self._monitor_leadership())
             self._leadership_task.add_done_callback(self._leadership_monitor_completed)
             startup_cleanup.pop_all()
@@ -657,6 +658,29 @@ class TradingScheduler(
             "Trading scheduler leadership monitor crashed; writer stopped error=%s",
             detail,
             exc_info=(type(error), error, error.__traceback__),
+        )
+        self._fatal_exit(70)
+
+    def _scheduler_loop_completed(self, scheduler_task: asyncio.Task[None]) -> None:
+        if self._stop_event.is_set():
+            return
+        if scheduler_task.cancelled():
+            error: BaseException | None = None
+            state_reason = "scheduler_loop_cancelled_unexpectedly"
+            detail = "task_cancelled"
+        else:
+            error = scheduler_task.exception()
+            if error is None:
+                state_reason = "scheduler_loop_exited_unexpectedly"
+                detail = "task_returned"
+            else:
+                state_reason, detail = "scheduler_loop_failed", type(error).__name__
+        self._latch_leadership_failure(state_reason=state_reason, detail=detail)
+        logger.critical(
+            "Scheduler loop stopped unexpectedly reason=%s detail=%s",
+            state_reason,
+            detail,
+            exc_info=error,
         )
         self._fatal_exit(70)
 

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
@@ -65,6 +65,7 @@ class TradingScheduler(
         self,
         *,
         leadership: PostgresSchedulerLeadership | None = None,
+        fatal_exit: Callable[[int], object] | None = None,
     ) -> None:
         self.state = TradingState()
         self._task: Optional[asyncio.Task[None]] = None
@@ -77,6 +78,7 @@ class TradingScheduler(
             engine=database_engine,
             required=settings.trading_scheduler_leadership_required,
         )
+        self._fatal_exit = fatal_exit or os._exit
 
     @property
     def leadership_status(self) -> SchedulerLeadershipStatus:
@@ -566,6 +568,7 @@ class TradingScheduler(
                     "Trading scheduler leadership lost; writer stopped reason=%s",
                     reason,
                 )
+                self._fatal_exit(70)
                 return
         except asyncio.CancelledError:
             raise
@@ -591,6 +594,7 @@ class TradingScheduler(
             detail,
             exc_info=(type(error), error, error.__traceback__),
         )
+        self._fatal_exit(70)
 
     def _latch_leadership_failure(
         self,

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -887,30 +887,34 @@ class TradingScheduler(
         self._evaluate_safety_controls()
 
     def _set_trading_iteration_error(self, error: str | None) -> None:
-        previous_error = self.state.last_trading_error
+        previous_iteration_error = self._runtime_iteration_error()
         self.state.last_trading_error = error
-        self._refresh_runtime_iteration_error(previous_error=previous_error)
+        self._refresh_runtime_iteration_error(
+            previous_iteration_error=previous_iteration_error
+        )
 
     def _set_reconcile_iteration_error(self, error: str | None) -> None:
-        previous_error = self.state.last_reconcile_error
+        previous_iteration_error = self._runtime_iteration_error()
         self.state.last_reconcile_error = error
-        self._refresh_runtime_iteration_error(previous_error=previous_error)
+        self._refresh_runtime_iteration_error(
+            previous_iteration_error=previous_iteration_error
+        )
 
     def _set_autonomy_iteration_error(self, error: str | None) -> None:
-        previous_error = self.state.last_autonomy_error
+        previous_iteration_error = self._runtime_iteration_error()
         self.state.last_autonomy_error = error
-        self._refresh_runtime_iteration_error(previous_error=previous_error)
+        self._refresh_runtime_iteration_error(
+            previous_iteration_error=previous_iteration_error
+        )
 
     def _set_evidence_iteration_error(self, error: str | None) -> None:
-        previous_error = self.state.last_evidence_error
+        previous_iteration_error = self._runtime_iteration_error()
         self.state.last_evidence_error = error
-        self._refresh_runtime_iteration_error(previous_error=previous_error)
+        self._refresh_runtime_iteration_error(
+            previous_iteration_error=previous_iteration_error
+        )
 
-    def _refresh_runtime_iteration_error(
-        self,
-        *,
-        previous_error: str | None,
-    ) -> None:
+    def _runtime_iteration_error(self) -> str | None:
         active_errors = tuple(
             error
             for error in (
@@ -921,11 +925,17 @@ class TradingScheduler(
             )
             if error is not None
         )
-        if active_errors:
-            if self.state.last_error is None or self.state.last_error == previous_error:
-                self.state.last_error = ";".join(active_errors)
-        elif self.state.last_error == previous_error:
-            self.state.last_error = None
+        if not active_errors:
+            return None
+        return ";".join(active_errors)
+
+    def _refresh_runtime_iteration_error(
+        self,
+        *,
+        previous_iteration_error: str | None,
+    ) -> None:
+        if self.state.last_error in (None, previous_iteration_error):
+            self.state.last_error = self._runtime_iteration_error()
 
     async def _run_autonomy_iteration(self) -> None:
         try:

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -747,6 +747,8 @@ class TradingScheduler(
         self.state.last_error = None
         self.state.last_trading_error = None
         self.state.last_reconcile_error = None
+        self.state.last_autonomy_error = None
+        self.state.last_evidence_error = None
         self.state.last_ingest_signals_total = 0
         self.state.last_ingest_window_start = None
         self.state.last_ingest_window_end = None
@@ -894,6 +896,16 @@ class TradingScheduler(
         self.state.last_reconcile_error = error
         self._refresh_runtime_iteration_error(previous_error=previous_error)
 
+    def _set_autonomy_iteration_error(self, error: str | None) -> None:
+        previous_error = self.state.last_autonomy_error
+        self.state.last_autonomy_error = error
+        self._refresh_runtime_iteration_error(previous_error=previous_error)
+
+    def _set_evidence_iteration_error(self, error: str | None) -> None:
+        previous_error = self.state.last_evidence_error
+        self.state.last_evidence_error = error
+        self._refresh_runtime_iteration_error(previous_error=previous_error)
+
     def _refresh_runtime_iteration_error(
         self,
         *,
@@ -904,6 +916,8 @@ class TradingScheduler(
             for error in (
                 self.state.last_trading_error,
                 self.state.last_reconcile_error,
+                self.state.last_autonomy_error,
+                self.state.last_evidence_error,
             )
             if error is not None
         )
@@ -918,12 +932,11 @@ class TradingScheduler(
             if self._pipeline is None:
                 raise RuntimeError("trading_pipeline_not_initialized")
             await asyncio.to_thread(self._run_autonomous_cycle)
-            self.state.last_autonomy_error = None
+            self._set_autonomy_iteration_error(None)
         except Exception as exc:  # pragma: no cover - loop guard
             self._emit_runtime_loop_failure(loop_name="autonomy", error=exc)
             logger.exception("Autonomous loop failed: %s", exc)
-            self.state.last_error = str(exc)
-            self.state.last_autonomy_error = str(exc)
+            self._set_autonomy_iteration_error(str(exc))
             self.state.autonomy_failure_streak += 1
             self._clear_autonomy_result_state()
         finally:
@@ -934,10 +947,11 @@ class TradingScheduler(
             if self._pipeline is None:
                 raise RuntimeError("trading_pipeline_not_initialized")
             await asyncio.to_thread(self._run_evidence_continuity_check)
+            self._set_evidence_iteration_error(None)
         except Exception as exc:  # pragma: no cover - loop guard
             self._emit_runtime_loop_failure(loop_name="evidence", error=exc)
             logger.exception("Evidence continuity check failed: %s", exc)
-            self.state.last_error = str(exc)
+            self._set_evidence_iteration_error(str(exc))
 
 
 __all__ = ["TradingScheduler"]

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
 
 from ...config import TradingAccountLane, settings
+from ...db import engine as database_engine
 from ...observability import capture_posthog_event
 from ..execution import OrderExecutor
 from ..llm.dspy_programs.runtime import (
@@ -40,6 +41,10 @@ from .governance.governance_mixin_runtime_methods import (
     TradingSchedulerGovernanceRuntimeMethods,
 )
 from .governance.shared_context import TradingSchedulerGovernanceMixinFields
+from .leadership import (
+    PostgresSchedulerLeadership,
+    SchedulerLeadershipStatus,
+)
 from .pipeline import TradingPipeline
 from .pipeline_helpers import build_llm_policy_resolution
 from .runtime_pipeline_factory import build_trading_pipeline_for_account
@@ -54,13 +59,28 @@ class TradingScheduler(
     TradingSchedulerGovernanceDecisionMethods,
     TradingSchedulerGovernanceRuntimeMethods,
 ):
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        leadership: PostgresSchedulerLeadership | None = None,
+    ) -> None:
         self.state = TradingState()
         self._task: Optional[asyncio.Task[None]] = None
+        self._leadership_task: Optional[asyncio.Task[None]] = None
         self._stop_event = asyncio.Event()
         self._pipeline: Optional[TradingPipeline] = None
         self._pipelines: list[TradingPipeline] = []
         self._active_simulation_run_id: str | None = None
+        self._leadership = leadership or PostgresSchedulerLeadership(
+            engine=database_engine,
+            required=settings.trading_scheduler_leadership_required,
+        )
+
+    @property
+    def leadership_status(self) -> SchedulerLeadershipStatus:
+        """Return the process-local writer-fence state for probes and metrics."""
+
+        return self._leadership.status
 
     def _emit_autonomy_domain_telemetry(
         self,
@@ -448,11 +468,21 @@ class TradingScheduler(
     async def start(self) -> None:
         if self._task:
             return
-        self._assert_trading_shorts_startup_policy()
-        if not self._pipelines:
-            lanes = settings.trading_accounts
-            self._pipelines = [self._build_pipeline_for_account(lane) for lane in lanes]
-            self._pipeline = self._pipelines[0] if self._pipelines else None
+        try:
+            await asyncio.to_thread(self._leadership.acquire)
+            self._assert_trading_shorts_startup_policy()
+            if not self._pipelines:
+                lanes = settings.trading_accounts
+                self._pipelines = [
+                    self._build_pipeline_for_account(lane) for lane in lanes
+                ]
+                self._pipeline = self._pipelines[0] if self._pipelines else None
+        except Exception as exc:
+            self.state.running = False
+            self.state.last_error = f"scheduler_startup_failed:{type(exc).__name__}"
+            if self._leadership.status.acquired:
+                await asyncio.to_thread(self._leadership.release)
+            raise
         account_labels = ",".join(
             pipeline.account_label for pipeline in self._pipelines
         )
@@ -472,10 +502,9 @@ class TradingScheduler(
         self.state.signal_bootstrap_completed_at = None
         self.state.running = False
         self._task = asyncio.create_task(self._run_loop())
+        self._leadership_task = asyncio.create_task(self._monitor_leadership())
 
     async def stop(self) -> None:
-        if not self._task:
-            return
         account_labels = ",".join(
             pipeline.account_label
             for pipeline in (
@@ -484,11 +513,22 @@ class TradingScheduler(
         )
         logger.info("Trading scheduler stopping accounts=%s", account_labels or "none")
         self._stop_event.set()
-        self._task.cancel()
-        try:
-            await self._task
-        except asyncio.CancelledError:
-            pass
+        leadership_task = self._leadership_task
+        if leadership_task is not None:
+            leadership_task.cancel()
+            if leadership_task is not asyncio.current_task():
+                try:
+                    await leadership_task
+                except asyncio.CancelledError:
+                    pass
+        self._leadership_task = None
+        task = self._task
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         self._task = None
         self.state.startup_started_at = None
         self.state.signal_bootstrap_started_at = None
@@ -501,7 +541,49 @@ class TradingScheduler(
             pipeline.order_feed_ingestor.close()
         self._pipelines = []
         self._pipeline = None
+        await asyncio.to_thread(self._leadership.release)
         logger.info("Trading scheduler stopped")
+
+    async def _monitor_leadership(self) -> None:
+        """Cancel broker-affecting work as soon as the writer fence is lost."""
+
+        check_seconds = settings.trading_scheduler_leadership_check_seconds
+        try:
+            while not self._stop_event.is_set():
+                await asyncio.sleep(check_seconds)
+                healthy = await asyncio.to_thread(self._leadership.check)
+                if healthy:
+                    continue
+
+                status = self._leadership.status
+                reason = status.failure_reason or "leadership_unhealthy"
+                self.state.last_error = f"scheduler_leadership_lost:{reason}"
+                self.state.emergency_stop_active = True
+                self.state.emergency_stop_reason = "scheduler_leadership_lost"
+                self.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
+                self._stop_event.set()
+                task = self._task
+                if task is not None:
+                    task.cancel()
+                logger.critical(
+                    "Trading scheduler leadership lost; writer stopped reason=%s",
+                    reason,
+                )
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - last-resort process guard
+            self.state.last_error = (
+                f"scheduler_leadership_monitor_failed:{type(exc).__name__}"
+            )
+            self.state.emergency_stop_active = True
+            self.state.emergency_stop_reason = "scheduler_leadership_monitor_failed"
+            self.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
+            self._stop_event.set()
+            task = self._task
+            if task is not None:
+                task.cancel()
+            logger.exception("Trading scheduler leadership monitor failed")
 
     async def _run_loop(self) -> None:
         self.state.running = True

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Iterable, Mapping
+from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
 
@@ -43,6 +44,7 @@ from .governance.governance_mixin_runtime_methods import (
 from .governance.shared_context import TradingSchedulerGovernanceMixinFields
 from .leadership import (
     PostgresSchedulerLeadership,
+    SchedulerLeadershipError,
     SchedulerLeadershipStatus,
 )
 from .pipeline import TradingPipeline
@@ -470,6 +472,12 @@ class TradingScheduler(
             return
         try:
             await asyncio.to_thread(self._leadership.acquire)
+        except SchedulerLeadershipError as exc:
+            self.state.running = False
+            self.state.last_error = f"scheduler_startup_failed:{type(exc).__name__}"
+            raise
+        with ExitStack() as startup_cleanup:
+            startup_cleanup.callback(self._leadership.release)
             self._assert_trading_shorts_startup_policy()
             if not self._pipelines:
                 lanes = settings.trading_accounts
@@ -477,32 +485,28 @@ class TradingScheduler(
                     self._build_pipeline_for_account(lane) for lane in lanes
                 ]
                 self._pipeline = self._pipelines[0] if self._pipelines else None
-        except Exception as exc:
+            account_labels = ",".join(
+                pipeline.account_label for pipeline in self._pipelines
+            )
+            logger.info(
+                "Trading scheduler starting accounts=%s poll_interval_seconds=%s reconcile_interval_seconds=%s autonomy_enabled=%s autonomy_interval_seconds=%s evidence_enabled=%s evidence_interval_seconds=%s",
+                account_labels or "none",
+                settings.trading_poll_ms / 1000,
+                settings.trading_reconcile_ms / 1000,
+                settings.trading_autonomy_enabled,
+                max(30, settings.trading_autonomy_interval_seconds),
+                settings.trading_evidence_continuity_enabled,
+                max(300, settings.trading_evidence_continuity_interval_seconds),
+            )
+            self._stop_event.clear()
+            self.state.startup_started_at = datetime.now(timezone.utc)
+            self.state.signal_bootstrap_started_at = self.state.startup_started_at
+            self.state.signal_bootstrap_completed_at = None
             self.state.running = False
-            self.state.last_error = f"scheduler_startup_failed:{type(exc).__name__}"
-            if self._leadership.status.acquired:
-                await asyncio.to_thread(self._leadership.release)
-            raise
-        account_labels = ",".join(
-            pipeline.account_label for pipeline in self._pipelines
-        )
-        logger.info(
-            "Trading scheduler starting accounts=%s poll_interval_seconds=%s reconcile_interval_seconds=%s autonomy_enabled=%s autonomy_interval_seconds=%s evidence_enabled=%s evidence_interval_seconds=%s",
-            account_labels or "none",
-            settings.trading_poll_ms / 1000,
-            settings.trading_reconcile_ms / 1000,
-            settings.trading_autonomy_enabled,
-            max(30, settings.trading_autonomy_interval_seconds),
-            settings.trading_evidence_continuity_enabled,
-            max(300, settings.trading_evidence_continuity_interval_seconds),
-        )
-        self._stop_event.clear()
-        self.state.startup_started_at = datetime.now(timezone.utc)
-        self.state.signal_bootstrap_started_at = self.state.startup_started_at
-        self.state.signal_bootstrap_completed_at = None
-        self.state.running = False
-        self._task = asyncio.create_task(self._run_loop())
-        self._leadership_task = asyncio.create_task(self._monitor_leadership())
+            self._task = asyncio.create_task(self._run_loop())
+            self._leadership_task = asyncio.create_task(self._monitor_leadership())
+            self._leadership_task.add_done_callback(self._leadership_monitor_completed)
+            startup_cleanup.pop_all()
 
     async def stop(self) -> None:
         account_labels = ",".join(
@@ -517,10 +521,7 @@ class TradingScheduler(
         if leadership_task is not None:
             leadership_task.cancel()
             if leadership_task is not asyncio.current_task():
-                try:
-                    await leadership_task
-                except asyncio.CancelledError:
-                    pass
+                await asyncio.gather(leadership_task, return_exceptions=True)
         self._leadership_task = None
         task = self._task
         if task is not None:
@@ -557,14 +558,10 @@ class TradingScheduler(
 
                 status = self._leadership.status
                 reason = status.failure_reason or "leadership_unhealthy"
-                self.state.last_error = f"scheduler_leadership_lost:{reason}"
-                self.state.emergency_stop_active = True
-                self.state.emergency_stop_reason = "scheduler_leadership_lost"
-                self.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
-                self._stop_event.set()
-                task = self._task
-                if task is not None:
-                    task.cancel()
+                self._latch_leadership_failure(
+                    state_reason="scheduler_leadership_lost",
+                    detail=reason,
+                )
                 logger.critical(
                     "Trading scheduler leadership lost; writer stopped reason=%s",
                     reason,
@@ -572,18 +569,43 @@ class TradingScheduler(
                 return
         except asyncio.CancelledError:
             raise
-        except Exception as exc:  # pragma: no cover - last-resort process guard
-            self.state.last_error = (
-                f"scheduler_leadership_monitor_failed:{type(exc).__name__}"
-            )
-            self.state.emergency_stop_active = True
-            self.state.emergency_stop_reason = "scheduler_leadership_monitor_failed"
-            self.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
-            self._stop_event.set()
-            task = self._task
-            if task is not None:
-                task.cancel()
-            logger.exception("Trading scheduler leadership monitor failed")
+
+    def _leadership_monitor_completed(
+        self,
+        monitor_task: asyncio.Task[None],
+    ) -> None:
+        """Fail closed if the monitor itself exits with any unexpected error."""
+
+        if monitor_task.cancelled():
+            return
+        error = monitor_task.exception()
+        if error is None:
+            return
+        detail = type(error).__name__
+        self._latch_leadership_failure(
+            state_reason="scheduler_leadership_monitor_failed",
+            detail=detail,
+        )
+        logger.critical(
+            "Trading scheduler leadership monitor crashed; writer stopped error=%s",
+            detail,
+            exc_info=(type(error), error, error.__traceback__),
+        )
+
+    def _latch_leadership_failure(
+        self,
+        *,
+        state_reason: str,
+        detail: str,
+    ) -> None:
+        self.state.last_error = f"{state_reason}:{detail}"
+        self.state.emergency_stop_active = True
+        self.state.emergency_stop_reason = state_reason
+        self.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
+        self._stop_event.set()
+        task = self._task
+        if task is not None:
+            task.cancel()
 
     async def _run_loop(self) -> None:
         self.state.running = True

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -44,6 +44,7 @@ from .governance.governance_mixin_runtime_methods import (
 from .governance.shared_context import TradingSchedulerGovernanceMixinFields
 from .leadership import (
     PostgresSchedulerLeadership,
+    SchedulerLeadership,
     SchedulerLeadershipError,
     SchedulerLeadershipStatus,
 )
@@ -64,7 +65,7 @@ class TradingScheduler(
     def __init__(
         self,
         *,
-        leadership: PostgresSchedulerLeadership | None = None,
+        leadership: SchedulerLeadership | None = None,
         fatal_exit: Callable[[int], object] | None = None,
     ) -> None:
         self.state = TradingState()
@@ -519,19 +520,39 @@ class TradingScheduler(
         )
         logger.info("Trading scheduler stopping accounts=%s", account_labels or "none")
         self._stop_event.set()
-        leadership_task = self._leadership_task
-        if leadership_task is not None:
-            leadership_task.cancel()
-            if leadership_task is not asyncio.current_task():
-                await asyncio.gather(leadership_task, return_exceptions=True)
-        self._leadership_task = None
         task = self._task
-        if task is not None:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        drain_seconds = settings.trading_scheduler_shutdown_drain_seconds
+        deadline = asyncio.get_running_loop().time() + drain_seconds
+        if task is not None and task is not asyncio.current_task():
+            completed, _ = await asyncio.wait({task}, timeout=drain_seconds)
+            if not completed:
+                self._fail_closed_on_shutdown_timeout(
+                    phase="scheduler_loop",
+                    drain_seconds=drain_seconds,
+                )
+                return
+
+        leadership_task = self._leadership_task
+        if (
+            leadership_task is not None
+            and leadership_task is not asyncio.current_task()
+        ):
+            remaining_seconds = max(
+                0.0,
+                deadline - asyncio.get_running_loop().time(),
+            )
+            completed, _ = await asyncio.wait(
+                {leadership_task},
+                timeout=remaining_seconds,
+            )
+            if not completed:
+                self._fail_closed_on_shutdown_timeout(
+                    phase="leadership_monitor",
+                    drain_seconds=drain_seconds,
+                )
+                return
+
+        self._leadership_task = None
         self._task = None
         self.state.startup_started_at = None
         self.state.signal_bootstrap_started_at = None
@@ -547,13 +568,50 @@ class TradingScheduler(
         await asyncio.to_thread(self._leadership.release)
         logger.info("Trading scheduler stopped")
 
+    def _fail_closed_on_shutdown_timeout(
+        self,
+        *,
+        phase: str,
+        drain_seconds: float,
+    ) -> None:
+        reason = f"scheduler_shutdown_drain_timeout:{phase}"
+        self.state.last_error = reason
+        self.state.emergency_stop_active = True
+        self.state.emergency_stop_reason = reason
+        self.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
+        logger.critical(
+            "Trading scheduler shutdown drain timed out; retaining writer fence "
+            "phase=%s drain_seconds=%s",
+            phase,
+            drain_seconds,
+        )
+        self._fatal_exit(70)
+
     async def _monitor_leadership(self) -> None:
         """Cancel broker-affecting work as soon as the writer fence is lost."""
 
         check_seconds = settings.trading_scheduler_leadership_check_seconds
         try:
-            while not self._stop_event.is_set():
-                await asyncio.sleep(check_seconds)
+            while True:
+                scheduler_task = self._task
+                if self._stop_event.is_set():
+                    if scheduler_task is None or scheduler_task.done():
+                        return
+                    await asyncio.wait({scheduler_task}, timeout=check_seconds)
+                else:
+                    try:
+                        await asyncio.wait_for(
+                            self._stop_event.wait(),
+                            timeout=check_seconds,
+                        )
+                    except TimeoutError:
+                        pass
+
+                scheduler_task = self._task
+                if self._stop_event.is_set() and (
+                    scheduler_task is None or scheduler_task.done()
+                ):
+                    return
                 healthy = await asyncio.to_thread(self._leadership.check)
                 if healthy:
                     continue
@@ -653,7 +711,13 @@ class TradingScheduler(
                     await self._run_evidence_iteration()
                     last_evidence_check = now
 
-                await asyncio.sleep(poll_interval)
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(),
+                        timeout=poll_interval,
+                    )
+                except TimeoutError:
+                    pass
         finally:
             self.state.running = False
             logger.info("Trading scheduler loop exited")
@@ -681,6 +745,8 @@ class TradingScheduler(
         active_run_id: str,
     ) -> None:
         self.state.last_error = None
+        self.state.last_trading_error = None
+        self.state.last_reconcile_error = None
         self.state.last_ingest_signals_total = 0
         self.state.last_ingest_window_start = None
         self.state.last_ingest_window_end = None
@@ -730,63 +796,122 @@ class TradingScheduler(
         return now - last_run >= timedelta(seconds=interval_seconds)
 
     async def _run_trading_iteration(self) -> None:
-        try:
-            if self._pipeline is None:
-                raise RuntimeError("trading_pipeline_not_initialized")
-            active_pipelines = self._pipelines or [self._pipeline]
-            for pipeline in active_pipelines:
-                try:
-                    await asyncio.to_thread(pipeline.run_once)
-                except Exception as lane_exc:
-                    self._emit_runtime_loop_failure(
-                        loop_name="trading_lane",
-                        error=lane_exc,
-                        account_label=pipeline.account_label,
-                    )
-                    logger.exception(
-                        "Trading lane failed account=%s: %s",
-                        pipeline.account_label,
-                        lane_exc,
-                    )
-            self.state.last_run_at = datetime.now(timezone.utc)
-            self.state.last_error = None
-        except Exception as exc:  # pragma: no cover - loop guard
-            self._emit_runtime_loop_failure(loop_name="trading", error=exc)
-            logger.exception("Trading loop failed: %s", exc)
-            self.state.last_error = str(exc)
-        finally:
+        if self._pipeline is None:
+            error = RuntimeError("trading_pipeline_not_initialized")
+            self._emit_runtime_loop_failure(loop_name="trading", error=error)
+            self._set_trading_iteration_error(str(error))
             self._evaluate_safety_controls()
+            return
+
+        failed_accounts: list[str] = []
+        active_pipelines = self._pipelines or [self._pipeline]
+        for pipeline in active_pipelines:
+            outcome = (
+                await asyncio.gather(
+                    asyncio.to_thread(pipeline.run_once),
+                    return_exceptions=True,
+                )
+            )[0]
+            if isinstance(outcome, Exception):
+                failed_accounts.append(pipeline.account_label)
+                self._emit_runtime_loop_failure(
+                    loop_name="trading_lane",
+                    error=outcome,
+                    account_label=pipeline.account_label,
+                )
+                logger.error(
+                    "Trading lane failed account=%s error=%s",
+                    pipeline.account_label,
+                    outcome,
+                    exc_info=(type(outcome), outcome, outcome.__traceback__),
+                )
+            elif isinstance(outcome, BaseException):
+                raise outcome
+
+        if failed_accounts:
+            self._set_trading_iteration_error(
+                "trading_lane_failures:" + ",".join(failed_accounts)
+            )
+        else:
+            self.state.last_run_at = datetime.now(timezone.utc)
+            self._set_trading_iteration_error(None)
+        self._evaluate_safety_controls()
 
     async def _run_reconcile_iteration(self) -> None:
-        try:
-            if self._pipeline is None:
-                raise RuntimeError("trading_pipeline_not_initialized")
-            updates = 0
-            active_pipelines = self._pipelines or [self._pipeline]
-            for pipeline in active_pipelines:
-                try:
-                    updates += await asyncio.to_thread(pipeline.reconcile)
-                except Exception as lane_exc:
-                    self._emit_runtime_loop_failure(
-                        loop_name="reconcile_lane",
-                        error=lane_exc,
-                        account_label=pipeline.account_label,
-                    )
-                    logger.exception(
-                        "Reconcile lane failed account=%s: %s",
-                        pipeline.account_label,
-                        lane_exc,
-                    )
-            if updates:
-                logger.info("Reconciled %s executions", updates)
-            self.state.last_reconcile_at = datetime.now(timezone.utc)
-            self.state.last_error = None
-        except Exception as exc:  # pragma: no cover - loop guard
-            self._emit_runtime_loop_failure(loop_name="reconcile", error=exc)
-            logger.exception("Reconcile loop failed: %s", exc)
-            self.state.last_error = str(exc)
-        finally:
+        if self._pipeline is None:
+            error = RuntimeError("trading_pipeline_not_initialized")
+            self._emit_runtime_loop_failure(loop_name="reconcile", error=error)
+            self._set_reconcile_iteration_error(str(error))
             self._evaluate_safety_controls()
+            return
+
+        updates = 0
+        failed_accounts: list[str] = []
+        active_pipelines = self._pipelines or [self._pipeline]
+        for pipeline in active_pipelines:
+            outcome = (
+                await asyncio.gather(
+                    asyncio.to_thread(pipeline.reconcile),
+                    return_exceptions=True,
+                )
+            )[0]
+            if isinstance(outcome, Exception):
+                failed_accounts.append(pipeline.account_label)
+                self._emit_runtime_loop_failure(
+                    loop_name="reconcile_lane",
+                    error=outcome,
+                    account_label=pipeline.account_label,
+                )
+                logger.error(
+                    "Reconcile lane failed account=%s error=%s",
+                    pipeline.account_label,
+                    outcome,
+                    exc_info=(type(outcome), outcome, outcome.__traceback__),
+                )
+            elif isinstance(outcome, BaseException):
+                raise outcome
+            else:
+                updates += outcome
+
+        if updates:
+            logger.info("Reconciled %s executions", updates)
+        if failed_accounts:
+            self._set_reconcile_iteration_error(
+                "reconcile_lane_failures:" + ",".join(failed_accounts)
+            )
+        else:
+            self.state.last_reconcile_at = datetime.now(timezone.utc)
+            self._set_reconcile_iteration_error(None)
+        self._evaluate_safety_controls()
+
+    def _set_trading_iteration_error(self, error: str | None) -> None:
+        previous_error = self.state.last_trading_error
+        self.state.last_trading_error = error
+        self._refresh_runtime_iteration_error(previous_error=previous_error)
+
+    def _set_reconcile_iteration_error(self, error: str | None) -> None:
+        previous_error = self.state.last_reconcile_error
+        self.state.last_reconcile_error = error
+        self._refresh_runtime_iteration_error(previous_error=previous_error)
+
+    def _refresh_runtime_iteration_error(
+        self,
+        *,
+        previous_error: str | None,
+    ) -> None:
+        active_errors = tuple(
+            error
+            for error in (
+                self.state.last_trading_error,
+                self.state.last_reconcile_error,
+            )
+            if error is not None
+        )
+        if active_errors:
+            if self.state.last_error is None or self.state.last_error == previous_error:
+                self.state.last_error = ";".join(active_errors)
+        elif self.state.last_error == previous_error:
+            self.state.last_error = None
 
     async def _run_autonomy_iteration(self) -> None:
         try:

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -47,6 +47,7 @@ from .leadership import (
     SchedulerLeadership,
     SchedulerLeadershipError,
     SchedulerLeadershipStatus,
+    scheduler_advisory_lock_id,
 )
 from .pipeline import TradingPipeline
 from .pipeline_helpers import build_llm_policy_resolution
@@ -78,6 +79,9 @@ class TradingScheduler(
         self._leadership = leadership or PostgresSchedulerLeadership(
             engine=database_engine,
             required=settings.trading_scheduler_leadership_required,
+            lock_id=scheduler_advisory_lock_id(
+                settings.trading_scheduler_leadership_lock_name
+            ),
         )
         self._fatal_exit = fatal_exit or os._exit
 
@@ -479,6 +483,8 @@ class TradingScheduler(
             self.state.running = False
             self.state.last_error = f"scheduler_startup_failed:{type(exc).__name__}"
             raise
+        if str(self.state.last_error or "").startswith("scheduler_startup_failed:"):
+            self.state.last_error = None
         with ExitStack() as startup_cleanup:
             startup_cleanup.callback(self._leadership.release)
             self._assert_trading_shorts_startup_policy()

--- a/services/torghut/app/trading/scheduler/state/metrics.py
+++ b/services/torghut/app/trading/scheduler/state/metrics.py
@@ -618,6 +618,7 @@ class TradingState:
     autonomy_patches_total: int = 0
     last_autonomy_run_at: Optional[datetime] = None
     last_autonomy_error: Optional[str] = None
+    last_evidence_error: Optional[str] = None
     last_autonomy_reason: Optional[str] = None
     last_autonomy_run_id: Optional[str] = None
     last_autonomy_candidate_id: Optional[str] = None

--- a/services/torghut/app/trading/scheduler/state/metrics.py
+++ b/services/torghut/app/trading/scheduler/state/metrics.py
@@ -610,6 +610,8 @@ class TradingState:
     startup_started_at: Optional[datetime] = None
     last_run_at: Optional[datetime] = None
     last_reconcile_at: Optional[datetime] = None
+    last_trading_error: Optional[str] = None
+    last_reconcile_error: Optional[str] = None
     last_error: Optional[str] = None
     autonomy_runs_total: int = 0
     autonomy_signals_total: int = 0

--- a/services/torghut/tests/api/test_scheduler_proxy.py
+++ b/services/torghut/tests/api/test_scheduler_proxy.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from email.message import Message
+from urllib.error import URLError
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.api.scheduler_proxy import proxy_scheduler_response
+from app.config import settings
+
+
+class _UpstreamResponse:
+    def __init__(self, body: bytes, *, status: int, content_type: str) -> None:
+        self._body = body
+        self.status = status
+        self.headers = Message()
+        self.headers["Content-Type"] = content_type
+
+    def __enter__(self) -> _UpstreamResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class SchedulerRuntimeProxyTests(TestCase):
+    def test_returns_scheduler_payload_without_reinterpreting_runtime_truth(
+        self,
+    ) -> None:
+        upstream = _UpstreamResponse(
+            b'{"running":true}',
+            status=200,
+            content_type="application/json",
+        )
+        with (
+            patch.object(
+                settings,
+                "trading_scheduler_runtime_base_url",
+                "http://scheduler.internal/",
+            ),
+            patch.object(
+                settings,
+                "trading_scheduler_runtime_timeout_seconds",
+                1.5,
+            ),
+            patch(
+                "app.api.scheduler_proxy.urlopen",
+                return_value=upstream,
+            ) as mocked_open,
+        ):
+            response = proxy_scheduler_response(
+                path="/trading/status",
+                accept="application/json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b'{"running":true}')
+        request = mocked_open.call_args.args[0]
+        self.assertEqual(request.full_url, "http://scheduler.internal/trading/status")
+        self.assertEqual(mocked_open.call_args.kwargs["timeout"], 1.5)
+
+    def test_returns_explicit_unavailable_instead_of_inert_api_state(self) -> None:
+        with patch(
+            "app.api.scheduler_proxy.urlopen",
+            side_effect=URLError("scheduler down"),
+        ):
+            response = proxy_scheduler_response(
+                path="metrics",
+                accept="text/plain",
+            )
+
+        self.assertEqual(response.status_code, 503)
+        payload = json.loads(response.body)
+        self.assertEqual(payload["detail"], "scheduler_runtime_unavailable")
+        self.assertEqual(payload["owner"], "torghut-scheduler")
+
+
+__all__ = ["SchedulerRuntimeProxyTests"]

--- a/services/torghut/tests/api/test_trading_api_status_contract.py
+++ b/services/torghut/tests/api/test_trading_api_status_contract.py
@@ -13,8 +13,9 @@ from tests.api.trading_api_support import (
 
 
 class TestTradingApiStatusContract(TradingApiTestCaseBase):
-    def test_trading_status_exposes_only_operational_runtime_state(self) -> None:
+    def test_simulation_status_uses_process_local_scheduler_state(self) -> None:
         scheduler = TradingScheduler()
+        scheduler.state.last_error = "scheduler_startup_failed:SchedulerLeadershipError"
         freshness = {
             "state": "current",
             "accepted_sources": ["ta"],
@@ -31,7 +32,7 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             "execution_route": {"route": "alpaca"},
         }
         with (
-            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "process_role", "simulation"),
             patch(
                 "app.api.trading_status.get_trading_scheduler",
                 return_value=scheduler,
@@ -53,6 +54,12 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
                     None,
                 ),
             ),
+            patch(
+                "app.api.trading_status.proxy_scheduler_response",
+                side_effect=AssertionError(
+                    "simulation status must not proxy to the live scheduler"
+                ),
+            ) as status_proxy,
         ):
             response = self.client.get("/trading/status")
 
@@ -62,6 +69,8 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             set(payload),
             {
                 "service",
+                "process_role",
+                "runtime_owner",
                 "build",
                 "mode",
                 "pipeline_mode",
@@ -86,10 +95,18 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             },
         )
         self.assertEqual(payload["accepted_source_freshness"], freshness)
+        self.assertEqual(payload["process_role"], "simulation")
+        self.assertEqual(payload["runtime_owner"], "torghut-sim")
+        self.assertFalse(payload["running"])
+        self.assertEqual(
+            payload["last_error"],
+            "scheduler_startup_failed:SchedulerLeadershipError",
+        )
         self.assertEqual(payload["live_submission_gate"], gate)
         self.assertEqual(payload["capital_controls"]["gross_limit"], 4.0)
         self.assertEqual(payload["capital_controls"]["net_limit"], 0.5)
         self.assertEqual(payload["capital_controls"]["symbol_limit"], 0.5)
+        status_proxy.assert_not_called()
         for retired_key in (
             "autonomy",
             "control_plane_contract",
@@ -122,6 +139,28 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             'torghut_trading_runtime_owner_info{owner="torghut-scheduler"} 1',
             response.text,
         )
+
+    def test_simulation_metrics_report_local_role_and_owner(self) -> None:
+        scheduler = TradingScheduler()
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch(
+                "app.api.metrics.get_trading_scheduler",
+                return_value=scheduler,
+            ),
+        ):
+            response = self.client.get("/metrics")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            'torghut_process_role_info{role="simulation"} 1',
+            response.text,
+        )
+        self.assertIn(
+            'torghut_trading_runtime_owner_info{owner="torghut-sim"} 1',
+            response.text,
+        )
+        self.assertNotIn("torghut_api_process_ready", response.text)
 
     def test_stateless_api_proxies_scheduler_status_but_keeps_local_metrics(
         self,
@@ -191,3 +230,31 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             },
         )
         scheduler_open.assert_not_called()
+
+    def test_simulation_readyz_uses_fail_closed_local_readiness(self) -> None:
+        local_payload = {
+            "status": "not_ready",
+            "reason_codes": ["trading loop not started"],
+        }
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch(
+                "app.api.readiness.readiness_helpers.evaluate_core_readiness_payload",
+                return_value=(local_payload, 503),
+            ) as evaluate_readiness,
+        ):
+            response = self.client.get("/readyz")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.json(),
+            {
+                **local_payload,
+                "process_role": "simulation",
+                "runtime_owner": "torghut-sim",
+            },
+        )
+        evaluate_readiness.assert_called_once_with(
+            include_database_contract=True,
+            allow_stale_dependency_cache=True,
+        )

--- a/services/torghut/tests/api/test_trading_api_status_contract.py
+++ b/services/torghut/tests/api/test_trading_api_status_contract.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from fastapi.responses import JSONResponse, Response
+
+from app.config import settings
 from tests.api.trading_api_support import TradingApiTestCaseBase, patch
 
 
@@ -21,6 +24,7 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             "execution_route": {"route": "alpaca"},
         }
         with (
+            patch.object(settings, "process_role", "scheduler"),
             patch(
                 "app.api.trading_status.load_clickhouse_ta_status",
                 return_value=freshness,
@@ -89,8 +93,45 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             self.assertNotIn(retired_key, payload)
 
     def test_metrics_endpoint_is_prometheus_text(self) -> None:
-        response = self.client.get("/metrics")
+        with patch.object(settings, "process_role", "scheduler"):
+            response = self.client.get("/metrics")
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.headers["content-type"].startswith("text/plain"))
         self.assertIn("torghut_trading_capital_new_exposure_allowed", response.text)
+
+    def test_stateless_api_proxies_scheduler_runtime_surfaces(self) -> None:
+        with (
+            patch.object(settings, "process_role", "api"),
+            patch(
+                "app.api.trading_status.proxy_scheduler_response",
+                return_value=JSONResponse(
+                    status_code=200,
+                    content={"service": "torghut", "running": True},
+                ),
+            ) as status_proxy,
+            patch(
+                "app.api.metrics.proxy_scheduler_response",
+                return_value=Response(
+                    content="torghut_scheduler_leadership_acquired 1\n",
+                    media_type="text/plain",
+                ),
+            ) as metrics_proxy,
+        ):
+            status_response = self.client.get("/trading/status")
+            metrics_response = self.client.get("/metrics")
+
+        self.assertEqual(status_response.status_code, 200)
+        self.assertTrue(status_response.json()["running"])
+        self.assertIn(
+            "torghut_scheduler_leadership_acquired 1",
+            metrics_response.text,
+        )
+        status_proxy.assert_called_once_with(
+            path="/trading/status",
+            accept="application/json",
+        )
+        metrics_proxy.assert_called_once_with(
+            path="/metrics",
+            accept="text/plain; version=0.0.4",
+        )

--- a/services/torghut/tests/api/test_trading_api_status_contract.py
+++ b/services/torghut/tests/api/test_trading_api_status_contract.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
-from fastapi.responses import JSONResponse, Response
+from urllib.error import URLError
+
+from fastapi.responses import JSONResponse
 
 from app.config import settings
-from tests.api.trading_api_support import TradingApiTestCaseBase, patch
+from tests.api.trading_api_support import (
+    TradingApiTestCaseBase,
+    TradingScheduler,
+    patch,
+)
 
 
 class TestTradingApiStatusContract(TradingApiTestCaseBase):
     def test_trading_status_exposes_only_operational_runtime_state(self) -> None:
+        scheduler = TradingScheduler()
         freshness = {
             "state": "current",
             "accepted_sources": ["ta"],
@@ -25,6 +32,10 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
         }
         with (
             patch.object(settings, "process_role", "scheduler"),
+            patch(
+                "app.api.trading_status.get_trading_scheduler",
+                return_value=scheduler,
+            ),
             patch(
                 "app.api.trading_status.load_clickhouse_ta_status",
                 return_value=freshness,
@@ -93,14 +104,28 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
             self.assertNotIn(retired_key, payload)
 
     def test_metrics_endpoint_is_prometheus_text(self) -> None:
-        with patch.object(settings, "process_role", "scheduler"):
+        scheduler = TradingScheduler()
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch(
+                "app.api.metrics.get_trading_scheduler",
+                return_value=scheduler,
+            ),
+        ):
             response = self.client.get("/metrics")
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.headers["content-type"].startswith("text/plain"))
         self.assertIn("torghut_trading_capital_new_exposure_allowed", response.text)
+        self.assertIn('torghut_process_role_info{role="scheduler"} 1', response.text)
+        self.assertIn(
+            'torghut_trading_runtime_owner_info{owner="torghut-scheduler"} 1',
+            response.text,
+        )
 
-    def test_stateless_api_proxies_scheduler_runtime_surfaces(self) -> None:
+    def test_stateless_api_proxies_scheduler_status_but_keeps_local_metrics(
+        self,
+    ) -> None:
         with (
             patch.object(settings, "process_role", "api"),
             patch(
@@ -111,27 +136,58 @@ class TestTradingApiStatusContract(TradingApiTestCaseBase):
                 ),
             ) as status_proxy,
             patch(
-                "app.api.metrics.proxy_scheduler_response",
-                return_value=Response(
-                    content="torghut_scheduler_leadership_acquired 1\n",
-                    media_type="text/plain",
-                ),
-            ) as metrics_proxy,
+                "app.api.scheduler_proxy.urlopen",
+                side_effect=URLError("scheduler has zero replicas"),
+            ) as scheduler_open,
         ):
             status_response = self.client.get("/trading/status")
             metrics_response = self.client.get("/metrics")
 
         self.assertEqual(status_response.status_code, 200)
         self.assertTrue(status_response.json()["running"])
+        self.assertEqual(metrics_response.status_code, 200)
+        self.assertIn("torghut_api_process_ready 1", metrics_response.text)
+        self.assertIn('torghut_process_role_info{role="api"} 1', metrics_response.text)
         self.assertIn(
-            "torghut_scheduler_leadership_acquired 1",
+            'torghut_trading_runtime_owner_info{owner="torghut-scheduler"} 1',
             metrics_response.text,
         )
+        self.assertNotIn("torghut_scheduler_leadership_acquired", metrics_response.text)
         status_proxy.assert_called_once_with(
             path="/trading/status",
             accept="application/json",
         )
-        metrics_proxy.assert_called_once_with(
-            path="/metrics",
-            accept="text/plain; version=0.0.4",
+        scheduler_open.assert_not_called()
+
+    def test_stateless_api_readyz_is_local_when_scheduler_is_unavailable(self) -> None:
+        with (
+            patch.object(settings, "process_role", "api"),
+            patch(
+                "app.api.readiness.readiness_helpers.evaluate_core_readiness_payload",
+                side_effect=AssertionError(
+                    "API readiness must not read scheduler state"
+                ),
+            ),
+            patch(
+                "app.api.scheduler_proxy.urlopen",
+                side_effect=URLError("scheduler has zero replicas"),
+            ) as scheduler_open,
+        ):
+            response = self.client.get("/readyz")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "ok",
+                "reason_codes": [],
+                "process_role": "api",
+                "runtime_owner": "torghut-scheduler",
+                "scheduler": {
+                    "ownership": "external",
+                    "owner": "torghut-scheduler",
+                    "availability": "not_evaluated",
+                },
+            },
         )
+        scheduler_open.assert_not_called()

--- a/services/torghut/tests/api/trading_api_support.py
+++ b/services/torghut/tests/api/trading_api_support.py
@@ -501,7 +501,6 @@ class TradingApiTestCaseBase(TestCase):
             bind=engine, expire_on_commit=False, future=True
         )
         for session_local_target in (
-            "app.bootstrap.SessionLocal",
             "app.api.health_checks.shared_context.SessionLocal",
             "app.api.health_checks.load_options_catalog_freshness_summary.SessionLocal",
             "app.api.health_checks.remember_alpaca_success.SessionLocal",

--- a/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
+++ b/services/torghut/tests/config/test_parses_signal_staleness_critical_reasons.py
@@ -300,6 +300,7 @@ class TestParsesSignalStalenessCriticalReasons(_TestConfigBase):
             "trading_live_submit_enabled",
             "trading_simple_order_feed_telemetry_enabled",
             "trading_options_catalog_freshness_exact_route_scope_enabled",
+            "trading_scheduler_leadership_required",
             "trading_empirical_jobs_health_required",
             "trading_jangar_quant_health_required",
             "tigerbeetle_enabled",

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -317,13 +317,18 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
             "Replace=true",
         )
 
-    def test_sim_manifest_runs_paper_live_signal_profile(self) -> None:
+    def test_sim_manifest_contains_paper_live_signal_profile_for_safe_migration(
+        self,
+    ) -> None:
         sim_env = _load_knative_env(
             "argocd/applications/torghut/knative-service-sim.yaml"
         )
         live_env = _load_torghut_knative_env()
 
-        self.assertTrue(_manifest_bool(sim_env, "TRADING_ENABLED"))
+        self.assertFalse(
+            _manifest_bool(sim_env, "TRADING_ENABLED"),
+            "the old unfenced image must stop before the simulation role is promoted",
+        )
         self.assertEqual(
             sim_env.get("SIM_DB_DSN"),
             sim_env.get("DB_DSN"),

--- a/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_knative_env_wiring_is_safe_live_defaults.py
@@ -48,7 +48,8 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
         self.assertEqual(settings.trading_daily_loss_stop_pct_equity, 0.01)
         self.assertEqual(settings.trading_persistent_drawdown_stop_pct_equity, 0.05)
         self.assertEqual(settings.trading_order_reprice_seconds, 2.0)
-        self.assertEqual(settings.trading_order_max_attempts, 3)
+        self.assertEqual(settings.trading_order_max_attempts, 1)
+        self.assertEqual(settings.trading_execution_max_retries, 0)
         self.assertEqual(settings.trading_order_slippage_bps, 8.0)
         self.assertFalse(settings.trading_feature_flags_enabled)
         self.assertFalse(settings.trading_execution_advisor_enabled)
@@ -336,6 +337,8 @@ class TestKnativeEnvWiringIsSafeLiveDefaults(_TestLiveConfigManifestContractBase
         )
         self.assertEqual(sim_env.get("TRADING_MODE"), "paper")
         self.assertEqual(sim_env.get("TRADING_PIPELINE_MODE"), "simple")
+        self.assertEqual(sim_env.get("TRADING_ORDER_MAX_ATTEMPTS"), "1")
+        self.assertEqual(sim_env.get("TRADING_EXECUTION_MAX_RETRIES"), "0")
         self.assertTrue(_manifest_bool(sim_env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
         self.assertTrue(_manifest_bool(sim_env, "TRADING_ORDER_FEED_ENABLED"))
         self.assertTrue(

--- a/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_scheduler_observability_manifest.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping, cast
+from unittest import TestCase
+
+from yaml import safe_load
+
+
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "argocd").is_dir() and (parent / "services" / "torghut").is_dir():
+            return parent
+    raise AssertionError("repository root not found")
+
+
+def _configmap_data(relative_path: str, key: str) -> str:
+    manifest = safe_load((_repo_root() / relative_path).read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise AssertionError(f"{relative_path} did not parse to a mapping")
+    data = manifest.get("data")
+    if not isinstance(data, dict) or not isinstance(data.get(key), str):
+        raise AssertionError(f"{relative_path} missing data[{key!r}]")
+    return cast(str, data[key])
+
+
+def _mimir_groups() -> list[Mapping[str, object]]:
+    rules_yaml = _configmap_data(
+        "argocd/applications/observability/graf-mimir-rules.yaml",
+        "graf-rules.yaml",
+    )
+    payload = safe_load(rules_yaml)
+    if not isinstance(payload, dict) or not isinstance(payload.get("groups"), list):
+        raise AssertionError("embedded Mimir rules are malformed")
+    return cast(list[Mapping[str, object]], payload["groups"])
+
+
+class SchedulerObservabilityManifestTests(TestCase):
+    def test_api_availability_and_scheduler_availability_have_distinct_targets(
+        self,
+    ) -> None:
+        trading_group = next(
+            group
+            for group in _mimir_groups()
+            if group.get("name") == "torghut-trading.rules"
+        )
+        rules = cast(list[Mapping[str, object]], trading_group["rules"])
+        by_alert = {str(rule["alert"]): rule for rule in rules}
+
+        api_missing = str(by_alert["TorghutApiServiceMissing"]["expr"])
+        api_down = str(by_alert["TorghutActiveApiRevisionMetricsDown"]["expr"])
+        self.assertIn("kube_service_info", api_missing)
+        self.assertIn('service="torghut"', api_missing)
+        self.assertIn('service=~"torghut-[0-9]{5}-private"', api_down)
+        self.assertNotIn('service="torghut-scheduler"', api_missing)
+
+        for alert in ("TorghutSchedulerMetricsMissing", "TorghutSchedulerMetricsDown"):
+            expr = str(by_alert[alert]["expr"])
+            self.assertIn('service="torghut-scheduler"', expr)
+            self.assertIn('deployment="torghut-scheduler"', expr)
+            self.assertIn("kube_deployment_spec_replicas", expr)
+
+        writer_expr = str(by_alert["TorghutSchedulerWriterCountInvalid"]["expr"])
+        leadership_expr = str(by_alert["TorghutSchedulerLeadershipUnhealthy"]["expr"])
+        self.assertIn("torghut_scheduler_leadership_acquired", writer_expr)
+        self.assertIn("sum by (namespace)", writer_expr)
+        self.assertIn(") != 1", writer_expr)
+        self.assertIn("torghut_scheduler_leadership_healthy", leadership_expr)
+        for expr in (writer_expr, leadership_expr):
+            self.assertIn('service="torghut-scheduler"', expr)
+            self.assertIn("kube_deployment_spec_replicas", expr)
+            self.assertIn('deployment="torghut-scheduler"', expr)
+
+    def test_every_torghut_trading_rule_reads_scheduler_metrics(self) -> None:
+        expressions = [
+            str(rule.get("expr", ""))
+            for group in _mimir_groups()
+            for rule in cast(list[Mapping[str, object]], group.get("rules", []))
+            if "torghut_trading_" in str(rule.get("expr", ""))
+        ]
+        self.assertTrue(expressions)
+        for expression in expressions:
+            self.assertIn('service="torghut-scheduler"', expression)
+            self.assertNotIn('service="torghut"', expression)
+
+    def test_execution_dashboard_reads_scheduler_metrics(self) -> None:
+        dashboard_json = _configmap_data(
+            "argocd/applications/observability/torghut-execution-recovery-dashboard-configmap.yaml",
+            "torghut-execution-recovery-dashboard.json",
+        )
+        dashboard = json.loads(dashboard_json)
+        expressions = [
+            str(target.get("expr", ""))
+            for panel in dashboard.get("panels", [])
+            for target in panel.get("targets", [])
+            if "torghut_trading_" in str(target.get("expr", ""))
+        ]
+        self.assertTrue(expressions)
+        for expression in expressions:
+            self.assertIn('service="torghut-scheduler"', expression)
+            self.assertNotIn('service="torghut"', expression)
+
+    def test_namespace_alloy_discovers_scheduler_metrics_port(self) -> None:
+        alloy_config = _configmap_data(
+            "argocd/applications/torghut/alloy-configmap.yaml",
+            "config.river",
+        )
+        self.assertIn(
+            'regex         = "metric(s)?;.*|http;torghut-[0-9]{5}-private"',
+            alloy_config,
+        )

--- a/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
@@ -90,6 +90,8 @@ class SingleWriterSchedulerManifestTests(TestCase):
         )
         self.assertEqual(env["TORGHUT_PROCESS_ROLE"].get("value"), "scheduler")
         self.assertEqual(env["TRADING_ENABLED"].get("value"), "true")
+        self.assertEqual(env["TRADING_ORDER_MAX_ATTEMPTS"].get("value"), "1")
+        self.assertEqual(env["TRADING_EXECUTION_MAX_RETRIES"].get("value"), "0")
         self.assertEqual(
             env["TRADING_SCHEDULER_LEADERSHIP_REQUIRED"].get("value"), "true"
         )

--- a/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, cast
+from unittest import TestCase
+
+from yaml import safe_load
+
+
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "argocd").is_dir() and (parent / "services" / "torghut").is_dir():
+            return parent
+    raise AssertionError("repository root not found")
+
+
+def _load(relative_path: str) -> dict[str, object]:
+    payload = safe_load((_repo_root() / relative_path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{relative_path} did not parse to a mapping")
+    return cast(dict[str, object], payload)
+
+
+def _pod_spec(manifest: Mapping[str, object]) -> Mapping[str, object]:
+    spec = cast(Mapping[str, object], manifest["spec"])
+    template = cast(Mapping[str, object], spec["template"])
+    return cast(Mapping[str, object], template["spec"])
+
+
+def _container(manifest: Mapping[str, object]) -> Mapping[str, object]:
+    containers = cast(list[Mapping[str, object]], _pod_spec(manifest)["containers"])
+    if len(containers) != 1:
+        raise AssertionError("expected exactly one container")
+    return containers[0]
+
+
+def _env_by_name(container: Mapping[str, object]) -> dict[str, Mapping[str, object]]:
+    entries = cast(list[Mapping[str, object]], container.get("env", []))
+    result: dict[str, Mapping[str, object]] = {}
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            raise AssertionError("environment entry missing name")
+        if name in result:
+            raise AssertionError(f"duplicate environment entry: {name}")
+        result[name] = entry
+    return result
+
+
+class SingleWriterSchedulerManifestTests(TestCase):
+    def test_api_is_stateless_and_syncs_before_scheduler(self) -> None:
+        manifest = _load("argocd/applications/torghut/knative-service.yaml")
+        metadata = cast(Mapping[str, object], manifest["metadata"])
+        annotations = cast(Mapping[str, object], metadata["annotations"])
+        template = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], manifest["spec"])["template"],
+        )
+        template_metadata = cast(Mapping[str, object], template["metadata"])
+        template_annotations = cast(
+            Mapping[str, object], template_metadata["annotations"]
+        )
+        env = _env_by_name(_container(manifest))
+
+        self.assertEqual(annotations["argocd.argoproj.io/sync-wave"], "0")
+        self.assertNotIn("autoscaling.knative.dev/minScale", template_annotations)
+        self.assertEqual(env["TORGHUT_PROCESS_ROLE"].get("value"), "api")
+
+    def test_scheduler_is_contained_recreate_and_has_dedicated_probes(self) -> None:
+        manifest = _load("argocd/applications/torghut/scheduler-deployment.yaml")
+        metadata = cast(Mapping[str, object], manifest["metadata"])
+        annotations = cast(Mapping[str, object], metadata["annotations"])
+        spec = cast(Mapping[str, object], manifest["spec"])
+        strategy = cast(Mapping[str, object], spec["strategy"])
+        pod_spec = _pod_spec(manifest)
+        container = _container(manifest)
+        env = _env_by_name(container)
+
+        self.assertEqual(annotations["argocd.argoproj.io/sync-wave"], "2")
+        self.assertEqual(spec["replicas"], 0)
+        self.assertEqual(spec["revisionHistoryLimit"], 1)
+        self.assertEqual(strategy["type"], "Recreate")
+        self.assertEqual(pod_spec["serviceAccountName"], "torghut-runtime")
+        self.assertEqual(pod_spec["terminationGracePeriodSeconds"], 60)
+        self.assertEqual(container["command"], ["uvicorn"])
+        self.assertEqual(
+            container["args"],
+            ["app.scheduler_main:app", "--host", "0.0.0.0", "--port", "8183"],
+        )
+        self.assertEqual(env["TORGHUT_PROCESS_ROLE"].get("value"), "scheduler")
+        self.assertEqual(
+            env["TRADING_SCHEDULER_LEADERSHIP_REQUIRED"].get("value"), "true"
+        )
+        self.assertEqual(
+            env["TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS"].get("value"), "5"
+        )
+        readiness = cast(Mapping[str, object], container["readinessProbe"])
+        readiness_http = cast(Mapping[str, object], readiness["httpGet"])
+        liveness = cast(Mapping[str, object], container["livenessProbe"])
+        liveness_http = cast(Mapping[str, object], liveness["httpGet"])
+        self.assertEqual(readiness_http["path"], "/scheduler/readyz")
+        self.assertEqual(liveness_http["path"], "/healthz")
+        security_context = cast(Mapping[str, object], container["securityContext"])
+        seccomp = cast(Mapping[str, object], security_context["seccompProfile"])
+        self.assertEqual(seccomp["type"], "Unconfined")
+
+    def test_scheduler_and_api_runtime_environment_cannot_drift(self) -> None:
+        api_env = _env_by_name(
+            _container(_load("argocd/applications/torghut/knative-service.yaml"))
+        )
+        scheduler_env = _env_by_name(
+            _container(_load("argocd/applications/torghut/scheduler-deployment.yaml"))
+        )
+        api_env.pop("TORGHUT_PROCESS_ROLE")
+        scheduler_env.pop("TORGHUT_PROCESS_ROLE")
+        scheduler_only = {
+            "TRADING_SCHEDULER_LEADERSHIP_REQUIRED",
+            "TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS",
+        }
+        for name in scheduler_only:
+            self.assertNotIn(name, api_env)
+            scheduler_env.pop(name)
+
+        self.assertEqual(scheduler_env, api_env)
+
+    def test_scheduler_metrics_service_is_discoverable_by_alloy(self) -> None:
+        service = _load("argocd/applications/torghut/scheduler-service.yaml")
+        metadata = cast(Mapping[str, object], service["metadata"])
+        spec = cast(Mapping[str, object], service["spec"])
+        ports = cast(list[Mapping[str, object]], spec["ports"])
+
+        self.assertEqual(metadata["name"], "torghut-scheduler")
+        self.assertEqual(
+            ports, [{"name": "metrics", "port": 8183, "targetPort": "metrics"}]
+        )
+
+    def test_all_single_writer_resources_are_rendered(self) -> None:
+        kustomization = _load("argocd/applications/torghut/kustomization.yaml")
+        resources = set(cast(list[str], kustomization["resources"]))
+        self.assertTrue(
+            {
+                "scheduler-deployment.yaml",
+                "scheduler-service.yaml",
+            }.issubset(resources)
+        )
+        self.assertFalse(
+            any("revision-prune" in resource for resource in resources),
+            "revision cleanup is a guarded one-time operation, not a persistent Job",
+        )
+
+    def test_runtime_image_requires_scheduler_entrypoint(self) -> None:
+        dockerfile = (_repo_root() / "services/torghut/Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(dockerfile.count("test -f /app/app/scheduler_main.py"), 2)

--- a/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Mapping, cast
 from unittest import TestCase
 
-from yaml import safe_load
+from yaml import safe_load, safe_load_all
 
 
 def _repo_root() -> Path:
@@ -94,6 +94,16 @@ class SingleWriterSchedulerManifestTests(TestCase):
         self.assertEqual(
             env["TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS"].get("value"), "5"
         )
+        self.assertEqual(
+            env["TRADING_SCHEDULER_SHUTDOWN_DRAIN_SECONDS"].get("value"), "45"
+        )
+        self.assertEqual(
+            env["TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS"].get("value"), "30"
+        )
+        self.assertGreater(
+            pod_spec["terminationGracePeriodSeconds"],
+            int(cast(str, env["TRADING_SCHEDULER_SHUTDOWN_DRAIN_SECONDS"]["value"])),
+        )
         readiness = cast(Mapping[str, object], container["readinessProbe"])
         readiness_http = cast(Mapping[str, object], readiness["httpGet"])
         liveness = cast(Mapping[str, object], container["livenessProbe"])
@@ -147,6 +157,50 @@ class SingleWriterSchedulerManifestTests(TestCase):
             any("revision-prune" in resource for resource in resources),
             "revision cleanup is a guarded one-time operation, not a persistent Job",
         )
+
+        manifest_root = _repo_root() / "argocd/applications/torghut"
+        for resource_path in manifest_root.rglob("*.yaml"):
+            for document in safe_load_all(resource_path.read_text(encoding="utf-8")):
+                if not isinstance(document, dict):
+                    continue
+                manifest = cast(dict[str, object], document)
+                kind = str(manifest.get("kind") or "")
+                serialized = str(manifest).lower()
+                if kind in {"Job", "CronJob"}:
+                    self.assertNotIn("revisions.serving.knative.dev", serialized)
+                    self.assertNotIn("delete revision", serialized)
+                    self.assertNotIn("delete revisions", serialized)
+                if kind not in {"Role", "ClusterRole"}:
+                    continue
+                rules = cast(list[Mapping[str, object]], manifest.get("rules", []))
+                for rule in rules:
+                    api_groups = cast(list[str], rule.get("apiGroups", []))
+                    rule_resources = cast(list[str], rule.get("resources", []))
+                    verbs = cast(list[str], rule.get("verbs", []))
+                    grants_revision_delete = (
+                        "serving.knative.dev" in api_groups
+                        and bool({"revisions", "revisions/*"} & set(rule_resources))
+                        and bool({"delete", "deletecollection", "*"} & set(verbs))
+                    )
+                    self.assertFalse(
+                        grants_revision_delete,
+                        "revision cleanup must not have persistent delete RBAC",
+                    )
+
+    def test_one_time_cleanup_runbook_rejects_stale_or_tagged_traffic(self) -> None:
+        readme = (_repo_root() / "argocd/applications/torghut/README.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            '[[ "$KSVC_GENERATION" == "$KSVC_OBSERVED_GENERATION" ]]',
+            readme,
+        )
+        self.assertIn('PINNED_KSVC_UID="$KSVC_UID"', readme)
+        self.assertIn('PINNED_KSVC_GENERATION="$KSVC_GENERATION"', readme)
+        self.assertIn('(.spec.traffic[0].tag // "") == ""', readme)
+        self.assertIn('(.status.traffic[0].tag // "") == ""', readme)
+        self.assertIn('(.status.traffic[0].url // "") == ""', readme)
 
     def test_runtime_image_requires_scheduler_entrypoint(self) -> None:
         dockerfile = (_repo_root() / "services/torghut/Dockerfile").read_text(

--- a/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
@@ -65,6 +65,7 @@ class SingleWriterSchedulerManifestTests(TestCase):
         self.assertEqual(annotations["argocd.argoproj.io/sync-wave"], "0")
         self.assertNotIn("autoscaling.knative.dev/minScale", template_annotations)
         self.assertEqual(env["TORGHUT_PROCESS_ROLE"].get("value"), "api")
+        self.assertEqual(env["TRADING_ENABLED"].get("value"), "false")
 
     def test_scheduler_is_contained_recreate_and_has_dedicated_probes(self) -> None:
         manifest = _load("argocd/applications/torghut/scheduler-deployment.yaml")
@@ -88,6 +89,7 @@ class SingleWriterSchedulerManifestTests(TestCase):
             ["app.scheduler_main:app", "--host", "0.0.0.0", "--port", "8183"],
         )
         self.assertEqual(env["TORGHUT_PROCESS_ROLE"].get("value"), "scheduler")
+        self.assertEqual(env["TRADING_ENABLED"].get("value"), "true")
         self.assertEqual(
             env["TRADING_SCHEDULER_LEADERSHIP_REQUIRED"].get("value"), "true"
         )
@@ -123,6 +125,10 @@ class SingleWriterSchedulerManifestTests(TestCase):
         )
         api_env.pop("TORGHUT_PROCESS_ROLE")
         scheduler_env.pop("TORGHUT_PROCESS_ROLE")
+        api_trading_enabled = api_env.pop("TRADING_ENABLED")
+        scheduler_trading_enabled = scheduler_env.pop("TRADING_ENABLED")
+        self.assertEqual(api_trading_enabled.get("value"), "false")
+        self.assertEqual(scheduler_trading_enabled.get("value"), "true")
         scheduler_only = {
             "TRADING_SCHEDULER_LEADERSHIP_REQUIRED",
             "TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS",

--- a/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_single_writer_scheduler_manifest.py
@@ -139,6 +139,39 @@ class SingleWriterSchedulerManifestTests(TestCase):
 
         self.assertEqual(scheduler_env, api_env)
 
+    def test_simulation_keeps_an_isolated_local_scheduler_role(self) -> None:
+        live_env = _env_by_name(
+            _container(_load("argocd/applications/torghut/knative-service.yaml"))
+        )
+        scheduler_env = _env_by_name(
+            _container(_load("argocd/applications/torghut/scheduler-deployment.yaml"))
+        )
+        simulation_env = _env_by_name(
+            _container(_load("argocd/applications/torghut/knative-service-sim.yaml"))
+        )
+
+        self.assertEqual(live_env["TORGHUT_PROCESS_ROLE"].get("value"), "api")
+        self.assertEqual(
+            scheduler_env["TORGHUT_PROCESS_ROLE"].get("value"), "scheduler"
+        )
+        self.assertEqual(
+            simulation_env["TORGHUT_PROCESS_ROLE"].get("value"), "simulation"
+        )
+        self.assertEqual(simulation_env["TRADING_MODE"].get("value"), "paper")
+        self.assertEqual(simulation_env["TRADING_ENABLED"].get("value"), "false")
+        self.assertEqual(
+            simulation_env["TRADING_SCHEDULER_LEADERSHIP_REQUIRED"].get("value"),
+            "true",
+        )
+        self.assertEqual(
+            simulation_env["TRADING_SCHEDULER_LEADERSHIP_LOCK_NAME"].get("value"),
+            "torghut:simulation-scheduler",
+        )
+        self.assertNotEqual(
+            simulation_env["TRADING_SCHEDULER_LEADERSHIP_LOCK_NAME"].get("value"),
+            "torghut:trading-scheduler",
+        )
+
     def test_scheduler_metrics_service_is_discoverable_by_alloy(self) -> None:
         service = _load("argocd/applications/torghut/scheduler-service.yaml")
         metadata = cast(Mapping[str, object], service["metadata"])

--- a/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
+++ b/services/torghut/tests/live_config_manifest_contract/test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim.py
@@ -261,9 +261,9 @@ class TestTorghutScheduledMaintenance(_TestLiveConfigManifestContractBase):
         env_from = first_container.get("envFrom", [])
         self.assertEqual(env_from, [])
 
-    def test_manifest_simple_lane_profile_is_enforced(self) -> None:
+    def test_api_manifest_simple_lane_profile_is_enforced(self) -> None:
         env = _load_torghut_knative_env()
-        self.assertTrue(_manifest_bool(env, "TRADING_ENABLED"))
+        self.assertFalse(_manifest_bool(env, "TRADING_ENABLED"))
         self.assertEqual(env.get("TRADING_MODE"), "live")
         self.assertEqual(env.get("TRADING_PIPELINE_MODE"), "simple")
         self.assertEqual(env.get("TRADING_UNIVERSE_SOURCE"), "static")

--- a/services/torghut/tests/order_idempotency/test_decision_hash_stable_for_same_intent.py
+++ b/services/torghut/tests/order_idempotency/test_decision_hash_stable_for_same_intent.py
@@ -408,7 +408,7 @@ class TestDecisionHashStableForSameIntent(_TestOrderIdempotencyBase):
             self.assertEqual(len(executions), 1)
             self.assertEqual(len(alpaca_client.submitted), 1)
 
-    def test_retry_attempt_client_id_is_recovered_without_duplicate_submit(
+    def test_legacy_retry_attempt_client_id_is_recovered_without_duplicate_submit(
         self,
     ) -> None:
         settings.trading_mode = "live"
@@ -445,11 +445,11 @@ class TestDecisionHashStableForSameIntent(_TestOrderIdempotencyBase):
             )
             assert decision_row.decision_hash is not None
 
-            retry_client_order_id = f"{decision_row.decision_hash}-r2"
+            retry_client_order_id = f"{decision_row.decision_hash}-r3"
             alpaca_client = FakeAlpacaClient()
             alpaca_client.submitted.append(
                 {
-                    "id": "order-retry-2",
+                    "id": "order-retry-3",
                     "client_order_id": retry_client_order_id,
                     "symbol": "AAPL",
                     "side": "buy",
@@ -475,7 +475,7 @@ class TestDecisionHashStableForSameIntent(_TestOrderIdempotencyBase):
             persisted = session.execute(select(Execution)).scalars().all()
             self.assertEqual(len(persisted), 1)
             self.assertEqual(persisted[0].client_order_id, retry_client_order_id)
-            self.assertEqual(persisted[0].alpaca_order_id, "order-retry-2")
+            self.assertEqual(persisted[0].alpaca_order_id, "order-retry-3")
 
     def test_submit_order_records_tca_row_with_null_safe_defaults(self) -> None:
         with self.session_local() as session:

--- a/services/torghut/tests/scheduler/test_leadership.py
+++ b/services/torghut/tests/scheduler/test_leadership.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from app.trading.scheduler.leadership import (
+    DEFAULT_SCHEDULER_ADVISORY_LOCK_ID,
+    PostgresSchedulerLeadership,
+    SchedulerLeadershipError,
+    scheduler_advisory_lock_id,
+)
+
+
+NOW = datetime(2026, 7, 11, tzinfo=timezone.utc)
+
+
+def _engine_with_results(*values: object) -> tuple[Mock, Mock]:
+    connection = Mock()
+    connection.execute.side_effect = [
+        Mock(scalar_one=Mock(return_value=value)) for value in values
+    ]
+    engine = Mock()
+    engine.connect.return_value = connection
+    return engine, connection
+
+
+def test_lock_identifier_is_stable_signed_bigint() -> None:
+    assert scheduler_advisory_lock_id() == DEFAULT_SCHEDULER_ADVISORY_LOCK_ID
+    assert scheduler_advisory_lock_id() == scheduler_advisory_lock_id()
+    assert -(2**63) <= DEFAULT_SCHEDULER_ADVISORY_LOCK_ID < 2**63
+
+
+def test_disabled_leadership_never_opens_database_connection() -> None:
+    engine = Mock()
+    leadership = PostgresSchedulerLeadership(
+        engine=engine,
+        required=False,
+        now=lambda: NOW,
+    )
+
+    leadership.acquire()
+
+    assert leadership.check() is True
+    assert leadership.status.healthy is True
+    assert leadership.status.acquired is False
+    engine.connect.assert_not_called()
+
+
+def test_required_leadership_holds_dedicated_session_until_release() -> None:
+    engine, connection = _engine_with_results(True, 1, True)
+    leadership = PostgresSchedulerLeadership(
+        engine=engine,
+        required=True,
+        now=lambda: NOW,
+    )
+
+    leadership.acquire()
+
+    assert leadership.status.acquired is True
+    assert leadership.status.healthy is True
+    assert leadership.check() is True
+    assert leadership.status.last_checked_at == NOW
+
+    leadership.release()
+
+    assert leadership.status.acquired is False
+    assert leadership.status.healthy is False
+    assert leadership.status.failure_reason == "leadership_released"
+    connection.close.assert_called_once()
+
+
+def test_contended_leadership_fails_closed_and_closes_session() -> None:
+    engine, connection = _engine_with_results(False)
+    leadership = PostgresSchedulerLeadership(
+        engine=engine,
+        required=True,
+        now=lambda: NOW,
+    )
+
+    with pytest.raises(SchedulerLeadershipError, match="held by another process"):
+        leadership.acquire()
+
+    assert leadership.status.failure_reason == "leadership_contended"
+    assert leadership.status.healthy is False
+    connection.close.assert_called_once()
+
+
+def test_connection_loss_revokes_local_leadership() -> None:
+    engine, connection = _engine_with_results(True)
+    connection.execute.side_effect = [
+        Mock(scalar_one=Mock(return_value=True)),
+        OperationalError("SELECT 1", {}, RuntimeError("connection lost")),
+    ]
+    leadership = PostgresSchedulerLeadership(
+        engine=engine,
+        required=True,
+        now=lambda: NOW,
+    )
+    leadership.acquire()
+
+    assert leadership.check() is False
+    assert leadership.status.acquired is False
+    assert (
+        leadership.status.failure_reason
+        == "leadership_connection_lost:OperationalError"
+    )
+    connection.close.assert_called_once()

--- a/services/torghut/tests/scheduler/test_leadership.py
+++ b/services/torghut/tests/scheduler/test_leadership.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from sqlalchemy.exc import OperationalError
 
+from app.config import settings
+from app.trading.scheduler import runtime
 from app.trading.scheduler.leadership import (
     DEFAULT_SCHEDULER_ADVISORY_LOCK_ID,
+    DEFAULT_SCHEDULER_ADVISORY_LOCK_NAME,
     PostgresSchedulerLeadership,
     SchedulerLeadershipError,
     scheduler_advisory_lock_id,
@@ -31,6 +34,25 @@ def test_lock_identifier_is_stable_signed_bigint() -> None:
     assert scheduler_advisory_lock_id() == DEFAULT_SCHEDULER_ADVISORY_LOCK_ID
     assert scheduler_advisory_lock_id() == scheduler_advisory_lock_id()
     assert -(2**63) <= DEFAULT_SCHEDULER_ADVISORY_LOCK_ID < 2**63
+    assert scheduler_advisory_lock_id(
+        "torghut:simulation-scheduler"
+    ) != scheduler_advisory_lock_id(DEFAULT_SCHEDULER_ADVISORY_LOCK_NAME)
+
+
+def test_scheduler_uses_configured_advisory_lock_namespace() -> None:
+    lock_name = "torghut:simulation-scheduler"
+    with (
+        patch.object(settings, "trading_scheduler_leadership_required", True),
+        patch.object(settings, "trading_scheduler_leadership_lock_name", lock_name),
+        patch.object(runtime, "PostgresSchedulerLeadership") as leadership_class,
+    ):
+        runtime.TradingScheduler()
+
+    leadership_class.assert_called_once_with(
+        engine=runtime.database_engine,
+        required=True,
+        lock_id=scheduler_advisory_lock_id(lock_name),
+    )
 
 
 def test_disabled_leadership_never_opens_database_connection() -> None:

--- a/services/torghut/tests/scheduler/test_runtime_leadership.py
+++ b/services/torghut/tests/scheduler/test_runtime_leadership.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from dataclasses import replace
 from types import SimpleNamespace
-from typing import cast
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import Mock, patch
 
@@ -54,15 +54,32 @@ class _FakeLeadership:
         )
 
 
+class _StoppedLoopScheduler(TradingScheduler):
+    async def _run_loop(self) -> None:
+        await self._stop_event.wait()
+
+    def _assert_trading_shorts_startup_policy(self) -> None:
+        return
+
+
+class _BlockingBrokerScheduler(TradingScheduler):
+    def _assert_trading_shorts_startup_policy(self) -> None:
+        return
+
+    def _evaluate_safety_controls(self) -> None:
+        return
+
+
 class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
     @staticmethod
-    def _prepared_scheduler(leadership: _FakeLeadership) -> TradingScheduler:
-        async def block_until_cancelled() -> None:
-            await asyncio.Event().wait()
-
-        scheduler = TradingScheduler(
-            leadership=leadership,  # type: ignore[arg-type]
-            fatal_exit=Mock(),
+    def _prepared_scheduler(
+        leadership: _FakeLeadership,
+        *,
+        fatal_exit: Mock | None = None,
+    ) -> TradingScheduler:
+        scheduler = _StoppedLoopScheduler(
+            leadership=leadership,
+            fatal_exit=fatal_exit or Mock(),
         )
         scheduler._pipelines = [
             SimpleNamespace(
@@ -71,8 +88,6 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             )
         ]
         scheduler._pipeline = scheduler._pipelines[0]
-        scheduler._assert_trading_shorts_startup_policy = Mock()  # type: ignore[method-assign]
-        scheduler._run_loop = block_until_cancelled  # type: ignore[method-assign]
         return scheduler
 
     async def test_start_acquires_and_stop_releases_writer_fence(self) -> None:
@@ -121,7 +136,9 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
     ) -> None:
         leadership = _FakeLeadership()
         leadership.check_result = False
-        scheduler = self._prepared_scheduler(leadership)
+        fatal_called = asyncio.Event()
+        fatal_exit = Mock(side_effect=lambda _code: fatal_called.set())
+        scheduler = self._prepared_scheduler(leadership, fatal_exit=fatal_exit)
 
         with patch.object(
             settings,
@@ -129,11 +146,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             0.001,
         ):
             await scheduler.start()
-            for _ in range(100):
-                if scheduler.state.emergency_stop_active:
-                    break
-                await asyncio.sleep(0.001)
-            await asyncio.sleep(0)
+            await asyncio.wait_for(fatal_called.wait(), timeout=1.0)
 
         self.assertTrue(scheduler.state.emergency_stop_active)
         self.assertEqual(
@@ -146,14 +159,16 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         )
         self.assertTrue(scheduler._stop_event.is_set())
         self.assertTrue(scheduler._task is not None and scheduler._task.cancelled())
-        cast(Mock, scheduler._fatal_exit).assert_called_once_with(70)
+        fatal_exit.assert_called_once_with(70)
 
         await scheduler.stop()
 
     async def test_monitor_crash_cancels_loop_and_fails_closed(self) -> None:
         leadership = _FakeLeadership()
         leadership.check_error = RuntimeError("monitor exploded")
-        scheduler = self._prepared_scheduler(leadership)
+        fatal_called = asyncio.Event()
+        fatal_exit = Mock(side_effect=lambda _code: fatal_called.set())
+        scheduler = self._prepared_scheduler(leadership, fatal_exit=fatal_exit)
 
         with patch.object(
             settings,
@@ -161,11 +176,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             0.001,
         ):
             await scheduler.start()
-            for _ in range(100):
-                if scheduler.state.emergency_stop_active:
-                    break
-                await asyncio.sleep(0.001)
-            await asyncio.sleep(0)
+            await asyncio.wait_for(fatal_called.wait(), timeout=1.0)
 
         self.assertTrue(scheduler.state.emergency_stop_active)
         self.assertEqual(
@@ -177,9 +188,56 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             "scheduler_leadership_monitor_failed:RuntimeError",
         )
         self.assertTrue(scheduler._task is not None and scheduler._task.cancelled())
-        cast(Mock, scheduler._fatal_exit).assert_called_once_with(70)
+        fatal_exit.assert_called_once_with(70)
 
         await scheduler.stop()
+
+    async def test_shutdown_timeout_keeps_writer_fence_until_broker_work_drains(
+        self,
+    ) -> None:
+        leadership = _FakeLeadership()
+        fatal_exit = Mock()
+        scheduler = _BlockingBrokerScheduler(
+            leadership=leadership,
+            fatal_exit=fatal_exit,
+        )
+        run_once_started = threading.Event()
+        allow_run_once_to_finish = threading.Event()
+
+        def blocking_run_once() -> None:
+            run_once_started.set()
+            allow_run_once_to_finish.wait(timeout=2.0)
+
+        pipeline = SimpleNamespace(
+            account_label="paper",
+            order_feed_ingestor=SimpleNamespace(close=Mock()),
+            run_once=blocking_run_once,
+        )
+        scheduler._pipelines = [pipeline]
+        scheduler._pipeline = pipeline
+
+        with (
+            patch.object(settings, "trading_scheduler_shutdown_drain_seconds", 0.01),
+            patch.object(settings, "trading_scheduler_leadership_check_seconds", 0.01),
+        ):
+            await scheduler.start()
+            self.assertTrue(
+                await asyncio.to_thread(run_once_started.wait, 1.0),
+                "run_once did not start",
+            )
+            scheduler_task = scheduler._task
+            await scheduler.stop()
+
+        fatal_exit.assert_called_once_with(70)
+        self.assertEqual(leadership.release_calls, 0)
+        self.assertTrue(leadership.status.acquired)
+        self.assertIs(scheduler._task, scheduler_task)
+
+        allow_run_once_to_finish.set()
+        if scheduler_task is not None:
+            await asyncio.wait_for(scheduler_task, timeout=1.0)
+        await scheduler.stop()
+        self.assertEqual(leadership.release_calls, 1)
 
 
 __all__ = ["TradingSchedulerLeadershipTests"]

--- a/services/torghut/tests/scheduler/test_runtime_leadership.py
+++ b/services/torghut/tests/scheduler/test_runtime_leadership.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from types import SimpleNamespace
+from typing import cast
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import Mock, patch
 
@@ -59,7 +60,10 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         async def block_until_cancelled() -> None:
             await asyncio.Event().wait()
 
-        scheduler = TradingScheduler(leadership=leadership)  # type: ignore[arg-type]
+        scheduler = TradingScheduler(
+            leadership=leadership,  # type: ignore[arg-type]
+            fatal_exit=Mock(),
+        )
         scheduler._pipelines = [
             SimpleNamespace(
                 account_label="paper",
@@ -142,6 +146,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         )
         self.assertTrue(scheduler._stop_event.is_set())
         self.assertTrue(scheduler._task is not None and scheduler._task.cancelled())
+        cast(Mock, scheduler._fatal_exit).assert_called_once_with(70)
 
         await scheduler.stop()
 
@@ -172,6 +177,7 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             "scheduler_leadership_monitor_failed:RuntimeError",
         )
         self.assertTrue(scheduler._task is not None and scheduler._task.cancelled())
+        cast(Mock, scheduler._fatal_exit).assert_called_once_with(70)
 
         await scheduler.stop()
 

--- a/services/torghut/tests/scheduler/test_runtime_leadership.py
+++ b/services/torghut/tests/scheduler/test_runtime_leadership.py
@@ -22,6 +22,7 @@ class _FakeLeadership:
         self.check_calls = 0
         self.release_calls = 0
         self.check_result = True
+        self.check_error: Exception | None = None
 
     def acquire(self) -> None:
         self.acquire_calls += 1
@@ -31,6 +32,8 @@ class _FakeLeadership:
 
     def check(self) -> bool:
         self.check_calls += 1
+        if self.check_error is not None:
+            raise self.check_error
         if not self.check_result:
             self.status = replace(
                 self.status,
@@ -95,6 +98,20 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             "scheduler_startup_failed:SchedulerLeadershipError",
         )
 
+    async def test_post_acquire_startup_failure_releases_writer_fence(self) -> None:
+        leadership = _FakeLeadership()
+        scheduler = self._prepared_scheduler(leadership)
+        scheduler._assert_trading_shorts_startup_policy = Mock(
+            side_effect=RuntimeError("startup policy failed")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "startup policy failed"):
+            await scheduler.start()
+
+        self.assertIsNone(scheduler._task)
+        self.assertEqual(leadership.acquire_calls, 1)
+        self.assertEqual(leadership.release_calls, 1)
+
     async def test_leadership_loss_cancels_loop_and_latches_emergency_stop(
         self,
     ) -> None:
@@ -124,6 +141,36 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             "scheduler_leadership_lost:leadership_connection_lost:OperationalError",
         )
         self.assertTrue(scheduler._stop_event.is_set())
+        self.assertTrue(scheduler._task is not None and scheduler._task.cancelled())
+
+        await scheduler.stop()
+
+    async def test_monitor_crash_cancels_loop_and_fails_closed(self) -> None:
+        leadership = _FakeLeadership()
+        leadership.check_error = RuntimeError("monitor exploded")
+        scheduler = self._prepared_scheduler(leadership)
+
+        with patch.object(
+            settings,
+            "trading_scheduler_leadership_check_seconds",
+            0.001,
+        ):
+            await scheduler.start()
+            for _ in range(100):
+                if scheduler.state.emergency_stop_active:
+                    break
+                await asyncio.sleep(0.001)
+            await asyncio.sleep(0)
+
+        self.assertTrue(scheduler.state.emergency_stop_active)
+        self.assertEqual(
+            scheduler.state.emergency_stop_reason,
+            "scheduler_leadership_monitor_failed",
+        )
+        self.assertEqual(
+            scheduler.state.last_error,
+            "scheduler_leadership_monitor_failed:RuntimeError",
+        )
         self.assertTrue(scheduler._task is not None and scheduler._task.cancelled())
 
         await scheduler.stop()

--- a/services/torghut/tests/scheduler/test_runtime_leadership.py
+++ b/services/torghut/tests/scheduler/test_runtime_leadership.py
@@ -70,6 +70,16 @@ class _BlockingBrokerScheduler(TradingScheduler):
         return
 
 
+class _ReturningLoopScheduler(_StoppedLoopScheduler):
+    async def _run_loop(self) -> None:
+        return
+
+
+class _FailingLoopScheduler(_StoppedLoopScheduler):
+    async def _run_loop(self) -> None:
+        raise RuntimeError("scheduler loop exploded")
+
+
 class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
     @staticmethod
     def _prepared_scheduler(
@@ -92,7 +102,8 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
 
     async def test_start_acquires_and_stop_releases_writer_fence(self) -> None:
         leadership = _FakeLeadership()
-        scheduler = self._prepared_scheduler(leadership)
+        fatal_exit = Mock()
+        scheduler = self._prepared_scheduler(leadership, fatal_exit=fatal_exit)
 
         await scheduler.start()
         await scheduler.stop()
@@ -100,6 +111,81 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
         self.assertEqual(leadership.acquire_calls, 1)
         self.assertEqual(leadership.release_calls, 1)
         self.assertFalse(scheduler.leadership_status.acquired)
+        fatal_exit.assert_not_called()
+
+    async def test_unexpected_loop_return_is_process_fatal(self) -> None:
+        leadership = _FakeLeadership()
+        fatal_called = asyncio.Event()
+        fatal_exit = Mock(side_effect=lambda _code: fatal_called.set())
+        scheduler = _ReturningLoopScheduler(
+            leadership=leadership,
+            fatal_exit=fatal_exit,
+        )
+        scheduler._pipelines = self._prepared_scheduler(leadership)._pipelines
+        scheduler._pipeline = scheduler._pipelines[0]
+
+        await scheduler.start()
+        await asyncio.wait_for(fatal_called.wait(), timeout=1.0)
+
+        self.assertEqual(
+            scheduler.state.last_error,
+            "scheduler_loop_exited_unexpectedly:task_returned",
+        )
+        self.assertEqual(
+            scheduler.state.emergency_stop_reason,
+            "scheduler_loop_exited_unexpectedly",
+        )
+        fatal_exit.assert_called_once_with(70)
+        await scheduler.stop()
+
+    async def test_unexpected_loop_exception_is_process_fatal(self) -> None:
+        leadership = _FakeLeadership()
+        fatal_called = asyncio.Event()
+        fatal_exit = Mock(side_effect=lambda _code: fatal_called.set())
+        scheduler = _FailingLoopScheduler(
+            leadership=leadership,
+            fatal_exit=fatal_exit,
+        )
+        scheduler._pipelines = self._prepared_scheduler(leadership)._pipelines
+        scheduler._pipeline = scheduler._pipelines[0]
+
+        await scheduler.start()
+        await asyncio.wait_for(fatal_called.wait(), timeout=1.0)
+
+        self.assertEqual(
+            scheduler.state.last_error,
+            "scheduler_loop_failed:RuntimeError",
+        )
+        self.assertEqual(
+            scheduler.state.emergency_stop_reason,
+            "scheduler_loop_failed",
+        )
+        fatal_exit.assert_called_once_with(70)
+        await scheduler.stop()
+
+    async def test_unexpected_loop_cancellation_is_process_fatal(self) -> None:
+        leadership = _FakeLeadership()
+        fatal_called = asyncio.Event()
+        fatal_exit = Mock(side_effect=lambda _code: fatal_called.set())
+        scheduler = self._prepared_scheduler(leadership, fatal_exit=fatal_exit)
+
+        await scheduler.start()
+        scheduler_task = scheduler._task
+        self.assertIsNotNone(scheduler_task)
+        assert scheduler_task is not None
+        scheduler_task.cancel()
+        await asyncio.wait_for(fatal_called.wait(), timeout=1.0)
+
+        self.assertEqual(
+            scheduler.state.last_error,
+            "scheduler_loop_cancelled_unexpectedly:task_cancelled",
+        )
+        self.assertEqual(
+            scheduler.state.emergency_stop_reason,
+            "scheduler_loop_cancelled_unexpectedly",
+        )
+        fatal_exit.assert_called_once_with(70)
+        await scheduler.stop()
 
     async def test_startup_failure_releases_fence_without_starting_loop(self) -> None:
         leadership = _FakeLeadership(

--- a/services/torghut/tests/scheduler/test_runtime_leadership.py
+++ b/services/torghut/tests/scheduler/test_runtime_leadership.py
@@ -117,6 +117,28 @@ class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
             "scheduler_startup_failed:SchedulerLeadershipError",
         )
 
+    async def test_successful_leadership_retry_clears_only_startup_failure(
+        self,
+    ) -> None:
+        leadership = _FakeLeadership(
+            acquire_error=SchedulerLeadershipError("leadership contended")
+        )
+        scheduler = self._prepared_scheduler(leadership)
+        scheduler.state.last_trading_error = "preserve-latest-trading-error"
+
+        with self.assertRaisesRegex(SchedulerLeadershipError, "contended"):
+            await scheduler.start()
+
+        leadership.acquire_error = None
+        await scheduler.start()
+
+        self.assertIsNone(scheduler.state.last_error)
+        self.assertEqual(
+            scheduler.state.last_trading_error,
+            "preserve-latest-trading-error",
+        )
+        await scheduler.stop()
+
     async def test_post_acquire_startup_failure_releases_writer_fence(self) -> None:
         leadership = _FakeLeadership()
         scheduler = self._prepared_scheduler(leadership)

--- a/services/torghut/tests/scheduler/test_runtime_leadership.py
+++ b/services/torghut/tests/scheduler/test_runtime_leadership.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import Mock, patch
+
+from app.config import settings
+from app.trading.scheduler.leadership import (
+    SchedulerLeadershipError,
+    SchedulerLeadershipStatus,
+)
+from app.trading.scheduler.runtime import TradingScheduler
+
+
+class _FakeLeadership:
+    def __init__(self, *, acquire_error: Exception | None = None) -> None:
+        self.acquire_error = acquire_error
+        self.status = SchedulerLeadershipStatus(required=True, lock_id=42)
+        self.acquire_calls = 0
+        self.check_calls = 0
+        self.release_calls = 0
+        self.check_result = True
+
+    def acquire(self) -> None:
+        self.acquire_calls += 1
+        if self.acquire_error is not None:
+            raise self.acquire_error
+        self.status = replace(self.status, acquired=True, healthy=True)
+
+    def check(self) -> bool:
+        self.check_calls += 1
+        if not self.check_result:
+            self.status = replace(
+                self.status,
+                acquired=False,
+                healthy=False,
+                failure_reason="leadership_connection_lost:OperationalError",
+            )
+        return self.check_result
+
+    def release(self) -> None:
+        self.release_calls += 1
+        self.status = replace(
+            self.status,
+            acquired=False,
+            healthy=False,
+            failure_reason="leadership_released",
+        )
+
+
+class TradingSchedulerLeadershipTests(IsolatedAsyncioTestCase):
+    @staticmethod
+    def _prepared_scheduler(leadership: _FakeLeadership) -> TradingScheduler:
+        async def block_until_cancelled() -> None:
+            await asyncio.Event().wait()
+
+        scheduler = TradingScheduler(leadership=leadership)  # type: ignore[arg-type]
+        scheduler._pipelines = [
+            SimpleNamespace(
+                account_label="paper",
+                order_feed_ingestor=SimpleNamespace(close=Mock()),
+            )
+        ]
+        scheduler._pipeline = scheduler._pipelines[0]
+        scheduler._assert_trading_shorts_startup_policy = Mock()  # type: ignore[method-assign]
+        scheduler._run_loop = block_until_cancelled  # type: ignore[method-assign]
+        return scheduler
+
+    async def test_start_acquires_and_stop_releases_writer_fence(self) -> None:
+        leadership = _FakeLeadership()
+        scheduler = self._prepared_scheduler(leadership)
+
+        await scheduler.start()
+        await scheduler.stop()
+
+        self.assertEqual(leadership.acquire_calls, 1)
+        self.assertEqual(leadership.release_calls, 1)
+        self.assertFalse(scheduler.leadership_status.acquired)
+
+    async def test_startup_failure_releases_fence_without_starting_loop(self) -> None:
+        leadership = _FakeLeadership(
+            acquire_error=SchedulerLeadershipError("leadership contended")
+        )
+        scheduler = self._prepared_scheduler(leadership)
+
+        with self.assertRaisesRegex(SchedulerLeadershipError, "contended"):
+            await scheduler.start()
+
+        self.assertIsNone(scheduler._task)
+        self.assertEqual(leadership.release_calls, 0)
+        self.assertEqual(
+            scheduler.state.last_error,
+            "scheduler_startup_failed:SchedulerLeadershipError",
+        )
+
+    async def test_leadership_loss_cancels_loop_and_latches_emergency_stop(
+        self,
+    ) -> None:
+        leadership = _FakeLeadership()
+        leadership.check_result = False
+        scheduler = self._prepared_scheduler(leadership)
+
+        with patch.object(
+            settings,
+            "trading_scheduler_leadership_check_seconds",
+            0.001,
+        ):
+            await scheduler.start()
+            for _ in range(100):
+                if scheduler.state.emergency_stop_active:
+                    break
+                await asyncio.sleep(0.001)
+            await asyncio.sleep(0)
+
+        self.assertTrue(scheduler.state.emergency_stop_active)
+        self.assertEqual(
+            scheduler.state.emergency_stop_reason,
+            "scheduler_leadership_lost",
+        )
+        self.assertEqual(
+            scheduler.state.last_error,
+            "scheduler_leadership_lost:leadership_connection_lost:OperationalError",
+        )
+        self.assertTrue(scheduler._stop_event.is_set())
+        self.assertTrue(scheduler._task is not None and scheduler._task.cancelled())
+
+        await scheduler.stop()
+
+
+__all__ = ["TradingSchedulerLeadershipTests"]

--- a/services/torghut/tests/system/test_application_surface.py
+++ b/services/torghut/tests/system/test_application_surface.py
@@ -27,7 +27,7 @@ def test_build_registered_app_mounts_operational_routes(
         events.append(("api_routers", application.get_app() is app))
         return (_contract_router(),)
 
-    monkeypatch.setattr(application, "_current_app", None)
+    monkeypatch.setattr(application, "_apps_by_runtime_role", {})
     monkeypatch.setattr(application, "api_routers", api_routers)
 
     registered_app = application.build_registered_app(app)

--- a/services/torghut/tests/system/test_application_surface.py
+++ b/services/torghut/tests/system/test_application_surface.py
@@ -44,3 +44,20 @@ def test_build_registered_app_mounts_operational_routes(
 
     assert core_response.status_code == 200
     assert core_response.json() == {"surface": "core"}
+
+
+def test_build_registered_app_supports_simulation_runtime_role(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    app = FastAPI(title="torghut-simulation-contract-test")
+
+    monkeypatch.setattr(application, "_apps_by_runtime_role", {})
+    monkeypatch.setattr(application, "api_routers", lambda: (_contract_router(),))
+
+    registered_app = application.build_registered_app(
+        app,
+        runtime_role="simulation",
+    )
+
+    assert registered_app is app
+    assert application.get_app("simulation") is app

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import uuid
 from typing import Any, cast
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from alpaca.common.exceptions import APIError
 from alpaca.data.requests import StockBarsRequest
 from alpaca.trading.requests import GetOrdersRequest
+from requests import Response
+from requests.exceptions import HTTPError
 
 from app.alpaca_client import OrderFirewallViolation, TorghutAlpacaClient
 from app.alpaca_client import OrderFirewallToken
@@ -243,6 +246,115 @@ class TestAlpacaClient(TestCase):
         with self.assertRaises(AttributeError):
             getattr(client.trading, "cancel_orders")
 
+    def test_service_created_trading_client_makes_one_broker_mutation_attempt(
+        self,
+    ) -> None:
+        for status_code in (429, 504):
+            with self.subTest(status_code=status_code):
+                client = TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url="https://paper-api.alpaca.markets",
+                    data_client=DummyDataClient(),
+                )
+                response = Mock(spec=Response)
+                response.status_code = status_code
+                response.text = (
+                    f'{{"code": {status_code}, "message": "retryable failure"}}'
+                )
+                response.raise_for_status.side_effect = HTTPError(response=response)
+
+                with (
+                    patch(
+                        "alpaca.common.rest.Session.request", return_value=response
+                    ) as mock_request,
+                    patch("alpaca.common.rest.time.sleep") as mock_sleep,
+                    self.assertRaises(APIError) as raised,
+                ):
+                    OrderFirewall(client).submit_order(
+                        symbol="AAPL",
+                        side="buy",
+                        qty=1,
+                        order_type="market",
+                        time_in_force="day",
+                    )
+
+                self.assertEqual(raised.exception.status_code, status_code)
+                mock_request.assert_called_once()
+                self.assertEqual(mock_request.call_args.args[0], "POST")
+                mock_sleep.assert_not_called()
+
+    def test_service_created_read_client_keeps_sdk_retry_behavior(self) -> None:
+        for status_code in (429, 504):
+            with self.subTest(status_code=status_code):
+                client = TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url="https://paper-api.alpaca.markets",
+                    data_client=DummyDataClient(),
+                )
+                response = Mock(spec=Response)
+                response.status_code = status_code
+                response.text = (
+                    f'{{"code": {status_code}, "message": "retryable failure"}}'
+                )
+                response.raise_for_status.side_effect = HTTPError(response=response)
+
+                with (
+                    patch(
+                        "alpaca.common.rest.Session.request", return_value=response
+                    ) as mock_request,
+                    patch("alpaca.common.rest.time.sleep") as mock_sleep,
+                    self.assertRaises(APIError) as raised,
+                ):
+                    client.get_account()
+
+                self.assertEqual(raised.exception.status_code, status_code)
+                self.assertEqual(mock_request.call_count, 4)
+                self.assertEqual(
+                    [request.args[0] for request in mock_request.call_args_list],
+                    ["GET"] * 4,
+                )
+                self.assertEqual(mock_sleep.call_count, 3)
+
+    def test_service_created_trading_client_fails_closed_without_retry_control(
+        self,
+    ) -> None:
+        with (
+            patch("alpaca.trading.client.TradingClient.__init__", return_value=None),
+            self.assertRaisesRegex(
+                RuntimeError, "alpaca_sdk_retry_control_unavailable"
+            ),
+        ):
+            TorghutAlpacaClient(
+                api_key="k",
+                secret_key="s",
+                base_url="https://paper-api.alpaca.markets",
+                data_client=DummyDataClient(),
+            )
+
+    def test_injected_trading_client_retry_configuration_is_untouched(self) -> None:
+        class RetryConfiguredTradingClient(DummyTradingClient):
+            def __init__(self) -> None:
+                super().__init__()
+                self._retry = 7
+
+            @property
+            def configured_retry_attempts(self) -> int:
+                return self._retry
+
+        trading_client = RetryConfiguredTradingClient()
+
+        TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=trading_client,
+            data_client=DummyDataClient(),
+        )
+
+        self.assertEqual(trading_client.configured_retry_attempts, 7)
+
     def test_market_data_uses_data_endpoint_by_default(self) -> None:
         with patch("app.alpaca_client.StockHistoricalDataClient") as mock_data_client:
             TorghutAlpacaClient(
@@ -264,7 +376,10 @@ class TestAlpacaClient(TestCase):
 
         try:
             with (
-                patch("app.alpaca_client.TradingClient") as mock_trading_client,
+                patch("app.alpaca_client.TradingClient") as mock_read_trading_client,
+                patch(
+                    "app.alpaca_client._SingleAttemptTradingClient"
+                ) as mock_mutation_trading_client,
                 patch(
                     "app.alpaca_client.StockHistoricalDataClient"
                 ) as mock_data_client,
@@ -275,10 +390,12 @@ class TestAlpacaClient(TestCase):
                     base_url="https://api.alpaca.markets",
                 )
 
-                trading_kwargs = mock_trading_client.call_args.kwargs
+                read_trading_kwargs = mock_read_trading_client.call_args.kwargs
+                mutation_trading_kwargs = mock_mutation_trading_client.call_args.kwargs
                 data_kwargs = mock_data_client.call_args.kwargs
 
-                self.assertFalse(trading_kwargs.get("paper"))
+                self.assertFalse(read_trading_kwargs.get("paper"))
+                self.assertFalse(mutation_trading_kwargs.get("paper"))
                 self.assertFalse(data_kwargs.get("sandbox"))
         finally:
             config.settings.trading_mode = original
@@ -291,7 +408,10 @@ class TestAlpacaClient(TestCase):
 
         try:
             with (
-                patch("app.alpaca_client.TradingClient") as mock_trading_client,
+                patch("app.alpaca_client.TradingClient") as mock_read_trading_client,
+                patch(
+                    "app.alpaca_client._SingleAttemptTradingClient"
+                ) as mock_mutation_trading_client,
                 patch(
                     "app.alpaca_client.StockHistoricalDataClient"
                 ) as mock_data_client,
@@ -303,24 +423,37 @@ class TestAlpacaClient(TestCase):
                     paper=True,
                 )
 
-                trading_kwargs = mock_trading_client.call_args.kwargs
+                read_trading_kwargs = mock_read_trading_client.call_args.kwargs
+                mutation_trading_kwargs = mock_mutation_trading_client.call_args.kwargs
                 data_kwargs = mock_data_client.call_args.kwargs
 
-                self.assertTrue(trading_kwargs.get("paper"))
+                self.assertTrue(read_trading_kwargs.get("paper"))
+                self.assertTrue(mutation_trading_kwargs.get("paper"))
                 self.assertTrue(data_kwargs.get("sandbox"))
                 self.assertEqual(client.endpoint_class, "paper")
         finally:
             config.settings.trading_mode = original
 
     def test_alpaca_base_url_strips_v2_suffix(self) -> None:
-        with patch("app.alpaca_client.TradingClient") as mock_trading_client:
+        with (
+            patch("app.alpaca_client.TradingClient") as mock_read_trading_client,
+            patch(
+                "app.alpaca_client._SingleAttemptTradingClient"
+            ) as mock_mutation_trading_client,
+        ):
             TorghutAlpacaClient(
                 api_key="k",
                 secret_key="s",
                 base_url="https://paper-api.alpaca.markets/v2",
             )
 
-            trading_kwargs = mock_trading_client.call_args.kwargs
+            read_trading_kwargs = mock_read_trading_client.call_args.kwargs
+            mutation_trading_kwargs = mock_mutation_trading_client.call_args.kwargs
             self.assertEqual(
-                trading_kwargs.get("url_override"), "https://paper-api.alpaca.markets"
+                read_trading_kwargs.get("url_override"),
+                "https://paper-api.alpaca.markets",
+            )
+            self.assertEqual(
+                mutation_trading_kwargs.get("url_override"),
+                "https://paper-api.alpaca.markets",
             )

--- a/services/torghut/tests/test_main_api_refactor.py
+++ b/services/torghut/tests/test_main_api_refactor.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
 from app import main as main_module
+from app import scheduler_main
 from app.api.application import api_routers, get_app
 
 
@@ -35,6 +36,7 @@ def test_main_exports_operational_api_only() -> None:
 def test_main_public_contract_is_entrypoint_only() -> None:
     assert main_module.__all__ == ("app", "create_app")
     assert get_app() is main_module.app
+    assert get_app("scheduler") is scheduler_main.app
 
     removed_private_attrs = (
         "ROUTER_PROVIDERS",

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -10,6 +10,19 @@ from app.trading.strategy_runtime import RuntimeObservation
 
 
 class TestTradingMetrics(TestCase):
+    def test_scheduler_leadership_metrics_are_direct_gauges(self) -> None:
+        payload = render_trading_metrics(
+            {
+                "scheduler_leadership_acquired": 1,
+                "scheduler_leadership_healthy": 0,
+            }
+        )
+
+        self.assertIn("# TYPE torghut_scheduler_leadership_acquired gauge", payload)
+        self.assertIn("torghut_scheduler_leadership_acquired 1", payload)
+        self.assertIn("# TYPE torghut_scheduler_leadership_healthy gauge", payload)
+        self.assertIn("torghut_scheduler_leadership_healthy 0", payload)
+
     def test_metrics_payload_is_detached_from_mutable_state(self) -> None:
         metrics = TradingMetrics()
         metrics.no_signal_reason_total["cursor_ahead_of_stream"] = 1

--- a/services/torghut/tests/test_process_roles.py
+++ b/services/torghut/tests/test_process_roles.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+
+from app import bootstrap, scheduler_main
+from app.config import Settings, settings
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.state = SimpleNamespace(
+            running=False,
+            last_run_at=None,
+            last_error=None,
+        )
+        self.start = AsyncMock()
+        self.stop = AsyncMock()
+        self._leadership_status = SimpleNamespace(
+            required=True,
+            acquired=True,
+            healthy=True,
+            failure_reason=None,
+        )
+
+    @property
+    def leadership_status(self) -> SimpleNamespace:
+        return self._leadership_status
+
+
+class _FakeWhitepaperWorker:
+    def __init__(self, **_kwargs: object) -> None:
+        self.start = AsyncMock()
+        self.stop = AsyncMock()
+
+
+class ProcessRoleSettingsTests(TestCase):
+    def test_process_role_defaults_to_api_and_rejects_unknown_roles(self) -> None:
+        process_settings = Settings(_env_file=None)
+        self.assertEqual(process_settings.process_role, "api")
+        self.assertFalse(process_settings.trading_scheduler_leadership_required)
+        self.assertEqual(
+            process_settings.trading_scheduler_leadership_check_seconds, 5.0
+        )
+
+        with self.assertRaisesRegex(ValueError, "TORGHUT_PROCESS_ROLE"):
+            Settings(_env_file=None, TORGHUT_PROCESS_ROLE="worker")
+        with self.assertRaisesRegex(
+            ValueError, "TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS"
+        ):
+            Settings(
+                _env_file=None,
+                TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS=0,
+            )
+
+
+class ApiProcessRoleTests(IsolatedAsyncioTestCase):
+    async def test_api_lifespan_never_starts_trading_scheduler(self) -> None:
+        scheduler = _FakeScheduler()
+        app = FastAPI()
+        with (
+            patch.object(settings, "process_role", "api"),
+            patch.object(settings, "trading_enabled", True),
+            patch.object(bootstrap, "TradingScheduler", return_value=scheduler),
+            patch.object(bootstrap, "ensure_schema"),
+        ):
+            async with bootstrap.lifespan(app):
+                self.assertIs(app.state.trading_scheduler, scheduler)
+                self.assertFalse(hasattr(app.state, "whitepaper_worker"))
+
+        scheduler.start.assert_not_awaited()
+        scheduler.stop.assert_awaited_once()
+
+    async def test_api_lifespan_fails_closed_on_scheduler_role(self) -> None:
+        with patch.object(settings, "process_role", "scheduler"):
+            with self.assertRaisesRegex(RuntimeError, "expected=api"):
+                async with bootstrap.lifespan(FastAPI()):
+                    pass
+
+    def test_api_scheduler_status_declares_external_owner(self) -> None:
+        with patch.object(settings, "process_role", "api"):
+            ok, payload = bootstrap.evaluate_scheduler_status(_FakeScheduler())
+
+        self.assertTrue(ok)
+        self.assertEqual(payload["detail"], "external_scheduler")
+        self.assertEqual(payload["owner"], "torghut-scheduler")
+        self.assertFalse(payload["running"])
+
+
+class SchedulerProcessRoleTests(IsolatedAsyncioTestCase):
+    async def test_scheduler_lifespan_is_the_only_role_that_starts_loop(self) -> None:
+        scheduler = _FakeScheduler()
+        whitepaper_worker = _FakeWhitepaperWorker()
+        app = FastAPI()
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "trading_enabled", True),
+            patch.object(settings, "trading_autonomy_enabled", False),
+            patch.object(
+                scheduler_main,
+                "TradingScheduler",
+                return_value=scheduler,
+            ),
+            patch.object(
+                scheduler_main,
+                "WhitepaperKafkaWorker",
+                return_value=whitepaper_worker,
+            ),
+            patch.object(
+                scheduler_main, "whitepaper_workflow_enabled", return_value=True
+            ),
+            patch.object(scheduler_main, "ensure_schema") as ensure_schema,
+            patch.object(scheduler_main, "assert_dspy_cutover_migration_guard"),
+        ):
+            async with scheduler_main.scheduler_lifespan(app):
+                self.assertIs(app.state.trading_scheduler, scheduler)
+
+        ensure_schema.assert_called_once_with()
+        scheduler.start.assert_awaited_once()
+        scheduler.stop.assert_awaited_once()
+        whitepaper_worker.start.assert_awaited_once()
+        whitepaper_worker.stop.assert_awaited_once()
+
+    async def test_scheduler_lifespan_fails_closed_on_api_role(self) -> None:
+        with patch.object(settings, "process_role", "api"):
+            with self.assertRaisesRegex(RuntimeError, "expected=scheduler"):
+                async with scheduler_main.scheduler_lifespan(FastAPI()):
+                    pass
+
+
+class SchedulerReadinessTests(TestCase):
+    def test_readiness_requires_running_error_free_completed_cycle(self) -> None:
+        scheduler = _FakeScheduler()
+        with patch.object(settings, "process_role", "scheduler"):
+            self.assertFalse(
+                scheduler_main.scheduler_readiness_payload(scheduler)["ok"]
+            )
+
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            ready = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertTrue(ready["ok"])
+        self.assertEqual(ready["detail"], "ok")
+        self.assertIn("last_run_at", ready)
+
+    def test_readiness_fails_closed_when_latest_cycle_failed(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_error = "broker unavailable"
+
+        with patch.object(settings, "process_role", "scheduler"):
+            payload = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["last_error"], "broker unavailable")
+
+
+class SchedulerLivenessTests(TestCase):
+    def test_liveness_requires_healthy_acquired_leadership(self) -> None:
+        scheduler = _FakeScheduler()
+        with patch.object(settings, "process_role", "scheduler"):
+            payload = scheduler_main.scheduler_liveness_payload(scheduler)
+
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["detail"], "ok")
+
+    def test_liveness_fails_closed_when_leadership_is_unavailable(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.leadership_status.healthy = False
+
+        with patch.object(settings, "process_role", "scheduler"):
+            payload = scheduler_main.scheduler_liveness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_leadership_unhealthy")

--- a/services/torghut/tests/test_process_roles.py
+++ b/services/torghut/tests/test_process_roles.py
@@ -409,6 +409,11 @@ class SchedulerProcessRoleTests(IsolatedAsyncioTestCase):
 
 
 class SchedulerReadinessTests(TestCase):
+    def setUp(self) -> None:
+        trading_enabled = patch.object(settings, "trading_enabled", True)
+        trading_enabled.start()
+        self.addCleanup(trading_enabled.stop)
+
     def test_readiness_requires_running_error_free_completed_cycles(self) -> None:
         scheduler = _FakeScheduler()
         with patch.object(settings, "process_role", "scheduler"):
@@ -542,18 +547,66 @@ class SchedulerReadinessTests(TestCase):
 class SchedulerLivenessTests(TestCase):
     def test_liveness_requires_healthy_acquired_leadership(self) -> None:
         scheduler = _FakeScheduler()
-        with patch.object(settings, "process_role", "scheduler"):
+        scheduler.state.running = True
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "trading_enabled", True),
+        ):
             payload = scheduler_main.scheduler_liveness_payload(scheduler)
 
         self.assertTrue(payload["ok"])
         self.assertEqual(payload["detail"], "ok")
+        self.assertEqual(
+            payload["trading"],
+            {"enabled": True, "loop_required": True, "running": True},
+        )
 
     def test_liveness_fails_closed_when_leadership_is_unavailable(self) -> None:
         scheduler = _FakeScheduler()
+        scheduler.state.running = True
         scheduler.leadership_status.healthy = False
 
-        with patch.object(settings, "process_role", "scheduler"):
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "trading_enabled", True),
+        ):
             payload = scheduler_main.scheduler_liveness_payload(scheduler)
 
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["detail"], "scheduler_leadership_unhealthy")
+
+    def test_liveness_fails_closed_when_required_trading_loop_is_not_running(
+        self,
+    ) -> None:
+        scheduler = _FakeScheduler()
+
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "trading_enabled", True),
+        ):
+            payload = scheduler_main.scheduler_liveness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_loop_not_running")
+        self.assertEqual(
+            payload["trading"],
+            {"enabled": True, "loop_required": True, "running": False},
+        )
+
+    def test_liveness_permits_stopped_loop_when_trading_is_disabled(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.leadership_status.healthy = False
+        scheduler.leadership_status.acquired = False
+
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "trading_enabled", False),
+        ):
+            payload = scheduler_main.scheduler_liveness_payload(scheduler)
+
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["detail"], "trading_disabled")
+        self.assertEqual(
+            payload["trading"],
+            {"enabled": False, "loop_required": False, "running": False},
+        )

--- a/services/torghut/tests/test_process_roles.py
+++ b/services/torghut/tests/test_process_roles.py
@@ -254,6 +254,43 @@ class SimulationProcessRoleTests(IsolatedAsyncioTestCase):
         self.assertEqual(attempts, 2)
         scheduler.stop.assert_awaited_once()
 
+    async def test_simulation_supervisor_latches_non_retryable_startup_failure(
+        self,
+    ) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.start.side_effect = ValueError("invalid scheduler configuration")
+        app = FastAPI()
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch.object(settings, "trading_mode", "paper"),
+            patch.object(settings, "trading_enabled", True),
+            patch.object(settings, "trading_scheduler_leadership_required", True),
+            patch.object(
+                settings,
+                "trading_scheduler_leadership_lock_name",
+                "torghut:simulation-scheduler",
+            ),
+            patch.object(settings, "trading_autonomy_enabled", False),
+            patch.object(bootstrap, "TradingScheduler", return_value=scheduler),
+            patch.object(bootstrap, "whitepaper_workflow_enabled", return_value=False),
+            patch.object(bootstrap, "ensure_schema"),
+            patch.object(bootstrap, "_assert_dspy_cutover_migration_guard"),
+        ):
+            async with bootstrap.lifespan(app):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "invalid scheduler configuration",
+                ):
+                    await app.state.trading_scheduler_supervisor
+                await asyncio.sleep(0)
+                self.assertEqual(
+                    scheduler.state.last_error,
+                    "scheduler_startup_supervisor_failed:ValueError",
+                )
+
+        scheduler.start.assert_awaited_once()
+        scheduler.stop.assert_awaited_once()
+
     async def test_disabled_simulation_serves_without_starting_scheduler(self) -> None:
         scheduler = _FakeScheduler()
         app = FastAPI()

--- a/services/torghut/tests/test_process_roles.py
+++ b/services/torghut/tests/test_process_roles.py
@@ -46,6 +46,14 @@ class ProcessRoleSettingsTests(TestCase):
         self.assertEqual(
             process_settings.trading_scheduler_leadership_check_seconds, 5.0
         )
+        self.assertEqual(
+            process_settings.trading_scheduler_runtime_base_url,
+            "http://torghut-scheduler.torghut.svc.cluster.local:8183",
+        )
+        self.assertEqual(
+            process_settings.trading_scheduler_runtime_timeout_seconds,
+            2.0,
+        )
 
         with self.assertRaisesRegex(ValueError, "TORGHUT_PROCESS_ROLE"):
             Settings(_env_file=None, TORGHUT_PROCESS_ROLE="worker")
@@ -55,6 +63,13 @@ class ProcessRoleSettingsTests(TestCase):
             Settings(
                 _env_file=None,
                 TRADING_SCHEDULER_LEADERSHIP_CHECK_SECONDS=0,
+            )
+        with self.assertRaisesRegex(
+            ValueError, "TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS"
+        ):
+            Settings(
+                _env_file=None,
+                TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS=0,
             )
 
 

--- a/services/torghut/tests/test_process_roles.py
+++ b/services/torghut/tests/test_process_roles.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, patch
@@ -16,6 +16,8 @@ class _FakeScheduler:
         self.state = SimpleNamespace(
             running=False,
             last_run_at=None,
+            last_trading_error=None,
+            last_reconcile_error=None,
             last_error=None,
         )
         self.start = AsyncMock()
@@ -47,6 +49,12 @@ class ProcessRoleSettingsTests(TestCase):
             process_settings.trading_scheduler_leadership_check_seconds, 5.0
         )
         self.assertEqual(
+            process_settings.trading_scheduler_shutdown_drain_seconds, 45.0
+        )
+        self.assertEqual(
+            process_settings.trading_scheduler_success_max_age_seconds, 30.0
+        )
+        self.assertEqual(
             process_settings.trading_scheduler_runtime_base_url,
             "http://torghut-scheduler.torghut.svc.cluster.local:8183",
         )
@@ -70,6 +78,20 @@ class ProcessRoleSettingsTests(TestCase):
             Settings(
                 _env_file=None,
                 TRADING_SCHEDULER_RUNTIME_TIMEOUT_SECONDS=0,
+            )
+        with self.assertRaisesRegex(
+            ValueError, "TRADING_SCHEDULER_SHUTDOWN_DRAIN_SECONDS"
+        ):
+            Settings(
+                _env_file=None,
+                TRADING_SCHEDULER_SHUTDOWN_DRAIN_SECONDS=0,
+            )
+        with self.assertRaisesRegex(
+            ValueError, "TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS"
+        ):
+            Settings(
+                _env_file=None,
+                TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS=0,
             )
 
 
@@ -174,6 +196,53 @@ class SchedulerReadinessTests(TestCase):
 
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["last_error"], "broker unavailable")
+        self.assertEqual(payload["detail"], "scheduler_cycle_failed")
+
+    def test_readiness_fails_closed_when_last_success_is_stale(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        scheduler.state.last_run_at = datetime.now(timezone.utc) - timedelta(seconds=31)
+
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "trading_scheduler_success_max_age_seconds", 30.0),
+        ):
+            payload = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_success_stale")
+        self.assertGreater(payload["success_age_seconds"], 30.0)
+
+    def test_readiness_requires_healthy_writer_leadership(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.leadership_status.healthy = False
+
+        with patch.object(settings, "process_role", "scheduler"):
+            payload = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_leadership_unhealthy")
+
+    def test_readiness_cannot_mask_latest_trading_failure_with_shared_error_clear(
+        self,
+    ) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_error = None
+        scheduler.state.last_trading_error = "trading_lane_failures:paper-a"
+
+        with patch.object(settings, "process_role", "scheduler"):
+            payload = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_cycle_failed")
+        self.assertEqual(
+            payload["last_trading_error"],
+            "trading_lane_failures:paper-a",
+        )
 
 
 class SchedulerLivenessTests(TestCase):

--- a/services/torghut/tests/test_process_roles.py
+++ b/services/torghut/tests/test_process_roles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
@@ -9,6 +10,7 @@ from fastapi import FastAPI
 
 from app import bootstrap, scheduler_main
 from app.config import Settings, settings
+from app.trading.scheduler.leadership import SchedulerLeadershipError
 
 
 class _FakeScheduler:
@@ -16,6 +18,7 @@ class _FakeScheduler:
         self.state = SimpleNamespace(
             running=False,
             last_run_at=None,
+            last_reconcile_at=None,
             last_trading_error=None,
             last_reconcile_error=None,
             last_autonomy_error=None,
@@ -48,6 +51,10 @@ class ProcessRoleSettingsTests(TestCase):
         self.assertEqual(process_settings.process_role, "api")
         self.assertFalse(process_settings.trading_scheduler_leadership_required)
         self.assertEqual(
+            process_settings.trading_scheduler_leadership_lock_name,
+            "torghut:trading-scheduler",
+        )
+        self.assertEqual(
             process_settings.trading_scheduler_leadership_check_seconds, 5.0
         )
         self.assertEqual(
@@ -56,6 +63,7 @@ class ProcessRoleSettingsTests(TestCase):
         self.assertEqual(
             process_settings.trading_scheduler_success_max_age_seconds, 30.0
         )
+        self.assertEqual(process_settings.trading_reconcile_ms, 15000)
         self.assertEqual(
             process_settings.trading_scheduler_runtime_base_url,
             "http://torghut-scheduler.torghut.svc.cluster.local:8183",
@@ -64,6 +72,12 @@ class ProcessRoleSettingsTests(TestCase):
             process_settings.trading_scheduler_runtime_timeout_seconds,
             2.0,
         )
+        simulation_settings = Settings(
+            _env_file=None,
+            TORGHUT_PROCESS_ROLE="simulation",
+            TRADING_MODE="paper",
+        )
+        self.assertEqual(simulation_settings.process_role, "simulation")
 
         with self.assertRaisesRegex(ValueError, "TORGHUT_PROCESS_ROLE"):
             Settings(_env_file=None, TORGHUT_PROCESS_ROLE="worker")
@@ -95,6 +109,22 @@ class ProcessRoleSettingsTests(TestCase):
                 _env_file=None,
                 TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS=0,
             )
+
+    def test_reconcile_interval_must_fit_inside_success_freshness_window(
+        self,
+    ) -> None:
+        message = (
+            "TRADING_RECONCILE_MS must be strictly less than "
+            "TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS"
+        )
+        for reconcile_ms in (30000, 30001):
+            with self.subTest(reconcile_ms=reconcile_ms):
+                with self.assertRaisesRegex(ValueError, message):
+                    Settings(
+                        _env_file=None,
+                        TRADING_RECONCILE_MS=reconcile_ms,
+                        TRADING_SCHEDULER_SUCCESS_MAX_AGE_SECONDS=30,
+                    )
 
 
 class ApiProcessRoleTests(IsolatedAsyncioTestCase):
@@ -128,6 +158,176 @@ class ApiProcessRoleTests(IsolatedAsyncioTestCase):
         self.assertEqual(payload["detail"], "external_scheduler")
         self.assertEqual(payload["owner"], "torghut-scheduler")
         self.assertFalse(payload["running"])
+
+
+class SimulationProcessRoleTests(IsolatedAsyncioTestCase):
+    async def test_simulation_lifespan_starts_local_scheduler_and_worker(self) -> None:
+        scheduler = _FakeScheduler()
+        whitepaper_worker = _FakeWhitepaperWorker()
+        app = FastAPI()
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch.object(settings, "trading_mode", "paper"),
+            patch.object(settings, "trading_enabled", True),
+            patch.object(settings, "trading_scheduler_leadership_required", True),
+            patch.object(
+                settings,
+                "trading_scheduler_leadership_lock_name",
+                "torghut:simulation-scheduler",
+            ),
+            patch.object(settings, "trading_autonomy_enabled", False),
+            patch.object(bootstrap, "TradingScheduler", return_value=scheduler),
+            patch.object(
+                bootstrap,
+                "WhitepaperKafkaWorker",
+                return_value=whitepaper_worker,
+            ),
+            patch.object(bootstrap, "whitepaper_workflow_enabled", return_value=True),
+            patch.object(bootstrap, "ensure_schema") as ensure_schema,
+            patch.object(bootstrap, "_assert_dspy_cutover_migration_guard"),
+        ):
+            async with bootstrap.lifespan(app):
+                self.assertIs(app.state.trading_scheduler, scheduler)
+                self.assertIs(app.state.whitepaper_worker, whitepaper_worker)
+                await app.state.trading_scheduler_supervisor
+
+        ensure_schema.assert_called_once_with()
+        scheduler.start.assert_awaited_once()
+        scheduler.stop.assert_awaited_once()
+        whitepaper_worker.start.assert_awaited_once()
+        whitepaper_worker.stop.assert_awaited_once()
+
+    async def test_simulation_lifespan_stands_by_then_acquires_leadership(
+        self,
+    ) -> None:
+        scheduler = _FakeScheduler()
+        first_attempt_failed = asyncio.Event()
+        allow_acquisition = asyncio.Event()
+        attempts = 0
+
+        async def start_scheduler() -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                scheduler.state.last_error = (
+                    "scheduler_startup_failed:SchedulerLeadershipError"
+                )
+                first_attempt_failed.set()
+                raise SchedulerLeadershipError("leadership contended")
+            await allow_acquisition.wait()
+            scheduler.state.last_error = None
+            scheduler.state.running = True
+
+        scheduler.start.side_effect = start_scheduler
+        app = FastAPI()
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch.object(settings, "trading_mode", "paper"),
+            patch.object(settings, "trading_enabled", True),
+            patch.object(settings, "trading_scheduler_leadership_required", True),
+            patch.object(
+                settings,
+                "trading_scheduler_leadership_lock_name",
+                "torghut:simulation-scheduler",
+            ),
+            patch.object(settings, "trading_scheduler_leadership_check_seconds", 0.001),
+            patch.object(settings, "trading_autonomy_enabled", False),
+            patch.object(bootstrap, "TradingScheduler", return_value=scheduler),
+            patch.object(bootstrap, "whitepaper_workflow_enabled", return_value=False),
+            patch.object(bootstrap, "ensure_schema"),
+            patch.object(bootstrap, "_assert_dspy_cutover_migration_guard"),
+        ):
+            async with bootstrap.lifespan(app):
+                await asyncio.wait_for(first_attempt_failed.wait(), timeout=1)
+                self.assertFalse(scheduler.state.running)
+                self.assertFalse(
+                    bootstrap.evaluate_scheduler_status(scheduler)[0],
+                    "standby simulation must remain fail-closed",
+                )
+                allow_acquisition.set()
+                await asyncio.wait_for(
+                    app.state.trading_scheduler_supervisor,
+                    timeout=1,
+                )
+                self.assertTrue(scheduler.state.running)
+
+        self.assertEqual(attempts, 2)
+        scheduler.stop.assert_awaited_once()
+
+    async def test_disabled_simulation_serves_without_starting_scheduler(self) -> None:
+        scheduler = _FakeScheduler()
+        app = FastAPI()
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch.object(settings, "trading_mode", "paper"),
+            patch.object(settings, "trading_enabled", False),
+            patch.object(bootstrap, "TradingScheduler", return_value=scheduler),
+            patch.object(bootstrap, "whitepaper_workflow_enabled", return_value=False),
+            patch.object(bootstrap, "ensure_schema"),
+        ):
+            async with bootstrap.lifespan(app):
+                self.assertIs(app.state.trading_scheduler, scheduler)
+                self.assertFalse(hasattr(app.state, "trading_scheduler_supervisor"))
+
+        scheduler.start.assert_not_awaited()
+        scheduler.stop.assert_awaited_once()
+
+    async def test_simulation_lifespan_rejects_live_mode(self) -> None:
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch.object(settings, "trading_mode", "live"),
+            patch.object(settings, "trading_scheduler_leadership_required", True),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "torghut_simulation_process_mode_mismatch",
+            ):
+                async with bootstrap.lifespan(FastAPI()):
+                    pass
+
+    async def test_simulation_lifespan_requires_single_writer_leadership(self) -> None:
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch.object(settings, "trading_mode", "paper"),
+            patch.object(settings, "trading_enabled", True),
+            patch.object(settings, "trading_scheduler_leadership_required", False),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "torghut_simulation_scheduler_leadership_required",
+            ):
+                async with bootstrap.lifespan(FastAPI()):
+                    pass
+
+    async def test_simulation_lifespan_requires_isolated_leadership_lock(self) -> None:
+        with (
+            patch.object(settings, "process_role", "simulation"),
+            patch.object(settings, "trading_mode", "paper"),
+            patch.object(settings, "trading_enabled", True),
+            patch.object(settings, "trading_scheduler_leadership_required", True),
+            patch.object(
+                settings,
+                "trading_scheduler_leadership_lock_name",
+                "torghut:trading-scheduler",
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "torghut_simulation_scheduler_lock_must_be_isolated",
+            ):
+                async with bootstrap.lifespan(FastAPI()):
+                    pass
+
+    def test_simulation_scheduler_status_is_process_local(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        with patch.object(settings, "process_role", "simulation"):
+            ok, payload = bootstrap.evaluate_scheduler_status(scheduler)
+
+        self.assertTrue(ok)
+        self.assertEqual(payload["detail"], "ok")
+        self.assertTrue(payload["running"])
+        self.assertNotIn("owner", payload)
 
 
 class SchedulerProcessRoleTests(IsolatedAsyncioTestCase):
@@ -172,7 +372,7 @@ class SchedulerProcessRoleTests(IsolatedAsyncioTestCase):
 
 
 class SchedulerReadinessTests(TestCase):
-    def test_readiness_requires_running_error_free_completed_cycle(self) -> None:
+    def test_readiness_requires_running_error_free_completed_cycles(self) -> None:
         scheduler = _FakeScheduler()
         with patch.object(settings, "process_role", "scheduler"):
             self.assertFalse(
@@ -181,16 +381,19 @@ class SchedulerReadinessTests(TestCase):
 
             scheduler.state.running = True
             scheduler.state.last_run_at = datetime.now(timezone.utc)
+            scheduler.state.last_reconcile_at = datetime.now(timezone.utc)
             ready = scheduler_main.scheduler_readiness_payload(scheduler)
 
         self.assertTrue(ready["ok"])
         self.assertEqual(ready["detail"], "ok")
         self.assertIn("last_run_at", ready)
+        self.assertIn("last_reconcile_at", ready)
 
     def test_readiness_fails_closed_when_latest_cycle_failed(self) -> None:
         scheduler = _FakeScheduler()
         scheduler.state.running = True
         scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_reconcile_at = datetime.now(timezone.utc)
         scheduler.state.last_error = "broker unavailable"
 
         with patch.object(settings, "process_role", "scheduler"):
@@ -204,6 +407,7 @@ class SchedulerReadinessTests(TestCase):
         scheduler = _FakeScheduler()
         scheduler.state.running = True
         scheduler.state.last_run_at = datetime.now(timezone.utc) - timedelta(seconds=31)
+        scheduler.state.last_reconcile_at = datetime.now(timezone.utc)
 
         with (
             patch.object(settings, "process_role", "scheduler"),
@@ -219,6 +423,7 @@ class SchedulerReadinessTests(TestCase):
         scheduler = _FakeScheduler()
         scheduler.state.running = True
         scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_reconcile_at = datetime.now(timezone.utc)
         scheduler.leadership_status.healthy = False
 
         with patch.object(settings, "process_role", "scheduler"):
@@ -233,6 +438,7 @@ class SchedulerReadinessTests(TestCase):
         scheduler = _FakeScheduler()
         scheduler.state.running = True
         scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_reconcile_at = datetime.now(timezone.utc)
         scheduler.state.last_error = None
         scheduler.state.last_trading_error = "trading_lane_failures:paper-a"
 
@@ -250,6 +456,7 @@ class SchedulerReadinessTests(TestCase):
         scheduler = _FakeScheduler()
         scheduler.state.running = True
         scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_reconcile_at = datetime.now(timezone.utc)
         scheduler.state.last_autonomy_error = "autonomy unavailable"
 
         with patch.object(settings, "process_role", "scheduler"):
@@ -258,6 +465,41 @@ class SchedulerReadinessTests(TestCase):
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["detail"], "scheduler_cycle_failed")
         self.assertEqual(payload["last_autonomy_error"], "autonomy unavailable")
+
+    def test_readiness_requires_completed_reconcile_cycle(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        scheduler.state.last_run_at = datetime.now(timezone.utc)
+
+        with patch.object(settings, "process_role", "scheduler"):
+            payload = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_reconcile_success_missing")
+        self.assertTrue(payload["trading_success_is_fresh"])
+        self.assertFalse(payload["reconcile_success_is_fresh"])
+        self.assertNotIn("last_reconcile_at", payload)
+
+    def test_readiness_fails_closed_when_reconcile_success_is_stale(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_reconcile_at = datetime.now(timezone.utc) - timedelta(
+            seconds=31
+        )
+
+        with (
+            patch.object(settings, "process_role", "scheduler"),
+            patch.object(settings, "trading_scheduler_success_max_age_seconds", 30.0),
+        ):
+            payload = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_reconcile_success_stale")
+        self.assertTrue(payload["trading_success_is_fresh"])
+        self.assertFalse(payload["reconcile_success_is_fresh"])
+        self.assertIn("last_reconcile_at", payload)
+        self.assertGreater(payload["reconcile_success_age_seconds"], 30.0)
 
 
 class SchedulerLivenessTests(TestCase):

--- a/services/torghut/tests/test_process_roles.py
+++ b/services/torghut/tests/test_process_roles.py
@@ -18,6 +18,8 @@ class _FakeScheduler:
             last_run_at=None,
             last_trading_error=None,
             last_reconcile_error=None,
+            last_autonomy_error=None,
+            last_evidence_error=None,
             last_error=None,
         )
         self.start = AsyncMock()
@@ -243,6 +245,19 @@ class SchedulerReadinessTests(TestCase):
             payload["last_trading_error"],
             "trading_lane_failures:paper-a",
         )
+
+    def test_readiness_exposes_autonomy_error_when_shared_error_is_clear(self) -> None:
+        scheduler = _FakeScheduler()
+        scheduler.state.running = True
+        scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler.state.last_autonomy_error = "autonomy unavailable"
+
+        with patch.object(settings, "process_role", "scheduler"):
+            payload = scheduler_main.scheduler_readiness_payload(scheduler)
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["detail"], "scheduler_cycle_failed")
+        self.assertEqual(payload["last_autonomy_error"], "autonomy unavailable")
 
 
 class SchedulerLivenessTests(TestCase):

--- a/services/torghut/tests/test_scheduler_market_context_status.py
+++ b/services/torghut/tests/test_scheduler_market_context_status.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from app import config
 from app.trading.llm.schema import MarketContextBundle
@@ -53,6 +53,7 @@ class _PipelineWithLlmReview:
 
 class _PipelineLabelStub:
     account_label = "live"
+    order_feed_ingestor = SimpleNamespace(close=Mock())
 
 
 class TestTradingSchedulerMarketContextStatus(TestCase):
@@ -476,13 +477,14 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
 
     def test_start_reports_existing_pipeline_labels(self) -> None:
         async def run_once() -> None:
-            scheduler = TradingScheduler()
+            fatal_exit = Mock()
+            scheduler = TradingScheduler(fatal_exit=fatal_exit)
             pipeline = _PipelineLabelStub()
             cast(Any, scheduler)._pipelines = [pipeline]
             cast(Any, scheduler)._pipeline = pipeline
 
             async def fake_run_loop() -> None:
-                return None
+                await scheduler._stop_event.wait()
 
             with (
                 patch.object(scheduler, "_assert_trading_shorts_startup_policy"),
@@ -491,7 +493,9 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
                 await scheduler.start()
                 task = scheduler._task
                 self.assertIsNotNone(task)
-                await cast(asyncio.Task[None], task)
+                self.assertFalse(cast(asyncio.Task[None], task).done())
+                await scheduler.stop()
+                fatal_exit.assert_not_called()
 
         asyncio.run(run_once())
 

--- a/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
@@ -239,6 +239,32 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
         self.assertIsNone(scheduler.state.last_evidence_error)
         self.assertIsNone(scheduler.state.last_error)
 
+    def test_successful_retries_clear_aggregate_iteration_error(self) -> None:
+        scheduler = TradingScheduler()
+
+        scheduler._set_trading_iteration_error("trading unavailable")
+        scheduler._set_reconcile_iteration_error("reconcile unavailable")
+
+        self.assertEqual(
+            scheduler.state.last_error,
+            "trading unavailable;reconcile unavailable",
+        )
+
+        scheduler._set_trading_iteration_error(None)
+        self.assertEqual(scheduler.state.last_error, "reconcile unavailable")
+
+        scheduler._set_reconcile_iteration_error(None)
+        self.assertIsNone(scheduler.state.last_error)
+
+    def test_iteration_recovery_preserves_non_iteration_runtime_error(self) -> None:
+        scheduler = TradingScheduler()
+        scheduler._set_trading_iteration_error("trading unavailable")
+        scheduler.state.last_error = "leadership_lost"
+
+        scheduler._set_trading_iteration_error(None)
+
+        self.assertEqual(scheduler.state.last_error, "leadership_lost")
+
     def test_run_reconcile_iteration_continues_with_partial_lane_failure(self) -> None:
         scheduler = TradingScheduler()
         failing_lane = _PipelineIterationStub(

--- a/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
@@ -298,6 +298,40 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
         self.assertEqual(failing_lane.reconcile_last_error, "reconcile_failed")
         self.assertEqual(healthy_lane.reconcile_last_error, None)
 
+    def test_reconcile_success_timestamp_advances_only_after_all_lanes_succeed(
+        self,
+    ) -> None:
+        scheduler = TradingScheduler()
+        previous_success = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        failing_lane = _PipelineIterationStub(
+            account_label="paper-a",
+            reconcile_fail=True,
+        )
+        healthy_lane = _PipelineIterationStub(
+            account_label="paper-b",
+            reconcile_return=2,
+        )
+        scheduler._pipelines = [failing_lane, healthy_lane]
+        scheduler._pipeline = failing_lane
+        scheduler.state.last_reconcile_at = previous_success
+        scheduler._evaluate_safety_controls = lambda: None
+
+        asyncio.run(scheduler._run_reconcile_iteration())
+
+        self.assertEqual(scheduler.state.last_reconcile_at, previous_success)
+        self.assertEqual(
+            scheduler.state.last_reconcile_error,
+            "reconcile_lane_failures:paper-a",
+        )
+
+        failing_lane.reconcile_fail = False
+        asyncio.run(scheduler._run_reconcile_iteration())
+
+        self.assertIsNotNone(scheduler.state.last_reconcile_at)
+        assert scheduler.state.last_reconcile_at is not None
+        self.assertGreater(scheduler.state.last_reconcile_at, previous_success)
+        self.assertIsNone(scheduler.state.last_reconcile_error)
+
     def test_run_autonomy_iteration_triggers_rollback_when_failure_streak_exceeds_limit(
         self,
     ) -> None:

--- a/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
@@ -184,6 +184,61 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
         self.assertIsNone(scheduler.state.last_reconcile_error)
         self.assertIsNotNone(scheduler.state.last_reconcile_at)
 
+    def test_successful_autonomy_retry_clears_its_readiness_error(self) -> None:
+        scheduler = TradingScheduler()
+        lane = _PipelineIterationStub(account_label="paper-a")
+        scheduler._pipelines = [lane]
+        scheduler._pipeline = lane
+        scheduler._evaluate_safety_controls = lambda: None
+
+        with patch.object(
+            scheduler,
+            "_run_autonomous_cycle",
+            side_effect=RuntimeError("autonomy unavailable"),
+        ):
+            asyncio.run(scheduler._run_autonomy_iteration())
+
+        self.assertEqual(scheduler.state.last_error, "autonomy unavailable")
+        self.assertEqual(
+            scheduler.state.last_autonomy_error,
+            "autonomy unavailable",
+        )
+
+        with patch.object(scheduler, "_run_autonomous_cycle", return_value=None):
+            asyncio.run(scheduler._run_autonomy_iteration())
+
+        self.assertIsNone(scheduler.state.last_autonomy_error)
+        self.assertIsNone(scheduler.state.last_error)
+
+    def test_successful_evidence_retry_clears_its_readiness_error(self) -> None:
+        scheduler = TradingScheduler()
+        lane = _PipelineIterationStub(account_label="paper-a")
+        scheduler._pipelines = [lane]
+        scheduler._pipeline = lane
+
+        with patch.object(
+            scheduler,
+            "_run_evidence_continuity_check",
+            side_effect=RuntimeError("evidence unavailable"),
+        ):
+            asyncio.run(scheduler._run_evidence_iteration())
+
+        self.assertEqual(scheduler.state.last_error, "evidence unavailable")
+        self.assertEqual(
+            scheduler.state.last_evidence_error,
+            "evidence unavailable",
+        )
+
+        with patch.object(
+            scheduler,
+            "_run_evidence_continuity_check",
+            return_value=None,
+        ):
+            asyncio.run(scheduler._run_evidence_iteration())
+
+        self.assertIsNone(scheduler.state.last_evidence_error)
+        self.assertIsNone(scheduler.state.last_error)
+
     def test_run_reconcile_iteration_continues_with_partial_lane_failure(self) -> None:
         scheduler = TradingScheduler()
         failing_lane = _PipelineIterationStub(

--- a/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
+++ b/services/torghut/tests/trading_scheduler_autonomy/test_emergency_stop_incident_contains_hooks_and_provenance.py
@@ -116,11 +116,73 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
 
         self.assertEqual(failing_lane.run_once_calls, 1)
         self.assertEqual(healthy_lane.run_once_calls, 1)
-        self.assertIsNone(scheduler.state.last_error)
+        self.assertEqual(
+            scheduler.state.last_error,
+            "trading_lane_failures:paper-a",
+        )
+        self.assertEqual(
+            scheduler.state.last_trading_error,
+            "trading_lane_failures:paper-a",
+        )
         self.assertEqual(safety_calls["count"], 1)
-        self.assertIsNotNone(scheduler.state.last_run_at)
+        self.assertIsNone(scheduler.state.last_run_at)
         self.assertEqual(failing_lane.run_once_last_error, "run_once_failed")
         self.assertEqual(healthy_lane.run_once_last_error, None)
+
+    def test_run_trading_iteration_never_records_success_when_all_lanes_fail(
+        self,
+    ) -> None:
+        scheduler = TradingScheduler()
+        first_lane = _PipelineIterationStub(
+            account_label="paper-a",
+            run_once_fail=True,
+        )
+        second_lane = _PipelineIterationStub(
+            account_label="paper-b",
+            run_once_fail=True,
+        )
+        scheduler._pipelines = [first_lane, second_lane]
+        scheduler._pipeline = first_lane
+
+        asyncio.run(scheduler._run_trading_iteration())
+
+        self.assertEqual(first_lane.run_once_calls, 1)
+        self.assertEqual(second_lane.run_once_calls, 1)
+        self.assertEqual(
+            scheduler.state.last_error,
+            "trading_lane_failures:paper-a,paper-b",
+        )
+        self.assertEqual(
+            scheduler.state.last_trading_error,
+            "trading_lane_failures:paper-a,paper-b",
+        )
+        self.assertIsNone(scheduler.state.last_run_at)
+
+    def test_successful_reconcile_cannot_mask_latest_trading_failure(self) -> None:
+        scheduler = TradingScheduler()
+        lane = _PipelineIterationStub(
+            account_label="paper-a",
+            run_once_fail=True,
+            reconcile_return=1,
+        )
+        scheduler._pipelines = [lane]
+        scheduler._pipeline = lane
+        scheduler.state.last_run_at = datetime.now(timezone.utc)
+        scheduler._evaluate_safety_controls = lambda: None
+
+        asyncio.run(scheduler._run_trading_iteration())
+        asyncio.run(scheduler._run_reconcile_iteration())
+
+        self.assertEqual(
+            scheduler.state.last_error,
+            "trading_lane_failures:paper-a",
+        )
+        self.assertEqual(
+            scheduler.state.last_trading_error,
+            "trading_lane_failures:paper-a",
+        )
+        self.assertIsNone(scheduler.state.last_reconcile_error)
+        self.assertIsNotNone(scheduler.state.last_reconcile_at)
 
     def test_run_reconcile_iteration_continues_with_partial_lane_failure(self) -> None:
         scheduler = TradingScheduler()
@@ -146,9 +208,12 @@ class TestEmergencyStopIncidentContainsHooksAndProvenance(
         self.assertEqual(failing_lane.reconcile_calls, 1)
         self.assertEqual(healthy_lane.reconcile_calls, 1)
         self.assertEqual(healthy_lane.reconcile_return, 2)
-        self.assertIsNone(scheduler.state.last_error)
+        self.assertEqual(
+            scheduler.state.last_error,
+            "reconcile_lane_failures:paper-a",
+        )
         self.assertEqual(safety_calls["count"], 1)
-        self.assertIsNotNone(scheduler.state.last_reconcile_at)
+        self.assertIsNone(scheduler.state.last_reconcile_at)
         self.assertEqual(failing_lane.reconcile_last_error, "reconcile_failed")
         self.assertEqual(healthy_lane.reconcile_last_error, None)
 


### PR DESCRIPTION
## Summary

- split Torghut's stateless Knative API from the trading and whitepaper background scheduler
- add a zero-replica `Recreate` scheduler Deployment with PostgreSQL advisory-lock leadership, process-fatal lock-loss handling, and fail-closed probes
- remove API `minScale` so obsolete immutable revisions cannot remain hot and run background work
- set API `TRADING_ENABLED=false` so even the previous image cannot start a second trader if Argo applies the manifest before image promotion completes
- keep `/trading/status` fail-closed on the scheduler while making API readiness and metrics process-local so a zero-replica scheduler cannot break the stateless API rollout
- route scheduler metrics and alerts to the dedicated workload and update image-promotion tooling for both runtime manifests
- carry the scheduler manifest through release change detection, generated deploy PRs, and deploy-automerge allowlists so its image digest cannot drift from the API
- require the digest-pinned multi-architecture image contract even for scheduler-only release manifest changes
- make post-deploy verification strict for both stages: exact API containment at scheduler replicas `0`, and separate API plus scheduler-owned runtime proof at replicas `1`
- bound post-deploy contract convergence across the source-to-image-promotion gap without accepting the previous image's runtime shape
- preserve `torghut-sim` as an explicit paper-only, process-local runtime instead of accidentally proxying the live scheduler
- stage the first simulation migration at `TRADING_ENABLED=false`, then use an isolated advisory-lock namespace and nonblocking standby supervisor for duplicate-free future Knative handoffs
- require strict post-deploy proof of either exact simulation containment or an enabled/running local simulation, based on the live KService desired state
- drain in-flight broker work before releasing leadership, hard-exit without unlocking on timeout, and require fresh error-free trading and all-lane reconciliation cycles for scheduler readiness
- terminate the scheduler process if its enabled trading loop returns, crashes, or is cancelled unexpectedly, and make liveness expose the required loop state
- pin ordinary decision submissions to one lifecycle attempt and zero Torghut transport retries until durable broker mutation receipts exist
- split service-owned Alpaca reads from mutations so safe GETs retain SDK retries while submit, cancel, and cancel-all perform exactly one HTTP attempt; emergency closeout attempts remain a separate risk-control contract
- preserve read-only recovery of historical base, `-r2`, and `-r3` broker idempotency keys so the one-attempt cutover cannot create a duplicate order
- verify the API, simulation, and scheduler release manifests directly and require one commit plus image digest across all three
- document an exact one-time cleanup transaction that pins KService UID/generation, rejects tagged routes, deletes only named legacy revisions, and proves zero scheduler locks; prohibit persistent cleanup Jobs and RBAC

## Related Issues

None.

## Testing

- clean staged-slice worktree: 110 focused scheduler, API, manifest-contract, and loop regression tests passed
- final scheduler-loop liveness regressions: 37 passed
- scheduler normal-stop CI regression plus leadership suite: 11 passed
- final retry-containment suite: 47 Alpaca, order-lifecycle, API, simulation, and scheduler manifest tests passed
- mutation/read transport regressions prove POST 429/504 makes one request and zero sleeps while GET 429/504 retains four requests and three sleeps
- historical broker-id recovery and order-lifecycle regression suite: 24 passed, including `-r3` recovery with no new submit
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.strict.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.strict.json`
- full `ruff format --check`, `ruff check`, unused-import gate, bytecode compile, structural Pylint, changed-line quality/design gates, file-length gate, tech-debt ratchet, and migration graph
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts` (5 passed, 81 assertions)
- `bun test packages/scripts/src/torghut/__tests__/deploy-automerge-workflow.test.ts` (9 passed, 63 assertions)
- combined deploy-automerge and build-push workflow contracts: 29 passed, 273 assertions
- final post-deploy live/simulation contracts: 56 passed, 201 assertions; Oxfmt, Oxlint, and actionlint passed
- final clean P0a slice: 97 focused Python tests passed, including simulation standby handoff, local status/readiness/metrics, reconciliation freshness, and historical simulation reconfiguration
- API/scheduler/simulation role manifest contracts and Torghut Kustomize render passed
- final render: 75 resources; Kubernetes client dry-run passed all resources; Kubeconform reported 65 valid, 0 invalid, 0 errors, and 10 skipped custom resources
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `kustomize build --enable-helm argocd/applications/torghut`
- `kustomize build --enable-helm argocd/applications/observability`
- extracted cleanup Bash blocks pass `bash -n`; strict generation and untagged-traffic predicates pass against the live KService without mutation

## Screenshots (if applicable)

N/A; this is a runtime and GitOps containment change.

## Breaking Changes

The API image no longer starts trading, reconciliation, or whitepaper background loops. `/trading/status` returns `503` while the scheduler is unavailable; API `/readyz` and `/metrics` now report only stateless API process truth. Ordinary decision submission is fail-closed at one lifecycle attempt with zero Torghut or Alpaca mutation-transport retries until durable mutation receipts exist; safe broker reads retain SDK retries, while read-only recovery continues to reconcile historical base, `-r2`, and `-r3` broker IDs without authorizing a new attempt. Emergency closeout remains governed by its separate risk-control contract. The new scheduler Deployment intentionally remains at zero replicas for the P0a containment rollout and must not be scaled to one until the scheduler-free API revision and zero-writer cutover are verified. `torghut-sim` is also intentionally disabled for the first image migration so the previous unfenced image stops; a separate small GitOps follow-up will re-enable it under the isolated simulation leadership fence. A later gated change will activate the live advisory-locked scheduler.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
