### PR TITLE
feat(torghut): add strict alpaca order lookup

### DIFF
--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -37,6 +37,17 @@ class OrderFirewallViolation(PermissionError):
     """Raised when broker mutation methods are called outside OrderFirewall."""
 
 
+class AlpacaStrictOrderLookupMalformedError(RuntimeError):
+    """Raised when an exact broker lookup returns no trustworthy order payload."""
+
+
+def _is_explicit_http_not_found(exc: APIError) -> bool:
+    """Return whether Alpaca supplied an unambiguous HTTP 404 status."""
+
+    status_code: object = getattr(exc, "status_code", None)
+    return type(status_code) is int and status_code == 404
+
+
 _RESERVED_ORDER_EXTRA_PARAMS = frozenset(
     {
         "limit_price",
@@ -208,8 +219,7 @@ class TorghutAlpacaClient:
         try:
             asset = self.trading.get_asset(symbol_or_asset_id)
         except APIError as exc:
-            status_code = getattr(exc, "status_code", None)
-            if isinstance(status_code, int) and status_code == 404:
+            if _is_explicit_http_not_found(exc):
                 return None
             raise
         if asset is None:
@@ -241,14 +251,37 @@ class TorghutAlpacaClient:
         try:
             order = self.trading.get_order_by_client_id(client_order_id)
         except APIError as exc:
-            status_code = getattr(exc, "status_code", None)
-            if isinstance(status_code, int) and status_code == 404:
+            if _is_explicit_http_not_found(exc):
                 return None
             raise
         if order is None:
             return None
 
         return self._model_to_dict(order)
+
+    def get_order_by_client_order_id_strict(
+        self, client_order_id: str
+    ) -> dict[str, object] | None:
+        """Read one exact client id once; only an explicit broker 404 means absent."""
+
+        if not client_order_id.strip():
+            raise ValueError("alpaca_client_order_id_required")
+        try:
+            order = self._trading.get_order_by_client_id(client_order_id)
+        except APIError as exc:
+            if _is_explicit_http_not_found(exc):
+                return None
+            raise
+        if order is None:
+            raise AlpacaStrictOrderLookupMalformedError(
+                "alpaca_strict_order_lookup_missing_payload"
+            )
+        raw = self._extract_model_payload(order)
+        if any(not isinstance(key, str) for key in raw):
+            raise AlpacaStrictOrderLookupMalformedError(
+                "alpaca_strict_order_lookup_non_string_key"
+            )
+        return {cast(str, key): value for key, value in raw.items()}
 
     def submit_order(
         self,
@@ -476,6 +509,7 @@ def _normalize_alpaca_base_url(base_url: Optional[str]) -> Optional[str]:
 
 
 __all__ = [
+    "AlpacaStrictOrderLookupMalformedError",
     "OrderFirewallToken",
     "OrderFirewallViolation",
     "TorghutAlpacaClient",

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -11,7 +11,11 @@ from alpaca.trading.requests import GetOrdersRequest
 from requests import Response
 from requests.exceptions import HTTPError
 
-from app.alpaca_client import OrderFirewallViolation, TorghutAlpacaClient
+from app.alpaca_client import (
+    AlpacaStrictOrderLookupMalformedError,
+    OrderFirewallViolation,
+    TorghutAlpacaClient,
+)
 from app.alpaca_client import OrderFirewallToken
 from app.config import settings
 from app.trading.firewall import OrderFirewall
@@ -51,7 +55,7 @@ class DummyTradingClient:
     def get_order_by_id(self, order_id: str) -> DummyModel:
         return DummyModel(id=order_id, symbol="AAPL")
 
-    def get_order_by_client_id(self, client_id: str) -> DummyModel:
+    def get_order_by_client_id(self, client_id: str) -> DummyModel | None:
         return DummyModel(id="order-xyz", client_order_id=client_id)
 
     def submit_order(self, order_data: Any) -> DummyModel:
@@ -304,6 +308,175 @@ class TestAlpacaClient(TestCase):
         assert order is not None
         self.assertEqual(order["id"], "order-xyz")
         self.assertEqual(order["client_order_id"], "client-123")
+
+        strict_order = client.get_order_by_client_order_id_strict("client-123")
+        assert strict_order is not None
+        self.assertEqual(strict_order["id"], "order-xyz")
+        self.assertEqual(strict_order["client_order_id"], "client-123")
+
+    def test_strict_client_order_lookup_rejects_missing_or_malformed_payload(
+        self,
+    ) -> None:
+        class MalformedLookupTradingClient(DummyTradingClient):
+            def __init__(self, payload: object) -> None:
+                super().__init__()
+                self.payload = payload
+
+            def get_order_by_client_id(self, client_id: str) -> Any:
+                del client_id
+                return self.payload
+
+        for payload, expected_error in (
+            (None, "missing_payload"),
+            ({1: "not-a-string-key"}, "non_string_key"),
+        ):
+            with self.subTest(expected_error=expected_error):
+                client = TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url="https://paper-api.alpaca.markets",
+                    trading_client=MalformedLookupTradingClient(payload),
+                    data_client=DummyDataClient(),
+                )
+
+                with self.assertRaisesRegex(
+                    AlpacaStrictOrderLookupMalformedError,
+                    expected_error,
+                ):
+                    client.get_order_by_client_order_id_strict("client-123")
+
+    def test_strict_client_order_lookup_requires_non_empty_client_id(self) -> None:
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=DummyTradingClient(),
+            data_client=DummyDataClient(),
+        )
+
+        for client_order_id in ("", "   "):
+            with (
+                self.subTest(client_order_id=repr(client_order_id)),
+                self.assertRaisesRegex(ValueError, "client_order_id_required"),
+            ):
+                client.get_order_by_client_order_id_strict(client_order_id)
+
+    def test_strict_client_order_lookup_uses_exact_endpoint_and_only_404_is_absent(
+        self,
+    ) -> None:
+        for status_code in (401, 403, 404, 429, 500, 503):
+            with self.subTest(status_code=status_code):
+                client = TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url="https://paper-api.alpaca.markets",
+                    data_client=DummyDataClient(),
+                )
+                response = Mock(spec=Response)
+                response.status_code = status_code
+                response.text = (
+                    f'{{"code": {status_code}, "message": "lookup failure"}}'
+                )
+                response.raise_for_status.side_effect = HTTPError(response=response)
+
+                with (
+                    patch(
+                        "alpaca.common.rest.Session.request", return_value=response
+                    ) as mock_request,
+                    patch("alpaca.common.rest.time.sleep") as mock_sleep,
+                ):
+                    if status_code == 404:
+                        self.assertIsNone(
+                            client.get_order_by_client_order_id_strict("client-123")
+                        )
+                    else:
+                        with self.assertRaises(APIError) as raised:
+                            client.get_order_by_client_order_id_strict("client-123")
+                        self.assertEqual(raised.exception.status_code, status_code)
+
+                mock_request.assert_called_once()
+                self.assertEqual(mock_request.call_args.args[0], "GET")
+                self.assertTrue(
+                    mock_request.call_args.args[1].endswith(
+                        "/orders:by_client_order_id"
+                    )
+                )
+                self.assertEqual(
+                    mock_request.call_args.kwargs["params"],
+                    {"client_order_id": "client-123"},
+                )
+                mock_sleep.assert_not_called()
+
+    def test_404_classification_rejects_404_like_non_integer_statuses(self) -> None:
+        class IntLike404(int):
+            pass
+
+        class FailingReadTradingClient(DummyTradingClient):
+            def __init__(self, error: APIError) -> None:
+                super().__init__()
+                self.error = error
+
+            def get_asset(self, symbol_or_asset_id: str) -> DummyModel:
+                del symbol_or_asset_id
+                raise self.error
+
+            def get_order_by_client_id(self, client_id: str) -> DummyModel | None:
+                del client_id
+                raise self.error
+
+        for status_code in (True, "404", 404.0, IntLike404(404), None):
+            with self.subTest(status_code=repr(status_code)):
+                response = Mock(spec=Response)
+                response.status_code = status_code
+                error = APIError(
+                    '{"code": 404, "message": "lookup failure"}',
+                    HTTPError(response=response),
+                )
+                client = TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url="https://paper-api.alpaca.markets",
+                    trading_client=FailingReadTradingClient(error),
+                    data_client=DummyDataClient(),
+                )
+
+                for lookup in (
+                    lambda: client.get_asset("AAPL"),
+                    lambda: client.get_order_by_client_order_id("client-123"),
+                    lambda: client.get_order_by_client_order_id_strict("client-123"),
+                ):
+                    with self.assertRaises(APIError) as raised:
+                        lookup()
+                    self.assertIs(raised.exception, error)
+
+    def test_explicit_http_404_is_not_found_for_optional_reads(self) -> None:
+        response = Mock(spec=Response)
+        response.status_code = 404
+        error = APIError(
+            '{"code": 404, "message": "not found"}',
+            HTTPError(response=response),
+        )
+
+        class NotFoundTradingClient(DummyTradingClient):
+            def get_asset(self, symbol_or_asset_id: str) -> DummyModel:
+                del symbol_or_asset_id
+                raise error
+
+            def get_order_by_client_id(self, client_id: str) -> DummyModel | None:
+                del client_id
+                raise error
+
+        client = TorghutAlpacaClient(
+            api_key="k",
+            secret_key="s",
+            base_url="https://paper-api.alpaca.markets",
+            trading_client=NotFoundTradingClient(),
+            data_client=DummyDataClient(),
+        )
+
+        self.assertIsNone(client.get_asset("AAPL"))
+        self.assertIsNone(client.get_order_by_client_order_id("client-123"))
+        self.assertIsNone(client.get_order_by_client_order_id_strict("client-123"))
 
     def test_get_asset_returns_model_from_read_surface(self) -> None:
         client = TorghutAlpacaClient(


### PR DESCRIPTION
## Summary

- Add a single-attempt exact Alpaca client-order-id lookup for ambiguous submission recovery.
- Treat only a real integer HTTP 404 as absence; propagate authentication, server, malformed, and fake-404 failures as indeterminate errors.
- Centralize the 404 classifier for optional asset and client-order reads without changing the existing order-submission parameter allowlist.

## Related Issues

None.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_alpaca_client.py -q` (22 passed)
- `uv run --frozen ruff format app/alpaca_client.py tests/test_alpaca_client.py`
- `uv run --frozen ruff check app/alpaca_client.py tests/test_alpaca_client.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/alpaca_client.py tests/test_alpaca_client.py`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- Focused coverage plus `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 80 --base-ref origin/main` (21/21 changed executable lines, 100%)
- `kubectl get deploy -n torghut` confirmed `torghut-scheduler` remains at 0 replicas.

## Screenshots (if applicable)

N/A. No UI changes.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation change is required for this internal recovery primitive.
