### PR TITLE
chore(bumba): promote nix image sha-0db1bb25b35c027e03c6ef0cabc9a75a07af409a

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@c8836acd9fc5b89845bc27fd8cb475225789db17
+              value: bumba@0db1bb25b35c027e03c6ef0cabc9a75a07af409a
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:455eba121eb359f5467c215bfe3a855656b572bab612a578fe810f93aa471d86
+    digest: sha256:7749da850b14dba03117da2e8d53f728787d0b3ca69beee84a96cf7702274194
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:7749da850b14dba03117da2e8d53f728787d0b3ca69beee84a96cf7702274194`.
- Source commit: `0db1bb25b35c027e03c6ef0cabc9a75a07af409a`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:7749da850b14dba03117da2e8d53f728787d0b3ca69beee84a96cf7702274194" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.