### PR TITLE
chore(arc): promote runner image sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -53,7 +53,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:578cfa96457948232aa056412e9f1dbdaeccb976418c7030ff8ba3fb8382eb60
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -64,7 +64,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:578cfa96457948232aa056412e9f1dbdaeccb976418c7030ff8ba3fb8382eb60
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |
@@ -174,7 +174,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:578cfa96457948232aa056412e9f1dbdaeccb976418c7030ff8ba3fb8382eb60
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -185,7 +185,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:578cfa96457948232aa056412e9f1dbdaeccb976418c7030ff8ba3fb8382eb60
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |
@@ -298,7 +298,7 @@ spec:
                 fsGroupChangePolicy: OnRootMismatch
               initContainers:
                 - name: init-dind-externals
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:578cfa96457948232aa056412e9f1dbdaeccb976418c7030ff8ba3fb8382eb60
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f
                   command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
                   resources:
                     requests:
@@ -309,7 +309,7 @@ spec:
                       memory: "256Mi"
               containers:
                 - name: runner
-                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:578cfa96457948232aa056412e9f1dbdaeccb976418c7030ff8ba3fb8382eb60
+                  image: registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f
                   command: ["/bin/bash", "-lc"]
                   args:
                     - |


### PR DESCRIPTION
## Summary

- Promote ARC runner containers to `registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f`.
- Source commit: `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`.
- Keep `docker:dind` unchanged and preserve node-local lab runner work dirs.
- Built by the Nix OCI image workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/arc-runner@sha256:f104125c6521dfe50c08e92edb239530f47f2307e288a60822e3a7db0234664f" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.