### PR TITLE
fix(agents): align Spark fallback effort

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -8,7 +8,7 @@ spec:
     type: codex-app-server
     codex:
       model: gpt-5.3-codex-spark
-      effort: xhigh
+      effort: high
       sandbox: danger-full-access
       approval: never
       cwd: /workspace/lab
@@ -30,7 +30,7 @@ spec:
       content: |-
         model = "gpt-5.3-codex-spark"
         model_reasoning_summary = "none"
-        model_reasoning_effort = "xhigh"
+        model_reasoning_effort = "high"
         model_verbosity = "medium"
         approval_policy = "never"
         sandbox_mode = "danger-full-access"

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -594,7 +594,7 @@ describe('scheduled AgentRun templates', () => {
     expect(objectAt(spec, 'argsTemplate')).toEqual([])
     expect(objectAt(adapter, 'type')).toBe('codex-app-server')
     expect(objectAt(codex, 'model')).toBe('gpt-5.3-codex-spark')
-    expect(objectAt(codex, 'effort')).toBe('xhigh')
+    expect(objectAt(codex, 'effort')).toBe('high')
     expect(objectAt(codex, 'sandbox')).toBe('danger-full-access')
     expect(objectAt(codex, 'approval')).toBe('never')
     expect(objectAt(codex, 'cwd')).toBe('/workspace/lab')
@@ -607,6 +607,8 @@ describe('scheduled AgentRun templates', () => {
     expect(objectAt(envTemplate, 'CODEX_MODEL_FALLBACKS')).not.toContain('gpt-5.3-codex-spark')
     expect(objectAt(envTemplate, 'CODEX_MAX_SESSION_ATTEMPTS')).toBe('5')
     expect(objectAt(codexConfig, 'content')).toContain('model = "gpt-5.3-codex-spark"')
+    expect(objectAt(codexConfig, 'content')).toContain('model_reasoning_effort = "high"')
+    expect(objectAt(codexConfig, 'content')).not.toContain('model_reasoning_effort = "xhigh"')
     expect(objectAt(codexConfig, 'content')).not.toContain('model = "gpt-5.6-sol"')
     expect((inputFiles ?? []).map((inputFile) => objectAt(inputFile, 'path'))).not.toContain(
       '/root/.codex/provider-codex-spark.json',


### PR DESCRIPTION
## Summary

- Lower the codex-spark provider reasoning effort from `xhigh` to `high`.
- Keep the adapter and generated Codex config aligned so non-Spark fallback models receive a supported effort.
- Add manifest regression assertions that reject a reintroduction of `xhigh`.

## Related Issues

Follow-up to Codex review on #12341.

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'renders Codex app-server adapter metadata instead of legacy provider wrapper scripts'` (1 passed)
- Oxfmt on the provider manifest and focused test
- Oxlint on the focused test
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
