### PR TITLE
fix(app): retry auth migrations and preserve redirects

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -37,6 +37,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^25.6.0",
+    "@types/pg": "^8.18.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 
 import Header from '../components/Header'
 import { getCurrentUserServerFn } from '../server/auth/server-fns'
+import { resolveLoginNext } from './login-redirect'
 
 import appCss from '../styles.css?url'
 
@@ -18,7 +19,7 @@ export const Route = createRootRoute({
       throw redirect({
         to: '/login',
         search: {
-          next: location.pathname,
+          next: resolveLoginNext(location),
         },
       })
     }

--- a/apps/app/src/routes/login-redirect.test.ts
+++ b/apps/app/src/routes/login-redirect.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveLoginNext } from './login-redirect'
+
+describe('resolveLoginNext', () => {
+  it('preserves path, query string, and hash', () => {
+    expect(resolveLoginNext({ href: '/reports?window=1d#drawdown' })).toBe('/reports?window=1d#drawdown')
+  })
+})

--- a/apps/app/src/routes/login-redirect.ts
+++ b/apps/app/src/routes/login-redirect.ts
@@ -1,0 +1,1 @@
+export const resolveLoginNext = (location: { href: string }): string => location.href

--- a/apps/app/src/server/auth/auth.server.ts
+++ b/apps/app/src/server/auth/auth.server.ts
@@ -3,6 +3,7 @@ import { tanstackStartCookies } from 'better-auth/tanstack-start'
 import { genericOAuth, keycloak } from 'better-auth/plugins'
 import { Pool } from 'pg'
 
+import { createMigrationRunner } from './migration-runner'
 import type { SessionUser } from './types'
 
 const requireEnv = (key: string): string => {
@@ -34,16 +35,10 @@ export const auth = betterAuth({
   ],
 })
 
-let migrationsPromise: Promise<void> | null = null
-export const ensureAuthMigrations = async () => {
-  if (!migrationsPromise) {
-    migrationsPromise = (async () => {
-      const ctx = await auth.$context
-      await ctx.runMigrations()
-    })()
-  }
-  await migrationsPromise
-}
+export const ensureAuthMigrations = createMigrationRunner(async () => {
+  const ctx = await auth.$context
+  await ctx.runMigrations()
+})
 
 export const getCurrentUser = async (request: Request): Promise<SessionUser | null> => {
   await ensureAuthMigrations()
@@ -102,7 +97,6 @@ export const logoutResponse = async (request: Request): Promise<Response> => {
 
   const result = await auth.api.signOut({
     headers: request.headers,
-    body: {},
     returnHeaders: true,
     returnStatus: true,
   })

--- a/apps/app/src/server/auth/migration-runner.test.ts
+++ b/apps/app/src/server/auth/migration-runner.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMigrationRunner } from './migration-runner'
+
+describe('createMigrationRunner', () => {
+  it('shares one in-flight migration attempt', async () => {
+    let resolveMigration: (() => void) | undefined
+    const runMigrations = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMigration = resolve
+        }),
+    )
+    const ensureMigrations = createMigrationRunner(runMigrations)
+
+    const first = ensureMigrations()
+    const second = ensureMigrations()
+    expect(runMigrations).toHaveBeenCalledTimes(1)
+
+    resolveMigration?.()
+    await Promise.all([first, second])
+  })
+
+  it('retries after a transient migration failure', async () => {
+    const runMigrations = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce()
+    const ensureMigrations = createMigrationRunner(runMigrations)
+
+    await expect(ensureMigrations()).rejects.toThrow('database unavailable')
+    await expect(ensureMigrations()).resolves.toBeUndefined()
+    expect(runMigrations).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/app/src/server/auth/migration-runner.ts
+++ b/apps/app/src/server/auth/migration-runner.ts
@@ -1,0 +1,15 @@
+export const createMigrationRunner = (runMigrations: () => Promise<void>) => {
+  let migrationsPromise: Promise<void> | null = null
+
+  return async () => {
+    if (!migrationsPromise) {
+      const pending = runMigrations()
+      migrationsPromise = pending
+      pending.catch(() => {
+        if (migrationsPromise === pending) migrationsPromise = null
+      })
+    }
+
+    await migrationsPromise
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^25.6.0",
+        "@types/pg": "^8.18.0",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",


### PR DESCRIPTION
## Summary

- Retries Better Auth migrations after transient failures and preserves the complete protected destination across login redirects.
- Adds or preserves regression coverage for the reviewed failure mode where a local harness is available.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/2905#discussion_r2779874711 (also covers https://github.com/proompteng/lab/pull/2906#discussion_r2779897684 and https://github.com/proompteng/lab/pull/2905#discussion_r2779874715)

## Testing

- 3 focused Vitest tests passed.\n- `tsc --noEmit -p apps/app/tsconfig.json` passed.\n- Oxc lint passed with 0 warnings and 0 errors.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Documentation and follow-up linkage are included.
