### PR TITLE
fix(torghut): bound Hyperliquid runtime dependency reads

### DIFF
--- a/services/torghut/app/hyperliquid_execution/api.py
+++ b/services/torghut/app/hyperliquid_execution/api.py
@@ -11,6 +11,7 @@ from typing import AsyncIterator, cast
 from fastapi import FastAPI, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.db import SessionLocal
 from app.trading.loop_status import (
@@ -182,6 +183,7 @@ async def _runtime_loop() -> None:
 
 def _run_one_cycle() -> CycleResult:
     session = SessionLocal()
+    cycle_failed = False
     try:
         result = runtime_state.service.run_once(session)
         runtime_state.latest_cycle = result
@@ -189,12 +191,21 @@ def _run_one_cycle() -> CycleResult:
         runtime_state.metrics.record_cycle(result)
         return result
     except Exception as exc:
-        session.rollback()
+        cycle_failed = True
         runtime_state.latest_error = f"{type(exc).__name__}:{exc}"
         runtime_state.metrics.record_error(exc)
+        try:
+            session.rollback()
+        except SQLAlchemyError:
+            logger.exception("Hyperliquid execution cycle rollback failed")
         raise
     finally:
-        session.close()
+        try:
+            session.close()
+        except SQLAlchemyError:
+            if not cycle_failed:
+                raise
+            logger.exception("Hyperliquid execution cycle session close failed")
 
 
 def _runtime_report_payload() -> dict[str, object]:

--- a/services/torghut/app/hyperliquid_execution/feed_reader.py
+++ b/services/torghut/app/hyperliquid_execution/feed_reader.py
@@ -94,28 +94,13 @@ class ClickHouseFeedReader:
         database = _identifier(self._config.clickhouse_database)
         network = _sql_string(self._config.market_data_network)
         market_list = ", ".join(_sql_string(market_id) for market_id in market_ids)
-        query = f"""
-        SELECT
-          market_id,
-          coin,
-          dex,
-          event_ts,
-          price,
-          momentum_5m_bps,
-          spread_bps,
-          liquidity_usd,
-          volatility_bps,
-          book_imbalance,
-          source_lag_seconds,
-          bid_price,
-          ask_price,
-          quote_lag_seconds
-        FROM {database}.hyperliquid_runtime_latest_features
-        WHERE network = {network}
-          AND market_id IN ({market_list})
-        ORDER BY event_ts DESC
-        LIMIT {len(market_ids)}
-        """
+        query = _latest_feature_query(
+            database=database,
+            network=network,
+            market_list=market_list,
+            limit=len(market_ids),
+            quote_lookback_seconds=max(1, self._config.signal_staleness_seconds),
+        )
         return [_feature_from_row(row) for row in self.query_json_each_row(query)]
 
     def status(self) -> FeedStatus:
@@ -241,6 +226,95 @@ class ClickHouseFeedReader:
             reason=reason,
             details=details,
         )
+
+
+def _latest_feature_query(
+    *,
+    database: str,
+    network: str,
+    market_list: str,
+    limit: int,
+    quote_lookback_seconds: int,
+) -> str:
+    """Build a key-filtered latest-feature query without expanding the global view."""
+
+    return f"""
+        SELECT
+          features.market_id AS market_id,
+          features.coin AS coin,
+          features.dex AS dex,
+          features.latest_event_ts AS event_ts,
+          features.price AS price,
+          features.momentum_5m_bps AS momentum_5m_bps,
+          features.spread_bps AS spread_bps,
+          features.liquidity_usd AS liquidity_usd,
+          features.volatility_bps AS volatility_bps,
+          features.book_imbalance AS book_imbalance,
+          features.source_lag_seconds AS source_lag_seconds,
+          quotes.bid_price AS bid_price,
+          quotes.ask_price AS ask_price,
+          greatest(
+            0,
+            dateDiff('second', quotes.quote_ingest_ts, now64(3))
+          ) AS quote_lag_seconds
+        FROM
+        (
+          SELECT
+            network,
+            market_id,
+            argMax(coin, event_ts) AS coin,
+            argMax(dex, event_ts) AS dex,
+            max(event_ts) AS latest_event_ts,
+            argMax(price, event_ts) AS price,
+            argMaxIf(momentum_5m_bps, event_ts, interval = '5m') AS momentum_5m_bps,
+            argMax(spread_bps, event_ts) AS spread_bps,
+            argMax(liquidity_usd, event_ts) AS liquidity_usd,
+            argMax(volatility_bps, event_ts) AS volatility_bps,
+            argMax(book_imbalance, event_ts) AS book_imbalance,
+            argMax(source_lag_seconds, event_ts) AS source_lag_seconds
+          FROM {database}.hyperliquid_ta_features
+          PREWHERE network = {network}
+            AND market_id IN ({market_list})
+          WHERE event_ts >= now() - INTERVAL 2 HOUR
+          GROUP BY network, market_id
+        ) AS features
+        LEFT JOIN
+        (
+          SELECT
+            network,
+            market_id,
+            argMax(
+              toFloat64OrZero(JSONExtractString(payload, 'bbo', 1, 'px')),
+              parseDateTimeBestEffort(ingest_ts)
+            ) AS bid_price,
+            argMax(
+              toFloat64OrZero(JSONExtractString(payload, 'bbo', 2, 'px')),
+              parseDateTimeBestEffort(ingest_ts)
+            ) AS ask_price,
+            max(toDateTime64(parseDateTimeBestEffort(ingest_ts), 3, 'UTC'))
+              AS quote_ingest_ts
+          FROM {database}.hyperliquid_bbo
+          WHERE network = {network}
+            AND market_id IN ({market_list})
+            AND channel = 'bbo'
+            AND market_type = 'perp'
+            AND event_ts >= concat(
+              formatDateTime(
+                now() - toIntervalSecond({quote_lookback_seconds}),
+                '%Y-%m-%dT%H:%i:%S',
+                'UTC'
+              ),
+              '.000Z'
+            )
+            AND parseDateTimeBestEffort(ingest_ts) >=
+              now() - toIntervalSecond({quote_lookback_seconds})
+          GROUP BY network, market_id
+        ) AS quotes
+          ON features.network = quotes.network
+          AND features.market_id = quotes.market_id
+        ORDER BY features.latest_event_ts DESC
+        LIMIT {limit}
+        """
 
 
 def _request_clickhouse(

--- a/services/torghut/app/hyperliquid_execution/service.py
+++ b/services/torghut/app/hyperliquid_execution/service.py
@@ -13,10 +13,12 @@ from .exchange import HyperliquidExecutionExchange
 from .feed_reader import FeedStatus
 from .maintenance import close_largest_positions_over_cap, risk_state_over_cap
 from .models import (
+    AccountState,
     CycleRecord,
     CycleResult,
     ExecutionMarket,
     FeatureSnapshot,
+    Fill,
     OpenOrder,
     RiskState,
     RuntimeDependencyStatus,
@@ -209,39 +211,46 @@ class HyperliquidExecutionService:
                 max_markets=self._config.max_markets_per_cycle,
             ),
         )
-        repository.upsert_markets(feed_markets)
         execution_markets, execution_status = self._exchange.filter_supported_markets(
             feed_markets
         )
         liquid_markets, liquidity_status = self._exchange.filter_crossable_markets(
             execution_markets
         )
-        fresh_features = self._fresh_features(liquid_markets)
-        selected_markets, selected_features = _select_markets_with_fresh_features(
-            liquid_markets, fresh_features
+        selection = _selected_execution(
+            liquid_markets,
+            self._fresh_features(liquid_markets),
         )
-        feature_status = _feature_status(liquid_markets, fresh_features)
-        open_order_status = self._reconcile_exchange_state(
-            repository, selected_markets, observed_at
-        )
+        exchange_state = self._read_exchange_state(selection.markets)
         exchange_status = self._exchange.dependency_status()
+        execution_metadata_details = self._exchange.execution_metadata_details()
+
+        # Complete every dependency read before opening the cycle transaction.
+        # PostgreSQL enforces a short idle-in-transaction timeout, while these
+        # HTTP/SDK reads can legitimately consume their full network timeout.
+        repository.upsert_markets(feed_markets)
+        open_order_status = self._persist_exchange_state(
+            repository,
+            exchange_state,
+            observed_at,
+        )
         return _CycleContext(
-            markets=selected_markets,
-            features=selected_features,
+            markets=selection.markets,
+            features=selection.features,
             dependencies=feed_status.statuses
             + (
                 execution_status,
                 liquidity_status,
-                feature_status,
+                selection.status,
                 open_order_status,
                 exchange_status,
             ),
             universe_details=universe_details(
                 feed_details,
                 (execution_status, liquidity_status),
-                feature_status,
-                selected_markets,
-                self._exchange.execution_metadata_details(),
+                selection.status,
+                selection.markets,
+                execution_metadata_details,
             ),
         )
 
@@ -257,25 +266,32 @@ class HyperliquidExecutionService:
             if feature.source_lag_seconds <= self._config.signal_staleness_seconds
         )
 
-    def _reconcile_exchange_state(
+    def _read_exchange_state(
         self,
-        repository: HyperliquidExecutionRepository,
         execution_markets: tuple[ExecutionMarket, ...],
+    ) -> "_ReconciledExchangeState":
+        market_id_by_coin = market_id_by_reconciliation_coin(execution_markets)
+        return _ReconciledExchangeState(
+            fills=tuple(self._exchange.reconcile_fills(market_id_by_coin)),
+            account_state=self._exchange.reconcile_account(market_id_by_coin),
+            open_order_coins=self._exchange.reconcile_open_order_coins(
+                frozenset(market_id_by_coin)
+            ),
+        )
+
+    @staticmethod
+    def _persist_exchange_state(
+        repository: HyperliquidExecutionRepository,
+        exchange_state: "_ReconciledExchangeState",
         observed_at: datetime,
     ) -> RuntimeDependencyStatus:
-        market_id_by_coin = market_id_by_reconciliation_coin(execution_markets)
-        repository.upsert_fills(self._exchange.reconcile_fills(market_id_by_coin))
-        repository.upsert_account_state(
-            self._exchange.reconcile_account(market_id_by_coin)
-        )
-        open_coins = self._exchange.reconcile_open_order_coins(
-            frozenset(market_id_by_coin)
-        )
+        repository.upsert_fills(exchange_state.fills)
+        repository.upsert_account_state(exchange_state.account_state)
         return RuntimeDependencyStatus(
             name="hyperliquid_open_orders",
             ready=True,
             observed_at=observed_at,
-            details={"open_order_coins": sorted(open_coins)},
+            details={"open_order_coins": sorted(exchange_state.open_order_coins)},
         )
 
 
@@ -306,6 +322,20 @@ class _CycleContext:
     features: tuple[FeatureSnapshot, ...]
     dependencies: tuple[RuntimeDependencyStatus, ...]
     universe_details: dict[str, object]
+
+
+@dataclass(frozen=True)
+class _ReconciledExchangeState:
+    fills: tuple[Fill, ...]
+    account_state: AccountState
+    open_order_coins: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _SelectedExecution:
+    markets: tuple[ExecutionMarket, ...]
+    features: tuple[FeatureSnapshot, ...]
+    status: RuntimeDependencyStatus
 
 
 @dataclass(frozen=True)
@@ -400,6 +430,21 @@ def _select_markets_with_fresh_features(
         feature_by_market_id[market.market_id] for market in selected_markets
     )
     return selected_markets, selected_features
+
+
+def _selected_execution(
+    markets: tuple[ExecutionMarket, ...],
+    features: tuple[FeatureSnapshot, ...],
+) -> _SelectedExecution:
+    selected_markets, selected_features = _select_markets_with_fresh_features(
+        markets,
+        features,
+    )
+    return _SelectedExecution(
+        markets=selected_markets,
+        features=selected_features,
+        status=_feature_status(markets, features),
+    )
 
 
 def _cycle_universe_details(

--- a/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
+++ b/services/torghut/tests/hyperliquid_execution/test_runtime_surfaces.py
@@ -153,7 +153,10 @@ def test_feed_reader_builds_queries_parses_features_and_reports_status() -> None
     assert status.ready is True
     assert status.statuses[0].name == "hyperliquid_candles"
     assert "hyperliquid_market_catalog" in reader.queries[0]
-    assert "hyperliquid_runtime_latest_features" in reader.queries[1]
+    assert "FROM torghut.hyperliquid_ta_features" in reader.queries[1]
+    assert "PREWHERE network = 'mainnet'" in reader.queries[1]
+    assert "FROM torghut.hyperliquid_bbo" in reader.queries[1]
+    assert "now() - toIntervalSecond(120)" in reader.queries[1]
 
     failing = _FailingFeedReader(config)
     assert failing.status().statuses[0].reason == "clickhouse_query_failed:RuntimeError"
@@ -482,7 +485,7 @@ class _FakeFeedReader(ClickHouseFeedReader):
         includes_format: bool = False,
     ) -> list[dict[str, object]]:
         self.queries.append(query)
-        if "hyperliquid_runtime_latest_features" in query:
+        if "argMaxIf(momentum_5m_bps" in query:
             return [
                 {
                     "market_id": "hl:perp:xyz:NVDA",

--- a/services/torghut/tests/hyperliquid_execution/test_service_transaction_boundary.py
+++ b/services/torghut/tests/hyperliquid_execution/test_service_transaction_boundary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Never
+from typing import Never, cast
 
 from pytest import MonkeyPatch, raises
 from sqlalchemy.exc import SQLAlchemyError
@@ -19,6 +19,7 @@ from app.hyperliquid_execution.models import (
     RuntimeDependencyStatus,
 )
 from app.hyperliquid_execution.metrics import HyperliquidExecutionMetrics
+from app.hyperliquid_execution.repository import HyperliquidExecutionRepository
 from app.hyperliquid_execution.service import HyperliquidExecutionService
 
 
@@ -36,7 +37,7 @@ def test_dependency_reads_finish_before_cycle_database_transaction() -> None:
     repository = _RecordingRepository(events)
 
     context = service._load_context(  # pylint: disable=protected-access
-        repository,  # type: ignore[arg-type]
+        cast(HyperliquidExecutionRepository, repository),
         observed_at,
     )
 

--- a/services/torghut/tests/hyperliquid_execution/test_service_transaction_boundary.py
+++ b/services/torghut/tests/hyperliquid_execution/test_service_transaction_boundary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any
+from typing import Never
 
 from pytest import MonkeyPatch, raises
 from sqlalchemy.exc import SQLAlchemyError
@@ -15,6 +15,7 @@ from app.hyperliquid_execution.models import (
     AccountState,
     ExecutionMarket,
     FeatureSnapshot,
+    Fill,
     RuntimeDependencyStatus,
 )
 from app.hyperliquid_execution.metrics import HyperliquidExecutionMetrics
@@ -111,7 +112,7 @@ class _RecordingRepository:
 
 
 class _FailingCycleService:
-    def run_once(self, _session: object) -> Any:
+    def run_once(self, _session: object) -> Never:
         raise TimeoutError("clickhouse timed out")
 
 
@@ -194,7 +195,7 @@ class _RecordingExchange:
         self._events.append("external:liquidity")
         return markets, RuntimeDependencyStatus("liquidity", True)
 
-    def reconcile_fills(self, _market_id_by_coin: dict[str, str]) -> list[Any]:
+    def reconcile_fills(self, _market_id_by_coin: dict[str, str]) -> list[Fill]:
         self._events.append("external:fills")
         return []
 

--- a/services/torghut/tests/hyperliquid_execution/test_service_transaction_boundary.py
+++ b/services/torghut/tests/hyperliquid_execution/test_service_transaction_boundary.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from pytest import MonkeyPatch, raises
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.hyperliquid_execution import api
+from app.hyperliquid_execution.config import HyperliquidExecutionConfig
+from app.hyperliquid_execution.feed_reader import FeedStatus
+from app.hyperliquid_execution.models import (
+    AccountSnapshot,
+    AccountState,
+    ExecutionMarket,
+    FeatureSnapshot,
+    RuntimeDependencyStatus,
+)
+from app.hyperliquid_execution.metrics import HyperliquidExecutionMetrics
+from app.hyperliquid_execution.service import HyperliquidExecutionService
+
+
+def test_dependency_reads_finish_before_cycle_database_transaction() -> None:
+    events: list[str] = []
+    observed_at = datetime(2026, 7, 11, 22, 0, tzinfo=timezone.utc)
+    config = HyperliquidExecutionConfig.from_env(
+        {"HYPERLIQUID_EXECUTION_TRADE_COINS": "BTC"}
+    )
+    service = HyperliquidExecutionService(
+        config=config,
+        feed=_RecordingFeed(events, observed_at),
+        exchange=_RecordingExchange(events, observed_at),
+    )
+    repository = _RecordingRepository(events)
+
+    context = service._load_context(  # pylint: disable=protected-access
+        repository,  # type: ignore[arg-type]
+        observed_at,
+    )
+
+    first_database_call = next(
+        index for index, event in enumerate(events) if event.startswith("db:")
+    )
+    assert events[:first_database_call] == [
+        "external:feed_status",
+        "external:catalog",
+        "external:execution_metadata",
+        "external:liquidity",
+        "external:features",
+        "external:fills",
+        "external:account",
+        "external:open_orders",
+        "external:exchange_status",
+        "external:execution_details",
+    ]
+    assert events[first_database_call:] == [
+        "db:markets",
+        "db:fills",
+        "db:account",
+    ]
+    assert context.markets[0].coin == "BTC"
+    assert context.dependencies[-2].name == "hyperliquid_open_orders"
+    assert context.dependencies[-1].name == "hyperliquid_exchange"
+
+
+def test_cycle_failure_truth_survives_broken_connection_cleanup(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    session = _RollbackFailingSession()
+    old_service = api.runtime_state.service
+    old_error = api.runtime_state.latest_error
+    old_metrics = api.runtime_state.metrics
+    try:
+        api.runtime_state.service = _FailingCycleService()
+        api.runtime_state.latest_error = None
+        api.runtime_state.metrics = HyperliquidExecutionMetrics()
+        monkeypatch.setattr(api, "SessionLocal", lambda: session)
+
+        with raises(TimeoutError, match="clickhouse timed out"):
+            api._run_one_cycle()  # pylint: disable=protected-access
+
+        assert api.runtime_state.latest_error == "TimeoutError:clickhouse timed out"
+        assert session.rollback_calls == 1
+        assert session.close_calls == 1
+        assert session.closed
+        assert (
+            'torghut_hyperliquid_execution_errors_total{error="TimeoutError"} 1'
+            in api.runtime_state.metrics.render("torghut_hyperliquid_execution")
+        )
+    finally:
+        api.runtime_state.service = old_service
+        api.runtime_state.latest_error = old_error
+        api.runtime_state.metrics = old_metrics
+
+
+class _RecordingRepository:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def upsert_markets(self, _markets: object) -> int:
+        self._events.append("db:markets")
+        return 1
+
+    def upsert_fills(self, _fills: object) -> int:
+        self._events.append("db:fills")
+        return 0
+
+    def upsert_account_state(self, _state: object) -> None:
+        self._events.append("db:account")
+
+
+class _FailingCycleService:
+    def run_once(self, _session: object) -> Any:
+        raise TimeoutError("clickhouse timed out")
+
+
+class _RollbackFailingSession:
+    def __init__(self) -> None:
+        self.rollback_calls = 0
+        self.close_calls = 0
+        self.closed = False
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+        raise SQLAlchemyError("connection was terminated")
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.closed = True
+        raise SQLAlchemyError("connection close failed")
+
+
+class _RecordingFeed:
+    def __init__(self, events: list[str], observed_at: datetime) -> None:
+        self._events = events
+        self._observed_at = observed_at
+
+    def status(self) -> FeedStatus:
+        self._events.append("external:feed_status")
+        return FeedStatus(
+            True,
+            (RuntimeDependencyStatus("feed", True, observed_at=self._observed_at),),
+        )
+
+    def load_catalog_rows(self) -> list[dict[str, object]]:
+        self._events.append("external:catalog")
+        return [
+            {
+                "market_id": "hl:perp:default:BTC",
+                "coin": "BTC",
+                "dex": "default",
+                "network": "mainnet",
+                "market_type": "perp",
+                "dayNtlVlm": "1000000",
+            }
+        ]
+
+    def load_feature_rows(self, _market_ids: list[str]) -> list[FeatureSnapshot]:
+        self._events.append("external:features")
+        return [
+            FeatureSnapshot(
+                market_id="hl:perp:default:BTC",
+                coin="BTC",
+                dex="default",
+                event_ts=self._observed_at,
+                price=Decimal("50000"),
+                momentum_5m_bps=Decimal("5"),
+                spread_bps=Decimal("1"),
+                liquidity_usd=Decimal("1000000"),
+                volatility_bps=Decimal("10"),
+                book_imbalance=Decimal("0"),
+                source_lag_seconds=1,
+            )
+        ]
+
+
+class _RecordingExchange:
+    def __init__(self, events: list[str], observed_at: datetime) -> None:
+        self._events = events
+        self._observed_at = observed_at
+
+    def filter_supported_markets(
+        self,
+        markets: tuple[ExecutionMarket, ...],
+    ) -> tuple[tuple[ExecutionMarket, ...], RuntimeDependencyStatus]:
+        self._events.append("external:execution_metadata")
+        return markets, RuntimeDependencyStatus("metadata", True)
+
+    def filter_crossable_markets(
+        self,
+        markets: tuple[ExecutionMarket, ...],
+    ) -> tuple[tuple[ExecutionMarket, ...], RuntimeDependencyStatus]:
+        self._events.append("external:liquidity")
+        return markets, RuntimeDependencyStatus("liquidity", True)
+
+    def reconcile_fills(self, _market_id_by_coin: dict[str, str]) -> list[Any]:
+        self._events.append("external:fills")
+        return []
+
+    def reconcile_account(self, _market_id_by_coin: dict[str, str]) -> AccountState:
+        self._events.append("external:account")
+        return AccountState(
+            account=AccountSnapshot(
+                observed_at=self._observed_at,
+                account_value_usd=Decimal("0"),
+                withdrawable_usd=Decimal("0"),
+                gross_exposure_usd=Decimal("0"),
+                raw_payload={},
+            ),
+            positions=(),
+        )
+
+    def reconcile_open_order_coins(self, _coins: frozenset[str]) -> frozenset[str]:
+        self._events.append("external:open_orders")
+        return frozenset()
+
+    def dependency_status(self) -> RuntimeDependencyStatus:
+        self._events.append("external:exchange_status")
+        return RuntimeDependencyStatus(
+            "hyperliquid_exchange", True, observed_at=self._observed_at
+        )
+
+    def execution_metadata_details(self) -> dict[str, object]:
+        self._events.append("external:execution_details")
+        return {}


### PR DESCRIPTION
## Summary

- Read Hyperliquid feed and exchange dependencies before opening the PostgreSQL cycle transaction, preventing external network latency from tripping the 15-second idle-in-transaction timeout.
- Replace the global `hyperliquid_runtime_latest_features` view read with a market-keyed, freshness-bounded query over the underlying TA and BBO tables.
- Preserve the original cycle failure in runtime status and metrics when SQLAlchemy rollback or close also fails.
- Add regressions for dependency ordering, cleanup error truth, and the bounded ClickHouse query shape.

## Related Issues

None.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/hyperliquid_execution/api.py app/hyperliquid_execution/feed_reader.py app/hyperliquid_execution/service.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/hyperliquid_execution/test_service_transaction_boundary.py`
- `uv run --frozen ruff check app/hyperliquid_execution/api.py app/hyperliquid_execution/feed_reader.py app/hyperliquid_execution/service.py tests/hyperliquid_execution/test_runtime_surfaces.py tests/hyperliquid_execution/test_service_transaction_boundary.py`
- `uv run --frozen pytest -q tests/hyperliquid_execution` (101 passed)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.strict.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.strict.json`
- `uv run --frozen python -m compileall -q app/hyperliquid_execution tests/hyperliquid_execution`
- `git diff --check`
- Read-only live query validation against the existing ClickHouse data returned BTC, ETH, HYPE, and SOL. The bounded query completed in 17 ms server time while reading 12,536 rows / 1.75 MB; the deployed global-view query took 14,671 ms while reading 53,610,350 rows / 4.56 GB.

## Rollout impact

The Torghut Hyperliquid runtime image must rebuild and roll out through normal GitOps CI/CD. There are no schema, migration, configuration, or secret changes. No direct cluster mutation was performed for this fix.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required because the runtime API and operator contract are unchanged.
