### PR TITLE
test(symphony): cover missing leader credentials

### DIFF
--- a/services/symphony/src/leader-election.test.ts
+++ b/services/symphony/src/leader-election.test.ts
@@ -1,10 +1,51 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 
-import { formatKubernetesMicroTime } from './leader-election'
+import { Effect } from 'effect'
+
+import { formatKubernetesMicroTime, LeaderElectionService, makeLeaderElectionLayer } from './leader-election'
+import type { Logger } from './logger'
+
+const originalEnvironment = { ...process.env }
+
+afterEach(() => {
+  process.env = { ...originalEnvironment }
+})
 
 describe('leader election lease timestamp formatting', () => {
   test('formats Kubernetes MicroTime values with six fractional digits', () => {
     expect(formatKubernetesMicroTime(new Date('2026-03-15T00:16:00.123Z'))).toBe('2026-03-15T00:16:00.123000Z')
     expect(formatKubernetesMicroTime(new Date('2026-03-15T00:16:00.000Z'))).toBe('2026-03-15T00:16:00.000000Z')
+  })
+})
+
+describe('leader election startup', () => {
+  test('remains a follower when required service-account credentials are unavailable', async () => {
+    process.env.KUBERNETES_SERVICE_HOST = 'kubernetes.default.svc'
+    process.env.SYMPHONY_LEADER_ELECTION_ENABLED = 'true'
+    process.env.SYMPHONY_LEADER_ELECTION_LEASE_NAMESPACE = 'symphony'
+
+    const logger: Logger = {
+      log: () => undefined,
+      child: () => logger,
+    }
+    const layer = makeLeaderElectionLayer(logger, {
+      readOptionalFile: () => Effect.succeed(null),
+    })
+    const status = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* LeaderElectionService
+        yield* service.start
+        yield* Effect.sleep('10 millis')
+        const snapshot = yield* service.status
+        yield* service.stop
+        return snapshot
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(status.required).toBe(true)
+    expect(status.isLeader).toBe(false)
+    expect(status.lastError).toBe(
+      'leader election is enabled but Kubernetes service-account credentials are incomplete',
+    )
   })
 })

--- a/services/symphony/src/leader-election.ts
+++ b/services/symphony/src/leader-election.ts
@@ -238,14 +238,16 @@ const readOptionalFile = (filePath: string) =>
     Effect.catchAll(() => Effect.succeed<string | null>(null)),
   )
 
-const resolveLeaderElectionConfig = (): Effect.Effect<LeaderElectionConfig, never, never> =>
+const resolveLeaderElectionConfig = (
+  readFileOptional: typeof readOptionalFile = readOptionalFile,
+): Effect.Effect<LeaderElectionConfig, never, never> =>
   Effect.gen(function* () {
     const inCluster = Boolean(process.env.KUBERNETES_SERVICE_HOST)
     const defaultEnabled = inCluster
     const enabled = parseBooleanEnv(process.env.SYMPHONY_LEADER_ELECTION_ENABLED, defaultEnabled)
     const namespace =
       (process.env.SYMPHONY_LEADER_ELECTION_LEASE_NAMESPACE ?? '').trim() ||
-      (yield* readOptionalFile(NAMESPACE_PATH)) ||
+      (yield* readFileOptional(NAMESPACE_PATH)) ||
       null
 
     const required = enabled
@@ -297,14 +299,18 @@ export class LeaderElectionService extends Context.Tag('symphony/LeaderElectionS
   LeaderElectionServiceDefinition
 >() {}
 
-export const makeLeaderElectionLayer = (logger: Logger) =>
+export const makeLeaderElectionLayer = (
+  logger: Logger,
+  dependencies: { readOptionalFile?: typeof readOptionalFile } = {},
+) =>
   Layer.effect(
     LeaderElectionService,
     Effect.gen(function* () {
       const leaderLogger = logger.child({ component: 'leader-election' })
-      const config = yield* resolveLeaderElectionConfig()
-      const token = (yield* readOptionalFile(TOKEN_PATH)) ?? ''
-      const ca = (yield* readOptionalFile(CA_PATH)) ?? ''
+      const readFileOptional = dependencies.readOptionalFile ?? readOptionalFile
+      const config = yield* resolveLeaderElectionConfig(readFileOptional)
+      const token = (yield* readFileOptional(TOKEN_PATH)) ?? ''
+      const ca = (yield* readFileOptional(CA_PATH)) ?? ''
       const credentialError =
         config.required && (!token || !ca || !config.leaseNamespace)
           ? 'leader election is enabled but Kubernetes service-account credentials are incomplete'


### PR DESCRIPTION
## Summary

- Add dependency injection for service-account file reads in the leader-election layer.
- Exercise startup with leader election required and token/CA files unavailable.
- Assert Symphony remains a follower and surfaces the fail-closed credential error.

## Related Issues

Follow-up to #12299.

## Testing

- `bun test services/symphony/src/leader-election.test.ts` (2 passed)
- `bun node_modules/oxfmt/bin/oxfmt --check services/symphony/src/leader-election.ts services/symphony/src/leader-election.test.ts`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/symphony/src/leader-election.ts services/symphony/src/leader-election.test.ts`
- `bun node_modules/typescript/bin/tsc --project packages/otel/tsconfig.json --pretty false`
- `bun node_modules/typescript/bin/tsc -p packages/codex/tsconfig.json`
- `bun node_modules/typescript/bin/tsc -p services/symphony/tsconfig.json --noEmit`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
