### PR TITLE
fix(bumba): authenticate git with basic auth

### DIFF
--- a/services/bumba/src/event-consumer.test.ts
+++ b/services/bumba/src/event-consumer.test.ts
@@ -494,7 +494,7 @@ test('missing merge commits are fetched with GitHub auth and without auto-mainte
   try {
     expect(__test__.buildAuthenticatedGitArgs(['fetch', '--no-auto-maintenance', 'origin', 'deadbeef'])).toEqual([
       '-c',
-      'http.extraheader=Authorization: Bearer github-token',
+      'http.extraheader=Authorization: Basic eC1hY2Nlc3MtdG9rZW46Z2l0aHViLXRva2Vu',
       'fetch',
       '--no-auto-maintenance',
       'origin',
@@ -527,7 +527,7 @@ test('failed authenticated git fetch retries anonymously for public repositories
       {
         args: [
           '-c',
-          'http.extraheader=Authorization: Bearer stale-token',
+          'http.extraheader=Authorization: Basic eC1hY2Nlc3MtdG9rZW46c3RhbGUtdG9rZW4=',
           'fetch',
           '--no-auto-maintenance',
           'origin',

--- a/services/bumba/src/event-consumer.ts
+++ b/services/bumba/src/event-consumer.ts
@@ -399,7 +399,9 @@ const buildMainMergeNoteWorkflowId = (deliveryId: string) => `bumba-main-note-${
 
 const buildAuthenticatedGitArgs = (args: string[]) => {
   const token = normalizeOptionalText(process.env.GITHUB_TOKEN) ?? normalizeOptionalText(process.env.GH_TOKEN)
-  return token ? ['-c', `http.extraheader=Authorization: Bearer ${token}`, ...args] : args
+  if (!token) return args
+  const credentials = Buffer.from(`x-access-token:${token}`).toString('base64')
+  return ['-c', `http.extraheader=Authorization: Basic ${credentials}`, ...args]
 }
 
 export const runGitFetchWithPublicFallback = async <T extends { exitCode: number }>(


### PR DESCRIPTION
## Summary

- authenticate GitHub smart-HTTP fetches using Basic `x-access-token` credentials
- retain anonymous fallback for public repositories when authenticated fetches fail
- update focused header and fallback regression coverage

## Related Issues

None

## Testing

- `bun test services/bumba/src` (79 passed)
- `bun run --cwd services/bumba tsc`
- `bunx oxfmt --check services/bumba/src/event-consumer.ts services/bumba/src/event-consumer.test.ts`
- `bunx oxlint --config .oxlintrc.json services/bumba/src/event-consumer.ts services/bumba/src/event-consumer.test.ts` (one pre-existing warning)
- live diagnostic: GitHub API accepted the PAT; Git smart HTTP rejected Bearer and accepted Basic `x-access-token`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.