### PR TITLE
chore(froussard): promote nix image sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:dbaec7a7b53d59c7c568e83e8ed5026764b91c095ae48cad4d60d636561e21bc
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:d70a6ec686205b59b1ddf15324989738eed9d5fb583ef6104e0821105fe3b278
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -73,7 +73,7 @@ spec:
             - name: FROUSSARD_VERSION
               value: v0.571.1-491-ga931fba9e
             - name: FROUSSARD_COMMIT
-              value: 90cc200975cce30cfa233e63f3e23546a45d4653
+              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Promote `froussard` to `registry.ide-newton.ts.net/lab/froussard@sha256:d70a6ec686205b59b1ddf15324989738eed9d5fb583ef6104e0821105fe3b278`.
- Source commit: `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/froussard@sha256:d70a6ec686205b59b1ddf15324989738eed9d5fb583ef6104e0821105fe3b278" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.