### PR TITLE
fix(argocd): prepare PostHog cascading removal

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -412,6 +412,7 @@ spec:
                 path: argocd/applications/posthog
                 namespace: posthog
                 renderWithLovely: false
+                cascadeResourcesOnDeletion: true
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
                 automation: manual

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -43,9 +43,10 @@ describe('enabled app inventory', () => {
     expect(productApplicationSet.spec?.syncPolicy?.preserveResourcesOnDeletion).toBe(true)
   })
 
-  it('cascades Olden resources when its generated Application is deleted', () => {
+  it('cascades resources for generated Applications that are disabled destructively', () => {
     const productElements = productApplicationSet.spec?.generators?.[0]?.matrix?.generators?.[1]?.list?.elements ?? []
     expect(productElements.find((candidate) => candidate.name === 'olden')?.cascadeResourcesOnDeletion).toBe(true)
+    expect(productElements.find((candidate) => candidate.name === 'posthog')?.cascadeResourcesOnDeletion).toBe(true)
     expect(productApplicationSet.spec?.templatePatch).toContain('resources-finalizer.argocd.argoproj.io')
   })
 


### PR DESCRIPTION
## Summary

- Add cascading resource deletion to the generated PostHog Argo CD Application.
- Keep PostHog enabled during this preparatory rollout so the Application receives its resources finalizer.
- Extend the enabled-app regression test to require the PostHog cascade contract.

## Related Issues

None.

## Testing

- `nix develop -c bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `nix develop -c bunx oxfmt --check packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `nix develop -c bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None in this preparatory change. A follow-up will disable PostHog and intentionally delete its managed resources and data.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
