### PR TITLE
chore(jangar): promote image sha-5edc4cf88b6481ca4a6b25461628666717536796

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-12T10:18:29Z
+    deploy.knative.dev/rollout: 2026-07-12T10:46:55Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: c5aafd37a2ab89ff342da6ede6cb02e67003a93f
+              value: 5edc4cf88b6481ca4a6b25461628666717536796
             - name: JANGAR_GITOPS_REVISION
-              value: c5aafd37a2ab89ff342da6ede6cb02e67003a93f
+              value: 5edc4cf88b6481ca4a6b25461628666717536796
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29188444975"
+              value: "29189271969"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:e06bee0b33fa20a5e06e3f8f9a8cbc5f03ea7923daa1d0291a580b36e67941f2
+              value: sha256:64889afc0a9c7054ce5741e31ea388cc4ff7cb8ec904cde2de7fba79a13dd9be
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: c5aafd37a2ab89ff342da6ede6cb02e67003a93f
+              value: 5edc4cf88b6481ca4a6b25461628666717536796
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:e06bee0b33fa20a5e06e3f8f9a8cbc5f03ea7923daa1d0291a580b36e67941f2
+              value: sha256:64889afc0a9c7054ce5741e31ea388cc4ff7cb8ec904cde2de7fba79a13dd9be
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-c5aafd37a2ab89ff342da6ede6cb02e67003a93f
-    digest: sha256:e06bee0b33fa20a5e06e3f8f9a8cbc5f03ea7923daa1d0291a580b36e67941f2
+    newTag: sha-5edc4cf88b6481ca4a6b25461628666717536796
+    digest: sha256:64889afc0a9c7054ce5741e31ea388cc4ff7cb8ec904cde2de7fba79a13dd9be


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `5edc4cf88b6481ca4a6b25461628666717536796`
- Image tag: `sha-5edc4cf88b6481ca4a6b25461628666717536796`
- Image digest: `sha256:64889afc0a9c7054ce5741e31ea388cc4ff7cb8ec904cde2de7fba79a13dd9be`
- Source CI run: `29189271969`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates