### PR TITLE
chore(bumba): promote nix image sha-c5aafd37a2ab89ff342da6ede6cb02e67003a93f

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@0db1bb25b35c027e03c6ef0cabc9a75a07af409a
+              value: bumba@c5aafd37a2ab89ff342da6ede6cb02e67003a93f
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:7749da850b14dba03117da2e8d53f728787d0b3ca69beee84a96cf7702274194
+    digest: sha256:781ce313ecb266c6bcd5f4636af375488c388dfc016e6f515692c842daee9e77
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:781ce313ecb266c6bcd5f4636af375488c388dfc016e6f515692c842daee9e77`.
- Source commit: `c5aafd37a2ab89ff342da6ede6cb02e67003a93f`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:781ce313ecb266c6bcd5f4636af375488c388dfc016e6f515692c842daee9e77" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.