### PR TITLE
refactor(torghut): centralize migration fixture paths

### DIFF
--- a/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
+++ b/services/torghut/tests/hyperliquid_execution/test_migration_manifest.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.migration_testing import migration_path
 
-TORGHUT_ROOT = Path(__file__).resolve().parents[2]
+
 REPO_ROOT = Path(__file__).resolve().parents[4]
-MIGRATION = (
-    TORGHUT_ROOT / "migrations/versions/0056_hyperliquid_execution_v2_hard_reset.py"
-)
-MULTIFACTOR_MIGRATION = (
-    TORGHUT_ROOT / "migrations/versions/0057_generic_multifactor_machine.py"
-)
+MIGRATION = migration_path("0056_hyperliquid_execution_v2_hard_reset.py")
+MULTIFACTOR_MIGRATION = migration_path("0057_generic_multifactor_machine.py")
 CONFIGMAP = REPO_ROOT / "argocd/applications/torghut-hyperliquid-runtime/configmap.yaml"
 DEPLOYMENT = (
     REPO_ROOT / "argocd/applications/torghut-hyperliquid-runtime/deployment.yaml"

--- a/services/torghut/tests/migration_testing.py
+++ b/services/torghut/tests/migration_testing.py
@@ -8,10 +8,18 @@ from types import ModuleType
 _MIGRATIONS_ROOT = Path(__file__).resolve().parents[1] / "migrations" / "versions"
 
 
-def load_migration_module(filename: str) -> ModuleType:
+def migration_path(filename: str) -> Path:
+    if Path(filename).name != filename:
+        raise AssertionError(f"migration_filename_must_be_basename:{filename}")
+
     path = _MIGRATIONS_ROOT / filename
     if not path.is_file():
-        raise AssertionError(f"migration_not_found:{filename}")
+        raise AssertionError(f"migration_not_found:{filename}:expected_path={path}")
+    return path
+
+
+def load_migration_module(filename: str) -> ModuleType:
+    path = migration_path(filename)
 
     revision = filename.partition("_")[0]
     module_name = f"torghut_migration_{revision}"

--- a/services/torghut/tests/test_migration_testing.py
+++ b/services/torghut/tests/test_migration_testing.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.migration_testing import migration_path
+
+
+def test_migration_path_resolves_known_migration() -> None:
+    path = migration_path("0057_generic_multifactor_machine.py")
+
+    assert path.name == "0057_generic_multifactor_machine.py"
+    assert path.parent.name == "versions"
+
+
+def test_migration_path_reports_expected_location() -> None:
+    filename = "9999_missing_test_migration.py"
+
+    with pytest.raises(AssertionError) as exc_info:
+        migration_path(filename)
+
+    message = str(exc_info.value)
+    assert message.startswith(f"migration_not_found:{filename}:expected_path=")
+    assert message.endswith(f"/migrations/versions/{filename}")
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ("../0057_generic_multifactor_machine.py", "nested/migration.py"),
+)
+def test_migration_path_rejects_non_basename(filename: str) -> None:
+    with pytest.raises(
+        AssertionError,
+        match=f"^migration_filename_must_be_basename:{filename}$",
+    ):
+        migration_path(filename)


### PR DESCRIPTION
## Summary

- Centralize migration fixture path resolution in `tests.migration_testing` instead of rebuilding repository-relative paths in individual suites.
- Reject non-basename migration inputs so test helpers cannot silently resolve outside the Alembic versions directory.
- Add deterministic missing-file diagnostics with the expected path and focused regression coverage.

## Related Issues

None.

## Testing

- `uv run --frozen pytest -q tests/test_migration_testing.py tests/hyperliquid_execution/test_migration_manifest.py tests/test_broker_mutation_receipt_migration.py tests/test_trade_decision_submission_claim_migration.py` (14 passed)
- `uv run --frozen ruff format --check tests/migration_testing.py tests/test_migration_testing.py tests/hyperliquid_execution/test_migration_manifest.py`
- `uv run --frozen ruff check tests/migration_testing.py tests/test_migration_testing.py tests/hyperliquid_execution/test_migration_manifest.py`
- All five Pyright profiles passed with zero errors.
- `git diff --check origin/main..HEAD`

## Breaking Changes

None. This changes test-only migration fixture utilities.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for test-only helper consolidation.
