### PR TITLE
chore(torghut): promote image sha-893e1cfc47a62fff4e6ed885cdd6432f078bf43c

### DIFF
--- a/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/db-migrations-job.yaml
@@ -22,7 +22,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: migrate
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           imagePullPolicy: Always
           workingDir: /app
           command:
@@ -52,9 +52,9 @@ spec:
               alembic -c /app/alembic.ini upgrade heads
           env:
             - name: TORGHUT_COMMIT
-              value: 95aa430167fb1993df25d557caeeac9cae2f56fe
+              value: 893e1cfc47a62fff4e6ed885cdd6432f078bf43c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+              value: sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
             - name: PYTHONPATH
               value: /app
             - name: DB_DSN

--- a/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
+++ b/argocd/applications/torghut-hyperliquid-runtime/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-hyperliquid-runtime
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           imagePullPolicy: Always
           command:
             - uvicorn
@@ -46,9 +46,9 @@ spec:
                 name: torghut-hyperliquid-runtime-config
           env:
             - name: TORGHUT_COMMIT
-              value: 95aa430167fb1993df25d557caeeac9cae2f56fe
+              value: 893e1cfc47a62fff4e6ed885cdd6432f078bf43c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+              value: sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -72,9 +72,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1745-g95aa43016
+              value: v0.596.0-1747-g893e1cfc4
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 95aa430167fb1993df25d557caeeac9cae2f56fe
+              value: 893e1cfc47a62fff4e6ed885cdd6432f078bf43c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -77,9 +77,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.596.0-1745-g95aa43016
+              value: v0.596.0-1747-g893e1cfc4
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 95aa430167fb1993df25d557caeeac9cae2f56fe
+              value: 893e1cfc47a62fff4e6ed885cdd6432f078bf43c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           workingDir: /app
           command:
             - /bin/sh

--- a/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
+++ b/argocd/applications/torghut/generated-resource-retention-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-generated-resource-retention
           containers:
             - name: prune-generated-residue
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-12T03:02:05Z"
+        client.knative.dev/updateTimestamp: "2026-07-12T03:34:39Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           ports:
             - name: http1
               containerPort: 8181
@@ -543,11 +543,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1745-g95aa43016
+              value: v0.596.0-1747-g893e1cfc4
             - name: TORGHUT_COMMIT
-              value: 95aa430167fb1993df25d557caeeac9cae2f56fe
+              value: 893e1cfc47a62fff4e6ed885cdd6432f078bf43c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+              value: sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-07-12T03:02:05Z"
+        client.knative.dev/updateTimestamp: "2026-07-12T03:34:39Z"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
     spec:
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           ports:
             - name: http1
               containerPort: 8181
@@ -448,11 +448,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1745-g95aa43016
+              value: v0.596.0-1747-g893e1cfc4
             - name: TORGHUT_COMMIT
-              value: 95aa430167fb1993df25d557caeeac9cae2f56fe
+              value: 893e1cfc47a62fff4e6ed885cdd6432f078bf43c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+              value: sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/scheduler-deployment.yaml
+++ b/argocd/applications/torghut/scheduler-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           command:
             - uvicorn
           args:
@@ -464,11 +464,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-1745-g95aa43016
+              value: v0.596.0-1747-g893e1cfc4
             - name: TORGHUT_COMMIT
-              value: 95aa430167fb1993df25d557caeeac9cae2f56fe
+              value: 893e1cfc47a62fff4e6ed885cdd6432f078bf43c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+              value: sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
             - name: TORGHUT_REQUIRED_IMAGE_PLATFORMS
               value: linux/amd64,linux/arm64
             - name: TORGHUT_OBSERVED_IMAGE_PLATFORMS

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: torghut-runtime
           containers:
             - name: run-zero-notional-drift-repair
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:180e0e63299ce45f6b1f1efce2408bfc8173a41e9cc8fb844b0de09e6501f8b4
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `893e1cfc47a62fff4e6ed885cdd6432f078bf43c`
- Image tag: `sha-893e1cfc47a62fff4e6ed885cdd6432f078bf43c`
- Image digest: `sha256:31f4b70f71dc5f08e9e0b4977da77b29039a976cda6a6545fc7c838d5c0bccc2`
- Manifests: core Torghut, simulation, jobs/workflows, Hyperliquid runtime, options catalog, options enricher