### PR TITLE
fix(torghut): enforce qty-only Alpaca submission

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -37,6 +37,32 @@ class OrderFirewallViolation(PermissionError):
     """Raised when broker mutation methods are called outside OrderFirewall."""
 
 
+_RESERVED_ORDER_EXTRA_PARAMS = frozenset(
+    {
+        "limit_price",
+        "notional",
+        "order_type",
+        "qty",
+        "side",
+        "stop_price",
+        "symbol",
+        "time_in_force",
+        "type",
+    }
+)
+_ALLOWED_ORDER_EXTRA_PARAMS = frozenset(
+    {
+        "client_order_id",
+        "extended_hours",
+        "legs",
+        "order_class",
+        "position_intent",
+        "stop_loss",
+        "take_profit",
+    }
+)
+
+
 class _ReadOnlyTradingClientLike(Protocol):
     def get_account(self) -> Any: ...
 
@@ -239,6 +265,22 @@ class TorghutAlpacaClient:
     ) -> Dict[str, Any]:
         self._require_firewall_caller()
         self._require_firewall_token(firewall_token)
+        order_extra_params = dict(extra_params or {})
+        reserved_extra_params = sorted(
+            _RESERVED_ORDER_EXTRA_PARAMS.intersection(order_extra_params)
+        )
+        if reserved_extra_params:
+            raise ValueError(
+                "alpaca_order_extra_params_reserved:" + ",".join(reserved_extra_params)
+            )
+        unsupported_extra_params = sorted(
+            set(order_extra_params).difference(_ALLOWED_ORDER_EXTRA_PARAMS)
+        )
+        if unsupported_extra_params:
+            raise ValueError(
+                "alpaca_order_extra_params_unsupported:"
+                + ",".join(unsupported_extra_params)
+            )
         side_enum = OrderSide(side.lower())
         tif_enum = TimeInForce(time_in_force.lower())
         payload = {
@@ -247,8 +289,7 @@ class TorghutAlpacaClient:
             "side": side_enum,
             "time_in_force": tif_enum,
         }
-        if extra_params:
-            payload.update(extra_params)
+        payload.update(order_extra_params)
 
         order_type_lower = order_type.lower()
         if order_type_lower == "market":

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -138,6 +138,122 @@ class TestAlpacaClient(TestCase):
         cancelled = firewall.cancel_all_orders()
         self.assertEqual(len(cancelled), 2)
 
+    def test_order_extra_params_cannot_override_wrapper_owned_fields(self) -> None:
+        trading_client = DummyTradingClient()
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=trading_client,
+            data_client=DummyDataClient(),
+        )
+        firewall = OrderFirewall(client)
+
+        with patch.object(
+            trading_client,
+            "submit_order",
+            wraps=trading_client.submit_order,
+        ) as submit_order:
+            reserved_values: dict[str, object] = {
+                "limit_price": "200",
+                "notional": "100",
+                "order_type": "limit",
+                "qty": "100",
+                "side": "sell",
+                "stop_price": "90",
+                "symbol": "MSFT",
+                "time_in_force": "gtc",
+                "type": "limit",
+            }
+            for reserved_key, reserved_value in reserved_values.items():
+                with (
+                    self.subTest(reserved_key=reserved_key),
+                    self.assertRaisesRegex(
+                        ValueError,
+                        rf"alpaca_order_extra_params_reserved:{reserved_key}",
+                    ),
+                ):
+                    firewall.submit_order(
+                        symbol="AAPL",
+                        side="buy",
+                        qty=1,
+                        order_type="market",
+                        time_in_force="day",
+                        extra_params={reserved_key: reserved_value},
+                    )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "alpaca_order_extra_params_reserved:side,symbol,time_in_force",
+            ):
+                OrderFirewall(client).submit_order(
+                    symbol="AAPL",
+                    side="buy",
+                    qty=1,
+                    order_type="market",
+                    time_in_force="day",
+                    extra_params={
+                        "side": "sell",
+                        "symbol": "MSFT",
+                        "time_in_force": "gtc",
+                    },
+                )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "alpaca_order_extra_params_unsupported:simulation_context",
+            ):
+                OrderFirewall(client).submit_order(
+                    symbol="AAPL",
+                    side="buy",
+                    qty=1,
+                    order_type="market",
+                    time_in_force="day",
+                    extra_params={"simulation_context": {"source": "simulation"}},
+                )
+
+            submit_order.assert_not_called()
+
+    def test_order_extra_params_preserve_supported_sdk_fields(self) -> None:
+        class RecordingTradingClient(DummyTradingClient):
+            def __init__(self) -> None:
+                super().__init__()
+                self.submitted_order: Any | None = None
+
+            def submit_order(self, order_data: Any) -> DummyModel:
+                self.submitted_order = order_data
+                return super().submit_order(order_data)
+
+        trading_client = RecordingTradingClient()
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=trading_client,
+            data_client=DummyDataClient(),
+        )
+
+        submitted = OrderFirewall(client).submit_order(
+            symbol="AAPL",
+            side="buy",
+            qty=1,
+            order_type="market",
+            time_in_force="day",
+            extra_params={
+                "client_order_id": "client-123",
+                "extended_hours": False,
+            },
+        )
+
+        self.assertEqual(submitted["status"], "accepted")
+        submitted_order = trading_client.submitted_order
+        assert submitted_order is not None
+        self.assertEqual(
+            submitted_order.client_order_id,
+            "client-123",
+        )
+        self.assertFalse(submitted_order.extended_hours)
+
     def test_attribute_only_model_payload_uses_public_vars(self) -> None:
         class AttributeOnlyTradingClient(DummyTradingClient):
             def get_account(self) -> AttributeOnlyModel:


### PR DESCRIPTION
## Summary

- Reject Alpaca order `extra_params` that attempt to override wrapper-owned fields, including `qty` and `notional`.
- Allow only the supported optional Alpaca SDK order fields so broker payload construction remains fail-closed.
- Add regression coverage proving reserved and unsupported fields never reach `submit_order` while supported fields remain available.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/test_alpaca_client.py` (17 passed)
- `uv run --frozen ruff check app/alpaca_client.py tests/test_alpaca_client.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git range-diff 5841bc594ea00aeaa53bad21a1edc73051197b3d..e6d594293 286c75c1b8ad78103dea4106eddc8127011b4ca5..HEAD`
- Verified `argocd/applications/torghut/scheduler-deployment.yaml` remains at `spec.replicas: 0`.

## Screenshots (if applicable)

N/A; backend-only broker admission change.

## Breaking Changes

None. Unsupported or wrapper-owned `extra_params` now fail closed instead of being forwarded to Alpaca.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation update is required for this internal safety boundary.
