### PR TITLE
fix(miel): preserve accepted orders on ledger failure

### DIFF
--- a/services/miel/internal/trading/service.go
+++ b/services/miel/internal/trading/service.go
@@ -3,6 +3,7 @@ package trading
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	sdkalpaca "github.com/alpacahq/alpaca-trade-api-go/v3/alpaca"
@@ -44,7 +45,9 @@ func (s *Service) SubmitMarketOrder(ctx context.Context, symbol string, qty floa
 
 	if s.ledger != nil {
 		if err := s.ledger.RecordOrder(ctx, order); err != nil {
-			return nil, fmt.Errorf("record order in ledger: %w", err)
+			// The broker has already accepted the order. Returning an error here
+			// invites callers to retry and submit a duplicate live order.
+			slog.ErrorContext(ctx, "failed to record accepted broker order in ledger", "order_id", order.ID, "error", err)
 		}
 	}
 

--- a/services/miel/internal/trading/service_test.go
+++ b/services/miel/internal/trading/service_test.go
@@ -3,6 +3,7 @@ package trading
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,11 +17,40 @@ import (
 
 type ledgerRecorderStub struct {
 	orders []*sdkalpaca.Order
+	err    error
 }
 
 func (s *ledgerRecorderStub) RecordOrder(_ context.Context, order *sdkalpaca.Order) error {
 	s.orders = append(s.orders, order)
-	return nil
+	return s.err
+}
+
+func TestSubmitMarketOrderReturnsAcceptedOrderWhenLedgerWriteFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(sdkalpaca.Order{ID: "order-accepted", Symbol: "AAPL", Side: sdkalpaca.Buy}); err != nil {
+			t.Fatalf("encode order: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cfg := config.Config{
+		AlpacaAPIKey:         "key",
+		AlpacaAPISecret:      "secret",
+		AlpacaTradingBaseURL: server.URL,
+		AlpacaMarketDataURL:  server.URL,
+		RequestTimeout:       time.Second,
+	}
+	recorder := &ledgerRecorderStub{err: errors.New("ledger unavailable")}
+	svc := NewService(alpaca.NewClient(cfg), recorder)
+
+	order, err := svc.SubmitMarketOrder(context.Background(), "AAPL", 1, "buy", "day", false)
+	if err != nil {
+		t.Fatalf("accepted broker order must not be reported as failed: %v", err)
+	}
+	if order.ID != "order-accepted" {
+		t.Fatalf("unexpected order id %s", order.ID)
+	}
 }
 
 func (s *ledgerRecorderStub) RecordBacktest(context.Context, backtest.Result) error { return nil }


### PR DESCRIPTION
## Summary

- Returns an already accepted broker order even when the accounting ledger write fails, preventing caller retries from duplicating the live order.
- Adds or preserves regression coverage for the reviewed failure mode where a local harness is available.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/1082#discussion_r2399826088

## Testing

- Added a Go regression test for an accepted order followed by a ledger failure.\n- Go toolchain is unavailable in agents-shell; repository CI is authoritative.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Documentation and follow-up linkage are included.
