### PR TITLE
chore(jangar): promote image sha-0db1bb25b35c027e03c6ef0cabc9a75a07af409a

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-12T02:29:30Z
+    deploy.knative.dev/rollout: 2026-07-12T09:34:48Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: c1f09e6d651cdfed462e484346044948aebc9849
+              value: 0db1bb25b35c027e03c6ef0cabc9a75a07af409a
             - name: JANGAR_GITOPS_REVISION
-              value: c1f09e6d651cdfed462e484346044948aebc9849
+              value: 0db1bb25b35c027e03c6ef0cabc9a75a07af409a
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29176314808"
+              value: "29187269052"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:892867d4d69c280967e4e85c271799b2b1aa5e1bdff83b9bc537d9305bdd1c4b
+              value: sha256:f574f6392c86274840ca7019ac7a99abb4b8f35ade7f08d7d858719ff3c4ab16
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: c1f09e6d651cdfed462e484346044948aebc9849
+              value: 0db1bb25b35c027e03c6ef0cabc9a75a07af409a
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:892867d4d69c280967e4e85c271799b2b1aa5e1bdff83b9bc537d9305bdd1c4b
+              value: sha256:f574f6392c86274840ca7019ac7a99abb4b8f35ade7f08d7d858719ff3c4ab16
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-c1f09e6d651cdfed462e484346044948aebc9849
-    digest: sha256:892867d4d69c280967e4e85c271799b2b1aa5e1bdff83b9bc537d9305bdd1c4b
+    newTag: sha-0db1bb25b35c027e03c6ef0cabc9a75a07af409a
+    digest: sha256:f574f6392c86274840ca7019ac7a99abb4b8f35ade7f08d7d858719ff3c4ab16


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `0db1bb25b35c027e03c6ef0cabc9a75a07af409a`
- Image tag: `sha-0db1bb25b35c027e03c6ef0cabc9a75a07af409a`
- Image digest: `sha256:f574f6392c86274840ca7019ac7a99abb4b8f35ade7f08d7d858719ff3c4ab16`
- Source CI run: `29187269052`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates