### PR TITLE
refactor(torghut): extract receipt normalization primitives

### DIFF
--- a/services/torghut/app/trading/broker_mutation_receipts/canonicalization.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/canonicalization.py
@@ -3,17 +3,12 @@
 from __future__ import annotations
 
 import hashlib
-import ipaddress
 import json
-import posixpath
-import re
-import unicodedata
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import cast
-from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 from .types import (
     BrokerMutationIntent,
@@ -36,12 +31,12 @@ from .types import (
 from .validation import (
     MAX_CANONICAL_INTENT_BYTES,
     MAX_CANONICAL_EVIDENCE_BYTES,
-    MAX_CANONICAL_NESTING,
     BrokerMutationReceiptValidationError,
+    canonical_json_value,
     enum_value,
+    normalize_endpoint_url,
     optional_uuid,
     optional_text,
-    reject_control_characters,
     required_text,
     sha256_hex,
 )
@@ -50,20 +45,6 @@ from .validation import (
 BROKER_MUTATION_INTENT_SCHEMA_VERSION = "torghut.broker-mutation-intent.v1"
 _RECOVERY_EVIDENCE_SCHEMA_VERSION = "torghut.broker-mutation-recovery-evidence.v1"
 _SETTLEMENT_EVIDENCE_SCHEMA_VERSION = "torghut.broker-mutation-settlement-evidence.v1"
-_DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
-_SECRET_BEARING_KEY_MARKERS = (
-    "apikey",
-    "authorization",
-    "bearer",
-    "cookie",
-    "credential",
-    "password",
-    "passwd",
-    "privatekey",
-    "secret",
-    "token",
-)
-
 _ROUTES: tuple[BrokerMutationRoute, ...] = ("alpaca", "hyperliquid")
 _OPERATIONS: tuple[BrokerMutationOperation, ...] = (
     "submit_order",
@@ -129,71 +110,8 @@ class _NormalizedIntentFields:
 def fingerprint_broker_endpoint(endpoint_url: str) -> str:
     """Hash a credential-free normalized endpoint without returning the URL."""
 
-    normalized = _normalized_endpoint_url(endpoint_url)
+    normalized = normalize_endpoint_url(endpoint_url)
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-
-
-def _normalized_endpoint_url(endpoint_url: str) -> str:
-    raw = required_text(endpoint_url, field="endpoint_url", maximum=2048)
-    try:
-        parsed = urlsplit(raw)
-        port = parsed.port
-    except ValueError as exc:
-        raise BrokerMutationReceiptValidationError("endpoint_url_invalid") from exc
-    scheme = parsed.scheme.lower()
-    if scheme not in {"http", "https"}:
-        raise BrokerMutationReceiptValidationError("endpoint_url_scheme_invalid")
-    if parsed.username is not None or parsed.password is not None:
-        raise BrokerMutationReceiptValidationError("endpoint_url_credentials_forbidden")
-    if parsed.query or parsed.fragment:
-        raise BrokerMutationReceiptValidationError(
-            "endpoint_url_query_or_fragment_forbidden"
-        )
-    hostname = parsed.hostname
-    if hostname is None:
-        raise BrokerMutationReceiptValidationError("endpoint_url_host_required")
-    normalized_host = _normalized_endpoint_host(hostname)
-    if ":" in normalized_host:
-        normalized_host = f"[{normalized_host}]"
-    default_port = 443 if scheme == "https" else 80
-    authority = (
-        normalized_host if port in {None, default_port} else f"{normalized_host}:{port}"
-    )
-    path = _normalized_endpoint_path(parsed.path)
-    normalized = urlunsplit(SplitResult(scheme, authority, path, "", ""))
-    reject_control_characters(normalized, field="endpoint_url")
-    return normalized
-
-
-def _normalized_endpoint_host(hostname: str) -> str:
-    if "%" in hostname:
-        raise BrokerMutationReceiptValidationError("endpoint_url_host_invalid")
-    try:
-        return ipaddress.ip_address(hostname).compressed.lower()
-    except ValueError:
-        pass
-    try:
-        normalized = hostname.rstrip(".").encode("idna").decode("ascii").lower()
-    except UnicodeError as exc:
-        raise BrokerMutationReceiptValidationError("endpoint_url_host_invalid") from exc
-    if (
-        not normalized
-        or len(normalized) > 253
-        or any(_DNS_LABEL.fullmatch(label) is None for label in normalized.split("."))
-    ):
-        raise BrokerMutationReceiptValidationError("endpoint_url_host_invalid")
-    return normalized
-
-
-def _normalized_endpoint_path(path: str) -> str:
-    if not path or path == "/":
-        return "/"
-    if not path.startswith("/"):
-        raise BrokerMutationReceiptValidationError("endpoint_url_path_invalid")
-    normalized = posixpath.normpath(path)
-    if path.endswith("/") and normalized != "/":
-        normalized = normalized.rstrip("/")
-    return normalized
 
 
 def build_broker_mutation_intent(
@@ -254,8 +172,9 @@ def _normalize_intent_request(
             request.client_request_id, field="client_request_id", maximum=128
         ),
         target=_normalize_target(request.target),
-        request_payload=_canonical_json_value(
-            request.request_payload, path="request", depth=0
+        request_payload=cast(
+            CanonicalJsonValue,
+            canonical_json_value(request.request_payload, path="request", depth=0),
         ),
         submission_claim_id=optional_uuid(
             request.submission_claim_id, field="submission_claim_id"
@@ -366,7 +285,7 @@ def canonicalize_broker_mutation_evidence(payload: object) -> tuple[str, str]:
 
     if not isinstance(payload, Mapping):
         raise BrokerMutationReceiptValidationError("evidence_must_be_object")
-    normalized = _canonical_json_value(
+    normalized = canonical_json_value(
         cast(Mapping[object, object], payload),
         path="evidence",
         depth=0,
@@ -711,118 +630,6 @@ def _validate_operation_contract(
         raise BrokerMutationReceiptValidationError(
             "close_all_positions_contract_invalid"
         )
-
-
-def _canonical_json_value(
-    value: object, *, path: str, depth: int
-) -> CanonicalJsonValue:
-    if depth > MAX_CANONICAL_NESTING:
-        raise BrokerMutationReceiptValidationError(
-            f"canonical_intent_nesting_too_deep:{MAX_CANONICAL_NESTING}"
-        )
-    if value is None or isinstance(value, bool):
-        return value
-    if isinstance(value, int):
-        if value.bit_length() > MAX_CANONICAL_INTENT_BYTES * 4:
-            raise BrokerMutationReceiptValidationError(f"{path}_integer_too_large")
-        try:
-            rendered_integer = str(value)
-        except (MemoryError, ValueError) as exc:
-            raise BrokerMutationReceiptValidationError(
-                f"{path}_integer_too_large"
-            ) from exc
-        if len(rendered_integer) > MAX_CANONICAL_INTENT_BYTES:
-            raise BrokerMutationReceiptValidationError(f"{path}_integer_too_large")
-        return value
-    if isinstance(value, float):
-        raise BrokerMutationReceiptValidationError(f"{path}_float_forbidden")
-    if isinstance(value, Decimal):
-        return _canonical_decimal(value, path=path)
-    if isinstance(value, str):
-        reject_control_characters(value, field=path)
-        return unicodedata.normalize("NFC", value)
-    if isinstance(value, Mapping):
-        return _canonical_mapping(
-            cast(Mapping[object, object], value),
-            path=path,
-            depth=depth,
-        )
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return [
-            _canonical_json_value(item, path=f"{path}[{index}]", depth=depth + 1)
-            for index, item in enumerate(cast(Sequence[object], value))
-        ]
-    raise BrokerMutationReceiptValidationError(
-        f"{path}_type_unsupported:{type(value).__name__}"
-    )
-
-
-def _canonical_mapping(
-    value: Mapping[object, object],
-    *,
-    path: str,
-    depth: int,
-) -> dict[str, CanonicalJsonValue]:
-    normalized: dict[str, CanonicalJsonValue] = {}
-    for raw_key, raw_value in value.items():
-        if not isinstance(raw_key, str):
-            raise BrokerMutationReceiptValidationError(f"{path}_key_must_be_string")
-        key = required_text(raw_key, field=f"{path}_key", maximum=128)
-        if key != unicodedata.normalize("NFC", raw_key):
-            raise BrokerMutationReceiptValidationError(
-                f"{path}_key_surrounding_whitespace_forbidden"
-            )
-        _reject_secret_bearing_key(key, path=path)
-        if key in normalized:
-            raise BrokerMutationReceiptValidationError(f"{path}_key_collision:{key}")
-        normalized[key] = _canonical_json_value(
-            raw_value,
-            path=f"{path}.{key}",
-            depth=depth + 1,
-        )
-    return normalized
-
-
-def _reject_secret_bearing_key(key: str, *, path: str) -> None:
-    security_key = re.sub(
-        r"[^a-z0-9]",
-        "",
-        unicodedata.normalize("NFKC", key).casefold(),
-    )
-    if any(marker in security_key for marker in _SECRET_BEARING_KEY_MARKERS):
-        raise BrokerMutationReceiptValidationError(
-            f"{path}_secret_bearing_key_forbidden"
-        )
-
-
-def _canonical_decimal(value: Decimal, *, path: str) -> str:
-    if not value.is_finite():
-        raise BrokerMutationReceiptValidationError(f"{path}_decimal_non_finite")
-    if value.is_zero():
-        return "0"
-    sign, raw_digits, raw_exponent = value.as_tuple()
-    exponent = cast(int, raw_exponent)
-    digits = list(raw_digits)
-    while digits and digits[-1] == 0:
-        digits.pop()
-        exponent += 1
-    coefficient = "".join(str(digit) for digit in digits) or "0"
-    if exponent >= 0:
-        if len(coefficient) + exponent > MAX_CANONICAL_INTENT_BYTES:
-            raise BrokerMutationReceiptValidationError(f"{path}_decimal_too_large")
-        rendered = coefficient + ("0" * exponent)
-    else:
-        decimal_position = len(coefficient) + exponent
-        if decimal_position > 0:
-            rendered = (
-                f"{coefficient[:decimal_position]}.{coefficient[decimal_position:]}"
-            )
-        else:
-            leading_zeros = -decimal_position
-            if len(coefficient) + leading_zeros > MAX_CANONICAL_INTENT_BYTES:
-                raise BrokerMutationReceiptValidationError(f"{path}_decimal_too_large")
-            rendered = f"0.{('0' * leading_zeros)}{coefficient}"
-    return f"-{rendered}" if sign else rendered
 
 
 __all__ = [

--- a/services/torghut/app/trading/broker_mutation_receipts/validation.py
+++ b/services/torghut/app/trading/broker_mutation_receipts/validation.py
@@ -1,12 +1,17 @@
-"""Strict validation primitives for durable broker-mutation receipts."""
+"""Strict normalization and validation primitives for broker-mutation receipts."""
 
 from __future__ import annotations
 
+import ipaddress
+import posixpath
 import re
 import unicodedata
 import uuid
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import TypeVar, cast
+from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 
 RECEIPT_MIN_LEASE_SECONDS = 5
@@ -20,6 +25,19 @@ MAX_CANONICAL_EVIDENCE_BYTES = 4_096
 MAX_CANONICAL_NESTING = 32
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_SECRET_BEARING_KEY_MARKERS = (
+    "apikey",
+    "authorization",
+    "bearer",
+    "cookie",
+    "credential",
+    "password",
+    "passwd",
+    "privatekey",
+    "secret",
+    "token",
+)
 _EnumValue = TypeVar("_EnumValue", bound=str)
 
 
@@ -37,6 +55,71 @@ class BrokerMutationReceiptFenceError(BrokerMutationReceiptError):
 
 class BrokerMutationReceiptConflictError(BrokerMutationReceiptError):
     """Durable receipt truth conflicts with the requested mutation."""
+
+
+def normalize_endpoint_url(endpoint_url: str) -> str:
+    """Normalize a credential-free HTTP endpoint before fingerprinting."""
+
+    raw = required_text(endpoint_url, field="endpoint_url", maximum=2048)
+    try:
+        parsed = urlsplit(raw)
+        port = parsed.port
+    except ValueError as exc:
+        raise BrokerMutationReceiptValidationError("endpoint_url_invalid") from exc
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise BrokerMutationReceiptValidationError("endpoint_url_scheme_invalid")
+    if parsed.username is not None or parsed.password is not None:
+        raise BrokerMutationReceiptValidationError("endpoint_url_credentials_forbidden")
+    if parsed.query or parsed.fragment:
+        raise BrokerMutationReceiptValidationError(
+            "endpoint_url_query_or_fragment_forbidden"
+        )
+    hostname = parsed.hostname
+    if hostname is None:
+        raise BrokerMutationReceiptValidationError("endpoint_url_host_required")
+    normalized_host = _normalize_endpoint_host(hostname)
+    if ":" in normalized_host:
+        normalized_host = f"[{normalized_host}]"
+    default_port = 443 if scheme == "https" else 80
+    authority = (
+        normalized_host if port in {None, default_port} else f"{normalized_host}:{port}"
+    )
+    path = _normalize_endpoint_path(parsed.path)
+    normalized = urlunsplit(SplitResult(scheme, authority, path, "", ""))
+    reject_control_characters(normalized, field="endpoint_url")
+    return normalized
+
+
+def _normalize_endpoint_host(hostname: str) -> str:
+    if "%" in hostname:
+        raise BrokerMutationReceiptValidationError("endpoint_url_host_invalid")
+    try:
+        return ipaddress.ip_address(hostname).compressed.lower()
+    except ValueError:
+        pass
+    try:
+        normalized = hostname.rstrip(".").encode("idna").decode("ascii").lower()
+    except UnicodeError as exc:
+        raise BrokerMutationReceiptValidationError("endpoint_url_host_invalid") from exc
+    if (
+        not normalized
+        or len(normalized) > 253
+        or any(_DNS_LABEL.fullmatch(label) is None for label in normalized.split("."))
+    ):
+        raise BrokerMutationReceiptValidationError("endpoint_url_host_invalid")
+    return normalized
+
+
+def _normalize_endpoint_path(path: str) -> str:
+    if not path or path == "/":
+        return "/"
+    if not path.startswith("/"):
+        raise BrokerMutationReceiptValidationError("endpoint_url_path_invalid")
+    normalized = posixpath.normpath(path)
+    if path.endswith("/") and normalized != "/":
+        normalized = normalized.rstrip("/")
+    return normalized
 
 
 def required_text(value: object, *, field: str, maximum: int) -> str:
@@ -130,6 +213,118 @@ def as_utc_datetime(value: object, *, field: str) -> datetime:
     if value.tzinfo is None:
         raise BrokerMutationReceiptValidationError(f"{field}_must_be_timezone_aware")
     return value.astimezone(timezone.utc)
+
+
+def canonical_json_value(value: object, *, path: str, depth: int) -> object:
+    """Normalize a bounded JSON value while rejecting unsafe representations."""
+
+    if depth > MAX_CANONICAL_NESTING:
+        raise BrokerMutationReceiptValidationError(
+            f"canonical_intent_nesting_too_deep:{MAX_CANONICAL_NESTING}"
+        )
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value.bit_length() > MAX_CANONICAL_INTENT_BYTES * 4:
+            raise BrokerMutationReceiptValidationError(f"{path}_integer_too_large")
+        try:
+            rendered_integer = str(value)
+        except (MemoryError, ValueError) as exc:
+            raise BrokerMutationReceiptValidationError(
+                f"{path}_integer_too_large"
+            ) from exc
+        if len(rendered_integer) > MAX_CANONICAL_INTENT_BYTES:
+            raise BrokerMutationReceiptValidationError(f"{path}_integer_too_large")
+        return value
+    if isinstance(value, float):
+        raise BrokerMutationReceiptValidationError(f"{path}_float_forbidden")
+    if isinstance(value, Decimal):
+        return _canonical_decimal(value, path=path)
+    if isinstance(value, str):
+        reject_control_characters(value, field=path)
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, Mapping):
+        return _canonical_mapping(
+            cast(Mapping[object, object], value),
+            path=path,
+            depth=depth,
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [
+            canonical_json_value(item, path=f"{path}[{index}]", depth=depth + 1)
+            for index, item in enumerate(cast(Sequence[object], value))
+        ]
+    raise BrokerMutationReceiptValidationError(
+        f"{path}_type_unsupported:{type(value).__name__}"
+    )
+
+
+def _canonical_mapping(
+    value: Mapping[object, object],
+    *,
+    path: str,
+    depth: int,
+) -> dict[str, object]:
+    normalized: dict[str, object] = {}
+    for raw_key, raw_value in value.items():
+        if not isinstance(raw_key, str):
+            raise BrokerMutationReceiptValidationError(f"{path}_key_must_be_string")
+        key = required_text(raw_key, field=f"{path}_key", maximum=128)
+        if key != unicodedata.normalize("NFC", raw_key):
+            raise BrokerMutationReceiptValidationError(
+                f"{path}_key_surrounding_whitespace_forbidden"
+            )
+        _reject_secret_bearing_key(key, path=path)
+        if key in normalized:
+            raise BrokerMutationReceiptValidationError(f"{path}_key_collision:{key}")
+        normalized[key] = canonical_json_value(
+            raw_value,
+            path=f"{path}.{key}",
+            depth=depth + 1,
+        )
+    return normalized
+
+
+def _reject_secret_bearing_key(key: str, *, path: str) -> None:
+    security_key = re.sub(
+        r"[^a-z0-9]",
+        "",
+        unicodedata.normalize("NFKC", key).casefold(),
+    )
+    if any(marker in security_key for marker in _SECRET_BEARING_KEY_MARKERS):
+        raise BrokerMutationReceiptValidationError(
+            f"{path}_secret_bearing_key_forbidden"
+        )
+
+
+def _canonical_decimal(value: Decimal, *, path: str) -> str:
+    if not value.is_finite():
+        raise BrokerMutationReceiptValidationError(f"{path}_decimal_non_finite")
+    if value.is_zero():
+        return "0"
+    sign, raw_digits, raw_exponent = value.as_tuple()
+    exponent = cast(int, raw_exponent)
+    digits = list(raw_digits)
+    while digits and digits[-1] == 0:
+        digits.pop()
+        exponent += 1
+    coefficient = "".join(str(digit) for digit in digits) or "0"
+    if exponent >= 0:
+        if len(coefficient) + exponent > MAX_CANONICAL_INTENT_BYTES:
+            raise BrokerMutationReceiptValidationError(f"{path}_decimal_too_large")
+        rendered = coefficient + ("0" * exponent)
+    else:
+        decimal_position = len(coefficient) + exponent
+        if decimal_position > 0:
+            rendered = (
+                f"{coefficient[:decimal_position]}.{coefficient[decimal_position:]}"
+            )
+        else:
+            leading_zeros = -decimal_position
+            if len(coefficient) + leading_zeros > MAX_CANONICAL_INTENT_BYTES:
+                raise BrokerMutationReceiptValidationError(f"{path}_decimal_too_large")
+            rendered = f"0.{('0' * leading_zeros)}{coefficient}"
+    return f"-{rendered}" if sign else rendered
 
 
 __all__ = [

--- a/services/torghut/tests/test_broker_mutation_receipt_canonicalization.py
+++ b/services/torghut/tests/test_broker_mutation_receipt_canonicalization.py
@@ -71,6 +71,26 @@ def test_endpoint_fingerprint_normalizes_only_credential_free_origin_and_path() 
             fingerprint_broker_endpoint(invalid)
 
 
+@pytest.mark.parametrize(
+    ("variant", "canonical"),
+    [
+        (
+            "https://[2001:0db8:0000:0000:0000:0000:0000:0001]:443/v2/../v3/",
+            "https://[2001:db8::1]/v3",
+        ),
+        ("https://bücher.example./v2", "https://xn--bcher-kva.example/v2"),
+        ("http://EXAMPLE.com:80/a/./b/../c/", "http://example.com/a/c"),
+    ],
+)
+def test_endpoint_fingerprint_preserves_host_and_path_normalization(
+    variant: str,
+    canonical: str,
+) -> None:
+    assert fingerprint_broker_endpoint(variant) == fingerprint_broker_endpoint(
+        canonical
+    )
+
+
 def test_intent_is_stable_and_uses_exact_decimal_strings() -> None:
     first = _submit_intent(
         request={
@@ -256,6 +276,16 @@ def test_evidence_is_canonical_hashed_and_rejects_floats() -> None:
         canonicalize_broker_mutation_evidence({"latency_seconds": 0.5})
     with pytest.raises(BrokerMutationReceiptValidationError, match="must_be_object"):
         canonicalize_broker_mutation_evidence("unstructured")
+
+
+def test_evidence_normalization_preserves_canonical_edge_cases() -> None:
+    encoded, _ = canonicalize_broker_mutation_evidence(
+        {"values": (Decimal("-0.000"), Decimal("1E+2"), "e\u0301")}
+    )
+
+    assert json.loads(encoded) == {"values": ["0", "100", "é"]}
+    with pytest.raises(BrokerMutationReceiptValidationError, match="key_collision"):
+        canonicalize_broker_mutation_evidence({"é": 1, "e\u0301": 2})
 
 
 def test_recovery_evidence_binds_identity_and_outcome() -> None:


### PR DESCRIPTION
## Summary

- Move endpoint URL normalization and canonical JSON normalization into the shared broker-receipt validation module.
- Keep receipt intent, evidence, and endpoint fingerprints behaviorally stable while reducing the canonicalization module size.
- Add focused coverage for IPv6, IDNA, path, decimal, Unicode, and canonical-key collision edge cases.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/test_broker_mutation_receipt_canonicalization.py` (31 passed)
- `uv run --frozen ruff format --check app/trading/broker_mutation_receipts/canonicalization.py app/trading/broker_mutation_receipts/validation.py tests/test_broker_mutation_receipt_canonicalization.py`
- `uv run --frozen ruff check app/trading/broker_mutation_receipts/canonicalization.py app/trading/broker_mutation_receipts/validation.py tests/test_broker_mutation_receipt_canonicalization.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/broker_mutation_receipts/canonicalization.py app/trading/broker_mutation_receipts/validation.py tests/test_broker_mutation_receipt_canonicalization.py`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `uv run --frozen python -m compileall -q app/trading/broker_mutation_receipts/canonicalization.py app/trading/broker_mutation_receipts/validation.py tests/test_broker_mutation_receipt_canonicalization.py`
- Verified `argocd/applications/torghut/scheduler-deployment.yaml` remains at `spec.replicas: 0`.

## Screenshots (if applicable)

N/A - internal Python refactor with no UI changes.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation or release-note changes are required for this internal refactor.
