### PR TITLE
fix(torghut): restart production TA job

### DIFF
--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:42795996988cbe90c5c9c06a8b97a4710ac0fa9df3799cadff0839fac640bc12
   imagePullPolicy: IfNotPresent
-  restartNonce: 27
+  restartNonce: 28
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:


### PR DESCRIPTION
## Summary

- Increment the production `torghut-ta` Flink restart nonce from 27 to 28.
- Reconcile the failed job after cluster resource pressure cleared.
- Preserve the current image, parallelism, slot count, and stateless recovery mode.

## Related Issues

None.

## Testing

- `nix develop -c kustomize build --enable-helm argocd/applications/torghut`
- `nix develop -c bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
