### PR TITLE
chore(sag): promote image sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    digest: sha256:d6accf1ff4f7eecb4f97b772dd0bcb5cd303030c007ed5bfda2b7bd123808b9d
+    digest: sha256:db853a1f47ac790835ed94c4fd7ed89245006e3f72c168e343bb5953a05cfe23


### PR DESCRIPTION
## Summary
Promote the Sag image into GitOps manifests.

- Source commit: `d8d24cd01df091dedde7e32c262fea96cc3d7d11`
- Image tag: `sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11`
- Image digest: `sha256:db853a1f47ac790835ed94c4fd7ed89245006e3f72c168e343bb5953a05cfe23`