### PR TITLE
fix(jangar): exclude cancellations from provider failures

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
@@ -29,7 +29,7 @@ describe('torghut market-context agent helpers', () => {
           updatedAt: new Date('2026-03-05T19:58:00.000Z'),
         },
         {
-          status: 'cancelled',
+          status: 'failed',
           error: 'provider_attempt_timeout',
           updatedAt: new Date('2026-03-05T19:55:00.000Z'),
         },
@@ -45,6 +45,37 @@ describe('torghut market-context agent helpers', () => {
     expect(state.consecutiveFailures).toBe(3)
     expect(state.cooldownRemainingSeconds).toBe(780)
     expect(state.lastError).toBe('provider_turn_failed')
+  })
+
+  it('does not count operator cancellations as provider failures', async () => {
+    const { resolveProviderCircuitStateFromRows } = await import('../torghut-market-context-agents')
+
+    const state = resolveProviderCircuitStateFromRows({
+      provider: 'codex-spark',
+      threshold: 2,
+      cooldownSeconds: 900,
+      now: new Date('2026-03-05T20:00:00.000Z'),
+      rows: [
+        {
+          status: 'failed',
+          error: 'provider_turn_failed',
+          updatedAt: new Date('2026-03-05T19:58:00.000Z'),
+        },
+        {
+          status: 'cancelled',
+          error: 'market_closed',
+          updatedAt: new Date('2026-03-05T19:57:00.000Z'),
+        },
+        {
+          status: 'failed',
+          error: 'older_failure',
+          updatedAt: new Date('2026-03-05T19:56:00.000Z'),
+        },
+      ],
+    })
+
+    expect(state.cooldownOpen).toBe(false)
+    expect(state.consecutiveFailures).toBe(1)
   })
 
   it('keeps provider circuit closed when a success breaks the failure chain', async () => {

--- a/services/jangar/src/server/torghut-market-context-agents.ts
+++ b/services/jangar/src/server/torghut-market-context-agents.ts
@@ -538,7 +538,7 @@ export const resolveProviderCircuitStateFromRows = (params: {
   for (const row of params.rows) {
     const status = row.status.trim().toLowerCase()
     if (status === 'succeeded' || status === 'partial') break
-    if (status !== 'failed' && status !== 'cancelled') break
+    if (status !== 'failed') break
     consecutiveFailures += 1
     if (!lastFailureAt) {
       lastFailureAt = row.updatedAt
@@ -592,7 +592,7 @@ const buildDegradedSnapshotMetadata = (params: {
   payload.providerCircuit = coercePayload(params.latestRun.metadata.providerCircuit)
   payload.fallbackUsed = payload.provider !== preferredProvider
 
-  if (params.latestRun.status === 'failed' || params.latestRun.status === 'cancelled') {
+  if (params.latestRun.status === 'failed') {
     payload.generationFailed = true
     payload.degradedReason =
       payload.lastFailureCategory ?? params.latestRun.error ?? `${params.domain}_generation_failed_all_models`
@@ -616,7 +616,7 @@ export const getMarketContextProviderResult = async (params: {
 
   if (!db) {
     const riskFlags = [`${params.domain}_missing`, `${params.domain}_database_unavailable`]
-    if (latestRun?.status === 'failed' || latestRun?.status === 'cancelled') {
+    if (latestRun?.status === 'failed') {
       riskFlags.push(`${params.domain}_generation_failed_all_models`, 'market_context_degraded_last_good')
     }
     return {
@@ -658,7 +658,7 @@ export const getMarketContextProviderResult = async (params: {
       settings,
       now,
     })
-    if (latestRun?.status === 'failed' || latestRun?.status === 'cancelled') {
+    if (latestRun?.status === 'failed') {
       riskFlags.add(`${params.domain}_generation_failed_all_models`)
       riskFlags.add('market_context_degraded_last_good')
     }


### PR DESCRIPTION
## Summary

- Stops operator or market-state cancellations from opening provider failure circuits or being reported as generation failures.
- Adds focused regression coverage for the reviewed failure mode.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex reviews:
- https://github.com/proompteng/lab/pull/4071#discussion_r2892442362\n- https://github.com/proompteng/lab/pull/4071#discussion_r2892442364

## Testing

- 12 focused Vitest tests passed.\n- Oxc lint passed with 0 warnings and 0 errors.\n- Diff and formatting checks passed.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Historical review linkage is included.
