### PR TITLE
docs: optimize repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,12 @@
 ## Codex Reviews
 
 - Treat Codex review as a required PR completion gate in addition to CI. Codex feedback can arrive after status checks pass, so do not merge or report a PR ready immediately after `gh pr checks` succeeds.
-- Let the automatic Codex review run while CI is active. After CI completes, inspect the current head SHA, review submissions, and unresolved threads once; do not trigger or poll for Codex review.
+- Let the automatic Codex review run while CI is active. After CI completes, inspect the current head SHA, review submissions, unresolved threads, and PR reactions once; do not trigger or poll for Codex review.
+- Treat a `+1` reaction from `chatgpt-codex-connector[bot]` on the PR as Codex approval when the reaction was created after the current head commit and there are no unresolved actionable Codex threads. GitHub reactions do not carry a reviewed commit SHA, so a later head commit makes the reaction stale and requires a new Codex review signal.
 - Fetch thread-aware review state; flat issue/PR comments are insufficient. Inspect unresolved inline threads, review submissions, resolution state, and the reviewed commit SHA.
 - Address actionable findings in severity order, with P0/P1 correctness, security, data-loss, and rollout issues blocking all lower-priority work. Add regression coverage or exact live validation appropriate to the finding.
 - Push the fix before replying. Reply with the commit and validation evidence, and resolve the thread only after the fix is present on the PR branch.
-- Do not merge or report a PR ready while an actionable Codex thread is unresolved, Codex review is still pending, or the only Codex review targets an older commit.
+- Do not merge or report a PR ready while an actionable Codex thread is unresolved, Codex review is still pending, or the only Codex review signal targets or predates the current head commit.
 
 ## UI/UX
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,206 +1,123 @@
-# Repository Guidelines
+# Repository Agent Guide
 
-## Project Structure & Module Organization
+## Operating Contract
 
-- `apps/`: Next.js/TanStack frontends (tests co-located).
-- `packages/`: shared TS libs + Convex backend (`packages/backend`).
+- Complete the requested outcome before yielding. For complex work, keep a short plan, update it at meaningful milestones, and verify that every requested item is finished.
+- For review, explanation, diagnosis, or planning requests, inspect and report without changing state. For build, fix, or change requests, make the in-scope edits and run relevant non-destructive validation without asking first.
+- Require confirmation for destructive actions, external writes not inherent to the requested workflow, purchases, credential or permission changes, and material scope expansion.
+- Start from concrete evidence: current files, exact identifiers, failing commands, logs, tests, or live readback. Reproduce defects before fixing them when practical.
+- Keep prompts, plans, progress updates, and final responses lean. State each instruction or fact once. Explain notable tool decisions, not routine calls.
+- Check the nearest `README` or nested `AGENTS.md` for component-specific rules.
+
+## Repository Map
+
+- `apps/`: Next.js and TanStack frontends; tests are co-located.
+- `packages/`: shared TypeScript libraries and the Convex backend in `packages/backend`.
 - `services/`: Go, Kotlin, Rails, and Python services.
-- `argocd/`, `kubernetes/`, `tofu/`, `ansible/`: infra + GitOps.
-- `scripts/`, `packages/scripts/`: build/deploy helpers.
-- `scripts/init_skill.py`: bootstrap new skills in `skills/`.
-- `skills/`: agent skills; each skill includes a `SKILL.md`.
+- `argocd/`, `kubernetes/`, `tofu/`, `ansible/`: infrastructure and GitOps.
+- `scripts/`, `packages/scripts/`: build and typed deployment helpers.
+- `skills/`: agent skills; bootstrap with `scripts/init_skill.py`.
 
-## Prereqs
+## Toolchain
 
-- Prefer `nix develop` from the repo root before running build, test, or infra commands. Run `toolchain-doctor`
-  inside the shell when a tool version looks suspect.
-- Node 24.11.1 + Bun 1.3.14 (root `package.json`).
-- Go 1.25.5 for repo parity; Go services support 1.24+.
-- Ruby 3.4.7 + Bundler 2.7+ for `services/dernier`.
-- Python 3.9–3.12 for `apps/alchimie`; 3.11–3.12 for `services/torghut`.
+- Prefer `nix develop` from the repository root. Run `toolchain-doctor` inside the shell when versions look wrong.
+- Pinned versions: Node 24.11.1, Bun 1.3.14, Go 1.25.5, Ruby 3.4.7 with Bundler 2.7+, and Helm 3. Go services support Go 1.24+.
+- Python support: 3.9–3.12 for `apps/alchimie`; 3.11–3.12 for `services/torghut`.
+- Helm 4 is not supported for `kustomize --enable-helm` in this repository.
+- Optional local direnv setup: copy `.envrc.example` to `.envrc`, then run `direnv allow`.
+- Do not edit generated output (`dist/`, `build/`, `_generated`) or lockfiles (`bun.lock`, `bun.lockb`) directly; use the owning generator.
 
-## Tooling Versions (Nix)
+## Discovery and Commands
 
-- Use `nix develop` to get the pinned repo toolchain. This includes Helm 3 for `kustomize --enable-helm`;
-  helm v4 is not supported there yet.
-- Optional direnv setup is local-only: copy `.envrc.example` to `.envrc` and run `direnv allow`.
+- Search code with `bun run atlas:code-search --query "<query>" --repository proompteng/lab --limit 10`. Narrow only as needed with `--path-prefix`, `--language`, then `--ref`.
+- Install dependencies with `bun install`.
+- Frontends: `bun run dev:<app>`, `bun run build:<app>`, `bun run start:<app>`.
+- Convex: `bun run dev:convex`, `bun run --filter @proompteng/backend codegen`, `bun run seed:models`.
+- TypeScript formatting and linting: `bun run format`, `bun run lint:<name>`, `bunx oxfmt --check <paths>`.
+- Protobufs: `bun run proto:generate`.
+- Go: `go test ./services/...`, `go build ./services/...`; run `go mod tidy` in a service when dependencies change.
+- Infrastructure: `bun run tf:plan`, `bun run tf:apply`, `bun run lint:argocd`, `bun run ansible`.
+- Scope workspace commands with `bun run --filter <workspace> <script>`.
+- Focused tests: `bun run --filter <workspace> test -- <file> -t "<name>"`, `bun test -t "<name>" <file>`, `go test ./services/prt -run <TestName>`, `./gradlew test --tests "<class>"`, `bundle exec rails test <file>:<line>`, or `pytest <file> -k "<pattern>"`.
+- Memories service, when the task uses it: `bun run --filter memories retrieve-memory --query … --limit <n>` and `bun run --filter memories save-memory --task-name … --content … --summary … --tags …`.
 
-## Build, Test, and Development Commands
+## Code Standards
 
-- `bun install`: dependencies.
-- `bun run dev:<app>` / `bun run build:<app>` / `bun run start:<app>`: run/build/serve a frontend.
-- `bun run dev:convex`: run the Convex backend locally.
-- `bun run --filter @proompteng/backend codegen` / `bun run seed:models`: Convex codegen/seed.
-- `bun run format` / `bun run lint:<name>` / `bunx oxfmt --check <paths>`: format or lint JS/TS.
-- `bun run proto:generate`: regenerate protobuf outputs.
-- `go test ./services/...` / `go build ./services/...`: test or build Go services; run `go mod tidy` in the service when touching deps.
-- Infra: `bun run tf:plan`, `bun run tf:apply`, `bun run lint:argocd`, `bun run ansible`.
+- Oxfmt is authoritative: 2 spaces, single quotes, trailing commas, 120-column width.
+- Imports: standard library, third party, then internal, separated by blank lines.
+- Names: `kebab-case` files, `PascalCase` components and types, `camelCase` functions.
+- Prefer explicit control flow over nested ternaries and use `async`/`await` consistently.
+- Go: run `gofmt`; wrap errors with context using `fmt.Errorf("context: %w", err)`.
+- Kotlin: run `ktlint`. Rails follows its default style.
+- UI: Tailwind only; order classes layout → spacing → sizing → typography → colors and use `cn()` for conditionals.
+- Use the zinc palette, responsive utilities, accessible interaction states, and content-driven dimensions rather than hardcoded widths or heights.
+- Forms use Zod schemas in `schemas/`, `zodResolver`, validation after typing, and inline errors.
+- Compose or configure base shadcn components; do not edit them directly. Add components through the shadcn CLI.
 
-## Workspace Filtering & Single-Test Patterns
+## Testing and Review
 
-- Scope with `bun run --filter <workspace> <script>` (multiple filters ok).
-- JS tests: `bun run --filter <workspace> test -- path/to/test.ts -t "name"` (Vitest) or `bun test -t "name" tests/foo.test.ts` (Bun).
-- Other: `go test ./services/prt -run TestName`; `./gradlew test --tests "pkg.ClassTest"`; `bundle exec rails test test/models/user_test.rb:42`; `pytest alchimie_tests/test_file.py -k "pattern"`.
+- Co-locate tests using `*.test.ts(x)`, `*_test.go`, `src/test/kotlin/*Test.kt`, Rails `test/**`, or `alchimie_tests/`.
+- Run the smallest test that proves the behavior, then broaden validation in proportion to risk.
+- Bug fixes require a regression test that fails before the fix and passes after it. If that is not feasible, document why and record exact manual validation.
+- Review only actionable issues introduced by the change. Prioritize correctness, security, data loss, error handling, performance, and missing tests; avoid speculative or stylistic findings.
+- Treat exposed secrets, authorization gaps, and PII logging as highest priority.
+- Infra changes under `argocd/`, `kubernetes/`, `tofu/`, or `ansible/` require rollout and impact notes.
 
-## Code Search Helpers
+## Git, Pull Requests, and CI
 
-- Default command:
-  `bun run atlas:code-search --query "<what you need>" --repository proompteng/lab --limit 10`
-- Narrow only if needed: add `--path-prefix <path>`, then `--language <name>`, then `--ref <ref>`.
-
-## Memories Service Helpers
-
-- Save: `bun run --filter memories save-memory --task-name … --content … --summary … --tags …`.
-- Retrieve: `bun run --filter memories retrieve-memory --query … --limit <n>`; uses `schemas/embeddings/memories.sql` and OpenAI embedding env vars.
-
-## Memories
-
-- Make sure to read memories before the turn.
-- Make sure to save memories after the turn.
-
-## Coding Style & Naming Conventions
-
-- Oxfmt: 2-space indent, single quotes, trailing commas, 120-char width (`.oxfmtrc.json`).
-- Imports: standard → third-party → internal; blank lines between groups.
-- Naming: `kebab-case` files, `PascalCase` components/types, `camelCase` functions.
-- Prefer explicit `if/else` over nested ternaries; use `async/await` consistently.
-- Go: `gofmt -w <files>`; wrap errors with context (`fmt.Errorf("context: %w", err)`).
-- Kotlin: `ktlint`; Rails follows default Ruby style.
-
-## Semantic Commit Conventions
-
-- Use Conventional Commits: `<type>(<scope>): <summary>` (scope optional).
-- Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `ci`, `perf`, `revert`.
-- PR titles must follow the same semantic convention.
-- Create PRs by copying `.github/PULL_REQUEST_TEMPLATE.md` into a temp file, fill the description there, then run `gh pr create --title "<type>(<scope>): <summary>" --body-file <temp file>`.
-
-## Pull Requests
-
-- PR descriptions must reflect the actual changes in the PR. Do not include aspirational TODOs or unrelated work.
-- PR body MUST be created from `.github/PULL_REQUEST_TEMPLATE.md` and fully filled in before opening/updating the PR.
-- Do not leave template placeholders in the PR body (examples: `TODO`, `TBD`, `<...>`, `[...]`, unchecked checklist items with no explanation).
-- Do not duplicate template sections (example: multiple `## Summary` blocks). Keep exactly one copy of each template section you use.
-- If a template section is not applicable, write `N/A` for that section (don’t delete the header, and don’t leave it blank).
-- Before running `gh pr create` or `gh pr edit`, do a quick placeholder scan on the temp body file and remove anything that reads like template scaffolding.
-- If a PR body is wrong after creation, fix it immediately with `gh pr edit <num> --body-file <temp file>` rather than “patching” it in the GitHub UI.
-
-## Codex Reviews
-
-- Treat automatic Codex review as a merge gate alongside CI. Do not request `@codex review`; let the configured automatic review start on its own.
-- After CI finishes, poll the PR every 30–60 seconds for the current head SHA, Codex reactions, submitted reviews, and inline findings from `chatgpt-codex-connector[bot]`. Continue until review completes or Codex posts an actionable finding; avoid tighter polling.
-- Interpret an `eyes` reaction as review in progress. Interpret a `+1` reaction created after the current head commit as review complete with no blocking findings unless Codex also posted an actionable finding. A reaction or review that predates the current head is stale.
-- Evaluate only actionable issues introduced by the PR that affect correctness, security, performance, maintainability, or developer experience. Prioritize severe findings and skip nits unless they block understanding or verification of the change.
-- For each actionable finding, verify the cited code and line range, fix the issue, and add focused regression coverage or exact validation. Push the fix before replying with the commit and evidence; resolve the finding only after the fix is on the branch.
-- Merge only when the current head is mergeable, required CI is green, Codex review is complete for that head, and no blocking finding remains. Any new push resets the Codex gate.
-
-## UI/UX
-
-- Tailwind CSS only; class order layout → spacing → sizing → typography → colors; use `cn()` for conditionals.
-- Zinc palette (primary zinc-900/100, secondary zinc-700/300), responsive utilities, no hardcoded widths/heights.
-- Forms: Zod schemas in `schemas/` + `zodResolver`; validate after typing and keep errors inline.
-- Do not edit base shadcn components directly; customize via composition or props.
-- Add new shadcn components via the shadcn CLI; do not hand-create component files.
-
-## Testing Guidelines
-
-- Co-locate tests: `*.test.ts(x)`, `*_test.go`, `src/test/kotlin/*Test.kt`, `test/**`, `alchimie_tests/`.
-- Prefer fast unit tests; add integration tests when needed.
-- For bug fixes, add a regression test that fails before the fix and passes after. If not feasible, document why and the exact manual validation performed.
-
-## Agent Execution Guidelines
-
-- Use precise code pointers (file paths, identifiers, stack traces) to narrow search.
-- Reproduce issues before changes; keep logs and failing commands.
-- Split large tasks; surface ambiguities early; use the planning tool `functions.update_plan` when appropriate.
-- For deploying services, prefer the existing typed deploy tooling under `packages/scripts/` over ad-hoc shell scripts.
-
-## Sub-agents
-
-- Use sub-agents only for parallelizable work (repo discovery, grepping, reading docs, drafting focused diffs, writing test plans). Keep a single source of truth for decisions and final changes in the main agent.
-- Sub-agent tools are `functions.spawn_agent`, `functions.send_input`, `functions.wait`, and `functions.close_agent` (some runtimes also support `resume_agent`).
-- Delegate with a concrete prompt and explicit ownership. Sub-agents must not touch files outside their ownership; if needed, report back and ask the main agent to re-scope.
-- Prompt template:
-
-```text
-Objective: <one sentence>
-Ownership: You own <path/glob> only
-Scope: <do X; avoid Y>
-Constraints: <style/testing/infra constraints>
-Output:
-- Option A: findings with exact file pointers + suggested `rg`/test commands
-- Option B: patch limited to ownership + validation command(s)
-```
-
-- Assign clear ownership to avoid merge conflicts: only one agent edits a given file set at a time; other agents should produce findings, notes, or patches against different files.
-- Default output preference: if the agent is unsure, it should return `rg` commands to run + file pointers rather than a speculative patch.
-- Avoid expensive/slow work by default: sub-agents should not run `bun install` or full test suites unless explicitly requested. Prefer the smallest targeted build/test command that validates the scoped change.
-- Keep spawned agents from idling: queue work in small chunks; use `functions.wait` with a bounded timeout to poll for results; redirect quickly with `functions.send_input` (set `interrupt: true` when needed); and call `functions.close_agent` once an agent has completed its scope.
-- Prefer a hub-and-spoke workflow: continuously integrate results, adjust priorities, and keep agents fed with the next highest-value task until the overall goal is complete.
-- Operating loop: spawn a small number of agents (start with 2-4); track `agent_id -> lane + next task`; `functions.wait` for updates; integrate results; immediately `functions.send_input` the next chunk; and `functions.close_agent` when a lane is done or blocked.
-- Avoid tight polling: use `functions.wait` with timeouts in the 30-60s range; the runtime may enforce a minimum wait timeout.
-
-## Review Guidelines
-
-- Focus on correctness regressions, error handling, and missing tests.
-- Treat bug fixes without regression tests as blocking unless explicitly justified.
-- Flag infra changes in `argocd/`, `tofu/`, `kubernetes/`, or `ansible/` for rollout/impact notes.
-- Treat security issues (secrets, auth gaps, PII logging) as highest priority.
-
-## Merge Guidelines
-
-- Use squash merges for pull requests.
-- Always create new work branches from a fresh `main`
-- Use `gh pr merge 2202 --squash -R proompteng/lab` (no `--delete-branch`; avoids worktree checkout conflicts).
-
-## CI/CD
-
-- Do not deploy services directly from local worktrees for normal changes; push commits and let CI/CD build, publish, and roll out.
-- Wait until all checks are green before reporting that a PR is ready (example: `gh pr checks 2298 --watch -R proompteng/lab`).
-- Before opening or updating a PR, ensure all mandatory checks are green and fix CI breakages (especially strict type-checks like Pyright) before requesting review or merge.
-- Require linting in CI for each language path touched by the change (for example `oxfmt --check`/Oxlint for TS, `ruff` for Python, and service-specific Go linters as applicable).
-- For `services/torghut` changes, do not claim type-checks are passing until all three CI pyright profiles pass locally:
+- Create work branches from fresh `main` using the `codex/` prefix.
+- Use Conventional Commits and matching PR titles: `<type>(<scope>): <summary>`. Common types are `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `ci`, `perf`, and `revert`.
+- Build every PR body from `.github/PULL_REQUEST_TEMPLATE.md`. Describe only actual changes, fill each retained section, use `N/A` where appropriate, check completed checklist items, and remove placeholders or duplicate sections before create or update.
+- Run focused local validation before pushing. Fix all required CI failures before reporting the PR ready or merging.
+- Ensure CI provides language-appropriate linting for every touched path: Oxlint/Oxfmt for TypeScript, Ruff for Python, and the service-specific Go linter where applicable.
+- For `services/torghut`, run all required type checks before claiming success:
   - `uv sync --frozen --extra dev`
   - `uv run --frozen pyright --project pyrightconfig.json`
   - `uv run --frozen pyright --project pyrightconfig.alpha.json`
   - `uv run --frozen pyright --project pyrightconfig.scripts.json`
+- Use squash merges: `gh pr merge <number> --squash -R proompteng/lab`. Do not pass `--delete-branch`, which conflicts with worktrees.
+- Normal deployments flow through committed CI/CD and GitOps; do not deploy services directly from a worktree.
 
-## Generated Artifacts & Safety
+## Codex Review Gate
 
-- Do not edit generated directories (`dist/`, `build/`, `_generated`) or lockfiles (`bun.lock`, `bun.lockb`); regenerate via the owning tool.
-- Default to GitOps (edit `argocd/` manifests and let Argo CD sync). Only apply directly to the cluster when explicitly asked or in an emergency, and document the deviation.
-- Argo CD apps under `argocd/applications/**` should not include `Namespace` manifests; namespaces are created via ApplicationSet `CreateNamespace=true` and `managedNamespaceMetadata` (Pod Security labels, etc).
-  - Upstream remote bases/releases often include `Namespace` objects; drop them from the rendered output (Kustomize `patches` with `$patch: delete`) so Argo applies namespace metadata from the ApplicationSet instead of owning the Namespace resource.
-  - `$patch: delete` removes the object from Kustomize output; it does not delete the live Namespace (the only risk is Argo prune, so avoid pruning Namespaces or set `argocd.argoproj.io/sync-options: Prune=false` on the Namespace via `managedNamespaceMetadata.annotations`).
-- Avoid introducing deprecated Kubernetes/KubeVirt features in new manifests; if a component warns a field/feature gate is deprecated, remove it unless there is a documented requirement.
-- Talos machine configs: do not define multiple `machine.files` entries with the same `path`. Talos will fail `writeUserFiles` with `resource ... already exists`, which prevents CRI/Kubelet from coming up (often surfacing as `/etc/kubernetes/bootstrap-kubeconfig: read-only file system`). Multi-document machine configs are hard to surgically edit via patches; prefer generating/applying a corrected full config via `talosctl apply-config` if you need to remove a duplicate entry.
+- Automatic Codex review is required alongside CI. Let it start automatically; do not post `@codex review`.
+- After CI finishes, poll every 30–60 seconds for the current head SHA and signals from `chatgpt-codex-connector[bot]`: PR reactions, submitted reviews, and inline findings.
+- `eyes` means review is running. A `+1` created after the current head commit means review completed without blocking findings unless Codex also posted an actionable finding. Signals that predate the current head are stale.
+- For each actionable finding, verify the cited code and range, fix it, add focused regression coverage or exact validation, then push. Reply with the commit and evidence and resolve the finding only after the fix is present.
+- A new push resets the review gate. Merge only when required CI is green, the PR is mergeable, Codex completed review of the current head, and no blocking finding remains.
 
-## Kubernetes (kubectl)
+## Sub-agents
 
-- Use explicit namespaces with kubectl (e.g., `kubectl get pods -n <ns>`).
-- If `kubectl config current-context` is unset in this Coder workspace, bootstrap an `in-cluster` context using
-  `/var/run/secrets/kubernetes.io/serviceaccount/{token,ca.crt,namespace}` with
-  `https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}` before running cluster checks.
-- If `kubectl` auth fails (`Unauthorized` / `You must be logged in to the server`), refresh the `service-user`
-  credential from `/var/run/secrets/kubernetes.io/serviceaccount/token`, set the `in-cluster` CA from
-  `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, and verify with `kubectl auth whoami` before retrying.
-- Helm charts present: run from `nix develop`, then `kustomize build --enable-helm <path> | kubectl apply -n <ns> -f -`.
-- CNPG access: `kubectl cnpg psql -n <ns> <cluster> -- <psql args>` (psql flags after `--`).
+- Use sub-agents only for independent parallel work. Give each one a concrete objective, exclusive file ownership or a read-only scope, constraints, and expected evidence.
+- Keep one decision owner. Do not let agents edit overlapping files; prefer findings with exact pointers when ownership is uncertain.
+- Avoid expensive installs and full suites in delegated discovery. Use targeted validation, 30–60 second waits, and close completed agents promptly.
 
-## AgentRuns (agents namespace)
+## GitOps and Infrastructure Safety
 
-- Docs: `docs/agents/agentrun-creation-guide.md`, `docs/agents/crd-yaml-spec.md`, Torghut templates/safety: `docs/torghut/design-system/v1/agentruns-handoff.md`.
-- Prompt precedence: avoid `AgentRun.spec.parameters.prompt` when referencing an ImplementationSpec (it overrides `ImplementationSpec.spec.text`).
-- TTL: use top-level `AgentRun.spec.ttlSecondsAfterFinished` (do not rely on `spec.runtime.config` for TTL).
-- PR/VCS runs: set `spec.vcsRef.name`, `spec.vcsPolicy` (read-write), and a unique `spec.parameters.head` branch (repo convention: `codex/...`).
-- In-cluster callbacks/auth: default to service-account tokens from `/var/run/secrets/kubernetes.io/serviceaccount/token` when no explicit token is provided; for whitepaper finalize callbacks use `JANGAR_WHITEPAPER_FINALIZE_USE_SERVICE_ACCOUNT_TOKEN=true` (optional override path: `JANGAR_WHITEPAPER_SERVICE_ACCOUNT_TOKEN_PATH`).
-- Verify after apply: inspect controller-generated ConfigMap labeled `agents.proompteng.ai/agent-run=<run-name>` and check `run.json.prompt`; if failing early, compare `agentrun.status.contract.requiredKeys` vs `spec.parameters`.
-- Monitor: `kubectl -n agents get agentrun <name>`; `kubectl -n agents get job -l agents.proompteng.ai/agent-run=<name> -o name`; `kubectl -n agents logs -f job/<job-name>`.
+- Default to GitOps: edit manifests and let Argo CD reconcile. Apply directly only when explicitly requested or during a documented emergency.
+- Argo applications under `argocd/applications/**` must not render `Namespace` objects. ApplicationSet owns namespaces through `CreateNamespace=true` and `managedNamespaceMetadata`.
+- Remove upstream `Namespace` objects with a Kustomize `$patch: delete`; this removes them from rendered output, not from the cluster. Avoid namespace pruning or set `argocd.argoproj.io/sync-options: Prune=false` through managed namespace annotations.
+- Do not introduce deprecated Kubernetes or KubeVirt fields or feature gates without a documented requirement.
+- Talos configs must not contain duplicate `machine.files[].path` values. Duplicate paths break `writeUserFiles` and can prevent CRI and Kubelet startup. For multi-document configs, generate and apply a corrected full config rather than attempting a fragile patch.
+
+## Kubernetes
+
+- Always pass an explicit namespace to `kubectl`.
+- If no context exists in Coder, create an `in-cluster` context from `/var/run/secrets/kubernetes.io/serviceaccount/{token,ca.crt,namespace}` and `https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}`.
+- On `Unauthorized` or login errors, refresh the `service-user` token and in-cluster CA, then verify with `kubectl auth whoami` before retrying.
+- Render Helm-backed Kustomize overlays from `nix develop`: `kustomize build --enable-helm <path> | kubectl apply -n <ns> -f -`.
+- CNPG: `kubectl cnpg psql -n <ns> <cluster> -- <psql args>`.
+
+## AgentRuns
+
+- Sources of truth: `docs/agents/agentrun-creation-guide.md`, `docs/agents/crd-yaml-spec.md`, and `docs/torghut/design-system/v1/agentruns-handoff.md`.
+- When using an ImplementationSpec, omit `spec.parameters.prompt`; it overrides `ImplementationSpec.spec.text`.
+- Set TTL with top-level `spec.ttlSecondsAfterFinished`.
+- PR/VCS runs require `spec.vcsRef.name`, read-write `spec.vcsPolicy`, and a unique `spec.parameters.head` using `codex/...`.
+- Default in-cluster callbacks to the service-account token. Whitepaper finalize callbacks use `JANGAR_WHITEPAPER_FINALIZE_USE_SERVICE_ACCOUNT_TOKEN=true`; override the path with `JANGAR_WHITEPAPER_SERVICE_ACCOUNT_TOKEN_PATH` only when needed.
+- After apply, inspect the controller ConfigMap labeled `agents.proompteng.ai/agent-run=<name>` and verify `run.json.prompt`. For early failures, compare `status.contract.requiredKeys` with `spec.parameters`.
+- Monitor with `kubectl -n agents get agentrun <name>`, `kubectl -n agents get job -l agents.proompteng.ai/agent-run=<name> -o name`, and `kubectl -n agents logs -f job/<job>`.
 
 ## Temporal
 
-- Temporal CLI usage, address, namespace, and task queue defaults live in `skills/temporal/SKILL.md` (source of truth).
-
-## When in Doubt
-
-- Check the nearest README for service-specific commands.
-- Search internet with correct keyword and questions containing context using web.run.
+- Use `skills/temporal/SKILL.md` as the source of truth for Temporal CLI address, namespace, and task queue defaults.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,8 @@
 
 ## Codex Reviews
 
-- Treat automatic Codex review as a merge gate alongside CI. Do not request `@codex review` or poll for completion.
-- After CI finishes, inspect the PR once for the current head SHA, Codex reactions, submitted reviews, and inline findings from `chatgpt-codex-connector[bot]`.
+- Treat automatic Codex review as a merge gate alongside CI. Do not request `@codex review`; let the configured automatic review start on its own.
+- After CI finishes, poll the PR every 30–60 seconds for the current head SHA, Codex reactions, submitted reviews, and inline findings from `chatgpt-codex-connector[bot]`. Continue until review completes or Codex posts an actionable finding; avoid tighter polling.
 - Interpret an `eyes` reaction as review in progress. Interpret a `+1` reaction created after the current head commit as review complete with no blocking findings unless Codex also posted an actionable finding. A reaction or review that predates the current head is stale.
 - Evaluate only actionable issues introduced by the PR that affect correctness, security, performance, maintainability, or developer experience. Prioritize severe findings and skip nits unless they block understanding or verification of the change.
 - For each actionable finding, verify the cited code and line range, fix the issue, and add focused regression coverage or exact validation. Push the fix before replying with the commit and evidence; resolve the finding only after the fix is on the branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,12 +86,12 @@
 
 ## Codex Reviews
 
-- Treat Codex review as a required PR completion gate in addition to CI. Codex feedback can arrive after status checks pass, so do not merge or report a PR ready immediately after `gh pr checks` succeeds.
-- Let the automatic Codex review run while CI is active. After CI completes, inspect the current head SHA, review submissions, unresolved threads, and PR reactions once; do not trigger or poll for Codex review.
-- Treat a `+1` reaction from `chatgpt-codex-connector[bot]` on the PR as Codex approval when the reaction was created after the current head commit and there are no unresolved actionable Codex threads. GitHub reactions do not carry a reviewed commit SHA, so a later head commit makes the reaction stale and requires a new Codex review signal.
-- Address actionable findings in severity order, with P0/P1 correctness, security, data-loss, and rollout issues blocking all lower-priority work. Add regression coverage or exact live validation appropriate to the finding.
-- Push the fix before replying. Reply with the commit and validation evidence, and resolve the thread only after the fix is present on the PR branch.
-- Do not merge or report a PR ready while an actionable Codex thread is unresolved, Codex review is still pending, or the only Codex review signal targets or predates the current head commit.
+- Treat automatic Codex review as a merge gate alongside CI. Do not request `@codex review` or poll for completion.
+- After CI finishes, inspect the PR once for the current head SHA, Codex reactions, submitted reviews, and inline findings from `chatgpt-codex-connector[bot]`.
+- Interpret an `eyes` reaction as review in progress. Interpret a `+1` reaction created after the current head commit as review complete with no blocking findings unless Codex also posted an actionable finding. A reaction or review that predates the current head is stale.
+- Evaluate only actionable issues introduced by the PR that affect correctness, security, performance, maintainability, or developer experience. Prioritize severe findings and skip nits unless they block understanding or verification of the change.
+- For each actionable finding, verify the cited code and line range, fix the issue, and add focused regression coverage or exact validation. Push the fix before replying with the commit and evidence; resolve the finding only after the fix is on the branch.
+- Merge only when the current head is mergeable, required CI is green, Codex review is complete for that head, and no blocking finding remains. Any new push resets the Codex gate.
 
 ## UI/UX
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,6 @@
 - Treat Codex review as a required PR completion gate in addition to CI. Codex feedback can arrive after status checks pass, so do not merge or report a PR ready immediately after `gh pr checks` succeeds.
 - Let the automatic Codex review run while CI is active. After CI completes, inspect the current head SHA, review submissions, unresolved threads, and PR reactions once; do not trigger or poll for Codex review.
 - Treat a `+1` reaction from `chatgpt-codex-connector[bot]` on the PR as Codex approval when the reaction was created after the current head commit and there are no unresolved actionable Codex threads. GitHub reactions do not carry a reviewed commit SHA, so a later head commit makes the reaction stale and requires a new Codex review signal.
-- Fetch thread-aware review state; flat issue/PR comments are insufficient. Inspect unresolved inline threads, review submissions, resolution state, and the reviewed commit SHA.
 - Address actionable findings in severity order, with P0/P1 correctness, security, data-loss, and rollout issues blocking all lower-priority work. Add regression coverage or exact live validation appropriate to the finding.
 - Push the fix before replying. Reply with the commit and validation evidence, and resolve the thread only after the fix is present on the PR branch.
 - Do not merge or report a PR ready while an actionable Codex thread is unresolved, Codex review is still pending, or the only Codex review signal targets or predates the current head commit.


### PR DESCRIPTION
## Summary

- Rewrite `AGENTS.md` around a concise operating contract with explicit autonomy, approval, persistence, and evidence boundaries.
- Consolidate repository layout, toolchain, commands, code standards, testing, PR/CI, and sub-agent guidance without losing project-specific constraints.
- Preserve and simplify the GitOps, Argo namespace, Talos, Kubernetes, AgentRun, Temporal, and Torghut validation rules.
- Define a current-head Codex merge gate with 30–60 second polling and explicit `eyes`, `+1`, stale-signal, finding, and completion semantics.

## Related Issues

Follow-up to #12263.

## Testing

- `git diff --check`
- Verified all critical toolchain, regression-test, Pyright, squash-merge, GitOps, Talos, Kubernetes, AgentRun, Temporal, and Codex-review rules remain present.
- Verified the rules against #12263, where `chatgpt-codex-connector[bot]` posted a current-head `+1` with no actionable finding.
- Cross-checked the OpenAI Cookbook code-review workflow and official GPT-5.6 Sol prompting guidance.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.