### PR TITLE
ci(docs): run RBD runbook regression

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -9,6 +9,7 @@ on:
       - 'argocd/root.yaml'
       - 'argocd/applicationsets/**'
       - 'argocd/applications/**'
+      - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
       - '.github/workflows/scripts-ci.yml'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'argocd/root.yaml'
       - 'argocd/applicationsets/**'
       - 'argocd/applications/**'
+      - 'docs/runbooks/rook-ceph-client-ops-performance.md'
       - 'docs/nix-enabled-app-build-performance-rollout-plan.md'
       - '.github/workflows/scripts-ci.yml'
 

--- a/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
+++ b/packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts
@@ -13,3 +13,10 @@ it('selects RBD CSI nodeplugin pods by label without silently skipping mapped KR
   expect(runbook).toContain('-c csi-rbdplugin -- rbd showmapped --format json')
   expect(runbook).not.toContain("rg 'rook-ceph\\.rbd\\.csi\\.ceph\\.com-nodeplugin'")
 })
+
+it('runs the packages scripts regression suite when the protected runbook changes', () => {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/scripts-ci.yml'), 'utf8')
+  const runbookPath = "'docs/runbooks/rook-ceph-client-ops-performance.md'"
+
+  expect(workflow.split(runbookPath)).toHaveLength(3)
+})


### PR DESCRIPTION
## Summary

- Trigger the packages/scripts CI workflow when the protected Rook-Ceph client operations runbook changes.
- Cover both push and pull-request path filters.
- Add a regression assertion that keeps the workflow trigger coupled to the runbook test.

## Related Issues

Follow-up to #12297.

## Testing

- `bun test packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts` (2 passed)
- `bun node_modules/oxfmt/bin/oxfmt --check .github/workflows/scripts-ci.yml packages/scripts/src/docs/__tests__/rook-ceph-runbook.test.ts`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
