### PR TITLE
chore(symphony): promote image sha-95ffea0e6bd58e03742b71606d11af9d8fb01898

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T02:24:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T23:41:42Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-c1f09e6d651cdfed462e484346044948aebc9849"
-    digest: sha256:a2a2b38f84ece86ec92247e3d4ebdc37119062d60b2482d7c453a2c18ff50297
+    newTag: "sha-95ffea0e6bd58e03742b71606d11af9d8fb01898"
+    digest: sha256:1dd64cdf33af1b62e7d915df83256b3628b27214c5805f7adb356b1c7e8a6c24

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T02:24:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T23:41:42Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-c1f09e6d651cdfed462e484346044948aebc9849"
-    digest: sha256:a2a2b38f84ece86ec92247e3d4ebdc37119062d60b2482d7c453a2c18ff50297
+    newTag: "sha-95ffea0e6bd58e03742b71606d11af9d8fb01898"
+    digest: sha256:1dd64cdf33af1b62e7d915df83256b3628b27214c5805f7adb356b1c7e8a6c24

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T02:24:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-12T23:41:42Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-c1f09e6d651cdfed462e484346044948aebc9849"
-    digest: sha256:a2a2b38f84ece86ec92247e3d4ebdc37119062d60b2482d7c453a2c18ff50297
+    newTag: "sha-95ffea0e6bd58e03742b71606d11af9d8fb01898"
+    digest: sha256:1dd64cdf33af1b62e7d915df83256b3628b27214c5805f7adb356b1c7e8a6c24


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `95ffea0e6bd58e03742b71606d11af9d8fb01898`
- Image tag: `sha-95ffea0e6bd58e03742b71606d11af9d8fb01898`
- Image digest: `sha256:1dd64cdf33af1b62e7d915df83256b3628b27214c5805f7adb356b1c7e8a6c24`