### PR TITLE
chore(jangar): promote image sha-c5aafd37a2ab89ff342da6ede6cb02e67003a93f

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-12T09:34:48Z
+    deploy.knative.dev/rollout: 2026-07-12T10:18:29Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 0db1bb25b35c027e03c6ef0cabc9a75a07af409a
+              value: c5aafd37a2ab89ff342da6ede6cb02e67003a93f
             - name: JANGAR_GITOPS_REVISION
-              value: 0db1bb25b35c027e03c6ef0cabc9a75a07af409a
+              value: c5aafd37a2ab89ff342da6ede6cb02e67003a93f
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29187269052"
+              value: "29188444975"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:f574f6392c86274840ca7019ac7a99abb4b8f35ade7f08d7d858719ff3c4ab16
+              value: sha256:e06bee0b33fa20a5e06e3f8f9a8cbc5f03ea7923daa1d0291a580b36e67941f2
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 0db1bb25b35c027e03c6ef0cabc9a75a07af409a
+              value: c5aafd37a2ab89ff342da6ede6cb02e67003a93f
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:f574f6392c86274840ca7019ac7a99abb4b8f35ade7f08d7d858719ff3c4ab16
+              value: sha256:e06bee0b33fa20a5e06e3f8f9a8cbc5f03ea7923daa1d0291a580b36e67941f2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-0db1bb25b35c027e03c6ef0cabc9a75a07af409a
-    digest: sha256:f574f6392c86274840ca7019ac7a99abb4b8f35ade7f08d7d858719ff3c4ab16
+    newTag: sha-c5aafd37a2ab89ff342da6ede6cb02e67003a93f
+    digest: sha256:e06bee0b33fa20a5e06e3f8f9a8cbc5f03ea7923daa1d0291a580b36e67941f2


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `c5aafd37a2ab89ff342da6ede6cb02e67003a93f`
- Image tag: `sha-c5aafd37a2ab89ff342da6ede6cb02e67003a93f`
- Image digest: `sha256:e06bee0b33fa20a5e06e3f8f9a8cbc5f03ea7923daa1d0291a580b36e67941f2`
- Source CI run: `29188444975`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates