### PR TITLE
chore(oirat): promote nix image sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:df5410d7c20aed97db5cc509db6d2d9e6526663874c8bc5ec1fd2e52271a9eb9
+    digest: sha256:afb6b7ff310a90bf2202b9d96280f27bf6329604524297926e9a8e4ca5c79d85


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:afb6b7ff310a90bf2202b9d96280f27bf6329604524297926e9a8e4ca5c79d85`.
- Source commit: `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:afb6b7ff310a90bf2202b9d96280f27bf6329604524297926e9a8e4ca5c79d85" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.