### PR TITLE
refactor(torghut): unify primary receipt claims

### DIFF
--- a/services/torghut/app/trading/broker_mutation_receipts/acquisition.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/acquisition.py
@@ -188,33 +188,12 @@ def _acquire_primary(
         raise BrokerMutationReceiptConflictError("broker_mutation_primary_token_reuse")
     values = full_state_values_from_event(event)
     values.update(
-        sequence_no=event.sequence_no + 1,
-        event_type="primary_claimed",
-        state="claimed",
-        event_writer_generation=request.writer_generation,
-        primary_token=request.token,
-        primary_epoch=event.primary_epoch + 1,
-        primary_owner=request.owner,
-        primary_writer_generation=request.writer_generation,
-        submission_claim_token=(
-            request.submission_claim_handle.claim_token
-            if request.submission_claim_handle is not None
-            else None
-        ),
-        submission_claim_fencing_epoch=(
-            request.submission_claim_handle.fencing_epoch
-            if request.submission_claim_handle is not None
-            else None
-        ),
-        submission_claim_owner=(
-            request.submission_claim_handle.claim_owner
-            if request.submission_claim_handle is not None
-            else None
-        ),
-        primary_claimed_at=now,
-        primary_lease_expires_at=now + timedelta(seconds=request.lease_seconds),
-        released_at=None,
-        release_reason=None,
+        _primary_claim_event_values(
+            request,
+            now,
+            sequence_no=event.sequence_no + 1,
+            primary_epoch=event.primary_epoch + 1,
+        )
     )
     append_full_state_event(session, receipt_id=header.id, values=values)
     return BrokerMutationReceiptAcquireResult(
@@ -280,34 +259,7 @@ def _initial_event_values(
     request: _PrimaryRequest,
     now: datetime,
 ) -> dict[str, object]:
-    return {
-        "sequence_no": 1,
-        "event_type": "primary_claimed",
-        "state": "claimed",
-        "event_writer_generation": request.writer_generation,
-        "primary_token": request.token,
-        "primary_epoch": 1,
-        "primary_owner": request.owner,
-        "primary_writer_generation": request.writer_generation,
-        "submission_claim_token": (
-            request.submission_claim_handle.claim_token
-            if request.submission_claim_handle is not None
-            else None
-        ),
-        "submission_claim_fencing_epoch": (
-            request.submission_claim_handle.fencing_epoch
-            if request.submission_claim_handle is not None
-            else None
-        ),
-        "submission_claim_owner": (
-            request.submission_claim_handle.claim_owner
-            if request.submission_claim_handle is not None
-            else None
-        ),
-        "primary_claimed_at": now,
-        "primary_lease_expires_at": now + timedelta(seconds=request.lease_seconds),
-        "released_at": None,
-        "release_reason": None,
+    values: dict[str, object] = {
         "broker_io_started_at": None,
         "recovery_after": None,
         "recovery_token": None,
@@ -328,6 +280,50 @@ def _initial_event_values(
         "settlement_evidence_json": None,
         "settlement_evidence_sha256": None,
         "settled_at": None,
+    }
+    values.update(
+        _primary_claim_event_values(
+            request,
+            now,
+            sequence_no=1,
+            primary_epoch=1,
+        )
+    )
+    return values
+
+
+def _primary_claim_event_values(
+    request: _PrimaryRequest,
+    now: datetime,
+    *,
+    sequence_no: int,
+    primary_epoch: int,
+) -> dict[str, object]:
+    """Serialize the complete primary fence for both first claim and takeover."""
+
+    submission_handle = request.submission_claim_handle
+    return {
+        "sequence_no": sequence_no,
+        "event_type": "primary_claimed",
+        "state": "claimed",
+        "event_writer_generation": request.writer_generation,
+        "primary_token": request.token,
+        "primary_epoch": primary_epoch,
+        "primary_owner": request.owner,
+        "primary_writer_generation": request.writer_generation,
+        "submission_claim_token": (
+            submission_handle.claim_token if submission_handle is not None else None
+        ),
+        "submission_claim_fencing_epoch": (
+            submission_handle.fencing_epoch if submission_handle is not None else None
+        ),
+        "submission_claim_owner": (
+            submission_handle.claim_owner if submission_handle is not None else None
+        ),
+        "primary_claimed_at": now,
+        "primary_lease_expires_at": now + timedelta(seconds=request.lease_seconds),
+        "released_at": None,
+        "release_reason": None,
     }
 
 

--- a/services/torghut/tests/test_broker_mutation_receipt_lifecycle.py
+++ b/services/torghut/tests/test_broker_mutation_receipt_lifecycle.py
@@ -193,6 +193,18 @@ def test_primary_acquisition_renew_release_and_reacquire(tmp_path: Path) -> None
         same = _acquire(session, "cancel-1", token=token_a)
     assert same.outcome == "already_owned"
     with sessions() as session:
+        with pytest.raises(
+            BrokerMutationReceiptConflictError,
+            match="primary_identity_conflict",
+        ):
+            _acquire(
+                session,
+                "cancel-1",
+                owner="writer-b",
+                generation=2,
+                token=token_a,
+            )
+    with sessions() as session:
         busy = _acquire(
             session,
             "cancel-1",
@@ -228,6 +240,12 @@ def test_primary_acquisition_renew_release_and_reacquire(tmp_path: Path) -> None
         with pytest.raises(BrokerMutationReceiptFenceError):
             renew_broker_mutation_receipt(session, handle=handle_a)
     with sessions() as session:
+        with pytest.raises(
+            BrokerMutationReceiptConflictError,
+            match="primary_token_reuse",
+        ):
+            _acquire(session, "cancel-1", token=token_a)
+    with sessions() as session:
         reacquired = _acquire(
             session,
             "cancel-1",
@@ -238,6 +256,12 @@ def test_primary_acquisition_renew_release_and_reacquire(tmp_path: Path) -> None
     assert reacquired.outcome == "acquired"
     assert reacquired.receipt.primary_handle.primary_epoch == 2
     assert reacquired.receipt.primary_handle.primary_token == token_b
+    assert reacquired.receipt.primary_handle.primary_owner == "writer-b"
+    assert reacquired.receipt.primary_handle.primary_writer_generation == 2
+    assert reacquired.receipt.lifecycle.event_type == "primary_claimed"
+    assert reacquired.receipt.lifecycle.event_writer_generation == 2
+    assert reacquired.receipt.lifecycle.released_at is None
+    assert reacquired.receipt.lifecycle.release_reason is None
 
     with sessions() as session:
         history = get_broker_mutation_receipt_history(
@@ -306,6 +330,25 @@ def test_broker_io_is_irreversible_and_primary_settlement_is_idempotent(
         == broker_io.lifecycle.sequence_no
     )
     with sessions() as session:
+        active = _acquire(
+            session,
+            "cancel-terminal",
+            owner="writer-b",
+            generation=2,
+            token=uuid.uuid4(),
+        )
+    assert active.outcome == "busy"
+    _force_recovery_due(sessions, broker_io.receipt_id)
+    with sessions() as session:
+        recovery_due = _acquire(
+            session,
+            "cancel-terminal",
+            owner="writer-b",
+            generation=2,
+            token=uuid.uuid4(),
+        )
+    assert recovery_due.outcome == "recovery_required"
+    with sessions() as session:
         with pytest.raises(BrokerMutationReceiptFenceError):
             release_broker_mutation_receipt(
                 session,
@@ -336,6 +379,16 @@ def test_broker_io_is_irreversible_and_primary_settlement_is_idempotent(
             settlement=acknowledged,
         )
     assert idempotent.lifecycle.sequence_no == settled.lifecycle.sequence_no
+    with sessions() as session:
+        terminal = _acquire(
+            session,
+            "cancel-terminal",
+            owner="writer-b",
+            generation=2,
+            token=uuid.uuid4(),
+        )
+    assert terminal.outcome == "settled"
+    assert terminal.receipt.lifecycle.sequence_no == settled.lifecycle.sequence_no
 
     rejected = build_broker_mutation_settlement(
         BrokerMutationSettlementRequest(


### PR DESCRIPTION
## Summary

- Centralize the exact `primary_claimed` receipt/event fence envelope shared by initial acquisition and expired/released takeover.
- Preserve every acquisition outcome and all token/epoch rotation, owner/generation, and old-handle fencing semantics.
- Expand characterization coverage for already-owned, busy, recovery-required, settled, token-reuse rejection, takeover rotation, and release-marker clearing.

## Related Issues

None.

## Testing

- `uv run --frozen pytest -q tests/test_broker_mutation_receipt_lifecycle.py` (5 passed)
- `TORGHUT_TEST_POSTGRES_DSN=postgresql+psycopg://torghut:torghut@127.0.0.1:57635/torghut uv run --frozen pytest -q tests/execution/test_broker_mutation_receipts_postgres.py tests/execution/test_broker_mutation_linked_receipts_postgres.py` (4 passed)
- `uv run --frozen ruff format --check app/trading/broker_mutation_receipts/acquisition.py tests/test_broker_mutation_receipt_lifecycle.py`
- `uv run --frozen ruff check app/trading/broker_mutation_receipts/acquisition.py tests/test_broker_mutation_receipt_lifecycle.py`
- All five Pyright profiles, structural/custom/design/file-length Pylint gates, and the Torghut tech-debt ratchet passed before the conflict-free rebase onto current `main`.
- `git diff --check origin/main..HEAD`

## Breaking Changes

None. This is a behavior-preserving internal receipt-acquisition refactor; runtime receipt wiring remains disabled.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for the internal refactor.
