### PR TITLE
chore(torghut): promote ws image sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -54,9 +54,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: main-sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: TORGHUT_WS_COMMIT
-              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -55,9 +55,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: main-sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: TORGHUT_WS_COMMIT
-              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut websocket image into GitOps manifests.

- Source commit: `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- Image tag: `sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- Image digest: `sha256:2789b8b87ba8547cb6f00e32838004c0c3d753e651f16070c741587b7e483567`