### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:2de983bd71c31a340889134f55fe972d1feea3a88d1ffd99fdbf7ed475afb25d
+    digest: sha256:5be62419bcd1414551198b4de234408d0cfd231f46775d6b4b2fcda94683cd0a
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:9d4a9f6886184f0a4b28d5ff17f72222796ff3ab7852818e07cffd3a4f093d11
+    digest: sha256:10689e1e095f6b05388f0dd5791c89545cd539a7a9988e29c02f3b2d7d6c240e
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/olden/kustomization.yaml
+++ b/argocd/applications/olden/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - service.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/olden
-    digest: sha256:36c0833883487eb2d6dedb60a8dfea5d1e889d50f0621f4ebd93ea1adaf6d2fc
+    digest: sha256:72994d0daa7fc852f0a160b673a121138164f39bb5a4dc1148ef7dc0610cf2d2
     newName: registry.ide-newton.ts.net/lab/olden

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:469af30118aa17cfce70b8e1b9e56b4ef85cf1c9a981c1d945c37cb895377381
+  digest: sha256:3943c22c108b558abb3f69f15498b0d7ddea48e7778ff23f70eeec4d5532f80b
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:7f00e90d55d00f0fa3ce59df13d535e01ebdad4e02879ae7a1e8928b7063b812
+    digest: sha256:bfebc1dc998a19daddeb3063647e9fd5d5cbb143f34c5f76faf87d7d97ec8cba
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:5be62419bcd1414551198b4de234408d0cfd231f46775d6b4b2fcda94683cd0a` from `67fb1140821003687e79d29358e529f2543cfcea`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:10689e1e095f6b05388f0dd5791c89545cd539a7a9988e29c02f3b2d7d6c240e` from `67fb1140821003687e79d29358e529f2543cfcea`
- `olden`: `registry.ide-newton.ts.net/lab/olden@sha256:72994d0daa7fc852f0a160b673a121138164f39bb5a4dc1148ef7dc0610cf2d2` from `67fb1140821003687e79d29358e529f2543cfcea`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:3943c22c108b558abb3f69f15498b0d7ddea48e7778ff23f70eeec4d5532f80b` from `67fb1140821003687e79d29358e529f2543cfcea`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:bfebc1dc998a19daddeb3063647e9fd5d5cbb143f34c5f76faf87d7d97ec8cba` from `67fb1140821003687e79d29358e529f2543cfcea`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.