### PR TITLE
chore(oirat): promote nix image sha-67fb1140821003687e79d29358e529f2543cfcea

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:1b0ee4bd19ef6670438ff952504b6154c3686a4664678176d19045abddb63367
+    digest: sha256:63751bf7bd03b19e61a32fd689bc3c50861a820d5929da629ed118ef0da70cd4


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:63751bf7bd03b19e61a32fd689bc3c50861a820d5929da629ed118ef0da70cd4`.
- Source commit: `67fb1140821003687e79d29358e529f2543cfcea`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:63751bf7bd03b19e61a32fd689bc3c50861a820d5929da629ed118ef0da70cd4" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.