### PR TITLE
fix(jangar): require durable cache artifacts

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
@@ -437,8 +437,8 @@ describe('submitTorghutSimulationRun', () => {
       cache_key: cacheKey,
       lane: 'equity',
       status: 'ready',
-      artifact_path: 'artifacts/torghut/simulations/prior-run/source-dump.jsonl.zst',
-      chunk_manifest_path: 'artifacts/torghut/simulations/prior-run/source-dump.jsonl.zst.manifest.json',
+      artifact_path: 's3://torghut-simulations/cache/prior-run/source-dump.jsonl.zst',
+      chunk_manifest_path: 's3://torghut-simulations/cache/prior-run/source-dump.jsonl.zst.manifest.json',
       built_by_run_id: 'prior-run',
       hit_count: 2,
     })
@@ -453,15 +453,15 @@ describe('submitTorghutSimulationRun', () => {
     expect(result.run.cacheStatus).toBe('hit')
     const cacheRow = state.cache.get(cacheKey)
     expect(cacheRow?.status).toBe('ready')
-    expect(cacheRow?.artifact_path).toBe('artifacts/torghut/simulations/prior-run/source-dump.jsonl.zst')
+    expect(cacheRow?.artifact_path).toBe('s3://torghut-simulations/cache/prior-run/source-dump.jsonl.zst')
     expect(cacheRow?.chunk_manifest_path).toBe(
-      'artifacts/torghut/simulations/prior-run/source-dump.jsonl.zst.manifest.json',
+      's3://torghut-simulations/cache/prior-run/source-dump.jsonl.zst.manifest.json',
     )
     expect(cacheRow?.built_by_run_id).toBe('prior-run')
     expect(cacheRow?.hit_count).toBe(3)
     expect((state.runs.get('sim-cache-hit-proof')?.metadata as Record<string, unknown>)?.cacheDecision).toBe('hit')
     expect((state.runs.get('sim-cache-hit-proof')?.metadata as Record<string, unknown>)?.cacheArtifactPath).toBe(
-      'artifacts/torghut/simulations/prior-run/source-dump.jsonl.zst',
+      's3://torghut-simulations/cache/prior-run/source-dump.jsonl.zst',
     )
   })
 
@@ -503,6 +503,16 @@ describe('submitTorghutSimulationRun', () => {
       .digest('hex')
     const expectedArtifactPath = `s3://argo-workflows/torghut-simulation-cache/${cacheKey}/source-dump.jsonl.zst`
     const expectedManifestPath = `${expectedArtifactPath}.manifest.json`
+
+    state.cache.set(cacheKey, {
+      cache_key: cacheKey,
+      lane: 'equity',
+      status: 'ready',
+      artifact_path: 'artifacts/local-only/source-dump.jsonl.zst',
+      chunk_manifest_path: 'artifacts/local-only/source-dump.jsonl.zst.manifest.json',
+      built_by_run_id: 'stale-local-run',
+      hit_count: 4,
+    })
 
     const result = await submitTorghutSimulationRun({
       runId: 'sim-cache-miss-proof',

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -1127,7 +1127,7 @@ export const submitTorghutSimulationRun = async (request: TorghutSimulationRunRe
   const outputRoot = String(runtime.output_root ?? DEFAULT_OUTPUT_ROOT)
   const workflowOutputRoot = resolveWorkflowOutputRoot(outputRoot)
   const artifactRoot = `${outputRoot.replace(/\/+$/, '')}/${normalizeRunToken(runId)}`
-  const cachedDataset =
+  const cachedDatasetRow =
     requestedCachePolicy === 'refresh'
       ? null
       : await db
@@ -1136,6 +1136,12 @@ export const submitTorghutSimulationRun = async (request: TorghutSimulationRunRe
           .where('cache_key', '=', cacheKey)
           .where('status', '=', 'ready')
           .executeTakeFirst()
+  const cachedArtifactPath = asString(cachedDatasetRow?.artifact_path)
+  const cachedChunkManifestPath = asString(cachedDatasetRow?.chunk_manifest_path)
+  const cachedDataset =
+    cachedDatasetRow && cachedArtifactPath?.startsWith('s3://') && cachedChunkManifestPath?.startsWith('s3://')
+      ? cachedDatasetRow
+      : null
   const cacheDecision = cachedDataset ? 'hit' : requestedCachePolicy === 'refresh' ? 'refresh' : 'miss'
   const cacheStatus = cachedDataset ? 'hit' : 'miss'
   const cachePaths = buildDatasetCacheArtifactPaths(cacheKey, asString(performance.dumpFormat) ?? DEFAULT_DUMP_FORMAT)
@@ -1426,7 +1432,7 @@ export const submitTorghutSimulationCampaign = async (request: TorghutSimulation
       const label = asString(windowSpec.label)
       if (label) manifest.window_label = label
       manifest.campaign = {
-        ...(asRecord(manifest.campaign) ?? {}),
+        ...asRecord(manifest.campaign),
         campaignId,
         windowSetRef: normalized.windowSetRef,
         gateConfigRef: normalized.gateConfigRef,


### PR DESCRIPTION
## Summary

- Treats a ready simulation-cache row as a hit only when both artifact and chunk-manifest paths are durable S3 locations.
- Adds focused regression coverage for the reviewed failure mode.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex reviews:
- https://github.com/proompteng/lab/pull/4468#discussion_r2936080745\n- https://github.com/proompteng/lab/pull/4478#discussion_r2936141606

## Testing

- 4 focused Vitest tests passed.\n- Covers both a valid durable hit and a non-durable ready row that must miss.\n- Oxc lint passed with 0 warnings and 0 errors.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Historical review linkage is included.
