### PR TITLE
feat(torghut): project order-feed lineage coverage

### DIFF
--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Project order-feed lineage coverage without changing the database.
+
+The projection is deliberately diagnostic.  It compares filled execution rows
+with canonical fill events persisted in ``execution_order_events`` and reports
+the source-window and Kafka-offset evidence needed before those rows can be
+used for runtime-ledger or P&L promotion.  It never updates rows, creates
+source windows, repairs links, or claims profitability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import create_engine, exists, func, or_, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.models import Execution, ExecutionOrderEvent
+
+
+SCHEMA_VERSION = "torghut.order-feed-coverage-projection.v1"
+FILL_EVENT_TYPES = frozenset({"fill", "filled", "partial_fill", "partially_filled"})
+FILLED_EXECUTION_STATUSES = frozenset(
+    {"fill", "filled", "partial_fill", "partially_filled"}
+)
+
+BLOCKER_EXECUTION_FILL_LINEAGE = "execution_fill_event_lineage_missing"
+BLOCKER_UNLINKED_FILL_EVENTS = "unlinked_fill_events_present"
+BLOCKER_FILL_EVENT_SOURCE_WINDOW = "fill_events_missing_source_window"
+BLOCKER_FILL_EVENT_SOURCE_OFFSET = "fill_events_missing_source_offset"
+BLOCKER_FILL_EVENT_ORDER_IDENTITY = "fill_events_missing_order_identity"
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
+def _parse_datetime(value: object) -> datetime:
+    text = str(value).strip()
+    if not text:
+        raise argparse.ArgumentTypeError("datetime cannot be empty")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid datetime: {text}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _bounded_limit(value: object, *, default: int = 100) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit must be an integer") from exc
+    return max(1, min(parsed, 5000)) if parsed else default
+
+
+def _event_time_expression() -> Any:
+    return func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+
+
+def _execution_time_expression() -> Any:
+    return func.coalesce(
+        Execution.order_feed_last_event_ts,
+        Execution.last_update_at,
+        Execution.created_at,
+    )
+
+
+def _scope_predicates(
+    column: Any,
+    *,
+    account_label: str | None,
+    window_start: datetime | None,
+    window_end: datetime | None,
+    time_expression: Any,
+) -> list[ColumnElement[bool]]:
+    predicates: list[ColumnElement[bool]] = []
+    if account_label:
+        predicates.append(column == account_label)
+    if window_start is not None:
+        predicates.append(time_expression >= window_start)
+    if window_end is not None:
+        predicates.append(time_expression < window_end)
+    return predicates
+
+
+def _fill_event_predicate() -> ColumnElement[bool]:
+    """Identify canonical broker fill lifecycle events.
+
+    ``filled_qty_delta`` is included as a fallback for events whose broker
+    taxonomy was normalized away but whose positive delta was already proven by
+    the order-feed repair path.  A cumulative quantity without a positive
+    delta is intentionally not treated as a fill event here.
+    """
+
+    return or_(
+        func.lower(ExecutionOrderEvent.event_type).in_(FILL_EVENT_TYPES),
+        func.lower(ExecutionOrderEvent.status).in_(FILL_EVENT_TYPES),
+        ExecutionOrderEvent.filled_qty_delta > 0,
+    )
+
+
+def _filled_execution_predicate() -> ColumnElement[bool]:
+    return or_(
+        Execution.filled_qty > 0,
+        func.lower(Execution.status).in_(FILLED_EXECUTION_STATUSES),
+    )
+
+
+def _count(session: Session, statement: Any) -> int:
+    value = session.scalar(statement)
+    return int(value or 0)
+
+
+def _ratio(numerator: int, denominator: int) -> str | None:
+    if denominator <= 0:
+        return None
+    return str(
+        (Decimal(numerator) / Decimal(denominator)).quantize(Decimal("0.000001"))
+    )
+
+
+def _iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    normalized = (
+        value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    )
+    return normalized.astimezone(timezone.utc).isoformat()
+
+
+def _decimal_text(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _execution_sample(row: Execution) -> dict[str, object]:
+    return {
+        "execution_id": str(row.id),
+        "account_label": row.alpaca_account_label,
+        "alpaca_order_id": row.alpaca_order_id,
+        "client_order_id": row.client_order_id,
+        "symbol": row.symbol,
+        "status": row.status,
+        "filled_qty": _decimal_text(row.filled_qty),
+        "activity_at": _iso(
+            row.order_feed_last_event_ts or row.last_update_at or row.created_at
+        ),
+    }
+
+
+def _event_sample(row: ExecutionOrderEvent) -> dict[str, object]:
+    return {
+        "event_id": str(row.id),
+        "account_label": row.alpaca_account_label,
+        "alpaca_order_id": row.alpaca_order_id,
+        "client_order_id": row.client_order_id,
+        "symbol": row.symbol,
+        "event_type": row.event_type,
+        "status": row.status,
+        "filled_qty": _decimal_text(row.filled_qty),
+        "filled_qty_delta": _decimal_text(row.filled_qty_delta),
+        "event_ts": _iso(row.event_ts),
+        "source_topic": row.source_topic,
+        "source_partition": row.source_partition,
+        "source_offset": row.source_offset,
+        "execution_id": str(row.execution_id) if row.execution_id else None,
+        "source_window_id": str(row.source_window_id) if row.source_window_id else None,
+    }
+
+
+def _sample_rows(
+    session: Session,
+    statement: Any,
+    *,
+    sample_limit: int,
+) -> list[dict[str, object]]:
+    rows = session.scalars(statement.limit(sample_limit)).all()
+    return [_execution_sample(row) for row in rows]
+
+
+def _sample_events(
+    session: Session,
+    statement: Any,
+    *,
+    sample_limit: int,
+) -> list[dict[str, object]]:
+    rows = session.scalars(statement.limit(sample_limit)).all()
+    return [_event_sample(row) for row in rows]
+
+
+def _blockers(
+    *,
+    filled_executions_missing_fill_event: int,
+    unlinked_fill_events: int,
+    linked_fill_events_missing_source_window: int,
+    linked_fill_events_missing_source_offset: int,
+    fill_events_missing_order_identity: int,
+) -> list[str]:
+    blockers: list[str] = []
+    if filled_executions_missing_fill_event:
+        blockers.append(BLOCKER_EXECUTION_FILL_LINEAGE)
+    if unlinked_fill_events:
+        blockers.append(BLOCKER_UNLINKED_FILL_EVENTS)
+    if linked_fill_events_missing_source_window:
+        blockers.append(BLOCKER_FILL_EVENT_SOURCE_WINDOW)
+    if linked_fill_events_missing_source_offset:
+        blockers.append(BLOCKER_FILL_EVENT_SOURCE_OFFSET)
+    if fill_events_missing_order_identity:
+        blockers.append(BLOCKER_FILL_EVENT_ORDER_IDENTITY)
+    return blockers
+
+
+def project_order_feed_coverage(
+    session: Session,
+    *,
+    account_label: str | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
+    sample_limit: int = 25,
+) -> dict[str, object]:
+    """Return a read-only execution-to-fill-event coverage projection."""
+
+    if (
+        window_start is not None
+        and window_end is not None
+        and window_end <= window_start
+    ):
+        raise ValueError("window_end_must_be_after_window_start")
+    bounded_sample_limit = _bounded_limit(sample_limit, default=25)
+    execution_scope = _scope_predicates(
+        Execution.alpaca_account_label,
+        account_label=account_label,
+        window_start=window_start,
+        window_end=window_end,
+        time_expression=_execution_time_expression(),
+    )
+    event_scope = _scope_predicates(
+        ExecutionOrderEvent.alpaca_account_label,
+        account_label=account_label,
+        window_start=window_start,
+        window_end=window_end,
+        time_expression=_event_time_expression(),
+    )
+    fill_predicate = _fill_event_predicate()
+    filled_execution_predicate = _filled_execution_predicate()
+    linked_any_event = exists(
+        select(1).where(
+            ExecutionOrderEvent.execution_id == Execution.id,
+            *event_scope,
+        )
+    )
+    linked_fill_event = exists(
+        select(1).where(
+            ExecutionOrderEvent.execution_id == Execution.id,
+            fill_predicate,
+            *event_scope,
+        )
+    )
+
+    execution_count = _count(
+        session,
+        select(func.count(Execution.id)).where(*execution_scope),
+    )
+    filled_execution_count = _count(
+        session,
+        select(func.count(Execution.id)).where(
+            *execution_scope,
+            filled_execution_predicate,
+        ),
+    )
+    execution_with_any_event_count = _count(
+        session,
+        select(func.count(Execution.id)).where(*execution_scope, linked_any_event),
+    )
+    execution_with_fill_event_count = _count(
+        session,
+        select(func.count(Execution.id)).where(*execution_scope, linked_fill_event),
+    )
+    filled_executions_missing_fill_event = _count(
+        session,
+        select(func.count(Execution.id)).where(
+            *execution_scope,
+            filled_execution_predicate,
+            ~linked_fill_event,
+        ),
+    )
+    fill_event_scope = [*event_scope, fill_predicate]
+    fill_event_count = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(*fill_event_scope),
+    )
+    linked_fill_event_count = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(
+            *fill_event_scope,
+            ExecutionOrderEvent.execution_id.is_not(None),
+        ),
+    )
+    unlinked_fill_event_count = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(
+            *fill_event_scope,
+            ExecutionOrderEvent.execution_id.is_(None),
+        ),
+    )
+    linked_fill_events_missing_source_window = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(
+            *fill_event_scope,
+            ExecutionOrderEvent.execution_id.is_not(None),
+            ExecutionOrderEvent.source_window_id.is_(None),
+        ),
+    )
+    linked_fill_events_missing_source_offset = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(
+            *fill_event_scope,
+            ExecutionOrderEvent.execution_id.is_not(None),
+            or_(
+                ExecutionOrderEvent.source_partition.is_(None),
+                ExecutionOrderEvent.source_offset.is_(None),
+            ),
+        ),
+    )
+    fill_events_missing_order_identity = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(
+            *fill_event_scope,
+            ExecutionOrderEvent.alpaca_order_id.is_(None),
+            ExecutionOrderEvent.client_order_id.is_(None),
+        ),
+    )
+    positive_fill_delta_event_count = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(
+            *event_scope,
+            ExecutionOrderEvent.filled_qty_delta > 0,
+        ),
+    )
+    positive_fill_delta_unlinked_count = _count(
+        session,
+        select(func.count(ExecutionOrderEvent.id)).where(
+            *event_scope,
+            ExecutionOrderEvent.filled_qty_delta > 0,
+            ExecutionOrderEvent.execution_id.is_(None),
+        ),
+    )
+
+    missing_execution_sample = _sample_rows(
+        session,
+        select(Execution)
+        .where(*execution_scope, filled_execution_predicate, ~linked_fill_event)
+        .order_by(_execution_time_expression().asc().nullslast(), Execution.id.asc()),
+        sample_limit=bounded_sample_limit,
+    )
+    unlinked_fill_event_sample = _sample_events(
+        session,
+        select(ExecutionOrderEvent)
+        .where(*fill_event_scope, ExecutionOrderEvent.execution_id.is_(None))
+        .order_by(
+            _event_time_expression().asc().nullslast(), ExecutionOrderEvent.id.asc()
+        ),
+        sample_limit=bounded_sample_limit,
+    )
+
+    blockers = _blockers(
+        filled_executions_missing_fill_event=filled_executions_missing_fill_event,
+        unlinked_fill_events=unlinked_fill_event_count,
+        linked_fill_events_missing_source_window=linked_fill_events_missing_source_window,
+        linked_fill_events_missing_source_offset=linked_fill_events_missing_source_offset,
+        fill_events_missing_order_identity=fill_events_missing_order_identity,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "read_only": True,
+        "writes_performed": False,
+        "mutates_database": False,
+        "submits_orders": False,
+        "profitability_claimed": False,
+        "promotion_authority_eligible": False,
+        "authority_reason": "coverage_projection_is_diagnostic_only",
+        "account_label": account_label,
+        "window": {
+            "start": _iso(window_start),
+            "end": _iso(window_end),
+        },
+        "population": {
+            "execution_count": execution_count,
+            "filled_execution_count": filled_execution_count,
+            "execution_with_any_event_count": execution_with_any_event_count,
+            "execution_with_fill_event_count": execution_with_fill_event_count,
+            "filled_executions_missing_fill_event_count": filled_executions_missing_fill_event,
+        },
+        "event_lineage": {
+            "fill_event_count": fill_event_count,
+            "linked_fill_event_count": linked_fill_event_count,
+            "unlinked_fill_event_count": unlinked_fill_event_count,
+            "linked_fill_events_missing_source_window_count": linked_fill_events_missing_source_window,
+            "linked_fill_events_missing_source_offset_count": linked_fill_events_missing_source_offset,
+            "fill_events_missing_order_identity_count": fill_events_missing_order_identity,
+            "positive_fill_delta_event_count": positive_fill_delta_event_count,
+            "positive_fill_delta_unlinked_count": positive_fill_delta_unlinked_count,
+        },
+        "coverage": {
+            "filled_execution_to_fill_event_ratio": _ratio(
+                execution_with_fill_event_count,
+                filled_execution_count,
+            ),
+            "fill_event_to_execution_ratio": _ratio(
+                linked_fill_event_count,
+                fill_event_count,
+            ),
+        },
+        "blockers": blockers,
+        "samples": {
+            "filled_executions_missing_fill_event": missing_execution_sample,
+            "unlinked_fill_events": unlinked_fill_event_sample,
+        },
+        "sample_limit": bounded_sample_limit,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn-env", default="DB_DSN")
+    parser.add_argument("--account-label", default=None)
+    parser.add_argument("--window-start", type=_parse_datetime, default=None)
+    parser.add_argument("--window-end", type=_parse_datetime, default=None)
+    parser.add_argument("--sample-limit", type=int, default=25)
+    parser.add_argument(
+        "--fail-on-blockers",
+        action="store_true",
+        help="return exit code 1 when the projection finds lineage blockers",
+    )
+    parser.add_argument("--json", action="store_true", help="emit compact JSON")
+    return parser.parse_args()
+
+
+def run_report(args: argparse.Namespace) -> dict[str, object]:
+    dsn_env = str(args.dsn_env).strip()
+    dsn = os.environ.get(dsn_env)
+    if not dsn:
+        raise SystemExit(f"missing DSN env var: {dsn_env}")
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    with session_factory() as session:
+        report = project_order_feed_coverage(
+            session,
+            account_label=args.account_label,
+            window_start=args.window_start,
+            window_end=args.window_end,
+            sample_limit=args.sample_limit,
+        )
+        session.rollback()
+    return report
+
+
+def main() -> int:
+    args = _parse_args()
+    report = run_report(args)
+    print(
+        json.dumps(report, separators=(",", ":"))
+        if args.json
+        else json.dumps(report, indent=2, sort_keys=True)
+    )
+    return 1 if args.fail_on_blockers and report["blockers"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -15,11 +15,11 @@ import json
 import os
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any
 
 from sqlalchemy import create_engine, exists, func, or_, select
+from sqlalchemy.sql import ColumnElement
+from sqlalchemy.sql.base import Executable
 from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.sql.elements import ColumnElement
 
 from app.models import Execution, ExecutionOrderEvent
 
@@ -69,11 +69,11 @@ def _bounded_limit(value: object, *, default: int = 100) -> int:
     return max(1, min(parsed, 5000)) if parsed else default
 
 
-def _event_time_expression() -> Any:
+def _event_time_expression() -> ColumnElement[object]:
     return func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
 
 
-def _execution_time_expression() -> Any:
+def _execution_time_expression() -> ColumnElement[object]:
     return func.coalesce(
         Execution.order_feed_last_event_ts,
         Execution.last_update_at,
@@ -82,12 +82,12 @@ def _execution_time_expression() -> Any:
 
 
 def _scope_predicates(
-    column: Any,
+    column: ColumnElement[object],
     *,
     account_label: str | None,
     window_start: datetime | None,
     window_end: datetime | None,
-    time_expression: Any,
+    time_expression: ColumnElement[object],
 ) -> list[ColumnElement[bool]]:
     predicates: list[ColumnElement[bool]] = []
     if account_label:
@@ -122,7 +122,7 @@ def _filled_execution_predicate() -> ColumnElement[bool]:
     )
 
 
-def _count(session: Session, statement: Any) -> int:
+def _count(session: Session, statement: Executable) -> int:
     value = session.scalar(statement)
     return int(value or 0)
 
@@ -187,7 +187,7 @@ def _event_sample(row: ExecutionOrderEvent) -> dict[str, object]:
 
 def _sample_rows(
     session: Session,
-    statement: Any,
+    statement: Executable,
     *,
     sample_limit: int,
 ) -> list[dict[str, object]]:
@@ -197,7 +197,7 @@ def _sample_rows(
 
 def _sample_events(
     session: Session,
-    statement: Any,
+    statement: Executable,
     *,
     sample_limit: int,
 ) -> list[dict[str, object]]:

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -17,8 +17,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 
-from sqlalchemy import create_engine, exists, func, or_, select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy import and_, create_engine, exists, func, or_, select
+from sqlalchemy.orm import Session, aliased, sessionmaker
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql.base import Executable
 from sqlalchemy.sql.functions import count as sql_count
@@ -58,6 +58,7 @@ class _CoveragePredicates:
     event_scope: tuple[ColumnElement[bool], ...]
     fill_event_scope: tuple[ColumnElement[bool], ...]
     filled_execution_predicate: ColumnElement[bool]
+    event_has_unique_execution: ColumnElement[bool]
     linked_any_event: ColumnElement[bool]
     linked_fill_event: ColumnElement[bool]
 
@@ -192,6 +193,29 @@ def _fill_event_predicate() -> ColumnElement[bool]:
         func.lower(ExecutionOrderEvent.status).in_(FILL_EVENT_TYPES),
         ExecutionOrderEvent.filled_qty > 0,
         ExecutionOrderEvent.filled_qty_delta > 0,
+    )
+
+
+def _event_execution_identity_match(
+    *,
+    execution_id: ColumnElement[object],
+    account_label: ColumnElement[object],
+    alpaca_order_id: ColumnElement[object],
+    client_order_id: ColumnElement[object],
+) -> ColumnElement[bool]:
+    return and_(
+        account_label == ExecutionOrderEvent.alpaca_account_label,
+        or_(
+            execution_id == ExecutionOrderEvent.execution_id,
+            and_(
+                func.nullif(ExecutionOrderEvent.alpaca_order_id, "").is_not(None),
+                alpaca_order_id == ExecutionOrderEvent.alpaca_order_id,
+            ),
+            and_(
+                func.nullif(ExecutionOrderEvent.client_order_id, "").is_not(None),
+                client_order_id == ExecutionOrderEvent.client_order_id,
+            ),
+        ),
     )
 
 
@@ -349,15 +373,37 @@ def _coverage_predicates(
     )
     fill_event_predicate = _fill_event_predicate()
     filled_execution_predicate = _filled_execution_predicate()
+    candidate_execution = aliased(Execution)
+    candidate_match = _event_execution_identity_match(
+        execution_id=candidate_execution.id,
+        account_label=candidate_execution.alpaca_account_label,
+        alpaca_order_id=candidate_execution.alpaca_order_id,
+        client_order_id=candidate_execution.client_order_id,
+    )
+    candidate_count = (
+        select(func.count(candidate_execution.id))
+        .where(candidate_match)
+        .correlate(ExecutionOrderEvent)
+        .scalar_subquery()
+    )
+    event_has_unique_execution = candidate_count == 1
+    current_execution_match = _event_execution_identity_match(
+        execution_id=Execution.id,
+        account_label=Execution.alpaca_account_label,
+        alpaca_order_id=Execution.alpaca_order_id,
+        client_order_id=Execution.client_order_id,
+    )
     linked_any_event = exists(
         select(1).where(
-            ExecutionOrderEvent.execution_id == Execution.id,
+            current_execution_match,
+            event_has_unique_execution,
             *event_scope,
         )
     )
     linked_fill_event = exists(
         select(1).where(
-            ExecutionOrderEvent.execution_id == Execution.id,
+            current_execution_match,
+            event_has_unique_execution,
             fill_event_predicate,
             *event_scope,
         )
@@ -367,6 +413,7 @@ def _coverage_predicates(
         event_scope=event_scope,
         fill_event_scope=(*event_scope, fill_event_predicate),
         filled_execution_predicate=filled_execution_predicate,
+        event_has_unique_execution=event_has_unique_execution,
         linked_any_event=linked_any_event,
         linked_fill_event=linked_fill_event,
     )
@@ -435,10 +482,15 @@ def _lineage_counts(
     has_delta_provenance = normalized_fill_quantity_basis.in_(
         FILL_DELTA_PROVENANCE_ALIASES
     )
-    linked_fill_event_predicate = ExecutionOrderEvent.execution_id.is_not(None)
+    linked_fill_event_predicate = predicates.event_has_unique_execution
     linked_execution_has_trade_decision = exists(
         select(1).where(
-            Execution.id == ExecutionOrderEvent.execution_id,
+            _event_execution_identity_match(
+                execution_id=Execution.id,
+                account_label=Execution.alpaca_account_label,
+                alpaca_order_id=Execution.alpaca_order_id,
+                client_order_id=Execution.client_order_id,
+            ),
             Execution.trade_decision_id.is_not(None),
         )
     )
@@ -474,7 +526,7 @@ def _lineage_counts(
             session,
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
-                ExecutionOrderEvent.execution_id.is_(None),
+                ~linked_fill_event_predicate,
             ),
         ),
     )
@@ -483,7 +535,7 @@ def _lineage_counts(
             session,
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
-                ExecutionOrderEvent.execution_id.is_not(None),
+                linked_fill_event_predicate,
                 ExecutionOrderEvent.source_window_id.is_(None),
             ),
         ),
@@ -491,7 +543,7 @@ def _lineage_counts(
             session,
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
-                ExecutionOrderEvent.execution_id.is_not(None),
+                linked_fill_event_predicate,
                 or_(
                     ExecutionOrderEvent.source_partition.is_(None),
                     ExecutionOrderEvent.source_offset.is_(None),
@@ -558,7 +610,7 @@ def _lineage_counts(
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *event_scope,
                 ExecutionOrderEvent.filled_qty_delta > 0,
-                ExecutionOrderEvent.execution_id.is_(None),
+                ~predicates.event_has_unique_execution,
             ),
         ),
     )
@@ -591,7 +643,7 @@ def _coverage_samples(
         select(ExecutionOrderEvent)
         .where(
             *predicates.fill_event_scope,
-            ExecutionOrderEvent.execution_id.is_(None),
+            ~predicates.event_has_unique_execution,
         )
         .order_by(
             _event_time_expression().asc().nullslast(), ExecutionOrderEvent.id.asc()

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -37,6 +37,7 @@ BLOCKER_UNLINKED_FILL_EVENTS = "unlinked_fill_events_present"
 BLOCKER_FILL_EVENT_SOURCE_WINDOW = "fill_events_missing_source_window"
 BLOCKER_FILL_EVENT_SOURCE_OFFSET = "fill_events_missing_source_offset"
 BLOCKER_FILL_EVENT_ORDER_IDENTITY = "fill_events_missing_order_identity"
+BLOCKER_FILL_EVENT_TRADE_DECISION = "fill_events_missing_trade_decision"
 
 
 @dataclass(frozen=True)
@@ -70,6 +71,7 @@ class _SourceEvidenceCounts:
     linked_fill_events_missing_source_window: int
     linked_fill_events_missing_source_offset: int
     fill_events_missing_order_identity: int
+    linked_fill_events_missing_trade_decision: int
 
 
 @dataclass(frozen=True)
@@ -139,6 +141,7 @@ def _execution_time_expression() -> ColumnElement[object]:
     return func.coalesce(
         Execution.order_feed_last_event_ts,
         Execution.last_update_at,
+        Execution.updated_at,
         Execution.created_at,
     )
 
@@ -173,6 +176,7 @@ def _fill_event_predicate() -> ColumnElement[bool]:
     return or_(
         func.lower(ExecutionOrderEvent.event_type).in_(FILL_EVENT_TYPES),
         func.lower(ExecutionOrderEvent.status).in_(FILL_EVENT_TYPES),
+        ExecutionOrderEvent.filled_qty > 0,
         ExecutionOrderEvent.filled_qty_delta > 0,
     )
 
@@ -226,7 +230,10 @@ def _execution_sample(row: Execution) -> dict[str, object]:
         "status": row.status,
         "filled_qty": _decimal_text(row.filled_qty),
         "activity_at": _iso(
-            row.order_feed_last_event_ts or row.last_update_at or row.created_at
+            row.order_feed_last_event_ts
+            or row.last_update_at
+            or row.updated_at
+            or row.created_at
         ),
     }
 
@@ -278,6 +285,7 @@ def _blockers(
     linked_fill_events_missing_source_window: int,
     linked_fill_events_missing_source_offset: int,
     fill_events_missing_order_identity: int,
+    linked_fill_events_missing_trade_decision: int,
 ) -> list[str]:
     blockers: list[str] = []
     if filled_executions_missing_fill_event:
@@ -290,6 +298,8 @@ def _blockers(
         blockers.append(BLOCKER_FILL_EVENT_SOURCE_OFFSET)
     if fill_events_missing_order_identity:
         blockers.append(BLOCKER_FILL_EVENT_ORDER_IDENTITY)
+    if linked_fill_events_missing_trade_decision:
+        blockers.append(BLOCKER_FILL_EVENT_TRADE_DECISION)
     return blockers
 
 
@@ -441,6 +451,14 @@ def _lineage_counts(
                 ExecutionOrderEvent.client_order_id.is_(None),
             ),
         ),
+        linked_fill_events_missing_trade_decision=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                ExecutionOrderEvent.execution_id.is_not(None),
+                ExecutionOrderEvent.trade_decision_id.is_(None),
+            ),
+        ),
     )
     fill_deltas = _FillDeltaCounts(
         positive_fill_delta_event_count=_count(
@@ -548,6 +566,9 @@ def _projection_payload(
             "fill_events_missing_order_identity_count": (
                 lineage.source_evidence.fill_events_missing_order_identity
             ),
+            "linked_fill_events_missing_trade_decision_count": (
+                lineage.source_evidence.linked_fill_events_missing_trade_decision
+            ),
             "positive_fill_delta_event_count": lineage.fill_deltas.positive_fill_delta_event_count,
             "positive_fill_delta_unlinked_count": (
                 lineage.fill_deltas.positive_fill_delta_unlinked_count
@@ -613,6 +634,9 @@ def project_order_feed_coverage(
         ),
         fill_events_missing_order_identity=(
             lineage.source_evidence.fill_events_missing_order_identity
+        ),
+        linked_fill_events_missing_trade_decision=(
+            lineage.source_evidence.linked_fill_events_missing_trade_decision
         ),
     )
     counts = _ProjectionCounts(

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -23,7 +23,7 @@ from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql.base import Executable
 from sqlalchemy.sql.functions import count as sql_count
 
-from app.models import Execution, ExecutionOrderEvent
+from app.models import Execution, ExecutionOrderEvent, TradeDecision
 
 
 SCHEMA_VERSION = "torghut.order-feed-coverage-projection.v1"
@@ -40,7 +40,16 @@ BLOCKER_FILL_EVENT_ORDER_IDENTITY = "fill_events_missing_order_identity"
 BLOCKER_FILL_EVENT_TRADE_DECISION = "fill_events_missing_trade_decision"
 BLOCKER_FILL_EVENT_DELTA_BASIS = "order_feed_fill_delta_basis_missing"
 BLOCKER_FILL_EVENT_DELTA = "order_feed_fill_delta_missing"
-FILL_DELTA_PROVENANCE_BASES = frozenset({"delta", "cumulative_to_delta"})
+FILL_DELTA_PROVENANCE_ALIASES = frozenset(
+    {
+        "delta",
+        "fill_delta",
+        "filled_delta",
+        "cumulative_to_delta",
+        "cumulative_delta",
+        "cum_to_delta",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -414,13 +423,38 @@ def _lineage_counts(
 ) -> _LineageCounts:
     fill_event_scope = predicates.fill_event_scope
     event_scope = predicates.event_scope
-    normalized_fill_quantity_basis = func.lower(
-        func.trim(ExecutionOrderEvent.fill_quantity_basis)
+    normalized_fill_quantity_basis = func.replace(
+        func.replace(
+            func.lower(func.trim(ExecutionOrderEvent.fill_quantity_basis)),
+            "-",
+            "_",
+        ),
+        " ",
+        "_",
     )
     has_delta_provenance = normalized_fill_quantity_basis.in_(
-        FILL_DELTA_PROVENANCE_BASES
+        FILL_DELTA_PROVENANCE_ALIASES
     )
     linked_fill_event_predicate = ExecutionOrderEvent.execution_id.is_not(None)
+    linked_execution_has_trade_decision = exists(
+        select(1).where(
+            Execution.id == ExecutionOrderEvent.execution_id,
+            Execution.trade_decision_id.is_not(None),
+        )
+    )
+    client_order_decision_match = exists(
+        select(1).where(
+            TradeDecision.alpaca_account_label
+            == ExecutionOrderEvent.alpaca_account_label,
+            TradeDecision.decision_hash
+            == func.nullif(ExecutionOrderEvent.client_order_id, ""),
+        )
+    )
+    resolved_trade_decision = or_(
+        ExecutionOrderEvent.trade_decision_id.is_not(None),
+        linked_execution_has_trade_decision,
+        client_order_decision_match,
+    )
     # Keep this SQL-only projection conservative: runtime can derive a delta
     # from a well-formed raw broker payload, but this diagnostic deliberately
     # requires the persisted structured proof before reporting promotion-ready.
@@ -483,7 +517,7 @@ def _lineage_counts(
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
                 linked_fill_event_predicate,
-                ExecutionOrderEvent.trade_decision_id.is_(None),
+                ~resolved_trade_decision,
             ),
         ),
         linked_fill_events_missing_delta_basis=_count(

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -581,10 +581,7 @@ def _lineage_counts(
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
                 linked_fill_event_predicate,
-                or_(
-                    ExecutionOrderEvent.source_partition.is_(None),
-                    ExecutionOrderEvent.source_offset.is_(None),
-                ),
+                ExecutionOrderEvent.source_offset.is_(None),
             ),
         ),
         fill_events_missing_order_identity=_count(

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -226,6 +226,77 @@ def _filled_execution_predicate() -> ColumnElement[bool]:
     )
 
 
+def _has_delta_provenance_predicate() -> ColumnElement[bool]:
+    normalized_basis = func.replace(
+        func.replace(
+            func.lower(func.trim(ExecutionOrderEvent.fill_quantity_basis)),
+            "-",
+            "_",
+        ),
+        " ",
+        "_",
+    )
+    return normalized_basis.in_(FILL_DELTA_PROVENANCE_ALIASES)
+
+
+def _resolved_trade_decision_predicate(
+    predicates: _CoveragePredicates,
+) -> ColumnElement[bool]:
+    event_decision_ref_present = ExecutionOrderEvent.trade_decision_id.is_not(None)
+    execution_identity_match = _event_execution_identity_match(
+        execution_id=Execution.id,
+        account_label=Execution.alpaca_account_label,
+        alpaca_order_id=Execution.alpaca_order_id,
+        client_order_id=Execution.client_order_id,
+    )
+    linked_execution_has_trade_decision = exists(
+        select(1).where(
+            execution_identity_match,
+            Execution.trade_decision_id.is_not(None),
+        )
+    )
+    linked_execution_decision_ref_present = and_(
+        predicates.event_has_unique_execution,
+        linked_execution_has_trade_decision,
+    )
+    event_decision_account_match = exists(
+        select(1).where(
+            TradeDecision.id == ExecutionOrderEvent.trade_decision_id,
+            TradeDecision.alpaca_account_label
+            == ExecutionOrderEvent.alpaca_account_label,
+        )
+    )
+    linked_execution_decision_account_match = exists(
+        select(1).where(
+            execution_identity_match,
+            Execution.trade_decision_id == TradeDecision.id,
+            TradeDecision.alpaca_account_label
+            == ExecutionOrderEvent.alpaca_account_label,
+        )
+    )
+    client_order_decision_match = exists(
+        select(1).where(
+            TradeDecision.alpaca_account_label
+            == ExecutionOrderEvent.alpaca_account_label,
+            TradeDecision.decision_hash
+            == func.nullif(ExecutionOrderEvent.client_order_id, ""),
+        )
+    )
+    return or_(
+        and_(event_decision_ref_present, event_decision_account_match),
+        and_(
+            ~event_decision_ref_present,
+            linked_execution_decision_ref_present,
+            linked_execution_decision_account_match,
+        ),
+        and_(
+            ~event_decision_ref_present,
+            ~linked_execution_decision_ref_present,
+            client_order_decision_match,
+        ),
+    )
+
+
 def _count(session: Session, statement: Executable) -> int:
     value = session.scalar(statement)
     return int(value or 0)
@@ -470,76 +541,9 @@ def _lineage_counts(
 ) -> _LineageCounts:
     fill_event_scope = predicates.fill_event_scope
     event_scope = predicates.event_scope
-    normalized_fill_quantity_basis = func.replace(
-        func.replace(
-            func.lower(func.trim(ExecutionOrderEvent.fill_quantity_basis)),
-            "-",
-            "_",
-        ),
-        " ",
-        "_",
-    )
-    has_delta_provenance = normalized_fill_quantity_basis.in_(
-        FILL_DELTA_PROVENANCE_ALIASES
-    )
+    has_delta_provenance = _has_delta_provenance_predicate()
     linked_fill_event_predicate = predicates.event_has_unique_execution
-    event_decision_ref_present = ExecutionOrderEvent.trade_decision_id.is_not(None)
-    linked_execution_has_trade_decision = exists(
-        select(1).where(
-            _event_execution_identity_match(
-                execution_id=Execution.id,
-                account_label=Execution.alpaca_account_label,
-                alpaca_order_id=Execution.alpaca_order_id,
-                client_order_id=Execution.client_order_id,
-            ),
-            Execution.trade_decision_id.is_not(None),
-        )
-    )
-    linked_execution_decision_ref_present = and_(
-        predicates.event_has_unique_execution,
-        linked_execution_has_trade_decision,
-    )
-    event_decision_account_match = exists(
-        select(1).where(
-            TradeDecision.id == ExecutionOrderEvent.trade_decision_id,
-            TradeDecision.alpaca_account_label
-            == ExecutionOrderEvent.alpaca_account_label,
-        )
-    )
-    linked_execution_decision_account_match = exists(
-        select(1).where(
-            _event_execution_identity_match(
-                execution_id=Execution.id,
-                account_label=Execution.alpaca_account_label,
-                alpaca_order_id=Execution.alpaca_order_id,
-                client_order_id=Execution.client_order_id,
-            ),
-            Execution.trade_decision_id == TradeDecision.id,
-            TradeDecision.alpaca_account_label
-            == ExecutionOrderEvent.alpaca_account_label,
-        )
-    )
-    client_order_decision_match = exists(
-        select(1).where(
-            TradeDecision.alpaca_account_label
-            == ExecutionOrderEvent.alpaca_account_label,
-            TradeDecision.decision_hash
-            == func.nullif(ExecutionOrderEvent.client_order_id, ""),
-        )
-    )
-    resolved_trade_decision = or_(
-        and_(event_decision_ref_present, event_decision_account_match),
-        and_(
-            ~event_decision_ref_present,
-            linked_execution_decision_ref_present,
-            linked_execution_decision_account_match,
-        ),
-        and_(
-            ~event_decision_ref_present,
-            ~linked_execution_decision_ref_present,
-            client_order_decision_match,
-        ),
-    )
+    resolved_trade_decision = _resolved_trade_decision_predicate(predicates)
     # Keep this SQL-only projection conservative: runtime can derive a delta
     # from a well-formed raw broker payload, but this diagnostic deliberately
     # requires the persisted structured proof before reporting promotion-ready.

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -16,7 +16,6 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any
 
 from sqlalchemy import create_engine, exists, func, or_, select
 from sqlalchemy.orm import Session, sessionmaker
@@ -190,7 +189,7 @@ def _count(session: Session, statement: Executable) -> int:
     return int(value or 0)
 
 
-def _count_expression(column: object) -> Any:
+def _count_expression(column: object) -> ColumnElement[int]:
     return sql_count(column)
 
 

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -38,6 +38,9 @@ BLOCKER_FILL_EVENT_SOURCE_WINDOW = "fill_events_missing_source_window"
 BLOCKER_FILL_EVENT_SOURCE_OFFSET = "fill_events_missing_source_offset"
 BLOCKER_FILL_EVENT_ORDER_IDENTITY = "fill_events_missing_order_identity"
 BLOCKER_FILL_EVENT_TRADE_DECISION = "fill_events_missing_trade_decision"
+BLOCKER_FILL_EVENT_DELTA_BASIS = "order_feed_fill_delta_basis_missing"
+BLOCKER_FILL_EVENT_DELTA = "order_feed_fill_delta_missing"
+FILL_DELTA_PROVENANCE_BASES = frozenset({"delta", "cumulative_to_delta"})
 
 
 @dataclass(frozen=True)
@@ -72,6 +75,8 @@ class _SourceEvidenceCounts:
     linked_fill_events_missing_source_offset: int
     fill_events_missing_order_identity: int
     linked_fill_events_missing_trade_decision: int
+    linked_fill_events_missing_delta_basis: int
+    linked_fill_events_missing_delta: int
 
 
 @dataclass(frozen=True)
@@ -286,6 +291,8 @@ def _blockers(
     linked_fill_events_missing_source_offset: int,
     fill_events_missing_order_identity: int,
     linked_fill_events_missing_trade_decision: int,
+    linked_fill_events_missing_delta_basis: int,
+    linked_fill_events_missing_delta: int,
 ) -> list[str]:
     blockers: list[str] = []
     if filled_executions_missing_fill_event:
@@ -300,6 +307,10 @@ def _blockers(
         blockers.append(BLOCKER_FILL_EVENT_ORDER_IDENTITY)
     if linked_fill_events_missing_trade_decision:
         blockers.append(BLOCKER_FILL_EVENT_TRADE_DECISION)
+    if linked_fill_events_missing_delta_basis:
+        blockers.append(BLOCKER_FILL_EVENT_DELTA_BASIS)
+    if linked_fill_events_missing_delta:
+        blockers.append(BLOCKER_FILL_EVENT_DELTA)
     return blockers
 
 
@@ -403,6 +414,16 @@ def _lineage_counts(
 ) -> _LineageCounts:
     fill_event_scope = predicates.fill_event_scope
     event_scope = predicates.event_scope
+    normalized_fill_quantity_basis = func.lower(
+        func.trim(ExecutionOrderEvent.fill_quantity_basis)
+    )
+    has_delta_provenance = normalized_fill_quantity_basis.in_(
+        FILL_DELTA_PROVENANCE_BASES
+    )
+    linked_fill_event_predicate = ExecutionOrderEvent.execution_id.is_not(None)
+    # Keep this SQL-only projection conservative: runtime can derive a delta
+    # from a well-formed raw broker payload, but this diagnostic deliberately
+    # requires the persisted structured proof before reporting promotion-ready.
     fill_events = _FillEventCounts(
         fill_event_count=_count(
             session,
@@ -412,7 +433,7 @@ def _lineage_counts(
             session,
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
-                ExecutionOrderEvent.execution_id.is_not(None),
+                linked_fill_event_predicate,
             ),
         ),
         unlinked_fill_event_count=_count(
@@ -447,16 +468,46 @@ def _lineage_counts(
             session,
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
-                ExecutionOrderEvent.alpaca_order_id.is_(None),
-                ExecutionOrderEvent.client_order_id.is_(None),
+                or_(
+                    ExecutionOrderEvent.alpaca_order_id.is_(None),
+                    func.trim(ExecutionOrderEvent.alpaca_order_id) == "",
+                ),
+                or_(
+                    ExecutionOrderEvent.client_order_id.is_(None),
+                    func.trim(ExecutionOrderEvent.client_order_id) == "",
+                ),
             ),
         ),
         linked_fill_events_missing_trade_decision=_count(
             session,
             select(_count_expression(ExecutionOrderEvent.id)).where(
                 *fill_event_scope,
-                ExecutionOrderEvent.execution_id.is_not(None),
+                linked_fill_event_predicate,
                 ExecutionOrderEvent.trade_decision_id.is_(None),
+            ),
+        ),
+        linked_fill_events_missing_delta_basis=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                linked_fill_event_predicate,
+                or_(
+                    ExecutionOrderEvent.fill_quantity_basis.is_(None),
+                    func.trim(ExecutionOrderEvent.fill_quantity_basis) == "",
+                    ~has_delta_provenance,
+                ),
+            ),
+        ),
+        linked_fill_events_missing_delta=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                linked_fill_event_predicate,
+                has_delta_provenance,
+                or_(
+                    ExecutionOrderEvent.filled_qty_delta.is_(None),
+                    ExecutionOrderEvent.filled_qty_delta <= 0,
+                ),
             ),
         ),
     )
@@ -569,6 +620,12 @@ def _projection_payload(
             "linked_fill_events_missing_trade_decision_count": (
                 lineage.source_evidence.linked_fill_events_missing_trade_decision
             ),
+            "linked_fill_events_missing_delta_basis_count": (
+                lineage.source_evidence.linked_fill_events_missing_delta_basis
+            ),
+            "linked_fill_events_missing_delta_count": (
+                lineage.source_evidence.linked_fill_events_missing_delta
+            ),
             "positive_fill_delta_event_count": lineage.fill_deltas.positive_fill_delta_event_count,
             "positive_fill_delta_unlinked_count": (
                 lineage.fill_deltas.positive_fill_delta_unlinked_count
@@ -637,6 +694,12 @@ def project_order_feed_coverage(
         ),
         linked_fill_events_missing_trade_decision=(
             lineage.source_evidence.linked_fill_events_missing_trade_decision
+        ),
+        linked_fill_events_missing_delta_basis=(
+            lineage.source_evidence.linked_fill_events_missing_delta_basis
+        ),
+        linked_fill_events_missing_delta=(
+            lineage.source_evidence.linked_fill_events_missing_delta
         ),
     )
     counts = _ProjectionCounts(

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -13,13 +13,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Any
 
 from sqlalchemy import create_engine, exists, func, or_, select
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql.base import Executable
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.sql.functions import count as sql_count
 
 from app.models import Execution, ExecutionOrderEvent
 
@@ -35,6 +38,66 @@ BLOCKER_UNLINKED_FILL_EVENTS = "unlinked_fill_events_present"
 BLOCKER_FILL_EVENT_SOURCE_WINDOW = "fill_events_missing_source_window"
 BLOCKER_FILL_EVENT_SOURCE_OFFSET = "fill_events_missing_source_offset"
 BLOCKER_FILL_EVENT_ORDER_IDENTITY = "fill_events_missing_order_identity"
+
+
+@dataclass(frozen=True)
+class _CoveragePredicates:
+    execution_scope: tuple[ColumnElement[bool], ...]
+    event_scope: tuple[ColumnElement[bool], ...]
+    fill_event_scope: tuple[ColumnElement[bool], ...]
+    filled_execution_predicate: ColumnElement[bool]
+    linked_any_event: ColumnElement[bool]
+    linked_fill_event: ColumnElement[bool]
+
+
+@dataclass(frozen=True)
+class _PopulationCounts:
+    execution_count: int
+    filled_execution_count: int
+    execution_with_any_event_count: int
+    execution_with_fill_event_count: int
+    filled_executions_missing_fill_event: int
+
+
+@dataclass(frozen=True)
+class _FillEventCounts:
+    fill_event_count: int
+    linked_fill_event_count: int
+    unlinked_fill_event_count: int
+
+
+@dataclass(frozen=True)
+class _SourceEvidenceCounts:
+    linked_fill_events_missing_source_window: int
+    linked_fill_events_missing_source_offset: int
+    fill_events_missing_order_identity: int
+
+
+@dataclass(frozen=True)
+class _FillDeltaCounts:
+    positive_fill_delta_event_count: int
+    positive_fill_delta_unlinked_count: int
+
+
+@dataclass(frozen=True)
+class _LineageCounts:
+    fill_events: _FillEventCounts
+    source_evidence: _SourceEvidenceCounts
+    fill_deltas: _FillDeltaCounts
+
+
+@dataclass(frozen=True)
+class _CoverageSamples:
+    missing_executions: list[dict[str, object]]
+    unlinked_fill_events: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class _ProjectionCounts:
+    population: _PopulationCounts
+    lineage: _LineageCounts
+    samples: _CoverageSamples
+    blockers: list[str]
 
 
 def _sqlalchemy_dsn(dsn: str) -> str:
@@ -125,6 +188,10 @@ def _filled_execution_predicate() -> ColumnElement[bool]:
 def _count(session: Session, statement: Executable) -> int:
     value = session.scalar(statement)
     return int(value or 0)
+
+
+def _count_expression(column: object) -> Any:
+    return sql_count(column)
 
 
 def _ratio(numerator: int, denominator: int) -> str | None:
@@ -227,6 +294,286 @@ def _blockers(
     return blockers
 
 
+def _coverage_predicates(
+    *,
+    account_label: str | None,
+    window_start: datetime | None,
+    window_end: datetime | None,
+) -> _CoveragePredicates:
+    execution_scope = tuple(
+        _scope_predicates(
+            Execution.alpaca_account_label,
+            account_label=account_label,
+            window_start=window_start,
+            window_end=window_end,
+            time_expression=_execution_time_expression(),
+        )
+    )
+    event_scope = tuple(
+        _scope_predicates(
+            ExecutionOrderEvent.alpaca_account_label,
+            account_label=account_label,
+            window_start=window_start,
+            window_end=window_end,
+            time_expression=_event_time_expression(),
+        )
+    )
+    fill_event_predicate = _fill_event_predicate()
+    filled_execution_predicate = _filled_execution_predicate()
+    linked_any_event = exists(
+        select(1).where(
+            ExecutionOrderEvent.execution_id == Execution.id,
+            *event_scope,
+        )
+    )
+    linked_fill_event = exists(
+        select(1).where(
+            ExecutionOrderEvent.execution_id == Execution.id,
+            fill_event_predicate,
+            *event_scope,
+        )
+    )
+    return _CoveragePredicates(
+        execution_scope=execution_scope,
+        event_scope=event_scope,
+        fill_event_scope=(*event_scope, fill_event_predicate),
+        filled_execution_predicate=filled_execution_predicate,
+        linked_any_event=linked_any_event,
+        linked_fill_event=linked_fill_event,
+    )
+
+
+def _population_counts(
+    session: Session,
+    predicates: _CoveragePredicates,
+) -> _PopulationCounts:
+    execution_scope = predicates.execution_scope
+    filled_execution_predicate = predicates.filled_execution_predicate
+    linked_any_event = predicates.linked_any_event
+    linked_fill_event = predicates.linked_fill_event
+    return _PopulationCounts(
+        execution_count=_count(
+            session,
+            select(_count_expression(Execution.id)).where(*execution_scope),
+        ),
+        filled_execution_count=_count(
+            session,
+            select(_count_expression(Execution.id)).where(
+                *execution_scope,
+                filled_execution_predicate,
+            ),
+        ),
+        execution_with_any_event_count=_count(
+            session,
+            select(_count_expression(Execution.id)).where(
+                *execution_scope,
+                linked_any_event,
+            ),
+        ),
+        execution_with_fill_event_count=_count(
+            session,
+            select(_count_expression(Execution.id)).where(
+                *execution_scope,
+                linked_fill_event,
+            ),
+        ),
+        filled_executions_missing_fill_event=_count(
+            session,
+            select(_count_expression(Execution.id)).where(
+                *execution_scope,
+                filled_execution_predicate,
+                ~linked_fill_event,
+            ),
+        ),
+    )
+
+
+def _lineage_counts(
+    session: Session,
+    predicates: _CoveragePredicates,
+) -> _LineageCounts:
+    fill_event_scope = predicates.fill_event_scope
+    event_scope = predicates.event_scope
+    fill_events = _FillEventCounts(
+        fill_event_count=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(*fill_event_scope),
+        ),
+        linked_fill_event_count=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                ExecutionOrderEvent.execution_id.is_not(None),
+            ),
+        ),
+        unlinked_fill_event_count=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                ExecutionOrderEvent.execution_id.is_(None),
+            ),
+        ),
+    )
+    source_evidence = _SourceEvidenceCounts(
+        linked_fill_events_missing_source_window=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                ExecutionOrderEvent.execution_id.is_not(None),
+                ExecutionOrderEvent.source_window_id.is_(None),
+            ),
+        ),
+        linked_fill_events_missing_source_offset=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                ExecutionOrderEvent.execution_id.is_not(None),
+                or_(
+                    ExecutionOrderEvent.source_partition.is_(None),
+                    ExecutionOrderEvent.source_offset.is_(None),
+                ),
+            ),
+        ),
+        fill_events_missing_order_identity=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *fill_event_scope,
+                ExecutionOrderEvent.alpaca_order_id.is_(None),
+                ExecutionOrderEvent.client_order_id.is_(None),
+            ),
+        ),
+    )
+    fill_deltas = _FillDeltaCounts(
+        positive_fill_delta_event_count=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *event_scope,
+                ExecutionOrderEvent.filled_qty_delta > 0,
+            ),
+        ),
+        positive_fill_delta_unlinked_count=_count(
+            session,
+            select(_count_expression(ExecutionOrderEvent.id)).where(
+                *event_scope,
+                ExecutionOrderEvent.filled_qty_delta > 0,
+                ExecutionOrderEvent.execution_id.is_(None),
+            ),
+        ),
+    )
+    return _LineageCounts(
+        fill_events=fill_events,
+        source_evidence=source_evidence,
+        fill_deltas=fill_deltas,
+    )
+
+
+def _coverage_samples(
+    session: Session,
+    predicates: _CoveragePredicates,
+    *,
+    sample_limit: int,
+) -> _CoverageSamples:
+    missing_executions = _sample_rows(
+        session,
+        select(Execution)
+        .where(
+            *predicates.execution_scope,
+            predicates.filled_execution_predicate,
+            ~predicates.linked_fill_event,
+        )
+        .order_by(_execution_time_expression().asc().nullslast(), Execution.id.asc()),
+        sample_limit=sample_limit,
+    )
+    unlinked_fill_events = _sample_events(
+        session,
+        select(ExecutionOrderEvent)
+        .where(
+            *predicates.fill_event_scope,
+            ExecutionOrderEvent.execution_id.is_(None),
+        )
+        .order_by(
+            _event_time_expression().asc().nullslast(), ExecutionOrderEvent.id.asc()
+        ),
+        sample_limit=sample_limit,
+    )
+    return _CoverageSamples(
+        missing_executions=missing_executions,
+        unlinked_fill_events=unlinked_fill_events,
+    )
+
+
+def _projection_payload(
+    *,
+    account_label: str | None,
+    window_start: datetime | None,
+    window_end: datetime | None,
+    counts: _ProjectionCounts,
+    sample_limit: int,
+) -> dict[str, object]:
+    population = counts.population
+    lineage = counts.lineage
+    samples = counts.samples
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "read_only": True,
+        "writes_performed": False,
+        "mutates_database": False,
+        "submits_orders": False,
+        "profitability_claimed": False,
+        "promotion_authority_eligible": False,
+        "authority_reason": "coverage_projection_is_diagnostic_only",
+        "account_label": account_label,
+        "window": {
+            "start": _iso(window_start),
+            "end": _iso(window_end),
+        },
+        "population": {
+            "execution_count": population.execution_count,
+            "filled_execution_count": population.filled_execution_count,
+            "execution_with_any_event_count": population.execution_with_any_event_count,
+            "execution_with_fill_event_count": population.execution_with_fill_event_count,
+            "filled_executions_missing_fill_event_count": (
+                population.filled_executions_missing_fill_event
+            ),
+        },
+        "event_lineage": {
+            "fill_event_count": lineage.fill_events.fill_event_count,
+            "linked_fill_event_count": lineage.fill_events.linked_fill_event_count,
+            "unlinked_fill_event_count": lineage.fill_events.unlinked_fill_event_count,
+            "linked_fill_events_missing_source_window_count": (
+                lineage.source_evidence.linked_fill_events_missing_source_window
+            ),
+            "linked_fill_events_missing_source_offset_count": (
+                lineage.source_evidence.linked_fill_events_missing_source_offset
+            ),
+            "fill_events_missing_order_identity_count": (
+                lineage.source_evidence.fill_events_missing_order_identity
+            ),
+            "positive_fill_delta_event_count": lineage.fill_deltas.positive_fill_delta_event_count,
+            "positive_fill_delta_unlinked_count": (
+                lineage.fill_deltas.positive_fill_delta_unlinked_count
+            ),
+        },
+        "coverage": {
+            "filled_execution_to_fill_event_ratio": _ratio(
+                population.execution_with_fill_event_count,
+                population.filled_execution_count,
+            ),
+            "fill_event_to_execution_ratio": _ratio(
+                lineage.fill_events.linked_fill_event_count,
+                lineage.fill_events.fill_event_count,
+            ),
+        },
+        "blockers": counts.blockers,
+        "samples": {
+            "filled_executions_missing_fill_event": samples.missing_executions,
+            "unlinked_fill_events": samples.unlinked_fill_events,
+        },
+        "sample_limit": sample_limit,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
 def project_order_feed_coverage(
     session: Session,
     *,
@@ -244,198 +591,44 @@ def project_order_feed_coverage(
     ):
         raise ValueError("window_end_must_be_after_window_start")
     bounded_sample_limit = _bounded_limit(sample_limit, default=25)
-    execution_scope = _scope_predicates(
-        Execution.alpaca_account_label,
+    predicates = _coverage_predicates(
         account_label=account_label,
         window_start=window_start,
         window_end=window_end,
-        time_expression=_execution_time_expression(),
     )
-    event_scope = _scope_predicates(
-        ExecutionOrderEvent.alpaca_account_label,
-        account_label=account_label,
-        window_start=window_start,
-        window_end=window_end,
-        time_expression=_event_time_expression(),
-    )
-    fill_predicate = _fill_event_predicate()
-    filled_execution_predicate = _filled_execution_predicate()
-    linked_any_event = exists(
-        select(1).where(
-            ExecutionOrderEvent.execution_id == Execution.id,
-            *event_scope,
-        )
-    )
-    linked_fill_event = exists(
-        select(1).where(
-            ExecutionOrderEvent.execution_id == Execution.id,
-            fill_predicate,
-            *event_scope,
-        )
-    )
-
-    execution_count = _count(
+    population = _population_counts(session, predicates)
+    lineage = _lineage_counts(session, predicates)
+    samples = _coverage_samples(
         session,
-        select(func.count(Execution.id)).where(*execution_scope),
-    )
-    filled_execution_count = _count(
-        session,
-        select(func.count(Execution.id)).where(
-            *execution_scope,
-            filled_execution_predicate,
-        ),
-    )
-    execution_with_any_event_count = _count(
-        session,
-        select(func.count(Execution.id)).where(*execution_scope, linked_any_event),
-    )
-    execution_with_fill_event_count = _count(
-        session,
-        select(func.count(Execution.id)).where(*execution_scope, linked_fill_event),
-    )
-    filled_executions_missing_fill_event = _count(
-        session,
-        select(func.count(Execution.id)).where(
-            *execution_scope,
-            filled_execution_predicate,
-            ~linked_fill_event,
-        ),
-    )
-    fill_event_scope = [*event_scope, fill_predicate]
-    fill_event_count = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(*fill_event_scope),
-    )
-    linked_fill_event_count = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(
-            *fill_event_scope,
-            ExecutionOrderEvent.execution_id.is_not(None),
-        ),
-    )
-    unlinked_fill_event_count = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(
-            *fill_event_scope,
-            ExecutionOrderEvent.execution_id.is_(None),
-        ),
-    )
-    linked_fill_events_missing_source_window = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(
-            *fill_event_scope,
-            ExecutionOrderEvent.execution_id.is_not(None),
-            ExecutionOrderEvent.source_window_id.is_(None),
-        ),
-    )
-    linked_fill_events_missing_source_offset = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(
-            *fill_event_scope,
-            ExecutionOrderEvent.execution_id.is_not(None),
-            or_(
-                ExecutionOrderEvent.source_partition.is_(None),
-                ExecutionOrderEvent.source_offset.is_(None),
-            ),
-        ),
-    )
-    fill_events_missing_order_identity = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(
-            *fill_event_scope,
-            ExecutionOrderEvent.alpaca_order_id.is_(None),
-            ExecutionOrderEvent.client_order_id.is_(None),
-        ),
-    )
-    positive_fill_delta_event_count = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(
-            *event_scope,
-            ExecutionOrderEvent.filled_qty_delta > 0,
-        ),
-    )
-    positive_fill_delta_unlinked_count = _count(
-        session,
-        select(func.count(ExecutionOrderEvent.id)).where(
-            *event_scope,
-            ExecutionOrderEvent.filled_qty_delta > 0,
-            ExecutionOrderEvent.execution_id.is_(None),
-        ),
-    )
-
-    missing_execution_sample = _sample_rows(
-        session,
-        select(Execution)
-        .where(*execution_scope, filled_execution_predicate, ~linked_fill_event)
-        .order_by(_execution_time_expression().asc().nullslast(), Execution.id.asc()),
+        predicates,
         sample_limit=bounded_sample_limit,
     )
-    unlinked_fill_event_sample = _sample_events(
-        session,
-        select(ExecutionOrderEvent)
-        .where(*fill_event_scope, ExecutionOrderEvent.execution_id.is_(None))
-        .order_by(
-            _event_time_expression().asc().nullslast(), ExecutionOrderEvent.id.asc()
-        ),
-        sample_limit=bounded_sample_limit,
-    )
-
     blockers = _blockers(
-        filled_executions_missing_fill_event=filled_executions_missing_fill_event,
-        unlinked_fill_events=unlinked_fill_event_count,
-        linked_fill_events_missing_source_window=linked_fill_events_missing_source_window,
-        linked_fill_events_missing_source_offset=linked_fill_events_missing_source_offset,
-        fill_events_missing_order_identity=fill_events_missing_order_identity,
+        filled_executions_missing_fill_event=population.filled_executions_missing_fill_event,
+        unlinked_fill_events=lineage.fill_events.unlinked_fill_event_count,
+        linked_fill_events_missing_source_window=(
+            lineage.source_evidence.linked_fill_events_missing_source_window
+        ),
+        linked_fill_events_missing_source_offset=(
+            lineage.source_evidence.linked_fill_events_missing_source_offset
+        ),
+        fill_events_missing_order_identity=(
+            lineage.source_evidence.fill_events_missing_order_identity
+        ),
     )
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "read_only": True,
-        "writes_performed": False,
-        "mutates_database": False,
-        "submits_orders": False,
-        "profitability_claimed": False,
-        "promotion_authority_eligible": False,
-        "authority_reason": "coverage_projection_is_diagnostic_only",
-        "account_label": account_label,
-        "window": {
-            "start": _iso(window_start),
-            "end": _iso(window_end),
-        },
-        "population": {
-            "execution_count": execution_count,
-            "filled_execution_count": filled_execution_count,
-            "execution_with_any_event_count": execution_with_any_event_count,
-            "execution_with_fill_event_count": execution_with_fill_event_count,
-            "filled_executions_missing_fill_event_count": filled_executions_missing_fill_event,
-        },
-        "event_lineage": {
-            "fill_event_count": fill_event_count,
-            "linked_fill_event_count": linked_fill_event_count,
-            "unlinked_fill_event_count": unlinked_fill_event_count,
-            "linked_fill_events_missing_source_window_count": linked_fill_events_missing_source_window,
-            "linked_fill_events_missing_source_offset_count": linked_fill_events_missing_source_offset,
-            "fill_events_missing_order_identity_count": fill_events_missing_order_identity,
-            "positive_fill_delta_event_count": positive_fill_delta_event_count,
-            "positive_fill_delta_unlinked_count": positive_fill_delta_unlinked_count,
-        },
-        "coverage": {
-            "filled_execution_to_fill_event_ratio": _ratio(
-                execution_with_fill_event_count,
-                filled_execution_count,
-            ),
-            "fill_event_to_execution_ratio": _ratio(
-                linked_fill_event_count,
-                fill_event_count,
-            ),
-        },
-        "blockers": blockers,
-        "samples": {
-            "filled_executions_missing_fill_event": missing_execution_sample,
-            "unlinked_fill_events": unlinked_fill_event_sample,
-        },
-        "sample_limit": bounded_sample_limit,
-        "completed_at": datetime.now(timezone.utc).isoformat(),
-    }
+    counts = _ProjectionCounts(
+        population=population,
+        lineage=lineage,
+        samples=samples,
+        blockers=blockers,
+    )
+    return _projection_payload(
+        account_label=account_label,
+        window_start=window_start,
+        window_end=window_end,
+        counts=counts,
+        sample_limit=bounded_sample_limit,
+    )
 
 
 def _parse_args() -> argparse.Namespace:
@@ -455,6 +648,8 @@ def _parse_args() -> argparse.Namespace:
 
 
 def run_report(args: argparse.Namespace) -> dict[str, object]:
+    """Run the read-only projection using the configured database DSN."""
+
     dsn_env = str(args.dsn_env).strip()
     dsn = os.environ.get(dsn_env)
     if not dsn:
@@ -480,6 +675,8 @@ def run_report(args: argparse.Namespace) -> dict[str, object]:
 
 
 def main() -> int:
+    """Print the projection and optionally fail when blockers are present."""
+
     args = _parse_args()
     report = run_report(args)
     print(

--- a/services/torghut/scripts/reconcile_order_feed_coverage.py
+++ b/services/torghut/scripts/reconcile_order_feed_coverage.py
@@ -483,6 +483,7 @@ def _lineage_counts(
         FILL_DELTA_PROVENANCE_ALIASES
     )
     linked_fill_event_predicate = predicates.event_has_unique_execution
+    event_decision_ref_present = ExecutionOrderEvent.trade_decision_id.is_not(None)
     linked_execution_has_trade_decision = exists(
         select(1).where(
             _event_execution_identity_match(
@@ -494,6 +495,30 @@ def _lineage_counts(
             Execution.trade_decision_id.is_not(None),
         )
     )
+    linked_execution_decision_ref_present = and_(
+        predicates.event_has_unique_execution,
+        linked_execution_has_trade_decision,
+    )
+    event_decision_account_match = exists(
+        select(1).where(
+            TradeDecision.id == ExecutionOrderEvent.trade_decision_id,
+            TradeDecision.alpaca_account_label
+            == ExecutionOrderEvent.alpaca_account_label,
+        )
+    )
+    linked_execution_decision_account_match = exists(
+        select(1).where(
+            _event_execution_identity_match(
+                execution_id=Execution.id,
+                account_label=Execution.alpaca_account_label,
+                alpaca_order_id=Execution.alpaca_order_id,
+                client_order_id=Execution.client_order_id,
+            ),
+            Execution.trade_decision_id == TradeDecision.id,
+            TradeDecision.alpaca_account_label
+            == ExecutionOrderEvent.alpaca_account_label,
+        )
+    )
     client_order_decision_match = exists(
         select(1).where(
             TradeDecision.alpaca_account_label
@@ -503,9 +528,17 @@ def _lineage_counts(
         )
     )
     resolved_trade_decision = or_(
-        ExecutionOrderEvent.trade_decision_id.is_not(None),
-        linked_execution_has_trade_decision,
-        client_order_decision_match,
+        and_(event_decision_ref_present, event_decision_account_match),
+        and_(
+            ~event_decision_ref_present,
+            linked_execution_decision_ref_present,
+            linked_execution_decision_account_match,
+        ),
+        and_(
+            ~event_decision_ref_present,
+            ~linked_execution_decision_ref_present,
+            client_order_decision_match,
+        ),
     )
     # Keep this SQL-only projection conservative: runtime can derive a delta
     # from a well-formed raw broker payload, but this diagnostic deliberately

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import io
+import json
+import os
+import sys
+from argparse import ArgumentTypeError, Namespace
 from datetime import datetime, timezone
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from app.models import Base, Execution, ExecutionOrderEvent
+from scripts import reconcile_order_feed_coverage as coverage_script
 from scripts.reconcile_order_feed_coverage import project_order_feed_coverage
 
 
@@ -54,7 +61,7 @@ def _event(
     execution_id: object = None,
     event_type: str | None = "fill",
     status: str | None = "filled",
-    filled_qty: str = "1",
+    filled_qty: str | None = "1",
     filled_qty_delta: str | None = "1",
     source_window_id: object = None,
     source_partition: int | None = 0,
@@ -74,7 +81,7 @@ def _event(
         client_order_id=client_order_id,
         event_type=event_type,
         status=status,
-        filled_qty=Decimal(filled_qty),
+        filled_qty=(Decimal(filled_qty) if filled_qty is not None else None),
         filled_qty_delta=(
             Decimal(filled_qty_delta) if filled_qty_delta is not None else None
         ),
@@ -263,3 +270,183 @@ class TestOrderFeedCoverageProjection(TestCase):
                     window_start=datetime(2026, 7, 11, tzinfo=UTC),
                     window_end=datetime(2026, 7, 10, tzinfo=UTC),
                 )
+
+    def test_helper_parsers_and_bounds_fail_closed(self) -> None:
+        self.assertEqual(
+            coverage_script._sqlalchemy_dsn("postgres://user:pass@db/torghut"),
+            "postgresql+psycopg://user:pass@db/torghut",
+        )
+        self.assertEqual(
+            coverage_script._sqlalchemy_dsn("postgresql://user:pass@db/torghut"),
+            "postgresql+psycopg://user:pass@db/torghut",
+        )
+        self.assertEqual(
+            coverage_script._sqlalchemy_dsn("postgresql+psycopg://db/torghut"),
+            "postgresql+psycopg://db/torghut",
+        )
+        self.assertEqual(
+            coverage_script._sqlalchemy_dsn("sqlite+pysqlite:///:memory:"),
+            "sqlite+pysqlite:///:memory:",
+        )
+        self.assertEqual(
+            coverage_script._parse_datetime("2026-07-10T14:30:00Z").isoformat(),
+            "2026-07-10T14:30:00+00:00",
+        )
+        self.assertEqual(
+            coverage_script._parse_datetime("2026-07-10T14:30:00").isoformat(),
+            "2026-07-10T14:30:00+00:00",
+        )
+        with self.assertRaisesRegex(ArgumentTypeError, "datetime cannot be empty"):
+            coverage_script._parse_datetime(" ")
+        with self.assertRaisesRegex(ArgumentTypeError, "invalid datetime"):
+            coverage_script._parse_datetime("not-a-date")
+        with self.assertRaisesRegex(ValueError, "limit must be an integer"):
+            coverage_script._bounded_limit("not-an-int")
+        self.assertEqual(coverage_script._bounded_limit(0, default=25), 25)
+        self.assertEqual(coverage_script._bounded_limit(6000), 5000)
+        self.assertEqual(coverage_script._bounded_limit(-1), 1)
+        self.assertIsNone(coverage_script._ratio(0, 0))
+        self.assertIsNone(coverage_script._iso(None))
+        self.assertIsNone(coverage_script._decimal_text(None))
+
+    def test_projection_serializes_null_event_fields_and_empty_coverage(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            session.add(
+                _event(
+                    fingerprint="null-unlinked-fill",
+                    event_type="fill",
+                    status="filled",
+                    filled_qty=None,
+                    filled_qty_delta=None,
+                    source_window_id=None,
+                    source_partition=None,
+                    source_offset=None,
+                    alpaca_order_id=None,
+                    client_order_id=None,
+                )
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session, sample_limit=-1)
+            sample = report["samples"]["unlinked_fill_events"][0]
+
+            self.assertEqual(report["population"]["execution_count"], 0)
+            self.assertEqual(report["event_lineage"]["fill_event_count"], 1)
+            self.assertIsNone(
+                report["coverage"]["filled_execution_to_fill_event_ratio"]
+            )
+            self.assertEqual(report["sample_limit"], 1)
+            self.assertIsNone(sample["filled_qty"])
+            self.assertIsNone(sample["filled_qty_delta"])
+            self.assertIsNone(sample["execution_id"])
+            self.assertIsNone(sample["source_window_id"])
+
+    def test_parse_args_covers_read_only_cli_flags(self) -> None:
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "reconcile_order_feed_coverage.py",
+                "--dsn-env",
+                "TEST_DSN",
+                "--account-label",
+                "PA3SX7FYNUTF",
+                "--window-start",
+                "2026-07-10T14:00:00Z",
+                "--window-end",
+                "2026-07-10T15:00:00Z",
+                "--sample-limit",
+                "7",
+                "--fail-on-blockers",
+                "--json",
+            ],
+        ):
+            args = coverage_script._parse_args()
+
+        self.assertEqual(args.dsn_env, "TEST_DSN")
+        self.assertEqual(args.account_label, "PA3SX7FYNUTF")
+        self.assertEqual(args.sample_limit, 7)
+        self.assertTrue(args.fail_on_blockers)
+        self.assertTrue(args.json)
+        self.assertEqual(args.window_start.isoformat(), "2026-07-10T14:00:00+00:00")
+        self.assertEqual(args.window_end.isoformat(), "2026-07-10T15:00:00+00:00")
+
+    def test_run_report_reads_dsn_rolls_back_and_rejects_missing_dsn(self) -> None:
+        fake_session = MagicMock()
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = None
+        fake_factory = MagicMock(return_value=fake_session)
+        args = Namespace(
+            dsn_env="TEST_DSN",
+            account_label="PA3SX7FYNUTF",
+            window_start=None,
+            window_end=None,
+            sample_limit=5,
+        )
+        expected = {"blockers": [], "read_only": True}
+        with (
+            patch.dict(os.environ, {"TEST_DSN": "postgresql://example/torghut"}),
+            patch.object(
+                coverage_script, "create_engine", return_value=object()
+            ) as create_engine,
+            patch.object(coverage_script, "sessionmaker", return_value=fake_factory),
+            patch.object(
+                coverage_script,
+                "project_order_feed_coverage",
+                return_value=expected,
+            ) as project,
+        ):
+            self.assertEqual(coverage_script.run_report(args), expected)
+
+        create_engine.assert_called_once_with(
+            "postgresql+psycopg://example/torghut",
+            pool_pre_ping=True,
+            future=True,
+        )
+        project.assert_called_once_with(
+            fake_session,
+            account_label="PA3SX7FYNUTF",
+            window_start=None,
+            window_end=None,
+            sample_limit=5,
+        )
+        fake_session.rollback.assert_called_once_with()
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            self.assertRaisesRegex(SystemExit, "missing DSN env var: MISSING_DSN"),
+        ):
+            coverage_script.run_report(
+                Namespace(
+                    dsn_env="MISSING_DSN",
+                    account_label=None,
+                    window_start=None,
+                    window_end=None,
+                    sample_limit=25,
+                )
+            )
+
+    def test_main_emits_compact_and_pretty_json_and_fail_code(self) -> None:
+        compact_args = Namespace(json=True, fail_on_blockers=False)
+        compact_report = {"blockers": [], "read_only": True}
+        compact_stdout = io.StringIO()
+        with (
+            patch.object(coverage_script, "_parse_args", return_value=compact_args),
+            patch.object(coverage_script, "run_report", return_value=compact_report),
+            patch("sys.stdout", compact_stdout),
+        ):
+            self.assertEqual(coverage_script.main(), 0)
+        self.assertEqual(json.loads(compact_stdout.getvalue()), compact_report)
+
+        pretty_args = Namespace(json=False, fail_on_blockers=True)
+        pretty_report = {"blockers": ["unlinked_fill_events_present"]}
+        pretty_stdout = io.StringIO()
+        with (
+            patch.object(coverage_script, "_parse_args", return_value=pretty_args),
+            patch.object(coverage_script, "run_report", return_value=pretty_report),
+            patch("sys.stdout", pretty_stdout),
+        ):
+            self.assertEqual(coverage_script.main(), 1)
+        self.assertIn("\n", pretty_stdout.getvalue())
+        self.assertEqual(json.loads(pretty_stdout.getvalue()), pretty_report)

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -452,6 +452,37 @@ class TestOrderFeedCoverageProjection(TestCase):
             )
             self.assertIn("fill_events_missing_trade_decision", report["blockers"])
 
+    def test_source_offset_without_partition_is_valid_evidence(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            execution = _execution(
+                order_id="offset-without-partition",
+                filled_qty="1",
+                status="filled",
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                _event(
+                    fingerprint="offset-without-partition-fill",
+                    execution_id=execution.id,
+                    source_window_id=execution.id,
+                    source_partition=None,
+                    source_offset=42,
+                )
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session)
+
+            self.assertEqual(
+                report["event_lineage"][
+                    "linked_fill_events_missing_source_offset_count"
+                ],
+                0,
+            )
+            self.assertNotIn("fill_events_missing_source_offset", report["blockers"])
+
     def test_execution_window_uses_updated_at_and_reports_sample_activity(self) -> None:
         engine = _engine()
         with Session(engine) as session:

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import sys
+import uuid
 from argparse import ArgumentTypeError, Namespace
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -19,6 +20,7 @@ from scripts.reconcile_order_feed_coverage import project_order_feed_coverage
 
 
 UTC = timezone.utc
+TRADE_DECISION_ID = uuid.UUID("00000000-0000-0000-0000-000000000777")
 
 
 def _engine() -> object:
@@ -68,6 +70,7 @@ def _event(
     source_offset: int | None = 1,
     alpaca_order_id: str | None = "order-linked",
     client_order_id: str | None = "client-order-linked",
+    trade_decision_id: object = TRADE_DECISION_ID,
 ) -> ExecutionOrderEvent:
     return ExecutionOrderEvent(
         event_fingerprint=fingerprint,
@@ -88,6 +91,7 @@ def _event(
         avg_fill_price=Decimal("100"),
         raw_event={"event": event_type or status or "unknown"},
         execution_id=execution_id,
+        trade_decision_id=trade_decision_id,
         source_window_id=source_window_id,
         created_at=datetime(2026, 7, 10, 14, 31, tzinfo=UTC),
     )
@@ -138,6 +142,13 @@ class TestOrderFeedCoverageProjection(TestCase):
                         client_order_id=None,
                     ),
                     _event(
+                        fingerprint="linked-fill-without-trade-decision",
+                        execution_id=linked_execution.id,
+                        trade_decision_id=None,
+                        source_window_id=linked_execution.id,
+                        source_offset=12,
+                    ),
+                    _event(
                         fingerprint="unlinked-fill",
                         event_type="partial_fill",
                         status="partially_filled",
@@ -166,13 +177,14 @@ class TestOrderFeedCoverageProjection(TestCase):
             self.assertEqual(
                 report["event_lineage"],
                 {
-                    "fill_event_count": 3,
-                    "linked_fill_event_count": 2,
+                    "fill_event_count": 4,
+                    "linked_fill_event_count": 3,
                     "unlinked_fill_event_count": 1,
                     "linked_fill_events_missing_source_window_count": 1,
                     "linked_fill_events_missing_source_offset_count": 1,
                     "fill_events_missing_order_identity_count": 1,
-                    "positive_fill_delta_event_count": 3,
+                    "linked_fill_events_missing_trade_decision_count": 1,
+                    "positive_fill_delta_event_count": 4,
                     "positive_fill_delta_unlinked_count": 1,
                 },
             )
@@ -180,7 +192,7 @@ class TestOrderFeedCoverageProjection(TestCase):
                 report["coverage"],
                 {
                     "filled_execution_to_fill_event_ratio": "0.500000",
-                    "fill_event_to_execution_ratio": "0.666667",
+                    "fill_event_to_execution_ratio": "0.750000",
                 },
             )
             self.assertEqual(
@@ -191,6 +203,7 @@ class TestOrderFeedCoverageProjection(TestCase):
                     "fill_events_missing_source_window",
                     "fill_events_missing_source_offset",
                     "fill_events_missing_order_identity",
+                    "fill_events_missing_trade_decision",
                 ],
             )
             self.assertEqual(
@@ -200,6 +213,56 @@ class TestOrderFeedCoverageProjection(TestCase):
             self.assertEqual(report["read_only"], True)
             self.assertEqual(report["writes_performed"], False)
             self.assertEqual(report["promotion_authority_eligible"], False)
+
+    def test_execution_window_uses_updated_at_and_reports_sample_activity(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            execution = _execution(
+                order_id="updated-at-only",
+                filled_qty="2",
+                status="filled",
+                activity_at=datetime(2026, 7, 9, 15, 0, tzinfo=UTC),
+            )
+            execution.order_feed_last_event_ts = None
+            execution.last_update_at = None
+            execution.updated_at = datetime(2026, 7, 10, 15, 0, tzinfo=UTC)
+            session.add(execution)
+            session.commit()
+
+            report = project_order_feed_coverage(
+                session,
+                window_start=datetime(2026, 7, 10, 14, 0, tzinfo=UTC),
+                window_end=datetime(2026, 7, 10, 16, 0, tzinfo=UTC),
+            )
+
+            self.assertEqual(report["population"]["execution_count"], 1)
+            self.assertEqual(
+                report["samples"]["filled_executions_missing_fill_event"][0][
+                    "activity_at"
+                ],
+                "2026-07-10T15:00:00+00:00",
+            )
+
+    def test_filled_qty_only_event_is_fill_activity(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            session.add(
+                _event(
+                    fingerprint="cumulative-filled-qty",
+                    event_type="status",
+                    status="new",
+                    filled_qty="1",
+                    filled_qty_delta=None,
+                    execution_id=None,
+                )
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session)
+
+            self.assertEqual(report["event_lineage"]["fill_event_count"], 1)
+            self.assertEqual(report["event_lineage"]["unlinked_fill_event_count"], 1)
+            self.assertIn("unlinked_fill_events_present", report["blockers"])
 
     def test_projection_scopes_account_and_window_and_does_not_mutate_rows(
         self,

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from app.models import Base, Execution, ExecutionOrderEvent
+from app.models import Base, Execution, ExecutionOrderEvent, Strategy, TradeDecision
 from scripts import reconcile_order_feed_coverage as coverage_script
 from scripts.reconcile_order_feed_coverage import project_order_feed_coverage
 
@@ -265,6 +265,13 @@ class TestOrderFeedCoverageProjection(TestCase):
                         source_offset=11,
                         filled_qty_delta=None,
                     ),
+                    _event(
+                        fingerprint="accepted-delta-basis-alias",
+                        execution_id=execution.id,
+                        source_window_id=execution.id,
+                        source_offset=12,
+                        fill_quantity_basis="cum_to_delta",
+                    ),
                 ]
             )
             session.commit()
@@ -286,6 +293,67 @@ class TestOrderFeedCoverageProjection(TestCase):
                     "order_feed_fill_delta_missing",
                 ],
             )
+
+    def test_trade_decision_fallbacks_match_runtime_resolution(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            linked_execution = _execution(
+                order_id="decision-fallback-execution",
+                filled_qty="1",
+                status="filled",
+            )
+            linked_execution.trade_decision_id = TRADE_DECISION_ID
+            client_execution = _execution(
+                order_id="decision-client-fallback-execution",
+                filled_qty="1",
+                status="filled",
+            )
+            session.add_all([linked_execution, client_execution])
+            strategy = Strategy(
+                name="coverage-test-strategy",
+                base_timeframe="1Min",
+                universe_type="static",
+            )
+            client_decision = TradeDecision(
+                strategy=strategy,
+                alpaca_account_label="PA3SX7FYNUTF",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"action": "buy"},
+                decision_hash="client-decision-fallback",
+            )
+            session.add(client_decision)
+            session.flush()
+            session.add_all(
+                [
+                    _event(
+                        fingerprint="decision-from-execution",
+                        execution_id=linked_execution.id,
+                        trade_decision_id=None,
+                        source_window_id=linked_execution.id,
+                        source_offset=20,
+                    ),
+                    _event(
+                        fingerprint="decision-from-client-order",
+                        execution_id=client_execution.id,
+                        trade_decision_id=None,
+                        client_order_id="client-decision-fallback",
+                        source_window_id=client_execution.id,
+                        source_offset=21,
+                    ),
+                ]
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session)
+
+            self.assertEqual(
+                report["event_lineage"][
+                    "linked_fill_events_missing_trade_decision_count"
+                ],
+                0,
+            )
+            self.assertNotIn("fill_events_missing_trade_decision", report["blockers"])
 
     def test_execution_window_uses_updated_at_and_reports_sample_activity(self) -> None:
         engine = _engine()

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.models import Base, Execution, ExecutionOrderEvent
+from scripts.reconcile_order_feed_coverage import project_order_feed_coverage
+
+
+UTC = timezone.utc
+
+
+def _engine() -> object:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _execution(
+    *,
+    order_id: str,
+    account_label: str = "PA3SX7FYNUTF",
+    filled_qty: str = "0",
+    status: str = "new",
+    activity_at: datetime = datetime(2026, 7, 10, 14, 30, tzinfo=UTC),
+) -> Execution:
+    return Execution(
+        alpaca_account_label=account_label,
+        alpaca_order_id=order_id,
+        client_order_id=f"client-{order_id}",
+        symbol="AAPL",
+        side="buy",
+        order_type="market",
+        time_in_force="day",
+        submitted_qty=Decimal("2"),
+        filled_qty=Decimal(filled_qty),
+        status=status,
+        raw_order={"id": order_id},
+        created_at=activity_at,
+        updated_at=activity_at,
+        last_update_at=activity_at,
+        order_feed_last_event_ts=activity_at,
+    )
+
+
+def _event(
+    *,
+    fingerprint: str,
+    account_label: str = "PA3SX7FYNUTF",
+    execution_id: object = None,
+    event_type: str | None = "fill",
+    status: str | None = "filled",
+    filled_qty: str = "1",
+    filled_qty_delta: str | None = "1",
+    source_window_id: object = None,
+    source_partition: int | None = 0,
+    source_offset: int | None = 1,
+    alpaca_order_id: str | None = "order-linked",
+    client_order_id: str | None = "client-order-linked",
+) -> ExecutionOrderEvent:
+    return ExecutionOrderEvent(
+        event_fingerprint=fingerprint,
+        source_topic="alpaca.trade_updates",
+        source_partition=source_partition,
+        source_offset=source_offset,
+        alpaca_account_label=account_label,
+        event_ts=datetime(2026, 7, 10, 14, 31, tzinfo=UTC),
+        symbol="AAPL",
+        alpaca_order_id=alpaca_order_id,
+        client_order_id=client_order_id,
+        event_type=event_type,
+        status=status,
+        filled_qty=Decimal(filled_qty),
+        filled_qty_delta=(
+            Decimal(filled_qty_delta) if filled_qty_delta is not None else None
+        ),
+        avg_fill_price=Decimal("100"),
+        raw_event={"event": event_type or status or "unknown"},
+        execution_id=execution_id,
+        source_window_id=source_window_id,
+        created_at=datetime(2026, 7, 10, 14, 31, tzinfo=UTC),
+    )
+
+
+class TestOrderFeedCoverageProjection(TestCase):
+    def test_projection_exposes_missing_execution_fill_event_lineage(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            linked_execution = _execution(
+                order_id="order-linked",
+                filled_qty="1",
+                status="filled",
+            )
+            missing_execution = _execution(
+                order_id="order-missing",
+                filled_qty="2",
+                status="filled",
+            )
+            unfilled_execution = _execution(order_id="order-unfilled")
+            session.add_all([linked_execution, missing_execution, unfilled_execution])
+            session.flush()
+            session.add_all(
+                [
+                    _event(
+                        fingerprint="linked-fill",
+                        execution_id=linked_execution.id,
+                        source_window_id=linked_execution.id,
+                        source_offset=10,
+                    ),
+                    _event(
+                        fingerprint="linked-new",
+                        execution_id=linked_execution.id,
+                        event_type="new",
+                        status="new",
+                        filled_qty="0",
+                        filled_qty_delta=None,
+                        source_window_id=linked_execution.id,
+                        source_offset=11,
+                    ),
+                    _event(
+                        fingerprint="linked-fill-without-source-evidence",
+                        execution_id=linked_execution.id,
+                        source_window_id=None,
+                        source_partition=None,
+                        source_offset=None,
+                        alpaca_order_id=None,
+                        client_order_id=None,
+                    ),
+                    _event(
+                        fingerprint="unlinked-fill",
+                        event_type="partial_fill",
+                        status="partially_filled",
+                        filled_qty="2",
+                        filled_qty_delta="1",
+                        source_window_id=None,
+                        source_partition=None,
+                        source_offset=None,
+                    ),
+                ]
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session, account_label="PA3SX7FYNUTF")
+
+            self.assertEqual(
+                report["population"],
+                {
+                    "execution_count": 3,
+                    "filled_execution_count": 2,
+                    "execution_with_any_event_count": 1,
+                    "execution_with_fill_event_count": 1,
+                    "filled_executions_missing_fill_event_count": 1,
+                },
+            )
+            self.assertEqual(
+                report["event_lineage"],
+                {
+                    "fill_event_count": 3,
+                    "linked_fill_event_count": 2,
+                    "unlinked_fill_event_count": 1,
+                    "linked_fill_events_missing_source_window_count": 1,
+                    "linked_fill_events_missing_source_offset_count": 1,
+                    "fill_events_missing_order_identity_count": 1,
+                    "positive_fill_delta_event_count": 3,
+                    "positive_fill_delta_unlinked_count": 1,
+                },
+            )
+            self.assertEqual(
+                report["coverage"],
+                {
+                    "filled_execution_to_fill_event_ratio": "0.500000",
+                    "fill_event_to_execution_ratio": "0.666667",
+                },
+            )
+            self.assertEqual(
+                report["blockers"],
+                [
+                    "execution_fill_event_lineage_missing",
+                    "unlinked_fill_events_present",
+                    "fill_events_missing_source_window",
+                    "fill_events_missing_source_offset",
+                    "fill_events_missing_order_identity",
+                ],
+            )
+            self.assertEqual(
+                len(report["samples"]["filled_executions_missing_fill_event"]), 1
+            )
+            self.assertEqual(len(report["samples"]["unlinked_fill_events"]), 1)
+            self.assertEqual(report["read_only"], True)
+            self.assertEqual(report["writes_performed"], False)
+            self.assertEqual(report["promotion_authority_eligible"], False)
+
+    def test_projection_scopes_account_and_window_and_does_not_mutate_rows(
+        self,
+    ) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            in_window = _execution(
+                order_id="order-in-window",
+                filled_qty="1",
+                status="filled",
+                activity_at=datetime(2026, 7, 10, 15, 0, tzinfo=UTC),
+            )
+            outside_window = _execution(
+                order_id="order-outside-window",
+                filled_qty="1",
+                status="filled",
+                activity_at=datetime(2026, 7, 11, 15, 0, tzinfo=UTC),
+            )
+            other_account = _execution(
+                order_id="order-other-account",
+                account_label="TORGHUT_SIM",
+                filled_qty="1",
+                status="filled",
+                activity_at=datetime(2026, 7, 10, 15, 0, tzinfo=UTC),
+            )
+            session.add_all([in_window, outside_window, other_account])
+            session.flush()
+            session.add(
+                _event(
+                    fingerprint="in-window-fill",
+                    execution_id=in_window.id,
+                    source_window_id=in_window.id,
+                    source_offset=20,
+                )
+            )
+            session.commit()
+
+            before = (in_window.filled_qty, in_window.status, in_window.raw_order)
+            report = project_order_feed_coverage(
+                session,
+                account_label="PA3SX7FYNUTF",
+                window_start=datetime(2026, 7, 10, 14, 0, tzinfo=UTC),
+                window_end=datetime(2026, 7, 10, 16, 0, tzinfo=UTC),
+                sample_limit=0,
+            )
+
+            self.assertEqual(report["population"]["execution_count"], 1)
+            self.assertEqual(report["population"]["filled_execution_count"], 1)
+            self.assertEqual(
+                report["population"]["filled_executions_missing_fill_event_count"], 0
+            )
+            self.assertEqual(report["event_lineage"]["fill_event_count"], 1)
+            self.assertEqual(report["blockers"], [])
+            self.assertEqual(report["sample_limit"], 25)
+            self.assertEqual(
+                (in_window.filled_qty, in_window.status, in_window.raw_order),
+                before,
+            )
+
+    def test_projection_rejects_reversed_window(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            with self.assertRaisesRegex(
+                ValueError, "window_end_must_be_after_window_start"
+            ):
+                project_order_feed_coverage(
+                    session,
+                    window_start=datetime(2026, 7, 11, tzinfo=UTC),
+                    window_end=datetime(2026, 7, 10, tzinfo=UTC),
+                )

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -156,6 +156,8 @@ class TestOrderFeedCoverageProjection(TestCase):
                         status="partially_filled",
                         filled_qty="2",
                         filled_qty_delta="1",
+                        alpaca_order_id="unlinked-order",
+                        client_order_id="unlinked-client",
                         source_window_id=None,
                         source_partition=None,
                         source_offset=None,
@@ -354,6 +356,39 @@ class TestOrderFeedCoverageProjection(TestCase):
                 0,
             )
             self.assertNotIn("fill_events_missing_trade_decision", report["blockers"])
+
+    def test_order_identity_fallback_links_unique_execution(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            execution = _execution(
+                order_id="order-id-fallback",
+                filled_qty="1",
+                status="filled",
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                _event(
+                    fingerprint="order-id-fallback-fill",
+                    execution_id=None,
+                    alpaca_order_id=execution.alpaca_order_id,
+                    client_order_id=None,
+                    source_window_id=execution.id,
+                    source_offset=30,
+                )
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session)
+
+            self.assertEqual(report["population"]["execution_with_fill_event_count"], 1)
+            self.assertEqual(
+                report["population"]["filled_executions_missing_fill_event_count"],
+                0,
+            )
+            self.assertEqual(report["event_lineage"]["linked_fill_event_count"], 1)
+            self.assertEqual(report["event_lineage"]["unlinked_fill_event_count"], 0)
+            self.assertNotIn("unlinked_fill_events_present", report["blockers"])
 
     def test_execution_window_uses_updated_at_and_reports_sample_activity(self) -> None:
         engine = _engine()

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -26,6 +26,24 @@ TRADE_DECISION_ID = uuid.UUID("00000000-0000-0000-0000-000000000777")
 def _engine() -> object:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        strategy = Strategy(
+            name="coverage-default-strategy",
+            base_timeframe="1Min",
+            universe_type="static",
+        )
+        session.add(
+            TradeDecision(
+                id=TRADE_DECISION_ID,
+                strategy=strategy,
+                alpaca_account_label="PA3SX7FYNUTF",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"action": "buy"},
+                decision_hash="coverage-default-decision",
+            )
+        )
+        session.commit()
     return engine
 
 
@@ -389,6 +407,50 @@ class TestOrderFeedCoverageProjection(TestCase):
             self.assertEqual(report["event_lineage"]["linked_fill_event_count"], 1)
             self.assertEqual(report["event_lineage"]["unlinked_fill_event_count"], 0)
             self.assertNotIn("unlinked_fill_events_present", report["blockers"])
+
+    def test_trade_decision_account_scope_is_enforced(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            execution = _execution(
+                order_id="wrong-account-decision-execution",
+                filled_qty="1",
+                status="filled",
+            )
+            wrong_account_strategy = Strategy(
+                name="wrong-account-strategy",
+                base_timeframe="1Min",
+                universe_type="static",
+            )
+            wrong_account_decision = TradeDecision(
+                id=uuid.uuid4(),
+                strategy=wrong_account_strategy,
+                alpaca_account_label="OTHER_ACCOUNT",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"action": "buy"},
+                decision_hash="wrong-account-decision",
+            )
+            session.add_all([execution, wrong_account_decision])
+            session.flush()
+            session.add(
+                _event(
+                    fingerprint="wrong-account-decision-fill",
+                    execution_id=execution.id,
+                    trade_decision_id=wrong_account_decision.id,
+                    client_order_id=None,
+                )
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session)
+
+            self.assertEqual(
+                report["event_lineage"][
+                    "linked_fill_events_missing_trade_decision_count"
+                ],
+                1,
+            )
+            self.assertIn("fill_events_missing_trade_decision", report["blockers"])
 
     def test_execution_window_uses_updated_at_and_reports_sample_activity(self) -> None:
         engine = _engine()

--- a/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
+++ b/services/torghut/tests/reconcile_order_feed_coverage/test_projection.py
@@ -71,6 +71,7 @@ def _event(
     alpaca_order_id: str | None = "order-linked",
     client_order_id: str | None = "client-order-linked",
     trade_decision_id: object = TRADE_DECISION_ID,
+    fill_quantity_basis: str | None = "delta",
 ) -> ExecutionOrderEvent:
     return ExecutionOrderEvent(
         event_fingerprint=fingerprint,
@@ -88,6 +89,7 @@ def _event(
         filled_qty_delta=(
             Decimal(filled_qty_delta) if filled_qty_delta is not None else None
         ),
+        fill_quantity_basis=fill_quantity_basis,
         avg_fill_price=Decimal("100"),
         raw_event={"event": event_type or status or "unknown"},
         execution_id=execution_id,
@@ -184,6 +186,8 @@ class TestOrderFeedCoverageProjection(TestCase):
                     "linked_fill_events_missing_source_offset_count": 1,
                     "fill_events_missing_order_identity_count": 1,
                     "linked_fill_events_missing_trade_decision_count": 1,
+                    "linked_fill_events_missing_delta_basis_count": 0,
+                    "linked_fill_events_missing_delta_count": 0,
                     "positive_fill_delta_event_count": 4,
                     "positive_fill_delta_unlinked_count": 1,
                 },
@@ -213,6 +217,75 @@ class TestOrderFeedCoverageProjection(TestCase):
             self.assertEqual(report["read_only"], True)
             self.assertEqual(report["writes_performed"], False)
             self.assertEqual(report["promotion_authority_eligible"], False)
+
+    def test_blank_order_identity_is_blocked(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            session.add(
+                _event(
+                    fingerprint="blank-order-identity",
+                    alpaca_order_id="",
+                    client_order_id="   ",
+                    execution_id=None,
+                )
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session)
+
+            self.assertEqual(
+                report["event_lineage"]["fill_events_missing_order_identity_count"],
+                1,
+            )
+            self.assertIn("fill_events_missing_order_identity", report["blockers"])
+
+    def test_linked_fill_events_missing_delta_proof_are_blocked(self) -> None:
+        engine = _engine()
+        with Session(engine) as session:
+            execution = _execution(
+                order_id="delta-proof-execution",
+                filled_qty="2",
+                status="filled",
+            )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    _event(
+                        fingerprint="missing-delta-basis",
+                        execution_id=execution.id,
+                        source_window_id=execution.id,
+                        source_offset=10,
+                        fill_quantity_basis=None,
+                    ),
+                    _event(
+                        fingerprint="missing-delta",
+                        execution_id=execution.id,
+                        source_window_id=execution.id,
+                        source_offset=11,
+                        filled_qty_delta=None,
+                    ),
+                ]
+            )
+            session.commit()
+
+            report = project_order_feed_coverage(session)
+
+            self.assertEqual(
+                report["event_lineage"]["linked_fill_events_missing_delta_basis_count"],
+                1,
+            )
+            self.assertEqual(
+                report["event_lineage"]["linked_fill_events_missing_delta_count"],
+                1,
+            )
+            self.assertEqual(
+                report["blockers"][-2:],
+                [
+                    "order_feed_fill_delta_basis_missing",
+                    "order_feed_fill_delta_missing",
+                ],
+            )
 
     def test_execution_window_uses_updated_at_and_reports_sample_activity(self) -> None:
         engine = _engine()


### PR DESCRIPTION
## Summary

- Adds a SELECT-only execution-to-fill-event lineage coverage projection for one account and optional time window.
- Reports missing execution links, unlinked fill events, source-window/offset gaps, identity gaps, bounded samples, and coverage ratios.
- Encodes read-only, no-write, no-order-submission, and non-authoritative profitability metadata in the output contract.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/reconcile_order_feed_coverage/test_projection.py -q` (3 passed)
- `uv run --frozen ruff check scripts/reconcile_order_feed_coverage.py tests/reconcile_order_feed_coverage/test_projection.py`
- `uv run --frozen ruff format --check scripts/reconcile_order_feed_coverage.py tests/reconcile_order_feed_coverage/test_projection.py`
- All three Torghut Pyright profiles (`pyrightconfig.json`, `pyrightconfig.alpha.json`, `pyrightconfig.scripts.json`)

## Screenshots (if applicable)

N/A (CLI/reporting change)

## Breaking Changes

None. The projection is intentionally unwired and has no migration or write path. The generated report remains diagnostic-only until feed lineage is repaired and separately promoted.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
