### PR TITLE
fix(bumba): omit hosted reasoning temperature

### DIFF
--- a/services/bumba/src/activities/index.test.ts
+++ b/services/bumba/src/activities/index.test.ts
@@ -661,4 +661,63 @@ describe('bumba completions', () => {
       }
     }
   })
+
+  it('omits temperature for hosted GPT-5.6 completion requests', async () => {
+    const previousFetch = globalThis.fetch
+    const previousEnv = {
+      OPENAI_API_BASE_URL: process.env.OPENAI_API_BASE_URL,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      OPENAI_COMPLETION_MODEL: process.env.OPENAI_COMPLETION_MODEL,
+      OPENAI_COMPLETION_TEMPERATURE: process.env.OPENAI_COMPLETION_TEMPERATURE,
+      OPENAI_COMPLETION_TOP_P: process.env.OPENAI_COMPLETION_TOP_P,
+      OPENAI_COMPLETION_REASONING_EFFORT: process.env.OPENAI_COMPLETION_REASONING_EFFORT,
+      OPENAI_COMPLETION_TIMEOUT_MS: process.env.OPENAI_COMPLETION_TIMEOUT_MS,
+      OPENAI_COMPLETION_MAX_OUTPUT_TOKENS: process.env.OPENAI_COMPLETION_MAX_OUTPUT_TOKENS,
+    }
+
+    process.env.OPENAI_API_BASE_URL = 'https://api.openai.com/v1'
+    process.env.OPENAI_API_KEY = 'test-key'
+    delete process.env.OPENAI_COMPLETION_MODEL
+    delete process.env.OPENAI_COMPLETION_TEMPERATURE
+    delete process.env.OPENAI_COMPLETION_TOP_P
+    delete process.env.OPENAI_COMPLETION_REASONING_EFFORT
+    process.env.OPENAI_COMPLETION_TIMEOUT_MS = '5000'
+    process.env.OPENAI_COMPLETION_MAX_OUTPUT_TOKENS = '256'
+
+    let requestBody: Record<string, unknown> | null = null
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : null
+      return new Response(
+        'data: {"choices":[{"delta":{"content":"{\\"summary\\":\\"ok\\",\\"enriched\\":\\"- tuned\\"}"}}]}\n\ndata: [DONE]\n\n',
+        {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        },
+      )
+    }) as typeof fetch
+
+    try {
+      const result = await activities.enrichWithModel({
+        filename: 'sample.ts',
+        content: 'export const sample = true\n',
+        astSummary: '- export const sample',
+        context: '',
+      })
+
+      expect(result.summary).toBe('ok')
+      if (!requestBody) {
+        throw new Error('expected completion request body')
+      }
+      const body = requestBody as Record<string, unknown>
+      expect(body.model).toBe('gpt-5.6-sol')
+      expect(body).not.toHaveProperty('temperature')
+      expect(body).not.toHaveProperty('top_p')
+      expect(body.reasoning_effort).toBe('high')
+    } finally {
+      globalThis.fetch = previousFetch
+      for (const [key, value] of Object.entries(previousEnv)) {
+        restoreEnv(key, value)
+      }
+    }
+  })
 })

--- a/services/bumba/src/activities/index.ts
+++ b/services/bumba/src/activities/index.ts
@@ -577,14 +577,15 @@ const resolveCompletionDefaults = (apiBaseUrl: string) => {
   const hosted = isHostedOpenAiBaseUrl(apiBaseUrl)
   return {
     model: hosted ? DEFAULT_OPENAI_COMPLETION_MODEL : DEFAULT_SELF_HOSTED_COMPLETION_MODEL,
-    temperature: hosted ? 0 : DEFAULT_SELF_HOSTED_COMPLETION_TEMPERATURE,
+    temperature: hosted ? null : DEFAULT_SELF_HOSTED_COMPLETION_TEMPERATURE,
     topP: hosted ? null : DEFAULT_SELF_HOSTED_COMPLETION_TOP_P,
     reasoningEffort: hosted ? 'high' : DEFAULT_SELF_HOSTED_COMPLETION_REASONING_EFFORT,
   }
 }
 
-const loadCompletionTemperature = (fallback: number) => {
+const loadCompletionTemperature = (fallback: number | null) => {
   const temperature = normalizeOptionalFloat(process.env.OPENAI_COMPLETION_TEMPERATURE) ?? fallback
+  if (temperature === null) return null
   if (!Number.isFinite(temperature) || temperature < 0) {
     throw createNonRetryableError(
       'OPENAI_COMPLETION_TEMPERATURE must be a non-negative number',
@@ -2999,7 +3000,7 @@ export const activities = {
       model,
       stream: true,
       max_tokens: maxOutputTokens,
-      temperature,
+      ...(temperature === null ? {} : { temperature }),
       ...(topP === null ? {} : { top_p: topP }),
       ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
       messages,


### PR DESCRIPTION
## Summary

- Default hosted OpenAI completion temperature to unset instead of `0`.
- Omit `temperature` from hosted GPT-5.6 chat-completion payloads while preserving explicit overrides and self-hosted defaults.
- Add regression coverage for hosted GPT-5.6 and retain existing Flamingo payload coverage.

## Related Issues

Follow-up to Codex review on #12341.

## Testing

- `bun node_modules/typescript/bin/tsc --project packages/otel/tsconfig.json --pretty false`
- `bun node_modules/typescript/bin/tsc --project packages/temporal-bun-sdk/tsconfig.json --pretty false`
- `bun test services/bumba/src/activities/index.test.ts` (27 passed)
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bumba/tsconfig.json`
- Oxfmt and Oxlint on both changed files
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
