### PR TITLE
fix: close merged Codex review feedback

### DIFF
--- a/.github/actions/setup-nix-toolchain/action.yml
+++ b/.github/actions/setup-nix-toolchain/action.yml
@@ -106,7 +106,15 @@ runs:
         set -euo pipefail
         export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
         store_info_log="$(mktemp)"
-        if nix store info >"${store_info_log}" 2>&1; then
+        write_probe="$(mktemp)"
+        trap 'rm -f "${store_info_log}" "${write_probe}"' EXIT
+        printf 'lab-nix-store-write-probe\n' > "${write_probe}"
+
+        probe_store_write() {
+          nix store add-file "${write_probe}" >/dev/null
+        }
+
+        if nix store info >"${store_info_log}" 2>&1 && probe_store_write; then
           rm -f "${store_info_log}"
           exit 0
         fi
@@ -114,11 +122,13 @@ runs:
           echo 'NIX_REMOTE=daemon' >> "${GITHUB_ENV}"
           export NIX_REMOTE=daemon
           nix store info
+          probe_store_write
           rm -f "${store_info_log}"
           exit 0
         fi
         real_nix="$(command -v nix)"
-        if sudo -n --preserve-env=NIX_CONFIG,NIX_SSL_CERT_FILE "${real_nix}" store info >/dev/null 2>&1; then
+        if sudo -n --preserve-env=NIX_CONFIG,NIX_SSL_CERT_FILE "${real_nix}" store info >/dev/null 2>&1 &&
+          sudo -n --preserve-env=NIX_CONFIG,NIX_SSL_CERT_FILE "${real_nix}" store add-file "${write_probe}" >/dev/null 2>&1; then
           wrapper_dir="${RUNNER_TEMP:-/tmp}/lab-nix-sudo-wrapper"
           mkdir -p "${wrapper_dir}"
           cat > "${wrapper_dir}/nix" <<EOF
@@ -129,7 +139,9 @@ runs:
           chmod +x "${wrapper_dir}/nix"
           echo "${wrapper_dir}" >> "${GITHUB_PATH}"
           echo 'LAB_NIX_WITH_SUDO=true' >> "${GITHUB_ENV}"
+          echo "LAB_NIX_WRAPPER_DIR=${wrapper_dir}" >> "${GITHUB_ENV}"
           PATH="${wrapper_dir}:${PATH}" nix store info
+          PATH="${wrapper_dir}:${PATH}" nix store add-file "${write_probe}" >/dev/null
           rm -f "${store_info_log}"
           exit 0
         fi
@@ -145,7 +157,8 @@ runs:
         REQUIRE_PREINSTALLED: ${{ inputs.require-preinstalled }}
       run: |
         set -euo pipefail
-        export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+        wrapper_prefix="${LAB_NIX_WRAPPER_DIR:+${LAB_NIX_WRAPPER_DIR}:}"
+        export PATH="${wrapper_prefix}${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
         missing=()
         required_commands=(
           nix

--- a/.github/workflows/arc-runner-build-push.yml
+++ b/.github/workflows/arc-runner-build-push.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   pull_request:
     paths:
+      - 'flake.nix'
       - 'nix/images/arc-runner.nix'
       - 'flake.lock'
       - 'nix/packages.nix'
@@ -22,6 +23,7 @@ on:
     branches:
       - main
     paths:
+      - 'flake.nix'
       - 'nix/images/arc-runner.nix'
       - 'flake.lock'
       - 'nix/packages.nix'

--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -98,10 +98,6 @@ jobs:
             changed_paths="$(git diff --name-only "${source_sha}..HEAD")"
             arc_image_input_changes="$(
               printf '%s\n' "${changed_paths}" | grep -E \
-                -e '^\.github/actions/setup-nix-toolchain/' \
-                -e '^\.github/workflows/arc-runner-build-push\.yml$' \
-                -e '^\.github/workflows/nix-oci-build-common\.yml$' \
-                -e '^flake\.nix$' \
                 -e '^flake\.lock$' \
                 -e '^nix/images/arc-runner\.nix$' \
                 -e '^nix/packages\.nix$' \
@@ -113,7 +109,6 @@ jobs:
                 -e '^nix/oci-doctor\.sh$' \
                 -e '^nix/oci-inspect-archive\.sh$' \
                 -e '^nix/oci-push\.sh$' \
-                -e '^nix/oci-release-contract\.sh$' \
                 -e '^nix/toolchain-doctor\.sh$' || true
             )"
             if [[ -n "${arc_image_input_changes}" ]]; then

--- a/.github/workflows/arc-runner-release.yml
+++ b/.github/workflows/arc-runner-release.yml
@@ -98,6 +98,7 @@ jobs:
             changed_paths="$(git diff --name-only "${source_sha}..HEAD")"
             arc_image_input_changes="$(
               printf '%s\n' "${changed_paths}" | grep -E \
+                -e '^flake\.nix$' \
                 -e '^flake\.lock$' \
                 -e '^nix/images/arc-runner\.nix$' \
                 -e '^nix/packages\.nix$' \

--- a/.github/workflows/attic-release.yml
+++ b/.github/workflows/attic-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       image_tag:
-        description: Image tag to promote (defaults to source short SHA)
+        description: Image tag to promote (defaults to sha-<full commit SHA>)
         required: false
         type: string
       image_digest:

--- a/.github/workflows/enabled-product-nix-release.yml
+++ b/.github/workflows/enabled-product-nix-release.yml
@@ -123,23 +123,23 @@ jobs:
             case "${service}" in
               proompteng)
                 manifest_path="argocd/applications/proompteng/kustomization.yaml"
-                input_paths=(apps/landing packages/backend packages/design nix/images/proompteng.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock)
+                input_paths=(apps/landing packages/backend packages/design nix/images/proompteng.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock)
                 ;;
               app)
                 manifest_path="argocd/applications/app/kustomization.yaml"
-                input_paths=(apps/app packages/design nix/images/app.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock)
+                input_paths=(apps/app packages/design nix/images/app.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock)
                 ;;
               synthesis)
                 manifest_path="argocd/applications/synthesis/kustomization.yaml"
-                input_paths=(apps/synthesis packages/design nix/images/synthesis.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock)
+                input_paths=(apps/synthesis packages/design nix/images/synthesis.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock)
                 ;;
               docs)
                 manifest_path="argocd/applications/docs/kustomization.yaml"
-                input_paths=(apps/docs packages/design nix/images/docs.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock)
+                input_paths=(apps/docs packages/design nix/images/docs.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock)
                 ;;
               olden)
                 manifest_path="argocd/applications/olden/kustomization.yaml"
-                input_paths=(apps/olden packages/design nix/images/olden.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock)
+                input_paths=(apps/olden packages/design nix/images/olden.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock)
                 ;;
               *)
                 echo "Unsupported service in release contract: ${service}" >&2

--- a/.github/workflows/enabled-simple-nix-release.yml
+++ b/.github/workflows/enabled-simple-nix-release.yml
@@ -136,13 +136,13 @@ jobs:
 
           case "${SERVICE}" in
             oirat)
-              paths=(services/oirat packages/discord nix/images/oirat.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock tsconfig.base.json)
+              paths=(services/oirat packages/discord nix/images/oirat.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock tsconfig.base.json)
               ;;
             bumba)
-              paths=(services/bumba packages/temporal-bun-sdk nix/images/bumba.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock tsconfig.base.json)
+              paths=(services/bumba packages/temporal-bun-sdk nix/images/bumba.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/ci-run-timed.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock tsconfig.base.json)
               ;;
             froussard)
-              paths=(apps/froussard packages/agent-contracts packages/codex packages/discord packages/otel nix/images/froussard.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh nix/oci-release-contract.sh flake.lock bun.lock tsconfig.base.json)
+              paths=(apps/froussard packages/agent-contracts packages/codex packages/discord packages/otel nix/images/froussard.nix nix/images/bun-workspace-service.nix nix/packages.nix nix/cache-push.sh nix/ci-nix-oci-summary.sh nix/oci-inspect-archive.sh nix/oci-push.sh flake.lock bun.lock tsconfig.base.json)
               ;;
           esac
 

--- a/.github/workflows/headlamp-release.yml
+++ b/.github/workflows/headlamp-release.yml
@@ -117,8 +117,6 @@ jobs:
             nix/ci-run-timed.sh
             nix/oci-inspect-archive.sh
             nix/oci-push.sh
-            nix/oci-release-contract.sh
-            flake.nix
             flake.lock
           )
 

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       image_tag:
-        description: Image tag to promote (defaults to short SHA)
+        description: Image tag to promote (defaults to sha-<full commit SHA>)
         required: false
         type: string
       image_digest:

--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -85,7 +85,7 @@ jobs:
             exit 0
           fi
 
-          allowed_authors=("app/github-actions" "github-actions[bot]" "gregkonush")
+          bot_authors=("app/github-actions" "github-actions[bot]")
           legacy_release_paths=(
             "argocd/applications/khoshut/kustomization.yaml"
             "argocd/applications/analysis/kustomization.yaml"
@@ -126,6 +126,7 @@ jobs:
           PR_STATE="$(jq -r '.state // ""' <<< "$pr_json")"
           PR_AUTHOR="$(jq -r '.user.login // ""' <<< "$pr_json")"
           PR_HEAD_REF="$(jq -r '.head.ref // ""' <<< "$pr_json")"
+          PR_HEAD_SHA="$(jq -r '.head.sha // ""' <<< "$pr_json")"
           PR_BASE_REF="$(jq -r '.base.ref // ""' <<< "$pr_json")"
           PR_HEAD_REPO="$(jq -r '.head.repo.full_name // ""' <<< "$pr_json")"
           PR_IS_DRAFT="$(jq -r '.draft // false' <<< "$pr_json")"
@@ -162,9 +163,25 @@ jobs:
             exit 0
           fi
 
-          if ! contains "$PR_AUTHOR" "${allowed_authors[@]}"; then
-            echo "reason=author-not-allowlisted" >> "$GITHUB_OUTPUT"
+          if ! [[ "$PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "reason=invalid-head-sha" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          if ! contains "$PR_AUTHOR" "${bot_authors[@]}"; then
+            if [[ "$PR_AUTHOR" != "gregkonush" ]]; then
+              echo "reason=author-not-allowlisted" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            commit_json="$(gh api "repos/$GH_REPO/commits/$PR_HEAD_SHA")"
+            commit_committer_login="$(jq -r '.committer.login // ""' <<< "$commit_json")"
+            commit_committer_email="$(jq -r '.commit.committer.email // ""' <<< "$commit_json")"
+            if [[ "$commit_committer_login" != "github-actions[bot]" ]] ||
+              [[ "$commit_committer_email" != "41898282+github-actions[bot]@users.noreply.github.com" ]]; then
+              echo "reason=human-authored-release-pr" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           has_opt_out_label=$(
@@ -261,4 +278,5 @@ jobs:
             exit 0
           fi
 
-          gh pr merge "$PR_NUMBER" -R "$GH_REPO" --auto --squash
+          current_head_sha="$(gh pr view "$PR_NUMBER" -R "$GH_REPO" --json headRefOid --jq '.headRefOid')"
+          gh pr merge "$PR_NUMBER" -R "$GH_REPO" --auto --squash --match-head-commit "$current_head_sha"

--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -247,6 +247,7 @@ jobs:
           done
 
           echo "eligible=true" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
           echo "reason=eligible:${release_kind}" >> "$GITHUB_OUTPUT"
 
       - name: Eligibility summary
@@ -263,6 +264,7 @@ jobs:
           GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.gates.outputs.head_sha }}
         run: |
           set -euo pipefail
 
@@ -278,5 +280,4 @@ jobs:
             exit 0
           fi
 
-          current_head_sha="$(gh pr view "$PR_NUMBER" -R "$GH_REPO" --json headRefOid --jq '.headRefOid')"
-          gh pr merge "$PR_NUMBER" -R "$GH_REPO" --auto --squash --match-head-commit "$current_head_sha"
+          gh pr merge "$PR_NUMBER" -R "$GH_REPO" --auto --squash --match-head-commit "$PR_HEAD_SHA"

--- a/.github/workflows/sag-release.yml
+++ b/.github/workflows/sag-release.yml
@@ -109,7 +109,6 @@ jobs:
               nix/ci-run-timed.sh
               nix/oci-inspect-archive.sh
               nix/oci-push.sh
-              nix/oci-release-contract.sh
               flake.lock
               bun.lock
               tsconfig.base.json

--- a/.github/workflows/symphony-release.yml
+++ b/.github/workflows/symphony-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       image_tag:
-        description: Image tag to promote (defaults to source short SHA)
+        description: Image tag to promote (defaults to sha-<full commit SHA>)
         required: false
         type: string
       image_digest:

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -71,6 +71,7 @@ jobs:
           GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
@@ -428,6 +429,7 @@ jobs:
           GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
@@ -456,4 +458,4 @@ jobs:
               ;;
           esac
 
-          gh pr merge "${PR_NUMBER}" -R "${GH_REPO}" --squash
+          gh pr merge "${PR_NUMBER}" -R "${GH_REPO}" --squash --match-head-commit "${PR_HEAD_SHA}"

--- a/.github/workflows/torghut-hyperliquid-feed-release.yml
+++ b/.github/workflows/torghut-hyperliquid-feed-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       image_tag:
-        description: Image tag to promote (defaults to source short SHA)
+        description: Image tag to promote (defaults to sha-<full commit SHA>)
         required: false
         type: string
       image_digest:
@@ -130,7 +130,6 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
-                    nix/oci-release-contract.sh \
                     flake.lock
                 )"
                 if [ -n "${FEED_CHANGES}" ]; then
@@ -152,7 +151,7 @@ jobs:
             if [ -n "${IMAGE_TAG_INPUT}" ]; then
               TAG="${IMAGE_TAG_INPUT}"
             else
-              TAG="$(git rev-parse --short=8 "${SOURCE_SHA}")"
+              TAG="sha-${SOURCE_SHA}"
             fi
           fi
 

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       image_tag:
-        description: Image tag to promote (defaults to source short SHA)
+        description: Image tag to promote (defaults to sha-<full commit SHA>)
         required: false
         type: string
       image_digest:
@@ -132,13 +132,8 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
-                    nix/oci-release-contract.sh \
                     flake.lock \
-                    services/torghut/uv.lock \
-                    .github/workflows/torghut-build-push.yaml \
-                    .github/workflows/torghut-release.yml \
-                    .github/workflows/nix-oci-build-common.yml \
-                    .github/actions/setup-nix-toolchain
+                    services/torghut/uv.lock
                 )"
                 if [ -n "${TORGHUT_CHANGES}" ]; then
                   echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; newer Torghut build inputs changed:"
@@ -159,7 +154,7 @@ jobs:
             if [ -n "${IMAGE_TAG_INPUT}" ]; then
               TAG="${IMAGE_TAG_INPUT}"
             else
-              TAG="$(git rev-parse --short=8 "${SOURCE_SHA}")"
+              TAG="sha-${SOURCE_SHA}"
             fi
           fi
 

--- a/.github/workflows/torghut-ta-release.yml
+++ b/.github/workflows/torghut-ta-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       image_tag:
-        description: Image tag to promote (defaults to source short SHA)
+        description: Image tag to promote (defaults to sha-<full commit SHA>)
         required: false
         type: string
       image_digest:
@@ -130,7 +130,6 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
-                    nix/oci-release-contract.sh \
                     flake.lock
                 )"
                 if [ -n "${TA_CHANGES}" ]; then
@@ -152,7 +151,7 @@ jobs:
             if [ -n "${IMAGE_TAG_INPUT}" ]; then
               TAG="${IMAGE_TAG_INPUT}"
             else
-              TAG="$(git rev-parse --short=8 "${SOURCE_SHA}")"
+              TAG="sha-${SOURCE_SHA}"
             fi
           fi
 

--- a/.github/workflows/torghut-ws-release.yml
+++ b/.github/workflows/torghut-ws-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       image_tag:
-        description: Image tag to promote (defaults to source short SHA)
+        description: Image tag to promote (defaults to sha-<full commit SHA>)
         required: false
         type: string
       image_digest:
@@ -130,7 +130,6 @@ jobs:
                     nix/ci-run-timed.sh \
                     nix/oci-inspect-archive.sh \
                     nix/oci-push.sh \
-                    nix/oci-release-contract.sh \
                     flake.lock
                 )"
                 if [ -n "${WS_CHANGES}" ]; then
@@ -152,7 +151,7 @@ jobs:
             if [ -n "${IMAGE_TAG_INPUT}" ]; then
               TAG="${IMAGE_TAG_INPUT}"
             else
-              TAG="$(git rev-parse --short=8 "${SOURCE_SHA}")"
+              TAG="sha-${SOURCE_SHA}"
             fi
           fi
 

--- a/docs/nix-enabled-app-rollout-evidence-2026-07-05.md
+++ b/docs/nix-enabled-app-rollout-evidence-2026-07-05.md
@@ -23,6 +23,8 @@ This is the final report for the enabled-app Nix build performance rollout as of
   `.github/workflows/froussard-ci.yml`, `.github/workflows/arc-runner-build-push.yml`, and
   `.github/workflows/attic-build-push.yaml`, and `.github/workflows/headlamp-ci.yml` using
   `.github/workflows/nix-oci-build-common.yml`; product apps use `.github/workflows/product-nix-images.yml`;
+  the Symphony family uses `.github/workflows/symphony-build-push.yaml` and
+  `.github/workflows/symphony-release.yml`;
   Jangar uses `.github/workflows/jangar-build-push.yaml`; Agents uses `.github/workflows/agents-build-push.yml`;
   Torghut uses `.github/workflows/torghut-build-push.yaml`, `.github/workflows/torghut-ta-build-push.yaml`,
   `.github/workflows/torghut-ws-build-push.yaml`, and `.github/workflows/torghut-hyperliquid-feed-build-push.yaml`.
@@ -634,8 +636,20 @@ Current enabled-app readback plus Olden's final pre-disable evidence:
 ### Product Cache Status
 
 The product build jobs used Attic setup and pushed build-platform helper closures plus image archive closures to Attic.
-The release contracts prove digest and platform identity, but they do not include normalized `cacheProvenance` objects.
-This checkpoint therefore records job wall times and does not claim cache-hit counts.
+The same run's performance summaries provide normalized cache and phase evidence from the real build jobs:
+
+| Service/platform | Attic substitutions | cache.nixos.org substitutions | Local builds | Planned local blocks | Build archive | Push platform image |
+| ---------------- | ------------------: | -----------------------------: | -----------: | -------------------: | ------------: | ------------------: |
+| `docs/amd64` | 0 | 45 | 14 | 2 | 81s | 63s |
+| `docs/arm64` | 1 | 14 | 1 | 1 | 71s | 50s |
+| `app/amd64` | 1 | 14 | 1 | 1 | 322s | 73s |
+| `app/arm64` | 0 | 45 | 14 | 2 | 406s | 97s |
+| `olden/amd64` | 1 | 14 | 1 | 1 | 61s | 57s |
+| `olden/arm64` | 1 | 14 | 1 | 1 | 85s | 54s |
+| `proompteng/amd64` | 0 | 45 | 14 | 2 | 70s | 72s |
+| `proompteng/arm64` | 0 | 45 | 14 | 2 | 150s | 57s |
+| `synthesis/amd64` | 1 | 14 | 1 | 1 | 123s | 53s |
+| `synthesis/arm64` | 0 | 45 | 14 | 2 | 312s | 69s |
 
 The July 4 product run is not yet a clean performance win across the board: `app` arm64 took `41m31s` and `synthesis`
 arm64 took `29m31s`, largely in image archive warming. The next product optimization should reduce or bound closure
@@ -770,7 +784,8 @@ Current readback:
 - Deployment status: `ready=1`, `available=1`, `updated=1`, generation equals observed generation
 - Pod: `jangar-5747b5586b-vd62t`, `2/2 Running`, `0` restarts
 - Service endpoints: `10.244.5.21:8080`
-- Readiness smoke: `http://jangar/healthz` returned `200` from an in-cluster `curlimages/curl` pod.
+- Readiness smoke: `http://jangar/health` returned `200` from an in-cluster `curlimages/curl` pod, matching the
+  deployed readiness probe and current Jangar health route.
 
 Post-deploy verifier run [28760860423](https://github.com/proompteng/lab/actions/runs/28760860423) proved the
 full Jangar runtime verifier contract on `main`:
@@ -877,6 +892,20 @@ Current readback:
 - in-cluster service smoke:
   - `http://agents/ready` returned `HTTP 200`
   - `http://agents-shell/readyz` returned `HTTP 200`
+
+Runner execution proof was completed on 2026-07-11 with AgentRun
+`agents-shell-audit-every-unresolved-review-thread-auth-eb474464`:
+
+- AgentRun phase: `Succeeded`
+- runtime Job: `agents-shell-audit-every-unresolved-review-thread-auth-2ca59ed6`
+- runner image:
+  `registry.ide-newton.ts.net/lab/agents-codex-runner:sha-350c4bde2ca3ed0f704c959eb2c386c9010cc606@sha256:1e9e47aaedadf5429de22359e48262520cb2787f38dbd29bc0971aaaf52e80c7`
+- runner adapter/model: `codex-app-server` / `gpt-5.5`
+- execution window: `2026-07-11T16:51:14Z` through `2026-07-11T16:59:49Z`
+- workload result: searched 461 merged pull requests and enumerated 94 unresolved Codex review threads across
+  61 merged pull requests
+- runner exit code: `0`; Kubernetes Job reached `Complete` with one succeeded pod
+- no repository changes or pull request were created by the audit run
 
 ### Agents Cache Status
 

--- a/nix/attic-release-metadata.sh
+++ b/nix/attic-release-metadata.sh
@@ -48,7 +48,7 @@ else
     source_sha="$(git rev-parse "${source_sha}^{commit}")"
   fi
   if [[ -z "${tag}" ]]; then
-    tag="sha-$(git rev-parse --short=12 "${source_sha}")"
+    tag="sha-${source_sha}"
   fi
   if [[ -z "${digest}" ]]; then
     digest="$(crane digest "${image}:${tag}")"

--- a/nix/ci-nix-oci-summary.sh
+++ b/nix/ci-nix-oci-summary.sh
@@ -57,6 +57,25 @@ count_image_cache_status() {
   echo "${count}"
 }
 
+count_image_cache_status_rows() {
+  local expected_status="$1"
+  if ! compgen -G "${log_dir}/image-cache-push-status-*.txt" >/dev/null; then
+    echo 0
+    return
+  fi
+  awk -F $'\t' -v expected="${expected_status}" '$1 == expected {count += 1} END {print count + 0}' \
+    "${log_dir}"/image-cache-push-status-*.txt
+}
+
+sum_image_cache_skipped_bytes() {
+  if ! compgen -G "${log_dir}/image-cache-push-status-*.txt" >/dev/null; then
+    echo 0
+    return
+  fi
+  awk -F $'\t' '$1 == "skipped-size" {total += $2} END {print total + 0}' \
+    "${log_dir}"/image-cache-push-status-*.txt
+}
+
 count_existing_image_archives() {
   local image_tar archive_count
   archive_count=0
@@ -98,6 +117,8 @@ image_archives="$(count_existing_image_archives)"
 image_archive_bytes="$(sum_existing_image_archive_bytes)"
 image_cache_warm_successes="$(count_image_cache_status succeeded)"
 image_cache_warm_failures="$(count_image_cache_status failed)"
+image_cache_warm_skipped_size="$(count_image_cache_status_rows skipped-size)"
+image_cache_warm_skipped_bytes="$(sum_image_cache_skipped_bytes)"
 
 {
   echo "## Nix OCI Cache Summary"
@@ -120,6 +141,8 @@ image_cache_warm_failures="$(count_image_cache_status failed)"
   echo "| Existing image archive bytes | ${image_archive_bytes} |"
   echo "| Image archive Attic warm successes | ${image_cache_warm_successes} |"
   echo "| Image archive Attic warm failures | ${image_cache_warm_failures} |"
+  echo "| Image archive Attic warm size skips | ${image_cache_warm_skipped_size} |"
+  echo "| Image archive Attic warm skipped bytes | ${image_cache_warm_skipped_bytes} |"
   echo
 
   if [[ -f "${timings_file}" ]]; then

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,7 +11,7 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-OyGhoRH+YX4/sBagr0nu7yaoGvQYhRQyyHeyRIU3vlY=";
+    x86_64-linux = "sha256-llSaRQ6Sva/ZNLvY5vCNIu0TYJH6Zc36E0aUXEs576Y=";
     aarch64-linux = "sha256-llSaRQ6Sva/ZNLvY5vCNIu0TYJH6Zc36E0aUXEs576Y=";
   };
   installFilters = [

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-sQoweSUF9OxBXPLU9c7Jhvqay1GrF202JfWkTnTn6G4=";
-    aarch64-linux = "sha256-sQoweSUF9OxBXPLU9c7Jhvqay1GrF202JfWkTnTn6G4=";
+    x86_64-linux = "sha256-OyGhoRH+YX4/sBagr0nu7yaoGvQYhRQyyHeyRIU3vlY=";
+    aarch64-linux = "sha256-OyGhoRH+YX4/sBagr0nu7yaoGvQYhRQyyHeyRIU3vlY=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -12,7 +12,7 @@ import ./bun-workspace-service.nix {
   packageName = "@proompteng/bumba";
   depsHash = {
     x86_64-linux = "sha256-OyGhoRH+YX4/sBagr0nu7yaoGvQYhRQyyHeyRIU3vlY=";
-    aarch64-linux = "sha256-OyGhoRH+YX4/sBagr0nu7yaoGvQYhRQyyHeyRIU3vlY=";
+    aarch64-linux = "sha256-llSaRQ6Sva/ZNLvY5vCNIu0TYJH6Zc36E0aUXEs576Y=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-21YVEeBdNggoDr53RT9gjRJEVjrYNL06vB7k07hyx10=";
-    aarch64-linux = "sha256-fmFLCik0rMBdyLXL70aPUTcobPPb5pMnWVA2y5n9ur4=";
+    x86_64-linux = "sha256-ryxS3BrZImWQKWh6iBxi6XYrOpai4LWBJIDVrrBgApc=";
+    aarch64-linux = "sha256-2Hjd12e3j93mezdhrsTKh5GRrk3458cPwIqLuhu5GQY=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-JMCejKayysUbH4ZjgoKBrRSqKglEGjio/zo/M0WpRGU=";
-    aarch64-linux = "sha256-5y6nWzSl7n2JOw1GGmULQ1zaUbktxRFAZDVXocRhiv8=";
+    x86_64-linux = "sha256-21YVEeBdNggoDr53RT9gjRJEVjrYNL06vB7k07hyx10=";
+    aarch64-linux = "sha256-fmFLCik0rMBdyLXL70aPUTcobPPb5pMnWVA2y5n9ur4=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-k0pJJlADVVDAgpsv5k0IE2nZWzTCKgMHGxoZw6Ob7jA=";
-    aarch64-linux = "sha256-luK//9t5OVFSK1v7I3Yd+fwHtR7Vkhx3nlRh5wxYm00=";
+    x86_64-linux = "sha256-Bn6qTAvOi8BZ0QB1lHOo5mVpuCd0o/fSMffth63fmro=";
+    aarch64-linux = "sha256-iuHkC2sgWeMo79weQ9Hp9hTINBqVSjUTHrms19/J1Jw=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-HlcpG+m5TFAbu1Aa+N/BOzPSERhSPQxxJv3VyL51mvQ=";
-    aarch64-linux = "sha256-Kac9lgXk/JrNiWy7tHmMF8kq5yIMXE99UYR9szhbLxc=";
+    x86_64-linux = "sha256-k0pJJlADVVDAgpsv5k0IE2nZWzTCKgMHGxoZw6Ob7jA=";
+    aarch64-linux = "sha256-luK//9t5OVFSK1v7I3Yd+fwHtR7Vkhx3nlRh5wxYm00=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/packages/scripts/src/jangar/resolve-release-metadata.ts
+++ b/packages/scripts/src/jangar/resolve-release-metadata.ts
@@ -12,7 +12,7 @@ const defaultContractPath = '.artifacts/jangar/release-contract.json'
 const defaultImage = 'registry.ide-newton.ts.net/lab/jangar'
 
 const buildTriggerPathRegex =
-  /^(services\/jangar\/|services\/bumba\/|packages\/(agent-contracts|codex|cx-tools|design|discord|otel|temporal-bun-sdk)\/|nix\/images\/jangar\.nix$|nix\/images\/openai-codex-cli\.nix$|nix\/images\/bun-workspace-service\.nix$|nix\/packages\.nix$|nix\/cache-push\.sh$|nix\/ci-nix-oci-summary\.sh$|nix\/ci-run-timed\.sh$|nix\/oci-inspect-archive\.sh$|nix\/oci-push\.sh$|nix\/oci-release-contract\.sh$|flake\.lock$|bun\.lock$|tsconfig\.base\.json$)/
+  /^(services\/jangar\/|services\/bumba\/|packages\/(agent-contracts|codex|cx-tools|design|discord|otel|temporal-bun-sdk)\/|nix\/images\/jangar\.nix$|nix\/images\/openai-codex-cli\.nix$|nix\/images\/bun-workspace-service\.nix$|nix\/packages\.nix$|nix\/cache-push\.sh$|nix\/ci-nix-oci-summary\.sh$|nix\/ci-run-timed\.sh$|nix\/oci-inspect-archive\.sh$|nix\/oci-push\.sh$|flake\.lock$|bun\.lock$|tsconfig\.base\.json$)/
 
 type CliOptions = {
   eventName?: string
@@ -243,7 +243,7 @@ const resolveReleaseMetadata = (options: ResolveReleaseMetadataOptions): Release
     reason = stalenessDecision.reason
   } else {
     sourceSha = options.commitShaInput?.trim() || mainHead
-    tag = options.imageTagInput?.trim() || sourceSha.slice(0, 8)
+    tag = options.imageTagInput?.trim() || `sha-${sourceSha}`
     reason = 'manual-or-dispatch'
   }
 

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -177,12 +177,16 @@ describe('ARC Nix runner toolchain', () => {
         toolchainScriptPath,
       )
     }
-    for (const arcImageInputPath of [...arcRunnerBuildTriggerPaths, ...arcRunnerToolchainScriptPaths]) {
+    for (const arcImageInputPath of [
+      ...arcRunnerBuildTriggerPaths,
+      ...arcRunnerToolchainScriptPaths.filter((path) => !arcRunnerReleaseOnlyScriptPaths.has(path)),
+    ]) {
       expect(arcRunnerReleaseWorkflow, `${arcImageInputPath} must block stale ARC runner promotion`).toContain(
         releaseGuardFragmentForPath(arcImageInputPath),
       )
     }
-    expect(arcRunnerReleaseWorkflow).toContain('flake\\.nix')
+    expect(arcRunnerReleaseWorkflow).not.toContain('nix/oci-release-contract\\.sh')
+    expect(arcRunnerReleaseWorkflow).not.toContain('flake\\.nix')
     expect(arcRunnerReleaseWorkflow).not.toContain('\\.github/workflows/arc-runner-release\\.yml')
     expect(arcRunnerReleaseWorkflow).toContain('nix run .#assert-oci-platforms')
     expect(arcRunnerReleaseWorkflow).not.toContain('docker buildx')

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -144,8 +144,7 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerBuildWorkflow).toContain(
       "latest: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}",
     )
-    expect(arcRunnerBuildWorkflow).not.toContain("- 'flake.nix'")
-    expect(arcRunnerBuildWorkflow).not.toContain('- flake.nix')
+    expect(arcRunnerBuildTriggerPaths).toContain('flake.nix')
     expect(arcRunnerBuildWorkflow).not.toContain('docker buildx')
     expect(arcRunnerBuildWorkflow).not.toContain('docker/setup-buildx-action')
     expect(arcRunnerBuildWorkflow).not.toContain('docker run')
@@ -186,7 +185,7 @@ describe('ARC Nix runner toolchain', () => {
       )
     }
     expect(arcRunnerReleaseWorkflow).not.toContain('nix/oci-release-contract\\.sh')
-    expect(arcRunnerReleaseWorkflow).not.toContain('flake\\.nix')
+    expect(arcRunnerReleaseWorkflow).toContain('flake\\.nix')
     expect(arcRunnerReleaseWorkflow).not.toContain('\\.github/workflows/arc-runner-release\\.yml')
     expect(arcRunnerReleaseWorkflow).toContain('nix run .#assert-oci-platforms')
     expect(arcRunnerReleaseWorkflow).not.toContain('docker buildx')

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -91,6 +91,19 @@ describe('enabled app inventory', () => {
     expect(entry('headlamp').workflowPaths).toContain('.github/workflows/headlamp-ci.yml')
   })
 
+  it('preserves sibling digest pins for Helm values and Kustomize images', () => {
+    expect(entry('app').repoImages).toEqual([
+      'registry.ide-newton.ts.net/lab/app@sha256:586a5a937f5812b059ff5f228fe8c6f7efb05c5a1ce3c67e4452fa6a8041c7ff',
+    ])
+    expect(entry('agents').repoImages).toEqual([
+      'registry.ide-newton.ts.net/lab/agents-codex-runner@sha256:1e9e47aaedadf5429de22359e48262520cb2787f38dbd29bc0971aaaf52e80c7',
+      'registry.ide-newton.ts.net/lab/agents-control-plane@sha256:bf03a79b1fce3ed2f404e4fe04b2c7e5711740dd9b2ad530a9c3381112202cb3',
+      'registry.ide-newton.ts.net/lab/agents-controller@sha256:c60652f0ca10496edb27116e1b7afa7c8e59b73e3b7361173602491d9b32d7e5',
+      'registry.ide-newton.ts.net/lab/agents-shell@sha256:837942c706d7bde2462b08e053b6c91fb3c0d4d30db95874fb0de460438837d0',
+      'registry.ide-newton.ts.net/lab/anypi:a5796fc2b@sha256:4e4e7ac9f646c061baaa7478ae42bf3acefc2ab46b2640ffa52b677cb8ed86ca',
+    ])
+  })
+
   it('marks only approved early build-owning apps as Nix image candidates', () => {
     for (const name of [
       'oirat',
@@ -237,7 +250,9 @@ describe('enabled app inventory', () => {
     expect(entry('tigresse')).toMatchObject({
       class: 'vendor-manifest',
       hasHelmChart: true,
-      repoImages: ['registry.ide-newton.ts.net/lab/tigresse'],
+      repoImages: [
+        'registry.ide-newton.ts.net/lab/tigresse@sha256:a357c07d629f9561f04b3452c1d9c41b81b9d816d29de415bd0141e859e92e39',
+      ],
     })
     expect(entry('tigresse').deferredReason).toContain('proompteng/tigresse')
   })

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -81,7 +81,9 @@ describe('enabled app inventory', () => {
     expect(entry('headlamp')).toMatchObject({
       class: 'nix-image',
       hasHelmChart: true,
-      repoImages: ['registry.ide-newton.ts.net/lab/headlamp@sha256'],
+      repoImages: [
+        'registry.ide-newton.ts.net/lab/headlamp@sha256:6d61f6563c3df42d176b1d445a757df48f0c6f84c02baa4f4f76dbd258ee2ddd',
+      ],
       nixImageAttr: 'headlamp-image',
       buildScriptPath: 'packages/scripts/src/headlamp/build-image.ts',
       deployScriptPath: 'packages/scripts/src/headlamp/deploy-service.ts',

--- a/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
+++ b/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
@@ -128,6 +128,58 @@ describe('Nix rollout report', () => {
     expect(report.releaseContracts.missingForNixImages).toEqual(['app'])
   })
 
+  it('rejects truncated digests even when they use the sha256 prefix', () => {
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'app',
+          nixImageAttr: 'app-image',
+          buildScriptPath: 'packages/scripts/src/app/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/app/deploy-service.ts',
+          workflowPaths: ['.github/workflows/product-nix-images.yml'],
+        }),
+      ]),
+      releaseContracts: [
+        validContract({ digest: 'sha256:todo', reference: 'registry.ide-newton.ts.net/lab/app@sha256:todo' }),
+      ],
+      requireContracts: true,
+    })
+
+    expect(report.releaseContracts.valid).toBe(0)
+    expect(report.releaseContracts.invalid[0]).toContain('digest is not a full sha256 digest')
+    expect(report.releaseContracts.missingForNixImages).toEqual(['app'])
+  })
+
+  it('requires release-contract coverage for every image owned by a Nix app', () => {
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'agents',
+          repoImages: [
+            'registry.ide-newton.ts.net/lab/agents-controller',
+            'registry.ide-newton.ts.net/lab/agents-runner',
+          ],
+          nixImageAttr: 'agents-controller-image',
+          buildScriptPath: 'packages/scripts/src/agents/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/agents/deploy-service.ts',
+          workflowPaths: ['.github/workflows/agents-build-push.yml'],
+        }),
+      ]),
+      releaseContracts: [
+        validContract({
+          service: 'agents-controller',
+          image: 'registry.ide-newton.ts.net/lab/agents-controller',
+          reference:
+            'registry.ide-newton.ts.net/lab/agents-controller@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          packageAttr: 'agents-controller-image',
+        }),
+      ],
+      requireContracts: true,
+    })
+
+    expect(report.releaseContracts.missingForNixImages).toEqual(['agents:registry.ide-newton.ts.net/lab/agents-runner'])
+  })
+
   it('formats a markdown report with inventory and gate sections', () => {
     const report = buildNixRolloutReport({
       inventory: inventory([

--- a/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
+++ b/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
@@ -155,6 +155,35 @@ describe('Nix rollout report', () => {
     expect(report.releaseContracts.missingForNixImages).toEqual(['torghut'])
   })
 
+  it('fails closed for incomplete digest references', () => {
+    const digest = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'headlamp',
+          repoImages: ['registry.ide-newton.ts.net/lab/headlamp@sha256'],
+          nixImageAttr: 'headlamp-image',
+          buildScriptPath: 'packages/scripts/src/headlamp/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/headlamp/deploy-service.ts',
+          workflowPaths: ['.github/workflows/headlamp-ci.yml'],
+        }),
+      ]),
+      releaseContracts: [
+        validContract({
+          service: 'headlamp',
+          image: 'registry.ide-newton.ts.net/lab/headlamp',
+          digest,
+          reference: `registry.ide-newton.ts.net/lab/headlamp@${digest}`,
+          packageAttr: 'headlamp-image',
+        }),
+      ],
+      requireContracts: true,
+    })
+
+    expect(report.releaseContracts.valid).toBe(1)
+    expect(report.releaseContracts.missingForNixImages).toEqual(['headlamp'])
+  })
+
   it('flags invalid release contracts and missing required contract coverage', () => {
     const report = buildNixRolloutReport({
       inventory: inventory([

--- a/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
+++ b/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
@@ -125,6 +125,36 @@ describe('Nix rollout report', () => {
     expect(report.releaseContracts.missingForNixImages).toEqual([])
   })
 
+  it('requires a digest-pinned manifest ref to match the release contract digest', () => {
+    const deployedDigest = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const staleContractDigest = 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'torghut',
+          repoImages: [`registry.ide-newton.ts.net/lab/torghut@${deployedDigest}`],
+          nixImageAttr: 'torghut-image',
+          buildScriptPath: 'packages/scripts/src/torghut/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/torghut/deploy-service.ts',
+          workflowPaths: ['.github/workflows/torghut-build-push.yaml'],
+        }),
+      ]),
+      releaseContracts: [
+        validContract({
+          service: 'torghut',
+          image: 'registry.ide-newton.ts.net/lab/torghut',
+          digest: staleContractDigest,
+          reference: `registry.ide-newton.ts.net/lab/torghut@${staleContractDigest}`,
+          packageAttr: 'torghut-image',
+        }),
+      ],
+      requireContracts: true,
+    })
+
+    expect(report.releaseContracts.valid).toBe(1)
+    expect(report.releaseContracts.missingForNixImages).toEqual(['torghut'])
+  })
+
   it('flags invalid release contracts and missing required contract coverage', () => {
     const report = buildNixRolloutReport({
       inventory: inventory([

--- a/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
+++ b/packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts
@@ -97,6 +97,34 @@ describe('Nix rollout report', () => {
     })
   })
 
+  it('normalizes digest-pinned manifest refs before checking contract coverage', () => {
+    const digest = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const report = buildNixRolloutReport({
+      inventory: inventory([
+        entry({
+          name: 'torghut',
+          repoImages: [`registry.ide-newton.ts.net/lab/torghut@${digest}`],
+          nixImageAttr: 'torghut-image',
+          buildScriptPath: 'packages/scripts/src/torghut/build-image.ts',
+          deployScriptPath: 'packages/scripts/src/torghut/deploy-service.ts',
+          workflowPaths: ['.github/workflows/torghut-build-push.yaml'],
+        }),
+      ]),
+      releaseContracts: [
+        validContract({
+          service: 'torghut',
+          image: 'registry.ide-newton.ts.net/lab/torghut',
+          digest,
+          reference: `registry.ide-newton.ts.net/lab/torghut@${digest}`,
+          packageAttr: 'torghut-image',
+        }),
+      ],
+      requireContracts: true,
+    })
+
+    expect(report.releaseContracts.missingForNixImages).toEqual([])
+  })
+
   it('flags invalid release contracts and missing required contract coverage', () => {
     const report = buildNixRolloutReport({
       inventory: inventory([

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -1470,7 +1470,10 @@ describe('native OCI build workflows', () => {
     expect(releasePrAutomergeWorkflow).not.toContain(
       'allowed_authors=("app/github-actions" "github-actions[bot]" "gregkonush")',
     )
-    expect(releasePrAutomergeWorkflow).toContain('--match-head-commit "$current_head_sha"')
+    expect(releasePrAutomergeWorkflow).toContain('echo "head_sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"')
+    expect(releasePrAutomergeWorkflow).toContain('PR_HEAD_SHA: ${{ steps.gates.outputs.head_sha }}')
+    expect(releasePrAutomergeWorkflow).toContain('--match-head-commit "$PR_HEAD_SHA"')
+    expect(releasePrAutomergeWorkflow).not.toContain('current_head_sha="$(gh pr view')
     expect(torghutDeployAutomergeWorkflow).toContain('--match-head-commit "${PR_HEAD_SHA}"')
     expect(releasePrAutomergeWorkflow).toContain('reason=eligible:${release_kind}')
   })

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -152,7 +152,6 @@ const nixImageHelperInputs = [
   'nix/ci-run-timed.sh',
   'nix/oci-inspect-archive.sh',
   'nix/oci-push.sh',
-  'nix/oci-release-contract.sh',
 ]
 
 afterEach(() => {
@@ -522,7 +521,21 @@ describe('native OCI build workflows', () => {
     expect(ciNixOciSummaryScript).toContain('Existing image archive bytes')
     expect(ciNixOciSummaryScript).toContain('Image archive Attic warm successes')
     expect(ciNixOciSummaryScript).toContain('Image archive Attic warm failures')
+    expect(ciNixOciSummaryScript).toContain('Image archive Attic warm size skips')
+    expect(ciNixOciSummaryScript).toContain('Image archive Attic warm skipped bytes')
+    expect(ciNixOciSummaryScript).toContain('count_image_cache_status_rows skipped-size')
     expect(ciNixOciSummaryScript).toContain('GITHUB_STEP_SUMMARY')
+  })
+
+  it('proves Nix store writes and preserves the sudo wrapper for later composite steps', () => {
+    const setupNixToolchain = readRepoFile('.github/actions/setup-nix-toolchain/action.yml')
+
+    expect(setupNixToolchain).toContain('nix store add-file "${write_probe}"')
+    expect(setupNixToolchain).toContain('LAB_NIX_WRAPPER_DIR=${wrapper_dir}')
+    expect(setupNixToolchain).toContain('wrapper_prefix="${LAB_NIX_WRAPPER_DIR:+${LAB_NIX_WRAPPER_DIR}:}"')
+    expect(setupNixToolchain).toContain(
+      'export PATH="${wrapper_prefix}${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"',
+    )
   })
 
   it('keeps Nix image derivations deterministic and dockerTools-backed', () => {
@@ -627,6 +640,7 @@ describe('native OCI build workflows', () => {
     ]) {
       expect(workflow).not.toContain('.github/workflows/')
       expect(workflow).not.toContain('packages/scripts/src/shared/nix-oci-deploy.ts')
+      expect(workflow).not.toContain('nix/oci-release-contract.sh')
       for (const helperInput of nixImageHelperInputs) {
         expect(workflow).toContain(helperInput)
       }
@@ -634,6 +648,7 @@ describe('native OCI build workflows', () => {
 
     expect(symphonyReleaseMetadataScript).not.toContain('.github\\/workflows\\/')
     expect(symphonyReleaseMetadataScript).not.toContain('setup-nix-toolchain')
+    expect(symphonyReleaseMetadataScript).not.toContain('nix\\/oci-release-contract\\.sh')
     for (const helperInput of nixImageHelperInputs) {
       expect(symphonyReleaseMetadataScript).toContain(helperInput.replaceAll('/', '\\/').replaceAll('.', '\\.'))
     }
@@ -642,10 +657,29 @@ describe('native OCI build workflows', () => {
     expect(jangarReleaseMetadataScript).not.toContain('setup-nix-toolchain')
     expect(jangarReleaseMetadataScript).not.toContain('packages\\/scripts\\/src\\/jangar')
     expect(jangarReleaseMetadataScript).not.toContain('packages\\/scripts\\/src\\/shared')
+    expect(jangarReleaseMetadataScript).not.toContain('nix\\/oci-release-contract\\.sh')
     expect(jangarReleaseMetadataScript).toContain('images\\/jangar\\.nix')
     for (const helperInput of nixImageHelperInputs) {
       expect(jangarReleaseMetadataScript).toContain(helperInput.replaceAll('/', '\\/').replaceAll('.', '\\.'))
     }
+  })
+
+  it('uses the published full-SHA tag for manual Nix image promotions', () => {
+    expect(jangarReleaseMetadataScript).toContain('`sha-${sourceSha}`')
+    expect(jangarReleaseMetadataScript).not.toContain('sourceSha.slice(0, 8)')
+    expect(symphonyReleaseMetadataScript).toContain('`sha-${sourceSha}`')
+    expect(symphonyReleaseMetadataScript).not.toContain('sourceSha.slice(0, 8)')
+    for (const workflow of [
+      torghutReleaseWorkflow,
+      torghutTaReleaseWorkflow,
+      torghutWsReleaseWorkflow,
+      torghutHyperliquidFeedReleaseWorkflow,
+    ]) {
+      expect(workflow).toContain('TAG="sha-${SOURCE_SHA}"')
+      expect(workflow).not.toContain('git rev-parse --short=8')
+    }
+    expect(atticReleaseMetadataScript).toContain('tag="sha-${source_sha}"')
+    expect(atticReleaseMetadataScript).not.toContain('git rev-parse --short=12')
   })
 
   it('does not fan out migrated image builds on workflow-only changes', () => {
@@ -1429,7 +1463,15 @@ describe('native OCI build workflows', () => {
     )
     expect(releasePrAutomergeWorkflow).toContain('[[ "$PR_HEAD_REF" =~ ^codex/product-nix-release-[0-9a-f]{40}$ ]]')
     expect(releasePrAutomergeWorkflow).toContain('for required_label in automated-pr nix-oci')
-    expect(releasePrAutomergeWorkflow).toContain('"gregkonush"')
+    expect(releasePrAutomergeWorkflow).toContain('[[ "$PR_AUTHOR" != "gregkonush" ]]')
+    expect(releasePrAutomergeWorkflow).toContain('commit_committer_login')
+    expect(releasePrAutomergeWorkflow).toContain('commit_committer_email')
+    expect(releasePrAutomergeWorkflow).toContain('reason=human-authored-release-pr')
+    expect(releasePrAutomergeWorkflow).not.toContain(
+      'allowed_authors=("app/github-actions" "github-actions[bot]" "gregkonush")',
+    )
+    expect(releasePrAutomergeWorkflow).toContain('--match-head-commit "$current_head_sha"')
+    expect(torghutDeployAutomergeWorkflow).toContain('--match-head-commit "${PR_HEAD_SHA}"')
     expect(releasePrAutomergeWorkflow).toContain('reason=eligible:${release_kind}')
   })
 

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -38,6 +38,7 @@ const labRepoURL = 'https://github.com/proompteng/lab.git'
 const labImagePrefix = 'registry.ide-newton.ts.net/lab/'
 const labImageRegistry = 'registry.ide-newton.ts.net'
 const sha256HexPattern = /^[0-9a-f]{64}$/
+const sha256DigestPattern = /^sha256:[0-9a-f]{64}$/
 
 const earlyNixImageApps = new Set([
   'agents',
@@ -247,24 +248,60 @@ const collectRepoImages = (yamlPath: string, document: unknown): string[] => {
     const registry = asString(record.registry)
     const repository = asString(record.repository)
     const tag = asString(record.tag)
-    const splitDigestReference =
-      repository?.endsWith('@sha256') && tag && sha256HexPattern.test(tag) ? `${repository}:${tag}` : undefined
-    if (repository?.startsWith(labImagePrefix)) images.add(splitDigestReference ?? repository)
-    if (registry === labImageRegistry && repository?.startsWith('lab/')) {
-      images.add(`${registry}/${splitDigestReference ?? repository}`)
+    const digest = asString(record.digest)
+    const qualifiedRepository = repository?.startsWith(labImagePrefix)
+      ? repository
+      : registry === labImageRegistry && repository?.startsWith('lab/')
+        ? `${registry}/${repository}`
+        : undefined
+    if (qualifiedRepository) {
+      images.add(imageReferenceWithSiblingDigest(qualifiedRepository, digest, tag))
     }
 
     if (basename(yamlPath) === 'kustomization.yaml' && Array.isArray(record.images)) {
       for (const entry of record.images) {
         if (!isRecord(entry)) continue
-        for (const key of ['name', 'newName']) {
-          const value = asString(entry[key])
-          if (value?.startsWith(labImagePrefix)) images.add(value)
+        const value = asString(entry.newName) ?? asString(entry.name)
+        if (value?.startsWith(labImagePrefix)) {
+          images.add(imageReferenceWithSiblingDigest(value, asString(entry.digest), asString(entry.newTag)))
         }
       }
     }
   })
   return [...images]
+}
+
+const imageReferenceWithSiblingDigest = (
+  repository: string,
+  digest: string | undefined,
+  tag: string | undefined,
+): string => {
+  if (repository.endsWith('@sha256') && tag && sha256HexPattern.test(tag)) {
+    return `${repository}:${tag}`
+  }
+  if (!repository.includes('@') && digest && sha256DigestPattern.test(digest)) {
+    return `${repository}@${digest}`
+  }
+  return repository
+}
+
+const imageRepository = (reference: string): string => {
+  const withoutDigest = reference.split('@', 1)[0] ?? reference
+  const lastSlash = withoutDigest.lastIndexOf('/')
+  const lastColon = withoutDigest.lastIndexOf(':')
+  return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest
+}
+
+const normalizeRepoImages = (images: Iterable<string>): string[] => {
+  const values = uniqueSorted(images)
+  const digestPinnedRepositories = new Set(
+    values
+      .filter((reference) => /@sha256:[0-9a-f]{64}$/.test(reference))
+      .map((reference) => imageRepository(reference)),
+  )
+  return values.filter(
+    (reference) => /@sha256:[0-9a-f]{64}$/.test(reference) || !digestPinnedRepositories.has(imageRepository(reference)),
+  )
 }
 
 const inspectApplicationPath = (root: string, entry: EnabledAppInventoryEntry): EnabledAppInventoryEntry => {
@@ -306,7 +343,7 @@ const inspectApplicationPath = (root: string, entry: EnabledAppInventoryEntry): 
   return {
     ...entry,
     hasHelmChart,
-    repoImages: uniqueSorted(repoImages),
+    repoImages: normalizeRepoImages(repoImages),
     buildScriptPath: existsSync(resolve(root, buildScriptPath)) ? buildScriptPath : undefined,
     deployScriptPath: existsSync(resolve(root, deployScriptPath)) ? deployScriptPath : undefined,
     workflowPaths,

--- a/packages/scripts/src/shared/enabled-apps.ts
+++ b/packages/scripts/src/shared/enabled-apps.ts
@@ -37,6 +37,7 @@ type JsonRecord = Record<string, unknown>
 const labRepoURL = 'https://github.com/proompteng/lab.git'
 const labImagePrefix = 'registry.ide-newton.ts.net/lab/'
 const labImageRegistry = 'registry.ide-newton.ts.net'
+const sha256HexPattern = /^[0-9a-f]{64}$/
 
 const earlyNixImageApps = new Set([
   'agents',
@@ -245,9 +246,12 @@ const collectRepoImages = (yamlPath: string, document: unknown): string[] => {
 
     const registry = asString(record.registry)
     const repository = asString(record.repository)
-    if (repository?.startsWith(labImagePrefix)) images.add(repository)
+    const tag = asString(record.tag)
+    const splitDigestReference =
+      repository?.endsWith('@sha256') && tag && sha256HexPattern.test(tag) ? `${repository}:${tag}` : undefined
+    if (repository?.startsWith(labImagePrefix)) images.add(splitDigestReference ?? repository)
     if (registry === labImageRegistry && repository?.startsWith('lab/')) {
-      images.add(`${registry}/${repository}`)
+      images.add(`${registry}/${splitDigestReference ?? repository}`)
     }
 
     if (basename(yamlPath) === 'kustomization.yaml' && Array.isArray(record.images)) {

--- a/packages/scripts/src/shared/nix-rollout-report.ts
+++ b/packages/scripts/src/shared/nix-rollout-report.ts
@@ -115,9 +115,21 @@ const imageRepository = (reference: string): string => {
   return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest
 }
 
+const imageDigest = (reference: string): string | undefined => {
+  const separator = reference.lastIndexOf('@')
+  if (separator < 0) return undefined
+  const digest = reference.slice(separator + 1)
+  return sha256DigestPattern.test(digest) ? digest : undefined
+}
+
 const contractCoversImage = (contract: NixRolloutReleaseContract, image: string): boolean => {
   const repository = imageRepository(image)
-  return imageRepository(contract.image) === repository && contract.reference === `${contract.image}@${contract.digest}`
+  const deployedDigest = imageDigest(image)
+  return (
+    imageRepository(contract.image) === repository &&
+    contract.reference === `${contract.image}@${contract.digest}` &&
+    (deployedDigest === undefined || deployedDigest === contract.digest)
+  )
 }
 
 const countByClass = (entries: EnabledAppInventoryEntry[]): Record<string, number> =>

--- a/packages/scripts/src/shared/nix-rollout-report.ts
+++ b/packages/scripts/src/shared/nix-rollout-report.ts
@@ -108,8 +108,17 @@ const validateReleaseContract = (contract: NixRolloutReleaseContract): string[] 
   return errors
 }
 
-const contractCoversImage = (contract: NixRolloutReleaseContract, image: string): boolean =>
-  contract.image === image && contract.reference === `${image}@${contract.digest}`
+const imageRepository = (reference: string): string => {
+  const withoutDigest = reference.split('@', 1)[0] ?? reference
+  const lastSlash = withoutDigest.lastIndexOf('/')
+  const lastColon = withoutDigest.lastIndexOf(':')
+  return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest
+}
+
+const contractCoversImage = (contract: NixRolloutReleaseContract, image: string): boolean => {
+  const repository = imageRepository(image)
+  return imageRepository(contract.image) === repository && contract.reference === `${contract.image}@${contract.digest}`
+}
 
 const countByClass = (entries: EnabledAppInventoryEntry[]): Record<string, number> =>
   entries.reduce<Record<string, number>>((counts, entry) => {

--- a/packages/scripts/src/shared/nix-rollout-report.ts
+++ b/packages/scripts/src/shared/nix-rollout-report.ts
@@ -43,6 +43,7 @@ export type NixRolloutReport = {
 }
 
 const requiredPlatforms: NixOciPlatform[] = ['linux/amd64', 'linux/arm64']
+const sha256DigestPattern = /^sha256:[0-9a-f]{64}$/
 
 const isRecord = (value: unknown): value is JsonRecord =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -96,7 +97,10 @@ const validateReleaseContract = (contract: NixRolloutReleaseContract): string[] 
   for (const field of ['service', 'image', 'tag', 'digest', 'reference', 'sourceSha', 'packageAttr'] as const) {
     if (!contract[field]) errors.push(`${field} is missing`)
   }
-  if (!contract.digest.startsWith('sha256:')) errors.push(`digest is not sha256: ${contract.digest}`)
+  if (!sha256DigestPattern.test(contract.digest)) errors.push(`digest is not a full sha256 digest: ${contract.digest}`)
+  if (contract.image && contract.digest && contract.reference !== `${contract.image}@${contract.digest}`) {
+    errors.push(`reference does not match image and digest: ${contract.reference}`)
+  }
   if (contract.builder !== 'nix-dockerTools-skopeo') errors.push(`builder is not nix-dockerTools-skopeo`)
   for (const platform of requiredPlatforms) {
     if (!contract.platforms.includes(platform)) errors.push(`missing platform ${platform}`)
@@ -104,10 +108,8 @@ const validateReleaseContract = (contract: NixRolloutReleaseContract): string[] 
   return errors
 }
 
-const contractCoversEntry = (contract: NixRolloutReleaseContract, entry: EnabledAppInventoryEntry): boolean =>
-  contract.service === entry.name ||
-  contract.packageAttr === entry.nixImageAttr ||
-  entry.repoImages.some((image) => contract.image === image || contract.reference.startsWith(`${image}@`))
+const contractCoversImage = (contract: NixRolloutReleaseContract, image: string): boolean =>
+  contract.image === image && contract.reference === `${image}@${contract.digest}`
 
 const countByClass = (entries: EnabledAppInventoryEntry[]): Record<string, number> =>
   entries.reduce<Record<string, number>>((counts, entry) => {
@@ -135,14 +137,23 @@ export const buildNixRolloutReport = (input: {
     if (entry.workflowPaths.length === 0) missing.push('workflow')
     return missing.length > 0 ? [`${entry.name}: missing ${missing.join(', ')}`] : []
   })
-  const invalidContracts = releaseContracts.flatMap((contract) => {
-    const errors = validateReleaseContract(contract)
-    return errors.length > 0 ? [`${contract.path}: ${errors.join('; ')}`] : []
-  })
+  const evaluatedContracts = releaseContracts.map((contract) => ({
+    contract,
+    errors: validateReleaseContract(contract),
+  }))
+  const invalidContracts = evaluatedContracts.flatMap(({ contract, errors }) =>
+    errors.length > 0 ? [`${contract.path}: ${errors.join('; ')}`] : [],
+  )
+  const validContracts = evaluatedContracts.filter(({ errors }) => errors.length === 0).map(({ contract }) => contract)
   const missingForNixImages = input.requireContracts
-    ? nixImages
-        .filter((entry) => !releaseContracts.some((contract) => contractCoversEntry(contract, entry)))
-        .map((entry) => entry.name)
+    ? nixImages.flatMap((entry) => {
+        const missingImages = entry.repoImages.filter(
+          (image) => !validContracts.some((contract) => contractCoversImage(contract, image)),
+        )
+        if (missingImages.length === 0) return []
+        if (entry.repoImages.length === 1) return [entry.name]
+        return missingImages.map((image) => `${entry.name}:${image}`)
+      })
     : []
 
   return {
@@ -158,7 +169,7 @@ export const buildNixRolloutReport = (input: {
     missingBuildContracts,
     releaseContracts: {
       provided: releaseContracts.length,
-      valid: releaseContracts.length - invalidContracts.length,
+      valid: validContracts.length,
       invalid: invalidContracts,
       missingForNixImages,
     },

--- a/packages/scripts/src/shared/nix-rollout-report.ts
+++ b/packages/scripts/src/shared/nix-rollout-report.ts
@@ -125,7 +125,9 @@ const imageDigest = (reference: string): string | undefined => {
 const contractCoversImage = (contract: NixRolloutReleaseContract, image: string): boolean => {
   const repository = imageRepository(image)
   const deployedDigest = imageDigest(image)
+  const malformedDigestReference = image.includes('@') && deployedDigest === undefined
   return (
+    !malformedDigestReference &&
     imageRepository(contract.image) === repository &&
     contract.reference === `${contract.image}@${contract.digest}` &&
     (deployedDigest === undefined || deployedDigest === contract.digest)

--- a/packages/scripts/src/symphony/resolve-release-metadata.ts
+++ b/packages/scripts/src/symphony/resolve-release-metadata.ts
@@ -24,7 +24,6 @@ const buildTriggerPathPatterns = [
   /^nix\/ci-run-timed\.sh$/,
   /^nix\/oci-inspect-archive\.sh$/,
   /^nix\/oci-push\.sh$/,
-  /^nix\/oci-release-contract\.sh$/,
   /^flake\.lock$/,
   /^package\.json$/,
   /^bun\.lock$/,
@@ -228,7 +227,7 @@ export const resolveReleaseMetadata = (options: ResolveReleaseMetadataOptions): 
     reason = stalenessDecision.reason
   } else {
     sourceSha = options.commitShaInput?.trim() || mainHead
-    tag = options.imageTagInput?.trim() || sourceSha.slice(0, 8)
+    tag = options.imageTagInput?.trim() || `sha-${sourceSha}`
     reason = 'manual-or-dispatch'
   }
 

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -143,22 +143,35 @@ describe('torghut build-push workflow', () => {
   })
 
   it('keeps core Torghut stale workflow promotions aligned with build trigger inputs', () => {
+    const staleDiffBlock = staleDiffBlockFor(releaseWorkflow, 'services/torghut')
     const freshnessPaths = [
       'services/torghut',
       'packages/scripts/src/torghut',
       'packages/scripts/src/shared/cli.ts',
       'packages/scripts/src/shared/git.ts',
       'nix/images/torghut.nix',
-      '.github/workflows/torghut-build-push.yaml',
-      '.github/workflows/torghut-release.yml',
-      '.github/workflows/nix-oci-build-common.yml',
-      '.github/actions/setup-nix-toolchain',
+      'nix/cache-push.sh',
+      'nix/ci-nix-oci-summary.sh',
+      'nix/ci-run-timed.sh',
+      'nix/oci-inspect-archive.sh',
+      'nix/oci-push.sh',
+      'flake.lock',
+      'services/torghut/uv.lock',
     ]
 
     expect(releaseWorkflow).toContain('git merge-base --is-ancestor "${SOURCE_SHA}" "${MAIN_HEAD}"')
     expect(releaseWorkflow).toContain('git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" --')
     for (const path of freshnessPaths) {
-      expect(releaseWorkflow).toContain(path)
+      expect(staleDiffBlock).toContain(path)
+    }
+    for (const releaseOnlyPath of [
+      'nix/oci-release-contract.sh',
+      '.github/workflows/torghut-build-push.yaml',
+      '.github/workflows/torghut-release.yml',
+      '.github/workflows/nix-oci-build-common.yml',
+      '.github/actions/setup-nix-toolchain',
+    ]) {
+      expect(staleDiffBlock).not.toContain(releaseOnlyPath)
     }
     expect(releaseWorkflow).toContain("':(glob,exclude)packages/scripts/src/torghut/__tests__/**'")
     expect(releaseWorkflow).toContain("':(glob,exclude)packages/scripts/src/torghut/**/*.test.ts'")
@@ -479,7 +492,7 @@ describe('torghut build-push workflow', () => {
       expect(staleDiffBlock).toContain('nix/ci-run-timed.sh')
       expect(staleDiffBlock).toContain('nix/oci-inspect-archive.sh')
       expect(staleDiffBlock).toContain('nix/oci-push.sh')
-      expect(staleDiffBlock).toContain('nix/oci-release-contract.sh')
+      expect(staleDiffBlock).not.toContain('nix/oci-release-contract.sh')
       expect(staleDiffBlock).toContain('flake.lock')
       expect(staleDiffBlock).not.toContain('.github/workflows/')
       expect(staleDiffBlock).not.toContain('packages/scripts/src/torghut/release-contract.ts')
@@ -502,7 +515,7 @@ describe('torghut build-push workflow', () => {
     expect(staleDiffBlock).toContain('nix/ci-run-timed.sh')
     expect(staleDiffBlock).toContain('nix/oci-inspect-archive.sh')
     expect(staleDiffBlock).toContain('nix/oci-push.sh')
-    expect(staleDiffBlock).toContain('nix/oci-release-contract.sh')
+    expect(staleDiffBlock).not.toContain('nix/oci-release-contract.sh')
     expect(staleDiffBlock).toContain('flake.lock')
     expect(staleDiffBlock).not.toContain('.github/workflows/')
     expect(staleDiffBlock).not.toContain('packages/scripts/src/torghut/release-contract.ts')

--- a/services/agents/src/server/memory-provider-schema.test.ts
+++ b/services/agents/src/server/memory-provider-schema.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createMemoryProviderAnnIndexIfReady,
+  ensureMemoryProviderSchema,
+  getMemoryProviderSchemaStatements,
+  type MemoryProviderQueryable,
+} from './memory-provider-schema'
+
+const makeQueryable = (options: { embeddingRows?: number; extensions?: string[] } = {}) => {
+  const calls: { sql: string; params?: unknown[] }[] = []
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    calls.push({ sql, params })
+    const normalized = sql.toLowerCase()
+    if (normalized.includes('select extname from pg_extension')) {
+      return { rows: (options.extensions ?? ['vector', 'pgcrypto']).map((extname) => ({ extname })) }
+    }
+    if (normalized.includes('select count(*)') && normalized.includes('memory_embeddings')) {
+      return { rows: [{ row_count: options.embeddingRows ?? 0 }] }
+    }
+    return { rows: [] }
+  })
+
+  return { calls, db: { query } as unknown as MemoryProviderQueryable }
+}
+
+describe('memory provider schema bootstrap', () => {
+  it('creates provider tables and base indexes without creating an IVFFlat index', async () => {
+    const { calls, db } = makeQueryable()
+
+    await ensureMemoryProviderSchema(db, { schema: 'public', embeddingDimension: 3 })
+
+    const sqlText = calls.map((call) => call.sql.toLowerCase()).join('\n')
+    expect(sqlText).toContain('create table if not exists "public"."memory_events"')
+    expect(sqlText).toContain('create table if not exists "public"."memory_kv"')
+    expect(sqlText).toContain('create table if not exists "public"."memory_embeddings"')
+    expect(sqlText).not.toContain('using ivfflat')
+  })
+
+  it('keeps the migration statement set free of the deferred ANN index', () => {
+    const sqlText = getMemoryProviderSchemaStatements(3, 'public').join('\n').toLowerCase()
+
+    expect(sqlText).toContain('memory_embeddings')
+    expect(sqlText).not.toContain('using ivfflat')
+  })
+
+  it('does not create the ANN index before enough embeddings exist', async () => {
+    const { calls, db } = makeQueryable({ embeddingRows: 99_999 })
+
+    await expect(createMemoryProviderAnnIndexIfReady(db, { schema: 'public', embeddingDimension: 3 })).resolves.toBe(
+      false,
+    )
+
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(false)
+  })
+
+  it('creates the ANN index after there are enough embeddings to train it', async () => {
+    const { calls, db } = makeQueryable({ embeddingRows: 100_000 })
+    await expect(createMemoryProviderAnnIndexIfReady(db, { schema: 'public', embeddingDimension: 3 })).resolves.toBe(
+      true,
+    )
+
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(true)
+    expect(calls.some((call) => call.sql.toLowerCase().includes('with (lists = 100)'))).toBe(true)
+  })
+
+  it('fails fast when the provider database is missing required extensions', async () => {
+    const { db } = makeQueryable({ extensions: [] })
+
+    await expect(ensureMemoryProviderSchema(db, { schema: 'public', embeddingDimension: 3 })).rejects.toThrow(
+      /missing required Postgres extensions in Memory provider database/i,
+    )
+  })
+})

--- a/services/agents/src/server/memory-provider-schema.ts
+++ b/services/agents/src/server/memory-provider-schema.ts
@@ -1,0 +1,152 @@
+import type { Pool, PoolClient } from 'pg'
+
+import { MAX_PGVECTOR_ANN_DIMENSION, supportsPgvectorAnnIndex } from './pgvector-indexing'
+
+export type MemoryProviderSchemaConnection = {
+  schema: string
+  embeddingDimension: number
+}
+
+export type MemoryProviderQueryable = Pick<Pool, 'query'> & {
+  connect?: () => Promise<PoolClient>
+}
+
+const REQUIRED_EXTENSIONS = ['vector', 'pgcrypto'] as const
+const PREFERRED_IVFFLAT_LISTS = 100
+const PREFERRED_IVFFLAT_ROWS_PER_LIST = 1000
+const MIN_IVFFLAT_INDEX_ROWS = PREFERRED_IVFFLAT_LISTS * PREFERRED_IVFFLAT_ROWS_PER_LIST
+
+const quoteIdentifier = (identifier: string) => {
+  const normalized = identifier.trim()
+  if (!normalized) throw new Error('Postgres identifier cannot be empty')
+  if (normalized.includes('\0')) throw new Error('Postgres identifier cannot contain a NUL byte')
+  return `"${normalized.replace(/"/g, '""')}"`
+}
+
+const normalizeEmbeddingDimension = (dimension: number) => {
+  if (!Number.isFinite(dimension) || dimension <= 0) {
+    throw new Error(`memory embedding dimension must be a positive integer; got ${dimension}`)
+  }
+  return Math.floor(dimension)
+}
+
+export const qualifyMemoryProviderTable = (schema: string, table: string) =>
+  `${quoteIdentifier(schema)}.${quoteIdentifier(table)}`
+
+export const getMemoryProviderSchemaStatements = (dimension: number, schema: string) => {
+  const embeddingDimension = normalizeEmbeddingDimension(dimension)
+  const eventsTable = qualifyMemoryProviderTable(schema, 'memory_events')
+  const kvTable = qualifyMemoryProviderTable(schema, 'memory_kv')
+  const embeddingsTable = qualifyMemoryProviderTable(schema, 'memory_embeddings')
+
+  return [
+    `CREATE TABLE IF NOT EXISTS ${eventsTable} (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload JSONB NOT NULL DEFAULT '{}'::JSONB
+    );`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_events_dataset_created_at_idx')}
+    ON ${eventsTable} (dataset, created_at DESC);`,
+    `CREATE TABLE IF NOT EXISTS ${kvTable} (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value JSONB NOT NULL DEFAULT '{}'::JSONB,
+      CONSTRAINT ${quoteIdentifier('memory_kv_dataset_key_key')} UNIQUE (dataset, key)
+    );`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_kv_dataset_key_idx')}
+    ON ${kvTable} (dataset, key);`,
+    `CREATE TABLE IF NOT EXISTS ${embeddingsTable} (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      dataset TEXT NOT NULL,
+      key TEXT NOT NULL,
+      embedding vector(${embeddingDimension}) NOT NULL,
+      metadata JSONB NOT NULL DEFAULT '{}'::JSONB
+    );`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_embeddings_dataset_key_idx')}
+    ON ${embeddingsTable} (dataset, key);`,
+    `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_embeddings_metadata_idx')}
+    ON ${embeddingsTable} USING GIN (metadata JSONB_PATH_OPS);`,
+  ]
+}
+
+const getMemoryProviderAnnIndexStatement = (dimension: number, schema: string, lists: number) => {
+  normalizeEmbeddingDimension(dimension)
+  const normalizedLists = Math.max(1, Math.floor(lists))
+  const embeddingsTable = qualifyMemoryProviderTable(schema, 'memory_embeddings')
+  return `CREATE INDEX IF NOT EXISTS ${quoteIdentifier('memory_embeddings_embedding_idx')}
+    ON ${embeddingsTable} USING ivfflat (embedding vector_cosine_ops) WITH (lists = ${normalizedLists});`
+}
+
+const estimateIvfflatLists = (rowCount: number) => {
+  if (rowCount < 1_000_000) return Math.max(1, Math.floor(rowCount / PREFERRED_IVFFLAT_ROWS_PER_LIST))
+  return Math.max(1, Math.floor(Math.sqrt(rowCount)))
+}
+
+export const ensureMemoryProviderExtensions = async (db: MemoryProviderQueryable) => {
+  const { rows } = await db.query<{ extname: string }>(
+    'SELECT extname FROM pg_extension WHERE extname = ANY($1::text[])',
+    [[...REQUIRED_EXTENSIONS]],
+  )
+
+  const installed = new Set(rows.map((row) => row.extname))
+  const missing = REQUIRED_EXTENSIONS.filter((ext) => !installed.has(ext))
+  if (missing.length > 0) {
+    throw new Error(
+      `missing required Postgres extensions in Memory provider database: ${missing.join(', ')}. ` +
+        'Install them as a privileged user (e.g. `CREATE EXTENSION vector; CREATE EXTENSION pgcrypto;`) ' +
+        'before using postgres Memory providers.',
+    )
+  }
+}
+
+export const ensureMemoryProviderSchema = async (
+  db: MemoryProviderQueryable,
+  connection: MemoryProviderSchemaConnection,
+) => {
+  await ensureMemoryProviderExtensions(db)
+  for (const statement of getMemoryProviderSchemaStatements(connection.embeddingDimension, connection.schema)) {
+    await db.query(statement)
+  }
+}
+
+export const createMemoryProviderAnnIndexIfReady = async (
+  db: MemoryProviderQueryable,
+  connection: MemoryProviderSchemaConnection,
+) => {
+  if (!supportsPgvectorAnnIndex(connection.embeddingDimension)) {
+    console.log('[agents:pgvector]', {
+      event: 'skip_ann_index',
+      context: `${connection.schema}.memory_embeddings`,
+      dimension: connection.embeddingDimension,
+      maxSupportedDimension: MAX_PGVECTOR_ANN_DIMENSION,
+    })
+    return false
+  }
+
+  const embeddingsTable = qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')
+  const { rows } = await db.query<{ row_count: string | number }>(
+    `SELECT COUNT(*)::bigint AS row_count FROM ${embeddingsTable}`,
+  )
+  const rowCount = Number(rows[0]?.row_count ?? 0)
+  if (!Number.isFinite(rowCount) || rowCount < MIN_IVFFLAT_INDEX_ROWS) return false
+
+  await db.query(
+    getMemoryProviderAnnIndexStatement(
+      connection.embeddingDimension,
+      connection.schema,
+      estimateIvfflatLists(rowCount),
+    ),
+  )
+  return true
+}
+
+export const __test__ = {
+  getMemoryProviderAnnIndexStatement,
+  quoteIdentifier,
+}

--- a/services/agents/src/server/memory-provider.test.ts
+++ b/services/agents/src/server/memory-provider.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { __test__, queryMemory, writeMemoryEmbedding, writeMemoryEvent } from './memory-provider'
+import type { MemoryProviderQueryable } from './memory-provider-schema'
+
+const connection = {
+  dataset: 'agent-memory',
+  schema: 'public',
+  embeddingDimension: 3,
+  connectionString: 'postgresql://provider-db',
+}
+
+const makePool = () => {
+  const calls: { sql: string; params?: unknown[] }[] = []
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    calls.push({ sql, params })
+    const normalized = sql.toLowerCase()
+    if (normalized.includes('select extname from pg_extension')) {
+      return { rows: [{ extname: 'vector' }, { extname: 'pgcrypto' }] }
+    }
+    if (normalized.includes('from "public"."memory_embeddings"') && normalized.includes('embedding <=>')) {
+      return { rows: [{ key: 'note-1', score: 0.9, metadata: { source: 'test' } }] }
+    }
+    return { rows: [] }
+  })
+
+  const client = {
+    query,
+    release: vi.fn(),
+  }
+  return {
+    calls,
+    client,
+    pool: {
+      query,
+      connect: vi.fn(async () => client),
+    } as unknown as MemoryProviderQueryable,
+  }
+}
+
+describe('memory provider operations', () => {
+  const previousEnv: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of [
+      'NODE_ENV',
+      'OPENAI_API_KEY',
+      'OPENAI_EMBEDDING_API_BASE_URL',
+      'OPENAI_API_BASE_URL',
+      'OPENAI_API_BASE',
+      'OPENAI_EMBEDDING_DIMENSION',
+    ]) {
+      previousEnv[key] = process.env[key]
+    }
+    process.env.NODE_ENV = 'test'
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_EMBEDDING_API_BASE_URL
+    delete process.env.OPENAI_API_BASE_URL
+    delete process.env.OPENAI_API_BASE
+    process.env.OPENAI_EMBEDDING_DIMENSION = '3'
+  })
+
+  afterEach(() => {
+    __test__.resetMemoryProviderState()
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  })
+
+  it('bootstraps the resolved provider database before writing events', async () => {
+    const { calls, pool } = makePool()
+    __test__.setMemoryProviderPoolFactory(() => pool)
+
+    await writeMemoryEvent(connection, 'sync-started', { ok: true })
+
+    const createTableIndex = calls.findIndex((call) => call.sql.toLowerCase().includes('create table if not exists'))
+    const insertIndex = calls.findIndex((call) =>
+      call.sql.toLowerCase().includes('insert into "public"."memory_events"'),
+    )
+    expect(createTableIndex).toBeGreaterThanOrEqual(0)
+    expect(insertIndex).toBeGreaterThan(createTableIndex)
+    expect(calls[insertIndex]?.params).toEqual(['agent-memory', 'sync-started', { ok: true }])
+  })
+
+  it('does not create the IVFFlat index in the embedding write path', async () => {
+    const { calls, pool } = makePool()
+    __test__.setMemoryProviderPoolFactory(() => pool)
+
+    await writeMemoryEmbedding(connection, 'note-1', 'hello world', { source: 'test' })
+
+    const insertIndex = calls.findIndex((call) =>
+      call.sql.toLowerCase().includes('insert into "public"."memory_embeddings"'),
+    )
+    expect(insertIndex).toBeGreaterThanOrEqual(0)
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(false)
+  })
+
+  it('queries memory without creating an online IVFFlat index', async () => {
+    const { calls, client, pool } = makePool()
+    __test__.setMemoryProviderPoolFactory(() => pool)
+
+    await expect(queryMemory(connection, 'hello', 1)).resolves.toEqual([
+      { key: 'note-1', score: 0.9, metadata: { source: 'test' } },
+    ])
+
+    const queryIndex = calls.findIndex(
+      (call) =>
+        call.sql.toLowerCase().includes('from "public"."memory_embeddings"') &&
+        call.sql.toLowerCase().includes('embedding <=>'),
+    )
+    expect(queryIndex).toBeGreaterThanOrEqual(0)
+    expect(calls.some((call) => call.sql === 'BEGIN')).toBe(true)
+    expect(calls.some((call) => call.sql === 'SET LOCAL ivfflat.probes = 10')).toBe(true)
+    expect(calls.some((call) => call.sql === 'COMMIT')).toBe(true)
+    expect(client.release).toHaveBeenCalledTimes(1)
+    expect(calls.some((call) => call.sql.toLowerCase().includes('using ivfflat'))).toBe(false)
+  })
+})

--- a/services/agents/src/server/memory-provider.ts
+++ b/services/agents/src/server/memory-provider.ts
@@ -4,6 +4,12 @@ import { Pool } from 'pg'
 
 import { type KubernetesClient, RESOURCE_MAP } from './kube-types'
 import { resolveEmbeddingConfig } from './memory-config'
+import {
+  createMemoryProviderAnnIndexIfReady,
+  ensureMemoryProviderSchema,
+  qualifyMemoryProviderTable,
+  type MemoryProviderQueryable,
+} from './memory-provider-schema'
 import { asRecord, asString, readNested } from './primitives'
 
 export type MemoryConnection = {
@@ -22,9 +28,12 @@ export type MemoryQueryResult = {
 type EnvSource = Record<string, string | undefined>
 
 const DEFAULT_MEMORY_DATABASE_POOL_MAX = 2
+const DEFAULT_MEMORY_IVFFLAT_PROBES = 10
 
 const globalState = globalThis as typeof globalThis & {
+  __agentsMemoryProviderPoolFactory?: (connectionString: string) => MemoryProviderQueryable
   __agentsMemoryProviderPools?: Map<string, Pool>
+  __agentsMemoryProviderSchemaReady?: Map<string, Promise<void>>
 }
 
 const parsePositiveInt = (value: string | undefined, fallback: number) => {
@@ -85,7 +94,10 @@ const getPoolCache = () => {
   return globalState.__agentsMemoryProviderPools
 }
 
-const getMemoryPool = (connectionString: string) => {
+const getMemoryPool = (connectionString: string): MemoryProviderQueryable => {
+  const testPoolFactory = globalState.__agentsMemoryProviderPoolFactory
+  if (testPoolFactory) return testPoolFactory(connectionString)
+
   const pools = getPoolCache()
   const existing = pools.get(connectionString)
   if (existing) return existing
@@ -99,10 +111,38 @@ const getMemoryPool = (connectionString: string) => {
   return created
 }
 
+const getSchemaReadyCache = () => {
+  if (!globalState.__agentsMemoryProviderSchemaReady) {
+    globalState.__agentsMemoryProviderSchemaReady = new Map<string, Promise<void>>()
+  }
+  return globalState.__agentsMemoryProviderSchemaReady
+}
+
+const memoryProviderSchemaCacheKey = (connection: MemoryConnection) =>
+  `${connection.connectionString}\0${connection.schema}\0${connection.embeddingDimension}`
+
+const ensureProviderSchemaReady = async (connection: MemoryConnection, pool: MemoryProviderQueryable) => {
+  const cache = getSchemaReadyCache()
+  const key = memoryProviderSchemaCacheKey(connection)
+  let ready = cache.get(key)
+  if (!ready) {
+    ready = ensureMemoryProviderSchema(pool, connection)
+    cache.set(key, ready)
+  }
+
+  try {
+    await ready
+  } catch (error) {
+    cache.delete(key)
+    throw error
+  }
+}
+
 export const closeMemoryProviderPools = async () => {
   const pools = getPoolCache()
   const activePools = [...pools.values()]
   pools.clear()
+  globalState.__agentsMemoryProviderSchemaReady?.clear()
   await Promise.all(activePools.map((pool) => pool.end()))
 }
 
@@ -230,16 +270,19 @@ export const writeMemoryEvent = async (
   payload: Record<string, unknown>,
 ) => {
   const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
   await pool.query(
-    `INSERT INTO ${connection.schema}.memory_events (dataset, event_type, payload) VALUES ($1, $2, $3)`,
+    `INSERT INTO ${qualifyMemoryProviderTable(connection.schema, 'memory_events')} (dataset, event_type, payload)
+     VALUES ($1, $2, $3)`,
     [connection.dataset, eventType, payload],
   )
 }
 
 export const writeMemoryKv = async (connection: MemoryConnection, key: string, value: Record<string, unknown>) => {
   const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
   await pool.query(
-    `INSERT INTO ${connection.schema}.memory_kv (dataset, key, value)
+    `INSERT INTO ${qualifyMemoryProviderTable(connection.schema, 'memory_kv')} (dataset, key, value)
      VALUES ($1, $2, $3)
      ON CONFLICT (dataset, key)
      DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
@@ -256,8 +299,9 @@ export const writeMemoryEmbedding = async (
   const embedding = await embedText(text, connection.embeddingDimension)
   const vector = vectorToPg(embedding)
   const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
   await pool.query(
-    `INSERT INTO ${connection.schema}.memory_embeddings (dataset, key, embedding, metadata)
+    `INSERT INTO ${qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')} (dataset, key, embedding, metadata)
      VALUES ($1, $2, $3::vector, $4)`,
     [connection.dataset, key, vector, metadata],
   )
@@ -271,17 +315,52 @@ export const queryMemory = async (
   const embedding = await embedText(query, connection.embeddingDimension)
   const vector = vectorToPg(embedding)
   const pool = getMemoryPool(connection.connectionString)
-  const { rows } = await pool.query(
-    `SELECT key, metadata, (1 - (embedding <=> $1::vector)) as score
-     FROM ${connection.schema}.memory_embeddings
+  await ensureProviderSchemaReady(connection, pool)
+  const statement = `SELECT key, metadata, (1 - (embedding <=> $1::vector)) as score
+     FROM ${qualifyMemoryProviderTable(connection.schema, 'memory_embeddings')}
      WHERE dataset = $2
      ORDER BY embedding <=> $1::vector
-     LIMIT $3`,
-    [vector, connection.dataset, limit],
-  )
-  return rows.map((row: { key: string; score: number | null; metadata: Record<string, unknown> }) => ({
+     LIMIT $3`
+  const parameters = [vector, connection.dataset, limit]
+  const probes = parsePositiveInt(process.env.AGENTS_MEMORY_IVFFLAT_PROBES, DEFAULT_MEMORY_IVFFLAT_PROBES)
+  const client = pool.connect ? await pool.connect() : null
+  let rows: Array<{ key: string; score: number | null; metadata: Record<string, unknown> }>
+  if (client) {
+    try {
+      await client.query('BEGIN')
+      await client.query(`SET LOCAL ivfflat.probes = ${probes}`)
+      const result = await client.query(statement, parameters)
+      rows = result.rows
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined)
+      throw error
+    } finally {
+      client.release()
+    }
+  } else {
+    const result = await pool.query(statement, parameters)
+    rows = result.rows
+  }
+  return rows.map((row) => ({
     key: row.key,
     score: row.score,
     metadata: row.metadata ?? {},
   }))
+}
+
+export const createMemoryEmbeddingIndexIfReady = async (connection: MemoryConnection) => {
+  const pool = getMemoryPool(connection.connectionString)
+  await ensureProviderSchemaReady(connection, pool)
+  return createMemoryProviderAnnIndexIfReady(pool, connection)
+}
+
+export const __test__ = {
+  resetMemoryProviderState: () => {
+    delete globalState.__agentsMemoryProviderPoolFactory
+    globalState.__agentsMemoryProviderSchemaReady?.clear()
+  },
+  setMemoryProviderPoolFactory: (factory: (connectionString: string) => MemoryProviderQueryable) => {
+    globalState.__agentsMemoryProviderPoolFactory = factory
+  },
 }

--- a/services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts
+++ b/services/agents/src/server/migrations/20260705_agents_memory_provider_tables.ts
@@ -2,70 +2,14 @@ import { type Kysely, sql } from 'kysely'
 
 import type { AgentsDatabase } from '../db'
 import { resolveEmbeddingConfig } from '../memory-config'
-import { createPgvectorAnnIndexIfSupported } from '../pgvector-indexing'
+import { getMemoryProviderSchemaStatements } from '../memory-provider-schema'
 
 const resolveEmbeddingDimension = () => resolveEmbeddingConfig(process.env).dimension
 
 export const up = async (db: Kysely<AgentsDatabase>) => {
   const embeddingDimension = resolveEmbeddingDimension()
 
-  await sql`
-    CREATE TABLE IF NOT EXISTS memory_events (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      dataset TEXT NOT NULL,
-      event_type TEXT NOT NULL,
-      payload JSONB NOT NULL DEFAULT '{}'::JSONB
-    );
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_events_dataset_created_at_idx
-    ON memory_events (dataset, created_at DESC);
-  `.execute(db)
-
-  await sql`
-    CREATE TABLE IF NOT EXISTS memory_kv (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      dataset TEXT NOT NULL,
-      key TEXT NOT NULL,
-      value JSONB NOT NULL DEFAULT '{}'::JSONB,
-      CONSTRAINT memory_kv_dataset_key_key UNIQUE (dataset, key)
-    );
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_kv_dataset_key_idx
-    ON memory_kv (dataset, key);
-  `.execute(db)
-
-  await sql`
-    CREATE TABLE IF NOT EXISTS memory_embeddings (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      dataset TEXT NOT NULL,
-      key TEXT NOT NULL,
-      embedding vector(${sql.raw(String(embeddingDimension))}) NOT NULL,
-      metadata JSONB NOT NULL DEFAULT '{}'::JSONB
-    );
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_embeddings_dataset_key_idx
-    ON memory_embeddings (dataset, key);
-  `.execute(db)
-
-  await sql`
-    CREATE INDEX IF NOT EXISTS memory_embeddings_metadata_idx
-    ON memory_embeddings USING GIN (metadata JSONB_PATH_OPS);
-  `.execute(db)
-
-  await createPgvectorAnnIndexIfSupported(
-    db,
-    embeddingDimension,
-    'CREATE INDEX IF NOT EXISTS memory_embeddings_embedding_idx ON memory_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);',
-    'memory_embeddings',
-  )
+  for (const statement of getMemoryProviderSchemaStatements(embeddingDimension, 'public')) {
+    await sql.raw(statement).execute(db)
+  }
 }

--- a/services/agents/src/server/v1/memory-operations.test.ts
+++ b/services/agents/src/server/v1/memory-operations.test.ts
@@ -102,6 +102,39 @@ describe('memory operations API', () => {
     expect(queryMemory).toHaveBeenCalledWith(connection, 'find notes', 5)
   })
 
+  it('runs embedding index maintenance through the leader-gated operation path', async () => {
+    const connection = {
+      dataset: 'agent-memory',
+      schema: 'public',
+      embeddingDimension: 1536,
+      connectionString: 'postgresql://agents-memory',
+    }
+    const requireLeaderForMutation = vi.fn(() => null)
+    const createMemoryEmbeddingIndexIfReady = vi.fn(async () => true)
+
+    const response = await postMemoryOperationsHandler(
+      request({
+        memoryRef: 'agent-memory',
+        namespace: 'agents',
+        operation: 'embedding-index',
+      }),
+      {
+        kubeClient: {} as never,
+        requireLeaderForMutation,
+        resolveMemoryConnection: vi.fn(async () => connection),
+        createMemoryEmbeddingIndexIfReady,
+      },
+    )
+
+    await expect(json(response)).resolves.toMatchObject({
+      ok: true,
+      operation: 'embedding-index',
+      created: true,
+    })
+    expect(requireLeaderForMutation).toHaveBeenCalled()
+    expect(createMemoryEmbeddingIndexIfReady).toHaveBeenCalledWith(connection)
+  })
+
   it('gates memory mutations on the elected Agents leader', async () => {
     const response = await postMemoryOperationsHandler(
       request({

--- a/services/agents/src/server/v1/memory-operations.ts
+++ b/services/agents/src/server/v1/memory-operations.ts
@@ -1,4 +1,5 @@
 import {
+  createMemoryEmbeddingIndexIfReady as defaultCreateMemoryEmbeddingIndexIfReady,
   queryMemory as defaultQueryMemory,
   resolveMemoryConnection as defaultResolveMemoryConnection,
   writeMemoryEmbedding as defaultWriteMemoryEmbedding,
@@ -18,6 +19,7 @@ export type MemoryOperationsApiDependencies = {
   writeMemoryKv?: typeof defaultWriteMemoryKv
   writeMemoryEmbedding?: typeof defaultWriteMemoryEmbedding
   queryMemory?: typeof defaultQueryMemory
+  createMemoryEmbeddingIndexIfReady?: typeof defaultCreateMemoryEmbeddingIndexIfReady
 }
 
 type MemoryOperationPayload =
@@ -49,6 +51,11 @@ type MemoryOperationPayload =
       namespace: string
       query: string
       limit?: number
+    }
+  | {
+      operation: 'embedding-index'
+      memoryRef: string
+      namespace: string
     }
 
 const getKubeClient = (deps: MemoryOperationsApiDependencies) =>
@@ -125,7 +132,11 @@ export const parseMemoryOperationPayload = (payload: Record<string, unknown>): M
     }
   }
 
-  throw new Error('operation must be one of event, kv, embedding, query')
+  if (operation === 'embedding-index') {
+    return { operation, memoryRef, namespace }
+  }
+
+  throw new Error('operation must be one of event, kv, embedding, query, embedding-index')
 }
 
 export const postMemoryOperationsHandler = async (request: Request, deps: MemoryOperationsApiDependencies = {}) => {
@@ -173,6 +184,19 @@ export const postMemoryOperationsHandler = async (request: Request, deps: Memory
         operation: parsed.operation,
         memoryRef: parsed.memoryRef,
         namespace: parsed.namespace,
+      })
+    }
+
+    if (parsed.operation === 'embedding-index') {
+      const created = await (deps.createMemoryEmbeddingIndexIfReady ?? defaultCreateMemoryEmbeddingIndexIfReady)(
+        connection,
+      )
+      return okResponse({
+        ok: true,
+        operation: parsed.operation,
+        memoryRef: parsed.memoryRef,
+        namespace: parsed.namespace,
+        created,
       })
     }
 

--- a/services/headlamp/patches/0004-static-copy-writable.patch
+++ b/services/headlamp/patches/0004-static-copy-writable.patch
@@ -36,3 +36,26 @@ index 811495890..ae21b1b85 100644
  		config.StaticDir = dir
  	}
  
+diff --git a/backend/cmd/headlamp_test.go b/backend/cmd/headlamp_test.go
+index 637501f..6d4eacb 100644
+--- a/backend/cmd/headlamp_test.go
++++ b/backend/cmd/headlamp_test.go
+@@ -1754,0 +1755,18 @@ func TestHandleClusterServiceProxy(t *testing.T) {
++
++func TestMakeStaticIndexWritable(t *testing.T) {
++	staticDir := t.TempDir()
++	indexPath := filepath.Join(staticDir, "index.html")
++	original := []byte("<html>original</html>")
++
++	require.NoError(t, os.WriteFile(indexPath, original, 0o444))
++	require.NoError(t, makeStaticIndexWritable(staticDir))
++
++	contents, err := os.ReadFile(indexPath)
++	require.NoError(t, err)
++	require.Equal(t, original, contents)
++
++	info, err := os.Stat(indexPath)
++	require.NoError(t, err)
++	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
++	require.NoError(t, os.WriteFile(indexPath, []byte("<html>updated</html>"), 0o600))
++}

--- a/services/headlamp/scripts/test-upstream.sh
+++ b/services/headlamp/scripts/test-upstream.sh
@@ -17,5 +17,5 @@ if grep -R -n -E "handleClusterAuthError|navigate\\(createRouteURL\\('login'" "$
 fi
 
 cd "$WORK_DIR/backend"
-go test ./cmd -run 'Test(GetOrCreateConnection|EstablishClusterConnection|GetOrCreateConnection_HTTPWatchStream|Reconnect|Reconnect_WithToken|OIDCTokenRefreshMiddleware)'
+go test ./cmd -run 'Test(GetOrCreateConnection|EstablishClusterConnection|GetOrCreateConnection_HTTPWatchStream|Reconnect|Reconnect_WithToken|OIDCTokenRefreshMiddleware|MakeStaticIndexWritable)'
 go test ./pkg/auth -run 'Test(GetCookiePath|GetWebSocketCookiePath|GetBaseCookiePath|SetAndGetAuthCookie|GetAuthCookieChunked|ClearAuthCookie|SetTokenCookieClearsLegacyRootPathChunks|SetTokenCookie_UsesTokenExpiryForMaxAge|GetNewToken_PreHTTPFailures)'

--- a/services/torghut/app/hyperliquid_execution/api.py
+++ b/services/torghut/app/hyperliquid_execution/api.py
@@ -141,6 +141,7 @@ def trading_loop_status() -> JSONResponse:
                 generated_at=datetime.now(timezone.utc),
                 trading_mode=_loop_status_trading_mode(runtime_state.config),
                 trading_enabled=runtime_state.config.trading_enabled,
+                configured_symbols=runtime_state.config.trade_coins,
             ),
         )
     finally:

--- a/services/torghut/app/hyperliquid_execution/exchange.py
+++ b/services/torghut/app/hyperliquid_execution/exchange.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 from dataclasses import replace
 from datetime import datetime, timezone
-from decimal import Decimal, ROUND_DOWN, ROUND_UP
+from decimal import Decimal, InvalidOperation, ROUND_DOWN, ROUND_UP
 from typing import Any, Mapping, Protocol, cast
 
 from .config import HyperliquidExecutionConfig
@@ -33,6 +33,7 @@ _SUPPORTED_LIMIT_TIFS = {"Ioc"}
 _BPS_DENOMINATOR = Decimal("10000")
 _BOOK_UNAVAILABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     AttributeError,
+    InvalidOperation,
     LookupError,
     OSError,
     RuntimeError,
@@ -533,6 +534,7 @@ class HyperliquidSdkExecutionExchange:
                 self._config.exchange_api_url,
                 skip_ws=True,
                 perp_dexs=list(perp_dexs),
+                timeout=float(self._config.exchange_staleness_seconds),
             )
             self._sdk_info_perp_dexs = perp_dexs
         return self._sdk_info

--- a/services/torghut/app/hyperliquid_execution/sdk_aliases.py
+++ b/services/torghut/app/hyperliquid_execution/sdk_aliases.py
@@ -15,7 +15,15 @@ def register_sdk_market_alias(
         return
     if alias in name_to_coin or metadata_name not in name_to_coin:
         return
-    name_to_coin[alias] = name_to_coin[metadata_name]
+    metadata_coin = name_to_coin[metadata_name]
+    name_to_coin[alias] = alias
+    coin_to_asset = _coin_to_asset(sdk_client)
+    if coin_to_asset is not None and alias not in coin_to_asset:
+        asset = coin_to_asset.get(metadata_coin)
+        if asset is None:
+            asset = coin_to_asset.get(metadata_name)
+        if asset is not None:
+            coin_to_asset[alias] = asset
 
 
 def _name_to_coin(sdk_client: object) -> dict[str, object] | None:
@@ -26,4 +34,15 @@ def _name_to_coin(sdk_client: object) -> dict[str, object] | None:
     nested = getattr(info, "name_to_coin", None)
     if isinstance(nested, dict):
         return cast(dict[str, object], nested)
+    return None
+
+
+def _coin_to_asset(sdk_client: object) -> dict[object, object] | None:
+    direct = getattr(sdk_client, "coin_to_asset", None)
+    if isinstance(direct, dict):
+        return cast(dict[object, object], direct)
+    info = getattr(sdk_client, "info", None)
+    nested = getattr(info, "coin_to_asset", None)
+    if isinstance(nested, dict):
+        return cast(dict[object, object], nested)
     return None

--- a/services/torghut/app/hyperliquid_execution/slippage.py
+++ b/services/torghut/app/hyperliquid_execution/slippage.py
@@ -12,7 +12,10 @@ def sdk_mid_price(info: object, coin: str, dex: str) -> Decimal | None:
     raw_mid = cast(Mapping[str, object], mid_loader(**{"dex": dex})).get(coin)
     if raw_mid is None:
         return None
-    return Decimal(str(raw_mid))
+    mid_price = Decimal(str(raw_mid))
+    if not mid_price.is_finite() or mid_price <= Decimal("0"):
+        raise ValueError("invalid_mid_price")
+    return mid_price
 
 
 def sdk_slippage_limit_price(

--- a/services/torghut/app/trading/loop_status.py
+++ b/services/torghut/app/trading/loop_status.py
@@ -94,6 +94,7 @@ class LoopStatusOptions:
     min_recent_fills: int = DEFAULT_MIN_RECENT_FILLS
     freshness_threshold_seconds: int = DEFAULT_FRESHNESS_THRESHOLD_SECONDS
     account_freshness_seconds: int = DEFAULT_ACCOUNT_FRESHNESS_SECONDS
+    configured_symbols: Sequence[str] = ()
 
 
 @dataclass(frozen=True)
@@ -297,6 +298,7 @@ def _proof_summary(
         rows.positions,
         raw_exchange_positions,
         _selected_symbols(rows),
+        options.configured_symbols,
     )
     return LoopProofSummary(
         query_errors=tuple(rows.query_errors),

--- a/services/torghut/app/trading/loop_status.py
+++ b/services/torghut/app/trading/loop_status.py
@@ -300,6 +300,9 @@ def _proof_summary(
         _selected_symbols(rows),
         options.configured_symbols,
     )
+    unmanaged_raw_positions = unmanaged_exchange_positions(
+        raw_exchange_positions, managed_raw_positions
+    )
     return LoopProofSummary(
         query_errors=tuple(rows.query_errors),
         market_feature_at=latest_feature_at,
@@ -318,10 +321,9 @@ def _proof_summary(
         position_count=len(rows.positions),
         raw_exchange_positions=tuple(raw_exchange_positions),
         managed_exchange_positions=tuple(managed_raw_positions),
-        unmanaged_exchange_positions=tuple(
-            unmanaged_exchange_positions(raw_exchange_positions, managed_raw_positions)
-        ),
+        unmanaged_exchange_positions=tuple(unmanaged_raw_positions),
         positions_reconciled=account_fresh
+        and not unmanaged_raw_positions
         and position_coin_set(rows.positions)
         == position_coin_set(managed_raw_positions),
         stale_open_order_count=len(rows.stale_open_orders),

--- a/services/torghut/app/trading/loop_status_positions.py
+++ b/services/torghut/app/trading/loop_status_positions.py
@@ -32,13 +32,18 @@ def managed_exchange_positions(
     persisted_positions: Sequence[Mapping[str, object]],
     raw_exchange_positions: Sequence[Mapping[str, object]],
     selected_symbols: Sequence[str],
+    configured_symbols: Sequence[str] = (),
 ) -> list[Mapping[str, object]]:
     managed_coins = position_coin_set(persisted_positions)
-    managed_coins.update(selected_symbols)
+    managed_coins.update(_canonical_coin(symbol) for symbol in selected_symbols)
+    managed_coins.update(_canonical_coin(symbol) for symbol in configured_symbols)
     return [
         position
         for position in raw_exchange_positions
-        if _optional_text(position.get("coin")) in managed_coins
+        if (
+            (coin := _optional_text(position.get("coin"))) is not None
+            and _canonical_coin(coin) in managed_coins
+        )
     ]
 
 
@@ -56,8 +61,14 @@ def unmanaged_exchange_positions(
 
 def position_coin_set(rows: Sequence[Mapping[str, object]]) -> set[str]:
     return {
-        coin for row in rows if (coin := _optional_text(row.get("coin"))) is not None
+        _canonical_coin(coin)
+        for row in rows
+        if (coin := _optional_text(row.get("coin"))) is not None
     }
+
+
+def _canonical_coin(value: str) -> str:
+    return value.strip().split(":")[-1].upper()
 
 
 def _account_position_rows(

--- a/services/torghut/app/trading/loop_status_positions.py
+++ b/services/torghut/app/trading/loop_status_positions.py
@@ -34,15 +34,37 @@ def managed_exchange_positions(
     selected_symbols: Sequence[str],
     configured_symbols: Sequence[str] = (),
 ) -> list[Mapping[str, object]]:
-    managed_coins = position_coin_set(persisted_positions)
-    managed_coins.update(_canonical_coin(symbol) for symbol in selected_symbols)
-    managed_coins.update(_canonical_coin(symbol) for symbol in configured_symbols)
+    configured_keys = {_coin_key(symbol) for symbol in configured_symbols}
+    configured_scoped_bases = {
+        _base_coin(key) for key in configured_keys if _is_scoped_coin(key)
+    }
+    exact_scoped_keys = {key for key in configured_keys if _is_scoped_coin(key)}
+    unscoped_bases = {
+        _base_coin(key) for key in configured_keys if not _is_scoped_coin(key)
+    }
+    for symbol in [
+        *(
+            coin
+            for row in persisted_positions
+            if (coin := _optional_text(row.get("coin"))) is not None
+        ),
+        *selected_symbols,
+    ]:
+        key = _coin_key(symbol)
+        if _is_scoped_coin(key):
+            exact_scoped_keys.add(key)
+        elif _base_coin(key) not in configured_scoped_bases:
+            unscoped_bases.add(_base_coin(key))
     return [
         position
         for position in raw_exchange_positions
         if (
             (coin := _optional_text(position.get("coin"))) is not None
-            and _canonical_coin(coin) in managed_coins
+            and _matches_managed_coin(
+                coin,
+                exact_scoped_keys=exact_scoped_keys,
+                unscoped_bases=unscoped_bases,
+            )
         )
     ]
 
@@ -68,7 +90,34 @@ def position_coin_set(rows: Sequence[Mapping[str, object]]) -> set[str]:
 
 
 def _canonical_coin(value: str) -> str:
-    return value.strip().split(":")[-1].upper()
+    return _base_coin(_coin_key(value))
+
+
+def _coin_key(value: str) -> str:
+    parts = [part.strip() for part in value.split(":") if part.strip()]
+    if len(parts) <= 1:
+        return (parts[0] if parts else "").upper()
+    return f"{parts[0].lower()}:{parts[-1].upper()}"
+
+
+def _base_coin(value: str) -> str:
+    return value.split(":")[-1].upper()
+
+
+def _is_scoped_coin(value: str) -> bool:
+    return ":" in value
+
+
+def _matches_managed_coin(
+    value: str,
+    *,
+    exact_scoped_keys: set[str],
+    unscoped_bases: set[str],
+) -> bool:
+    key = _coin_key(value)
+    if _is_scoped_coin(key):
+        return key in exact_scoped_keys or _base_coin(key) in unscoped_bases
+    return _base_coin(key) in unscoped_bases
 
 
 def _account_position_rows(

--- a/services/torghut/app/trading/loop_status_positions.py
+++ b/services/torghut/app/trading/loop_status_positions.py
@@ -10,14 +10,15 @@ from typing import cast
 def raw_account_positions(account_row: Mapping[str, object]) -> list[dict[str, object]]:
     payload = _mapping_payload(account_row.get("raw_payload"))
     positions: list[dict[str, object]] = []
-    for raw_position in _account_position_rows(payload):
+    for dex_scope, raw_position in _account_position_rows(payload):
         position = _mapping_payload(raw_position.get("position"))
         coin = _optional_text(position.get("coin"))
         if coin is None:
             continue
+        scoped_coin = _position_coin_for_scope(coin, dex_scope)
         positions.append(
             {
-                "coin": coin,
+                "coin": scoped_coin,
                 "size": _optional_text(position.get("szi")) or "0",
                 "entry_price": _optional_text(position.get("entryPx")),
                 "notional_usd": _optional_text(position.get("positionValue")) or "0",
@@ -122,26 +123,46 @@ def _matches_managed_coin(
 
 def _account_position_rows(
     payload: Mapping[str, object],
-) -> list[Mapping[str, object]]:
-    rows: list[Mapping[str, object]] = []
-    _extend_position_rows(rows, payload.get("assetPositions"))
+) -> list[tuple[str | None, Mapping[str, object]]]:
+    rows: list[tuple[str | None, Mapping[str, object]]] = []
+    _extend_position_rows(rows, payload.get("assetPositions"), dex_scope=None)
     dex_states = payload.get("dexStates")
     if isinstance(dex_states, Mapping):
-        for raw_state in cast(Mapping[object, object], dex_states).values():
+        for raw_dex, raw_state in cast(Mapping[object, object], dex_states).items():
             state = _mapping_payload(raw_state)
-            _extend_position_rows(rows, state.get("assetPositions"))
+            _extend_position_rows(
+                rows,
+                state.get("assetPositions"),
+                dex_scope=_optional_text(raw_dex),
+            )
     clearinghouse_state = _mapping_payload(payload.get("clearinghouseState"))
-    _extend_position_rows(rows, clearinghouse_state.get("assetPositions"))
+    _extend_position_rows(
+        rows,
+        clearinghouse_state.get("assetPositions"),
+        dex_scope=None,
+    )
     return rows
 
 
-def _extend_position_rows(rows: list[Mapping[str, object]], value: object) -> None:
+def _position_coin_for_scope(coin: str, dex_scope: str | None) -> str:
+    key = _coin_key(coin)
+    if dex_scope is None or _is_scoped_coin(key):
+        return key
+    return _coin_key(f"{dex_scope}:{coin}")
+
+
+def _extend_position_rows(
+    rows: list[tuple[str | None, Mapping[str, object]]],
+    value: object,
+    *,
+    dex_scope: str | None,
+) -> None:
     if not isinstance(value, list):
         return
     for raw_position in cast(list[object], value):
         if not isinstance(raw_position, Mapping):
             continue
-        rows.append(cast(Mapping[str, object], raw_position))
+        rows.append((dex_scope, cast(Mapping[str, object], raw_position)))
 
 
 def _mapping_payload(value: object) -> Mapping[str, object]:

--- a/services/torghut/tests/hyperliquid_execution/test_exchange_order_submission.py
+++ b/services/torghut/tests/hyperliquid_execution/test_exchange_order_submission.py
@@ -48,7 +48,8 @@ def test_exchange_submits_ioc_order() -> None:
 
     assert result.status == "filled"
     assert result.exchange_order_id == "123"
-    assert sdk.info.name_to_coin["xyz:NVDA"] == sdk.info.name_to_coin["NVDA"]
+    assert sdk.info.name_to_coin["xyz:NVDA"] == "xyz:NVDA"
+    assert sdk.info.coin_to_asset["xyz:NVDA"] == sdk.info.coin_to_asset[0]
     assert sdk.market_opens == [
         {
             "name": "xyz:NVDA",
@@ -115,5 +116,6 @@ def test_exchange_cancels_by_oid() -> None:
     result = exchange.cancel_order(order)
 
     assert result.status == "cancelled"
-    assert sdk.info.name_to_coin["xyz:NVDA"] == sdk.info.name_to_coin["NVDA"]
+    assert sdk.info.name_to_coin["xyz:NVDA"] == "xyz:NVDA"
+    assert sdk.info.coin_to_asset["xyz:NVDA"] == sdk.info.coin_to_asset[0]
     assert sdk.cancels == [("xyz:NVDA", 123)]

--- a/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
+++ b/services/torghut/tests/hyperliquid_execution/test_exchange_policy.py
@@ -205,11 +205,17 @@ def test_exchange_reduce_only_close_uses_sdk_market_close() -> None:
 
 class _FakeSdkInfo:
     def __init__(self) -> None:
-        self.name_to_coin: dict[str, int] = {
+        self.name_to_coin: dict[str, object] = {
             "NVDA": 0,
             "HALT": 1,
             "AMD": 2,
             "SPX": 3,
+        }
+        self.coin_to_asset: dict[object, int] = {
+            0: 110000,
+            1: 110001,
+            2: 110002,
+            3: 110003,
         }
 
 

--- a/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
+++ b/services/torghut/tests/hyperliquid_execution/test_liquidity_gate.py
@@ -187,10 +187,28 @@ def test_exchange_reports_mid_lookup_failure_as_unavailable_liquidity() -> None:
     assert status.details["skipped"] == {"NVDA": "book_unavailable:RuntimeError"}
 
 
+def test_exchange_reports_malformed_mid_as_unavailable_liquidity() -> None:
+    exchange = _Exchange(
+        HyperliquidExecutionConfig.from_env({}),
+        sdk=_Sdk(),
+        info=_Info(
+            {"xyz:NVDA": {"levels": [[{"px": "99"}], [{"px": "101"}]]}},
+            mids={"NVDA": "not-a-number"},
+        ),
+    )
+
+    selected, status = exchange.filter_crossable_markets((_market("NVDA", "xyz"),))
+
+    assert selected == ()
+    assert status.ready is False
+    assert status.details["skipped"] == {"NVDA": "book_unavailable:InvalidOperation"}
+
+
 def test_exchange_info_client_reloads_with_known_builder_dexes(
     monkeypatch: MonkeyPatch,
 ) -> None:
     constructed_dexes: list[tuple[str, ...]] = []
+    constructed_timeouts: list[float] = []
 
     class _FakeInfo:
         def __init__(
@@ -199,9 +217,11 @@ def test_exchange_info_client_reloads_with_known_builder_dexes(
             *,
             skip_ws: bool,
             perp_dexs: list[str],
+            timeout: float,
         ) -> None:
             assert skip_ws is True
             constructed_dexes.append(tuple(perp_dexs))
+            constructed_timeouts.append(timeout)
 
     class _FakeInfoModule:
         Info = _FakeInfo
@@ -222,6 +242,7 @@ def test_exchange_info_client_reloads_with_known_builder_dexes(
     exchange._info()
 
     assert constructed_dexes == [("",), ("", "xyz")]
+    assert constructed_timeouts == [120.0, 120.0]
 
 
 def test_service_skips_uncrossable_testnet_markets_before_signals() -> None:

--- a/services/torghut/tests/test_loop_status_positions.py
+++ b/services/torghut/tests/test_loop_status_positions.py
@@ -11,6 +11,7 @@ from app.trading.loop_status import (
 from app.trading.loop_status_positions import (
     managed_exchange_positions,
     position_coin_set,
+    raw_account_positions,
 )
 
 
@@ -60,6 +61,28 @@ def test_unconfigured_unpersisted_coin_is_not_claimed() -> None:
     assert managed_exchange_positions((), raw, (), ("xyz:MU",)) == []
 
 
+def test_raw_dex_positions_inherit_parent_scope_when_coin_is_unscoped() -> None:
+    positions = raw_account_positions(
+        {
+            "raw_payload": {
+                "dexStates": {
+                    "xyz": {
+                        "assetPositions": [{"position": {"coin": "NVDA", "szi": "1"}}]
+                    },
+                    "abc": {
+                        "assetPositions": [{"position": {"coin": "NVDA", "szi": "2"}}]
+                    },
+                }
+            }
+        }
+    )
+
+    assert [(row["coin"], row["size"]) for row in positions] == [
+        ("abc:NVDA", "2"),
+        ("xyz:NVDA", "1"),
+    ]
+
+
 def test_unmanaged_scoped_position_blocks_reconciliation() -> None:
     generated_at = datetime(2026, 7, 11, 17, 0, tzinfo=timezone.utc)
     rows = LoopStatusRows(
@@ -74,14 +97,10 @@ def test_unmanaged_scoped_position_blocks_reconciliation() -> None:
             "raw_payload": {
                 "dexStates": {
                     "xyz": {
-                        "assetPositions": [
-                            {"position": {"coin": "xyz:NVDA", "szi": "1"}}
-                        ]
+                        "assetPositions": [{"position": {"coin": "NVDA", "szi": "1"}}]
                     },
                     "abc": {
-                        "assetPositions": [
-                            {"position": {"coin": "abc:NVDA", "szi": "1"}}
-                        ]
+                        "assetPositions": [{"position": {"coin": "NVDA", "szi": "1"}}]
                     },
                 }
             },

--- a/services/torghut/tests/test_loop_status_positions.py
+++ b/services/torghut/tests/test_loop_status_positions.py
@@ -1,0 +1,38 @@
+"""Regression coverage for scoped and durable loop-status position ownership."""
+
+from app.trading.loop_status_positions import (
+    managed_exchange_positions,
+    position_coin_set,
+)
+
+
+def test_scoped_exchange_coin_matches_persisted_canonical_coin() -> None:
+    raw = ({"coin": "xyz:NVDA", "size": "1"},)
+
+    managed = managed_exchange_positions(
+        ({"coin": "NVDA"},),
+        raw,
+        (),
+    )
+
+    assert managed == list(raw)
+    assert position_coin_set(managed) == {"NVDA"}
+
+
+def test_configured_coin_remains_managed_when_not_selected_this_cycle() -> None:
+    raw = ({"coin": "xyz:MU", "size": "1"},)
+
+    managed = managed_exchange_positions(
+        (),
+        raw,
+        (),
+        ("xyz:MU",),
+    )
+
+    assert managed == list(raw)
+
+
+def test_unconfigured_unpersisted_coin_is_not_claimed() -> None:
+    raw = ({"coin": "xyz:UNMANAGED", "size": "1"},)
+
+    assert managed_exchange_positions((), raw, (), ("xyz:MU",)) == []

--- a/services/torghut/tests/test_loop_status_positions.py
+++ b/services/torghut/tests/test_loop_status_positions.py
@@ -32,6 +32,20 @@ def test_configured_coin_remains_managed_when_not_selected_this_cycle() -> None:
     assert managed == list(raw)
 
 
+def test_scoped_configuration_does_not_claim_same_coin_on_another_dex() -> None:
+    configured = {"coin": "xyz:NVDA", "size": "1"}
+    other_dex = {"coin": "abc:NVDA", "size": "1"}
+
+    managed = managed_exchange_positions(
+        ({"coin": "NVDA"},),
+        (configured, other_dex),
+        ("NVDA",),
+        ("xyz:NVDA",),
+    )
+
+    assert managed == [configured]
+
+
 def test_unconfigured_unpersisted_coin_is_not_claimed() -> None:
     raw = ({"coin": "xyz:UNMANAGED", "size": "1"},)
 

--- a/services/torghut/tests/test_loop_status_positions.py
+++ b/services/torghut/tests/test_loop_status_positions.py
@@ -1,5 +1,13 @@
 """Regression coverage for scoped and durable loop-status position ownership."""
 
+from datetime import datetime, timezone
+
+from app.trading.loop_status import (
+    LoopStatusOptions,
+    LoopStatusRows,
+    _blockers,
+    _proof_summary,
+)
 from app.trading.loop_status_positions import (
     managed_exchange_positions,
     position_coin_set,
@@ -50,3 +58,51 @@ def test_unconfigured_unpersisted_coin_is_not_claimed() -> None:
     raw = ({"coin": "xyz:UNMANAGED", "size": "1"},)
 
     assert managed_exchange_positions((), raw, (), ("xyz:MU",)) == []
+
+
+def test_unmanaged_scoped_position_blocks_reconciliation() -> None:
+    generated_at = datetime(2026, 7, 11, 17, 0, tzinfo=timezone.utc)
+    rows = LoopStatusRows(
+        latest_cycle={},
+        latest_signal={},
+        latest_order={},
+        counts_24h={},
+        fill_summary={},
+        latest_fill={},
+        latest_account={
+            "observed_at": generated_at,
+            "raw_payload": {
+                "dexStates": {
+                    "xyz": {
+                        "assetPositions": [
+                            {"position": {"coin": "xyz:NVDA", "szi": "1"}}
+                        ]
+                    },
+                    "abc": {
+                        "assetPositions": [
+                            {"position": {"coin": "abc:NVDA", "szi": "1"}}
+                        ]
+                    },
+                }
+            },
+        },
+        positions=({"coin": "NVDA"},),
+        performance={},
+        stale_open_orders=(),
+        unexpected_live_alpaca={},
+        query_errors=(),
+    )
+    summary = _proof_summary(
+        rows,
+        LoopStatusOptions(
+            generated_at=generated_at,
+            configured_symbols=("xyz:NVDA",),
+        ),
+    )
+
+    assert [row["coin"] for row in summary.managed_exchange_positions] == ["xyz:NVDA"]
+    assert [row["coin"] for row in summary.unmanaged_exchange_positions] == ["abc:NVDA"]
+    assert summary.positions_reconciled is False
+    assert "hyperliquid_position_reconciliation_missing" in _blockers(
+        summary, min_recent_fills=0
+    )


### PR DESCRIPTION
## Summary

- Audits 461 merged pull requests updated since 2026-07-01 and closes the 94 remaining unresolved Codex review threads across 61 merged PRs.
- Fixes still-reproducible defects in external Agents Memory database bootstrap/ANN maintenance, Hyperliquid scoped execution and position ownership, release automerge provenance/head pinning, Nix release contracts, store-write fallback, cache summaries, and manual promotion tags.
- Adds regression coverage for Headlamp static-copy permissions, Memory provider schema/index behavior, scoped market execution, durable loop-status reconciliation, and Nix workflow contracts.
- Aligns image-build versus stale-promotion inputs and updates rollout/runbook evidence, including successful Agents runner execution and current GitOps state.

## Related Issues

Review follow-up for unresolved Codex feedback on merged pull requests updated since 2026-07-01. No standalone issue.

## Testing

- `bun test services/agents/src/server/memory-provider-schema.test.ts services/agents/src/server/memory-provider.test.ts services/agents/src/server/v1/memory-operations.test.ts packages/scripts/src/shared/__tests__/nix-rollout-report.test.ts packages/scripts/src/shared/__tests__/oci.test.ts packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts` — 74 passed.
- `bun node_modules/typescript/bin/tsc --noEmit -p services/agents/tsconfig.json`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json <changed TypeScript files>` — 0 warnings, 0 errors.
- `pytest tests/test_loop_status_positions.py tests/hyperliquid_execution/test_exchange_order_submission.py tests/hyperliquid_execution/test_exchange_policy.py tests/hyperliquid_execution/test_exchange_market_open_contract.py tests/hyperliquid_execution/test_liquidity_gate.py` — 28 passed.
- `ruff format --check app tests scripts migrations`
- `ruff check app tests scripts migrations`
- `pyright --project pyrightconfig.json`
- `pyright --project pyrightconfig.alpha.json`
- `pyright --project pyrightconfig.scripts.json`
- `python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- Torghut structural, changed-line quality, changed-file design, and file-length Pylint gates.
- Parsed 18 changed workflow/action YAML files with PyYAML.
- `bash -n nix/attic-release-metadata.sh nix/ci-nix-oci-summary.sh services/headlamp/scripts/test-upstream.sh`
- Applied all Headlamp patches cleanly to upstream v0.40.1 and verified `TestMakeStaticIndexWritable` is present.
- Delegated AgentRun `agents-shell-audit-every-unresolved-review-thread-auth-eb474464` completed successfully on the production Agents Codex runner image and independently enumerated 461 merged PRs / 94 unresolved Codex threads.
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
