### PR TITLE
fix(jangar): honor planned decision timeout

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-trading-summary.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-trading-summary.test.ts
@@ -14,6 +14,11 @@ afterEach(() => {
 })
 
 describe('torghut trading summary reason parsing', () => {
+  it('uses the configured planned-decision timeout', () => {
+    expect(__private.resolveStalePlannedThresholdMs({ TRADING_PLANNED_DECISION_TIMEOUT_SECONDS: '90' })).toBe(90_000)
+    expect(__private.resolveStalePlannedThresholdMs({})).toBe(600_000)
+  })
+
   it('splits semicolon-delimited risk reasons into individual tokens', () => {
     expect(__private.splitRiskReason('shorts_not_allowed;symbol_capacity_exhausted')).toEqual([
       'shorts_not_allowed',

--- a/services/jangar/src/server/torghut-trading.ts
+++ b/services/jangar/src/server/torghut-trading.ts
@@ -158,7 +158,13 @@ const TORGHUT_API_BASE_URL = resolveTorghutEndpointsConfig(process.env).apiBaseU
 
 const SUBMITTED_DECISION_STATUSES = new Set(['submitted', 'filled', 'canceled', 'cancelled', 'expired'])
 const SUBMIT_ATTEMPT_DECISION_STAGES = new Set(['submit_requested', 'submitted', 'rejected_submit'])
-const STALE_PLANNED_THRESHOLD_MS = 60_000
+
+const resolveStalePlannedThresholdMs = (env: Record<string, string | undefined> = process.env) => {
+  const raw = env.TRADING_PLANNED_DECISION_TIMEOUT_SECONDS?.trim()
+  if (!raw) return 600_000
+  const seconds = Number.parseInt(raw, 10)
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : 600_000
+}
 
 const countMapToSortedList = (counts: Map<string, number>, limit = 12) =>
   [...counts.entries()]
@@ -824,7 +830,9 @@ export const buildTorghutTradingSummary = async (params: {
   const pnl = computeRealizedPnlAverageCostLongOnly(executions)
   const staleReferenceTime = Math.min(Date.parse(params.interval.endUtc), Date.now())
   const staleCutoffIso = toIsoString(
-    new Date((Number.isFinite(staleReferenceTime) ? staleReferenceTime : Date.now()) - STALE_PLANNED_THRESHOLD_MS),
+    new Date(
+      (Number.isFinite(staleReferenceTime) ? staleReferenceTime : Date.now()) - resolveStalePlannedThresholdMs(),
+    ),
   )
   const decisionLifecycle = summarizeDecisionLifecycle(decisions, staleCutoffIso)
   const runtimeProfitability: RuntimeProfitabilitySummary = profitabilityResult.ok
@@ -984,4 +992,5 @@ export const __private = {
   summarizeDecisionLifecycle,
   parseRuntimeProfitabilitySummary,
   parseRuntimeControlPlaneSummary,
+  resolveStalePlannedThresholdMs,
 }


### PR DESCRIPTION
## Summary

- Uses `TRADING_PLANNED_DECISION_TIMEOUT_SECONDS` for planned-decision expiry instead of a hard-coded one-minute cutoff.
- Adds focused regression coverage for the reviewed failure mode.
- Extracted from the historical unresolved Codex review audit onto fresh current main.

## Related Issues

Addresses historical Codex reviews:
- https://github.com/proompteng/lab/pull/4430#discussion_r2933744345

## Testing

- 9 focused Vitest tests passed.\n- Oxc lint passed with 0 warnings and 0 errors.\n- Diff and formatting checks passed.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Historical review linkage is included.
