### PR TITLE
chore(symphony): promote image sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T23:41:42Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-13T03:12:22Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-95ffea0e6bd58e03742b71606d11af9d8fb01898"
-    digest: sha256:1dd64cdf33af1b62e7d915df83256b3628b27214c5805f7adb356b1c7e8a6c24
+    newTag: "sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11"
+    digest: sha256:eb332d09be94988b76d106d8c657ae03a30045174defa946cc51eb62d213267b

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T23:41:42Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-13T03:12:22Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-95ffea0e6bd58e03742b71606d11af9d8fb01898"
-    digest: sha256:1dd64cdf33af1b62e7d915df83256b3628b27214c5805f7adb356b1c7e8a6c24
+    newTag: "sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11"
+    digest: sha256:eb332d09be94988b76d106d8c657ae03a30045174defa946cc51eb62d213267b

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-12T23:41:42Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-13T03:12:22Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -16,5 +16,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-95ffea0e6bd58e03742b71606d11af9d8fb01898"
-    digest: sha256:1dd64cdf33af1b62e7d915df83256b3628b27214c5805f7adb356b1c7e8a6c24
+    newTag: "sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11"
+    digest: sha256:eb332d09be94988b76d106d8c657ae03a30045174defa946cc51eb62d213267b


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `d8d24cd01df091dedde7e32c262fea96cc3d7d11`
- Image tag: `sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11`
- Image digest: `sha256:eb332d09be94988b76d106d8c657ae03a30045174defa946cc51eb62d213267b`