### PR TITLE
chore(symphony): promote image sha-c1f09e6d651cdfed462e484346044948aebc9849

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T00:49:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T02:24:09Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00"
-    digest: sha256:9cd07b47ac6bc181021888cc53523379e3fdc513030fd58a6daade374329d1d7
+    newTag: "sha-c1f09e6d651cdfed462e484346044948aebc9849"
+    digest: sha256:a2a2b38f84ece86ec92247e3d4ebdc37119062d60b2482d7c453a2c18ff50297

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T00:49:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T02:24:09Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00"
-    digest: sha256:9cd07b47ac6bc181021888cc53523379e3fdc513030fd58a6daade374329d1d7
+    newTag: "sha-c1f09e6d651cdfed462e484346044948aebc9849"
+    digest: sha256:a2a2b38f84ece86ec92247e3d4ebdc37119062d60b2482d7c453a2c18ff50297

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T00:49:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T02:24:09Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00"
-    digest: sha256:9cd07b47ac6bc181021888cc53523379e3fdc513030fd58a6daade374329d1d7
+    newTag: "sha-c1f09e6d651cdfed462e484346044948aebc9849"
+    digest: sha256:a2a2b38f84ece86ec92247e3d4ebdc37119062d60b2482d7c453a2c18ff50297


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `c1f09e6d651cdfed462e484346044948aebc9849`
- Image tag: `sha-c1f09e6d651cdfed462e484346044948aebc9849`
- Image digest: `sha256:a2a2b38f84ece86ec92247e3d4ebdc37119062d60b2482d7c453a2c18ff50297`