### PR TITLE
fix(jangar): harden quant stream and metrics

### DIFF
--- a/services/jangar/src/routes/api/torghut/trading/control-plane/quant/stream.test.ts
+++ b/services/jangar/src/routes/api/torghut/trading/control-plane/quant/stream.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchesQuantStreamAccount } from './stream'
+
+describe('quant stream account filtering', () => {
+  it('delivers only aggregate frames when no account is requested', () => {
+    expect(matchesQuantStreamAccount('', '')).toBe(true)
+    expect(matchesQuantStreamAccount('', 'paper-a')).toBe(false)
+  })
+
+  it('delivers only the requested account when scoped', () => {
+    expect(matchesQuantStreamAccount('paper-a', 'paper-a')).toBe(true)
+    expect(matchesQuantStreamAccount('paper-a', '')).toBe(false)
+    expect(matchesQuantStreamAccount('paper-a', 'paper-b')).toBe(false)
+  })
+})

--- a/services/jangar/src/routes/api/torghut/trading/control-plane/quant/stream.ts
+++ b/services/jangar/src/routes/api/torghut/trading/control-plane/quant/stream.ts
@@ -18,6 +18,9 @@ export const Route = createFileRoute('/api/torghut/trading/control-plane/quant/s
   },
 })
 
+export const matchesQuantStreamAccount = (requestedAccount: string, eventAccount: string) =>
+  requestedAccount ? eventAccount === requestedAccount : eventAccount === ''
+
 export const streamQuantEvents = async (request: Request) => {
   startTorghutQuantRuntime()
 
@@ -75,21 +78,21 @@ export const streamQuantEvents = async (request: Request) => {
         if (event.type === 'quant.metrics.snapshot') {
           if (event.frame.strategyId !== strategyIdResult.value) return
           if (event.frame.window !== windowResult.value) return
-          if (account && event.frame.account !== account) return
+          if (!matchesQuantStreamAccount(account, event.frame.account)) return
           push(event)
           return
         }
         if (event.type === 'quant.metrics.delta') {
           if (event.strategyId !== strategyIdResult.value) return
           if (event.window !== windowResult.value) return
-          if (account && event.account !== account) return
+          if (!matchesQuantStreamAccount(account, event.account)) return
           push(event)
           return
         }
         if (event.type === 'quant.alert.opened' || event.type === 'quant.alert.resolved') {
           if (event.alert.strategyId !== strategyIdResult.value) return
           if (event.alert.window !== windowResult.value) return
-          if (account && event.alert.account !== account) return
+          if (!matchesQuantStreamAccount(account, event.alert.account)) return
           push(event)
           return
         }

--- a/services/jangar/src/server/__tests__/torghut-config.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-config.test.ts
@@ -21,6 +21,14 @@ describe('torghut-config', () => {
     expect(config.policy.maxDrawdown1d).toBe(0.08)
   })
 
+  it('rejects unsupported quant windows instead of casting them', () => {
+    expect(() =>
+      resolveTorghutQuantRuntimeConfig({
+        JANGAR_TORGHUT_QUANT_WINDOWS_LIGHT: '1m,30m',
+      }),
+    ).toThrow('Unsupported Torghut quant window(s): 30m')
+  })
+
   it('normalizes torghut endpoints and health defaults', () => {
     expect(
       resolveTorghutEndpointsConfig({

--- a/services/jangar/src/server/__tests__/torghut-quant-metrics.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-quant-metrics.test.ts
@@ -28,13 +28,15 @@ describe('torghut quant metrics helpers', () => {
       { asOf: '2026-02-12T00:00:00.000Z', equity: 100 },
       { asOf: '2026-02-12T00:01:00.000Z', equity: 110 },
       { asOf: '2026-02-12T00:02:00.000Z', equity: 99 },
-      { asOf: '2026-02-12T00:03:00.000Z', equity: 105 },
+      { asOf: '2026-02-12T00:03:00.000Z', equity: 120 },
     ]
 
     const dd = __private.computeMaxDrawdown(series)
     // Peak 110 to trough 99 => -10%
     expect(dd.maxDrawdown).toBeCloseTo(-0.1, 6)
     expect(dd.drawdownDurationMinutes).toBe(1)
+    expect(dd.peakTs).toBe('2026-02-12T00:01:00.000Z')
+    expect(dd.troughTs).toBe('2026-02-12T00:02:00.000Z')
   })
 
   it('computes route provenance continuity ratios from execution metadata', () => {

--- a/services/jangar/src/server/torghut-config.ts
+++ b/services/jangar/src/server/torghut-config.ts
@@ -1,4 +1,5 @@
 import { normalizeTorghutSymbol } from './torghut-symbols'
+import { isQuantWindow, type QuantWindow } from './torghut-quant-contract'
 
 type EnvSource = Record<string, string | undefined>
 
@@ -21,8 +22,8 @@ export type TorghutQuantRuntimeConfig = {
   seriesSamplingMs: number
   streamHeartbeatMs: number
   maxStalenessSeconds: number
-  windowsLight: string[]
-  windowsHeavy: string[]
+  windowsLight: QuantWindow[]
+  windowsHeavy: QuantWindow[]
   alertsEnabled: boolean
   alertsEnabledFlagKey: string
   policy: QuantPolicyConfig
@@ -88,12 +89,17 @@ const parseNumber = (value: string | undefined, fallback: number) => {
   return Number.isFinite(parsed) ? parsed : fallback
 }
 
-const parseWindowList = (value: string | undefined, fallback: string[]) => {
+const parseWindowList = (value: string | undefined, fallback: QuantWindow[]): QuantWindow[] => {
   const normalized = (value ?? '')
     .split(',')
     .map((item) => item.trim())
     .filter((item) => item.length > 0)
-  return normalized.length > 0 ? normalized : [...fallback]
+  if (normalized.length === 0) return [...fallback]
+  const invalid = normalized.filter((window) => !isQuantWindow(window))
+  if (invalid.length > 0) {
+    throw new Error(`Unsupported Torghut quant window(s): ${invalid.join(', ')}`)
+  }
+  return normalized as QuantWindow[]
 }
 
 const normalizeUrl = (value: string | undefined, fallback: string) =>

--- a/services/jangar/src/server/torghut-quant-metrics.ts
+++ b/services/jangar/src/server/torghut-quant-metrics.ts
@@ -319,27 +319,31 @@ const annualizationFactor = (sampleSeconds: number | null) => {
 const computeMaxDrawdown = (series: Array<{ asOf: string; equity: number }>) => {
   let peak = -Infinity
   let maxDrawdown = 0
-  let peakTs: string | null = null
+  let currentPeakTs: string | null = null
+  let maxDrawdownPeakTs: string | null = null
   let troughTs: string | null = null
 
   for (const point of series) {
     if (point.equity > peak) {
       peak = point.equity
-      peakTs = point.asOf
+      currentPeakTs = point.asOf
     }
     if (peak > 0) {
       const drawdown = point.equity / peak - 1
       if (drawdown < maxDrawdown) {
         maxDrawdown = drawdown
+        maxDrawdownPeakTs = currentPeakTs
         troughTs = point.asOf
       }
     }
   }
 
   const durationMinutes =
-    peakTs && troughTs ? Math.max(0, Math.floor((Date.parse(troughTs) - Date.parse(peakTs)) / 60_000)) : null
+    maxDrawdownPeakTs && troughTs
+      ? Math.max(0, Math.floor((Date.parse(troughTs) - Date.parse(maxDrawdownPeakTs)) / 60_000))
+      : null
 
-  return { maxDrawdown, drawdownDurationMinutes: durationMinutes, peakTs, troughTs }
+  return { maxDrawdown, drawdownDurationMinutes: durationMinutes, peakTs: maxDrawdownPeakTs, troughTs }
 }
 
 const inferSnapshotSampleSeconds = (series: Array<{ asOf: string; equity: number }>) => {

--- a/services/jangar/src/server/torghut-quant-runtime.ts
+++ b/services/jangar/src/server/torghut-quant-runtime.ts
@@ -97,8 +97,8 @@ const loadConfig = (overrides?: { enabled?: boolean; alertsEnabled?: boolean }):
   const config = resolveTorghutQuantRuntimeConfig(process.env, overrides)
   return {
     ...config,
-    windowsLight: config.windowsLight as QuantWindow[],
-    windowsHeavy: config.windowsHeavy as QuantWindow[],
+    windowsLight: config.windowsLight,
+    windowsHeavy: config.windowsHeavy,
   }
 }
 


### PR DESCRIPTION
## Summary

- Restricts unscoped SSE streams to aggregate frames, validates configured quant windows, and preserves the peak timestamp associated with maximum drawdown.
- Adds focused regression coverage for the reviewed failure mode.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex reviews:
- https://github.com/proompteng/lab/pull/3042#discussion_r2800453246\n- https://github.com/proompteng/lab/pull/3042#discussion_r2800453249\n- https://github.com/proompteng/lab/pull/3042#discussion_r2800453253

## Testing

- 15 focused Vitest tests passed.\n- Quant branch project type-check passed before publication.\n- Oxc lint passed with 0 warnings and 0 errors.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Historical review linkage is included.
