### PR TITLE
fix(graf): preserve kn timeout units

### DIFF
--- a/packages/scripts/src/graf/deploy-service.test.ts
+++ b/packages/scripts/src/graf/deploy-service.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'bun:test'
+
+import { resolveGrafWaitTimeout } from './deploy-service'
+
+describe('resolveGrafWaitTimeout', () => {
+  it('preserves the duration unit expected by kn', () => {
+    expect(resolveGrafWaitTimeout({ GRAF_KN_WAIT_TIMEOUT: '45s' })).toBe('45s')
+  })
+
+  it('defaults to a unit-bearing duration', () => {
+    expect(resolveGrafWaitTimeout({})).toBe('300s')
+  })
+})

--- a/packages/scripts/src/graf/deploy-service.ts
+++ b/packages/scripts/src/graf/deploy-service.ts
@@ -9,6 +9,9 @@ import { buildImage } from './build-image'
 
 const manifestPath = resolve(repoRoot, 'argocd/applications/graf/knative-service.yaml')
 
+export const resolveGrafWaitTimeout = (env: Record<string, string | undefined> = process.env) =>
+  env.GRAF_KN_WAIT_TIMEOUT ?? '300s'
+
 const ensureResources = () => {
   ensureCli('docker')
   ensureCli('kn')
@@ -79,8 +82,7 @@ const updateManifestImage = (image: string, version: string, commit: string) => 
 }
 
 const applyManifest = async () => {
-  const rawTimeout = process.env.GRAF_KN_WAIT_TIMEOUT ?? '300s'
-  const waitTimeout = rawTimeout.replace(/s$/, '')
+  const waitTimeout = resolveGrafWaitTimeout()
   await run('kn', [
     'service',
     'apply',


### PR DESCRIPTION
## Summary

- Passes a unit-bearing duration to `kn --wait-timeout` instead of stripping the seconds suffix.
- Adds or preserves regression coverage for the reviewed failure mode where a local harness is available.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/1721#discussion_r2507608910

## Testing

- 2 Bun regression tests passed.\n- Oxc lint passed with 0 warnings and 0 errors.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Documentation and follow-up linkage are included.
