### PR TITLE
chore(bumba): promote nix image sha-c1f09e6d651cdfed462e484346044948aebc9849

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: bumba@c1f09e6d651cdfed462e484346044948aebc9849
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:476a1aff7f97d5fb84d48c38b2a954758c03f194b677762d9adf7bbc6c982504
+    digest: sha256:deb4398f0898f95713e661f8a08814b5a8b703ca0a0a70b502f90b4b25bac80d
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:deb4398f0898f95713e661f8a08814b5a8b703ca0a0a70b502f90b4b25bac80d`.
- Source commit: `c1f09e6d651cdfed462e484346044948aebc9849`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:deb4398f0898f95713e661f8a08814b5a8b703ca0a0a70b502f90b4b25bac80d" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.