### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:a8e2b4d5bb91f6509e57ae03060af1c30cfc335a6936f654b5c27713284b2682
+    digest: sha256:2de983bd71c31a340889134f55fe972d1feea3a88d1ffd99fdbf7ed475afb25d
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:6ec1bebaca80b5469c82f86bdb6f161a5465a4faa88641c743498f1874b6d666
+    digest: sha256:9d4a9f6886184f0a4b28d5ff17f72222796ff3ab7852818e07cffd3a4f093d11
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/olden/kustomization.yaml
+++ b/argocd/applications/olden/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - service.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/olden
-    digest: sha256:548fce6519f35dde8317749092ce3d2bb48a7f626539267752e6c4717cc3184c
+    digest: sha256:36c0833883487eb2d6dedb60a8dfea5d1e889d50f0621f4ebd93ea1adaf6d2fc
     newName: registry.ide-newton.ts.net/lab/olden

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:a414a161c3099a52d1b18809d4cf4714066c58fd8278ddbe185fe3b2a71ccfff
+  digest: sha256:469af30118aa17cfce70b8e1b9e56b4ef85cf1c9a981c1d945c37cb895377381
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:a154e168ab50e7ed3298454cf530c4cc3f2548d23e8dc0d0244bd1e230dc55da
+    digest: sha256:7f00e90d55d00f0fa3ce59df13d535e01ebdad4e02879ae7a1e8928b7063b812
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:2de983bd71c31a340889134f55fe972d1feea3a88d1ffd99fdbf7ed475afb25d` from `c1f09e6d651cdfed462e484346044948aebc9849`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:9d4a9f6886184f0a4b28d5ff17f72222796ff3ab7852818e07cffd3a4f093d11` from `c1f09e6d651cdfed462e484346044948aebc9849`
- `olden`: `registry.ide-newton.ts.net/lab/olden@sha256:36c0833883487eb2d6dedb60a8dfea5d1e889d50f0621f4ebd93ea1adaf6d2fc` from `c1f09e6d651cdfed462e484346044948aebc9849`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:469af30118aa17cfce70b8e1b9e56b4ef85cf1c9a981c1d945c37cb895377381` from `c1f09e6d651cdfed462e484346044948aebc9849`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:7f00e90d55d00f0fa3ce59df13d535e01ebdad4e02879ae7a1e8928b7063b812` from `c1f09e6d651cdfed462e484346044948aebc9849`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.