### PR TITLE
fix(flamingo): enforce benchmark smoke semantics

### DIFF
--- a/scripts/jangar/benchmark-flamingo-vllm.test.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+
+import { validateChatSmokeResponse } from './benchmark-flamingo-vllm'
+
+function textResponse(content: string, finishReason = 'stop', completionTokens = 8): unknown {
+  return {
+    choices: [{ finish_reason: finishReason, message: { content } }],
+    usage: { completion_tokens: completionTokens },
+  }
+}
+
+describe('validateChatSmokeResponse', () => {
+  test('accepts real OpenAI text completion fields', () => {
+    expect(validateChatSmokeResponse('exact-no-thinking', textResponse('qwen36-ready'))).toEqual([])
+    expect(validateChatSmokeResponse('medium-thinking', textResponse('qwen36-thinking-ready'))).toEqual([])
+  })
+
+  test('reads finish_reason from the choice rather than the message', () => {
+    const response = {
+      choices: [{ finish_reason: 'content_filter', message: { content: 'qwen36-ready', finish_reason: 'stop' } }],
+    }
+    expect(validateChatSmokeResponse('exact-no-thinking', response)).toContain(
+      'choices[0].finish_reason must be "stop" or "length", got "content_filter"',
+    )
+  })
+
+  test('reads completion_tokens from top-level usage', () => {
+    const response = {
+      choices: [
+        {
+          finish_reason: 'stop',
+          message: { content: 'qwen36-thinking-ready', completion_tokens: 8 },
+        },
+      ],
+      usage: { completion_tokens: 0 },
+    }
+    expect(validateChatSmokeResponse('medium-thinking', response)).toContain(
+      'usage.completion_tokens must be positive, got 0',
+    )
+  })
+
+  test('requires one exact structured tool call', () => {
+    const response = {
+      choices: [
+        {
+          finish_reason: 'tool_calls',
+          message: {
+            tool_calls: [
+              {
+                type: 'function',
+                function: { name: 'lookup_status', arguments: '{"id":"FLAMINGO-262K"}' },
+              },
+            ],
+          },
+        },
+      ],
+    }
+    expect(validateChatSmokeResponse('tool-call', response)).toEqual([])
+
+    const extraArgument = structuredClone(response)
+    const toolCalls = (extraArgument.choices[0].message as { tool_calls: Array<{ function: { arguments: string } }> })
+      .tool_calls
+    toolCalls[0].function.arguments = '{"id":"FLAMINGO-262K","extra":true}'
+    expect(validateChatSmokeResponse('tool-call', extraArgument)).toContain(
+      'tool call arguments must be exactly {"id":"FLAMINGO-262K"}',
+    )
+  })
+
+  test('validates dynamic long-context and prefix-cache markers', () => {
+    expect(validateChatSmokeResponse('long-context-220000', textResponse('flamingo-long-220000'))).toEqual([])
+    expect(validateChatSmokeResponse('prefix-cache-second', textResponse('prefix-cache-ready'))).toEqual([])
+    expect(validateChatSmokeResponse('long-context-220000', textResponse('wrong marker'))).not.toEqual([])
+  })
+
+  test('does not impose a response contract on unrelated smoke labels', () => {
+    expect(validateChatSmokeResponse('mtp-al-thinking-on', { choices: [] })).toEqual([])
+  })
+})

--- a/scripts/jangar/benchmark-flamingo-vllm.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.ts
@@ -19,6 +19,7 @@ type ChatResult = {
   status?: number
   response?: unknown
   error?: string
+  validationErrors?: string[]
 }
 
 type BenchmarkRun = {
@@ -466,7 +467,14 @@ async function chatSmoke(label: string, payload: unknown): Promise<ChatResult> {
       method: 'POST',
       body: JSON.stringify(payload),
     })
-    return { label, ok: true, elapsedMs: Date.now() - started, response }
+    const validationErrors = validateChatSmokeResponse(label, response)
+    return {
+      label,
+      ok: validationErrors.length === 0,
+      elapsedMs: Date.now() - started,
+      response,
+      validationErrors: validationErrors.length > 0 ? validationErrors : undefined,
+    }
   } catch (error) {
     return {
       label,
@@ -475,6 +483,100 @@ async function chatSmoke(label: string, payload: unknown): Promise<ChatResult> {
       error: error instanceof Error ? error.message : String(error),
     }
   }
+}
+
+type ChatChoice = {
+  finishReason?: unknown
+  message?: Record<string, unknown>
+}
+
+function firstChatChoice(response: unknown): ChatChoice | undefined {
+  if (!isRecord(response) || !Array.isArray(response.choices) || !isRecord(response.choices[0])) return undefined
+  const choice = response.choices[0]
+  return {
+    finishReason: choice.finish_reason,
+    message: isRecord(choice.message) ? choice.message : undefined,
+  }
+}
+
+function validateTextCompletion(response: unknown, expectedContent: string): string[] {
+  const choice = firstChatChoice(response)
+  if (!choice?.message) return ['missing choices[0].message']
+
+  const errors: string[] = []
+  const content = choice.message.content
+  if (typeof content !== 'string' || !content.includes(expectedContent)) {
+    errors.push(`choices[0].message.content must contain ${JSON.stringify(expectedContent)}`)
+  }
+  if (choice.finishReason !== 'stop' && choice.finishReason !== 'length') {
+    errors.push(`choices[0].finish_reason must be "stop" or "length", got ${JSON.stringify(choice.finishReason)}`)
+  }
+  return errors
+}
+
+function validateToolCall(response: unknown): string[] {
+  const choice = firstChatChoice(response)
+  if (!choice?.message) return ['missing choices[0].message']
+
+  const errors: string[] = []
+  if (choice.finishReason !== 'tool_calls') {
+    errors.push(`choices[0].finish_reason must be "tool_calls", got ${JSON.stringify(choice.finishReason)}`)
+  }
+
+  const toolCalls = choice.message.tool_calls
+  if (!Array.isArray(toolCalls) || toolCalls.length !== 1 || !isRecord(toolCalls[0])) {
+    errors.push('choices[0].message.tool_calls must contain exactly one tool call')
+    return errors
+  }
+
+  const toolCall = toolCalls[0]
+  if (toolCall.type !== 'function' || !isRecord(toolCall.function)) {
+    errors.push('tool call must be a function')
+    return errors
+  }
+  if (toolCall.function.name !== 'lookup_status') {
+    errors.push('tool call function name must be "lookup_status"')
+  }
+
+  const rawArguments = toolCall.function.arguments
+  if (typeof rawArguments !== 'string') {
+    errors.push('tool call arguments must be a JSON string')
+    return errors
+  }
+  try {
+    const parsedArguments: unknown = JSON.parse(rawArguments)
+    if (
+      !isRecord(parsedArguments) ||
+      Object.keys(parsedArguments).length !== 1 ||
+      parsedArguments.id !== 'FLAMINGO-262K'
+    ) {
+      errors.push('tool call arguments must be exactly {"id":"FLAMINGO-262K"}')
+    }
+  } catch {
+    errors.push('tool call arguments must be valid JSON')
+  }
+  return errors
+}
+
+export function validateChatSmokeResponse(label: string, response: unknown): string[] {
+  if (label === 'exact-no-thinking') return validateTextCompletion(response, 'qwen36-ready')
+  if (label === 'medium-thinking') {
+    const errors = validateTextCompletion(response, 'qwen36-thinking-ready')
+    const completionTokens =
+      isRecord(response) && isRecord(response.usage) ? response.usage.completion_tokens : undefined
+    if (typeof completionTokens !== 'number' || completionTokens <= 0) {
+      errors.push(`usage.completion_tokens must be positive, got ${JSON.stringify(completionTokens)}`)
+    }
+    return errors
+  }
+  if (label === 'tool-call') return validateToolCall(response)
+  if (label.startsWith('long-context-')) {
+    return validateTextCompletion(response, `flamingo-long-${label.slice('long-context-'.length)}`)
+  }
+  if (label === 'prefix-cache-first' || label === 'prefix-cache-second') {
+    return validateTextCompletion(response, 'prefix-cache-ready')
+  }
+  return []
 }
 
 function buildLongPrompt(targetTokens: number, marker: string): string {


### PR DESCRIPTION
## Summary

- Validate Flamingo chat smoke responses against the real OpenAI response schema at collection time.
- Fail benchmark runs for malformed text, tool-call, long-context, and prefix-cache responses even when HTTP succeeds.
- Add focused regression coverage for choice-level `finish_reason`, top-level `usage.completion_tokens`, and exact tool arguments.

## Related Issues

Supersedes #11514.

## Testing

- `bun test scripts/jangar/benchmark-flamingo-vllm.test.ts`
- `bunx oxfmt --check scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/benchmark-flamingo-vllm.test.ts`
- `bunx tsc --ignoreConfig --noEmit --skipLibCheck --types bun --module Preserve --moduleResolution Bundler --target ES2023 --moduleDetection force scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/benchmark-flamingo-vllm.test.ts`
- `bun run lint:flamingo-hard-migration`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Successful HTTP responses that violate the documented smoke contract now correctly fail the benchmark run.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
