### PR TITLE
fix(temporal): export workflow reuse policy

### DIFF
--- a/packages/temporal-bun-sdk/src/worker/index.ts
+++ b/packages/temporal-bun-sdk/src/worker/index.ts
@@ -1,5 +1,5 @@
 export { WorkerVersioningMode } from '../proto/temporal/api/enums/v1/deployment_pb'
-export { VersioningBehavior } from '../proto/temporal/api/enums/v1/workflow_pb'
+export { VersioningBehavior, WorkflowIdReusePolicy } from '../proto/temporal/api/enums/v1/workflow_pb'
 
 export type { BunWorkerHandle, CreateWorkerOptions } from '../worker'
 export { BunWorker, createWorker, runWorker } from '../worker'

--- a/packages/temporal-bun-sdk/tests/worker.public-api.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker.public-api.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test'
+
+import { VersioningBehavior, WorkflowIdReusePolicy } from '../src/worker/index'
+
+describe('worker public API', () => {
+  it('exports workflow start policy enums used by worker consumers', () => {
+    expect(VersioningBehavior.PINNED).toBeDefined()
+    expect(WorkflowIdReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Export `WorkflowIdReusePolicy` from the Temporal Bun SDK worker public subpath.
- Keep source-path consumers aligned with the package `./worker` export surface.
- Add a public-API regression test covering both worker workflow policy enums.

## Related Issues

Prerequisite for #12329 and #12330; follows the Bumba workflow reuse-policy integration merged in #12281.

## Testing

- `bun test packages/temporal-bun-sdk/tests/worker.public-api.test.ts` (1 passed)
- `bun node_modules/typescript/bin/tsc --project packages/temporal-bun-sdk/tsconfig.json --pretty false`
- `bun node_modules/oxfmt/bin/oxfmt --check packages/temporal-bun-sdk/src/worker/index.ts packages/temporal-bun-sdk/tests/worker.public-api.test.ts`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/temporal-bun-sdk/src/worker/index.ts packages/temporal-bun-sdk/tests/worker.public-api.test.ts`
- `bun node_modules/typescript/bin/tsc --noEmit --project services/jangar/tsconfig.paths.json`
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
