### PR TITLE
build(bumba): refresh arm64 dependency hash

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -12,7 +12,7 @@ import ./bun-workspace-service.nix {
   packageName = "@proompteng/bumba";
   depsHash = {
     x86_64-linux = "sha256-uY0V6XA1MVn8XEUN8cA85c1L5fPvW5Zs1rJwr80jRCA=";
-    aarch64-linux = "sha256-fkdC7RAPgQME79kor3txmeFTXwtmCKGS0nPkDTH1I40=";
+    aarch64-linux = "sha256-2JAE7RiucFzJvZ4Q56jx1tbJs0U+MFdbqV61SCaFA64=";
   };
   installFilters = [
     "@proompteng/bumba"


### PR DESCRIPTION
## Summary

- Refresh Bumba's arm64 fixed-output Bun dependency hash using the value computed by the post-merge Linux arm64 builder.
- Restore the multi-architecture Bumba image build required before the merged event-to-memory workflow can roll out.
- Leave the already-validated amd64 dependency hash unchanged.

## Related Issues

None

## Testing

- `nix eval --raw .#packages.x86_64-linux.bumba-image.name`
- `nix eval --raw .#packages.aarch64-linux.bumba-image.name`
- `git diff --check`
- Post-merge workflow evidence: Bumba run `29185263390`, arm64 job `86632736054`, computed `sha256-2JAE7RiucFzJvZ4Q56jx1tbJs0U+MFdbqV61SCaFA64=`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
