### PR TITLE
refactor(torghut): extract unlinked TigerBeetle refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
@@ -2,22 +2,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.elements import ColumnElement
 
 from app.config import Settings, settings
 from app.models import (
-    Execution,
-    ExecutionOrderEvent,
-    ExecutionTCAMetric,
     StrategyRuntimeLedgerBucket,
     TigerBeetleReconciliationRun,
+    TigerBeetleTransferRef,
     coerce_json_payload,
 )
 from app.trading.tigerbeetle_client import (
@@ -26,18 +24,9 @@ from app.trading.tigerbeetle_client import (
 )
 from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION,
-    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-    execution_tca_metric_source_id,
-    build_order_event_transfer_plan,
 )
-from app.trading.tigerbeetle_ledger_model import (
-    TRANSFER_KIND_EXECUTION_COST,
-    TRANSFER_KIND_EXECUTION_FILL,
-    TRANSFER_KIND_RUNTIME_NET_PNL,
-)
-
 
 from .shared_context import (
     BLOCKER_AMOUNT_MISMATCH,
@@ -55,10 +44,6 @@ from .shared_context import (
     BLOCKER_SOURCE_ROW_MISSING,
     BLOCKER_STABLE_REF_PAYLOAD_MISMATCH,
     BLOCKER_TRANSFER_MISSING,
-    BLOCKER_UNLINKED_COST,
-    BLOCKER_UNLINKED_EVENT,
-    BLOCKER_UNLINKED_EXECUTION,
-    BLOCKER_UNLINKED_RUNTIME_LEDGER,
     SCHEMA_VERSION,
     append_sample as _append_sample,
     archived_runtime_ledger_amount_micros as _archived_runtime_ledger_amount_micros,
@@ -66,12 +51,10 @@ from .shared_context import (
     compact_reconciliation_ref_counts as _compact_reconciliation_ref_counts,
     expected_source_amount_micros as _expected_source_amount_micros,
     legacy_unversioned_source_ref as _legacy_unversioned_source_ref,
-    order_event_ref_exists as _order_event_ref_exists,
     payload_int as _payload_int,
     payload_value as _payload_value,
     ref_matches_expected_event as _ref_matches_expected_event,
     ref_sample as _ref_sample,
-    source_ref_exists as _source_ref_exists,
     stable_ref_matches as _stable_ref_matches,
     transfer_lookup_key as _transfer_lookup_key,
     u128_text as _u128_text,
@@ -85,6 +68,473 @@ from .runtime_ledger_ref_coverage import (
     runtime_ledger_ref_matches_expected_bucket as _runtime_ledger_ref_matches_expected_bucket,
     tigerbeetle_ref_counts,
 )
+from .unlinked_refs import UnlinkedRefContext, collect_unlinked_refs
+
+
+@dataclass
+class _ReconciliationCounts:
+    checked_transfer_count: int = 0
+    missing_transfer_count: int = 0
+    mismatched_transfer_count: int = 0
+    source_row_missing_count: int = 0
+    source_amount_mismatch_count: int = 0
+    legacy_source_amount_unverifiable_count: int = 0
+    runtime_ledger_checked_transfer_count: int = 0
+    runtime_ledger_signed_transfer_count: int = 0
+    runtime_ledger_missing_signed_ref_count: int = 0
+    runtime_ledger_missing_account_ref_count: int = 0
+    archived_runtime_ledger_source_missing_count: int = 0
+    runtime_ledger_direction_mismatch_count: int = 0
+    runtime_ledger_metadata_mismatch_count: int = 0
+    stable_ref_mismatch_count: int = 0
+    unlinked_event_count: int = 0
+    unlinked_execution_count: int = 0
+    unlinked_cost_count: int = 0
+    unlinked_runtime_ledger_count: int = 0
+
+
+def _empty_counts() -> _ReconciliationCounts:
+    return _ReconciliationCounts()
+
+
+def _empty_strings() -> list[str]:
+    return []
+
+
+def _empty_samples() -> list[dict[str, object]]:
+    return []
+
+
+def _empty_transfer_refs() -> list[TigerBeetleTransferRef]:
+    return []
+
+
+def _empty_transfer_lookup() -> dict[str, object]:
+    return {}
+
+
+@dataclass
+class _ReconciliationState:
+    counts: _ReconciliationCounts = field(default_factory=_empty_counts)
+    blockers: list[str] = field(default_factory=_empty_strings)
+    mismatched_refs: list[dict[str, object]] = field(default_factory=_empty_samples)
+    missing_transfer_refs: list[dict[str, object]] = field(
+        default_factory=_empty_samples
+    )
+    missing_source_rows: list[dict[str, object]] = field(default_factory=_empty_samples)
+    unlinked_refs: list[dict[str, object]] = field(default_factory=_empty_samples)
+    legacy_source_amount_unverifiable_refs: list[dict[str, object]] = field(
+        default_factory=_empty_samples
+    )
+    ref_list: Sequence[TigerBeetleTransferRef] = field(
+        default_factory=_empty_transfer_refs
+    )
+    transfer_lookup: dict[str, object] = field(default_factory=_empty_transfer_lookup)
+    client_lookup_ok: bool = True
+    client_error: str | None = None
+
+
+@dataclass(frozen=True)
+class _TransferValidationContext:
+    ref: TigerBeetleTransferRef
+    actual: object
+    state: _ReconciliationState
+
+
+@dataclass(frozen=True)
+class _ReconciliationRequest:
+    settings_obj: Settings
+    client: TigerBeetleClientProtocol | None
+    limit: int
+    persist: bool
+    account_label: str | None
+
+
+@dataclass(frozen=True)
+class _PayloadBuildContext:
+    settings_obj: Settings
+    started_at: datetime
+    finished_at: datetime
+    state: _ReconciliationState
+    ref_counts: dict[str, object]
+    unique_blockers: list[str]
+    source_missing_count: int
+    ref_count_stable_ref_mismatch_count: int
+
+
+@dataclass(frozen=True)
+class _PersistenceContext:
+    settings_obj: Settings
+    started_at: datetime
+    finished_at: datetime
+    unique_blockers: list[str]
+    ref_counts: dict[str, object]
+    compact_ref_counts: dict[str, object]
+    payload: dict[str, object]
+    counts: _ReconciliationCounts
+
+
+# ---------------------------------------------------------------------------
+# Single transfer processing
+# ---------------------------------------------------------------------------
+
+
+def _process_single_transfer(
+    session: Session,
+    ref: TigerBeetleTransferRef,
+    actual: object | None,
+    settings_obj: Settings,
+    state: _ReconciliationState,
+) -> None:
+    """Validate a single transfer against expected state."""
+
+    counts = state.counts
+    if not _stable_ref_matches(ref):
+        counts.stable_ref_mismatch_count += 1
+        counts.mismatched_transfer_count += 1
+        state.blockers.append(BLOCKER_STABLE_REF_PAYLOAD_MISMATCH)
+        _append_sample(
+            state.mismatched_refs,
+            _ref_sample(
+                ref,
+                blocker=BLOCKER_STABLE_REF_PAYLOAD_MISMATCH,
+                reason="stable_ref_payload_does_not_match_transfer_ref_identity",
+            ),
+        )
+
+    if not state.client_lookup_ok:
+        return
+
+    if actual is None:
+        counts.missing_transfer_count += 1
+        state.blockers.append(BLOCKER_TRANSFER_MISSING)
+        _append_sample(
+            state.missing_transfer_refs,
+            _ref_sample(
+                ref,
+                blocker=BLOCKER_TRANSFER_MISSING,
+                reason="transfer_ref_not_found_in_tigerbeetle_lookup",
+            ),
+        )
+        return
+
+    validation = _TransferValidationContext(ref=ref, actual=actual, state=state)
+    _validate_transfer_fields(validation)
+    _validate_event_ref(session, settings_obj, validation)
+
+
+def _validate_transfer_fields(context: _TransferValidationContext) -> None:
+    _check_field(
+        context,
+        "amount",
+        lambda a, r: Decimal(str(_attr(a, "amount"))) != r.amount,
+        BLOCKER_AMOUNT_MISMATCH,
+    )
+    _check_field(
+        context,
+        "code",
+        lambda a, r: int(str(_attr(a, "code"))) != r.code,
+        BLOCKER_CODE_MISMATCH,
+    )
+    _check_field(
+        context,
+        "ledger",
+        lambda a, r: int(str(_attr(a, "ledger"))) != r.ledger,
+        BLOCKER_LEDGER_MISMATCH,
+    )
+
+    debit_account_id = _payload_value(context.ref, "debit_account_id")
+    if debit_account_id is not None and _u128_text(
+        _attr(context.actual, "debit_account_id")
+    ) != _u128_text(debit_account_id):
+        _check_and_append(
+            context,
+            BLOCKER_DEBIT_ACCOUNT_MISMATCH,
+            "actual_debit_account_differs_from_transfer_ref_payload",
+        )
+
+    credit_account_id = _payload_value(context.ref, "credit_account_id")
+    if credit_account_id is not None and _u128_text(
+        _attr(context.actual, "credit_account_id")
+    ) != _u128_text(credit_account_id):
+        _check_and_append(
+            context,
+            BLOCKER_CREDIT_ACCOUNT_MISMATCH,
+            "actual_credit_account_differs_from_transfer_ref_payload",
+        )
+
+
+def _check_field(
+    context: _TransferValidationContext,
+    field_name: str,
+    check_fn: Callable[[object, TigerBeetleTransferRef], bool],
+    blocker: str,
+) -> None:
+    if check_fn(context.actual, context.ref):
+        context.state.counts.mismatched_transfer_count += 1
+        context.state.blockers.append(blocker)
+        _append_sample(
+            context.state.mismatched_refs,
+            _ref_sample(
+                context.ref,
+                blocker=blocker,
+                reason=f"actual_{field_name}_differs_from_transfer_ref",
+                actual=context.actual,
+            ),
+        )
+
+
+def _check_and_append(
+    context: _TransferValidationContext,
+    blocker: str,
+    reason: str,
+) -> None:
+    context.state.counts.mismatched_transfer_count += 1
+    context.state.blockers.append(blocker)
+    _append_sample(
+        context.state.mismatched_refs,
+        _ref_sample(
+            context.ref,
+            blocker=blocker,
+            reason=reason,
+            actual=context.actual,
+        ),
+    )
+
+
+def _validate_event_ref(
+    session: Session,
+    settings_obj: Settings,
+    context: _TransferValidationContext,
+) -> None:
+    if not _ref_matches_expected_event(session, context.ref, settings_obj=settings_obj):
+        context.state.counts.mismatched_transfer_count += 1
+        context.state.blockers.append(BLOCKER_POSTGRES_REF_MISMATCH)
+        _append_sample(
+            context.state.mismatched_refs,
+            _ref_sample(
+                context.ref,
+                blocker=BLOCKER_POSTGRES_REF_MISMATCH,
+                reason="transfer_ref_no_longer_matches_order_event_plan",
+                actual=context.actual,
+            ),
+        )
+
+    if context.ref.source_type in {
+        SOURCE_TYPE_EXECUTION,
+        SOURCE_TYPE_EXECUTION_TCA_METRIC,
+        SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    }:
+        _validate_source_amount(session, context)
+
+    if context.ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
+        _validate_runtime_ledger(session, context)
+
+
+def _validate_source_amount(
+    session: Session,
+    context: _TransferValidationContext,
+) -> None:
+    ref = context.ref
+    counts = context.state.counts
+    expected_source_amount = _expected_source_amount_micros(session, ref)
+    if expected_source_amount is None:
+        archived_amount = _archived_runtime_ledger_amount_micros(ref)
+        if archived_amount is not None and ref.amount == archived_amount:
+            counts.archived_runtime_ledger_source_missing_count += 1
+        else:
+            counts.source_row_missing_count += 1
+            context.state.blockers.append(BLOCKER_SOURCE_ROW_MISSING)
+            _append_sample(
+                context.state.missing_source_rows,
+                _ref_sample(
+                    ref,
+                    blocker=BLOCKER_SOURCE_ROW_MISSING,
+                    reason="source_row_missing_or_source_id_not_uuid",
+                    actual=context.actual,
+                ),
+            )
+    elif ref.amount != expected_source_amount:
+        if _legacy_unversioned_source_ref(ref):
+            counts.legacy_source_amount_unverifiable_count += 1
+            _append_sample(
+                context.state.legacy_source_amount_unverifiable_refs,
+                _ref_sample(
+                    ref,
+                    blocker="tigerbeetle_legacy_source_amount_unverifiable",
+                    reason="legacy_source_ref_lacks_revision_or_archived_amount",
+                    actual=context.actual,
+                ),
+            )
+        else:
+            counts.source_amount_mismatch_count += 1
+            context.state.blockers.append(BLOCKER_SOURCE_AMOUNT_MISMATCH)
+            _append_sample(
+                context.state.mismatched_refs,
+                _ref_sample(
+                    ref,
+                    blocker=BLOCKER_SOURCE_AMOUNT_MISMATCH,
+                    reason="source_amount_micros_differs_from_transfer_ref",
+                    actual=context.actual,
+                ),
+            )
+
+
+def _validate_runtime_ledger(
+    session: Session,
+    context: _TransferValidationContext,
+) -> None:
+    ref = context.ref
+    counts = context.state.counts
+    counts.runtime_ledger_checked_transfer_count += 1
+    source_uuid = _uuid_or_none(ref.source_id)
+    bucket = (
+        session.get(StrategyRuntimeLedgerBucket, source_uuid)
+        if source_uuid is not None
+        else None
+    )
+    if bucket is not None:
+        direction_matches, metadata_matches = (
+            _runtime_ledger_ref_matches_expected_bucket(ref, context.actual, bucket)
+        )
+        if direction_matches:
+            counts.runtime_ledger_signed_transfer_count += 1
+        else:
+            counts.runtime_ledger_direction_mismatch_count += 1
+            counts.mismatched_transfer_count += 1
+            context.state.blockers.append(BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH)
+            _append_sample(
+                context.state.mismatched_refs,
+                _ref_sample(
+                    ref,
+                    blocker=BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH,
+                    reason="runtime_ledger_signed_direction_or_accounts_mismatch",
+                    actual=context.actual,
+                ),
+            )
+        if not metadata_matches:
+            counts.runtime_ledger_metadata_mismatch_count += 1
+            counts.mismatched_transfer_count += 1
+            context.state.blockers.append(BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH)
+            _append_sample(
+                context.state.mismatched_refs,
+                _ref_sample(
+                    ref,
+                    blocker=BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH,
+                    reason="runtime_ledger_metadata_mismatch",
+                    actual=context.actual,
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly
+# ---------------------------------------------------------------------------
+
+
+def _assemble_reconciliation_payload(
+    payload: dict[str, object],
+    state: _ReconciliationState,
+) -> dict[str, object]:
+    payload["missing_transfer_refs"] = state.missing_transfer_refs
+    payload["mismatched_refs"] = state.mismatched_refs
+    payload["missing_source_rows"] = state.missing_source_rows
+    payload["unlinked_refs"] = state.unlinked_refs
+    payload["legacy_source_amount_unverifiable_refs"] = (
+        state.legacy_source_amount_unverifiable_refs
+    )
+    payload["blocker_details"] = {
+        "missing_transfer_refs": state.missing_transfer_refs,
+        "mismatched_refs": state.mismatched_refs,
+        "missing_source_rows": state.missing_source_rows,
+        "unlinked_refs": state.unlinked_refs,
+        "legacy_source_amount_unverifiable_refs": (
+            state.legacy_source_amount_unverifiable_refs
+        ),
+    }
+    return payload
+
+
+def _build_payload_dict(context: _PayloadBuildContext) -> dict[str, object]:
+    settings_obj = context.settings_obj
+    counts = context.state.counts
+    ref_counts = context.ref_counts
+    ok = not context.unique_blockers
+    max_age_seconds = max(1, int(settings_obj.tigerbeetle_reconcile_max_age_seconds))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": ok,
+        "cluster_id": settings_obj.tigerbeetle_cluster_id,
+        "account_label": None,
+        "started_at": context.started_at.isoformat(),
+        "finished_at": context.finished_at.isoformat(),
+        "age_seconds": 0,
+        "reconciliation_stale": False,
+        "reconciliation_max_age_seconds": max_age_seconds,
+        "reconciliation_freshness": {
+            "observed_at": context.finished_at.isoformat(),
+            "age_seconds": 0,
+            "max_age_seconds": max_age_seconds,
+            "stale": False,
+        },
+        "authority": "accounting_parity_only",
+        "promotion_authority": False,
+        "overrides_runtime_ledger_authority": False,
+        "client_lookup_ok": context.state.client_lookup_ok,
+        "client_error": context.state.client_error,
+        "account_ref_count": _payload_int(ref_counts, "account_ref_count"),
+        "transfer_ref_count": _payload_int(ref_counts, "transfer_ref_count"),
+        "checked_transfer_count": counts.checked_transfer_count,
+        "missing_transfer_count": counts.missing_transfer_count,
+        "mismatched_transfer_count": counts.mismatched_transfer_count,
+        "mismatched_ref_count": counts.mismatched_transfer_count,
+        "source_missing_count": context.source_missing_count,
+        "source_row_missing_count": counts.source_row_missing_count,
+        "missing_source_row_count": counts.source_row_missing_count,
+        "source_amount_mismatch_count": counts.source_amount_mismatch_count,
+        "legacy_source_amount_unverifiable_count": counts.legacy_source_amount_unverifiable_count,
+        "runtime_ledger_checked_transfer_count": counts.runtime_ledger_checked_transfer_count,
+        "runtime_ledger_signed_transfer_count": counts.runtime_ledger_signed_transfer_count,
+        "runtime_ledger_ref_count": _payload_int(
+            ref_counts, "runtime_ledger_ref_count"
+        ),
+        "runtime_ledger_signed_ref_count": _payload_int(
+            ref_counts, "runtime_ledger_signed_ref_count"
+        ),
+        "runtime_ledger_missing_signed_ref_count": counts.runtime_ledger_missing_signed_ref_count,
+        "runtime_ledger_missing_account_ref_count": counts.runtime_ledger_missing_account_ref_count,
+        "stable_ref_count": _payload_int(ref_counts, "stable_ref_count"),
+        "stable_ref_missing_count": _payload_int(
+            ref_counts, "stable_ref_missing_count"
+        ),
+        "stable_ref_mismatch_count": max(
+            counts.stable_ref_mismatch_count,
+            context.ref_count_stable_ref_mismatch_count,
+        ),
+        "archived_runtime_ledger_source_missing_count": counts.archived_runtime_ledger_source_missing_count,
+        "runtime_ledger_direction_mismatch_count": counts.runtime_ledger_direction_mismatch_count,
+        "runtime_ledger_metadata_mismatch_count": counts.runtime_ledger_metadata_mismatch_count,
+        "unlinked_event_count": counts.unlinked_event_count,
+        "unlinked_order_event_ref_count": counts.unlinked_event_count,
+        "unlinked_execution_count": counts.unlinked_execution_count,
+        "unlinked_execution_ref_count": counts.unlinked_execution_count,
+        "unlinked_cost_count": counts.unlinked_cost_count,
+        "unlinked_cost_ref_count": counts.unlinked_cost_count,
+        "unlinked_runtime_ledger_count": counts.unlinked_runtime_ledger_count,
+        "unlinked_runtime_ledger_ref_count": counts.unlinked_runtime_ledger_count,
+        "ref_counts": ref_counts,
+        "missing_transfer_refs": [],
+        "mismatched_refs": [],
+        "missing_source_rows": [],
+        "unlinked_refs": [],
+        "legacy_source_amount_unverifiable_refs": [],
+        "blockers": context.unique_blockers,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def latest_tigerbeetle_reconciliation_status_payload(
@@ -155,591 +605,235 @@ def reconcile_tigerbeetle_transfers(
     persist: bool = True,
     account_label: str | None = None,
 ) -> dict[str, object]:
-    started_at = datetime.now(timezone.utc)
+    return _process_reconciliation(
+        session,
+        _ReconciliationRequest(
+            settings_obj=settings_obj,
+            client=client,
+            limit=limit,
+            persist=persist,
+            account_label=account_label,
+        ),
+    )
+
+
+def _run_client_lookup(
+    session: Session,
+    request: _ReconciliationRequest,
+) -> _ReconciliationState:
     refs = _reconciliation_transfer_refs(
         session,
-        cluster_id=settings_obj.tigerbeetle_cluster_id,
-        limit=limit,
+        cluster_id=request.settings_obj.tigerbeetle_cluster_id,
+        limit=request.limit,
     )
-    checked_transfer_count = len(refs)
-    missing_transfer_count = 0
-    mismatched_transfer_count = 0
-    source_row_missing_count = 0
-    source_amount_mismatch_count = 0
-    legacy_source_amount_unverifiable_count = 0
-    runtime_ledger_checked_transfer_count = 0
-    runtime_ledger_signed_transfer_count = 0
-    runtime_ledger_missing_signed_ref_count = 0
-    runtime_ledger_missing_account_ref_count = 0
-    archived_runtime_ledger_source_missing_count = 0
-    runtime_ledger_direction_mismatch_count = 0
-    runtime_ledger_metadata_mismatch_count = 0
-    stable_ref_mismatch_count = 0
-    blockers: list[str] = []
-    mismatched_refs: list[dict[str, object]] = []
-    missing_transfer_refs: list[dict[str, object]] = []
-    missing_source_rows: list[dict[str, object]] = []
-    unlinked_refs: list[dict[str, object]] = []
-    legacy_source_amount_unverifiable_refs: list[dict[str, object]] = []
-
-    transfer_lookup: dict[str, object] = {}
-    client_lookup_ok = True
-    client_error: str | None = None
-    owned_client = client is None
+    state = _ReconciliationState(ref_list=refs)
     tb_client: TigerBeetleClientProtocol | None = None
+    owned_client = request.client is None
+
     try:
         if refs:
-            tb_client = client or create_tigerbeetle_client(settings_obj)
+            tb_client = request.client or create_tigerbeetle_client(
+                request.settings_obj
+            )
             looked_up = tb_client.lookup_transfers(
                 [int(ref.transfer_id) for ref in refs]
             )
-            transfer_lookup = {
+            state.transfer_lookup = {
                 lookup_key: item
                 for item in looked_up
                 if (lookup_key := _transfer_lookup_key(item)) is not None
             }
     except Exception as exc:
-        client_lookup_ok = False
-        client_error = f"{type(exc).__name__}: {exc}"
-        blockers.append(BLOCKER_CLIENT_UNAVAILABLE)
+        state.client_lookup_ok = False
+        state.client_error = f"{type(exc).__name__}: {exc}"
+        state.blockers.append(BLOCKER_CLIENT_UNAVAILABLE)
     finally:
         if owned_client and tb_client is not None:
             close = getattr(tb_client, "close", None)
             if callable(close):
                 close()
+    return state
 
+
+def _process_refs(
+    session: Session,
+    refs: Sequence[TigerBeetleTransferRef],
+    settings_obj: Settings,
+    state: _ReconciliationState,
+) -> None:
+    state.counts.checked_transfer_count = len(refs)
     for ref in refs:
         ref_transfer_id = _u128_text(ref.transfer_id) or str(ref.transfer_id)
-        if not _stable_ref_matches(ref):
-            stable_ref_mismatch_count += 1
-            mismatched_transfer_count += 1
-            blockers.append(BLOCKER_STABLE_REF_PAYLOAD_MISMATCH)
-            _append_sample(
-                mismatched_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_STABLE_REF_PAYLOAD_MISMATCH,
-                    reason="stable_ref_payload_does_not_match_transfer_ref_identity",
-                ),
-            )
-        actual = transfer_lookup.get(ref_transfer_id) if client_lookup_ok else None
-        if client_lookup_ok:
-            if actual is None:
-                missing_transfer_count += 1
-                blockers.append(BLOCKER_TRANSFER_MISSING)
-                _append_sample(
-                    missing_transfer_refs,
-                    _ref_sample(
-                        ref,
-                        blocker=BLOCKER_TRANSFER_MISSING,
-                        reason="transfer_ref_not_found_in_tigerbeetle_lookup",
-                    ),
-                )
-                continue
-            if Decimal(str(_attr(actual, "amount"))) != ref.amount:
-                mismatched_transfer_count += 1
-                blockers.append(BLOCKER_AMOUNT_MISMATCH)
-                _append_sample(
-                    mismatched_refs,
-                    _ref_sample(
-                        ref,
-                        blocker=BLOCKER_AMOUNT_MISMATCH,
-                        reason="actual_amount_micros_differs_from_transfer_ref",
-                        actual=actual,
-                    ),
-                )
-            if int(str(_attr(actual, "code"))) != ref.code:
-                mismatched_transfer_count += 1
-                blockers.append(BLOCKER_CODE_MISMATCH)
-                _append_sample(
-                    mismatched_refs,
-                    _ref_sample(
-                        ref,
-                        blocker=BLOCKER_CODE_MISMATCH,
-                        reason="actual_code_differs_from_transfer_ref",
-                        actual=actual,
-                    ),
-                )
-            if int(str(_attr(actual, "ledger"))) != ref.ledger:
-                mismatched_transfer_count += 1
-                blockers.append(BLOCKER_LEDGER_MISMATCH)
-                _append_sample(
-                    mismatched_refs,
-                    _ref_sample(
-                        ref,
-                        blocker=BLOCKER_LEDGER_MISMATCH,
-                        reason="actual_ledger_differs_from_transfer_ref",
-                        actual=actual,
-                    ),
-                )
-            debit_account_id = _payload_value(ref, "debit_account_id")
-            if debit_account_id is not None and _u128_text(
-                _attr(actual, "debit_account_id")
-            ) != _u128_text(debit_account_id):
-                mismatched_transfer_count += 1
-                blockers.append(BLOCKER_DEBIT_ACCOUNT_MISMATCH)
-                _append_sample(
-                    mismatched_refs,
-                    _ref_sample(
-                        ref,
-                        blocker=BLOCKER_DEBIT_ACCOUNT_MISMATCH,
-                        reason=(
-                            "actual_debit_account_differs_from_transfer_ref_payload"
-                        ),
-                        actual=actual,
-                    ),
-                )
-            credit_account_id = _payload_value(ref, "credit_account_id")
-            if credit_account_id is not None and _u128_text(
-                _attr(actual, "credit_account_id")
-            ) != _u128_text(credit_account_id):
-                mismatched_transfer_count += 1
-                blockers.append(BLOCKER_CREDIT_ACCOUNT_MISMATCH)
-                _append_sample(
-                    mismatched_refs,
-                    _ref_sample(
-                        ref,
-                        blocker=BLOCKER_CREDIT_ACCOUNT_MISMATCH,
-                        reason=(
-                            "actual_credit_account_differs_from_transfer_ref_payload"
-                        ),
-                        actual=actual,
-                    ),
-                )
-        if not _ref_matches_expected_event(
+        actual = (
+            state.transfer_lookup.get(ref_transfer_id)
+            if state.client_lookup_ok
+            else None
+        )
+        _process_single_transfer(
             session,
             ref,
-            settings_obj=settings_obj,
-        ):
-            mismatched_transfer_count += 1
-            blockers.append(BLOCKER_POSTGRES_REF_MISMATCH)
-            _append_sample(
-                mismatched_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_POSTGRES_REF_MISMATCH,
-                    reason="transfer_ref_no_longer_matches_order_event_plan",
-                    actual=actual,
-                ),
-            )
-        if ref.source_type in {
-            SOURCE_TYPE_EXECUTION,
-            SOURCE_TYPE_EXECUTION_TCA_METRIC,
-            SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-        }:
-            expected_source_amount = _expected_source_amount_micros(session, ref)
-            if expected_source_amount is None:
-                archived_amount = _archived_runtime_ledger_amount_micros(ref)
-                if archived_amount is not None and ref.amount == archived_amount:
-                    archived_runtime_ledger_source_missing_count += 1
-                else:
-                    source_row_missing_count += 1
-                    blockers.append(BLOCKER_SOURCE_ROW_MISSING)
-                    _append_sample(
-                        missing_source_rows,
-                        _ref_sample(
-                            ref,
-                            blocker=BLOCKER_SOURCE_ROW_MISSING,
-                            reason="source_row_missing_or_source_id_not_uuid",
-                            actual=actual,
-                        ),
-                    )
-            elif ref.amount != expected_source_amount:
-                if _legacy_unversioned_source_ref(ref):
-                    legacy_source_amount_unverifiable_count += 1
-                    _append_sample(
-                        legacy_source_amount_unverifiable_refs,
-                        _ref_sample(
-                            ref,
-                            blocker="tigerbeetle_legacy_source_amount_unverifiable",
-                            reason=(
-                                "legacy_source_ref_lacks_revision_or_archived_amount"
-                            ),
-                            actual=actual,
-                        ),
-                    )
-                else:
-                    source_amount_mismatch_count += 1
-                    blockers.append(BLOCKER_SOURCE_AMOUNT_MISMATCH)
-                    _append_sample(
-                        mismatched_refs,
-                        _ref_sample(
-                            ref,
-                            blocker=BLOCKER_SOURCE_AMOUNT_MISMATCH,
-                            reason="source_amount_micros_differs_from_transfer_ref",
-                            actual=actual,
-                        ),
-                    )
-        if ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
-            runtime_ledger_checked_transfer_count += 1
-            source_uuid = _uuid_or_none(ref.source_id)
-            bucket = (
-                session.get(StrategyRuntimeLedgerBucket, source_uuid)
-                if source_uuid is not None
-                else None
-            )
-            if bucket is not None and actual is not None:
-                direction_matches, metadata_matches = (
-                    _runtime_ledger_ref_matches_expected_bucket(ref, actual, bucket)
-                )
-                if direction_matches:
-                    runtime_ledger_signed_transfer_count += 1
-                else:
-                    runtime_ledger_direction_mismatch_count += 1
-                    mismatched_transfer_count += 1
-                    blockers.append(BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH)
-                    _append_sample(
-                        mismatched_refs,
-                        _ref_sample(
-                            ref,
-                            blocker=BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH,
-                            reason="runtime_ledger_signed_direction_or_accounts_mismatch",
-                            actual=actual,
-                        ),
-                    )
-                if not metadata_matches:
-                    runtime_ledger_metadata_mismatch_count += 1
-                    mismatched_transfer_count += 1
-                    blockers.append(BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH)
-                    _append_sample(
-                        mismatched_refs,
-                        _ref_sample(
-                            ref,
-                            blocker=BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH,
-                            reason="runtime_ledger_metadata_mismatch",
-                            actual=actual,
-                        ),
-                    )
-
-    recent_events = (
-        session.execute(
-            select(ExecutionOrderEvent)
-            .order_by(ExecutionOrderEvent.created_at.desc())
-            .limit(limit)
+            actual,
+            settings_obj,
+            state,
         )
-        .scalars()
-        .all()
+
+
+def _collect_unlinked(
+    session: Session,
+    request: _ReconciliationRequest,
+    state: _ReconciliationState,
+) -> None:
+    collected = collect_unlinked_refs(
+        UnlinkedRefContext(
+            session=session,
+            settings_obj=request.settings_obj,
+            limit=request.limit,
+            account_label=request.account_label,
+            blockers=state.blockers,
+            samples=state.unlinked_refs,
+        )
     )
-    unlinked_event_count = 0
-    for event in recent_events:
-        if _order_event_ref_exists(session, event, settings_obj=settings_obj):
-            continue
-        if (
-            build_order_event_transfer_plan(
-                session,
-                event,
-                settings_obj=settings_obj,
-            )
-            is None
-        ):
-            continue
-        unlinked_event_count += 1
-        _append_sample(
-            unlinked_refs,
-            {
-                "blocker": BLOCKER_UNLINKED_EVENT,
-                "source_type": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
-                "source_id": str(event.id),
-                "event_fingerprint": event.event_fingerprint,
-            },
-        )
-    if unlinked_event_count:
-        blockers.append(BLOCKER_UNLINKED_EVENT)
+    state.counts.unlinked_event_count = collected.event_count
+    state.counts.unlinked_execution_count = collected.execution_count
+    state.counts.unlinked_cost_count = collected.cost_count
+    state.counts.unlinked_runtime_ledger_count = collected.runtime_ledger_count
 
-    recent_executions = (
-        session.execute(
-            select(Execution)
-            .where(
-                Execution.avg_fill_price.is_not(None),
-                Execution.filled_qty > 0,
-            )
-            .order_by(Execution.created_at.desc())
-            .limit(limit)
-        )
-        .scalars()
-        .all()
-    )
-    unlinked_execution_count = 0
-    for execution in recent_executions:
-        if _source_ref_exists(
-            session,
-            settings_obj=settings_obj,
-            source_type=SOURCE_TYPE_EXECUTION,
-            source_id=str(execution.id),
-            transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
-            source_pk=execution.id,
-        ):
-            continue
-        unlinked_execution_count += 1
-        _append_sample(
-            unlinked_refs,
-            {
-                "blocker": BLOCKER_UNLINKED_EXECUTION,
-                "source_type": SOURCE_TYPE_EXECUTION,
-                "source_id": str(execution.id),
-                "alpaca_order_id": execution.alpaca_order_id,
-            },
-        )
-    if unlinked_execution_count:
-        blockers.append(BLOCKER_UNLINKED_EXECUTION)
 
-    recent_cost_metrics = (
-        session.execute(
-            select(ExecutionTCAMetric)
-            .where(
-                ExecutionTCAMetric.shortfall_notional.is_not(None),
-                ExecutionTCAMetric.shortfall_notional != 0,
-            )
-            .order_by(ExecutionTCAMetric.computed_at.desc())
-            .limit(limit)
-        )
-        .scalars()
-        .all()
-    )
-    unlinked_cost_count = 0
-    for metric in recent_cost_metrics:
-        if _source_ref_exists(
-            session,
-            settings_obj=settings_obj,
-            source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
-            source_id=execution_tca_metric_source_id(metric),
-            transfer_kind=TRANSFER_KIND_EXECUTION_COST,
-            source_pk=metric.id,
-        ):
-            continue
-        unlinked_cost_count += 1
-        _append_sample(
-            unlinked_refs,
-            {
-                "blocker": BLOCKER_UNLINKED_COST,
-                "source_type": SOURCE_TYPE_EXECUTION_TCA_METRIC,
-                "source_id": execution_tca_metric_source_id(metric),
-                "execution_id": str(metric.execution_id),
-            },
-        )
-    if unlinked_cost_count:
-        blockers.append(BLOCKER_UNLINKED_COST)
+def _process_reconciliation(
+    session: Session,
+    request: _ReconciliationRequest,
+) -> dict[str, object]:
+    started_at = datetime.now(timezone.utc)
+    state = _run_client_lookup(session, request)
+    if state.ref_list:
+        _process_refs(session, state.ref_list, request.settings_obj, state)
+    _collect_unlinked(session, request, state)
+    return _build_final_payload(session, started_at, request, state)
 
-    runtime_bucket_filters: list[ColumnElement[bool]] = [
-        (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
-        | (StrategyRuntimeLedgerBucket.cost_amount != 0)
-    ]
-    if account_label:
-        runtime_bucket_filters.append(
-            StrategyRuntimeLedgerBucket.account_label == account_label
-        )
-    recent_runtime_buckets = (
-        session.execute(
-            select(StrategyRuntimeLedgerBucket)
-            .where(*runtime_bucket_filters)
-            .order_by(StrategyRuntimeLedgerBucket.bucket_ended_at.desc())
-            .limit(limit)
-        )
-        .scalars()
-        .all()
-    )
-    unlinked_runtime_ledger_count = 0
-    for bucket in recent_runtime_buckets:
-        if _source_ref_exists(
-            session,
-            settings_obj=settings_obj,
-            source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-            source_id=str(bucket.id),
-            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
-            source_pk=bucket.id,
-        ):
-            continue
-        unlinked_runtime_ledger_count += 1
-        _append_sample(
-            unlinked_refs,
-            {
-                "blocker": BLOCKER_UNLINKED_RUNTIME_LEDGER,
-                "source_type": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-                "source_id": str(bucket.id),
-                "run_id": bucket.run_id,
-                "candidate_id": bucket.candidate_id,
-            },
-        )
-    if unlinked_runtime_ledger_count:
-        blockers.append(BLOCKER_UNLINKED_RUNTIME_LEDGER)
 
+def _build_final_payload(
+    session: Session,
+    started_at: datetime,
+    request: _ReconciliationRequest,
+    state: _ReconciliationState,
+) -> dict[str, object]:
     finished_at = datetime.now(timezone.utc)
     source_missing_count = (
-        unlinked_event_count
-        + unlinked_execution_count
-        + unlinked_cost_count
-        + unlinked_runtime_ledger_count
-        + source_row_missing_count
-        + source_amount_mismatch_count
+        state.counts.unlinked_event_count
+        + state.counts.unlinked_execution_count
+        + state.counts.unlinked_cost_count
+        + state.counts.unlinked_runtime_ledger_count
+        + state.counts.source_row_missing_count
+        + state.counts.source_amount_mismatch_count
     )
     ref_counts = tigerbeetle_ref_counts(
         session,
-        cluster_id=settings_obj.tigerbeetle_cluster_id,
-        account_label=account_label,
+        cluster_id=request.settings_obj.tigerbeetle_cluster_id,
+        account_label=request.account_label,
     )
     compact_ref_counts = _compact_reconciliation_ref_counts(
-        ref_counts,
-        cluster_id=settings_obj.tigerbeetle_cluster_id,
+        ref_counts, cluster_id=request.settings_obj.tigerbeetle_cluster_id
     )
     runtime_ledger_missing_signed_ref_count = _payload_int(
-        ref_counts,
-        "runtime_ledger_missing_signed_ref_count",
+        ref_counts, "runtime_ledger_missing_signed_ref_count"
     )
     runtime_ledger_missing_account_ref_count = _payload_int(
-        ref_counts,
-        "runtime_ledger_missing_account_ref_count",
+        ref_counts, "runtime_ledger_missing_account_ref_count"
+    )
+    state.counts.runtime_ledger_missing_signed_ref_count = (
+        runtime_ledger_missing_signed_ref_count
+    )
+    state.counts.runtime_ledger_missing_account_ref_count = (
+        runtime_ledger_missing_account_ref_count
     )
     ref_count_stable_ref_mismatch_count = _payload_int(
-        ref_counts,
-        "stable_ref_mismatch_count",
+        ref_counts, "stable_ref_mismatch_count"
     )
     if runtime_ledger_missing_signed_ref_count:
-        blockers.append(BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING)
+        state.blockers.append(BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING)
     if runtime_ledger_missing_account_ref_count:
-        blockers.append(BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING)
+        state.blockers.append(BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING)
     if ref_count_stable_ref_mismatch_count:
-        blockers.append(BLOCKER_STABLE_REF_PAYLOAD_MISMATCH)
-    unique_blockers = sorted(set(blockers))
-    ok = not unique_blockers
-    max_age_seconds = max(1, int(settings_obj.tigerbeetle_reconcile_max_age_seconds))
-    payload: dict[str, object] = {
-        "schema_version": SCHEMA_VERSION,
-        "ok": ok,
-        "cluster_id": settings_obj.tigerbeetle_cluster_id,
-        "account_label": account_label,
-        "started_at": started_at.isoformat(),
-        "finished_at": finished_at.isoformat(),
-        "age_seconds": 0,
-        "reconciliation_stale": False,
-        "reconciliation_max_age_seconds": max_age_seconds,
-        "reconciliation_freshness": {
-            "observed_at": finished_at.isoformat(),
-            "age_seconds": 0,
-            "max_age_seconds": max_age_seconds,
-            "stale": False,
-        },
-        "authority": "accounting_parity_only",
-        "promotion_authority": False,
-        "overrides_runtime_ledger_authority": False,
-        "client_lookup_ok": client_lookup_ok,
-        "client_error": client_error,
-        "account_ref_count": _payload_int(ref_counts, "account_ref_count"),
-        "transfer_ref_count": _payload_int(ref_counts, "transfer_ref_count"),
-        "checked_transfer_count": checked_transfer_count,
-        "missing_transfer_count": missing_transfer_count,
-        "mismatched_transfer_count": mismatched_transfer_count,
-        "mismatched_ref_count": mismatched_transfer_count,
-        "source_missing_count": source_missing_count,
-        "source_row_missing_count": source_row_missing_count,
-        "missing_source_row_count": source_row_missing_count,
-        "source_amount_mismatch_count": source_amount_mismatch_count,
-        "legacy_source_amount_unverifiable_count": (
-            legacy_source_amount_unverifiable_count
-        ),
-        "runtime_ledger_checked_transfer_count": runtime_ledger_checked_transfer_count,
-        "runtime_ledger_signed_transfer_count": runtime_ledger_signed_transfer_count,
-        "runtime_ledger_ref_count": _payload_int(
-            ref_counts,
-            "runtime_ledger_ref_count",
-        ),
-        "runtime_ledger_signed_ref_count": _payload_int(
-            ref_counts,
-            "runtime_ledger_signed_ref_count",
-        ),
-        "runtime_ledger_missing_signed_ref_count": (
-            runtime_ledger_missing_signed_ref_count
-        ),
-        "runtime_ledger_missing_account_ref_count": (
-            runtime_ledger_missing_account_ref_count
-        ),
-        "stable_ref_count": _payload_int(ref_counts, "stable_ref_count"),
-        "stable_ref_missing_count": _payload_int(
-            ref_counts,
-            "stable_ref_missing_count",
-        ),
-        "stable_ref_mismatch_count": max(
-            stable_ref_mismatch_count,
-            ref_count_stable_ref_mismatch_count,
-        ),
-        "archived_runtime_ledger_source_missing_count": archived_runtime_ledger_source_missing_count,
-        "runtime_ledger_direction_mismatch_count": (
-            runtime_ledger_direction_mismatch_count
-        ),
-        "runtime_ledger_metadata_mismatch_count": (
-            runtime_ledger_metadata_mismatch_count
-        ),
-        "unlinked_event_count": unlinked_event_count,
-        "unlinked_order_event_ref_count": unlinked_event_count,
-        "unlinked_execution_count": unlinked_execution_count,
-        "unlinked_execution_ref_count": unlinked_execution_count,
-        "unlinked_cost_count": unlinked_cost_count,
-        "unlinked_cost_ref_count": unlinked_cost_count,
-        "unlinked_runtime_ledger_count": unlinked_runtime_ledger_count,
-        "unlinked_runtime_ledger_ref_count": unlinked_runtime_ledger_count,
-        "ref_counts": ref_counts,
-        "missing_transfer_refs": missing_transfer_refs,
-        "mismatched_refs": mismatched_refs,
-        "missing_source_rows": missing_source_rows,
-        "unlinked_refs": unlinked_refs,
-        "legacy_source_amount_unverifiable_refs": (
-            legacy_source_amount_unverifiable_refs
-        ),
-        "blocker_details": {
-            "missing_transfer_refs": missing_transfer_refs,
-            "mismatched_refs": mismatched_refs,
-            "missing_source_rows": missing_source_rows,
-            "unlinked_refs": unlinked_refs,
-            "legacy_source_amount_unverifiable_refs": (
-                legacy_source_amount_unverifiable_refs
-            ),
-        },
-        "blockers": unique_blockers,
-    }
-    if persist:
-        session.add(
-            TigerBeetleReconciliationRun(
-                cluster_id=settings_obj.tigerbeetle_cluster_id,
+        state.blockers.append(BLOCKER_STABLE_REF_PAYLOAD_MISMATCH)
+    unique_blockers = sorted(set(state.blockers))
+
+    payload = _build_payload_dict(
+        _PayloadBuildContext(
+            settings_obj=request.settings_obj,
+            started_at=started_at,
+            finished_at=finished_at,
+            state=state,
+            ref_counts=ref_counts,
+            unique_blockers=unique_blockers,
+            source_missing_count=source_missing_count,
+            ref_count_stable_ref_mismatch_count=(ref_count_stable_ref_mismatch_count),
+        )
+    )
+    payload = _assemble_reconciliation_payload(payload, state)
+    payload["account_label"] = request.account_label
+
+    if request.persist:
+        _persist_reconciliation_run(
+            session,
+            _PersistenceContext(
+                settings_obj=request.settings_obj,
                 started_at=started_at,
                 finished_at=finished_at,
-                status="ok" if ok else "degraded",
-                checked_transfer_count=checked_transfer_count,
-                missing_transfer_count=missing_transfer_count,
-                mismatched_transfer_count=mismatched_transfer_count,
-                source_missing_count=source_missing_count,
-                account_ref_count=_payload_int(compact_ref_counts, "account_ref_count"),
-                transfer_ref_count=_payload_int(
-                    compact_ref_counts, "transfer_ref_count"
-                ),
-                runtime_ledger_ref_count=_payload_int(
-                    compact_ref_counts,
-                    "runtime_ledger_ref_count",
-                ),
-                runtime_ledger_signed_ref_count=_payload_int(
-                    compact_ref_counts,
-                    "runtime_ledger_signed_ref_count",
-                ),
-                runtime_ledger_missing_signed_ref_count=(
-                    runtime_ledger_missing_signed_ref_count
-                ),
-                runtime_ledger_missing_account_ref_count=(
-                    runtime_ledger_missing_account_ref_count
-                ),
-                stable_ref_count=_payload_int(compact_ref_counts, "stable_ref_count"),
-                stable_ref_missing_count=_payload_int(
-                    compact_ref_counts,
-                    "stable_ref_missing_count",
-                ),
-                stable_ref_mismatch_count=max(
-                    stable_ref_mismatch_count,
-                    ref_count_stable_ref_mismatch_count,
-                ),
-                blockers_json=coerce_json_payload(unique_blockers),
-                ref_counts_json=coerce_json_payload(compact_ref_counts),
-                payload_json=coerce_json_payload(payload),
-            )
+                unique_blockers=unique_blockers,
+                ref_counts=ref_counts,
+                compact_ref_counts=compact_ref_counts,
+                payload=payload,
+                counts=state.counts,
+            ),
         )
-        session.flush()
     return payload
+
+
+def _persist_reconciliation_run(
+    session: Session,
+    context: _PersistenceContext,
+) -> None:
+    counts = context.counts
+    compact_ref_counts = context.compact_ref_counts
+    session.add(
+        TigerBeetleReconciliationRun(
+            cluster_id=context.settings_obj.tigerbeetle_cluster_id,
+            started_at=context.started_at,
+            finished_at=context.finished_at,
+            status="ok" if not context.unique_blockers else "degraded",
+            checked_transfer_count=counts.checked_transfer_count,
+            missing_transfer_count=counts.missing_transfer_count,
+            mismatched_transfer_count=counts.mismatched_transfer_count,
+            source_missing_count=counts.source_row_missing_count
+            + counts.source_amount_mismatch_count
+            + counts.unlinked_event_count
+            + counts.unlinked_execution_count
+            + counts.unlinked_cost_count
+            + counts.unlinked_runtime_ledger_count,
+            account_ref_count=_payload_int(compact_ref_counts, "account_ref_count"),
+            transfer_ref_count=_payload_int(compact_ref_counts, "transfer_ref_count"),
+            runtime_ledger_ref_count=_payload_int(
+                compact_ref_counts, "runtime_ledger_ref_count"
+            ),
+            runtime_ledger_signed_ref_count=_payload_int(
+                compact_ref_counts, "runtime_ledger_signed_ref_count"
+            ),
+            runtime_ledger_missing_signed_ref_count=counts.runtime_ledger_missing_signed_ref_count,
+            runtime_ledger_missing_account_ref_count=counts.runtime_ledger_missing_account_ref_count,
+            stable_ref_count=_payload_int(compact_ref_counts, "stable_ref_count"),
+            stable_ref_missing_count=_payload_int(
+                compact_ref_counts, "stable_ref_missing_count"
+            ),
+            stable_ref_mismatch_count=max(
+                counts.stable_ref_mismatch_count,
+                _payload_int(context.ref_counts, "stable_ref_mismatch_count"),
+            ),
+            blockers_json=coerce_json_payload(context.unique_blockers),
+            ref_counts_json=coerce_json_payload(compact_ref_counts),
+            payload_json=coerce_json_payload(context.payload),
+        )
+    )
+    session.flush()
 
 
 __all__ = (

--- a/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
@@ -142,6 +142,12 @@ class _TransferValidationContext:
 
 
 @dataclass(frozen=True)
+class _SourceValidationContext:
+    ref: TigerBeetleTransferRef
+    state: _ReconciliationState
+
+
+@dataclass(frozen=True)
 class _ReconciliationRequest:
     settings_obj: Settings
     client: TigerBeetleClientProtocol | None
@@ -202,6 +208,9 @@ def _process_single_transfer(
             ),
         )
 
+    source_validation = _SourceValidationContext(ref=ref, state=state)
+    _validate_postgres_source_ref(session, settings_obj, source_validation)
+
     if not state.client_lookup_ok:
         return
 
@@ -220,7 +229,8 @@ def _process_single_transfer(
 
     validation = _TransferValidationContext(ref=ref, actual=actual, state=state)
     _validate_transfer_fields(validation)
-    _validate_event_ref(session, settings_obj, validation)
+    if ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
+        _validate_runtime_ledger(session, validation)
 
 
 def _validate_transfer_fields(context: _TransferValidationContext) -> None:
@@ -302,10 +312,10 @@ def _check_and_append(
     )
 
 
-def _validate_event_ref(
+def _validate_postgres_source_ref(
     session: Session,
     settings_obj: Settings,
-    context: _TransferValidationContext,
+    context: _SourceValidationContext,
 ) -> None:
     if not _ref_matches_expected_event(session, context.ref, settings_obj=settings_obj):
         context.state.counts.mismatched_transfer_count += 1
@@ -316,7 +326,6 @@ def _validate_event_ref(
                 context.ref,
                 blocker=BLOCKER_POSTGRES_REF_MISMATCH,
                 reason="transfer_ref_no_longer_matches_order_event_plan",
-                actual=context.actual,
             ),
         )
 
@@ -327,13 +336,10 @@ def _validate_event_ref(
     }:
         _validate_source_amount(session, context)
 
-    if context.ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
-        _validate_runtime_ledger(session, context)
-
 
 def _validate_source_amount(
     session: Session,
-    context: _TransferValidationContext,
+    context: _SourceValidationContext,
 ) -> None:
     ref = context.ref
     counts = context.state.counts
@@ -351,7 +357,6 @@ def _validate_source_amount(
                     ref,
                     blocker=BLOCKER_SOURCE_ROW_MISSING,
                     reason="source_row_missing_or_source_id_not_uuid",
-                    actual=context.actual,
                 ),
             )
     elif ref.amount != expected_source_amount:
@@ -363,7 +368,6 @@ def _validate_source_amount(
                     ref,
                     blocker="tigerbeetle_legacy_source_amount_unverifiable",
                     reason="legacy_source_ref_lacks_revision_or_archived_amount",
-                    actual=context.actual,
                 ),
             )
         else:
@@ -375,7 +379,6 @@ def _validate_source_amount(
                     ref,
                     blocker=BLOCKER_SOURCE_AMOUNT_MISMATCH,
                     reason="source_amount_micros_differs_from_transfer_ref",
-                    actual=context.actual,
                 ),
             )
 

--- a/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py
@@ -335,6 +335,8 @@ def _validate_postgres_source_ref(
         SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
     }:
         _validate_source_amount(session, context)
+    if context.ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
+        context.state.counts.runtime_ledger_checked_transfer_count += 1
 
 
 def _validate_source_amount(
@@ -389,7 +391,6 @@ def _validate_runtime_ledger(
 ) -> None:
     ref = context.ref
     counts = context.state.counts
-    counts.runtime_ledger_checked_transfer_count += 1
     source_uuid = _uuid_or_none(ref.source_id)
     bucket = (
         session.get(StrategyRuntimeLedgerBucket, source_uuid)

--- a/services/torghut/app/trading/tigerbeetle_reconcile/unlinked_refs.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile/unlinked_refs.py
@@ -1,0 +1,231 @@
+"""Queries for source rows that are missing TigerBeetle transfer refs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.config import Settings
+from app.models import (
+    Execution,
+    ExecutionOrderEvent,
+    ExecutionTCAMetric,
+    StrategyRuntimeLedgerBucket,
+)
+from app.trading.tigerbeetle_journal import (
+    SOURCE_TYPE_EXECUTION,
+    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    build_order_event_transfer_plan,
+    execution_tca_metric_source_id,
+)
+from app.trading.tigerbeetle_ledger_model import (
+    TRANSFER_KIND_EXECUTION_COST,
+    TRANSFER_KIND_EXECUTION_FILL,
+    TRANSFER_KIND_RUNTIME_NET_PNL,
+)
+
+from .shared_context import (
+    BLOCKER_UNLINKED_COST,
+    BLOCKER_UNLINKED_EVENT,
+    BLOCKER_UNLINKED_EXECUTION,
+    BLOCKER_UNLINKED_RUNTIME_LEDGER,
+    append_sample,
+    order_event_ref_exists,
+    source_ref_exists,
+)
+
+
+@dataclass(frozen=True)
+class UnlinkedRefContext:
+    session: Session
+    settings_obj: Settings
+    limit: int
+    account_label: str | None
+    blockers: list[str]
+    samples: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class UnlinkedRefCounts:
+    event_count: int
+    execution_count: int
+    cost_count: int
+    runtime_ledger_count: int
+
+
+def collect_unlinked_refs(context: UnlinkedRefContext) -> UnlinkedRefCounts:
+    return UnlinkedRefCounts(
+        event_count=_query_unlinked_events(context),
+        execution_count=_query_unlinked_executions(context),
+        cost_count=_query_unlinked_costs(context),
+        runtime_ledger_count=_query_unlinked_runtime_buckets(context),
+    )
+
+
+def _query_unlinked_events(context: UnlinkedRefContext) -> int:
+    recent_events = (
+        context.session.execute(
+            select(ExecutionOrderEvent)
+            .order_by(ExecutionOrderEvent.created_at.desc())
+            .limit(context.limit)
+        )
+        .scalars()
+        .all()
+    )
+    unlinked_event_count = 0
+    for event in recent_events:
+        if order_event_ref_exists(
+            context.session, event, settings_obj=context.settings_obj
+        ):
+            continue
+        if (
+            build_order_event_transfer_plan(
+                context.session, event, settings_obj=context.settings_obj
+            )
+            is None
+        ):
+            continue
+        unlinked_event_count += 1
+        append_sample(
+            context.samples,
+            {
+                "blocker": BLOCKER_UNLINKED_EVENT,
+                "source_type": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                "source_id": str(event.id),
+                "event_fingerprint": event.event_fingerprint,
+            },
+        )
+    if unlinked_event_count:
+        context.blockers.append(BLOCKER_UNLINKED_EVENT)
+    return unlinked_event_count
+
+
+def _query_unlinked_executions(context: UnlinkedRefContext) -> int:
+    recent_executions = (
+        context.session.execute(
+            select(Execution)
+            .where(Execution.avg_fill_price.is_not(None), Execution.filled_qty > 0)
+            .order_by(Execution.created_at.desc())
+            .limit(context.limit)
+        )
+        .scalars()
+        .all()
+    )
+    unlinked_execution_count = 0
+    for execution in recent_executions:
+        if source_ref_exists(
+            context.session,
+            settings_obj=context.settings_obj,
+            source_type=SOURCE_TYPE_EXECUTION,
+            source_id=str(execution.id),
+            transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+            source_pk=execution.id,
+        ):
+            continue
+        unlinked_execution_count += 1
+        append_sample(
+            context.samples,
+            {
+                "blocker": BLOCKER_UNLINKED_EXECUTION,
+                "source_type": SOURCE_TYPE_EXECUTION,
+                "source_id": str(execution.id),
+                "alpaca_order_id": execution.alpaca_order_id,
+            },
+        )
+    if unlinked_execution_count:
+        context.blockers.append(BLOCKER_UNLINKED_EXECUTION)
+    return unlinked_execution_count
+
+
+def _query_unlinked_costs(context: UnlinkedRefContext) -> int:
+    recent_cost_metrics = (
+        context.session.execute(
+            select(ExecutionTCAMetric)
+            .where(
+                ExecutionTCAMetric.shortfall_notional.is_not(None),
+                ExecutionTCAMetric.shortfall_notional != 0,
+            )
+            .order_by(ExecutionTCAMetric.computed_at.desc())
+            .limit(context.limit)
+        )
+        .scalars()
+        .all()
+    )
+    unlinked_cost_count = 0
+    for metric in recent_cost_metrics:
+        if source_ref_exists(
+            context.session,
+            settings_obj=context.settings_obj,
+            source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
+            source_id=execution_tca_metric_source_id(metric),
+            transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+            source_pk=metric.id,
+        ):
+            continue
+        unlinked_cost_count += 1
+        append_sample(
+            context.samples,
+            {
+                "blocker": BLOCKER_UNLINKED_COST,
+                "source_type": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                "source_id": execution_tca_metric_source_id(metric),
+                "execution_id": str(metric.execution_id),
+            },
+        )
+    if unlinked_cost_count:
+        context.blockers.append(BLOCKER_UNLINKED_COST)
+    return unlinked_cost_count
+
+
+def _query_unlinked_runtime_buckets(context: UnlinkedRefContext) -> int:
+    runtime_bucket_filters: list[ColumnElement[bool]] = [
+        (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
+        | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+    ]
+    if context.account_label:
+        runtime_bucket_filters.append(
+            StrategyRuntimeLedgerBucket.account_label == context.account_label
+        )
+    recent_runtime_buckets = (
+        context.session.execute(
+            select(StrategyRuntimeLedgerBucket)
+            .where(*runtime_bucket_filters)
+            .order_by(StrategyRuntimeLedgerBucket.bucket_ended_at.desc())
+            .limit(context.limit)
+        )
+        .scalars()
+        .all()
+    )
+    unlinked_runtime_ledger_count = 0
+    for bucket in recent_runtime_buckets:
+        if source_ref_exists(
+            context.session,
+            settings_obj=context.settings_obj,
+            source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            source_id=str(bucket.id),
+            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+            source_pk=bucket.id,
+        ):
+            continue
+        unlinked_runtime_ledger_count += 1
+        append_sample(
+            context.samples,
+            {
+                "blocker": BLOCKER_UNLINKED_RUNTIME_LEDGER,
+                "source_type": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                "source_id": str(bucket.id),
+                "run_id": bucket.run_id,
+                "candidate_id": bucket.candidate_id,
+            },
+        )
+    if unlinked_runtime_ledger_count:
+        context.blockers.append(BLOCKER_UNLINKED_RUNTIME_LEDGER)
+    return unlinked_runtime_ledger_count
+
+
+__all__ = ("UnlinkedRefContext", "UnlinkedRefCounts", "collect_unlinked_refs")

--- a/services/torghut/tests/tigerbeetle_reconcile/test_reconciliation_blocks_unlinked_cost_ref.py
+++ b/services/torghut/tests/tigerbeetle_reconcile/test_reconciliation_blocks_unlinked_cost_ref.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from tests.tigerbeetle_reconcile.support import (
     BLOCKER_CLIENT_UNAVAILABLE,
     BLOCKER_CODE_MISMATCH,
+    BLOCKER_SOURCE_AMOUNT_MISMATCH,
+    BLOCKER_SOURCE_ROW_MISSING,
     BLOCKER_TRANSFER_MISSING,
     BLOCKER_UNLINKED_COST,
     BLOCKER_UNLINKED_RUNTIME_LEDGER,
@@ -268,6 +270,69 @@ class TestReconciliationBlocksUnlinkedCostRef(_TestTigerBeetleReconcileBase):
             self.assertIn("RuntimeError: lookup failed", str(payload["client_error"]))
             self.assertEqual(payload["missing_transfer_count"], 0)
             self.assertEqual(payload["missing_transfer_refs"], [])
+
+    def test_client_failure_preserves_postgres_source_validation(self) -> None:
+        with Session(self.engine) as session:
+            execution = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-client-failure-source-mismatch",
+                client_order_id="client-failure-source-mismatch",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-client-failure-source-mismatch"},
+            )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    TigerBeetleTransferRef(
+                        cluster_id=2001,
+                        transfer_id="1101",
+                        transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+                        ledger=LEDGER_USD_MICRO,
+                        code=TRANSFER_CODE_EXECUTION_FILL,
+                        amount=Decimal("1"),
+                        status="created",
+                        execution_id=execution.id,
+                        source_type=SOURCE_TYPE_EXECUTION,
+                        source_id=f"{execution.id}:current",
+                    ),
+                    TigerBeetleTransferRef(
+                        cluster_id=2001,
+                        transfer_id="1102",
+                        transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+                        ledger=LEDGER_USD_MICRO,
+                        code=TRANSFER_CODE_EXECUTION_FILL,
+                        amount=Decimal("190250000"),
+                        status="created",
+                        source_type=SOURCE_TYPE_EXECUTION,
+                        source_id="6f767a53-6b44-428a-bd85-2f662642f637",
+                    ),
+                ]
+            )
+            session.flush()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=FailingLookupClient(),
+            )
+
+            self.assertFalse(payload["ok"])
+            self.assertIn(BLOCKER_CLIENT_UNAVAILABLE, payload["blockers"])
+            self.assertIn(BLOCKER_SOURCE_AMOUNT_MISMATCH, payload["blockers"])
+            self.assertIn(BLOCKER_SOURCE_ROW_MISSING, payload["blockers"])
+            self.assertNotIn(BLOCKER_TRANSFER_MISSING, payload["blockers"])
+            self.assertEqual(payload["source_amount_mismatch_count"], 1)
+            self.assertEqual(payload["source_row_missing_count"], 1)
+            self.assertEqual(payload["source_missing_count"], 2)
+            self.assertEqual(payload["missing_transfer_count"], 0)
 
     def test_latest_reconciliation_payload_normalizes_blockers(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/tigerbeetle_reconcile/test_reconciliation_blocks_unlinked_cost_ref.py
+++ b/services/torghut/tests/tigerbeetle_reconcile/test_reconciliation_blocks_unlinked_cost_ref.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from tests.tigerbeetle_reconcile.support import (
     BLOCKER_CLIENT_UNAVAILABLE,
     BLOCKER_CODE_MISMATCH,
+    BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH,
+    BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH,
     BLOCKER_SOURCE_AMOUNT_MISMATCH,
     BLOCKER_SOURCE_ROW_MISSING,
     BLOCKER_TRANSFER_MISSING,
@@ -29,9 +31,12 @@ from tests.tigerbeetle_reconcile.support import (
     TigerBeetleTransferRef,
     TigerBeetleTransferSpec,
     _TestTigerBeetleReconcileBase,
+    _add_account_refs_for_plan,
     _add_ref,
+    _runtime_bucket,
     archived_runtime_ledger_amount_micros,
     attr,
+    build_runtime_ledger_bucket_transfer_plan,
     cost_amount_micros,
     execution_amount_micros,
     expected_source_amount_micros,
@@ -333,6 +338,68 @@ class TestReconciliationBlocksUnlinkedCostRef(_TestTigerBeetleReconcileBase):
             self.assertEqual(payload["source_row_missing_count"], 1)
             self.assertEqual(payload["source_missing_count"], 2)
             self.assertEqual(payload["missing_transfer_count"], 0)
+
+    def test_client_failure_preserves_runtime_ledger_checked_count(self) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            _add_account_refs_for_plan(session, plan)
+            transfer = plan.transfer_spec
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(transfer.transfer_id),
+                    transfer_kind=transfer.transfer_kind,
+                    ledger=transfer.ledger,
+                    code=transfer.code,
+                    amount=Decimal(transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "run_id": bucket.run_id,
+                        "candidate_id": bucket.candidate_id,
+                        "hypothesis_id": bucket.hypothesis_id,
+                        "observed_stage": bucket.observed_stage,
+                        "pnl_basis": bucket.pnl_basis,
+                        "ledger_schema_version": bucket.ledger_schema_version,
+                        "amount_source": str(plan.amount_source),
+                        "signed_amount_micros": plan.signed_amount_micros,
+                        "pnl_direction": plan.pnl_direction,
+                        "runtime_key": plan.runtime_key,
+                        "debit_account_id": str(transfer.debit_account_id),
+                        "credit_account_id": str(transfer.credit_account_id),
+                    },
+                )
+            )
+            session.flush()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=FailingLookupClient(),
+            )
+
+            self.assertFalse(payload["ok"])
+            self.assertIn(BLOCKER_CLIENT_UNAVAILABLE, payload["blockers"])
+            self.assertEqual(payload["runtime_ledger_checked_transfer_count"], 1)
+            self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 0)
+            self.assertEqual(payload["mismatched_transfer_count"], 0)
+            self.assertNotIn(BLOCKER_TRANSFER_MISSING, payload["blockers"])
+            self.assertNotIn(
+                BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH,
+                payload["blockers"],
+            )
+            self.assertNotIn(
+                BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH,
+                payload["blockers"],
+            )
 
     def test_latest_reconciliation_payload_normalizes_blockers(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Extracts unlinked TigerBeetle source-reference discovery from the reconciliation owner into a focused module.
- Preserves the exact TigerBeetle reconciliation behavior from PR #11756 while excluding its unrelated profitability-manifest refactor.
- Reduces the reconciliation owner below the 1,000-line module limit without changing public APIs or runtime configuration.

## Related Issues

Supersedes the TigerBeetle reconciliation portion of #11756.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/tigerbeetle_reconcile tests/journal_tigerbeetle_order_events/test_source_selection_and_reconciliation.py tests/journal_tigerbeetle_order_events/test_empty_selection_reconciliation_headroom.py` (55 passed)
- `uv run --frozen ruff check app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py app/trading/tigerbeetle_reconcile/unlinked_refs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py app/trading/tigerbeetle_reconcile/unlinked_refs.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks app/trading/tigerbeetle_reconcile/latest_tigerbeetle_reconciliation_status_p.py app/trading/tigerbeetle_reconcile/unlinked_refs.py`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- Focused coverage plus `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 80` (294/295 changed executable lines, 99.66%)
- `kubectl get deployment torghut-scheduler -n torghut` confirmed desired replicas remain `0`.

## Screenshots (if applicable)

N/A. Backend-only refactor with no UI changes.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation change is required for this internal refactor.
