### PR TITLE
chore(bumba): promote nix image sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@d0a8a7c7577258bb7bfd69acd32eb88d24a38608
+              value: bumba@d8d24cd01df091dedde7e32c262fea96cc3d7d11
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:f1065dac7ad77cdcd49824c893b487af1649418b604a4bb1430921d7e1d06ad2
+    digest: sha256:a8ec29a0ca8ee4d90f27b2d969b6723fe3fb3ed986fcf99c7746769ec3249fbf
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:a8ec29a0ca8ee4d90f27b2d969b6723fe3fb3ed986fcf99c7746769ec3249fbf`.
- Source commit: `d8d24cd01df091dedde7e32c262fea96cc3d7d11`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:a8ec29a0ca8ee4d90f27b2d969b6723fe3fb3ed986fcf99c7746769ec3249fbf" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.