### PR TITLE
chore(symphony): promote image sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-10T06:34:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T00:49:06Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-90cc200975cce30cfa233e63f3e23546a45d4653"
-    digest: sha256:54193ab6a6f418df3aff6442f0b75575b82e00e93a6ab6bbdf4e2e23bafc11d9
+    newTag: "sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00"
+    digest: sha256:9cd07b47ac6bc181021888cc53523379e3fdc513030fd58a6daade374329d1d7

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-10T06:34:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T00:49:06Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-90cc200975cce30cfa233e63f3e23546a45d4653"
-    digest: sha256:54193ab6a6f418df3aff6442f0b75575b82e00e93a6ab6bbdf4e2e23bafc11d9
+    newTag: "sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00"
+    digest: sha256:9cd07b47ac6bc181021888cc53523379e3fdc513030fd58a6daade374329d1d7

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-10T06:34:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T00:49:06Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-90cc200975cce30cfa233e63f3e23546a45d4653"
-    digest: sha256:54193ab6a6f418df3aff6442f0b75575b82e00e93a6ab6bbdf4e2e23bafc11d9
+    newTag: "sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00"
+    digest: sha256:9cd07b47ac6bc181021888cc53523379e3fdc513030fd58a6daade374329d1d7


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- Image tag: `sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- Image digest: `sha256:9cd07b47ac6bc181021888cc53523379e3fdc513030fd58a6daade374329d1d7`