### PR TITLE
fix(bumba): retry public git fetches

### DIFF
--- a/services/bumba/src/activities/index.ts
+++ b/services/bumba/src/activities/index.ts
@@ -9,7 +9,11 @@ import { Language, Parser } from 'web-tree-sitter'
 import { isMap, isScalar, isSeq, LineCounter, parseAllDocuments } from 'yaml'
 
 import { runCommandIsolated } from '../command-runner'
-import { publishMainMergeMemoryNoteActivity, type MainMergeMemoryNoteInput } from '../event-consumer'
+import {
+  publishMainMergeMemoryNoteActivity,
+  runGitFetchWithPublicFallback,
+  type MainMergeMemoryNoteInput,
+} from '../event-consumer'
 
 export type ReadRepoFileInput = {
   repoRoot: string
@@ -706,9 +710,6 @@ const runCommand = async (
   return result.stdout.length > 0 ? result.stdout : null
 }
 
-const buildGitAuthArgs = (token: string | null) =>
-  token ? ['-c', `http.extraheader=Authorization: Bearer ${token}`] : []
-
 const commitExistsLocally = async (repoRoot: string, commit: string) => {
   const result = await runCommandResult(['git', '-C', repoRoot, 'cat-file', '-e', `${commit}^{commit}`], repoRoot, {
     GIT_TERMINAL_PROMPT: '0',
@@ -717,40 +718,21 @@ const commitExistsLocally = async (repoRoot: string, commit: string) => {
 }
 
 const fetchCommitFromOrigin = async (repoRoot: string, commit: string) => {
-  const token = resolveGithubToken()
-  const args = [
-    'git',
-    '-C',
-    repoRoot,
-    ...buildGitAuthArgs(token),
-    'fetch',
-    '--no-auto-maintenance',
-    '--quiet',
-    '--depth=1',
-    'origin',
-    commit,
-  ]
-  const result = await runCommandResult(args, repoRoot, { GIT_TERMINAL_PROMPT: '0' })
+  const fetchArgs = ['fetch', '--no-auto-maintenance', '--quiet', '--depth=1', 'origin', commit]
+  const result = await runGitFetchWithPublicFallback(fetchArgs, (args) =>
+    runCommandResult(['git', '-C', repoRoot, ...args], repoRoot, { GIT_TERMINAL_PROMPT: '0' }),
+  )
   return result.exitCode === 0
 }
 
 const fetchFromOrigin = async (repoRoot: string, ref?: string) => {
-  const token = resolveGithubToken()
-  const args = [
-    'git',
-    '-C',
-    repoRoot,
-    ...buildGitAuthArgs(token),
-    'fetch',
-    '--no-auto-maintenance',
-    '--quiet',
-    '--depth=1',
-    'origin',
-  ]
+  const fetchArgs = ['fetch', '--no-auto-maintenance', '--quiet', '--depth=1', 'origin']
   if (ref) {
-    args.push(ref)
+    fetchArgs.push(ref)
   }
-  const result = await runCommandResult(args, repoRoot, { GIT_TERMINAL_PROMPT: '0' })
+  const result = await runGitFetchWithPublicFallback(fetchArgs, (args) =>
+    runCommandResult(['git', '-C', repoRoot, ...args], repoRoot, { GIT_TERMINAL_PROMPT: '0' }),
+  )
   return result.exitCode === 0
 }
 

--- a/services/bumba/src/event-consumer.test.ts
+++ b/services/bumba/src/event-consumer.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { afterEach, expect, test } from 'bun:test'
 import type { TemporalConfig } from '@proompteng/temporal-bun-sdk'
 
-import { __test__, createGithubEventConsumer } from './event-consumer'
+import { __test__, createGithubEventConsumer, runGitFetchWithPublicFallback } from './event-consumer'
 
 const ENV_KEYS = [
   'BUMBA_GITHUB_EVENT_CONSUMER_ENABLED',
@@ -455,6 +455,7 @@ test('loadMainMergeDiff reads exact change evidence from the local repository cl
     runGit('init')
     runGit('config', 'user.email', 'bumba@test.invalid')
     runGit('config', 'user.name', 'Bumba Test')
+    runGit('config', 'commit.gpgsign', 'false')
     await mkdir(join(repoRoot, 'src'))
     await mkdir(join(repoRoot, 'docs'))
     await writeFile(join(repoRoot, 'src/a.ts'), 'export const value = "old"\n')
@@ -504,6 +505,44 @@ test('missing merge commits are fetched with GitHub auth and without auto-mainte
     else process.env.GITHUB_TOKEN = previousGithubToken
     if (previousGhToken === undefined) delete process.env.GH_TOKEN
     else process.env.GH_TOKEN = previousGhToken
+  }
+})
+
+test('failed authenticated git fetch retries anonymously for public repositories', async () => {
+  const previousGithubToken = process.env.GITHUB_TOKEN
+  process.env.GITHUB_TOKEN = 'stale-token'
+  const calls: Array<{ args: string[]; allowFailure: boolean | undefined }> = []
+
+  try {
+    const result = await runGitFetchWithPublicFallback(
+      ['fetch', '--no-auto-maintenance', 'origin', 'deadbeef'],
+      async (args, allowFailure) => {
+        calls.push({ args, allowFailure })
+        return { exitCode: calls.length === 1 ? 128 : 0 }
+      },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(calls).toEqual([
+      {
+        args: [
+          '-c',
+          'http.extraheader=Authorization: Bearer stale-token',
+          'fetch',
+          '--no-auto-maintenance',
+          'origin',
+          'deadbeef',
+        ],
+        allowFailure: true,
+      },
+      {
+        args: ['fetch', '--no-auto-maintenance', 'origin', 'deadbeef'],
+        allowFailure: undefined,
+      },
+    ])
+  } finally {
+    if (previousGithubToken === undefined) delete process.env.GITHUB_TOKEN
+    else process.env.GITHUB_TOKEN = previousGithubToken
   }
 })
 

--- a/services/bumba/src/event-consumer.ts
+++ b/services/bumba/src/event-consumer.ts
@@ -402,6 +402,18 @@ const buildAuthenticatedGitArgs = (args: string[]) => {
   return token ? ['-c', `http.extraheader=Authorization: Bearer ${token}`, ...args] : args
 }
 
+export const runGitFetchWithPublicFallback = async <T extends { exitCode: number }>(
+  fetchArgs: string[],
+  runGit: (args: string[], allowFailure?: boolean) => Promise<T>,
+): Promise<T> => {
+  const authenticatedArgs = buildAuthenticatedGitArgs(fetchArgs)
+  if (authenticatedArgs.length > fetchArgs.length) {
+    const authenticatedResult = await runGit(authenticatedArgs, true)
+    if (authenticatedResult.exitCode === 0) return authenticatedResult
+  }
+  return runGit(fetchArgs)
+}
+
 const requestAgentsJsonEffect = (path: string, init?: RequestInit) =>
   Effect.tryPromise({
     try: async () => {
@@ -512,16 +524,9 @@ const loadMainMergeDiffEffect = (
       const beforeExists = (await runGit(['cat-file', '-e', `${before}^{commit}`], true)).exitCode === 0
       const commitExists = (await runGit(['cat-file', '-e', `${commit}^{commit}`], true)).exitCode === 0
       if (!beforeExists || !commitExists) {
-        await runGit(
-          buildAuthenticatedGitArgs([
-            'fetch',
-            '--no-auto-maintenance',
-            '--no-tags',
-            '--depth=2',
-            'origin',
-            before,
-            commit,
-          ]),
+        await runGitFetchWithPublicFallback(
+          ['fetch', '--no-auto-maintenance', '--no-tags', '--depth=2', 'origin', before, commit],
+          runGit,
         )
       }
 


### PR DESCRIPTION
## Summary

- retry repository fetches anonymously when configured GitHub authentication is rejected
- apply the fallback to merge-note diff loading and ordinary repository synchronization
- preserve authenticated-first behavior for private repositories and keep fetch maintenance disabled

## Related Issues

None

## Testing

- `bun test services/bumba/src` (79 passed)
- `bun run --cwd services/bumba tsc`
- `bunx oxfmt --check services/bumba/src`
- `bunx oxlint --config .oxlintrc.json services/bumba/src/event-consumer.ts services/bumba/src/event-consumer.test.ts services/bumba/src/activities/index.ts` (one pre-existing warning)
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.