### PR TITLE
test(docs): restore RBD inventory regression gate

### DIFF
--- a/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+
+it('selects RBD CSI nodeplugin pods by label without silently skipping mapped KRBD checks', () => {
+  const runbook = readFileSync(join(repoRoot, 'docs/runbooks/rook-ceph-client-ops-performance.md'), 'utf8')
+
+  expect(runbook).toContain("RBD_NODEPLUGIN_SELECTOR='app in (rook-ceph.rbd.csi.ceph.com-nodeplugin,csi-rbdplugin)'")
+  expect(runbook).toContain('select(any(.spec.containers[]?; .name=="csi-rbdplugin"))')
+  expect(runbook).toContain('No RBD CSI nodeplugin pods found with selector')
+  expect(runbook).toContain('-c csi-rbdplugin -- rbd showmapped --format json')
+  expect(runbook).not.toContain("rg 'rook-ceph\\.rbd\\.csi\\.ceph\\.com-nodeplugin'")
+})


### PR DESCRIPTION
## Summary

- Restores semantic regression coverage for RBD nodeplugin discovery, container selection, fail-closed zero-pod handling, and mapped-device inspection.
- Adds or preserves regression coverage for the reviewed failure mode where a local harness is available.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex review: https://github.com/proompteng/lab/pull/12246#discussion_r3565169325

## Testing

- 1 Bun test passed with 5 assertions.\n- Oxc lint passed with 0 warnings and 0 errors.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Documentation and follow-up linkage are included.
