### PR TITLE
fix(arc): cap lab runners at five per architecture

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -28,7 +28,7 @@ spec:
           scaleSetLabels:
             - arc-arm64
           minRunners: 1
-          maxRunners: 10
+          maxRunners: 5
           listenerTemplate:
             spec:
               dnsConfig:
@@ -153,7 +153,7 @@ spec:
           scaleSetLabels:
             - arc-amd64
           minRunners: 1
-          maxRunners: 10
+          maxRunners: 5
           listenerTemplate:
             spec:
               dnsConfig:

--- a/packages/scripts/src/shared/__tests__/arc-runner.test.ts
+++ b/packages/scripts/src/shared/__tests__/arc-runner.test.ts
@@ -70,10 +70,10 @@ describe('ARC Nix runner toolchain', () => {
     expect(arcRunnerReleaseWorkflow).not.toContain('PersistentVolumeClaim')
   })
 
-  it('keeps lab ARC runners capped until pod CIDR capacity soak completes', () => {
-    expect(runnerScaleSetBlock('arc-arm64')).toContain('maxRunners: 10')
+  it('keeps lab ARC runner concurrency capped', () => {
+    expect(runnerScaleSetBlock('arc-arm64')).toContain('maxRunners: 5')
     expect(runnerScaleSetBlock('arc-arm64')).toContain('minRunners: 1')
-    expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 10')
+    expect(runnerScaleSetBlock('arc-amd64')).toContain('maxRunners: 5')
     expect(runnerScaleSetBlock('arc-amd64')).toContain('minRunners: 1')
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('maxRunners: 5')
     expect(runnerScaleSetBlock('analysis-arm64')).toContain('minRunners: 1')


### PR DESCRIPTION
## Summary

- Cap the lab `arc-arm64` runner scale set at five concurrent runners.
- Cap the lab `arc-amd64` runner scale set at five concurrent runners.
- Update the ARC manifest regression test to enforce both limits.

## Related Issues

None.

## Testing

- `nix develop -c bun run lint:argocd`
- `nix develop -c bun test packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `nix develop -c bunx oxfmt --check packages/scripts/src/shared/__tests__/arc-runner.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
