### PR TITLE
chore(headlamp): promote nix image sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: 6d61f6563c3df42d176b1d445a757df48f0c6f84c02baa4f4f76dbd258ee2ddd
+  tag: c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:


### PR DESCRIPTION
## Summary

- Promote Headlamp to `registry.ide-newton.ts.net/lab/headlamp@sha256:c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3`.
- Source commit: `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`.
- Built by the shared Nix OCI workflow.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/headlamp@sha256:c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.