### PR TITLE
chore(froussard): promote nix image sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:8773f94f69d3e6c4dd5de2e8ed9440394d4c718a6f9c5953cb0bf26efce3fb1f
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:a302534b5266cbe975f9767731e5ea85f44318cb427b7702a8e1383895569db9
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -73,7 +73,7 @@ spec:
             - name: FROUSSARD_VERSION
               value: v0.571.1-491-ga931fba9e
             - name: FROUSSARD_COMMIT
-              value: c1f09e6d651cdfed462e484346044948aebc9849
+              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Promote `froussard` to `registry.ide-newton.ts.net/lab/froussard@sha256:a302534b5266cbe975f9767731e5ea85f44318cb427b7702a8e1383895569db9`.
- Source commit: `d8d24cd01df091dedde7e32c262fea96cc3d7d11`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/froussard@sha256:a302534b5266cbe975f9767731e5ea85f44318cb427b7702a8e1383895569db9" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.