### PR TITLE
fix(bumba): reap git subprocesses

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -26,11 +26,15 @@ import ./bun-workspace-service.nix {
     "bun --cwd=packages/temporal-bun-sdk run build"
   ];
   command = [
+    "tini"
+    "-g"
+    "--"
     "bun"
     "services/bumba/src/worker.ts"
   ];
   extraContents = [
     pkgs.git
+    pkgs.tini
   ];
   exposedPorts = {
     "3001/tcp" = { };

--- a/services/bumba/src/activities/index.ts
+++ b/services/bumba/src/activities/index.ts
@@ -8,6 +8,7 @@ import * as TSemaphore from 'effect/TSemaphore'
 import { Language, Parser } from 'web-tree-sitter'
 import { isMap, isScalar, isSeq, LineCounter, parseAllDocuments } from 'yaml'
 
+import { runCommandIsolated } from '../command-runner'
 import { publishMainMergeMemoryNoteActivity, type MainMergeMemoryNoteInput } from '../event-consumer'
 
 export type ReadRepoFileInput = {
@@ -651,25 +652,25 @@ type CommandResult = {
   stderr: string
 }
 
+const COMMAND_TIMEOUT_MS = 30_000
+
 const runCommandRaw = async (
   args: string[],
   cwd: string,
   env?: Record<string, string | undefined>,
 ): Promise<CommandResult> => {
   try {
-    const proc = Bun.spawn(args, {
-      cwd,
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: env ? { ...process.env, ...env } : process.env,
-    })
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ])
+    const result = await runCommandIsolated(args, cwd, COMMAND_TIMEOUT_MS, env)
+    const { stdout, stderr } = result
+    if (result.exitCode === null) {
+      return {
+        exitCode: 1,
+        stdout,
+        stderr: stderr || `command timed out after ${COMMAND_TIMEOUT_MS}ms`,
+      }
+    }
     return {
-      exitCode,
+      exitCode: result.exitCode,
       stdout,
       stderr,
     }
@@ -717,14 +718,35 @@ const commitExistsLocally = async (repoRoot: string, commit: string) => {
 
 const fetchCommitFromOrigin = async (repoRoot: string, commit: string) => {
   const token = resolveGithubToken()
-  const args = ['git', '-C', repoRoot, ...buildGitAuthArgs(token), 'fetch', '--quiet', '--depth=1', 'origin', commit]
+  const args = [
+    'git',
+    '-C',
+    repoRoot,
+    ...buildGitAuthArgs(token),
+    'fetch',
+    '--no-auto-maintenance',
+    '--quiet',
+    '--depth=1',
+    'origin',
+    commit,
+  ]
   const result = await runCommandResult(args, repoRoot, { GIT_TERMINAL_PROMPT: '0' })
   return result.exitCode === 0
 }
 
 const fetchFromOrigin = async (repoRoot: string, ref?: string) => {
   const token = resolveGithubToken()
-  const args = ['git', '-C', repoRoot, ...buildGitAuthArgs(token), 'fetch', '--quiet', '--depth=1', 'origin']
+  const args = [
+    'git',
+    '-C',
+    repoRoot,
+    ...buildGitAuthArgs(token),
+    'fetch',
+    '--no-auto-maintenance',
+    '--quiet',
+    '--depth=1',
+    'origin',
+  ]
   if (ref) {
     args.push(ref)
   }

--- a/services/bumba/src/command-runner.test.ts
+++ b/services/bumba/src/command-runner.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'bun:test'
+
+import { runCommandIsolated } from './command-runner'
+
+test('isolated commands do not block the worker event loop', async () => {
+  let timerFired = false
+  const command = runCommandIsolated(['sh', '-c', 'sleep 0.15; printf done'], process.cwd(), 1_000)
+
+  await new Promise<void>((resolve) => {
+    setTimeout(() => {
+      timerFired = true
+      resolve()
+    }, 20)
+  })
+
+  expect(timerFired).toBe(true)
+  expect(await command).toMatchObject({ exitCode: 0, stdout: 'done', stderr: '' })
+})
+
+test('isolated commands enforce their subprocess timeout', async () => {
+  const startedAt = Date.now()
+  const result = await runCommandIsolated(['sh', '-c', 'sleep 2'], process.cwd(), 50)
+
+  expect(result.exitCode).toBeNull()
+  expect(Date.now() - startedAt).toBeLessThan(1_000)
+})
+
+test('isolated command timeouts stop the entire process group', async () => {
+  const result = await runCommandIsolated(
+    ['sh', '-c', 'sleep 10 & child=$!; printf "$child"; wait "$child"'],
+    process.cwd(),
+    50,
+  )
+  const childPid = Number.parseInt(result.stdout, 10)
+
+  expect(result.exitCode).toBeNull()
+  expect(Number.isSafeInteger(childPid)).toBe(true)
+  const probe = Bun.spawnSync(['ps', '-o', 'stat=', '-p', String(childPid)], { stdout: 'pipe', stderr: 'pipe' })
+  const state = probe.stdout.toString().trim()
+  expect(state === '' || state.startsWith('Z')).toBe(true)
+})

--- a/services/bumba/src/command-runner.ts
+++ b/services/bumba/src/command-runner.ts
@@ -1,0 +1,44 @@
+export type IsolatedCommandResult = {
+  exitCode: number | null
+  stdout: string
+  stderr: string
+}
+
+const WORKER_RESPONSE_GRACE_MS = 5_000
+
+export const runCommandIsolated = (
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+  env?: Record<string, string | undefined>,
+): Promise<IsolatedCommandResult> =>
+  new Promise((resolve) => {
+    const worker = new Worker(new URL('./command-worker.ts', import.meta.url).href)
+    let settled = false
+
+    const finish = (result: IsolatedCommandResult) => {
+      if (settled) return
+      settled = true
+      clearTimeout(responseTimer)
+      worker.terminate()
+      resolve(result)
+    }
+
+    const responseTimer = setTimeout(() => {
+      finish({
+        exitCode: null,
+        stdout: '',
+        stderr: `command worker did not respond within ${timeoutMs + WORKER_RESPONSE_GRACE_MS}ms`,
+      })
+    }, timeoutMs + WORKER_RESPONSE_GRACE_MS)
+
+    worker.onmessage = (event: MessageEvent<IsolatedCommandResult>) => finish(event.data)
+    worker.onerror = (event) => {
+      finish({
+        exitCode: 1,
+        stdout: '',
+        stderr: event.message || 'command worker failed',
+      })
+    }
+    worker.postMessage({ args, cwd, env, timeoutMs })
+  })

--- a/services/bumba/src/command-worker.ts
+++ b/services/bumba/src/command-worker.ts
@@ -1,0 +1,38 @@
+type CommandRequest = {
+  args: string[]
+  cwd: string
+  env?: Record<string, string | undefined>
+  timeoutMs: number
+}
+
+globalThis.onmessage = (event: MessageEvent<CommandRequest>) => {
+  try {
+    const result = Bun.spawnSync(event.data.args, {
+      cwd: event.data.cwd,
+      detached: true,
+      env: event.data.env ? { ...process.env, ...event.data.env } : process.env,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: event.data.timeoutMs,
+    })
+    if (result.exitCode === null) {
+      try {
+        process.kill(-result.pid, 'SIGKILL')
+      } catch (error) {
+        const code = error instanceof Error && 'code' in error ? error.code : undefined
+        if (code !== 'ESRCH') throw error
+      }
+    }
+    globalThis.postMessage({
+      exitCode: result.exitCode,
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+    })
+  } catch (error) {
+    globalThis.postMessage({
+      exitCode: 1,
+      stdout: '',
+      stderr: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/services/bumba/src/dockerfile.test.ts
+++ b/services/bumba/src/dockerfile.test.ts
@@ -17,3 +17,10 @@ describe('bumba Dockerfile', () => {
     expect(dockerfile).not.toMatch(/^FROM oven\/bun:/m)
   })
 })
+
+test('the Nix image runs Bumba under tini so orphaned subprocesses are reaped', async () => {
+  const image = await readFile(resolve(import.meta.dir, '../../../nix/images/bumba.nix'), 'utf8')
+
+  expect(image).toContain('pkgs.tini')
+  expect(image).toMatch(/command = \[\s*"tini"\s*"-g"\s*"--"\s*"bun"/)
+})

--- a/services/bumba/src/event-consumer.ts
+++ b/services/bumba/src/event-consumer.ts
@@ -11,6 +11,8 @@ import { VersioningBehavior, WorkflowIdReusePolicy } from '@proompteng/temporal-
 import { SQL } from 'bun'
 import { Effect } from 'effect'
 
+import { runCommandIsolated } from './command-runner'
+
 const DEFAULT_TASK_QUEUE = 'bumba'
 const DEFAULT_REF = 'main'
 const DEFAULT_POLL_INTERVAL_MS = 10_000
@@ -22,6 +24,7 @@ const DEFAULT_ROUTING_ALIGNMENT_ENABLED = true
 const DEFAULT_ROUTING_ALIGNMENT_RPC_TIMEOUT_MS = 5_000
 const STALE_INGESTION_ERROR = 'stale nonterminal ingestion auto-failed by bumba event-consumer'
 const MAX_MERGE_DIFF_CHARS = 36_000
+const MERGE_DIFF_GIT_TIMEOUT_MS = 30_000
 
 const LOCK_FILENAMES = new Set([
   'bun.lock',
@@ -491,17 +494,15 @@ const loadMainMergeDiffEffect = (
       if (!before || /^0+$/.test(before)) return []
 
       const runGit = async (args: string[], allowFailure = false) => {
-        const child = Bun.spawn(['git', ...args], {
-          cwd: repoRoot,
-          env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-          stdout: 'pipe',
-          stderr: 'pipe',
+        const result = await runCommandIsolated(['git', ...args], repoRoot, MERGE_DIFF_GIT_TIMEOUT_MS, {
+          GIT_TERMINAL_PROMPT: '0',
         })
-        const [exitCode, stdout, stderr] = await Promise.all([
-          child.exited,
-          new Response(child.stdout).text(),
-          new Response(child.stderr).text(),
-        ])
+        const exitCode = result.exitCode
+        const stdout = result.stdout.toString()
+        const stderr = result.stderr.toString()
+        if (exitCode === null) {
+          throw new Error(`git ${args[0] ?? 'command'} timed out after ${MERGE_DIFF_GIT_TIMEOUT_MS}ms`)
+        }
         if (exitCode !== 0 && !allowFailure) {
           throw new Error(`git ${args[0] ?? 'command'} failed (${exitCode}): ${stderr.trim().slice(0, 1_000)}`)
         }


### PR DESCRIPTION
## Summary

- run bounded Bumba Git commands synchronously so the PID-1 Bun worker reaps every child
- enforce a 30-second command timeout for repository reads and merge-diff collection
- suppress Git auto-maintenance on all repository fetch paths

## Related Issues

None

## Testing

- `bun test services/bumba/src`
- `bun run --cwd services/bumba tsc`
- `bunx oxfmt --check services/bumba/src/event-consumer.ts services/bumba/src/activities/index.ts`
- `bunx oxlint --config .oxlintrc.json services/bumba/src/event-consumer.ts services/bumba/src/activities/index.ts` (one pre-existing warning in event-consumer.ts)
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.