### PR TITLE
refactor(torghut): extract profitability manifest helpers

### DIFF
--- a/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
+++ b/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
@@ -678,15 +678,12 @@ def append_profitability_stage_manifest_reasons(
         ctx, manifest_payload, manifest_path, policy_payload, artifact_root
     )
 
-    if (
-        bool(
-            policy_payload.get(
-                "promotion_require_profitability_stage_replay_contract", False
-            )
+    if bool(
+        policy_payload.get(
+            "promotion_require_profitability_stage_replay_contract", False
         )
-        and stages
     ):
-        _validate_replay_contract(ctx, manifest_payload, manifest_path, stages)
+        _validate_replay_contract(ctx, manifest_payload, manifest_path, stages or {})
 
     _validate_overall_manifest(ctx, manifest_payload, manifest_path, stages)
 

--- a/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
+++ b/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
@@ -576,7 +576,6 @@ def _validate_replay_artifact_hashes(
             "profitability_stage_manifest_replay_artifact_hashes_missing",
             str(manifest_path),
         )
-        return
 
     expected_stage_artifact_hashes: dict[str, str] = {}
     for stage_name in _PROFITABILITY_STAGE_ORDER:

--- a/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
+++ b/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
@@ -455,6 +455,13 @@ def _validate_overall_manifest(
 
     _validate_overall_status(ctx, manifest_payload, manifest_path, stages)
     _validate_stage_transition(ctx, manifest_payload, stages, manifest_path)
+    if str(manifest_payload.get("overall_status", "")).strip() == "fail":
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_stage_chain_not_passed",
+            str(manifest_path),
+            failure_reasons=_list_of_strings(manifest_payload.get("failure_reasons")),
+        )
 
 
 def _validate_overall_status(
@@ -523,15 +530,6 @@ def _validate_stage_transition(
                 stage=stage_name,
             )
             break
-
-    failure_reasons = _list_of_strings(manifest_payload.get("failure_reasons"))
-    if str(manifest_payload.get("overall_status", "")).strip() == "fail":
-        _add_manifest_reason(
-            ctx,
-            "profitability_stage_manifest_stage_chain_not_passed",
-            str(manifest_path),
-            failure_reasons=failure_reasons,
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
+++ b/services/torghut/app/trading/autonomy/policy_check/profitability_manifest.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+
 from .common import (
     Any,
     NON_AUTHORITATIVE_PROVENANCE,
-    Path,
     PROFITABILITY_STAGE_ORDER as _PROFITABILITY_STAGE_ORDER,
     PROFITABILITY_STAGE_REQUIRED_CHECKS as _PROFITABILITY_STAGE_REQUIRED_CHECKS,
     contract_from_artifact_payload,
     parse_evidence_contract,
     urlparse,
+)
+from .profitability_manifest_janus import (
+    append_janus_evidence_reasons as append_janus_evidence_reasons,
 )
 from .requirements import (
     as_dict as _as_dict,
@@ -18,7 +23,6 @@ from .requirements import (
     benchmark_parity_artifact_candidates as _benchmark_parity_artifact_candidates,
     benchmark_parity_artifact_reference as _benchmark_parity_artifact_reference,
     int_or_default as _int_or_default,
-    list_count as _list_count,
     list_of_strings as _list_of_strings,
     load_json_if_exists as _load_json_if_exists,
     normalize_artifact_path as _normalize_artifact_path,
@@ -26,6 +30,620 @@ from .requirements import (
     sha256_json as _sha256_json,
     sha256_path as _sha256_path,
 )
+
+
+@dataclass
+class _ValidationContext:
+    """Mutable validation state collected during manifest inspection."""
+
+    reasons: list[str]
+    reason_details: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class _ArtifactValidationRequest:
+    artifact_payload: dict[str, Any]
+    artifact_ref: str
+    manifest_path: Path
+    stage_name: str
+    require_authority: bool
+    artifact_root: Path
+
+
+def _add_reason(
+    ctx: _ValidationContext, reason: str, detail: dict[str, object]
+) -> None:
+    ctx.reasons.append(reason)
+    ctx.reason_details.append(detail)
+
+
+def _add_manifest_reason(
+    ctx: _ValidationContext, reason: str, artifact_ref: str, **fields: object
+) -> None:
+    detail: dict[str, object] = {"reason": reason, "artifact_ref": artifact_ref}
+    detail.update(fields)
+    _add_reason(ctx, reason, detail)
+
+
+# ---------------------------------------------------------------------------
+# Top-level manifest field validators
+# ---------------------------------------------------------------------------
+
+
+def _validate_manifest_top_level(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+) -> None:
+    """Validate manifest schema version, IDs, run context, and content hash."""
+
+    schema_version = str(manifest_payload.get("schema_version", "")).strip()
+    if schema_version != "profitability-stage-manifest-v1":
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_schema_version_invalid",
+            str(manifest_path),
+            schema_version=schema_version,
+        )
+
+    candidate_id = str(manifest_payload.get("candidate_id", "")).strip()
+    if not candidate_id:
+        _add_manifest_reason(
+            ctx, "profitability_stage_manifest_candidate_id_missing", str(manifest_path)
+        )
+
+    strategy_family = str(manifest_payload.get("strategy_family", "")).strip()
+    if not strategy_family:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_strategy_family_missing",
+            str(manifest_path),
+        )
+
+    _validate_run_context(ctx, manifest_payload, manifest_path)
+    _validate_content_hash(ctx, manifest_payload, manifest_path)
+
+
+def _validate_run_context(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+) -> None:
+    run_context = _as_dict(manifest_payload.get("run_context"))
+    if not run_context:
+        _add_manifest_reason(
+            ctx, "profitability_stage_manifest_run_context_missing", str(manifest_path)
+        )
+    elif not run_context.get("run_id"):
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_run_context_incomplete",
+            str(manifest_path),
+        )
+    elif not str(run_context.get("design_doc", "")).strip():
+        _add_manifest_reason(
+            ctx, "profitability_stage_manifest_design_doc_missing", str(manifest_path)
+        )
+    else:
+        design_doc = str(run_context.get("design_doc", "")).strip()
+        if not _is_valid_design_doc_reference(design_doc):
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_design_doc_invalid",
+                str(manifest_path),
+                design_doc=design_doc,
+            )
+
+
+def _validate_content_hash(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+) -> None:
+    content_hash = str(manifest_payload.get("content_hash", "")).strip()
+    if not content_hash:
+        _add_manifest_reason(
+            ctx, "profitability_stage_manifest_content_hash_missing", str(manifest_path)
+        )
+    else:
+        content_hash_payload = dict(manifest_payload)
+        content_hash_payload.pop("content_hash", None)
+        expected_content_hash = _sha256_json(content_hash_payload)
+        if content_hash != expected_content_hash:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_content_hash_mismatch",
+                str(manifest_path),
+                content_hash=content_hash,
+                expected_content_hash=expected_content_hash,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Stages validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_stages(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+    policy_payload: dict[str, Any],
+    artifact_root: Path,
+) -> dict[str, Any] | None:
+    """Validate stages presence, order, status, checks, and artifacts. Returns stages dict."""
+    stages_raw = manifest_payload.get("stages")
+    stages = _as_dict(stages_raw)
+    if not stages:
+        _add_manifest_reason(
+            ctx, "profitability_stage_manifest_stages_missing", str(manifest_path)
+        )
+        return None
+
+    _validate_stage_names(ctx, stages, manifest_path)
+    _validate_stage_payloads(ctx, stages, manifest_path)
+    _validate_stage_checks(ctx, stages, manifest_path, policy_payload)
+    _validate_stage_artifacts(ctx, stages, manifest_path, policy_payload, artifact_root)
+    return stages
+
+
+def _validate_stage_names(
+    ctx: _ValidationContext, stages: dict[str, Any], manifest_path: Path
+) -> None:
+    stage_names = tuple(name for name in _PROFITABILITY_STAGE_ORDER if name in stages)
+    if stage_names != _PROFITABILITY_STAGE_ORDER:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_stage_missing",
+            str(manifest_path),
+            stages_present=sorted(stages.keys()),
+        )
+    if set(stages) != set(_PROFITABILITY_STAGE_ORDER):
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_stage_set_invalid",
+            str(manifest_path),
+            expected_stages=list(_PROFITABILITY_STAGE_ORDER),
+            actual_stages=sorted(stages.keys()),
+        )
+
+
+def _validate_stage_payloads(
+    ctx: _ValidationContext, stages: dict[str, Any], manifest_path: Path
+) -> None:
+    for stage_name in _PROFITABILITY_STAGE_ORDER:
+        stage_payload = _as_dict(stages.get(stage_name))
+        if not stage_payload:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_stage_missing",
+                str(manifest_path),
+                stage=stage_name,
+            )
+            continue
+
+        status = str(stage_payload.get("status", "")).strip()
+        if status not in {"pass", "fail"}:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_stage_status_invalid",
+                str(manifest_path),
+                stage=stage_name,
+                status=status,
+            )
+
+        for required_key in ("checks", "artifacts", "owner", "completed_at_utc"):
+            if required_key not in stage_payload:
+                _add_manifest_reason(
+                    ctx,
+                    "profitability_stage_manifest_stage_structure_invalid",
+                    str(manifest_path),
+                    stage=stage_name,
+                    required_key=required_key,
+                )
+
+
+def _validate_stage_checks(
+    ctx: _ValidationContext,
+    stages: dict[str, Any],
+    manifest_path: Path,
+    policy_payload: dict[str, Any],
+) -> None:
+    for stage_name in _PROFITABILITY_STAGE_ORDER:
+        stage_payload = _as_dict(stages.get(stage_name))
+        if not stage_payload:
+            continue
+
+        required_checks = list(_PROFITABILITY_STAGE_REQUIRED_CHECKS.get(stage_name, ()))
+        if stage_name == "execution" and not bool(
+            policy_payload.get("promotion_require_expert_router_registry", False)
+        ):
+            required_checks = [
+                check
+                for check in required_checks
+                if check != "expert_router_registry_present"
+            ]
+
+        checks_payload = _as_list_of_dicts(stage_payload.get("checks"))
+        stage_checks: dict[str, str] = {}
+
+        for item in checks_payload:
+            check_name = str(item.get("check", "")).strip()
+            if not check_name:
+                _add_manifest_reason(
+                    ctx,
+                    "profitability_stage_manifest_stage_check_invalid",
+                    str(manifest_path),
+                    stage=stage_name,
+                )
+                continue
+            check_status = str(item.get("status", "")).strip()
+            if check_status not in {"pass", "fail"}:
+                _add_manifest_reason(
+                    ctx,
+                    "profitability_stage_manifest_stage_check_status_invalid",
+                    str(manifest_path),
+                    stage=stage_name,
+                    check=check_name,
+                )
+                continue
+            stage_checks[check_name] = check_status
+
+        for required_check in required_checks:
+            if required_check not in stage_checks:
+                _add_manifest_reason(
+                    ctx,
+                    "profitability_stage_manifest_required_check_missing",
+                    str(manifest_path),
+                    stage=stage_name,
+                    check=required_check,
+                )
+                continue
+            if stage_checks[required_check] != "pass":
+                _add_manifest_reason(
+                    ctx,
+                    "profitability_stage_manifest_required_check_failed",
+                    str(manifest_path),
+                    stage=stage_name,
+                    check=required_check,
+                )
+
+
+def _validate_stage_artifacts(
+    ctx: _ValidationContext,
+    stages: dict[str, Any],
+    manifest_path: Path,
+    policy_payload: dict[str, Any],
+    artifact_root: Path,
+) -> None:
+    for stage_name in _PROFITABILITY_STAGE_ORDER:
+        stage_payload = _as_dict(stages.get(stage_name))
+        if not stage_payload:
+            continue
+        artifacts = _as_dict(stage_payload.get("artifacts"))
+        if not artifacts:
+            continue
+
+        for artifact_payload_raw in artifacts.values():
+            artifact_payload = _as_dict(artifact_payload_raw)
+            artifact_ref = str(artifact_payload.get("path", "")).strip()
+            if not artifact_ref:
+                continue
+            _validate_single_artifact(
+                ctx,
+                _ArtifactValidationRequest(
+                    artifact_payload=artifact_payload,
+                    artifact_ref=artifact_ref,
+                    manifest_path=manifest_path,
+                    stage_name=stage_name,
+                    require_authority=stage_name in {"validation", "execution"},
+                    artifact_root=artifact_root,
+                ),
+            )
+
+
+def _validate_single_artifact(
+    ctx: _ValidationContext,
+    request: _ArtifactValidationRequest,
+) -> None:
+    artifact_file = request.artifact_root / request.artifact_ref
+    if not artifact_file.exists():
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_artifact_missing",
+            str(artifact_file),
+            stage=request.stage_name,
+        )
+        return
+
+    authority_payload = _as_dict(request.artifact_payload.get("artifact_authority"))
+    if not authority_payload:
+        authority_payload = contract_from_artifact_payload(
+            _load_json_if_exists(artifact_file)
+        )
+
+    if request.require_authority:
+        if not authority_payload:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_artifact_authority_missing",
+                str(artifact_file),
+                stage=request.stage_name,
+            )
+        else:
+            _validate_artifact_authority(
+                ctx,
+                authority_payload,
+                artifact_file,
+                request.stage_name,
+                request.manifest_path,
+            )
+
+    if (
+        artifact_file.suffix.lower() == ".json"
+        and _load_json_if_exists(artifact_file) is None
+    ):
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_artifact_invalid_json",
+            str(artifact_file),
+            stage=request.stage_name,
+        )
+
+    expected_sha = str(request.artifact_payload.get("sha256", "")).strip()
+    if expected_sha:
+        actual_sha = _sha256_path(artifact_file)
+        if expected_sha != actual_sha:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_artifact_hash_mismatch",
+                str(artifact_file),
+                stage=request.stage_name,
+                expected_sha256=expected_sha,
+                actual_sha256=actual_sha,
+            )
+
+
+def _validate_artifact_authority(
+    ctx: _ValidationContext,
+    authority_payload: dict[str, Any],
+    artifact_file: Path,
+    stage_name: str,
+    manifest_path: Path,
+) -> None:
+    normalized_contract = parse_evidence_contract(authority_payload)
+    provenance = str(normalized_contract.get("provenance", "")).strip()
+    if provenance in {item.value for item in NON_AUTHORITATIVE_PROVENANCE}:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_artifact_non_authoritative",
+            str(artifact_file),
+            stage=stage_name,
+            provenance=provenance,
+            maturity=normalized_contract.get("maturity"),
+        )
+    if not bool(normalized_contract.get("authoritative", False)):
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_artifact_authoritative_flag_false",
+            str(artifact_file),
+            stage=stage_name,
+            provenance=provenance,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Overall manifest validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_overall_manifest(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+    stages: dict[str, Any] | None,
+) -> None:
+    """Validate rollback_contract_ref, overall_status, failure_reasons, stage transitions."""
+
+    rollback_contract = manifest_payload.get("rollback_contract_ref")
+    if not rollback_contract:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_rollback_contract_ref_missing",
+            str(manifest_path),
+        )
+
+    _validate_overall_status(ctx, manifest_payload, manifest_path, stages)
+    _validate_stage_transition(ctx, manifest_payload, stages, manifest_path)
+
+
+def _validate_overall_status(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+    stages: dict[str, Any] | None,
+) -> None:
+    overall_status = str(manifest_payload.get("overall_status", "")).strip()
+    if overall_status not in {"pass", "fail"}:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_overall_status_invalid",
+            str(manifest_path),
+            overall_status=overall_status,
+        )
+
+    failure_reasons = _list_of_strings(manifest_payload.get("failure_reasons"))
+    if overall_status == "fail" and not failure_reasons:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_failure_reasons_missing",
+            str(manifest_path),
+        )
+
+    if overall_status in {"pass", "fail"} and stages:
+        stage_statuses: list[bool] = []
+        for stage_name in _PROFITABILITY_STAGE_ORDER:
+            stage_payload = _as_dict(stages.get(stage_name))
+            stage_statuses.append(
+                str(stage_payload.get("status", "")).strip() == "pass"
+            )
+        expected_overall_status = "pass" if all(stage_statuses) else "fail"
+        if overall_status != expected_overall_status:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_overall_status_mismatch",
+                str(manifest_path),
+                overall_status=overall_status,
+                calculated_overall_status=expected_overall_status,
+            )
+
+
+def _validate_stage_transition(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    stages: dict[str, Any] | None,
+    manifest_path: Path,
+) -> None:
+    if not stages:
+        return
+
+    ordered_stages = _PROFITABILITY_STAGE_ORDER
+    failure_encountered = False
+    for stage_name in ordered_stages:
+        stage_payload = _as_dict(stages.get(stage_name))
+        stage_status = str(stage_payload.get("status", "")).strip()
+        if stage_status != "pass":
+            failure_encountered = True
+            continue
+        if failure_encountered:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_stage_transition_violation",
+                str(manifest_path),
+                stage=stage_name,
+            )
+            break
+
+    failure_reasons = _list_of_strings(manifest_payload.get("failure_reasons"))
+    if str(manifest_payload.get("overall_status", "")).strip() == "fail":
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_stage_chain_not_passed",
+            str(manifest_path),
+            failure_reasons=failure_reasons,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Replay contract validation (conditional)
+# ---------------------------------------------------------------------------
+
+
+def _validate_replay_contract(
+    ctx: _ValidationContext,
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+    stages: dict[str, Any],
+) -> None:
+    replay_contract = _as_dict(manifest_payload.get("replay_contract"))
+    if not replay_contract:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_replay_contract_missing",
+            str(manifest_path),
+        )
+        return
+
+    _validate_replay_artifact_hashes(ctx, replay_contract, manifest_path, stages)
+    _validate_replay_contract_hash(ctx, replay_contract, manifest_path, stages)
+
+
+def _validate_replay_artifact_hashes(
+    ctx: _ValidationContext,
+    replay_contract: dict[str, Any],
+    manifest_path: Path,
+    stages: dict[str, Any],
+) -> None:
+    artifact_hashes_raw = _as_dict(replay_contract.get("artifact_hashes"))
+    artifact_hashes = {
+        str(key).strip(): str(value).strip()
+        for key, value in artifact_hashes_raw.items()
+        if str(key).strip() and str(value).strip()
+    }
+    if not artifact_hashes:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_replay_artifact_hashes_missing",
+            str(manifest_path),
+        )
+        return
+
+    expected_stage_artifact_hashes: dict[str, str] = {}
+    for stage_name in _PROFITABILITY_STAGE_ORDER:
+        stage_payload = _as_dict(stages.get(stage_name))
+        stage_artifacts = _as_dict(stage_payload.get("artifacts"))
+        for artifact_payload_raw in stage_artifacts.values():
+            artifact_payload = _as_dict(artifact_payload_raw)
+            artifact_ref = str(artifact_payload.get("path", "")).strip()
+            expected_sha = str(artifact_payload.get("sha256", "")).strip()
+            if not artifact_ref or not expected_sha:
+                continue
+            expected_stage_artifact_hashes[artifact_ref] = expected_sha
+
+    for artifact_ref, expected_sha in sorted(expected_stage_artifact_hashes.items()):
+        replay_sha = artifact_hashes.get(artifact_ref, "")
+        if not replay_sha:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_replay_artifact_hash_missing",
+                str(manifest_path),
+                stage_artifact_ref=artifact_ref,
+            )
+        elif replay_sha != expected_sha:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_replay_artifact_hash_mismatch",
+                str(manifest_path),
+                stage_artifact_ref=artifact_ref,
+                replay_sha256=replay_sha,
+                expected_sha256=expected_sha,
+            )
+
+
+def _validate_replay_contract_hash(
+    ctx: _ValidationContext,
+    replay_contract: dict[str, Any],
+    manifest_path: Path,
+    stages: dict[str, Any],
+) -> None:
+    contract_hash = str(replay_contract.get("contract_hash", "")).strip()
+    if not contract_hash:
+        _add_manifest_reason(
+            ctx,
+            "profitability_stage_manifest_replay_contract_hash_missing",
+            str(manifest_path),
+        )
+    else:
+        artifact_hashes_raw = _as_dict(replay_contract.get("artifact_hashes"))
+        artifact_hashes = {
+            str(key).strip(): str(value).strip()
+            for key, value in artifact_hashes_raw.items()
+            if str(key).strip() and str(value).strip()
+        }
+        expected_contract_hash = _sha256_json({"artifact_hashes": artifact_hashes})
+        if contract_hash != expected_contract_hash:
+            _add_manifest_reason(
+                ctx,
+                "profitability_stage_manifest_replay_contract_hash_mismatch",
+                str(manifest_path),
+                contract_hash=contract_hash,
+                expected_contract_hash=expected_contract_hash,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def append_profitability_stage_manifest_reasons(
@@ -43,439 +661,34 @@ def append_profitability_stage_manifest_reasons(
     )
     manifest_path = artifact_root / manifest_relpath
     manifest_payload = _load_json_if_exists(manifest_path)
+
     if manifest_payload is None:
-        if manifest_path.exists():
-            reasons.append("profitability_stage_manifest_invalid_json")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_invalid_json",
-                    "artifact_ref": str(manifest_path),
-                }
-            )
-        else:
-            reasons.append("profitability_stage_manifest_missing")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_missing",
-                    "artifact_ref": str(manifest_path),
-                }
-            )
+        reason = (
+            "profitability_stage_manifest_invalid_json"
+            if manifest_path.exists()
+            else "profitability_stage_manifest_missing"
+        )
+        reasons.append(reason)
+        reason_details.append({"reason": reason, "artifact_ref": str(manifest_path)})
         return
 
-    schema_version = str(manifest_payload.get("schema_version", "")).strip()
-    if schema_version != "profitability-stage-manifest-v1":
-        reasons.append("profitability_stage_manifest_schema_version_invalid")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_schema_version_invalid",
-                "artifact_ref": str(manifest_path),
-                "schema_version": schema_version,
-            }
-        )
+    ctx = _ValidationContext(reasons=reasons, reason_details=reason_details)
+    _validate_manifest_top_level(ctx, manifest_payload, manifest_path)
+    stages = _validate_stages(
+        ctx, manifest_payload, manifest_path, policy_payload, artifact_root
+    )
 
-    candidate_id = str(manifest_payload.get("candidate_id", "")).strip()
-    if not candidate_id:
-        reasons.append("profitability_stage_manifest_candidate_id_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_candidate_id_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-
-    strategy_family = str(manifest_payload.get("strategy_family", "")).strip()
-    if not strategy_family:
-        reasons.append("profitability_stage_manifest_strategy_family_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_strategy_family_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-
-    run_context = _as_dict(manifest_payload.get("run_context"))
-    if not run_context:
-        reasons.append("profitability_stage_manifest_run_context_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_run_context_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-    elif not run_context.get("run_id"):
-        reasons.append("profitability_stage_manifest_run_context_incomplete")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_run_context_incomplete",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-    elif not str(run_context.get("design_doc", "")).strip():
-        reasons.append("profitability_stage_manifest_design_doc_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_design_doc_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-    else:
-        design_doc = str(run_context.get("design_doc", "")).strip()
-        if not _is_valid_design_doc_reference(design_doc):
-            reasons.append("profitability_stage_manifest_design_doc_invalid")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_design_doc_invalid",
-                    "artifact_ref": str(manifest_path),
-                    "design_doc": design_doc,
-                }
+    if (
+        bool(
+            policy_payload.get(
+                "promotion_require_profitability_stage_replay_contract", False
             )
-
-    stages_raw = manifest_payload.get("stages")
-    stages = _as_dict(stages_raw)
-    if not stages:
-        reasons.append("profitability_stage_manifest_stages_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_stages_missing",
-                "artifact_ref": str(manifest_path),
-            }
         )
-    else:
-        stage_names = tuple(
-            name for name in _PROFITABILITY_STAGE_ORDER if name in stages
-        )
-        required_stage_names = _PROFITABILITY_STAGE_ORDER
-        if stage_names != required_stage_names:
-            reasons.append("profitability_stage_manifest_stage_missing")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_stage_missing",
-                    "artifact_ref": str(manifest_path),
-                    "stages_present": sorted(stages.keys()),
-                }
-            )
-        if set(stages) != set(required_stage_names):
-            reasons.append("profitability_stage_manifest_stage_set_invalid")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_stage_set_invalid",
-                    "artifact_ref": str(manifest_path),
-                    "expected_stages": list(required_stage_names),
-                    "actual_stages": sorted(stages.keys()),
-                }
-            )
-        for stage_name in required_stage_names:
-            stage_payload = _as_dict(stages.get(stage_name))
-            if not stage_payload:
-                reasons.append("profitability_stage_manifest_stage_missing")
-                reason_details.append(
-                    {
-                        "reason": "profitability_stage_manifest_stage_missing",
-                        "artifact_ref": str(manifest_path),
-                        "stage": stage_name,
-                    }
-                )
-                continue
-
-            status = str(stage_payload.get("status", "")).strip()
-            if status not in {"pass", "fail"}:
-                reasons.append("profitability_stage_manifest_stage_status_invalid")
-                reason_details.append(
-                    {
-                        "reason": "profitability_stage_manifest_stage_status_invalid",
-                        "artifact_ref": str(manifest_path),
-                        "stage": stage_name,
-                        "status": status,
-                    }
-                )
-            for required_key in ("checks", "artifacts", "owner", "completed_at_utc"):
-                if required_key not in stage_payload:
-                    reasons.append(
-                        "profitability_stage_manifest_stage_structure_invalid"
-                    )
-                    reason_details.append(
-                        {
-                            "reason": "profitability_stage_manifest_stage_structure_invalid",
-                            "artifact_ref": str(manifest_path),
-                            "stage": stage_name,
-                            "required_key": required_key,
-                        }
-                    )
-            checks_payload = _as_list_of_dicts(stage_payload.get("checks"))
-            stage_checks: dict[str, str] = {}
-            for item in checks_payload:
-                check_name = str(item.get("check", "")).strip()
-                if not check_name:
-                    reasons.append("profitability_stage_manifest_stage_check_invalid")
-                    reason_details.append(
-                        {
-                            "reason": "profitability_stage_manifest_stage_check_invalid",
-                            "artifact_ref": str(manifest_path),
-                            "stage": stage_name,
-                        }
-                    )
-                    continue
-                check_status = str(item.get("status", "")).strip()
-                if check_status not in {"pass", "fail"}:
-                    reasons.append(
-                        "profitability_stage_manifest_stage_check_status_invalid"
-                    )
-                    reason_details.append(
-                        {
-                            "reason": "profitability_stage_manifest_stage_check_status_invalid",
-                            "artifact_ref": str(manifest_path),
-                            "stage": stage_name,
-                            "check": check_name,
-                        }
-                    )
-                    continue
-                stage_checks[check_name] = check_status
-            required_checks = list(
-                _PROFITABILITY_STAGE_REQUIRED_CHECKS.get(stage_name, ())
-            )
-            if stage_name == "execution" and not bool(
-                policy_payload.get("promotion_require_expert_router_registry", False)
-            ):
-                required_checks = [
-                    check
-                    for check in required_checks
-                    if check != "expert_router_registry_present"
-                ]
-            for required_check in required_checks:
-                if required_check not in stage_checks:
-                    reasons.append(
-                        "profitability_stage_manifest_required_check_missing"
-                    )
-                    reason_details.append(
-                        {
-                            "reason": "profitability_stage_manifest_required_check_missing",
-                            "artifact_ref": str(manifest_path),
-                            "stage": stage_name,
-                            "check": required_check,
-                        }
-                    )
-                    continue
-                if stage_checks[required_check] != "pass":
-                    reasons.append("profitability_stage_manifest_required_check_failed")
-                    reason_details.append(
-                        {
-                            "reason": "profitability_stage_manifest_required_check_failed",
-                            "artifact_ref": str(manifest_path),
-                            "stage": stage_name,
-                            "check": required_check,
-                        }
-                    )
-            artifacts = _as_dict(stage_payload.get("artifacts"))
-            if not artifacts:
-                continue
-            for artifact_payload_raw in artifacts.values():
-                artifact_payload = _as_dict(artifact_payload_raw)
-                artifact_ref = str(artifact_payload.get("path", "")).strip()
-                if not artifact_ref:
-                    continue
-                expected_sha = str(artifact_payload.get("sha256", "")).strip()
-                artifact_file = artifact_root / artifact_ref
-                if not artifact_file.exists():
-                    reasons.append("profitability_stage_manifest_artifact_missing")
-                    reason_details.append(
-                        {
-                            "reason": "profitability_stage_manifest_artifact_missing",
-                            "artifact_ref": str(artifact_file),
-                            "stage": stage_name,
-                        }
-                    )
-                    continue
-                authority_payload = _as_dict(artifact_payload.get("artifact_authority"))
-                if not authority_payload:
-                    authority_payload = contract_from_artifact_payload(
-                        _load_json_if_exists(artifact_file)
-                    )
-                if stage_name in {"validation", "execution"}:
-                    if not authority_payload:
-                        reasons.append(
-                            "profitability_stage_manifest_artifact_authority_missing"
-                        )
-                        reason_details.append(
-                            {
-                                "reason": "profitability_stage_manifest_artifact_authority_missing",
-                                "artifact_ref": str(artifact_file),
-                                "stage": stage_name,
-                            }
-                        )
-                    else:
-                        normalized_contract = parse_evidence_contract(authority_payload)
-                        provenance = str(
-                            normalized_contract.get("provenance", "")
-                        ).strip()
-                        if provenance in {
-                            item.value for item in NON_AUTHORITATIVE_PROVENANCE
-                        }:
-                            reasons.append(
-                                "profitability_stage_manifest_artifact_non_authoritative"
-                            )
-                            reason_details.append(
-                                {
-                                    "reason": "profitability_stage_manifest_artifact_non_authoritative",
-                                    "artifact_ref": str(artifact_file),
-                                    "stage": stage_name,
-                                    "provenance": provenance,
-                                    "maturity": normalized_contract.get("maturity"),
-                                }
-                            )
-                        if not bool(normalized_contract.get("authoritative", False)):
-                            reasons.append(
-                                "profitability_stage_manifest_artifact_authoritative_flag_false"
-                            )
-                            reason_details.append(
-                                {
-                                    "reason": "profitability_stage_manifest_artifact_authoritative_flag_false",
-                                    "artifact_ref": str(artifact_file),
-                                    "stage": stage_name,
-                                    "provenance": provenance,
-                                }
-                            )
-                if (
-                    artifact_file.suffix.lower() == ".json"
-                    and _load_json_if_exists(artifact_file) is None
-                ):
-                    reasons.append("profitability_stage_manifest_artifact_invalid_json")
-                    reason_details.append(
-                        {
-                            "reason": "profitability_stage_manifest_artifact_invalid_json",
-                            "artifact_ref": str(artifact_file),
-                            "stage": stage_name,
-                        }
-                    )
-                if expected_sha:
-                    actual_sha = _sha256_path(artifact_file)
-                    if expected_sha != actual_sha:
-                        reasons.append(
-                            "profitability_stage_manifest_artifact_hash_mismatch"
-                        )
-                        reason_details.append(
-                            {
-                                "reason": "profitability_stage_manifest_artifact_hash_mismatch",
-                                "artifact_ref": str(artifact_file),
-                                "stage": stage_name,
-                                "expected_sha256": expected_sha,
-                                "actual_sha256": actual_sha,
-                            }
-                        )
-
-    if bool(
-        policy_payload.get(
-            "promotion_require_profitability_stage_replay_contract", False
-        )
+        and stages
     ):
-        _append_profitability_stage_manifest_replay_contract_reasons(
-            reasons=reasons,
-            reason_details=reason_details,
-            manifest_payload=manifest_payload,
-            manifest_path=manifest_path,
-            stages=stages,
-        )
+        _validate_replay_contract(ctx, manifest_payload, manifest_path, stages)
 
-    rollback_contract = manifest_payload.get("rollback_contract_ref")
-    if not rollback_contract:
-        reasons.append("profitability_stage_manifest_rollback_contract_ref_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_rollback_contract_ref_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-
-    content_hash = str(manifest_payload.get("content_hash", "")).strip()
-    if not content_hash:
-        reasons.append("profitability_stage_manifest_content_hash_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_content_hash_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-    else:
-        content_hash_payload = dict(manifest_payload)
-        content_hash_payload.pop("content_hash", None)
-        expected_content_hash = _sha256_json(content_hash_payload)
-        if content_hash != expected_content_hash:
-            reasons.append("profitability_stage_manifest_content_hash_mismatch")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_content_hash_mismatch",
-                    "artifact_ref": str(manifest_path),
-                    "content_hash": content_hash,
-                    "expected_content_hash": expected_content_hash,
-                }
-            )
-
-    overall_status = str(manifest_payload.get("overall_status", "")).strip()
-    if overall_status not in {"pass", "fail"}:
-        reasons.append("profitability_stage_manifest_overall_status_invalid")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_overall_status_invalid",
-                "artifact_ref": str(manifest_path),
-                "overall_status": overall_status,
-            }
-        )
-
-    failure_reasons = _list_of_strings(manifest_payload.get("failure_reasons"))
-    if overall_status == "fail":
-        if not failure_reasons:
-            reasons.append("profitability_stage_manifest_failure_reasons_missing")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_failure_reasons_missing",
-                    "artifact_ref": str(manifest_path),
-                }
-            )
-
-    if overall_status in {"pass", "fail"} and stages:
-        stage_statuses: list[bool] = []
-        for stage_name in _PROFITABILITY_STAGE_ORDER:
-            stage_payload = _as_dict(stages.get(stage_name))
-            stage_statuses.append(
-                str(stage_payload.get("status", "")).strip() == "pass"
-            )
-        expected_overall_status = "pass" if all(stage_statuses) else "fail"
-        if overall_status != expected_overall_status:
-            reasons.append("profitability_stage_manifest_overall_status_mismatch")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_overall_status_mismatch",
-                    "artifact_ref": str(manifest_path),
-                    "overall_status": overall_status,
-                    "calculated_overall_status": expected_overall_status,
-                }
-            )
-    ordered_stages = _PROFITABILITY_STAGE_ORDER
-    failure_encountered = False
-    for stage_name in ordered_stages:
-        stage_payload = _as_dict(stages.get(stage_name))
-        stage_status = str(stage_payload.get("status", "")).strip()
-        if stage_status != "pass":
-            failure_encountered = True
-            continue
-        if failure_encountered:
-            reasons.append("profitability_stage_manifest_stage_transition_violation")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_stage_transition_violation",
-                    "artifact_ref": str(manifest_path),
-                    "stage": stage_name,
-                }
-            )
-            break
-    if overall_status == "fail":
-        reasons.append("profitability_stage_manifest_stage_chain_not_passed")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_stage_chain_not_passed",
-                "artifact_ref": str(manifest_path),
-                "failure_reasons": failure_reasons,
-            }
-        )
+    _validate_overall_manifest(ctx, manifest_payload, manifest_path, stages)
 
 
 def append_portfolio_optimizer_evidence_reasons(
@@ -493,6 +706,7 @@ def append_portfolio_optimizer_evidence_reasons(
     )
     evidence_path = artifact_root / evidence_relpath
     evidence_payload = _load_json_if_exists(evidence_path)
+
     if evidence_payload is None:
         reason = (
             "portfolio_optimizer_evidence_invalid_json"
@@ -503,65 +717,82 @@ def append_portfolio_optimizer_evidence_reasons(
         reason_details.append({"reason": reason, "artifact_ref": str(evidence_path)})
         return
 
+    _validate_portfolio_optimizer_evidence(
+        reasons, reason_details, evidence_payload, str(evidence_path)
+    )
+
+
+def _validate_portfolio_optimizer_evidence(
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    evidence_payload: dict[str, Any],
+    artifact_ref: str,
+) -> None:
     schema_version = str(evidence_payload.get("schema_version", "")).strip()
     if schema_version != "torghut.portfolio-optimizer-evidence.v1":
         reasons.append("portfolio_optimizer_evidence_schema_invalid")
         reason_details.append(
             {
                 "reason": "portfolio_optimizer_evidence_schema_invalid",
-                "artifact_ref": str(evidence_path),
+                "artifact_ref": artifact_ref,
                 "schema_version": schema_version,
             }
         )
+
     if not str(evidence_payload.get("portfolio_candidate_id", "")).strip():
         reasons.append("portfolio_optimizer_evidence_candidate_id_missing")
         reason_details.append(
             {
                 "reason": "portfolio_optimizer_evidence_candidate_id_missing",
-                "artifact_ref": str(evidence_path),
+                "artifact_ref": artifact_ref,
             }
         )
+
     if _int_or_default(evidence_payload.get("sleeve_count"), 0) < 2:
         reasons.append("portfolio_optimizer_evidence_sleeve_count_insufficient")
         reason_details.append(
             {
                 "reason": "portfolio_optimizer_evidence_sleeve_count_insufficient",
-                "artifact_ref": str(evidence_path),
+                "artifact_ref": artifact_ref,
                 "sleeve_count": _int_or_default(
                     evidence_payload.get("sleeve_count"), 0
                 ),
             }
         )
+
     if not _as_dict(evidence_payload.get("optimizer_report")):
         reasons.append("portfolio_optimizer_report_missing")
         reason_details.append(
             {
                 "reason": "portfolio_optimizer_report_missing",
-                "artifact_ref": str(evidence_path),
+                "artifact_ref": artifact_ref,
             }
         )
+
     if not _as_dict(evidence_payload.get("objective_scorecard")):
         reasons.append("portfolio_optimizer_scorecard_missing")
         reason_details.append(
             {
                 "reason": "portfolio_optimizer_scorecard_missing",
-                "artifact_ref": str(evidence_path),
+                "artifact_ref": artifact_ref,
             }
         )
+
     if not bool(evidence_payload.get("target_met", False)):
         reasons.append("portfolio_optimizer_target_not_met")
         reason_details.append(
             {
                 "reason": "portfolio_optimizer_target_not_met",
-                "artifact_ref": str(evidence_path),
+                "artifact_ref": artifact_ref,
             }
         )
+
     if not bool(evidence_payload.get("oracle_passed", False)):
         reasons.append("portfolio_optimizer_oracle_not_passed")
         reason_details.append(
             {
                 "reason": "portfolio_optimizer_oracle_not_passed",
-                "artifact_ref": str(evidence_path),
+                "artifact_ref": artifact_ref,
             }
         )
 
@@ -585,101 +816,22 @@ def _is_valid_design_doc_reference(value: str) -> bool:
     return False
 
 
-def _append_profitability_stage_manifest_replay_contract_reasons(
+def append_profitability_evidence_reasons(
     *,
     reasons: list[str],
     reason_details: list[dict[str, object]],
-    manifest_payload: dict[str, Any],
-    manifest_path: Path,
-    stages: dict[str, Any],
+    policy_payload: dict[str, Any],
+    artifact_root: Path,
 ) -> None:
-    replay_contract = _as_dict(manifest_payload.get("replay_contract"))
-    if not replay_contract:
-        reasons.append("profitability_stage_manifest_replay_contract_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_replay_contract_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-        return
-
-    artifact_hashes_raw = _as_dict(replay_contract.get("artifact_hashes"))
-    artifact_hashes = {
-        str(key).strip(): str(value).strip()
-        for key, value in artifact_hashes_raw.items()
-        if str(key).strip() and str(value).strip()
-    }
-    if not artifact_hashes:
-        reasons.append("profitability_stage_manifest_replay_artifact_hashes_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_replay_artifact_hashes_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-
-    contract_hash = str(replay_contract.get("contract_hash", "")).strip()
-    if not contract_hash:
-        reasons.append("profitability_stage_manifest_replay_contract_hash_missing")
-        reason_details.append(
-            {
-                "reason": "profitability_stage_manifest_replay_contract_hash_missing",
-                "artifact_ref": str(manifest_path),
-            }
-        )
-    else:
-        expected_contract_hash = _sha256_json({"artifact_hashes": artifact_hashes})
-        if contract_hash != expected_contract_hash:
-            reasons.append("profitability_stage_manifest_replay_contract_hash_mismatch")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_replay_contract_hash_mismatch",
-                    "artifact_ref": str(manifest_path),
-                    "contract_hash": contract_hash,
-                    "expected_contract_hash": expected_contract_hash,
-                }
-            )
-
-    expected_stage_artifact_hashes: dict[str, str] = {}
-    for stage_name in _PROFITABILITY_STAGE_ORDER:
-        stage_payload = _as_dict(stages.get(stage_name))
-        stage_artifacts = _as_dict(stage_payload.get("artifacts"))
-        for artifact_payload_raw in stage_artifacts.values():
-            artifact_payload = _as_dict(artifact_payload_raw)
-            artifact_ref = str(artifact_payload.get("path", "")).strip()
-            expected_sha = str(artifact_payload.get("sha256", "")).strip()
-            if not artifact_ref or not expected_sha:
-                continue
-            expected_stage_artifact_hashes[artifact_ref] = expected_sha
-
-    for artifact_ref, expected_sha in sorted(expected_stage_artifact_hashes.items()):
-        replay_sha = artifact_hashes.get(artifact_ref, "")
-        if not replay_sha:
-            reasons.append("profitability_stage_manifest_replay_artifact_hash_missing")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_replay_artifact_hash_missing",
-                    "artifact_ref": str(manifest_path),
-                    "stage_artifact_ref": artifact_ref,
-                }
-            )
-            continue
-        if replay_sha != expected_sha:
-            reasons.append("profitability_stage_manifest_replay_artifact_hash_mismatch")
-            reason_details.append(
-                {
-                    "reason": "profitability_stage_manifest_replay_artifact_hash_mismatch",
-                    "artifact_ref": str(manifest_path),
-                    "stage_artifact_ref": artifact_ref,
-                    "replay_sha256": replay_sha,
-                    "expected_sha256": expected_sha,
-                }
-            )
+    _validate_profitability_validation_evidence(
+        reasons, reason_details, policy_payload, artifact_root
+    )
+    _validate_profitability_benchmark_evidence(
+        reasons, reason_details, policy_payload, artifact_root
+    )
 
 
-def append_profitability_evidence_reasons(
-    *,
+def _validate_profitability_validation_evidence(
     reasons: list[str],
     reason_details: list[dict[str, object]],
     policy_payload: dict[str, Any],
@@ -693,6 +845,7 @@ def append_profitability_evidence_reasons(
     )
     evidence_validation_path = artifact_root / evidence_validation_relpath
     evidence_validation_payload = _load_json_if_exists(evidence_validation_path)
+
     if evidence_validation_payload is None:
         reasons.append("profitability_evidence_validation_missing")
         reason_details.append(
@@ -713,6 +866,13 @@ def append_profitability_evidence_reasons(
             }
         )
 
+
+def _validate_profitability_benchmark_evidence(
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    policy_payload: dict[str, Any],
+    artifact_root: Path,
+) -> None:
     benchmark_relpath = str(
         policy_payload.get(
             "promotion_profitability_benchmark_artifact",
@@ -724,6 +884,7 @@ def append_profitability_evidence_reasons(
     minimum_regime_slices = int(
         policy_payload.get("promotion_profitability_min_regime_slices", 1)
     )
+
     if benchmark_payload is None:
         reasons.append("profitability_benchmark_missing")
         reason_details.append(
@@ -747,99 +908,6 @@ def append_profitability_evidence_reasons(
         )
 
 
-def append_janus_evidence_reasons(
-    *,
-    reasons: list[str],
-    reason_details: list[dict[str, object]],
-    policy_payload: dict[str, Any],
-    artifact_root: Path,
-) -> None:
-    event_path = artifact_root / str(
-        policy_payload.get(
-            "promotion_janus_event_car_artifact", "gates/janus-event-car-v1.json"
-        )
-    )
-    event_payload = _load_json_if_exists(event_path)
-    if event_payload is None:
-        reasons.append("janus_event_car_artifact_missing")
-        reason_details.append(
-            {
-                "reason": "janus_event_car_artifact_missing",
-                "artifact_ref": str(event_path),
-            }
-        )
-    else:
-        if str(event_payload.get("schema_version", "")).strip() != "janus-event-car-v1":
-            reasons.append("janus_event_car_schema_invalid")
-            reason_details.append(
-                {
-                    "reason": "janus_event_car_schema_invalid",
-                    "artifact_ref": str(event_path),
-                    "expected": "janus-event-car-v1",
-                }
-            )
-        event_count = _int_or_default(
-            _as_dict(event_payload.get("summary")).get("event_count"),
-            _list_count(event_payload.get("records")),
-        )
-        min_event_count = max(
-            1, _int_or_default(policy_payload.get("promotion_min_janus_event_count"), 1)
-        )
-        if event_count < min_event_count:
-            reasons.append("janus_event_car_count_below_minimum")
-            reason_details.append(
-                {
-                    "reason": "janus_event_car_count_below_minimum",
-                    "artifact_ref": str(event_path),
-                    "actual_event_count": event_count,
-                    "minimum_event_count": min_event_count,
-                }
-            )
-
-    reward_path = artifact_root / str(
-        policy_payload.get(
-            "promotion_janus_hgrm_reward_artifact", "gates/janus-hgrm-reward-v1.json"
-        )
-    )
-    reward_payload = _load_json_if_exists(reward_path)
-    if reward_payload is None:
-        reasons.append("janus_hgrm_reward_artifact_missing")
-        reason_details.append(
-            {
-                "reason": "janus_hgrm_reward_artifact_missing",
-                "artifact_ref": str(reward_path),
-            }
-        )
-        return
-
-    if str(reward_payload.get("schema_version", "")).strip() != "janus-hgrm-reward-v1":
-        reasons.append("janus_hgrm_reward_schema_invalid")
-        reason_details.append(
-            {
-                "reason": "janus_hgrm_reward_schema_invalid",
-                "artifact_ref": str(reward_path),
-                "expected": "janus-hgrm-reward-v1",
-            }
-        )
-    reward_count = _int_or_default(
-        _as_dict(reward_payload.get("summary")).get("reward_count"),
-        _list_count(reward_payload.get("rewards")),
-    )
-    min_reward_count = max(
-        1, _int_or_default(policy_payload.get("promotion_min_janus_reward_count"), 1)
-    )
-    if reward_count < min_reward_count:
-        reasons.append("janus_hgrm_reward_count_below_minimum")
-        reason_details.append(
-            {
-                "reason": "janus_hgrm_reward_count_below_minimum",
-                "artifact_ref": str(reward_path),
-                "actual_reward_count": reward_count,
-                "minimum_reward_count": min_reward_count,
-            }
-        )
-
-
 def append_benchmark_parity_evidence_reasons(
     *,
     reasons: list[str],
@@ -852,14 +920,12 @@ def append_benchmark_parity_evidence_reasons(
     benchmark_payload = _as_dict(evidence.get("benchmark_parity"))
     evidence_ref = str(benchmark_payload.get("artifact_ref") or "").strip()
     artifact_ref = _benchmark_parity_artifact_reference(
-        policy_payload=policy_payload,
-        gate_report_payload=gate_report_payload,
+        policy_payload=policy_payload, gate_report_payload=gate_report_payload
     )
     candidate_paths = [
         _normalize_artifact_path(candidate_ref, artifact_root=artifact_root)
         for candidate_ref in _benchmark_parity_artifact_candidates(
-            policy_payload=policy_payload,
-            gate_report_payload=gate_report_payload,
+            policy_payload=policy_payload, gate_report_payload=gate_report_payload
         )
     ]
     artifact_path = next(
@@ -869,39 +935,42 @@ def append_benchmark_parity_evidence_reasons(
         artifact_path = _normalize_artifact_path(
             evidence_ref, artifact_root=artifact_root
         )
+
     if artifact_path is None:
-        if evidence_ref:
-            reasons.append("benchmark_parity_artifact_ref_invalid")
-            reason_details.append(
-                {
-                    "reason": "benchmark_parity_artifact_ref_invalid",
-                    "artifact_ref": evidence_ref,
-                }
-            )
-        else:
-            reasons.append("benchmark_parity_artifact_ref_invalid")
-            reason_details.append(
-                {
-                    "reason": "benchmark_parity_artifact_ref_invalid",
-                    "artifact_ref": artifact_ref,
-                }
-            )
+        _add_manifest_reason(
+            _ValidationContext(reasons, reason_details),
+            "benchmark_parity_artifact_ref_invalid",
+            str(evidence_ref if evidence_ref else artifact_ref),
+        )
         return
-    parity_path = artifact_path
-    if not parity_path.exists():
+
+    _validate_benchmark_artifact_path(
+        reasons, reason_details, artifact_path, evidence_ref, artifact_ref
+    )
+
+
+def _validate_benchmark_artifact_path(
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    artifact_path: Path,
+    evidence_ref: str,
+    artifact_ref: str,
+) -> None:
+    if not artifact_path.exists():
         reasons.append("benchmark_parity_artifact_missing")
         reason_details.append(
             {
                 "reason": "benchmark_parity_artifact_missing",
-                "artifact_ref": str(parity_path),
+                "artifact_ref": str(artifact_path),
             }
         )
         return
-    if _load_json_if_exists(parity_path) is None:
+
+    if _load_json_if_exists(artifact_path) is None:
         reasons.append("benchmark_parity_artifact_invalid_json")
         reason_details.append(
             {
                 "reason": "benchmark_parity_artifact_invalid_json",
-                "artifact_ref": str(parity_path),
+                "artifact_ref": str(artifact_path),
             }
         )

--- a/services/torghut/app/trading/autonomy/policy_check/profitability_manifest_janus.py
+++ b/services/torghut/app/trading/autonomy/policy_check/profitability_manifest_janus.py
@@ -1,0 +1,141 @@
+"""Janus evidence validation for profitability promotion manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .common import Any
+from .requirements import (
+    as_dict as _as_dict,
+    int_or_default as _int_or_default,
+    list_count as _list_count,
+    load_json_if_exists as _load_json_if_exists,
+)
+
+
+def append_janus_evidence_reasons(
+    *,
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    policy_payload: dict[str, Any],
+    artifact_root: Path,
+) -> None:
+    _validate_janus_event_car(reasons, reason_details, policy_payload, artifact_root)
+    _validate_janus_hgrm_reward(reasons, reason_details, policy_payload, artifact_root)
+
+
+def _validate_janus_event_car(
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    policy_payload: dict[str, Any],
+    artifact_root: Path,
+) -> None:
+    event_path = artifact_root / str(
+        policy_payload.get(
+            "promotion_janus_event_car_artifact", "gates/janus-event-car-v1.json"
+        )
+    )
+    event_payload = _load_json_if_exists(event_path)
+
+    if event_payload is None:
+        reasons.append("janus_event_car_artifact_missing")
+        reason_details.append(
+            {
+                "reason": "janus_event_car_artifact_missing",
+                "artifact_ref": str(event_path),
+            }
+        )
+        return
+
+    _validate_janus_schema(
+        reasons, reason_details, event_payload, event_path, "janus-event-car-v1"
+    )
+    event_count = _int_or_default(
+        _as_dict(event_payload.get("summary")).get("event_count"),
+        _list_count(event_payload.get("records")),
+    )
+    min_event_count = max(
+        1, _int_or_default(policy_payload.get("promotion_min_janus_event_count"), 1)
+    )
+    if event_count < min_event_count:
+        reasons.append("janus_event_car_count_below_minimum")
+        reason_details.append(
+            {
+                "reason": "janus_event_car_count_below_minimum",
+                "artifact_ref": str(event_path),
+                "actual_event_count": event_count,
+                "minimum_event_count": min_event_count,
+            }
+        )
+
+
+def _validate_janus_hgrm_reward(
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    policy_payload: dict[str, Any],
+    artifact_root: Path,
+) -> None:
+    reward_path = artifact_root / str(
+        policy_payload.get(
+            "promotion_janus_hgrm_reward_artifact", "gates/janus-hgrm-reward-v1.json"
+        )
+    )
+    reward_payload = _load_json_if_exists(reward_path)
+
+    if reward_payload is None:
+        reasons.append("janus_hgrm_reward_artifact_missing")
+        reason_details.append(
+            {
+                "reason": "janus_hgrm_reward_artifact_missing",
+                "artifact_ref": str(reward_path),
+            }
+        )
+        return
+
+    _validate_janus_schema(
+        reasons, reason_details, reward_payload, reward_path, "janus-hgrm-reward-v1"
+    )
+    reward_count = _int_or_default(
+        _as_dict(reward_payload.get("summary")).get("reward_count"),
+        _list_count(reward_payload.get("rewards")),
+    )
+    min_reward_count = max(
+        1, _int_or_default(policy_payload.get("promotion_min_janus_reward_count"), 1)
+    )
+    if reward_count < min_reward_count:
+        reasons.append("janus_hgrm_reward_count_below_minimum")
+        reason_details.append(
+            {
+                "reason": "janus_hgrm_reward_count_below_minimum",
+                "artifact_ref": str(reward_path),
+                "actual_reward_count": reward_count,
+                "minimum_reward_count": min_reward_count,
+            }
+        )
+
+
+def _validate_janus_schema(
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    payload: dict[str, Any],
+    path: Path,
+    expected_schema: str,
+) -> None:
+    if str(payload.get("schema_version", "")).strip() == expected_schema:
+        return
+
+    reason = {
+        "janus-event-car-v1": "janus_event_car_schema_invalid",
+        "janus-hgrm-reward-v1": "janus_hgrm_reward_schema_invalid",
+    }[expected_schema]
+    reasons.append(reason)
+    reason_details.append(
+        {
+            "reason": reason,
+            "artifact_ref": str(path),
+            "expected": expected_schema,
+        }
+    )
+
+
+__all__ = ("append_janus_evidence_reasons",)

--- a/services/torghut/tests/policy_checks/test_policy_checks_manifest_a.py
+++ b/services/torghut/tests/policy_checks/test_policy_checks_manifest_a.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from app.trading.autonomy.policy_check.profitability_manifest import (
+    append_profitability_stage_manifest_reasons,
+)
 from tests.policy_checks.policy_checks_support import (
     Path,
     PolicyChecksTestCaseBase,
@@ -17,6 +20,52 @@ from tests.policy_checks.policy_checks_support import (
 
 
 class TestPolicyChecksManifestA(PolicyChecksTestCaseBase):
+    def test_required_replay_contract_is_checked_without_valid_stages(self) -> None:
+        for stages in ({}, []):
+            with self.subTest(stages=stages), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                manifest_path = (
+                    root / "profitability" / "profitability-stage-manifest-v1.json"
+                )
+                manifest_path.parent.mkdir(parents=True)
+                manifest_path.write_text(
+                    json.dumps({"stages": stages}),
+                    encoding="utf-8",
+                )
+                reasons: list[str] = []
+                reason_details: list[dict[str, object]] = []
+
+                append_profitability_stage_manifest_reasons(
+                    reasons=reasons,
+                    reason_details=reason_details,
+                    policy_payload={
+                        "promotion_require_profitability_stage_replay_contract": True
+                    },
+                    artifact_root=root,
+                )
+
+                self.assertEqual(
+                    reasons.count(
+                        "profitability_stage_manifest_replay_contract_missing"
+                    ),
+                    1,
+                )
+                replay_details = [
+                    detail
+                    for detail in reason_details
+                    if detail.get("reason")
+                    == "profitability_stage_manifest_replay_contract_missing"
+                ]
+                self.assertEqual(
+                    replay_details,
+                    [
+                        {
+                            "reason": "profitability_stage_manifest_replay_contract_missing",
+                            "artifact_ref": str(manifest_path),
+                        }
+                    ],
+                )
+
     def test_alpha_readiness_summary_skips_disabled_policy_gates(self) -> None:
         reasons, details = evaluate_alpha_readiness_summary(
             policy_payload={

--- a/services/torghut/tests/policy_checks/test_policy_checks_manifest_b.py
+++ b/services/torghut/tests/policy_checks/test_policy_checks_manifest_b.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from app.trading.autonomy.policy_check.profitability_manifest import (
+    append_profitability_stage_manifest_reasons,
+)
 from tests.policy_checks.policy_checks_support import (
     Path,
     PolicyChecksTestCaseBase,
@@ -17,6 +20,80 @@ from tests.policy_checks.policy_checks_support import (
 
 
 class TestPolicyChecksManifestB(PolicyChecksTestCaseBase):
+    def test_empty_replay_hashes_report_each_missing_stage_artifact_hash(self) -> None:
+        missing_hashes = object()
+        for artifact_hashes in (missing_hashes, {}, {" ": " "}):
+            with (
+                self.subTest(artifact_hashes=artifact_hashes),
+                tempfile.TemporaryDirectory() as tmpdir,
+            ):
+                root = Path(tmpdir)
+                manifest_path = (
+                    root / "profitability" / "profitability-stage-manifest-v1.json"
+                )
+                manifest_path.parent.mkdir(parents=True)
+                replay_contract: dict[str, object] = {"contract_hash": "invalid"}
+                if artifact_hashes is not missing_hashes:
+                    replay_contract["artifact_hashes"] = artifact_hashes
+                manifest_path.write_text(
+                    json.dumps(
+                        {
+                            "stages": {
+                                "research": {
+                                    "artifacts": {
+                                        "candidate_spec": {
+                                            "path": "research/candidate-spec.json",
+                                            "sha256": "abc123",
+                                        }
+                                    }
+                                }
+                            },
+                            "replay_contract": replay_contract,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                reasons: list[str] = []
+                reason_details: list[dict[str, object]] = []
+
+                append_profitability_stage_manifest_reasons(
+                    reasons=reasons,
+                    reason_details=reason_details,
+                    policy_payload={
+                        "promotion_require_profitability_stage_replay_contract": True
+                    },
+                    artifact_root=root,
+                )
+
+                self.assertEqual(
+                    reasons.count(
+                        "profitability_stage_manifest_replay_artifact_hashes_missing"
+                    ),
+                    1,
+                )
+                self.assertEqual(
+                    reasons.count(
+                        "profitability_stage_manifest_replay_artifact_hash_missing"
+                    ),
+                    1,
+                )
+                missing_details = [
+                    detail
+                    for detail in reason_details
+                    if detail.get("reason")
+                    == "profitability_stage_manifest_replay_artifact_hash_missing"
+                ]
+                self.assertEqual(
+                    missing_details,
+                    [
+                        {
+                            "reason": "profitability_stage_manifest_replay_artifact_hash_missing",
+                            "artifact_ref": str(manifest_path),
+                            "stage_artifact_ref": "research/candidate-spec.json",
+                        }
+                    ],
+                )
+
     def test_promotion_prerequisites_fail_when_profitability_stage_manifest_replay_hash_mismatch(
         self,
     ) -> None:

--- a/services/torghut/tests/policy_checks/test_policy_checks_manifest_regressions.py
+++ b/services/torghut/tests/policy_checks/test_policy_checks_manifest_regressions.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from app.trading.autonomy.policy_check.profitability_manifest import (
+    append_profitability_stage_manifest_reasons,
+)
+
+
+class TestPolicyChecksManifestRegressions(TestCase):
+    def test_failed_stage_chain_is_reported_without_valid_stages(self) -> None:
+        for stages in ({}, []):
+            with self.subTest(stages=stages), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                manifest_path = (
+                    root / "profitability" / "profitability-stage-manifest-v1.json"
+                )
+                manifest_path.parent.mkdir(parents=True)
+                manifest_path.write_text(
+                    json.dumps(
+                        {
+                            "stages": stages,
+                            "overall_status": "fail",
+                            "failure_reasons": ["validation_check_failed"],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                reasons: list[str] = []
+                reason_details: list[dict[str, object]] = []
+
+                append_profitability_stage_manifest_reasons(
+                    reasons=reasons,
+                    reason_details=reason_details,
+                    policy_payload={},
+                    artifact_root=root,
+                )
+
+                self.assertEqual(
+                    reasons.count(
+                        "profitability_stage_manifest_stage_chain_not_passed"
+                    ),
+                    1,
+                )
+                self.assertIn(
+                    {
+                        "reason": "profitability_stage_manifest_stage_chain_not_passed",
+                        "artifact_ref": str(manifest_path),
+                        "failure_reasons": ["validation_check_failed"],
+                    },
+                    reason_details,
+                )


### PR DESCRIPTION
## Summary

- Extract the profitability-manifest Janus validation helpers into a focused module.
- Reduce the main profitability manifest module below the 1,000-line file-length limit.
- Preserve the effective profitability-manifest behavior from the reconciled design-complexity branch without including its TigerBeetle changes.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest --cov=app --cov-report=xml:coverage.xml --cov-fail-under=0 tests/policy_checks/test_policy_checks_manifest_a.py tests/policy_checks/test_policy_checks_manifest_b.py tests/policy_checks/test_policy_checks_manifest_c.py tests/policy_checks/test_policy_checks_manifest_rollback.py tests/test_profitability_evidence_v4.py tests/test_generate_historical_profitability_manifests.py tests/test_explicit_module_facade_exports.py tests/autonomous_lane/test_lane_phase_manifest.py tests/autonomous_lane/test_lane_candidate_artifacts.py tests/autonomous_lane/test_autonomous_lane_governance_a.py tests/autonomous_lane/test_autonomous_lane_persistence_a.py tests/autonomous_lane/test_autonomous_lane_phase_b.py tests/historical_simulation/test_start_historical_simulation_lifecycle_b.py` (188 passed)
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 80 --base-ref origin/main` (88.63%)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff format --check app/trading/autonomy/policy_check/profitability_manifest.py app/trading/autonomy/policy_check/profitability_manifest_janus.py`
- `uv run --frozen ruff check app/trading/autonomy/policy_check/profitability_manifest.py app/trading/autonomy/policy_check/profitability_manifest_janus.py`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app/trading/autonomy/policy_check/profitability_manifest.py app/trading/autonomy/policy_check/profitability_manifest_janus.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks app/trading/autonomy/policy_check/profitability_manifest.py app/trading/autonomy/policy_check/profitability_manifest_janus.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/autonomy/policy_check/profitability_manifest.py app/trading/autonomy/policy_check/profitability_manifest_janus.py`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `kubectl get deploy torghut-scheduler -n torghut -o jsonpath='{.spec.replicas}'` (0)

## Screenshots (if applicable)

N/A; backend-only refactor.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; none are required for this behavior-preserving refactor.
