### PR TITLE
chore(bumba): promote nix image sha-074ab8264eefe0a28bc43929c38e8627645377c4

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@e785acfe802fb27d5bf64263e7c2832993e4e19f
+              value: bumba@074ab8264eefe0a28bc43929c38e8627645377c4
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:2f04602bdb3d12b09e922c53cbdb607293cfaa9dfb3df604976bf5d17ddd0c74
+    digest: sha256:8a5088a536443315d666778728f33361b854d0578db7317c43f95dc99df3b61a
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:8a5088a536443315d666778728f33361b854d0578db7317c43f95dc99df3b61a`.
- Source commit: `074ab8264eefe0a28bc43929c38e8627645377c4`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:8a5088a536443315d666778728f33361b854d0578db7317c43f95dc99df3b61a" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.