### PR TITLE
chore(froussard): promote nix image sha-c1f09e6d651cdfed462e484346044948aebc9849

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:d70a6ec686205b59b1ddf15324989738eed9d5fb583ef6104e0821105fe3b278
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:8773f94f69d3e6c4dd5de2e8ed9440394d4c718a6f9c5953cb0bf26efce3fb1f
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -73,7 +73,7 @@ spec:
             - name: FROUSSARD_VERSION
               value: v0.571.1-491-ga931fba9e
             - name: FROUSSARD_COMMIT
-              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: c1f09e6d651cdfed462e484346044948aebc9849
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Promote `froussard` to `registry.ide-newton.ts.net/lab/froussard@sha256:8773f94f69d3e6c4dd5de2e8ed9440394d4c718a6f9c5953cb0bf26efce3fb1f`.
- Source commit: `c1f09e6d651cdfed462e484346044948aebc9849`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/froussard@sha256:8773f94f69d3e6c4dd5de2e8ed9440394d4c718a6f9c5953cb0bf26efce3fb1f" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.