### PR TITLE
chore(torghut): promote ta image sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 28
+  restartNonce: 29
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -88,9 +88,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: TORGHUT_TA_COMMIT
-              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 30
+  restartNonce: 31
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: TORGHUT_TA_COMMIT
-              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 26
+  restartNonce: 27
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -159,9 +159,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: sha-0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
             - name: TORGHUT_TA_COMMIT
-              value: 0cbfd793dff3abc006eb2d511d5467cf35168a05
+              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut TA image into GitOps manifests.

- Source commit: `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- Image tag: `sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- Image digest: `sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12`
- Manifests: live TA, sim TA, options TA