### PR TITLE
fix(agents): block manual Codex review comments

### DIFF
--- a/services/agents/src/server/agents-shell-mcp.test.ts
+++ b/services/agents/src/server/agents-shell-mcp.test.ts
@@ -459,6 +459,25 @@ describe('agents-shell MCP tools', () => {
     await server.close()
   })
 
+  it('rejects manual Codex review comments before starting a shell job', async () => {
+    const config = makeConfig()
+    const { client, server, clientTransport, serverTransport } = await connectServer(config)
+
+    for (const name of ['shell_run', 'shell_start']) {
+      const result = await client.callTool({
+        name,
+        arguments: { command: "gh pr comment 12234 -R proompteng/lab --body '@codex review'" },
+      })
+      expect(result.isError).toBe(true)
+      expect(JSON.stringify(result.content)).toContain('manual Codex review comments are disabled')
+    }
+
+    await clientTransport.close()
+    await serverTransport.close()
+    await client.close()
+    await server.close()
+  })
+
   it('finishes process tools when a git descendant keeps stdio open after child exit', async () => {
     const config = makeConfig()
     mkdirSync(join(config.workspaceRoot, 'lab'), { recursive: true })

--- a/services/agents/src/server/agents-shell/cli-policy.test.ts
+++ b/services/agents/src/server/agents-shell/cli-policy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { requireAllowedShellCommand } from './cli-policy'
+
+describe('agents-shell CLI policy', () => {
+  it('blocks manual Codex review comments through gh pr comment', () => {
+    expect(() => requireAllowedShellCommand("gh pr comment 12234 -R proompteng/lab --body '@codex review'")).toThrow(
+      'manual Codex review comments are disabled',
+    )
+    expect(() =>
+      requireAllowedShellCommand(
+        "gh pr comment 12234 -R proompteng/lab --body '<!-- codex:review-request --> @codex review'",
+      ),
+    ).toThrow('manual Codex review comments are disabled')
+  })
+
+  it('blocks manual Codex review comments through writable gh api calls', () => {
+    expect(() =>
+      requireAllowedShellCommand("gh api -X POST repos/proompteng/lab/issues/12234/comments -f body='@codex review'"),
+    ).toThrow('manual Codex review comments are disabled')
+    expect(() =>
+      requireAllowedShellCommand(
+        'gh api graphql -f query=\'mutation { addComment(input: { body: "@codex review" }) { clientMutationId } }\'',
+      ),
+    ).toThrow('manual Codex review comments are disabled')
+  })
+
+  it('allows read-only inspection of existing manual review comments', () => {
+    expect(() => requireAllowedShellCommand("gh pr view 12234 --json comments | rg '@codex review'")).not.toThrow()
+  })
+})

--- a/services/agents/src/server/agents-shell/cli-policy.ts
+++ b/services/agents/src/server/agents-shell/cli-policy.ts
@@ -14,6 +14,14 @@ const READ_ONLY_KUBECTL_COMMANDS = new Set([
 ])
 const READ_ONLY_KUBECTL_AUTH_COMMANDS = new Set(['can-i', 'whoami'])
 const READ_ONLY_KUBECTL_ROLLOUT_COMMANDS = new Set(['history', 'status'])
+const MANUAL_CODEX_REVIEW_REQUEST = /(?:@codex\s+review\b|codex:review-request\b)/i
+const GH_PR_COMMENT_COMMAND = /\bgh\s+pr\s+comment\b/i
+const GH_API_COMMAND = /\bgh\s+api\b/i
+const GH_API_WRITE_METHOD = /(?:^|\s)(?:-X\s+|--method(?:=|\s+))(?:POST|PATCH)(?:\s|$)/i
+const GRAPHQL_MUTATION = /\bmutation\b/i
+
+const manualCodexReviewRequestError =
+  'manual Codex review comments are disabled; rely on the automatic repository review'
 
 export const normalizeCliArgs = (toolName: string, rawArgs: readonly string[]) => {
   const args = rawArgs.map((arg) => arg.trim()).filter(Boolean)
@@ -39,4 +47,16 @@ export const requireReadOnlyKubectlArgs = (args: readonly string[]) => {
   }
   if (command === 'rollout' && READ_ONLY_KUBECTL_ROLLOUT_COMMANDS.has(args[1] ?? '')) return
   throw new Error(`kubectl supports read-only cluster inspection only; use kubectl_admin for kubectl ${command}`)
+}
+
+export const requireAllowedShellCommand = (command: string) => {
+  if (!MANUAL_CODEX_REVIEW_REQUEST.test(command)) return
+
+  const postsPullRequestComment = GH_PR_COMMENT_COMMAND.test(command)
+  const writesGithubApi =
+    GH_API_COMMAND.test(command) && (GH_API_WRITE_METHOD.test(command) || GRAPHQL_MUTATION.test(command))
+
+  if (postsPullRequestComment || writesGithubApi) {
+    throw new Error(manualCodexReviewRequestError)
+  }
 }

--- a/services/agents/src/server/agents-shell/runner.ts
+++ b/services/agents/src/server/agents-shell/runner.ts
@@ -7,6 +7,7 @@ import { Effect } from 'effect'
 
 import { writeAuditLog } from './audit'
 import type { AuthContext } from './auth'
+import { requireAllowedShellCommand } from './cli-policy'
 import type { AgentsShellConfig } from './config'
 import { ShellJobStore, appendTail, tail, type CommandInput, type ShellJob } from './jobs'
 import { asPositiveInteger } from './limits'
@@ -56,6 +57,17 @@ export class AgentsShellRunner {
   }
 
   start(input: CommandInput, auth: AuthContext): ShellJob {
+    try {
+      requireAllowedShellCommand(input.command)
+    } catch (error) {
+      this.audit('shell_command_rejected', auth, {
+        command: input.command,
+        cwd: input.cwd,
+        reason: error instanceof Error ? error.message : String(error),
+      })
+      throw error
+    }
+
     if (this.runningJobs().length >= this.config.maxConcurrentJobs) {
       throw new Error(`max concurrent jobs reached: ${this.config.maxConcurrentJobs}`)
     }


### PR DESCRIPTION
## Summary

- Rejects manual `@codex review` and `codex:review-request` comments at the `agents-shell` command boundary before a process starts.
- Covers direct `gh pr comment`, writable `gh api`, and GraphQL mutation forms while preserving read-only review-comment inspection.
- Audits rejected commands and adds unit plus MCP regressions for synchronous and background shell jobs.

## Related Issues

Follow-up to the repeated manual review requests observed on #12234. No standalone issue.

## Testing

- `bunx vitest run --config vitest.config.ts src/server/agents-shell/cli-policy.test.ts src/server/agents-shell-mcp.test.ts` — 24 passed, 1 skipped.
- `bun run tsc`
- `bunx oxfmt --check src/server/agents-shell/cli-policy.ts src/server/agents-shell/cli-policy.test.ts src/server/agents-shell/runner.ts src/server/agents-shell-mcp.test.ts`
- `bunx oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json src/server/agents-shell/cli-policy.ts src/server/agents-shell/cli-policy.test.ts src/server/agents-shell/runner.ts src/server/agents-shell-mcp.test.ts` — 0 errors; one pre-existing warning in `agents-shell-mcp.test.ts:277`.
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation change is required for this internal policy guard.
