### PR TITLE
feat(torghut): validate Alpaca recovery observations

### DIFF
--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -30,6 +30,7 @@ _SYMBOL = re.compile(r"^[A-Z][A-Z0-9./-]{0,31}$")
 _ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit", "trailing_stop"})
 _TIME_IN_FORCE = frozenset({"day", "gtc", "opg", "cls", "ioc", "fok"})
 _BROKER_STATUSES = frozenset(status.value for status in OrderStatus)
+_FULL_FILL_PERMITTED_STATUSES = frozenset({"calculated", "filled"})
 _ZERO_FILL_STATUSES = frozenset(
     {
         "accepted",
@@ -502,7 +503,9 @@ def _lifecycle_is_valid(
         return False
     if (filled_qty == 0) != (filled_avg_price is None):
         return False
-    if (status == "filled") != (filled_qty == submitted_qty):
+    if (status == "filled" and filled_qty != submitted_qty) or (
+        filled_qty == submitted_qty and status not in _FULL_FILL_PERMITTED_STATUSES
+    ):
         return False
     if status == "partially_filled" and not 0 < filled_qty < submitted_qty:
         return False

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -27,6 +27,7 @@ from ..broker_mutation_receipts.validation import (
 
 
 _SYMBOL = re.compile(r"^[A-Z][A-Z0-9./-]{0,31}$")
+_DECIMAL_TEXT = re.compile(r"^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?$")
 _ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit", "trailing_stop"})
 _TIME_IN_FORCE = frozenset({"day", "gtc", "opg", "cls", "ioc", "fok"})
 _UNSUPPORTED_NESTED_ORDER_FIELDS = ("take_profit", "stop_loss", "legs")
@@ -573,6 +574,7 @@ def _decimal(
         isinstance(value, bool)
         or isinstance(value, float)
         or not isinstance(value, (str, int, Decimal))
+        or (isinstance(value, str) and _DECIMAL_TEXT.fullmatch(value) is None)
     ):
         return None
     try:

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -15,7 +15,7 @@ from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 from typing import cast
 
-from alpaca.trading.enums import OrderStatus
+from alpaca.trading.enums import OrderStatus, PositionIntent
 
 from ..broker_mutation_receipts import BrokerMutationIntent
 from ..broker_mutation_receipts.canonicalization import (
@@ -30,6 +30,7 @@ _SYMBOL = re.compile(r"^[A-Z][A-Z0-9./-]{0,31}$")
 _ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit", "trailing_stop"})
 _TIME_IN_FORCE = frozenset({"day", "gtc", "opg", "cls", "ioc", "fok"})
 _BROKER_STATUSES = frozenset(status.value for status in OrderStatus)
+_POSITION_INTENTS = frozenset(position_intent.value for position_intent in PositionIntent)
 _FULL_FILL_PERMITTED_STATUSES = frozenset({"calculated", "filled"})
 _ZERO_FILL_STATUSES = frozenset(
     {
@@ -393,7 +394,7 @@ def _parse_terms(
     order_type = _lower_text(payload.get(type_key), maximum=32)
     time_in_force = _lower_text(payload.get("time_in_force"), maximum=16)
     order_class = _normalized_order_class(payload.get("order_class"), broker=broker)
-    position_intent = _optional_lower_text(payload.get("position_intent"), maximum=32)
+    position_intent = _optional_position_intent(payload.get("position_intent"))
     extended_hours = payload.get("extended_hours")
     if (
         symbol is None
@@ -612,6 +613,13 @@ def _optional_lower_text(value: object, *, maximum: int) -> str | None | _Invali
         return None
     normalized = _lower_text(value, maximum=maximum)
     return normalized if normalized is not None else _INVALID
+
+
+def _optional_position_intent(value: object) -> str | None | _Invalid:
+    normalized = _optional_lower_text(value, maximum=32)
+    if normalized is None or normalized is _INVALID:
+        return normalized
+    return normalized if normalized in _POSITION_INTENTS else _INVALID
 
 
 def _indeterminate(

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -1,0 +1,627 @@
+"""Pure validation for an Alpaca order observed during submission recovery.
+
+This module deliberately has no persistence or execution-materialization imports. A
+recovery worker must first obtain a ``VALIDATED`` result before it can consider a
+separate terminal transition.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+from typing import cast
+
+from ..broker_mutation_receipts import BrokerMutationIntent
+from ..broker_mutation_receipts.canonicalization import (
+    verify_broker_mutation_intent,
+)
+from ..broker_mutation_receipts.validation import (
+    BrokerMutationReceiptValidationError,
+)
+
+
+_SYMBOL = re.compile(r"^[A-Z][A-Z0-9./-]{0,31}$")
+_ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit", "trailing_stop"})
+_TIME_IN_FORCE = frozenset({"day", "gtc", "opg", "cls", "ioc", "fok"})
+_BROKER_STATUSES = frozenset(
+    {
+        "accepted",
+        "accepted_for_bidding",
+        "calculated",
+        "canceled",
+        "done_for_day",
+        "expired",
+        "filled",
+        "new",
+        "partially_filled",
+        "pending_cancel",
+        "pending_new",
+        "pending_replace",
+        "rejected",
+        "replaced",
+        "stopped",
+        "suspended",
+    }
+)
+_ZERO_FILL_STATUSES = frozenset(
+    {"accepted", "accepted_for_bidding", "new", "pending_new", "rejected"}
+)
+
+
+class AlpacaRecoveryObservationOutcome(StrEnum):
+    """Whether an observed broker payload is safe for later recovery use."""
+
+    VALIDATED = "validated"
+    INDETERMINATE = "indeterminate"
+
+
+class AlpacaRecoveryObservationReason(StrEnum):
+    """Stable fail-closed classifications for nonterminal recovery evidence."""
+
+    INTENT_INVALID = "alpaca_recovery_intent_invalid"
+    ROUTE_INVALID = "alpaca_recovery_route_invalid"
+    OPERATION_INVALID = "alpaca_recovery_operation_invalid"
+    LINKAGE_INVALID = "alpaca_recovery_linkage_invalid"
+    ACCOUNT_REQUIRED = "alpaca_recovery_account_required"
+    ACCOUNT_MISMATCH = "alpaca_recovery_account_mismatch"
+    REQUEST_INVALID = "alpaca_recovery_request_invalid"
+    NOTIONAL_INDETERMINATE = "notional_submission_recovery_indeterminate"
+    REQUEST_QTY_INVALID = "alpaca_recovery_request_qty_invalid"
+    REQUEST_TERMS_INVALID = "alpaca_recovery_request_terms_invalid"
+    BROKER_PAYLOAD_INVALID = "alpaca_recovery_broker_payload_invalid"
+    BROKER_ORDER_ID_INVALID = "alpaca_recovery_broker_order_id_invalid"
+    BROKER_ORDER_ID_MISMATCH = "alpaca_recovery_broker_order_id_mismatch"
+    CLIENT_ORDER_ID_MISMATCH = "alpaca_recovery_client_order_id_mismatch"
+    ORDER_IDENTITY_MISMATCH = "alpaca_recovery_order_identity_mismatch"
+    BROKER_STATUS_INVALID = "alpaca_recovery_broker_status_invalid"
+    BROKER_FILL_INVALID = "alpaca_recovery_broker_fill_invalid"
+    BROKER_LIFECYCLE_INVALID = "alpaca_recovery_broker_lifecycle_invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class AlpacaOrderTerms:
+    """Exact economic and routing terms shared by request and broker order."""
+
+    symbol: str
+    side: str
+    qty: Decimal
+    order_type: str
+    time_in_force: str
+    limit_price: Decimal | None
+    stop_price: Decimal | None
+    trail_price: Decimal | None
+    trail_percent: Decimal | None
+    order_class: str
+    position_intent: str | None
+    extended_hours: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedAlpacaRecoveryOrder:
+    """Broker truth that exactly matches one canonical quantity submission."""
+
+    account_label: str
+    broker_order_id: str
+    client_order_id: str
+    status: str
+    filled_qty: Decimal
+    filled_avg_price: Decimal | None
+    terms: AlpacaOrderTerms
+
+
+@dataclass(frozen=True, slots=True)
+class AlpacaRecoveryObservation:
+    """A pure, nonterminal classification of one exact broker lookup result."""
+
+    outcome: AlpacaRecoveryObservationOutcome
+    reason: AlpacaRecoveryObservationReason | None
+    order: ValidatedAlpacaRecoveryOrder | None
+
+    @property
+    def validated(self) -> bool:
+        return self.outcome is AlpacaRecoveryObservationOutcome.VALIDATED
+
+
+@dataclass(frozen=True, slots=True)
+class _ExpectedRecovery:
+    account_label: str
+    terms: AlpacaOrderTerms
+
+
+@dataclass(frozen=True, slots=True)
+class _BrokerIdentity:
+    broker_order_id: str
+    client_order_id: str
+    terms: AlpacaOrderTerms
+
+
+def validate_alpaca_recovery_observation(
+    *,
+    intent: BrokerMutationIntent,
+    account_label: object,
+    broker_order: object,
+    expected_broker_order_id: object | None = None,
+) -> AlpacaRecoveryObservation:
+    """Classify broker evidence without mutating a receipt, claim, or execution."""
+
+    intent_failure = _validate_intent_identity(intent)
+    if intent_failure is not None:
+        return _indeterminate(intent_failure)
+    expected = _expected_recovery(intent, account_label)
+    if isinstance(expected, AlpacaRecoveryObservationReason):
+        return _indeterminate(expected)
+    broker_payload = _broker_payload(broker_order)
+    if broker_payload is None:
+        return _indeterminate(AlpacaRecoveryObservationReason.BROKER_PAYLOAD_INVALID)
+    identity = _broker_identity(
+        broker_payload,
+        intent=intent,
+        expected=expected,
+        expected_broker_order_id=expected_broker_order_id,
+    )
+    if isinstance(identity, AlpacaRecoveryObservationReason):
+        return _indeterminate(identity)
+    lifecycle = _broker_lifecycle(
+        broker_payload,
+        submitted_qty=expected.terms.qty,
+    )
+    if isinstance(lifecycle, AlpacaRecoveryObservationReason):
+        return _indeterminate(lifecycle)
+    status, filled_qty, filled_avg_price = lifecycle
+    return AlpacaRecoveryObservation(
+        outcome=AlpacaRecoveryObservationOutcome.VALIDATED,
+        reason=None,
+        order=ValidatedAlpacaRecoveryOrder(
+            account_label=expected.account_label,
+            broker_order_id=identity.broker_order_id,
+            client_order_id=identity.client_order_id,
+            status=status,
+            filled_qty=filled_qty,
+            filled_avg_price=filled_avg_price,
+            terms=identity.terms,
+        ),
+    )
+
+
+def _expected_recovery(
+    intent: BrokerMutationIntent,
+    account_label: object,
+) -> _ExpectedRecovery | AlpacaRecoveryObservationReason:
+    account = _validated_account(intent, account_label)
+    if isinstance(account, AlpacaRecoveryObservationReason):
+        return account
+    terms = _canonical_request_terms(intent)
+    if isinstance(terms, AlpacaRecoveryObservationReason):
+        return terms
+    return _ExpectedRecovery(account_label=account, terms=terms)
+
+
+def _validated_account(
+    intent: BrokerMutationIntent,
+    account_label: object,
+) -> str | AlpacaRecoveryObservationReason:
+    if not isinstance(account_label, str) or not account_label.strip():
+        return AlpacaRecoveryObservationReason.ACCOUNT_REQUIRED
+    observed_account = account_label.strip()
+    if observed_account != account_label or observed_account != intent.account_label:
+        return AlpacaRecoveryObservationReason.ACCOUNT_MISMATCH
+    return observed_account
+
+
+def _canonical_request_terms(
+    intent: BrokerMutationIntent,
+) -> AlpacaOrderTerms | AlpacaRecoveryObservationReason:
+    request = _canonical_request(intent)
+    if request is None:
+        return AlpacaRecoveryObservationReason.REQUEST_INVALID
+    sizing = _request_sizing(request)
+    if isinstance(sizing, AlpacaRecoveryObservationReason):
+        return sizing
+    terms = _parse_terms(request, qty=sizing, broker=False)
+    if terms is None:
+        return AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID
+    return terms
+
+
+def _broker_payload(value: object) -> Mapping[str, object] | None:
+    if not isinstance(value, Mapping):
+        return None
+    payload = cast(Mapping[object, object], value)
+    if any(not isinstance(key, str) for key in payload):
+        return None
+    return cast(Mapping[str, object], payload)
+
+
+def _broker_identity(
+    payload: Mapping[str, object],
+    *,
+    intent: BrokerMutationIntent,
+    expected: _ExpectedRecovery,
+    expected_broker_order_id: object | None,
+) -> _BrokerIdentity | AlpacaRecoveryObservationReason:
+    linkage = _broker_linkage(
+        payload,
+        intent=intent,
+        account_label=expected.account_label,
+        expected_broker_order_id=expected_broker_order_id,
+    )
+    if isinstance(linkage, AlpacaRecoveryObservationReason):
+        return linkage
+    broker_order_id, client_order_id = linkage
+    terms = _broker_terms(payload, expected=expected.terms)
+    if isinstance(terms, AlpacaRecoveryObservationReason):
+        return terms
+    return _BrokerIdentity(
+        broker_order_id=broker_order_id,
+        client_order_id=client_order_id,
+        terms=terms,
+    )
+
+
+def _broker_linkage(
+    payload: Mapping[str, object],
+    *,
+    intent: BrokerMutationIntent,
+    account_label: str,
+    expected_broker_order_id: object | None,
+) -> tuple[str, str] | AlpacaRecoveryObservationReason:
+    account_failure = _validate_broker_account(
+        payload,
+        observed_account=account_label,
+    )
+    if account_failure is not None:
+        return account_failure
+    broker_order_id = _bounded_text(payload.get("id"), maximum=128)
+    if broker_order_id is None:
+        return AlpacaRecoveryObservationReason.BROKER_ORDER_ID_INVALID
+    if not _broker_order_id_matches(broker_order_id, expected_broker_order_id):
+        return AlpacaRecoveryObservationReason.BROKER_ORDER_ID_MISMATCH
+    client_order_id = _bounded_text(payload.get("client_order_id"), maximum=128)
+    if client_order_id != intent.client_request_id:
+        return AlpacaRecoveryObservationReason.CLIENT_ORDER_ID_MISMATCH
+    return broker_order_id, cast(str, client_order_id)
+
+
+def _broker_order_id_matches(
+    broker_order_id: str,
+    expected_broker_order_id: object | None,
+) -> bool:
+    if expected_broker_order_id is None:
+        return True
+    expected_id = _bounded_text(expected_broker_order_id, maximum=128)
+    return expected_id == broker_order_id
+
+
+def _broker_terms(
+    payload: Mapping[str, object],
+    *,
+    expected: AlpacaOrderTerms,
+) -> AlpacaOrderTerms | AlpacaRecoveryObservationReason:
+    broker_qty = _decimal(payload.get("qty"), positive=True, allow_zero=False)
+    if broker_qty is None:
+        return AlpacaRecoveryObservationReason.BROKER_PAYLOAD_INVALID
+    if payload.get("notional") is not None:
+        return AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH
+    terms = _parse_terms(payload, qty=broker_qty, broker=True)
+    if terms is None or terms != expected:
+        return AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH
+    return terms
+
+
+def _broker_lifecycle(
+    payload: Mapping[str, object],
+    *,
+    submitted_qty: Decimal,
+) -> tuple[str, Decimal, Decimal | None] | AlpacaRecoveryObservationReason:
+    status = _bounded_text(payload.get("status"), maximum=64)
+    if status is None or status.lower() not in _BROKER_STATUSES:
+        return AlpacaRecoveryObservationReason.BROKER_STATUS_INVALID
+    normalized_status = status.lower()
+    fill = _parse_fill(payload)
+    if fill is None:
+        return AlpacaRecoveryObservationReason.BROKER_FILL_INVALID
+    filled_qty, filled_avg_price = fill
+    if not _lifecycle_is_valid(
+        status=normalized_status,
+        submitted_qty=submitted_qty,
+        filled_qty=filled_qty,
+        filled_avg_price=filled_avg_price,
+    ):
+        return AlpacaRecoveryObservationReason.BROKER_LIFECYCLE_INVALID
+    return normalized_status, filled_qty, filled_avg_price
+
+
+def _validate_intent_identity(
+    intent: BrokerMutationIntent,
+) -> AlpacaRecoveryObservationReason | None:
+    try:
+        verify_broker_mutation_intent(intent)
+    except (
+        BrokerMutationReceiptValidationError,
+        AttributeError,
+        TypeError,
+        ValueError,
+    ):
+        return AlpacaRecoveryObservationReason.INTENT_INVALID
+    if intent.broker_route != "alpaca":
+        return AlpacaRecoveryObservationReason.ROUTE_INVALID
+    if intent.operation != "submit_order":
+        return AlpacaRecoveryObservationReason.OPERATION_INVALID
+    if (
+        intent.submission_claim_id is None
+        or intent.target.kind != "order"
+        or intent.target.key != intent.client_request_id
+    ):
+        return AlpacaRecoveryObservationReason.LINKAGE_INVALID
+    return None
+
+
+def _canonical_request(intent: BrokerMutationIntent) -> Mapping[str, object] | None:
+    try:
+        document = json.loads(intent.canonical_intent_json)
+    except (TypeError, ValueError):  # pragma: no cover - verifier owns this failure
+        return None
+    if not isinstance(document, Mapping):
+        return None
+    request = cast(Mapping[str, object], document).get("request")
+    if not isinstance(request, Mapping):
+        return None
+    untyped_request = cast(Mapping[object, object], request)
+    if any(not isinstance(key, str) for key in untyped_request):
+        return None
+    return cast(Mapping[str, object], untyped_request)
+
+
+def _request_sizing(
+    request: Mapping[str, object],
+) -> Decimal | AlpacaRecoveryObservationReason:
+    if request.get("notional") is not None:
+        return AlpacaRecoveryObservationReason.NOTIONAL_INDETERMINATE
+    normalized_qty = _decimal(request.get("qty"), positive=True, allow_zero=False)
+    if normalized_qty is None:
+        return AlpacaRecoveryObservationReason.REQUEST_QTY_INVALID
+    return normalized_qty
+
+
+def _parse_terms(
+    payload: Mapping[str, object],
+    *,
+    qty: Decimal,
+    broker: bool,
+) -> AlpacaOrderTerms | None:
+    symbol = _bounded_text(payload.get("symbol"), maximum=32)
+    side = _lower_text(payload.get("side"), maximum=8)
+    type_key = "type" if broker else _request_type_key(payload)
+    if type_key is None:
+        return None
+    order_type = _lower_text(payload.get(type_key), maximum=32)
+    time_in_force = _lower_text(payload.get("time_in_force"), maximum=16)
+    order_class = _lower_text(payload.get("order_class"), maximum=32)
+    position_intent = _optional_lower_text(payload.get("position_intent"), maximum=32)
+    extended_hours = payload.get("extended_hours")
+    if (
+        symbol is None
+        or _SYMBOL.fullmatch(symbol) is None
+        or side not in {"buy", "sell"}
+        or order_type not in _ORDER_TYPES
+        or time_in_force not in _TIME_IN_FORCE
+        or order_class is None
+        or position_intent is _INVALID
+        or not isinstance(extended_hours, bool)
+    ):
+        return None
+    prices = _parse_prices(payload)
+    if prices is None or not _price_contract_is_valid(order_type, prices):
+        return None
+    return AlpacaOrderTerms(
+        symbol=symbol,
+        side=side,
+        qty=qty,
+        order_type=order_type,
+        time_in_force=time_in_force,
+        limit_price=prices[0],
+        stop_price=prices[1],
+        trail_price=prices[2],
+        trail_percent=prices[3],
+        order_class=order_class,
+        position_intent=cast(str | None, position_intent),
+        extended_hours=extended_hours,
+    )
+
+
+def _parse_prices(
+    payload: Mapping[str, object],
+) -> tuple[Decimal | None, Decimal | None, Decimal | None, Decimal | None] | None:
+    parsed = tuple(
+        _optional_positive_decimal(payload.get(field))
+        for field in ("limit_price", "stop_price", "trail_price", "trail_percent")
+    )
+    if _INVALID in parsed:
+        return None
+    return cast(
+        tuple[Decimal | None, Decimal | None, Decimal | None, Decimal | None],
+        parsed,
+    )
+
+
+def _request_type_key(payload: Mapping[str, object]) -> str | None:
+    present = [key for key in ("order_type", "type") if key in payload]
+    return present[0] if len(present) == 1 else None
+
+
+def _validate_broker_account(
+    payload: Mapping[str, object],
+    *,
+    observed_account: str,
+) -> AlpacaRecoveryObservationReason | None:
+    account_values = [
+        payload[key]
+        for key in ("alpaca_account_label", "account_label")
+        if key in payload
+    ]
+    if not account_values:
+        return None
+    normalized = [_bounded_text(value, maximum=64) for value in account_values]
+    if any(value is None for value in normalized):
+        return AlpacaRecoveryObservationReason.BROKER_PAYLOAD_INVALID
+    if any(value != observed_account for value in normalized):
+        return AlpacaRecoveryObservationReason.ACCOUNT_MISMATCH
+    return None
+
+
+def _parse_fill(
+    payload: Mapping[str, object],
+) -> tuple[Decimal, Decimal | None] | None:
+    if "filled_qty" not in payload or "filled_avg_price" not in payload:
+        return None
+    filled_qty = _decimal(payload.get("filled_qty"), positive=False, allow_zero=True)
+    if filled_qty is None:
+        return None
+    raw_avg = payload.get("filled_avg_price")
+    if raw_avg is None:
+        return filled_qty, None
+    avg_price = _decimal(raw_avg, positive=True, allow_zero=False)
+    if avg_price is None:
+        return None
+    return filled_qty, avg_price
+
+
+def _lifecycle_is_valid(
+    *,
+    status: str,
+    submitted_qty: Decimal,
+    filled_qty: Decimal,
+    filled_avg_price: Decimal | None,
+) -> bool:
+    if filled_qty > submitted_qty:
+        return False
+    if (filled_qty == 0) != (filled_avg_price is None):
+        return False
+    if status == "filled" and filled_qty != submitted_qty:
+        return False
+    if status == "partially_filled" and not 0 < filled_qty < submitted_qty:
+        return False
+    if status in _ZERO_FILL_STATUSES and filled_qty != 0:
+        return False
+    return True
+
+
+def _price_contract_is_valid(
+    order_type: str,
+    prices: tuple[Decimal | None, Decimal | None, Decimal | None, Decimal | None],
+) -> bool:
+    limit_price, stop_price, trail_price, trail_percent = prices
+    if order_type == "market":
+        return all(value is None for value in prices)
+    if order_type == "limit":
+        return limit_price is not None and all(
+            value is None for value in (stop_price, trail_price, trail_percent)
+        )
+    if order_type == "stop":
+        return stop_price is not None and all(
+            value is None for value in (limit_price, trail_price, trail_percent)
+        )
+    if order_type == "stop_limit":
+        return (
+            limit_price is not None
+            and stop_price is not None
+            and all(value is None for value in (trail_price, trail_percent))
+        )
+    return (
+        limit_price is None
+        and stop_price is None
+        and (trail_price is None) != (trail_percent is None)
+    )
+
+
+def _decimal(
+    value: object,
+    *,
+    positive: bool,
+    allow_zero: bool,
+) -> Decimal | None:
+    if (
+        isinstance(value, bool)
+        or isinstance(value, float)
+        or not isinstance(value, (str, int, Decimal))
+    ):
+        return None
+    try:
+        normalized = Decimal(value)
+    except (InvalidOperation, ValueError):
+        return None
+    if not normalized.is_finite():
+        return None
+    if (
+        normalized < 0
+        or (positive and normalized == 0)
+        or (not allow_zero and normalized == 0)
+    ):
+        return None
+    sign, digits, exponent = normalized.as_tuple()
+    del sign
+    scale = max(-cast(int, exponent), 0)
+    integer_digits = max(len(digits) - scale, 0)
+    if scale > 8 or integer_digits > 12:
+        return None
+    return normalized
+
+
+class _Invalid:
+    pass
+
+
+_INVALID = _Invalid()
+
+
+def _optional_positive_decimal(value: object) -> Decimal | None | _Invalid:
+    if value is None:
+        return None
+    normalized = _decimal(value, positive=True, allow_zero=False)
+    return normalized if normalized is not None else _INVALID
+
+
+def _bounded_text(value: object, *, maximum: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    if not value or value != value.strip() or len(value) > maximum:
+        return None
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        return None
+    return value
+
+
+def _lower_text(value: object, *, maximum: int) -> str | None:
+    normalized = _bounded_text(value, maximum=maximum)
+    return normalized.lower() if normalized is not None else None
+
+
+def _optional_lower_text(value: object, *, maximum: int) -> str | None | _Invalid:
+    if value is None:
+        return None
+    normalized = _lower_text(value, maximum=maximum)
+    return normalized if normalized is not None else _INVALID
+
+
+def _indeterminate(
+    reason: AlpacaRecoveryObservationReason,
+) -> AlpacaRecoveryObservation:
+    return AlpacaRecoveryObservation(
+        outcome=AlpacaRecoveryObservationOutcome.INDETERMINATE,
+        reason=reason,
+        order=None,
+    )
+
+
+__all__ = [
+    "AlpacaOrderTerms",
+    "AlpacaRecoveryObservation",
+    "AlpacaRecoveryObservationOutcome",
+    "AlpacaRecoveryObservationReason",
+    "ValidatedAlpacaRecoveryOrder",
+    "validate_alpaca_recovery_observation",
+]

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -15,6 +15,8 @@ from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 from typing import cast
 
+from alpaca.trading.enums import OrderStatus
+
 from ..broker_mutation_receipts import BrokerMutationIntent
 from ..broker_mutation_receipts.canonicalization import (
     verify_broker_mutation_intent,
@@ -27,28 +29,17 @@ from ..broker_mutation_receipts.validation import (
 _SYMBOL = re.compile(r"^[A-Z][A-Z0-9./-]{0,31}$")
 _ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit", "trailing_stop"})
 _TIME_IN_FORCE = frozenset({"day", "gtc", "opg", "cls", "ioc", "fok"})
-_BROKER_STATUSES = frozenset(
+_BROKER_STATUSES = frozenset(status.value for status in OrderStatus)
+_ZERO_FILL_STATUSES = frozenset(
     {
         "accepted",
         "accepted_for_bidding",
-        "calculated",
-        "canceled",
-        "done_for_day",
-        "expired",
-        "filled",
+        "held",
         "new",
-        "partially_filled",
-        "pending_cancel",
         "pending_new",
-        "pending_replace",
+        "pending_review",
         "rejected",
-        "replaced",
-        "stopped",
-        "suspended",
     }
-)
-_ZERO_FILL_STATUSES = frozenset(
-    {"accepted", "accepted_for_bidding", "new", "pending_new", "rejected"}
 )
 
 
@@ -511,7 +502,7 @@ def _lifecycle_is_valid(
         return False
     if (filled_qty == 0) != (filled_avg_price is None):
         return False
-    if status == "filled" and filled_qty != submitted_qty:
+    if (status == "filled") != (filled_qty == submitted_qty):
         return False
     if status == "partially_filled" and not 0 < filled_qty < submitted_qty:
         return False

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -213,6 +213,13 @@ def _canonical_request_terms(
     request = _canonical_request(intent)
     if request is None:
         return AlpacaRecoveryObservationReason.REQUEST_INVALID
+    request_client_order_id = request.get("client_order_id")
+    if (
+        request_client_order_id is not None
+        and _bounded_text(request_client_order_id, maximum=128)
+        != intent.client_request_id
+    ):
+        return AlpacaRecoveryObservationReason.REQUEST_INVALID
     sizing = _request_sizing(request)
     if isinstance(sizing, AlpacaRecoveryObservationReason):
         return sizing

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -409,7 +409,7 @@ def _parse_terms(
         or side not in {"buy", "sell"}
         or order_type not in _ORDER_TYPES
         or time_in_force not in _TIME_IN_FORCE
-        or order_class is None
+        or order_class != "simple"
         or position_intent is _INVALID
         or not isinstance(extended_hours, bool)
     ):
@@ -562,10 +562,13 @@ def _decimal(
         or (not allow_zero and normalized == 0)
     ):
         return None
+    if normalized == 0:
+        normalized = Decimal("0")
     sign, digits, exponent = normalized.as_tuple()
     del sign
-    scale = max(-cast(int, exponent), 0)
-    integer_digits = max(len(digits) - scale, 0)
+    normalized_exponent = cast(int, exponent)
+    scale = max(-normalized_exponent, 0)
+    integer_digits = max(len(digits) + normalized_exponent, 0)
     if scale > 8 or integer_digits > 12:
         return None
     return normalized

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -400,7 +400,7 @@ def _parse_terms(
         return None
     order_type = _lower_text(payload.get(type_key), maximum=32)
     time_in_force = _lower_text(payload.get("time_in_force"), maximum=16)
-    order_class = _lower_text(payload.get("order_class"), maximum=32)
+    order_class = _normalized_order_class(payload.get("order_class"), broker=broker)
     position_intent = _optional_lower_text(payload.get("position_intent"), maximum=32)
     extended_hours = payload.get("extended_hours")
     if (
@@ -453,6 +453,12 @@ def _request_type_key(payload: Mapping[str, object]) -> str | None:
     return present[0] if len(present) == 1 else None
 
 
+def _normalized_order_class(value: object, *, broker: bool) -> str | None:
+    if broker and isinstance(value, str) and value == "":
+        return "simple"
+    return _lower_text(value, maximum=32)
+
+
 def _validate_broker_account(
     payload: Mapping[str, object],
     *,
@@ -484,9 +490,11 @@ def _parse_fill(
     raw_avg = payload.get("filled_avg_price")
     if raw_avg is None:
         return filled_qty, None
-    avg_price = _decimal(raw_avg, positive=True, allow_zero=False)
+    avg_price = _decimal(raw_avg, positive=False, allow_zero=True)
     if avg_price is None:
         return None
+    if filled_qty == 0 and avg_price == 0:
+        return filled_qty, None
     return filled_qty, avg_price
 
 
@@ -497,7 +505,9 @@ def _lifecycle_is_valid(
     filled_qty: Decimal,
     filled_avg_price: Decimal | None,
 ) -> bool:
-    if filled_qty > submitted_qty:
+    if filled_qty > submitted_qty or (
+        filled_avg_price is not None and filled_avg_price <= 0
+    ):
         return False
     if (filled_qty == 0) != (filled_avg_price is None):
         return False

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -29,6 +29,7 @@ from ..broker_mutation_receipts.validation import (
 _SYMBOL = re.compile(r"^[A-Z][A-Z0-9./-]{0,31}$")
 _ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit", "trailing_stop"})
 _TIME_IN_FORCE = frozenset({"day", "gtc", "opg", "cls", "ioc", "fok"})
+_UNSUPPORTED_NESTED_ORDER_FIELDS = ("take_profit", "stop_loss", "legs")
 _BROKER_STATUSES = frozenset(status.value for status in OrderStatus)
 _POSITION_INTENTS = frozenset(
     position_intent.value for position_intent in PositionIntent
@@ -214,11 +215,7 @@ def _canonical_request_terms(
     if request is None:
         return AlpacaRecoveryObservationReason.REQUEST_INVALID
     request_client_order_id = request.get("client_order_id")
-    if (
-        request_client_order_id is not None
-        and _bounded_text(request_client_order_id, maximum=128)
-        != intent.client_request_id
-    ):
+    if _bounded_text(request_client_order_id, maximum=128) != intent.client_request_id:
         return AlpacaRecoveryObservationReason.REQUEST_INVALID
     sizing = _request_sizing(request)
     if isinstance(sizing, AlpacaRecoveryObservationReason):
@@ -404,7 +401,9 @@ def _parse_terms(
     time_in_force = _lower_text(payload.get("time_in_force"), maximum=16)
     order_class = _normalized_order_class(payload.get("order_class"), broker=broker)
     position_intent = _optional_position_intent(payload.get("position_intent"))
-    extended_hours = payload.get("extended_hours")
+    extended_hours = _normalized_extended_hours(
+        payload.get("extended_hours"), broker=broker
+    )
     if (
         symbol is None
         or _SYMBOL.fullmatch(symbol) is None
@@ -414,6 +413,10 @@ def _parse_terms(
         or order_class != "simple"
         or position_intent is _INVALID
         or not isinstance(extended_hours, bool)
+    ):
+        return None
+    if any(
+        payload.get(field) is not None for field in _UNSUPPORTED_NESTED_ORDER_FIELDS
     ):
         return None
     prices = _parse_prices(payload)
@@ -456,9 +459,17 @@ def _request_type_key(payload: Mapping[str, object]) -> str | None:
 
 
 def _normalized_order_class(value: object, *, broker: bool) -> str | None:
+    if not broker and value is None:
+        return "simple"
     if broker and isinstance(value, str) and value == "":
         return "simple"
     return _lower_text(value, maximum=32)
+
+
+def _normalized_extended_hours(value: object, *, broker: bool) -> object:
+    if not broker and value is None:
+        return False
+    return value
 
 
 def _validate_broker_account(

--- a/services/torghut/app/trading/execution/alpaca_recovery_observation.py
+++ b/services/torghut/app/trading/execution/alpaca_recovery_observation.py
@@ -30,7 +30,9 @@ _SYMBOL = re.compile(r"^[A-Z][A-Z0-9./-]{0,31}$")
 _ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit", "trailing_stop"})
 _TIME_IN_FORCE = frozenset({"day", "gtc", "opg", "cls", "ioc", "fok"})
 _BROKER_STATUSES = frozenset(status.value for status in OrderStatus)
-_POSITION_INTENTS = frozenset(position_intent.value for position_intent in PositionIntent)
+_POSITION_INTENTS = frozenset(
+    position_intent.value for position_intent in PositionIntent
+)
 _FULL_FILL_PERMITTED_STATUSES = frozenset({"calculated", "filled"})
 _ZERO_FILL_STATUSES = frozenset(
     {

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -54,6 +54,7 @@ _ZERO_FILL_ORDER_STATUSES = frozenset(
         "rejected",
     }
 )
+_FULL_FILL_PERMITTED_ORDER_STATUSES = frozenset({"calculated", "filled"})
 _PARTIAL_OR_ZERO_ORDER_STATUSES = _PINNED_ORDER_STATUSES.difference(
     _ZERO_FILL_ORDER_STATUSES,
     {"filled", "partially_filled"},
@@ -585,7 +586,7 @@ def test_every_pinned_status_has_exhaustive_zero_partial_and_full_fill_coverage(
         )
     )
     expected_valid = (
-        (status == "filled" and filled_qty == "2")
+        (status in _FULL_FILL_PERMITTED_ORDER_STATUSES and filled_qty == "2")
         or (status == "partially_filled" and filled_qty == "1")
         or (status in _ZERO_FILL_ORDER_STATUSES and filled_qty == "0")
         or (status in _PARTIAL_OR_ZERO_ORDER_STATUSES and filled_qty in {"0", "1"})
@@ -598,6 +599,28 @@ def test_every_pinned_status_has_exhaustive_zero_partial_and_full_fill_coverage(
     else:
         assert result.reason is AlpacaRecoveryObservationReason.BROKER_LIFECYCLE_INVALID
         assert result.order is None
+
+
+@pytest.mark.parametrize(
+    ("filled_qty", "filled_avg_price"),
+    [("0", None), ("1", "190"), ("2", "190")],
+)
+def test_calculated_explicitly_preserves_zero_partial_and_complete_fill_truth(
+    filled_qty: str,
+    filled_avg_price: str | None,
+) -> None:
+    result = _observe(
+        broker_order=_broker_order(
+            status="calculated",
+            filled_qty=filled_qty,
+            filled_avg_price=filled_avg_price,
+        )
+    )
+
+    assert result.validated
+    assert result.order is not None
+    assert result.order.status == "calculated"
+    assert result.order.filled_qty == Decimal(filled_qty)
 
 
 @pytest.mark.parametrize(

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -482,6 +482,55 @@ def test_positive_exponent_values_cannot_bypass_numeric_20_8_integer_bounds(
     )
 
 
+@pytest.mark.parametrize(
+    ("intent_overrides", "broker_overrides", "reason"),
+    [
+        (
+            {"qty": "1 "},
+            {},
+            AlpacaRecoveryObservationReason.REQUEST_QTY_INVALID,
+        ),
+        (
+            {"limit_price": "1_000"},
+            {},
+            AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
+        ),
+        (
+            {},
+            {"qty": "1\n"},
+            AlpacaRecoveryObservationReason.BROKER_PAYLOAD_INVALID,
+        ),
+        (
+            {},
+            {"filled_qty": "1_000"},
+            AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        ),
+        (
+            {},
+            {"filled_avg_price": "1\n"},
+            AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        ),
+        (
+            {},
+            {"limit_price": "1_000"},
+            AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH,
+        ),
+    ],
+)
+def test_numeric_string_fields_require_canonical_text(
+    intent_overrides: dict[str, object],
+    broker_overrides: dict[str, object],
+    reason: AlpacaRecoveryObservationReason,
+) -> None:
+    _assert_indeterminate(
+        reason,
+        result=_observe(
+            intent=_intent(**intent_overrides),
+            broker_order=_broker_order(**broker_overrides),
+        ),
+    )
+
+
 def test_twelve_integer_digit_scientific_values_remain_in_bounds() -> None:
     result = _observe(
         intent=_intent(qty="1e11", limit_price="1e11"),

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+
+from app.trading.broker_mutation_receipts import (
+    BrokerMutationIntentRequest,
+    BrokerMutationTarget,
+    build_broker_mutation_intent,
+)
+from app.trading.execution.alpaca_recovery_observation import (
+    AlpacaRecoveryObservationOutcome,
+    AlpacaRecoveryObservationReason,
+    validate_alpaca_recovery_observation,
+)
+
+
+_DECISION_ID = uuid.UUID("00000000-0000-0000-0000-000000000101")
+_CLIENT_ORDER_ID = "client-order-101"
+
+
+def _request(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": Decimal("2"),
+        "notional": None,
+        "order_type": "limit",
+        "time_in_force": "day",
+        "limit_price": Decimal("190.25"),
+        "stop_price": None,
+        "trail_price": None,
+        "trail_percent": None,
+        "order_class": "simple",
+        "position_intent": "buy_to_open",
+        "extended_hours": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _intent(
+    *,
+    broker_route: str = "alpaca",
+    operation: str = "submit_order",
+    target: BrokerMutationTarget | None = None,
+    submission_claim_id: uuid.UUID | None = _DECISION_ID,
+    **request_overrides: object,
+):
+    return build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route=broker_route,
+            account_label="paper-primary",
+            endpoint_fingerprint="a" * 64,
+            operation=operation,
+            risk_class="risk_increasing",
+            purpose="initial_submission",
+            workflow_id="decision/101",
+            client_request_id=_CLIENT_ORDER_ID,
+            target=target or BrokerMutationTarget(kind="order", key=_CLIENT_ORDER_ID),
+            request_payload=_request(**request_overrides),
+            submission_claim_id=submission_claim_id,
+        )
+    )
+
+
+def _broker_order(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": "broker-order-101",
+        "client_order_id": _CLIENT_ORDER_ID,
+        "status": "accepted",
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": "2",
+        "notional": None,
+        "type": "limit",
+        "time_in_force": "day",
+        "limit_price": "190.25",
+        "stop_price": None,
+        "trail_price": None,
+        "trail_percent": None,
+        "order_class": "simple",
+        "position_intent": "buy_to_open",
+        "extended_hours": False,
+        "filled_qty": "0",
+        "filled_avg_price": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _observe(
+    *,
+    intent=None,
+    account_label: object = "paper-primary",
+    broker_order: object | None = None,
+    expected_broker_order_id: object | None = None,
+):
+    return validate_alpaca_recovery_observation(
+        intent=intent or _intent(),
+        account_label=account_label,
+        broker_order=_broker_order() if broker_order is None else broker_order,
+        expected_broker_order_id=expected_broker_order_id,
+    )
+
+
+def _assert_indeterminate(
+    reason: AlpacaRecoveryObservationReason,
+    *,
+    result,
+) -> None:
+    assert result.outcome is AlpacaRecoveryObservationOutcome.INDETERMINATE
+    assert result.reason is reason
+    assert result.order is None
+    assert not result.validated
+
+
+def test_valid_quantity_observation_preserves_exact_broker_truth() -> None:
+    result = _observe(
+        broker_order=_broker_order(
+            status="partially_filled",
+            filled_qty="0.75",
+            filled_avg_price="190.125",
+            alpaca_account_label="paper-primary",
+        ),
+        expected_broker_order_id="broker-order-101",
+    )
+
+    assert result.outcome is AlpacaRecoveryObservationOutcome.VALIDATED
+    assert result.reason is None
+    assert result.validated
+    assert result.order is not None
+    assert result.order.account_label == "paper-primary"
+    assert result.order.broker_order_id == "broker-order-101"
+    assert result.order.client_order_id == _CLIENT_ORDER_ID
+    assert result.order.status == "partially_filled"
+    assert result.order.filled_qty == Decimal("0.75")
+    assert result.order.filled_avg_price == Decimal("190.125")
+    assert result.order.terms.qty == Decimal("2")
+    assert result.order.terms.limit_price == Decimal("190.25")
+    assert result.order.terms.position_intent == "buy_to_open"
+
+
+def test_notional_intent_cannot_be_recovered_from_computed_broker_qty() -> None:
+    result = _observe(
+        intent=_intent(qty=None, notional=Decimal("100")),
+        broker_order=_broker_order(
+            qty="0.525624",
+            notional=None,
+            status="filled",
+            filled_qty="0.525624",
+            filled_avg_price="190.25",
+        ),
+    )
+
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.NOTIONAL_INDETERMINATE,
+        result=result,
+    )
+
+
+def test_qty_plus_notional_intent_is_always_indeterminate() -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.NOTIONAL_INDETERMINATE,
+        result=_observe(intent=_intent(notional=Decimal("100"))),
+    )
+
+
+@pytest.mark.parametrize(
+    ("intent", "reason"),
+    [
+        (
+            _intent(broker_route="hyperliquid"),
+            AlpacaRecoveryObservationReason.ROUTE_INVALID,
+        ),
+        (
+            _intent(operation="replace_order"),
+            AlpacaRecoveryObservationReason.OPERATION_INVALID,
+        ),
+        (
+            _intent(target=BrokerMutationTarget(kind="order", key="different-client")),
+            AlpacaRecoveryObservationReason.LINKAGE_INVALID,
+        ),
+    ],
+)
+def test_intent_route_operation_and_linkage_are_fail_closed(intent, reason) -> None:
+    _assert_indeterminate(reason, result=_observe(intent=intent))
+
+
+def test_tampered_intent_is_nonterminal_invalid_data() -> None:
+    intent = _intent()
+    tampered = replace(intent, canonical_intent_sha256="f" * 64)
+
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.INTENT_INVALID,
+        result=_observe(intent=tampered),
+    )
+
+
+@pytest.mark.parametrize("account_label", [None, "", "   ", 7])
+def test_account_is_explicitly_required_without_a_default(
+    account_label: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.ACCOUNT_REQUIRED,
+        result=_observe(account_label=account_label),
+    )
+
+
+@pytest.mark.parametrize(
+    ("account_label", "broker_overrides"),
+    [
+        ("paper-secondary", {}),
+        (" paper-primary ", {}),
+        ("paper-primary", {"alpaca_account_label": "paper-secondary"}),
+        ("paper-primary", {"account_label": "paper-secondary"}),
+        (
+            "paper-primary",
+            {
+                "account_label": "paper-primary",
+                "alpaca_account_label": "paper-secondary",
+            },
+        ),
+    ],
+)
+def test_account_context_and_payload_cannot_drift(
+    account_label: object,
+    broker_overrides: dict[str, object],
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.ACCOUNT_MISMATCH,
+        result=_observe(
+            account_label=account_label,
+            broker_order=_broker_order(**broker_overrides),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "request_overrides",
+    [
+        {"qty": None},
+        {"qty": "not-a-number"},
+        {"qty": Decimal("0")},
+        {"qty": Decimal("-1")},
+        {"qty": Decimal("1.000000001")},
+        {"qty": Decimal("1000000000000")},
+    ],
+)
+def test_original_quantity_must_be_positive_exact_numeric_20_8(
+    request_overrides: dict[str, object],
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_QTY_INVALID,
+        result=_observe(intent=_intent(**request_overrides)),
+    )
+
+
+@pytest.mark.parametrize(
+    "request_overrides",
+    [
+        {"symbol": "aapl"},
+        {"side": "hold"},
+        {"order_type": "unknown"},
+        {"time_in_force": "never"},
+        {"limit_price": None},
+        {"limit_price": Decimal("0")},
+        {"limit_price": Decimal("190.25"), "stop_price": Decimal("180")},
+        {"trail_price": Decimal("1")},
+        {"order_class": None},
+        {"position_intent": 1},
+        {"extended_hours": "false"},
+        {"type": "limit"},
+    ],
+)
+def test_original_order_terms_must_be_unambiguous_and_complete(
+    request_overrides: dict[str, object],
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
+        result=_observe(intent=_intent(**request_overrides)),
+    )
+
+
+@pytest.mark.parametrize("trail_field", ["trail_price", "trail_percent"])
+def test_trailing_stop_validates_exactly_one_trail_term(trail_field: str) -> None:
+    request_overrides = {
+        "order_type": "trailing_stop",
+        "limit_price": None,
+        trail_field: Decimal("1.25"),
+    }
+    broker_overrides = {
+        "type": "trailing_stop",
+        "limit_price": None,
+        trail_field: "1.25",
+    }
+
+    result = _observe(
+        intent=_intent(**request_overrides),
+        broker_order=_broker_order(**broker_overrides),
+    )
+
+    assert result.validated
+    assert result.order is not None
+    assert getattr(result.order.terms, trail_field) == Decimal("1.25")
+
+
+@pytest.mark.parametrize(
+    "broker_order",
+    [
+        None,
+        [],
+        {1: "non-string-key"},
+    ],
+)
+def test_broker_payload_must_be_a_string_keyed_mapping(broker_order: object) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_PAYLOAD_INVALID,
+        result=validate_alpaca_recovery_observation(
+            intent=_intent(),
+            account_label="paper-primary",
+            broker_order=broker_order,
+        ),
+    )
+
+
+@pytest.mark.parametrize("broker_order_id", [None, "", " broker ", 1])
+def test_broker_order_id_is_required_and_bounded(broker_order_id: object) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_ORDER_ID_INVALID,
+        result=_observe(broker_order=_broker_order(id=broker_order_id)),
+    )
+
+
+@pytest.mark.parametrize("expected", ["different", "", 7])
+def test_known_broker_order_id_must_match_exactly(expected: object) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_ORDER_ID_MISMATCH,
+        result=_observe(expected_broker_order_id=expected),
+    )
+
+
+@pytest.mark.parametrize("client_order_id", [None, "different", 7])
+def test_client_order_id_must_match_canonical_linkage(client_order_id: object) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.CLIENT_ORDER_ID_MISMATCH,
+        result=_observe(broker_order=_broker_order(client_order_id=client_order_id)),
+    )
+
+
+@pytest.mark.parametrize(
+    "broker_overrides",
+    [
+        {"symbol": "MSFT"},
+        {"side": "sell"},
+        {"qty": "2.00000001"},
+        {"notional": "100"},
+        {"type": "market", "limit_price": None},
+        {"time_in_force": "gtc"},
+        {"limit_price": "190.26"},
+        {"stop_price": "180"},
+        {"trail_percent": "1"},
+        {"order_class": "bracket"},
+        {"position_intent": "sell_to_close"},
+        {"extended_hours": True},
+    ],
+)
+def test_broker_identity_and_all_applicable_terms_must_match_exactly(
+    broker_overrides: dict[str, object],
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH,
+        result=_observe(broker_order=_broker_order(**broker_overrides)),
+    )
+
+
+@pytest.mark.parametrize("status", [None, "", "unknown", 1])
+def test_broker_status_is_explicit_and_recognized(status: object) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_STATUS_INVALID,
+        result=_observe(broker_order=_broker_order(status=status)),
+    )
+
+
+@pytest.mark.parametrize(
+    "broker_overrides",
+    [
+        {"filled_qty": None},
+        {"filled_qty": 1.0},
+        {"filled_qty": "NaN"},
+        {"filled_qty": "-1"},
+        {"filled_qty": "0.000000001"},
+        {"filled_qty": "1000000000000"},
+        {"filled_avg_price": 190.0},
+        {"filled_avg_price": "NaN"},
+        {"filled_avg_price": "0"},
+        {"filled_avg_price": "0.000000001"},
+    ],
+)
+def test_fill_numbers_must_be_explicit_finite_and_numeric_20_8(
+    broker_overrides: dict[str, object],
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        result=_observe(broker_order=_broker_order(**broker_overrides)),
+    )
+
+
+@pytest.mark.parametrize("missing", ["filled_qty", "filled_avg_price"])
+def test_fill_fields_cannot_be_defaulted_when_missing(missing: str) -> None:
+    broker_order = _broker_order()
+    del broker_order[missing]
+
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        result=_observe(broker_order=broker_order),
+    )
+
+
+@pytest.mark.parametrize(
+    "broker_overrides",
+    [
+        {"filled_qty": "0", "filled_avg_price": "190"},
+        {"filled_qty": "0.5", "filled_avg_price": None},
+        {"filled_qty": "2.1", "filled_avg_price": "190"},
+        {"status": "filled", "filled_qty": "1", "filled_avg_price": "190"},
+        {"status": "filled", "filled_qty": "0", "filled_avg_price": None},
+        {
+            "status": "partially_filled",
+            "filled_qty": "0",
+            "filled_avg_price": None,
+        },
+        {
+            "status": "partially_filled",
+            "filled_qty": "2",
+            "filled_avg_price": "190",
+        },
+        {"status": "accepted", "filled_qty": "1", "filled_avg_price": "190"},
+        {"status": "rejected", "filled_qty": "1", "filled_avg_price": "190"},
+    ],
+)
+def test_status_fill_lifecycle_bounds_are_fail_closed(
+    broker_overrides: dict[str, object],
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_LIFECYCLE_INVALID,
+        result=_observe(broker_order=_broker_order(**broker_overrides)),
+    )
+
+
+@pytest.mark.parametrize(
+    "broker_overrides",
+    [
+        {"status": "filled", "filled_qty": "2", "filled_avg_price": "190"},
+        {
+            "status": "canceled",
+            "filled_qty": "0.5",
+            "filled_avg_price": "190",
+        },
+        {"status": "expired", "filled_qty": "0", "filled_avg_price": None},
+    ],
+)
+def test_supported_terminal_and_partial_lifecycle_truth_is_preserved(
+    broker_overrides: dict[str, object],
+) -> None:
+    result = _observe(broker_order=_broker_order(**broker_overrides))
+
+    assert result.validated
+    assert result.order is not None
+    assert result.order.status == broker_overrides["status"]
+
+
+def test_reason_values_are_stable_strings_for_future_persistence() -> None:
+    assert AlpacaRecoveryObservationReason.NOTIONAL_INDETERMINATE.value == (
+        "notional_submission_recovery_indeterminate"
+    )
+    assert AlpacaRecoveryObservationReason.ACCOUNT_REQUIRED.value == (
+        "alpaca_recovery_account_required"
+    )

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -144,6 +144,34 @@ def test_valid_quantity_observation_preserves_exact_broker_truth() -> None:
     assert result.order.terms.position_intent == "buy_to_open"
 
 
+def test_blank_broker_order_class_normalizes_to_explicit_simple_intent() -> None:
+    result = _observe(broker_order=_broker_order(order_class=""))
+
+    assert result.validated
+    assert result.order is not None
+    assert result.order.terms.order_class == "simple"
+
+
+def test_blank_canonical_order_class_remains_indeterminate() -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
+        result=_observe(
+            intent=_intent(order_class=""),
+            broker_order=_broker_order(order_class=""),
+        ),
+    )
+
+
+@pytest.mark.parametrize("broker_order_class", [" ", None, False, 0])
+def test_only_exact_broker_blank_class_normalizes_to_simple(
+    broker_order_class: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH,
+        result=_observe(broker_order=_broker_order(order_class=broker_order_class)),
+    )
+
+
 def test_notional_intent_cannot_be_recovered_from_computed_broker_qty() -> None:
     result = _observe(
         intent=_intent(qty=None, notional=Decimal("100")),
@@ -342,6 +370,7 @@ def test_twelve_integer_digit_scientific_values_remain_in_bounds() -> None:
         {"limit_price": Decimal("190.25"), "stop_price": Decimal("180")},
         {"trail_price": Decimal("1")},
         {"order_class": None},
+        {"order_class": ""},
         {"position_intent": 1},
         {"extended_hours": "false"},
         {"type": "limit"},
@@ -507,7 +536,6 @@ def test_broker_status_is_explicit_and_recognized(status: object) -> None:
         {"filled_qty": "1000000000000"},
         {"filled_avg_price": 190.0},
         {"filled_avg_price": "NaN"},
-        {"filled_avg_price": "0"},
         {"filled_avg_price": "0.000000001"},
     ],
 )
@@ -528,6 +556,91 @@ def test_fill_fields_cannot_be_defaulted_when_missing(missing: str) -> None:
     _assert_indeterminate(
         AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
         result=_observe(broker_order=broker_order),
+    )
+
+
+@pytest.mark.parametrize(
+    "zero_avg_price",
+    ["0", "0.00000000", "0e13", Decimal("0"), Decimal("-0")],
+)
+def test_numeric_zero_average_normalizes_to_none_for_zero_fill(
+    zero_avg_price: object,
+) -> None:
+    result = _observe(
+        broker_order=_broker_order(
+            status="accepted",
+            filled_qty="0",
+            filled_avg_price=zero_avg_price,
+        )
+    )
+
+    assert result.validated
+    assert result.order is not None
+    assert result.order.filled_qty == Decimal("0")
+    assert result.order.filled_avg_price is None
+
+
+@pytest.mark.parametrize(
+    "invalid_avg_price",
+    ["", "not-a-number", 0.0, False, True],
+)
+def test_malformed_float_and_boolean_zero_fill_averages_remain_invalid(
+    invalid_avg_price: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        result=_observe(
+            broker_order=_broker_order(
+                filled_qty="0",
+                filled_avg_price=invalid_avg_price,
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize("invalid_filled_qty", ["", "not-a-number", 0.0, False, True])
+def test_malformed_float_and_boolean_filled_quantities_remain_invalid(
+    invalid_filled_qty: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        result=_observe(
+            broker_order=_broker_order(
+                filled_qty=invalid_filled_qty,
+                filled_avg_price=None,
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize("zero_avg_price", ["0", Decimal("0")])
+def test_zero_average_with_positive_fill_remains_lifecycle_invalid(
+    zero_avg_price: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_LIFECYCLE_INVALID,
+        result=_observe(
+            broker_order=_broker_order(
+                status="partially_filled",
+                filled_qty="1",
+                filled_avg_price=zero_avg_price,
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize("nonzero_avg_price", ["190", Decimal("190")])
+def test_nonzero_average_with_zero_fill_remains_lifecycle_invalid(
+    nonzero_avg_price: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.BROKER_LIFECYCLE_INVALID,
+        result=_observe(
+            broker_order=_broker_order(
+                filled_qty="0",
+                filled_avg_price=nonzero_avg_price,
+            )
+        ),
     )
 
 

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from decimal import Decimal
 
 import pytest
-from alpaca.trading.enums import OrderStatus
+from alpaca.trading.enums import OrderStatus, PositionIntent
 
 from app.trading.broker_mutation_receipts import (
     BrokerMutationIntentRequest,
@@ -41,6 +41,14 @@ _PINNED_ORDER_STATUSES = frozenset(
         "replaced",
         "stopped",
         "suspended",
+    }
+)
+_PINNED_POSITION_INTENTS = frozenset(
+    {
+        "buy_to_open",
+        "buy_to_close",
+        "sell_to_open",
+        "sell_to_close",
     }
 )
 _ZERO_FILL_ORDER_STATUSES = frozenset(
@@ -198,6 +206,35 @@ def test_blank_canonical_order_class_remains_indeterminate() -> None:
             intent=_intent(order_class=""),
             broker_order=_broker_order(order_class=""),
         ),
+    )
+
+
+@pytest.mark.parametrize("position_intent", ["open", "close", "sell_short", "unknown"])
+def test_unsupported_canonical_position_intent_is_indeterminate(
+    position_intent: str,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
+        result=_observe(
+            intent=_intent(position_intent=position_intent),
+            broker_order=_broker_order(position_intent=position_intent),
+        ),
+    )
+
+
+@pytest.mark.parametrize("position_intent", ["open", "close", "sell_short", "unknown"])
+def test_unsupported_broker_position_intent_is_indeterminate(
+    position_intent: str,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH,
+        result=_observe(broker_order=_broker_order(position_intent=position_intent)),
+    )
+
+
+def test_pinned_position_intent_allow_list_has_no_unreviewed_drift() -> None:
+    assert frozenset(position_intent.value for position_intent in PositionIntent) == (
+        _PINNED_POSITION_INTENTS
     )
 
 

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -232,6 +232,24 @@ def test_unsupported_broker_position_intent_is_indeterminate(
     )
 
 
+@pytest.mark.parametrize("client_order_id", ["different-client", "", 7])
+def test_conflicting_canonical_client_order_id_is_indeterminate(
+    client_order_id: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_INVALID,
+        result=_observe(intent=_intent(client_order_id=client_order_id)),
+    )
+
+
+def test_matching_canonical_client_order_id_is_accepted() -> None:
+    result = _observe(intent=_intent(client_order_id=_CLIENT_ORDER_ID))
+
+    assert result.validated
+    assert result.order is not None
+    assert result.order.client_order_id == _CLIENT_ORDER_ID
+
+
 def test_pinned_position_intent_allow_list_has_no_unreviewed_drift() -> None:
     assert frozenset(position_intent.value for position_intent in PositionIntent) == (
         _PINNED_POSITION_INTENTS

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -260,6 +260,77 @@ def test_original_quantity_must_be_positive_exact_numeric_20_8(
 
 
 @pytest.mark.parametrize(
+    ("intent_overrides", "broker_overrides", "reason"),
+    [
+        (
+            {"qty": "1e13"},
+            {},
+            AlpacaRecoveryObservationReason.REQUEST_QTY_INVALID,
+        ),
+        (
+            {},
+            {"qty": "1e13"},
+            AlpacaRecoveryObservationReason.BROKER_PAYLOAD_INVALID,
+        ),
+        (
+            {},
+            {"qty": Decimal("1e13")},
+            AlpacaRecoveryObservationReason.BROKER_PAYLOAD_INVALID,
+        ),
+        (
+            {},
+            {"filled_qty": "1e13"},
+            AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        ),
+        (
+            {},
+            {"filled_avg_price": "1e13"},
+            AlpacaRecoveryObservationReason.BROKER_FILL_INVALID,
+        ),
+        (
+            {"limit_price": "1e13"},
+            {},
+            AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
+        ),
+        (
+            {},
+            {"limit_price": "1e13"},
+            AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH,
+        ),
+    ],
+)
+def test_positive_exponent_values_cannot_bypass_numeric_20_8_integer_bounds(
+    intent_overrides: dict[str, object],
+    broker_overrides: dict[str, object],
+    reason: AlpacaRecoveryObservationReason,
+) -> None:
+    _assert_indeterminate(
+        reason,
+        result=_observe(
+            intent=_intent(**intent_overrides),
+            broker_order=_broker_order(**broker_overrides),
+        ),
+    )
+
+
+def test_twelve_integer_digit_scientific_values_remain_in_bounds() -> None:
+    result = _observe(
+        intent=_intent(qty="1e11", limit_price="1e11"),
+        broker_order=_broker_order(
+            qty="1e11",
+            limit_price="1e11",
+            filled_qty="0e13",
+        ),
+    )
+
+    assert result.validated
+    assert result.order is not None
+    assert result.order.terms.qty == Decimal("1e11")
+    assert result.order.terms.limit_price == Decimal("1e11")
+    assert result.order.filled_qty == Decimal("0")
+
+
+@pytest.mark.parametrize(
     "request_overrides",
     [
         {"symbol": "aapl"},
@@ -282,6 +353,46 @@ def test_original_order_terms_must_be_unambiguous_and_complete(
     _assert_indeterminate(
         AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
         result=_observe(intent=_intent(**request_overrides)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("order_class", "nested_terms"),
+    [
+        (
+            "bracket",
+            {
+                "take_profit": {"limit_price": Decimal("210")},
+                "stop_loss": {"stop_price": Decimal("180")},
+            },
+        ),
+        (
+            "oto",
+            {"take_profit": {"limit_price": Decimal("210")}},
+        ),
+        (
+            "oco",
+            {
+                "legs": [
+                    {"type": "limit", "limit_price": Decimal("210")},
+                    {"type": "stop", "stop_price": Decimal("180")},
+                ]
+            },
+        ),
+    ],
+)
+def test_matching_complex_order_classes_remain_indeterminate_until_legs_are_modeled(
+    order_class: str,
+    nested_terms: dict[str, object],
+) -> None:
+    result = _observe(
+        intent=_intent(order_class=order_class, **nested_terms),
+        broker_order=_broker_order(order_class=order_class, **nested_terms),
+    )
+
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
+        result=result,
     )
 
 

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -84,6 +84,7 @@ def _request(**overrides: object) -> dict[str, object]:
         "order_class": "simple",
         "position_intent": "buy_to_open",
         "extended_hours": False,
+        "client_order_id": _CLIENT_ORDER_ID,
     }
     payload.update(overrides)
     return payload
@@ -242,6 +243,23 @@ def test_conflicting_canonical_client_order_id_is_indeterminate(
     )
 
 
+@pytest.mark.parametrize("client_order_id", [None])
+def test_canonical_client_order_id_is_required_and_non_null(
+    client_order_id: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_INVALID,
+        result=_observe(intent=_intent(client_order_id=client_order_id)),
+    )
+
+
+def test_missing_canonical_client_order_id_is_indeterminate() -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_INVALID,
+        result=_observe(intent=_intent_without_client_order_id()),
+    )
+
+
 def test_matching_canonical_client_order_id_is_accepted() -> None:
     result = _observe(intent=_intent(client_order_id=_CLIENT_ORDER_ID))
 
@@ -264,6 +282,35 @@ def test_only_exact_broker_blank_class_normalizes_to_simple(
         AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH,
         result=_observe(broker_order=_broker_order(order_class=broker_order_class)),
     )
+
+
+def _intent_without_client_order_id():
+    payload = _request()
+    del payload["client_order_id"]
+    return build_broker_mutation_intent(
+        BrokerMutationIntentRequest(
+            broker_route="alpaca",
+            account_label="paper-primary",
+            endpoint_fingerprint="a" * 64,
+            operation="submit_order",
+            risk_class="risk_increasing",
+            purpose="initial_submission",
+            workflow_id="decision/101",
+            client_request_id=_CLIENT_ORDER_ID,
+            target=BrokerMutationTarget(kind="order", key=_CLIENT_ORDER_ID),
+            request_payload=payload,
+            submission_claim_id=_DECISION_ID,
+        )
+    )
+
+
+def test_request_sdk_defaults_normalize_to_simple_and_false() -> None:
+    result = _observe(intent=_intent(order_class=None, extended_hours=None))
+
+    assert result.validated
+    assert result.order is not None
+    assert result.order.terms.order_class == "simple"
+    assert result.order.terms.extended_hours is False
 
 
 def test_notional_intent_cannot_be_recovered_from_computed_broker_qty() -> None:
@@ -463,7 +510,7 @@ def test_twelve_integer_digit_scientific_values_remain_in_bounds() -> None:
         {"limit_price": Decimal("0")},
         {"limit_price": Decimal("190.25"), "stop_price": Decimal("180")},
         {"trail_price": Decimal("1")},
-        {"order_class": None},
+        {"order_class": False},
         {"order_class": ""},
         {"position_intent": 1},
         {"extended_hours": "false"},
@@ -516,6 +563,61 @@ def test_matching_complex_order_classes_remain_indeterminate_until_legs_are_mode
     _assert_indeterminate(
         AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
         result=result,
+    )
+
+
+@pytest.mark.parametrize(
+    ("nested_field", "nested_value"),
+    [
+        ("take_profit", {"limit_price": "210"}),
+        ("stop_loss", {"stop_price": "180"}),
+        (
+            "legs",
+            [
+                {"type": "limit", "limit_price": "210"},
+                {"type": "stop", "stop_price": "180"},
+            ],
+        ),
+    ],
+)
+def test_simple_order_nested_terms_remain_indeterminate_until_modeled(
+    nested_field: str,
+    nested_value: object,
+) -> None:
+    overrides = {nested_field: nested_value}
+
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.REQUEST_TERMS_INVALID,
+        result=_observe(
+            intent=_intent(**overrides),
+            broker_order=_broker_order(**overrides),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("nested_field", "nested_value"),
+    [
+        ("take_profit", {"limit_price": "210"}),
+        ("stop_loss", {"stop_price": "180"}),
+        (
+            "legs",
+            [
+                {"type": "limit", "limit_price": "210"},
+                {"type": "stop", "stop_price": "180"},
+            ],
+        ),
+    ],
+)
+def test_simple_broker_nested_terms_remain_indeterminate_until_modeled(
+    nested_field: str,
+    nested_value: object,
+) -> None:
+    _assert_indeterminate(
+        AlpacaRecoveryObservationReason.ORDER_IDENTITY_MISMATCH,
+        result=_observe(
+            broker_order=_broker_order(**{nested_field: nested_value}),
+        ),
     )
 
 

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from decimal import Decimal
 
 import pytest
+from alpaca.trading.enums import OrderStatus
 
 from app.trading.broker_mutation_receipts import (
     BrokerMutationIntentRequest,
@@ -20,6 +21,43 @@ from app.trading.execution.alpaca_recovery_observation import (
 
 _DECISION_ID = uuid.UUID("00000000-0000-0000-0000-000000000101")
 _CLIENT_ORDER_ID = "client-order-101"
+_PINNED_ORDER_STATUSES = frozenset(
+    {
+        "accepted",
+        "accepted_for_bidding",
+        "calculated",
+        "canceled",
+        "done_for_day",
+        "expired",
+        "filled",
+        "held",
+        "new",
+        "partially_filled",
+        "pending_cancel",
+        "pending_new",
+        "pending_replace",
+        "pending_review",
+        "rejected",
+        "replaced",
+        "stopped",
+        "suspended",
+    }
+)
+_ZERO_FILL_ORDER_STATUSES = frozenset(
+    {
+        "accepted",
+        "accepted_for_bidding",
+        "held",
+        "new",
+        "pending_new",
+        "pending_review",
+        "rejected",
+    }
+)
+_PARTIAL_OR_ZERO_ORDER_STATUSES = _PINNED_ORDER_STATUSES.difference(
+    _ZERO_FILL_ORDER_STATUSES,
+    {"filled", "partially_filled"},
+)
 
 
 def _request(**overrides: object) -> dict[str, object]:
@@ -523,6 +561,43 @@ def test_broker_status_is_explicit_and_recognized(status: object) -> None:
         AlpacaRecoveryObservationReason.BROKER_STATUS_INVALID,
         result=_observe(broker_order=_broker_order(status=status)),
     )
+
+
+def test_pinned_sdk_order_status_allow_list_has_no_unreviewed_drift() -> None:
+    assert frozenset(status.value for status in OrderStatus) == _PINNED_ORDER_STATUSES
+
+
+@pytest.mark.parametrize("status", tuple(status.value for status in OrderStatus))
+@pytest.mark.parametrize(
+    ("filled_qty", "filled_avg_price"),
+    [("0", None), ("1", "190"), ("2", "190")],
+)
+def test_every_pinned_status_has_exhaustive_zero_partial_and_full_fill_coverage(
+    status: str,
+    filled_qty: str,
+    filled_avg_price: str | None,
+) -> None:
+    result = _observe(
+        broker_order=_broker_order(
+            status=status,
+            filled_qty=filled_qty,
+            filled_avg_price=filled_avg_price,
+        )
+    )
+    expected_valid = (
+        (status == "filled" and filled_qty == "2")
+        or (status == "partially_filled" and filled_qty == "1")
+        or (status in _ZERO_FILL_ORDER_STATUSES and filled_qty == "0")
+        or (status in _PARTIAL_OR_ZERO_ORDER_STATUSES and filled_qty in {"0", "1"})
+    )
+
+    assert result.validated is expected_valid
+    if expected_valid:
+        assert result.order is not None
+        assert result.order.status == status
+    else:
+        assert result.reason is AlpacaRecoveryObservationReason.BROKER_LIFECYCLE_INVALID
+        assert result.order is None
 
 
 @pytest.mark.parametrize(

--- a/services/torghut/tests/execution/test_alpaca_recovery_observation.py
+++ b/services/torghut/tests/execution/test_alpaca_recovery_observation.py
@@ -243,13 +243,10 @@ def test_conflicting_canonical_client_order_id_is_indeterminate(
     )
 
 
-@pytest.mark.parametrize("client_order_id", [None])
-def test_canonical_client_order_id_is_required_and_non_null(
-    client_order_id: object,
-) -> None:
+def test_canonical_client_order_id_is_required_and_non_null() -> None:
     _assert_indeterminate(
         AlpacaRecoveryObservationReason.REQUEST_INVALID,
-        result=_observe(intent=_intent(client_order_id=client_order_id)),
+        result=_observe(intent=_intent(client_order_id=None)),
     )
 
 
@@ -258,14 +255,6 @@ def test_missing_canonical_client_order_id_is_indeterminate() -> None:
         AlpacaRecoveryObservationReason.REQUEST_INVALID,
         result=_observe(intent=_intent_without_client_order_id()),
     )
-
-
-def test_matching_canonical_client_order_id_is_accepted() -> None:
-    result = _observe(intent=_intent(client_order_id=_CLIENT_ORDER_ID))
-
-    assert result.validated
-    assert result.order is not None
-    assert result.order.client_order_id == _CLIENT_ORDER_ID
 
 
 def test_pinned_position_intent_allow_list_has_no_unreviewed_drift() -> None:


### PR DESCRIPTION
## Summary

- Add a pure typed Alpaca recovery observation validator that cannot mutate receipt, claim, database, or execution state.
- Fail closed on route, linked submission identity, explicit account context, broker identifiers, canonical order terms, and broker lifecycle evidence.
- Classify every canonical notional or quantity-plus-notional submission as `notional_submission_recovery_indeterminate`, even when Alpaca returns a computed quantity.
- Preserve only exact quantity-order observations with finite numeric fill truth and coherent status/fill bounds for a later recovery slice.

## Related Issues

None.

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/execution/test_alpaca_recovery_observation.py` (90 passed)
- `uv run --frozen ruff check app/trading/execution/alpaca_recovery_observation.py tests/execution/test_alpaca_recovery_observation.py`
- `uv run --frozen ruff format --check app/trading/execution/alpaca_recovery_observation.py tests/execution/test_alpaca_recovery_observation.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main app/trading/execution/alpaca_recovery_observation.py tests/execution/test_alpaca_recovery_observation.py`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main --ignore-base-lines --enable=too-many-arguments,too-many-positional-arguments,too-many-branches,too-many-locals,too-many-return-statements,too-many-statements,too-many-nested-blocks app/trading/execution/alpaca_recovery_observation.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main app/trading/execution/alpaca_recovery_observation.py tests/execution/test_alpaca_recovery_observation.py`
- `uv run --frozen python scripts/run_pylint_torghut_structural_gate.py --paths app/trading/execution/alpaca_recovery_observation.py tests/execution/test_alpaca_recovery_observation.py`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 80 --base-ref origin/main` (96.92%, 315/325 changed executable lines)

## Screenshots (if applicable)

N/A. This change adds a backend validation contract with no user interface.

## Breaking Changes

None. The validator is new, pure, and not wired into a runtime mutation path in this slice.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are not required for this isolated internal contract.
