### PR TITLE
fix(graf): pass integer wait timeout

### DIFF
--- a/packages/scripts/src/graf/deploy-service.test.ts
+++ b/packages/scripts/src/graf/deploy-service.test.ts
@@ -3,11 +3,21 @@ import { describe, expect, it } from 'bun:test'
 import { resolveGrafWaitTimeout } from './deploy-service'
 
 describe('resolveGrafWaitTimeout', () => {
-  it('preserves the duration unit expected by kn', () => {
-    expect(resolveGrafWaitTimeout({ GRAF_KN_WAIT_TIMEOUT: '45s' })).toBe('45s')
+  it('normalizes a seconds suffix to the integer expected by kn', () => {
+    expect(resolveGrafWaitTimeout({ GRAF_KN_WAIT_TIMEOUT: '45s' })).toBe('45')
   })
 
-  it('defaults to a unit-bearing duration', () => {
-    expect(resolveGrafWaitTimeout({})).toBe('300s')
+  it('preserves an integer seconds override', () => {
+    expect(resolveGrafWaitTimeout({ GRAF_KN_WAIT_TIMEOUT: '90' })).toBe('90')
+  })
+
+  it('defaults to integer seconds', () => {
+    expect(resolveGrafWaitTimeout({})).toBe('300')
+  })
+
+  it('rejects unsupported duration formats', () => {
+    expect(() => resolveGrafWaitTimeout({ GRAF_KN_WAIT_TIMEOUT: '5m' })).toThrow(
+      'GRAF_KN_WAIT_TIMEOUT must be a positive integer number of seconds',
+    )
   })
 })

--- a/packages/scripts/src/graf/deploy-service.ts
+++ b/packages/scripts/src/graf/deploy-service.ts
@@ -9,8 +9,14 @@ import { buildImage } from './build-image'
 
 const manifestPath = resolve(repoRoot, 'argocd/applications/graf/knative-service.yaml')
 
-export const resolveGrafWaitTimeout = (env: Record<string, string | undefined> = process.env) =>
-  env.GRAF_KN_WAIT_TIMEOUT ?? '300s'
+export const resolveGrafWaitTimeout = (env: Record<string, string | undefined> = process.env) => {
+  const rawTimeout = (env.GRAF_KN_WAIT_TIMEOUT ?? '300').trim()
+  const match = /^(\d+)s?$/.exec(rawTimeout)
+  if (!match || Number.parseInt(match[1], 10) <= 0) {
+    throw new Error('GRAF_KN_WAIT_TIMEOUT must be a positive integer number of seconds')
+  }
+  return match[1]
+}
 
 const ensureResources = () => {
   ensureCli('docker')


### PR DESCRIPTION
## Summary

- Normalize Graf's `kn service apply --wait-timeout` value to integer seconds.
- Accept existing integer or `s`-suffixed overrides while rejecting unsupported formats and non-positive values.
- Add focused regression coverage for defaults, overrides, normalization, and invalid input.

## Related Issues

Follow-up to #12294.

## Testing

- `bun test packages/scripts/src/graf/deploy-service.test.ts` (4 passed)
- `bun node_modules/oxfmt/bin/oxfmt --check packages/scripts/src/graf/deploy-service.ts packages/scripts/src/graf/deploy-service.test.ts`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts/src/graf/deploy-service.ts packages/scripts/src/graf/deploy-service.test.ts`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
