### PR TITLE
chore(bumba): promote nix image sha-e136cc653fce5dd649322658cd5b6885d5ac0bdc

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@d8d24cd01df091dedde7e32c262fea96cc3d7d11
+              value: bumba@e136cc653fce5dd649322658cd5b6885d5ac0bdc
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:a8ec29a0ca8ee4d90f27b2d969b6723fe3fb3ed986fcf99c7746769ec3249fbf
+    digest: sha256:058f0d1c1d294904ebb3fe4ecffb1503a0cf94cc50f2d9b58c02aac2a89fce25
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:058f0d1c1d294904ebb3fe4ecffb1503a0cf94cc50f2d9b58c02aac2a89fce25`.
- Source commit: `e136cc653fce5dd649322658cd5b6885d5ac0bdc`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:058f0d1c1d294904ebb3fe4ecffb1503a0cf94cc50f2d9b58c02aac2a89fce25" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.