### PR TITLE
chore(jangar): promote image sha-c1f09e6d651cdfed462e484346044948aebc9849

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-12T00:53:15Z
+    deploy.knative.dev/rollout: 2026-07-12T02:29:30Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: c1f09e6d651cdfed462e484346044948aebc9849
             - name: JANGAR_GITOPS_REVISION
-              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: c1f09e6d651cdfed462e484346044948aebc9849
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29173231564"
+              value: "29176314808"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:0323aec2f8891959277ef09a148ebac05315a46db897f4adf83b510b1dbcf042
+              value: sha256:892867d4d69c280967e4e85c271799b2b1aa5e1bdff83b9bc537d9305bdd1c4b
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
+              value: c1f09e6d651cdfed462e484346044948aebc9849
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:0323aec2f8891959277ef09a148ebac05315a46db897f4adf83b510b1dbcf042
+              value: sha256:892867d4d69c280967e4e85c271799b2b1aa5e1bdff83b9bc537d9305bdd1c4b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-ccfdd9e0acf9a68ceb2b6fa32fd072fb038aec00
-    digest: sha256:0323aec2f8891959277ef09a148ebac05315a46db897f4adf83b510b1dbcf042
+    newTag: sha-c1f09e6d651cdfed462e484346044948aebc9849
+    digest: sha256:892867d4d69c280967e4e85c271799b2b1aa5e1bdff83b9bc537d9305bdd1c4b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `c1f09e6d651cdfed462e484346044948aebc9849`
- Image tag: `sha-c1f09e6d651cdfed462e484346044948aebc9849`
- Image digest: `sha256:892867d4d69c280967e4e85c271799b2b1aa5e1bdff83b9bc537d9305bdd1c4b`
- Source CI run: `29176314808`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates