### PR TITLE
fix(symphony): verify pod image reference

### DIFF
--- a/packages/scripts/src/symphony/verify-deployment.test.ts
+++ b/packages/scripts/src/symphony/verify-deployment.test.ts
@@ -1,30 +1,46 @@
 import { describe, expect, it } from 'bun:test'
 
-import { imageIdMatchesDigest, selectReadyContainerImages } from './verify-deployment'
+import { imageReferenceMatchesDigest, selectReadyContainerImages } from './verify-deployment'
 
 describe('Symphony deployment image verification', () => {
   const digest = `sha256:${'a'.repeat(64)}`
 
-  it('accepts Kubernetes image IDs pinned to the expected digest', () => {
-    expect(imageIdMatchesDigest(`registry.example/symphony@${digest}`, digest)).toBe(true)
-    expect(imageIdMatchesDigest(`docker-pullable://registry.example/symphony@${digest}`, digest)).toBe(true)
+  it('accepts Kubernetes image references pinned to the expected digest', () => {
+    expect(imageReferenceMatchesDigest(`registry.example/symphony@${digest}`, digest)).toBe(true)
+    expect(imageReferenceMatchesDigest(`docker-pullable://registry.example/symphony@${digest}`, digest)).toBe(true)
   })
 
-  it('selects the actual container name independently of the deployment name', () => {
-    expect(
-      selectReadyContainerImages(
-        {
-          items: [
-            {
-              metadata: { name: 'symphony-jangar-abc' },
-              status: {
-                containerStatuses: [{ name: 'symphony', imageID: `registry.example/symphony@${digest}`, ready: true }],
-              },
+  it('verifies the pinned pod spec when the runtime reports a platform-specific image ID', () => {
+    const runningImages = selectReadyContainerImages(
+      {
+        items: [
+          {
+            metadata: { name: 'symphony-jangar-abc' },
+            spec: {
+              containers: [{ name: 'symphony', image: `registry.example/symphony:main@${digest}` }],
             },
-          ],
-        },
-        'symphony',
-      ),
-    ).toEqual([{ pod: 'symphony-jangar-abc', imageID: `registry.example/symphony@${digest}` }])
+            status: {
+              containerStatuses: [
+                {
+                  name: 'symphony',
+                  imageID: `containerd://sha256:${'b'.repeat(64)}`,
+                  ready: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      'symphony',
+    )
+
+    expect(runningImages).toEqual([
+      {
+        pod: 'symphony-jangar-abc',
+        image: `registry.example/symphony:main@${digest}`,
+        imageID: `containerd://sha256:${'b'.repeat(64)}`,
+      },
+    ])
+    expect(runningImages.every((status) => imageReferenceMatchesDigest(status.image, digest))).toBe(true)
   })
 })

--- a/packages/scripts/src/symphony/verify-deployment.ts
+++ b/packages/scripts/src/symphony/verify-deployment.ts
@@ -33,6 +33,9 @@ type CommandResult = {
 type KubernetesPodList = {
   items?: Array<{
     metadata?: { name?: string }
+    spec?: {
+      containers?: Array<{ name?: string; image?: string }>
+    }
     status?: {
       containerStatuses?: Array<{ name?: string; imageID?: string; ready?: boolean }>
     }
@@ -303,25 +306,31 @@ const verifyServiceHealth = async (serviceBaseUrl: string) => {
   return stateBody
 }
 
-export const imageIdMatchesDigest = (imageId: string, expectedDigest: string): boolean => {
-  const normalizedImageId = imageId.trim()
+export const imageReferenceMatchesDigest = (imageReference: string, expectedDigest: string): boolean => {
+  const normalizedImageReference = imageReference.trim()
   const normalizedDigest = expectedDigest.trim()
   return (
-    normalizedImageId === normalizedDigest ||
-    normalizedImageId.endsWith(`@${normalizedDigest}`) ||
-    normalizedImageId.endsWith(`://${normalizedDigest}`)
+    normalizedImageReference === normalizedDigest ||
+    normalizedImageReference.endsWith(`@${normalizedDigest}`) ||
+    normalizedImageReference.endsWith(`://${normalizedDigest}`)
   )
 }
 
 export const selectReadyContainerImages = (
   podList: KubernetesPodList,
   containerName: string,
-): Array<{ pod: string; imageID: string }> =>
-  (podList.items ?? []).flatMap((pod) =>
-    (pod.status?.containerStatuses ?? [])
-      .filter((status) => status.name === containerName && status.ready === true && Boolean(status.imageID))
-      .map((status) => ({ pod: pod.metadata?.name ?? 'unknown', imageID: status.imageID as string })),
-  )
+): Array<{ pod: string; image: string; imageID: string | null }> =>
+  (podList.items ?? []).flatMap((pod) => {
+    const image = (pod.spec?.containers ?? []).find((candidate) => candidate.name === containerName)?.image
+    if (!image) return []
+    return (pod.status?.containerStatuses ?? [])
+      .filter((status) => status.name === containerName && status.ready === true)
+      .map((status) => ({
+        pod: pod.metadata?.name ?? 'unknown',
+        image,
+        imageID: status.imageID?.trim() || null,
+      }))
+  })
 
 const verifyRunningDigest = async (options: ResolvedOptions, expectedDigest: string) => {
   const podsResult = await runCommand('kubectl', [
@@ -338,10 +347,10 @@ const verifyRunningDigest = async (options: ResolvedOptions, expectedDigest: str
   const runningImages = selectReadyContainerImages(podList, options.containerName)
   if (runningImages.length === 0) {
     throw new Error(
-      `No ready '${options.containerName}' container image IDs were found for deployment ${options.deployment}`,
+      `No ready '${options.containerName}' container image references were found for deployment ${options.deployment}`,
     )
   }
-  const mismatches = runningImages.filter((status) => !imageIdMatchesDigest(status.imageID, expectedDigest))
+  const mismatches = runningImages.filter((status) => !imageReferenceMatchesDigest(status.image, expectedDigest))
   if (mismatches.length > 0) {
     throw new Error(
       `Running ${options.deployment} image digest does not match ${expectedDigest}: ${JSON.stringify(mismatches)}`,


### PR DESCRIPTION
## Summary

- Verify the digest pinned in each ready pod's container spec instead of requiring the runtime `imageID` to equal the multi-architecture index digest.
- Retain runtime image IDs in verification output for diagnostics.
- Add regression coverage for containerd reporting a platform-specific digest while the pod spec is pinned to the expected index digest.

## Related Issues

Follow-up to #12300.

## Testing

- `bun test packages/scripts/src/symphony/verify-deployment.test.ts` (2 passed)
- `bun node_modules/oxfmt/bin/oxfmt --check packages/scripts/src/symphony/verify-deployment.ts packages/scripts/src/symphony/verify-deployment.test.ts`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts/src/symphony/verify-deployment.ts packages/scripts/src/symphony/verify-deployment.test.ts`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
