### PR TITLE
chore(jangar): promote image sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-07-13T00:59:56Z
+    deploy.knative.dev/rollout: 2026-07-13T03:14:44Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: d477684f6afff4c7fdfb24093dacedcfc6c5157f
+              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
             - name: JANGAR_GITOPS_REVISION
-              value: d477684f6afff4c7fdfb24093dacedcfc6c5157f
+              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29215635146"
+              value: "29220275450"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:3ac49614a2787dd186f8d8ec64b0b0c37e5bb7334dc412d8c8a10bbb74c5537f
+              value: sha256:50ef1ad585d587de5f00a4ad416508d57351b51b1fe948a30b1684a2b2a482dc
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: d477684f6afff4c7fdfb24093dacedcfc6c5157f
+              value: d8d24cd01df091dedde7e32c262fea96cc3d7d11
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:3ac49614a2787dd186f8d8ec64b0b0c37e5bb7334dc412d8c8a10bbb74c5537f
+              value: sha256:50ef1ad585d587de5f00a4ad416508d57351b51b1fe948a30b1684a2b2a482dc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-d477684f6afff4c7fdfb24093dacedcfc6c5157f
-    digest: sha256:3ac49614a2787dd186f8d8ec64b0b0c37e5bb7334dc412d8c8a10bbb74c5537f
+    newTag: sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11
+    digest: sha256:50ef1ad585d587de5f00a4ad416508d57351b51b1fe948a30b1684a2b2a482dc


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `d8d24cd01df091dedde7e32c262fea96cc3d7d11`
- Image tag: `sha-d8d24cd01df091dedde7e32c262fea96cc3d7d11`
- Image digest: `sha256:50ef1ad585d587de5f00a4ad416508d57351b51b1fe948a30b1684a2b2a482dc`
- Source CI run: `29220275450`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates