### PR TITLE
chore(oirat): promote nix image sha-c1f09e6d651cdfed462e484346044948aebc9849

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:afb6b7ff310a90bf2202b9d96280f27bf6329604524297926e9a8e4ca5c79d85
+    digest: sha256:1b0ee4bd19ef6670438ff952504b6154c3686a4664678176d19045abddb63367


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:1b0ee4bd19ef6670438ff952504b6154c3686a4664678176d19045abddb63367`.
- Source commit: `c1f09e6d651cdfed462e484346044948aebc9849`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:1b0ee4bd19ef6670438ff952504b6154c3686a4664678176d19045abddb63367" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.