### PR TITLE
fix(torghut): bound loop status postgres reads

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -682,7 +682,8 @@ jobs:
             tests/execution/test_broker_mutation_receipts_postgres.py \
             tests/execution/test_broker_mutation_linked_receipts_postgres.py \
             tests/execution/test_broker_mutation_receipt_boundaries_postgres.py \
-            tests/execution/test_linked_submission_terminal_postgres.py
+            tests/execution/test_linked_submission_terminal_postgres.py \
+            tests/execution/test_loop_status_read_indexes_postgres.py
 
       - name: Upload PostgreSQL coverage data
         if: always()

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -432,6 +432,7 @@ describe('torghut build-push workflow', () => {
     expect(postgresJobBody).toContain('tests/execution/test_broker_mutation_linked_receipts_postgres.py')
     expect(postgresJobBody).toContain('tests/execution/test_broker_mutation_receipt_boundaries_postgres.py')
     expect(postgresJobBody).toContain('tests/execution/test_linked_submission_terminal_postgres.py')
+    expect(postgresJobBody).toContain('tests/execution/test_loop_status_read_indexes_postgres.py')
     expect(postgresJobBody).not.toContain('-n auto')
 
     const aggregateStart = ciWorkflow.indexOf('\n  lint-and-tests:')

--- a/services/torghut/migrations/versions/0062_loop_status_read_indexes.py
+++ b/services/torghut/migrations/versions/0062_loop_status_read_indexes.py
@@ -1,0 +1,88 @@
+"""Add bounded trading loop status read indexes.
+
+Revision ID: 0062_loop_status_read_indexes
+Revises: 0061_linked_submission_terminal
+Create Date: 2026-07-12 04:30:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0062_loop_status_read_indexes"
+down_revision = "0061_linked_submission_terminal"
+branch_labels = None
+depends_on = None
+
+_INDEXES: tuple[tuple[str, str, str], ...] = (
+    (
+        "ix_hyperliquid_execution_signals_generated_at_desc",
+        "hyperliquid_execution_signals",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  ix_hyperliquid_execution_signals_generated_at_desc
+ON hyperliquid_execution_signals (generated_at DESC)
+""",
+    ),
+    (
+        "ix_executions_created_at_desc",
+        "executions",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_executions_created_at_desc
+ON executions (created_at DESC)
+INCLUDE (alpaca_account_label)
+""",
+    ),
+    (
+        "ix_execution_order_events_activity_at_desc",
+        "execution_order_events",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  ix_execution_order_events_activity_at_desc
+ON execution_order_events ((COALESCE(event_ts, created_at)) DESC)
+INCLUDE (alpaca_account_label)
+""",
+    ),
+)
+
+_INDEX_VALIDITY_SQL = sa.text(
+    """
+    SELECT indisvalid
+      FROM pg_index
+     WHERE indexrelid = to_regclass(:index_name)
+    """
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    with op.get_context().autocommit_block():
+        for index_name, table_name, create_sql in _INDEXES:
+            if not inspector.has_table(table_name):
+                continue
+            validity = bind.execute(
+                _INDEX_VALIDITY_SQL,
+                {"index_name": index_name},
+            ).scalar_one_or_none()
+            if validity is True:
+                continue
+            if validity is False:
+                op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))
+            op.execute(sa.text(create_sql))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    with op.get_context().autocommit_block():
+        for index_name, table_name, _create_sql in reversed(_INDEXES):
+            if inspector.has_table(table_name):
+                op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))

--- a/services/torghut/migrations/versions/0062_loop_status_read_indexes.py
+++ b/services/torghut/migrations/versions/0062_loop_status_read_indexes.py
@@ -28,6 +28,24 @@ ON hyperliquid_execution_signals (generated_at DESC)
 """,
     ),
     (
+        "ix_hyperliquid_execution_orders_network_created_desc",
+        "hyperliquid_execution_orders",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  ix_hyperliquid_execution_orders_network_created_desc
+ON hyperliquid_execution_orders (execution_network, created_at DESC)
+""",
+    ),
+    (
+        "ix_hyperliquid_execution_fills_network_event_desc",
+        "hyperliquid_execution_fills",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  ix_hyperliquid_execution_fills_network_event_desc
+ON hyperliquid_execution_fills (execution_network, event_ts DESC)
+""",
+    ),
+    (
         "ix_executions_created_at_desc",
         "executions",
         """

--- a/services/torghut/tests/execution/test_loop_status_read_indexes_postgres.py
+++ b/services/torghut/tests/execution/test_loop_status_read_indexes_postgres.py
@@ -73,7 +73,7 @@ def _create_loop_status_tables(engine: Engine) -> None:
                     id bigint PRIMARY KEY,
                     finished_at timestamptz NOT NULL
                 );
-                CREATE INDEX ix_test_cycles_finished_at
+                CREATE INDEX ix_hyperliquid_execution_cycles_finished
                     ON hyperliquid_execution_cycles (finished_at);
 
                 CREATE TABLE hyperliquid_execution_signals (
@@ -92,27 +92,20 @@ def _create_loop_status_tables(engine: Engine) -> None:
                     execution_network text NOT NULL,
                     created_at timestamptz NOT NULL
                 );
-                CREATE INDEX ix_test_orders_network_created
-                    ON hyperliquid_execution_orders (execution_network, created_at);
 
                 CREATE TABLE hyperliquid_execution_fills (
                     id bigint PRIMARY KEY,
                     execution_network text NOT NULL,
                     event_ts timestamptz NOT NULL
                 );
-                CREATE INDEX ix_test_fills_network_event
-                    ON hyperliquid_execution_fills (execution_network, event_ts);
 
                 CREATE TABLE hyperliquid_execution_account_snapshots (
                     id bigint PRIMARY KEY,
                     execution_network text NOT NULL,
                     observed_at timestamptz NOT NULL
                 );
-                CREATE INDEX ix_test_accounts_network_observed
-                    ON hyperliquid_execution_account_snapshots (
-                        execution_network,
-                        observed_at
-                    );
+                CREATE INDEX ix_hyperliquid_execution_account_observed
+                    ON hyperliquid_execution_account_snapshots (observed_at);
 
                 CREATE TABLE executions (
                     id bigint PRIMARY KEY,
@@ -154,19 +147,19 @@ def _load_realistic_loop_status_rows(engine: Engine) -> None:
                 INSERT INTO hyperliquid_execution_orders (
                     id, execution_network, created_at
                 )
-                SELECT n, 'testnet', clock_timestamp() - make_interval(secs => n)
+                SELECT n, 'testnet', clock_timestamp() - make_interval(mins => n)
                   FROM generate_series(1, 5000) AS n;
 
                 INSERT INTO hyperliquid_execution_fills (
                     id, execution_network, event_ts
                 )
-                SELECT n, 'testnet', clock_timestamp() - make_interval(secs => n)
+                SELECT n, 'testnet', clock_timestamp() - make_interval(mins => n)
                   FROM generate_series(1, 5000) AS n;
 
                 INSERT INTO hyperliquid_execution_account_snapshots (
                     id, execution_network, observed_at
                 )
-                SELECT n, 'testnet', clock_timestamp() - make_interval(secs => n)
+                SELECT n, 'testnet', clock_timestamp() - make_interval(mins => n)
                   FROM generate_series(1, 75000) AS n;
 
                 INSERT INTO executions (id, created_at, alpaca_account_label)
@@ -227,6 +220,9 @@ def test_indexes_bound_exact_loop_status_reads_and_downgrade_symmetrically(
     unexpected_live_plan = _explain_json(harness.engine, _UNEXPECTED_LIVE_ALPACA_SQL)
     assert "ix_hyperliquid_execution_signals_generated_at_desc" in latest_plan
     assert "ix_hyperliquid_execution_signals_generated_at_desc" in counts_plan
+    assert "ix_hyperliquid_execution_orders_network_created_desc" in counts_plan
+    assert "ix_hyperliquid_execution_fills_network_event_desc" in counts_plan
+    assert "ix_hyperliquid_execution_account_observed" in counts_plan
     assert "ix_executions_created_at_desc" in unexpected_live_plan
     assert "ix_execution_order_events_activity_at_desc" in unexpected_live_plan
 
@@ -252,10 +248,14 @@ def test_indexes_bound_exact_loop_status_reads_and_downgrade_symmetrically(
             text(
                 """
                 SELECT to_regclass('ix_hyperliquid_execution_signals_generated_at_desc'),
+                       to_regclass('ix_hyperliquid_execution_orders_network_created_desc'),
+                       to_regclass('ix_hyperliquid_execution_fills_network_event_desc'),
                        to_regclass('ix_executions_created_at_desc'),
-                       to_regclass('ix_execution_order_events_activity_at_desc')
+                       to_regclass('ix_execution_order_events_activity_at_desc'),
+                       to_regclass('ix_hyperliquid_execution_account_observed')
                 """
             )
         ).one()
     assert version == "0061_linked_submission_terminal"
-    assert indexes == (None, None, None)
+    assert indexes[:5] == (None, None, None, None, None)
+    assert indexes[5] == "ix_hyperliquid_execution_account_observed"

--- a/services/torghut/tests/execution/test_loop_status_read_indexes_postgres.py
+++ b/services/torghut/tests/execution/test_loop_status_read_indexes_postgres.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine, make_url
+
+from app.config import settings
+from app.trading.loop_status import (
+    _COUNTS_24H_SQL,
+    _LATEST_SIGNAL_SQL,
+    _UNEXPECTED_LIVE_ALPACA_SQL,
+)
+from tests.execution.decision_submission_claims_postgres_support import (
+    POSTGRES_DSN,
+    SERVICE_ROOT,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LoopStatusIndexHarness:
+    engine: Engine
+    alembic: AlembicConfig
+
+
+@pytest.fixture
+def loop_status_index_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[LoopStatusIndexHarness]:
+    if POSTGRES_DSN is None:
+        pytest.skip("set TORGHUT_TEST_POSTGRES_DSN for the loop status index test")
+    schema = f"loop_status_indexes_{uuid.uuid4().hex}"
+    admin_engine = create_engine(POSTGRES_DSN, future=True)
+    schema_url = make_url(POSTGRES_DSN).update_query_dict(
+        {"options": f"-csearch_path={schema}"}
+    )
+    schema_engine = create_engine(schema_url, future=True)
+    try:
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+        _create_loop_status_tables(schema_engine)
+        _load_realistic_loop_status_rows(schema_engine)
+        monkeypatch.setattr(
+            settings,
+            "db_dsn",
+            schema_url.render_as_string(hide_password=False),
+        )
+        alembic = AlembicConfig(str(SERVICE_ROOT / "alembic.ini"))
+        command.stamp(alembic, "0061_linked_submission_terminal")
+        command.upgrade(alembic, "0062_loop_status_read_indexes")
+        _vacuum_loop_status_tables(schema_engine)
+        yield LoopStatusIndexHarness(engine=schema_engine, alembic=alembic)
+    finally:
+        schema_engine.dispose()
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        admin_engine.dispose()
+
+
+def _create_loop_status_tables(engine: Engine) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE hyperliquid_execution_cycles (
+                    id bigint PRIMARY KEY,
+                    finished_at timestamptz NOT NULL
+                );
+                CREATE INDEX ix_test_cycles_finished_at
+                    ON hyperliquid_execution_cycles (finished_at);
+
+                CREATE TABLE hyperliquid_execution_signals (
+                    id bigint PRIMARY KEY,
+                    generated_at timestamptz NOT NULL,
+                    feature_event_ts timestamptz NOT NULL,
+                    features jsonb NOT NULL,
+                    coin text NOT NULL,
+                    action text NOT NULL,
+                    edge_bps numeric NOT NULL,
+                    reason text NOT NULL
+                );
+
+                CREATE TABLE hyperliquid_execution_orders (
+                    id bigint PRIMARY KEY,
+                    execution_network text NOT NULL,
+                    created_at timestamptz NOT NULL
+                );
+                CREATE INDEX ix_test_orders_network_created
+                    ON hyperliquid_execution_orders (execution_network, created_at);
+
+                CREATE TABLE hyperliquid_execution_fills (
+                    id bigint PRIMARY KEY,
+                    execution_network text NOT NULL,
+                    event_ts timestamptz NOT NULL
+                );
+                CREATE INDEX ix_test_fills_network_event
+                    ON hyperliquid_execution_fills (execution_network, event_ts);
+
+                CREATE TABLE hyperliquid_execution_account_snapshots (
+                    id bigint PRIMARY KEY,
+                    execution_network text NOT NULL,
+                    observed_at timestamptz NOT NULL
+                );
+                CREATE INDEX ix_test_accounts_network_observed
+                    ON hyperliquid_execution_account_snapshots (
+                        execution_network,
+                        observed_at
+                    );
+
+                CREATE TABLE executions (
+                    id bigint PRIMARY KEY,
+                    created_at timestamptz NOT NULL,
+                    alpaca_account_label text NOT NULL
+                );
+
+                CREATE TABLE execution_order_events (
+                    id bigint PRIMARY KEY,
+                    event_ts timestamptz,
+                    created_at timestamptz NOT NULL,
+                    alpaca_account_label text NOT NULL
+                )
+                """
+            )
+        )
+
+
+def _load_realistic_loop_status_rows(engine: Engine) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO hyperliquid_execution_cycles (id, finished_at)
+                SELECT n, clock_timestamp() - make_interval(secs => n)
+                  FROM generate_series(1, 75000) AS n;
+
+                INSERT INTO hyperliquid_execution_signals (
+                    id, generated_at, feature_event_ts, features,
+                    coin, action, edge_bps, reason
+                )
+                SELECT n,
+                       clock_timestamp() - make_interval(secs => n),
+                       clock_timestamp() - make_interval(secs => n + 1),
+                       '{"source_lag_seconds":"1","quote_lag_seconds":"1"}'::jsonb,
+                       'BTC', 'hold', 0, 'test'
+                  FROM generate_series(1, 260000) AS n;
+
+                INSERT INTO hyperliquid_execution_orders (
+                    id, execution_network, created_at
+                )
+                SELECT n, 'testnet', clock_timestamp() - make_interval(secs => n)
+                  FROM generate_series(1, 5000) AS n;
+
+                INSERT INTO hyperliquid_execution_fills (
+                    id, execution_network, event_ts
+                )
+                SELECT n, 'testnet', clock_timestamp() - make_interval(secs => n)
+                  FROM generate_series(1, 5000) AS n;
+
+                INSERT INTO hyperliquid_execution_account_snapshots (
+                    id, execution_network, observed_at
+                )
+                SELECT n, 'testnet', clock_timestamp() - make_interval(secs => n)
+                  FROM generate_series(1, 75000) AS n;
+
+                INSERT INTO executions (id, created_at, alpaca_account_label)
+                SELECT n,
+                       clock_timestamp() - make_interval(mins => n),
+                       CASE WHEN n % 1000 = 0 THEN 'alpaca-live' ELSE 'paper' END
+                  FROM generate_series(1, 15000) AS n;
+
+                INSERT INTO execution_order_events (
+                    id, event_ts, created_at, alpaca_account_label
+                )
+                SELECT n,
+                       CASE
+                           WHEN n % 2 = 0 THEN NULL
+                           ELSE clock_timestamp() - make_interval(mins => n)
+                       END,
+                       clock_timestamp() - make_interval(mins => n),
+                       CASE
+                           WHEN n = 1 OR n % 10 = 0 THEN 'alpaca-live'
+                           ELSE 'paper'
+                       END
+                  FROM generate_series(1, 150000) AS n;
+                DELETE FROM execution_order_events
+                 WHERE id <> 1 AND id % 2500 <> 0
+                """
+            )
+        )
+
+
+def _vacuum_loop_status_tables(engine: Engine) -> None:
+    tables = (
+        "hyperliquid_execution_cycles",
+        "hyperliquid_execution_signals",
+        "hyperliquid_execution_orders",
+        "hyperliquid_execution_fills",
+        "hyperliquid_execution_account_snapshots",
+        "executions",
+        "execution_order_events",
+    )
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+        for table_name in tables:
+            connection.execute(text(f"VACUUM (ANALYZE) {table_name}"))
+
+
+def _explain_json(engine: Engine, sql: str) -> str:
+    with engine.begin() as connection:
+        plan = connection.execute(text(f"EXPLAIN (FORMAT JSON) {sql}")).scalar_one()
+    return json.dumps(plan)
+
+
+def test_indexes_bound_exact_loop_status_reads_and_downgrade_symmetrically(
+    loop_status_index_harness: LoopStatusIndexHarness,
+) -> None:
+    harness = loop_status_index_harness
+
+    latest_plan = _explain_json(harness.engine, _LATEST_SIGNAL_SQL)
+    counts_plan = _explain_json(harness.engine, _COUNTS_24H_SQL)
+    unexpected_live_plan = _explain_json(harness.engine, _UNEXPECTED_LIVE_ALPACA_SQL)
+    assert "ix_hyperliquid_execution_signals_generated_at_desc" in latest_plan
+    assert "ix_hyperliquid_execution_signals_generated_at_desc" in counts_plan
+    assert "ix_executions_created_at_desc" in unexpected_live_plan
+    assert "ix_execution_order_events_activity_at_desc" in unexpected_live_plan
+
+    started_at = time.monotonic()
+    with harness.engine.begin() as connection:
+        connection.execute(text("SET LOCAL statement_timeout = '1500ms'"))
+        latest = connection.execute(text(_LATEST_SIGNAL_SQL)).mappings().one()
+        counts = connection.execute(text(_COUNTS_24H_SQL)).mappings().one()
+        unexpected_live = (
+            connection.execute(text(_UNEXPECTED_LIVE_ALPACA_SQL)).mappings().one()
+        )
+    assert time.monotonic() - started_at < 4.5
+    assert latest["coin"] == "BTC"
+    assert counts["signals_24h"] > 0
+    assert unexpected_live == {"orders_24h": 1, "events_24h": 1}
+
+    command.downgrade(harness.alembic, "0061_linked_submission_terminal")
+    with harness.engine.connect() as connection:
+        version = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
+        indexes = connection.execute(
+            text(
+                """
+                SELECT to_regclass('ix_hyperliquid_execution_signals_generated_at_desc'),
+                       to_regclass('ix_executions_created_at_desc'),
+                       to_regclass('ix_execution_order_events_activity_at_desc')
+                """
+            )
+        ).one()
+    assert version == "0061_linked_submission_terminal"
+    assert indexes == (None, None, None)

--- a/services/torghut/tests/test_loop_status_read_indexes_migration.py
+++ b/services/torghut/tests/test_loop_status_read_indexes_migration.py
@@ -39,9 +39,17 @@ class TestLoopStatusReadIndexesMigration(TestCase):
 
         get_context.return_value.autocommit_block.assert_called_once_with()
         executed_sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
-        self.assertEqual(execute.call_count, 3)
-        self.assertEqual(executed_sql.count("CREATE INDEX CONCURRENTLY"), 3)
+        self.assertEqual(execute.call_count, 5)
+        self.assertEqual(executed_sql.count("CREATE INDEX CONCURRENTLY"), 5)
         self.assertIn("hyperliquid_execution_signals (generated_at DESC)", executed_sql)
+        self.assertIn(
+            "hyperliquid_execution_orders (execution_network, created_at DESC)",
+            executed_sql,
+        )
+        self.assertIn(
+            "hyperliquid_execution_fills (execution_network, event_ts DESC)",
+            executed_sql,
+        )
         self.assertIn("executions (created_at DESC)", executed_sql)
         self.assertIn("COALESCE(event_ts, created_at)", executed_sql)
         self.assertEqual(executed_sql.count("INCLUDE (alpaca_account_label)"), 2)
@@ -51,7 +59,7 @@ class TestLoopStatusReadIndexesMigration(TestCase):
         bind = MagicMock()
         bind.dialect.name = "postgresql"
         inspector = MagicMock()
-        inspector.has_table.side_effect = [True, False, True]
+        inspector.has_table.side_effect = [True, False, True, False, True]
 
         with (
             patch.object(module.op, "get_bind", return_value=bind),
@@ -61,13 +69,19 @@ class TestLoopStatusReadIndexesMigration(TestCase):
         ):
             module.upgrade()
 
-        self.assertEqual(execute.call_count, 2)
+        self.assertEqual(execute.call_count, 3)
 
     def test_upgrade_rebuilds_invalid_concurrent_index_residue(self) -> None:
         module = load_migration_module(MIGRATION_FILENAME)
         bind = MagicMock()
         bind.dialect.name = "postgresql"
-        bind.execute.return_value.scalar_one_or_none.side_effect = [False, True, True]
+        bind.execute.return_value.scalar_one_or_none.side_effect = [
+            True,
+            False,
+            False,
+            True,
+            True,
+        ]
         inspector = MagicMock()
         inspector.has_table.return_value = True
 
@@ -80,13 +94,19 @@ class TestLoopStatusReadIndexesMigration(TestCase):
             module.upgrade()
 
         executed_sql = [str(call.args[0]) for call in execute.call_args_list]
-        self.assertEqual(len(executed_sql), 2)
+        self.assertEqual(len(executed_sql), 4)
         self.assertIn(
             "DROP INDEX CONCURRENTLY IF EXISTS "
-            "ix_hyperliquid_execution_signals_generated_at_desc",
+            "ix_hyperliquid_execution_orders_network_created_desc",
             executed_sql[0],
         )
         self.assertIn("CREATE INDEX CONCURRENTLY", executed_sql[1])
+        self.assertIn(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "ix_hyperliquid_execution_fills_network_event_desc",
+            executed_sql[2],
+        )
+        self.assertIn("CREATE INDEX CONCURRENTLY", executed_sql[3])
 
     def test_upgrade_skips_non_postgres(self) -> None:
         module = load_migration_module(MIGRATION_FILENAME)
@@ -118,8 +138,20 @@ class TestLoopStatusReadIndexesMigration(TestCase):
 
         get_context.return_value.autocommit_block.assert_called_once_with()
         executed_sql = [str(call.args[0]) for call in execute.call_args_list]
-        self.assertEqual(len(executed_sql), 3)
+        self.assertEqual(len(executed_sql), 5)
         self.assertIn("ix_execution_order_events_activity_at_desc", executed_sql[0])
+        self.assertTrue(
+            any(
+                "ix_hyperliquid_execution_orders_network_created_desc" in sql
+                for sql in executed_sql
+            )
+        )
+        self.assertTrue(
+            any(
+                "ix_hyperliquid_execution_fills_network_event_desc" in sql
+                for sql in executed_sql
+            )
+        )
         self.assertIn(
             "ix_hyperliquid_execution_signals_generated_at_desc", executed_sql[-1]
         )

--- a/services/torghut/tests/test_loop_status_read_indexes_migration.py
+++ b/services/torghut/tests/test_loop_status_read_indexes_migration.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from tests.migration_testing import load_migration_module
+
+
+MIGRATION_FILENAME = "0062_loop_status_read_indexes.py"
+
+
+class TestLoopStatusReadIndexesMigration(TestCase):
+    def test_revision_follows_linked_submission_recovery(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+
+        self.assertEqual(module.revision, "0062_loop_status_read_indexes")
+        self.assertEqual(module.down_revision, "0061_linked_submission_terminal")
+
+    def test_index_names_fit_postgres_identifier_limit(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+
+        for index_name, _table_name, _create_sql in module._INDEXES:
+            self.assertLessEqual(len(index_name), 63, index_name)
+
+    def test_upgrade_adds_concurrent_time_first_indexes(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context") as get_context,
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        get_context.return_value.autocommit_block.assert_called_once_with()
+        executed_sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertEqual(execute.call_count, 3)
+        self.assertEqual(executed_sql.count("CREATE INDEX CONCURRENTLY"), 3)
+        self.assertIn("hyperliquid_execution_signals (generated_at DESC)", executed_sql)
+        self.assertIn("executions (created_at DESC)", executed_sql)
+        self.assertIn("COALESCE(event_ts, created_at)", executed_sql)
+        self.assertEqual(executed_sql.count("INCLUDE (alpaca_account_label)"), 2)
+
+    def test_upgrade_skips_missing_tables(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.has_table.side_effect = [True, False, True]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context"),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        self.assertEqual(execute.call_count, 2)
+
+    def test_upgrade_rebuilds_invalid_concurrent_index_residue(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        bind.execute.return_value.scalar_one_or_none.side_effect = [False, True, True]
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context"),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        executed_sql = [str(call.args[0]) for call in execute.call_args_list]
+        self.assertEqual(len(executed_sql), 2)
+        self.assertIn(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "ix_hyperliquid_execution_signals_generated_at_desc",
+            executed_sql[0],
+        )
+        self.assertIn("CREATE INDEX CONCURRENTLY", executed_sql[1])
+
+    def test_upgrade_skips_non_postgres(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = MagicMock()
+        bind.dialect.name = "sqlite"
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        execute.assert_not_called()
+
+    def test_downgrade_drops_concurrent_indexes_in_reverse_order(self) -> None:
+        module = load_migration_module(MIGRATION_FILENAME)
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context") as get_context,
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.downgrade()
+
+        get_context.return_value.autocommit_block.assert_called_once_with()
+        executed_sql = [str(call.args[0]) for call in execute.call_args_list]
+        self.assertEqual(len(executed_sql), 3)
+        self.assertIn("ix_execution_order_events_activity_at_desc", executed_sql[0])
+        self.assertIn(
+            "ix_hyperliquid_execution_signals_generated_at_desc", executed_sql[-1]
+        )
+        self.assertTrue(
+            all("DROP INDEX CONCURRENTLY IF EXISTS" in sql for sql in executed_sql)
+        )


### PR DESCRIPTION
## Summary

- add concurrent, time-first PostgreSQL indexes for the three loop-status reads that exceeded the production 1500 ms statement timeout
- repair interrupted invalid concurrent-index residues before rebuilding while leaving valid indexes untouched
- cover revision behavior, realistic PostgreSQL 18 plans and timeouts, symmetric downgrade, and required CI wiring

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/test_loop_status_read_indexes_migration.py` (7 passed)
- `TORGHUT_TEST_POSTGRES_DSN=postgresql+psycopg://torghut:torghut@127.0.0.1:55432/torghut_test uv run --frozen pytest -q tests/execution/test_loop_status_read_indexes_postgres.py` against `postgres:18-trixie` (1 passed)
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen ruff format --check migrations/versions/0062_loop_status_read_indexes.py tests/test_loop_status_read_indexes_migration.py tests/execution/test_loop_status_read_indexes_postgres.py`
- `uv run --frozen ruff check migrations/versions/0062_loop_status_read_indexes.py tests/test_loop_status_read_indexes_migration.py tests/execution/test_loop_status_read_indexes_postgres.py`
- `uv run --frozen ruff check migrations/versions/0062_loop_status_read_indexes.py tests/test_loop_status_read_indexes_migration.py tests/execution/test_loop_status_read_indexes_postgres.py --select F401 --preview`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/run_pylint_torghut_quality_diff_gate.py --base origin/main migrations/versions/0062_loop_status_read_indexes.py tests/test_loop_status_read_indexes_migration.py tests/execution/test_loop_status_read_indexes_postgres.py`
- `uv run --frozen python scripts/run_pylint_torghut_file_length_gate.py --base origin/main migrations/versions/0062_loop_status_read_indexes.py tests/test_loop_status_read_indexes_migration.py tests/execution/test_loop_status_read_indexes_postgres.py`
- `uv run --frozen python scripts/measure_torghut_tech_debt.py --baseline config/quality/tech-debt-baseline.json --enforce-ratchet --format markdown`
- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts` (22 passed)

## Screenshots (if applicable)

N/A; this is a PostgreSQL migration and CI-only change.

## Breaking Changes

None. Alembic applies revision `0062_loop_status_read_indexes` after `0061_linked_submission_terminal`; index creation and removal use PostgreSQL concurrent operations.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No separate documentation or release-note update is required for this narrow operational migration.
