### PR TITLE
perf(flamingo): right-size host resources

### DIFF
--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -89,6 +89,26 @@ and uncached 180K/220K/229K input probes with the configured 32K output budget.
   reclaim scans, working-set refaults, limit hits, OOMs, request errors,
   request aborts, or preemptions.
 
+Cold-start validation completed on July 13, 2026 UTC. The vLLM container
+restarted under the candidate cgroups, loaded all six checkpoint shards, and
+became ready in about two minutes. Startup confirmed `max model len 262144`, a
+`24.67 GiB` checkpoint, `23.23 GiB` of GPU model memory, and zero host-memory
+limit or OOM events. The fully salted post-cold profile then matched the
+original-resource control:
+
+| Metric | `16/64` CPU, `128/256Gi` control | `4/8` CPU, `32/40Gi` candidate |
+| --- | ---: | ---: |
+| Prompt tokens/s | `4930.81` | `4904.96` |
+| Generation tokens/s | `136.84` | `134.90` |
+| 229K uncached probe | `37.338s` | `37.366s` |
+| 4K scheduler output tokens/s | `565.82` | `567.77` |
+| 32K scheduler output tokens/s | `270.95` | `287.56` |
+| 128K scheduler output tokens/s | `34.91` | `35.19` |
+
+The post-cold run had zero failed smokes, warmups, benchmarks, or gates, and
+zero request errors, aborts, preemptions, memory-limit hits, reclaim scans, or
+working-set refaults.
+
 The `32Gi` request covers the measured working-set peak after GiB rounding; the
 `40Gi` limit leaves more than 20% burst headroom. Kubernetes memory metrics
 include active file cache, so do not interpret the full working set as vLLM

--- a/argocd/applications/flamingo/README.md
+++ b/argocd/applications/flamingo/README.md
@@ -66,6 +66,40 @@ assistant content. The active tool parser is `qwen3_coder`, which is the vLLM
 Qwen3.5/Qwen3.6 recipe recommendation for automatic tool calling.
 Reference: <https://docs.vllm.ai/projects/recipes/en/latest/Qwen/Qwen3.5.html>
 
+## Host CPU and Memory Sizing
+
+The Deployment requests `4` CPU cores and `32Gi` of regular host RAM, with
+limits of `8` cores and `40Gi`. These values do not reserve GPU VRAM;
+`nvidia.com/gpu: 1` and `--gpu-memory-utilization` govern the GPU allocation and
+vLLM's VRAM target. The production `--max-model-len 262144` profile is an
+invariant and was not reduced during host-resource tuning.
+
+The July 12, 2026 tuning run used isolated per-run prefix-cache salts and the
+full benchmark profile: concurrency through 16, 4K/32K/128K scheduler cells,
+and uncached 180K/220K/229K input probes with the configured 32K output budget.
+
+- The `16/64` CPU control and `4/8` candidate produced equivalent scheduler
+  throughput, TTFT, and TPOT within run-to-run noise.
+- The `2/4` CPU candidate increased mean and p99 TTFT for the 32K scheduler cell
+  by about 12% and 14%, respectively, so it was rejected.
+- vLLM reported a `24.67 GiB` checkpoint. The container's measured host-memory
+  peak was `31.65 GiB`: about `25 GiB` file-backed checkpoint cache and about
+  `5 GiB` anonymous runtime memory.
+- At `32Gi` requested and `40Gi` limited, the full profile completed with zero
+  reclaim scans, working-set refaults, limit hits, OOMs, request errors,
+  request aborts, or preemptions.
+
+The `32Gi` request covers the measured working-set peak after GiB rounding; the
+`40Gi` limit leaves more than 20% burst headroom. Kubernetes memory metrics
+include active file cache, so do not interpret the full working set as vLLM
+heap.
+
+Revalidate this budget after changing the model, image, checkpoint loading
+strategy, context/concurrency profile, or `/dev/shm` size. The required gate is
+a cold model load followed by the same fully salted full-context benchmark,
+without an OOM kill, restart loop, sustained throttling regression, or
+checkpoint-cache thrash.
+
 Do not enable concurrent partial prefill or DBO directly in this production
 profile on the pinned vLLM image. The July 3, 2026 rollout with
 `--max-num-partial-prefills 2` failed before engine startup with
@@ -220,6 +254,10 @@ Use the repo runner so output is comparable:
 bun run flamingo:benchmark --profile=smoke --candidate-id=baseline-live --fail-on-gate
 bun run flamingo:benchmark --profile=full --candidate-id=<candidate> --baseline-result=<baseline.json> --long-targets=180000,220000,229000 --fail-on-gate
 ```
+
+The runner assigns a distinct 256-bit `cache_salt` to each run and records it
+in the result. This prevents a previous candidate's prefix cache from making a
+later candidate appear faster while preserving within-run prefix-cache tests.
 
 Do not run the `full` profile against production while Saigak is still resident
 on Turin. On July 3, 2026, `full` reached `warmup-c16` and the vLLM engine died

--- a/argocd/applications/flamingo/deployment.yaml
+++ b/argocd/applications/flamingo/deployment.yaml
@@ -102,12 +102,12 @@ spec:
             failureThreshold: 6
           resources:
             requests:
-              cpu: "16"
-              memory: 128Gi
+              cpu: "4"
+              memory: 32Gi
               nvidia.com/gpu: "1"
             limits:
-              cpu: "64"
-              memory: 256Gi
+              cpu: "8"
+              memory: 40Gi
               nvidia.com/gpu: "1"
           securityContext:
             allowPrivilegeEscalation: false

--- a/scripts/jangar/benchmark-flamingo-vllm.test.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { validateChatSmokeResponse } from './benchmark-flamingo-vllm'
+import { validateChatSmokeResponse, withCacheSalt } from './benchmark-flamingo-vllm'
 
 function textResponse(content: string, finishReason = 'stop', completionTokens = 8): unknown {
   return {
@@ -8,6 +8,15 @@ function textResponse(content: string, finishReason = 'stop', completionTokens =
     usage: { completion_tokens: completionTokens },
   }
 }
+
+describe('withCacheSalt', () => {
+  test('isolates every chat payload without mutating the caller input', () => {
+    const payload = { model: 'qwen36-flamingo', messages: [{ role: 'user', content: 'hello' }] }
+
+    expect(withCacheSalt(payload, 'run-specific-salt')).toEqual({ ...payload, cache_salt: 'run-specific-salt' })
+    expect(payload).not.toHaveProperty('cache_salt')
+  })
+})
 
 describe('validateChatSmokeResponse', () => {
   test('accepts real OpenAI text completion fields', () => {

--- a/scripts/jangar/benchmark-flamingo-vllm.ts
+++ b/scripts/jangar/benchmark-flamingo-vllm.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { spawn } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 
@@ -133,6 +134,7 @@ export type RunSummary = {
   finishedAt?: string
   candidateId: string
   profile: string
+  cacheSalt: string
   contextTargets: number[]
   model: string
   tokenizer: string
@@ -188,6 +190,8 @@ for (const arg of process.argv.slice(2)) {
 
 const profile = args.get('profile') ?? process.env.FLAMINGO_BENCH_PROFILE ?? 'smoke'
 const candidateId = args.get('candidate-id') ?? process.env.FLAMINGO_CANDIDATE_ID ?? 'live'
+const cacheSalt =
+  args.get('cache-salt') ?? process.env.FLAMINGO_BENCH_CACHE_SALT ?? randomBytes(32).toString('base64url')
 const baselineResultPath = args.get('baseline-result') ?? process.env.FLAMINGO_BASELINE_RESULT
 const failOnGate = (args.get('fail-on-gate') ?? process.env.FLAMINGO_BENCH_FAIL_ON_GATE ?? 'false') !== 'false'
 const kubeContext = args.get('context') ?? process.env.KUBE_CONTEXT ?? 'galactic-tailscale'
@@ -309,6 +313,10 @@ async function fetchText(path: string): Promise<string> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function withCacheSalt(payload: unknown, salt: string): unknown {
+  return isRecord(payload) ? { ...payload, cache_salt: salt } : payload
 }
 
 function firstNumber(value: unknown): number | undefined {
@@ -465,7 +473,7 @@ async function chatSmoke(label: string, payload: unknown): Promise<ChatResult> {
   try {
     const response = await fetchJson('/chat/completions', {
       method: 'POST',
-      body: JSON.stringify(payload),
+      body: JSON.stringify(withCacheSalt(payload, cacheSalt)),
     })
     const validationErrors = validateChatSmokeResponse(label, response)
     return {
@@ -663,6 +671,8 @@ async function runBench(label: string, inputLen: number, outputLen: number, numP
     String(numPrompts),
     '--max-concurrency',
     String(concurrency),
+    '--extra-body',
+    JSON.stringify({ cache_salt: cacheSalt }),
     '--save-result',
     '--result-dir',
     podDir,
@@ -997,6 +1007,7 @@ async function main(): Promise<void> {
     startedAt: new Date().toISOString(),
     candidateId,
     profile,
+    cacheSalt,
     contextTargets,
     model,
     tokenizer,


### PR DESCRIPTION
## Summary

- Right-sizes Flamingo host resources from 16/64 CPU and 128/256Gi RAM to the measured 4/8 CPU and 32/40Gi RAM candidate.
- Preserves one GPU, `--gpu-memory-utilization 0.85`, FP8 KV cache, concurrency 16, and `--max-model-len 262144`.
- Isolates every benchmark and chat probe with a per-run 256-bit `cache_salt` so prior prefix-cache state cannot contaminate candidate comparisons.
- Documents the CPU knee, RAM working-set evidence, rejected CPU floor, and cold-start/full-context rollout gate.

## Related Issues

None

## Testing

- Live paired full-profile benchmarks at CPU 16/64, 8/16, 4/8, and 2/4 with 4K/32K/128K scheduler cells. The 2/4 candidate regressed 32K mean/p99 TTFT by about 12%/14%; 4/8 matched the control.
- Live full-profile benchmark at CPU 4/8 and RAM 32/40Gi with concurrency 16 and uncached 180K/220K/229K input probes: zero reclaim scans, refaults, limit hits, OOMs, request errors, aborts, or preemptions.
- `bun test scripts/jangar/benchmark-flamingo-vllm.test.ts`
- `bunx oxfmt --check scripts/jangar/benchmark-flamingo-vllm.ts scripts/jangar/benchmark-flamingo-vllm.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/flamingo`
- `bun run lint:flamingo-hard-migration`
- `bun run lint:argocd`
- Pending before ready/merge: cold model start under the candidate limits, followed by the same fully salted full-context benchmark.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.