### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:586a5a937f5812b059ff5f228fe8c6f7efb05c5a1ce3c67e4452fa6a8041c7ff
+    digest: sha256:a8e2b4d5bb91f6509e57ae03060af1c30cfc335a6936f654b5c27713284b2682
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:cf21ba6fbf2748f9db46f4b2d77731be54b11c97f80ef79a477b53f3c35beb75
+    digest: sha256:6ec1bebaca80b5469c82f86bdb6f161a5465a4faa88641c743498f1874b6d666
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/olden/kustomization.yaml
+++ b/argocd/applications/olden/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - service.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/olden
-    digest: sha256:2de252806508e7223e4a69f069a2999eeca794904f84c4583356b41f50af550c
+    digest: sha256:548fce6519f35dde8317749092ce3d2bb48a7f626539267752e6c4717cc3184c
     newName: registry.ide-newton.ts.net/lab/olden

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:68ec6a094936d44388504e9329cf8ae280823d81ca2458b3d5bcd4098d70e3ec
+  digest: sha256:a414a161c3099a52d1b18809d4cf4714066c58fd8278ddbe185fe3b2a71ccfff
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:a2b8df94bd38d5f281f2b29160ef626c8acbdd4d6a145405fcce57ee1f7a2311
+    digest: sha256:a154e168ab50e7ed3298454cf530c4cc3f2548d23e8dc0d0244bd1e230dc55da
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:a8e2b4d5bb91f6509e57ae03060af1c30cfc335a6936f654b5c27713284b2682` from `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:6ec1bebaca80b5469c82f86bdb6f161a5465a4faa88641c743498f1874b6d666` from `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- `olden`: `registry.ide-newton.ts.net/lab/olden@sha256:548fce6519f35dde8317749092ce3d2bb48a7f626539267752e6c4717cc3184c` from `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:a414a161c3099a52d1b18809d4cf4714066c58fd8278ddbe185fe3b2a71ccfff` from `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:a154e168ab50e7ed3298454cf530c4cc3f2548d23e8dc0d0244bd1e230dc55da` from `ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.