### PR TITLE
fix(argocd): remove bumba image updater writer

### DIFF
--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -152,24 +152,6 @@ spec:
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/dernier
-    - namePattern: bumba
-      writeBackConfig:
-        method: git:secret:argocd/image-updater-git-ssh
-        gitConfig:
-          repository: git@github.com:proompteng/lab.git
-          branch: main:release/{{.SHA256}}
-          writeBackTarget: kustomization:/argocd/applications/bumba
-      images:
-        - alias: bumba
-          imageName: registry.ide-newton.ts.net/lab/bumba:latest
-          commonUpdateSettings:
-            updateStrategy: newest-build
-            allowTags: 'regexp:^(sha-[0-9a-f]{7}|[0-9a-f]{40})$'
-            platforms:
-              - linux/arm64
-          manifestTargets:
-            kustomize:
-              name: registry.ide-newton.ts.net/lab/bumba
     - namePattern: bilig
       writeBackConfig:
         method: git:secret:argocd/image-updater-git-ssh

--- a/packages/scripts/src/shared/__tests__/oci.test.ts
+++ b/packages/scripts/src/shared/__tests__/oci.test.ts
@@ -67,6 +67,7 @@ const torghutCiWorkflow = readRepoFile('.github/workflows/torghut-ci.yml')
 const torghutDeployAutomergeWorkflow = readRepoFile('.github/workflows/torghut-deploy-automerge.yml')
 const autoPrReleaseBranchesWorkflow = readRepoFile('.github/workflows/auto-pr-release-branches.yml')
 const releasePrAutomergeWorkflow = readRepoFile('.github/workflows/release-pr-automerge.yml')
+const productImageUpdater = readRepoFile('argocd/applications/argocd/base/image-updater-product.yaml')
 const oiratWorkflow = readRepoFile('.github/workflows/oirat-ci.yml')
 const bumbaWorkflow = readRepoFile('.github/workflows/bumba-ci.yml')
 const froussardWorkflow = readRepoFile('.github/workflows/froussard-ci.yml')
@@ -1395,6 +1396,14 @@ describe('native OCI build workflows', () => {
       'inherit pkgs lib nodejs repoRevision;\n              repoRoot = ./.;\n              bun = exact.bun;',
     )
     expect(readRepoFile('argocd/applications/bumba/deployment.yaml')).toContain('TEMPORAL_WORKER_BUILD_ID')
+  })
+
+  it('keeps Bumba release ownership out of Argo CD Image Updater', () => {
+    expect(productImageUpdater).not.toContain('namePattern: bumba')
+    expect(productImageUpdater).not.toContain('writeBackTarget: kustomization:/argocd/applications/bumba')
+    expect(productImageUpdater).not.toContain('imageName: registry.ide-newton.ts.net/lab/bumba:latest')
+    expect(enabledSimpleReleaseWorkflow).toContain('- bumba')
+    expect(enabledSimpleReleaseWorkflow).toContain('argocd/applications/bumba/kustomization.yaml')
   })
 
   it('opens digest-pinning release PRs for enabled product app Nix builds', () => {


### PR DESCRIPTION
## Summary

- remove Bumba from the legacy Argo CD Image Updater git writer
- retain `enabled-simple-nix-release` as Bumba’s single release owner
- add regression coverage preventing the competing writer from returning

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/oci.test.ts` (47 passed)
- `kustomize build argocd/applications/argocd`
- `bun run lint:argocd` (0 invalid resources)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/oci.test.ts`
- `git diff --check`

## Infrastructure Impact

Argo CD Image Updater will stop tracking and writing Bumba image changes to `release/<sha256>` branches. Bumba image builds and digest-pinning promotions remain owned by `bumba-ci.yml` and `enabled-simple-nix-release.yml`. Existing orphaned Bumba release branches will be removed after the live ImageUpdater resource reconciles.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.