### PR TITLE
fix(bumba): disable fetch auto-maintenance

### DIFF
--- a/services/bumba/src/event-consumer.test.ts
+++ b/services/bumba/src/event-consumer.test.ts
@@ -484,17 +484,18 @@ test('loadMainMergeDiff reads exact change evidence from the local repository cl
   }
 })
 
-test('missing merge commits are fetched with GitHub auth when configured', () => {
+test('missing merge commits are fetched with GitHub auth and without auto-maintenance', () => {
   const previousGithubToken = process.env.GITHUB_TOKEN
   const previousGhToken = process.env.GH_TOKEN
   process.env.GITHUB_TOKEN = 'github-token'
   process.env.GH_TOKEN = 'fallback-token'
 
   try {
-    expect(__test__.buildAuthenticatedGitArgs(['fetch', 'origin', 'deadbeef'])).toEqual([
+    expect(__test__.buildAuthenticatedGitArgs(['fetch', '--no-auto-maintenance', 'origin', 'deadbeef'])).toEqual([
       '-c',
       'http.extraheader=Authorization: Bearer github-token',
       'fetch',
+      '--no-auto-maintenance',
       'origin',
       'deadbeef',
     ])

--- a/services/bumba/src/event-consumer.ts
+++ b/services/bumba/src/event-consumer.ts
@@ -511,7 +511,17 @@ const loadMainMergeDiffEffect = (
       const beforeExists = (await runGit(['cat-file', '-e', `${before}^{commit}`], true)).exitCode === 0
       const commitExists = (await runGit(['cat-file', '-e', `${commit}^{commit}`], true)).exitCode === 0
       if (!beforeExists || !commitExists) {
-        await runGit(buildAuthenticatedGitArgs(['fetch', '--no-tags', '--depth=2', 'origin', before, commit]))
+        await runGit(
+          buildAuthenticatedGitArgs([
+            'fetch',
+            '--no-auto-maintenance',
+            '--no-tags',
+            '--depth=2',
+            'origin',
+            before,
+            commit,
+          ]),
+        )
       }
 
       const changedPaths = (await runGit(['diff', '--name-only', '-z', before, commit])).stdout


### PR DESCRIPTION
## Summary

- disable Git auto-maintenance for merge-note fallback fetches
- prevent detached maintenance processes from retaining Bun subprocess pipes and stalling Temporal activities
- cover the safe fetch configuration in the event-consumer regression test

## Related Issues

None

## Testing

- `bun test services/bumba/src/event-consumer.test.ts`
- `bunx oxfmt --check services/bumba/src/event-consumer.ts services/bumba/src/event-consumer.test.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.